### PR TITLE
generic lookup actor: disable ut on windows

### DIFF
--- a/ydb/library/yql/providers/generic/actors/ut/ya.make
+++ b/ydb/library/yql/providers/generic/actors/ut/ya.make
@@ -8,9 +8,12 @@ PEERDIR(
     yql/essentials/sql/pg_dummy
 )
 
+IF (NOT OS_WINDOWS)
 SRCS(
     yql_generic_lookup_actor_ut.cpp
 )
+ELSE()
+ENDIF()
 
 YQL_LAST_ABI_VERSION()
 

--- a/ydb/library/yql/providers/generic/actors/ut/ya.make
+++ b/ydb/library/yql/providers/generic/actors/ut/ya.make
@@ -13,6 +13,7 @@ SRCS(
     yql_generic_lookup_actor_ut.cpp
 )
 ELSE()
+# TTestActorRuntimeBase(..., true) seems broken on windows
 ENDIF()
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -539,7 +539,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         loggerConfig.set_allcomponentslevel(::NYql::NProto::TLoggingConfig_ELevel::TLoggingConfig_ELevel_TRACE);
         NYql::NLog::InitLogger(loggerConfig, false);
 
-        TTestActorRuntimeBase runtime(1, 1, true);
+        TTestActorRuntimeBase runtime;
         runtime.Initialize();
         auto edge = runtime.AllocateEdgeActor();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

`TTestActorRuntimeBase runtime(1, 1, true)` misbehaves on windows (known issue, all other ut that use it also disabled on windows)
Also drive-by-drop `...,true` on one test that does not requires it.