### PR TITLE
Abort blobs compaction on failed KV/BS blob read

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2212,14 +2212,14 @@ void TPartition::Handle(TEvPQ::TEvBlobResponse::TPtr& ev, const TActorContext& c
         const auto* response = ev->Get();
         if (HasError(*response)) {
             AbortBlobsCompaction(TStringBuilder()
-                << "blob read failed: " << response->Error.ErrorStr);
+                << "blob read failed: " << response->Error.ErrorStr, ctx);
             return;
         }
         for (const auto& blob : response->GetBlobs()) {
             if (blob.Empty()) {
                 AbortBlobsCompaction(TStringBuilder()
                     << "empty blob in compaction read response"
-                    << " key=" << blob.Key.ToString());
+                    << " key=" << blob.Key.ToString(), ctx);
                 return;
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2209,7 +2209,21 @@ void TPartition::OnReadComplete(TReadInfo& info,
 void TPartition::Handle(TEvPQ::TEvBlobResponse::TPtr& ev, const TActorContext& ctx) {
     const ui64 cookie = ev->Get()->GetCookie();
     if (cookie == ERequestCookie::ReadBlobsForCompaction) {
-        BlobsForCompactionWereRead(ev->Get()->GetBlobs());
+        const auto* response = ev->Get();
+        if (HasError(*response)) {
+            AbortBlobsCompaction(TStringBuilder()
+                << "blob read failed: " << response->Error.ErrorStr);
+            return;
+        }
+        for (const auto& blob : response->GetBlobs()) {
+            if (blob.Empty()) {
+                AbortBlobsCompaction(TStringBuilder()
+                    << "empty blob in compaction read response"
+                    << " key=" << blob.Key.ToString());
+                return;
+            }
+        }
+        BlobsForCompactionWereRead(response->GetBlobs());
         return;
     }
     auto it = ReadInfo.find(cookie);

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -1240,6 +1240,7 @@ private:
                         const TActorContext& ctx);
 
     void TryRunCompaction(bool force = false);
+    void AbortBlobsCompaction(const TString& reason);
     void BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& blobs);
     void BlobsForCompactionWereWrite();
     ui64 NextReadCookie();

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -1240,7 +1240,7 @@ private:
                         const TActorContext& ctx);
 
     void TryRunCompaction(bool force = false);
-    void AbortBlobsCompaction(const TString& reason);
+    void AbortBlobsCompaction(const TString& reason, const TActorContext& ctx);
     void BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& blobs);
     void BlobsForCompactionWereWrite();
     ui64 NextReadCookie();

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -496,6 +496,29 @@ bool TPartition::InitNewHeadForCompaction()
     return true;
 }
 
+void TPartition::AbortBlobsCompaction(const TString& reason)
+{
+    const auto& ctx = ActorContext();
+
+    YDB_LOG_WARN_COMP(Service, "Abort blobs compaction",
+        {"logPrefix", NPQ_LOG_PREFIX},
+        {"reason", reason},
+        {"compactionInProgress", CompactionInProgress},
+        {"keysForCompaction", KeysForCompaction.size()},
+        {"compactionBlobsCount", CompactionBlobsCount});
+
+    CompactionInProgress = false;
+    KeysForCompaction.clear();
+    CompactionBlobsCount = 0;
+    FirstCompactionPart = Nothing();
+    CompactionBlobEncoder.ClearPartitionedBlob(Partition, MaxBlobSize);
+
+    // Do not retry immediately: a persistent KV/BS failure would loop.
+    // Compaction will be attempted again from the next write/wakeup path.
+    TryProcessGetWriteInfoRequest(ctx);
+    ProcessTxsAndUserActs(ctx);
+}
+
 void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& blobs)
 {
     const auto& ctx = ActorContext();

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -510,7 +510,8 @@ void TPartition::AbortBlobsCompaction(const TString& reason)
     CompactionInProgress = false;
     KeysForCompaction.clear();
     CompactionBlobsCount = 0;
-    FirstCompactionPart = Nothing();
+    // Keep FirstCompactionPart: on the read-failure path it still holds the
+    // init/restart skip marker and must not be cleared.
     CompactionBlobEncoder.ClearPartitionedBlob(Partition, MaxBlobSize);
 
     // Do not retry immediately: a persistent KV/BS failure would loop.

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -500,6 +500,13 @@ void TPartition::AbortBlobsCompaction(const TString& reason)
 {
     const auto& ctx = ActorContext();
 
+    if (!CompactionInProgress) {
+        YDB_LOG_WARN_COMP(Service, "Ignore abort blobs compaction: compaction is not in progress",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"reason", reason});
+        return;
+    }
+
     YDB_LOG_WARN_COMP(Service, "Abort blobs compaction",
         {"logPrefix", NPQ_LOG_PREFIX},
         {"reason", reason},

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -496,10 +496,8 @@ bool TPartition::InitNewHeadForCompaction()
     return true;
 }
 
-void TPartition::AbortBlobsCompaction(const TString& reason)
+void TPartition::AbortBlobsCompaction(const TString& reason, const TActorContext& ctx)
 {
-    const auto& ctx = ActorContext();
-
     if (!CompactionInProgress) {
         YDB_LOG_WARN_COMP(Service, "Ignore abort blobs compaction: compaction is not in progress",
             {"logPrefix", NPQ_LOG_PREFIX},
@@ -521,8 +519,10 @@ void TPartition::AbortBlobsCompaction(const TString& reason)
     // init/restart skip marker and must not be cleared.
     CompactionBlobEncoder.ClearPartitionedBlob(Partition, MaxBlobSize);
 
-    // Do not retry immediately: a persistent KV/BS failure would loop.
+    // Do not call TryRunCompaction here: a persistent KV/BS failure would loop.
     // Compaction will be attempted again from the next write/wakeup path.
+    // Resume deferred GetWriteInfo only — that path sets StopCompaction and does
+    // not restart blobs compaction.
     TryProcessGetWriteInfoRequest(ctx);
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -524,7 +524,6 @@ void TPartition::AbortBlobsCompaction(const TString& reason)
     // Do not retry immediately: a persistent KV/BS failure would loop.
     // Compaction will be attempted again from the next write/wakeup path.
     TryProcessGetWriteInfoRequest(ctx);
-    ProcessTxsAndUserActs(ctx);
 }
 
 void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& blobs)

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -474,7 +474,7 @@ void TestCompactionSurvivesFailedBlobRead(ECompactionBlobReadInjection injection
     bool injected = false;
     tc.Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
         if (auto* event = ev->CastAsLocal<TEvPQ::TEvBlobResponse>()) {
-            if (!injected && event->GetCookie() == 0) { // ERequestCookie::ReadBlobsForCompaction
+            if (!injected && event->GetCookie() == TPartition::ERequestCookie::ReadBlobsForCompaction) {
                 injected = true;
 
                 TVector<TRequestedBlob> blobs = event->GetBlobs();
@@ -4526,7 +4526,7 @@ Y_UNIT_TEST(PQ_Tablet_Does_Not_Remove_The_Blob_Until_The_Reading_Is_Complete)
     TAutoPtr<IEventHandle> blobResponseEvent;
     auto observe = [&](TAutoPtr<IEventHandle>& ev) {
         if (auto* event = ev->CastAsLocal<TEvPQ::TEvBlobResponse>()) {
-            if (event->GetCookie() == 0) { // ERequestCookie::ReadBlobsForCompaction
+            if (event->GetCookie() == TPartition::ERequestCookie::ReadBlobsForCompaction) {
                 return TTestActorRuntimeBase::EEventAction::PROCESS;
             }
             blobResponseEvent = ev;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -428,7 +428,8 @@ Y_UNIT_TEST(TestCompaction) {
 
 // Regression for https://github.com/ydb-platform/ydb/issues/49436:
 // failed KV/cache read for compaction (cookie=ReadBlobsForCompaction) must not
-// unpack empty blobs in CompactRequestedBlob/GetBatches.
+// unpack empty blobs in CompactRequestedBlob/GetBatches. After the failure goes
+// away, a later compaction must keep the same messages (no loss / no duplicates).
 Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
     TTestContext tc;
     TFinalizer finalizer(tc);
@@ -443,10 +444,16 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
     PQTabletPrepare({.partitions = 1, .lowWatermark = 10_MB, .writeSpeed = 50_MB},
                     {{"user1", true}}, tc);
 
-    for (ui64 i = 0; i < 8; ++i) {
+    const TString sourceId = "sourceid_compaction_fail_read";
+    constexpr ui64 initialMessages = 8;
+    constexpr ui64 totalMessages = 9;
+    TVector<TString> payloads;
+    payloads.reserve(totalMessages);
+    for (ui64 i = 0; i < initialMessages; ++i) {
+        payloads.emplace_back(TString(200_KB, static_cast<char>('a' + i)));
         TVector<std::pair<ui64, TString>> data;
-        data.emplace_back(i + 1, TString(200_KB, 'x'));
-        CmdWrite(0, "sourceid_compaction_fail_read", data, tc, false, {}, i == 0, "", -1, static_cast<i64>(i));
+        data.emplace_back(i + 1, payloads.back());
+        CmdWrite(0, sourceId, data, tc, false, {}, i == 0, "", -1, static_cast<i64>(i));
     }
 
     bool injected = false;
@@ -485,10 +492,41 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
 
     // After the fix: tablet stays alive and accepts further writes.
     // Before the fix: AFL_ENSURE(Data != End) aborts while handling the poisoned response.
+    payloads.emplace_back(TString(1_KB, 'y'));
     TVector<std::pair<ui64, TString>> more;
-    more.emplace_back(9, TString(1_KB, 'y'));
-    CmdWrite(0, "sourceid_compaction_fail_read", more, tc, false, {}, false, "", -1, 8);
-    PQGetPartInfo(0, 9, tc);
+    more.emplace_back(totalMessages, payloads.back());
+    CmdWrite(0, sourceId, more, tc, false, {}, false, "", -1, static_cast<i64>(initialMessages));
+    PQGetPartInfo(0, totalMessages, tc);
+
+    // Error is gone: next forced compaction must succeed and preserve the log.
+    tc.Runtime->SetObserverFunc([](TAutoPtr<IEventHandle>&) {
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+    CmdRunCompaction(0, tc);
+
+    auto assertExactLog = [&](const char* stage) {
+        PQGetPartInfo(0, totalMessages, tc);
+
+        TPQCmdReadSettings readSettings{
+            "", 0, 0, static_cast<ui32>(totalMessages + 1), 64_MB,
+            static_cast<ui32>(totalMessages), false,
+            {0, 1, 2, 3, 4, 5, 6, 7, 8}, 0, 0, "user1"};
+        const auto readResult = CmdReadAndGetResult(readSettings, tc);
+        UNIT_ASSERT_VALUES_EQUAL_C(readResult.ResultSize(), totalMessages, stage);
+        for (ui64 i = 0; i < totalMessages; ++i) {
+            const auto& msg = readResult.GetResult(i);
+            UNIT_ASSERT_VALUES_EQUAL_C(msg.GetOffset(), i, stage);
+            UNIT_ASSERT_VALUES_EQUAL_C(msg.GetSeqNo(), i + 1, stage);
+            UNIT_ASSERT_VALUES_EQUAL_C(msg.GetSourceId(), sourceId, stage);
+            UNIT_ASSERT_VALUES_EQUAL_C(msg.GetData(), payloads[i], stage);
+        }
+    };
+
+    assertExactLog("after successful compaction");
+
+    // Restart forces a fresh load from KV (compaction zone), not in-memory FastWrite state.
+    PQTabletRestart(tc);
+    assertExactLog("after restart");
 }
 
 Y_UNIT_TEST(BatchedMessagesWriteWithoutFeatureFlagFails) {

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -426,6 +426,70 @@ Y_UNIT_TEST(TestCompaction) {
     });
 }
 
+// Regression for https://github.com/ydb-platform/ydb/issues/49436:
+// failed KV/cache read for compaction (cookie=ReadBlobsForCompaction) must not
+// unpack empty blobs in CompactRequestedBlob/GetBatches.
+Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.EnableDetailedPQLog = true;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(50000);
+    // High threshold so writes do not trigger async compaction before we inject the failure.
+    // ForceCompaction still runs because it passes force=true.
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
+
+    // Blobs below low watermark are read+rewritten (not renamed) during compaction.
+    PQTabletPrepare({.partitions = 1, .lowWatermark = 10_MB, .writeSpeed = 50_MB},
+                    {{"user1", true}}, tc);
+
+    for (ui64 i = 0; i < 8; ++i) {
+        TVector<std::pair<ui64, TString>> data;
+        data.emplace_back(i + 1, TString(200_KB, 'x'));
+        CmdWrite(0, "sourceid_compaction_fail_read", data, tc, false, {}, i == 0, "", -1, static_cast<i64>(i));
+    }
+
+    bool injected = false;
+    tc.Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* event = ev->CastAsLocal<TEvPQ::TEvBlobResponse>()) {
+            if (!injected && event->GetCookie() == 0) { // ERequestCookie::ReadBlobsForCompaction
+                injected = true;
+
+                TVector<TRequestedBlob> blobs = event->GetBlobs();
+                UNIT_ASSERT_C(!blobs.empty(), "compaction blob read response has no blobs");
+                for (auto& blob : blobs) {
+                    blob.Clear();
+                }
+
+                const TActorId recipient = ev->Recipient;
+                const TActorId sender = ev->Sender;
+                // Same shape as production failure: Error set, keys present, RawValue empty.
+                ev.Reset(new IEventHandle(
+                    recipient,
+                    sender,
+                    new TEvPQ::TEvBlobResponse(
+                        /*cookie=*/0,
+                        std::move(blobs),
+                        TErrorInfo(NPersQueue::NErrorCode::ERROR, "injected BS/KV failure"))));
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    CmdRunCompaction(0, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] { return injected; };
+    tc.Runtime->DispatchEvents(options);
+    UNIT_ASSERT(injected);
+
+    // After the fix: tablet stays alive and accepts further writes.
+    // Before the fix: AFL_ENSURE(Data != End) aborts while handling the poisoned response.
+    TVector<std::pair<ui64, TString>> more;
+    more.emplace_back(9, TString(1_KB, 'y'));
+    CmdWrite(0, "sourceid_compaction_fail_read", more, tc, false, {}, false, "", -1, 8);
+    PQGetPartInfo(0, 9, tc);
+}
 
 Y_UNIT_TEST(BatchedMessagesWriteWithoutFeatureFlagFails) {
     TTestContext tc;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -427,10 +427,18 @@ Y_UNIT_TEST(TestCompaction) {
 }
 
 // Regression for https://github.com/ydb-platform/ydb/issues/49436:
-// failed KV/cache read for compaction (cookie=ReadBlobsForCompaction) must not
+// failed/partial KV/cache read for compaction (cookie=ReadBlobsForCompaction) must not
 // unpack empty blobs in CompactRequestedBlob/GetBatches. After the failure goes
 // away, a later compaction must keep the same messages (no loss / no duplicates).
-Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
+enum class ECompactionBlobReadInjection {
+    // Production shape from #49436: Error set, all RawValues cleared.
+    ErrorAndAllBlobsEmpty,
+    // Exercises the empty-blob branch with HasError==false. Keep Blobs[0] nonempty
+    // to satisfy TEvBlobResponse::Check(); clear a later blob (OVERRUN/crop-like).
+    OkWithLaterBlobEmpty,
+};
+
+void TestCompactionSurvivesFailedBlobRead(ECompactionBlobReadInjection injection) {
     TTestContext tc;
     TFinalizer finalizer(tc);
     tc.EnableDetailedPQLog = true;
@@ -471,20 +479,34 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
 
                 TVector<TRequestedBlob> blobs = event->GetBlobs();
                 UNIT_ASSERT_C(!blobs.empty(), "compaction blob read response has no blobs");
-                for (auto& blob : blobs) {
-                    blob.Clear();
+
+                TErrorInfo error;
+                switch (injection) {
+                    case ECompactionBlobReadInjection::ErrorAndAllBlobsEmpty:
+                        for (auto& blob : blobs) {
+                            blob.Clear();
+                        }
+                        error = TErrorInfo(NPersQueue::NErrorCode::ERROR, "injected BS/KV failure");
+                        break;
+                    case ECompactionBlobReadInjection::OkWithLaterBlobEmpty:
+                        UNIT_ASSERT_C(blobs.size() >= 2,
+                            "need at least two blobs to clear a later one while keeping Blobs[0]");
+                        UNIT_ASSERT_C(!blobs[0].Empty(), "Blobs[0] must stay nonempty for Check()");
+                        for (size_t i = 1; i < blobs.size(); ++i) {
+                            blobs[i].Clear();
+                        }
+                        // Default TErrorInfo is OK → HasError() == false.
+                        break;
                 }
 
                 const TActorId recipient = ev->Recipient;
                 const TActorId sender = ev->Sender;
-                // Same shape as production failure: Error set, keys present, RawValue empty.
-                ev.Reset(new IEventHandle(
-                    recipient,
-                    sender,
-                    new TEvPQ::TEvBlobResponse(
-                        /*cookie=*/0,
-                        std::move(blobs),
-                        TErrorInfo(NPersQueue::NErrorCode::ERROR, "injected BS/KV failure"))));
+                auto* poisoned = new TEvPQ::TEvBlobResponse(
+                    /*cookie=*/0,
+                    std::move(blobs),
+                    error);
+                poisoned->Check();
+                ev.Reset(new IEventHandle(recipient, sender, poisoned));
             }
         }
         return TTestActorRuntimeBase::EEventAction::PROCESS;
@@ -534,6 +556,14 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
     // Restart forces a fresh load from KV (compaction zone), not in-memory FastWrite state.
     PQTabletRestart(tc);
     assertExactLog("after restart");
+}
+
+Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
+    TestCompactionSurvivesFailedBlobRead(ECompactionBlobReadInjection::ErrorAndAllBlobsEmpty);
+}
+
+Y_UNIT_TEST(CompactionSurvivesEmptyLaterBlobWithoutError) {
+    TestCompactionSurvivesFailedBlobRead(ECompactionBlobReadInjection::OkWithLaterBlobEmpty);
 }
 
 Y_UNIT_TEST(BatchedMessagesWriteWithoutFeatureFlagFails) {

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -445,15 +445,22 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
                     {{"user1", true}}, tc);
 
     const TString sourceId = "sourceid_compaction_fail_read";
+    constexpr ui64 startOffset = 100;
     constexpr ui64 initialMessages = 8;
     constexpr ui64 totalMessages = 9;
+    const ui64 endOffset = startOffset + totalMessages;
     TVector<TString> payloads;
     payloads.reserve(totalMessages);
+    TVector<i32> expectedOffsets;
+    expectedOffsets.reserve(totalMessages);
+    for (ui64 i = 0; i < totalMessages; ++i) {
+        expectedOffsets.push_back(static_cast<i32>(startOffset + i));
+    }
     for (ui64 i = 0; i < initialMessages; ++i) {
         payloads.emplace_back(TString(200_KB, static_cast<char>('a' + i)));
         TVector<std::pair<ui64, TString>> data;
         data.emplace_back(i + 1, payloads.back());
-        CmdWrite(0, sourceId, data, tc, false, {}, i == 0, "", -1, static_cast<i64>(i));
+        CmdWrite(0, sourceId, data, tc, false, {}, i == 0, "", -1, static_cast<i64>(startOffset + i));
     }
 
     bool injected = false;
@@ -495,8 +502,8 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
     payloads.emplace_back(TString(1_KB, 'y'));
     TVector<std::pair<ui64, TString>> more;
     more.emplace_back(totalMessages, payloads.back());
-    CmdWrite(0, sourceId, more, tc, false, {}, false, "", -1, static_cast<i64>(initialMessages));
-    PQGetPartInfo(0, totalMessages, tc);
+    CmdWrite(0, sourceId, more, tc, false, {}, false, "", -1, static_cast<i64>(startOffset + initialMessages));
+    PQGetPartInfo(startOffset, endOffset, tc);
 
     // Error is gone: next forced compaction must succeed and preserve the log.
     tc.Runtime->SetObserverFunc([](TAutoPtr<IEventHandle>&) {
@@ -505,17 +512,17 @@ Y_UNIT_TEST(CompactionSurvivesFailedBlobRead) {
     CmdRunCompaction(0, tc);
 
     auto assertExactLog = [&](const char* stage) {
-        PQGetPartInfo(0, totalMessages, tc);
+        PQGetPartInfo(startOffset, endOffset, tc);
 
         TPQCmdReadSettings readSettings{
-            "", 0, 0, static_cast<ui32>(totalMessages + 1), 64_MB,
+            "", 0, static_cast<i64>(startOffset), static_cast<ui32>(totalMessages + 1), 64_MB,
             static_cast<ui32>(totalMessages), false,
-            {0, 1, 2, 3, 4, 5, 6, 7, 8}, 0, 0, "user1"};
+            expectedOffsets, 0, 0, "user1"};
         const auto readResult = CmdReadAndGetResult(readSettings, tc);
         UNIT_ASSERT_VALUES_EQUAL_C(readResult.ResultSize(), totalMessages, stage);
         for (ui64 i = 0; i < totalMessages; ++i) {
             const auto& msg = readResult.GetResult(i);
-            UNIT_ASSERT_VALUES_EQUAL_C(msg.GetOffset(), i, stage);
+            UNIT_ASSERT_VALUES_EQUAL_C(msg.GetOffset(), startOffset + i, stage);
             UNIT_ASSERT_VALUES_EQUAL_C(msg.GetSeqNo(), i + 1, stage);
             UNIT_ASSERT_VALUES_EQUAL_C(msg.GetSourceId(), sourceId, stage);
             UNIT_ASSERT_VALUES_EQUAL_C(msg.GetData(), payloads[i], stage);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Root cause for `verification=Data != End ... blob.size=0` on FastWrite keys (`d...?`): compaction (`ERequestCookie::ReadBlobsForCompaction`) ignored `HasError` / empty blobs and unpacked the response. Under nemesis KV/BS failures this aborted the process.

### Changes
- Check error/empty blobs in `Handle(TEvBlobResponse)` for compaction reads
- `AbortBlobsCompaction`: clear in-progress state, no immediate retry loop
- UT: inject poisoned cookie-0 response, assert tablet survives and accepts further writes

Related: #49436, #49386

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
