### PR TITLE
[KQP] Fix Explain Analyze stage CPU attribution

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2548,22 +2548,42 @@ public:
     NJson::TJsonValue Reconstruct(
         const NJson::TJsonValue& plan
     ) {
-        auto reconstructed = ReconstructImpl(plan, 0, 0, false, nullptr);
+        auto reconstructed = ReconstructImpl(plan, 0, 0, false, nullptr, Nothing());
         return reconstructed;
     }
 
 private:
+    static TMaybe<double> GetCpuTimeMs(const NJson::TJsonValue& stats) {
+        if (!stats.GetMapSafe().contains("CpuTimeUs")) {
+            return Nothing();
+        }
+
+        const auto& cpuTime = stats.GetMapSafe().at("CpuTimeUs");
+        const double cpuTimeUs = cpuTime.IsMap()
+            ? cpuTime.GetMapSafe().at("Max").GetDoubleSafe()
+            : cpuTime.GetDoubleSafe();
+        return cpuTimeUs / 1000.0;
+    }
+
+    static void ApplyCpuTime(NJson::TJsonValue& op, const TMaybe<double>& cpuTimeMs) {
+        if (cpuTimeMs) {
+            op["A-SelfCpu"] = *cpuTimeMs;
+        }
+    }
+
     NJson::TJsonValue ReconstructImpl(
         const NJson::TJsonValue& plan,
         int operatorIndex,
         int parentTaskCount,
         bool fromBroadcast,
-        const NJson::TJsonValue* inheritedTableStats
+        const NJson::TJsonValue* inheritedTableStats,
+        TMaybe<double> inheritedCpuTimeMs
     ) {
         int currentNodeId = NodeIDCounter++;
 
         int taskCount = parentTaskCount;
         const NJson::TJsonValue* ownTableStats = nullptr;
+        TMaybe<double> ownCpuTimeMs;
         if (plan.GetMapSafe().contains("Stats")) {
             const auto& stats = plan.GetMapSafe().at("Stats").GetMapSafe();
             if (stats.contains("Tasks")) {
@@ -2572,7 +2592,9 @@ private:
             if (stats.contains("Table")) {
                 ownTableStats = &stats.at("Table");
             }
+            ownCpuTimeMs = GetCpuTimeMs(plan.GetMapSafe().at("Stats"));
         }
+        const auto effectiveCpuTimeMs = ownCpuTimeMs ? ownCpuTimeMs : inheritedCpuTimeMs;
 
         NJson::TJsonValue result;
         result["PlanNodeId"] = currentNodeId;
@@ -2593,6 +2615,7 @@ private:
 
             op["Name"] = "Lookup";
             op["LookupKeyColumns"] = plan.GetMapSafe().at("LookupKeyColumns");
+            ApplyCpuTime(op, effectiveCpuTimeMs);
 
             newOps.AppendValue(std::move(op));
             result["Operators"] = std::move(newOps);
@@ -2625,7 +2648,7 @@ private:
             lookupPlan["Operators"] = std::move(lookupOps);
 
 	        if (plan.GetMapSafe().contains("Plans")) {
-                newPlans.AppendValue(ReconstructImpl(plan.GetMapSafe().at("Plans").GetArraySafe()[0], 0, taskCount, false, inheritedTableStats));
+                newPlans.AppendValue(ReconstructImpl(plan.GetMapSafe().at("Plans").GetArraySafe()[0], 0, taskCount, false, inheritedTableStats, Nothing()));
             }
 
             newPlans.AppendValue(std::move(lookupPlan));
@@ -2648,7 +2671,7 @@ private:
             if (plan.GetMapSafe().contains("CTE Name")) {
                 auto precompute = plan.GetMapSafe().at("CTE Name").GetStringSafe();
                 if (Precomputes.contains(precompute)) {
-                    planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr));
+                    planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing()));
                 }
             }
 
@@ -2675,6 +2698,7 @@ private:
                 if (plan.GetMapSafe().contains("E-Size")) {
                     op["E-Size"] = plan.GetMapSafe().at("E-Size");
                 }
+                ApplyCpuTime(op, effectiveCpuTimeMs);
 
                 newOps.AppendValue(std::move(op));
 
@@ -2683,14 +2707,29 @@ private:
             }
 
             const auto effectiveTableStats = ownTableStats ? ownTableStats : inheritedTableStats;
+            const auto isRegularPlan = [](const NJson::TJsonValue& child) {
+                const auto& childMap = child.GetMapSafe();
+                const bool isCte = !childMap.contains("Operators") && childMap.contains("CTE Name");
+                return !isCte && childMap.at("Node Type").GetStringSafe().find("Precompute") == TString::npos;
+            };
+            size_t regularPlansCount = 0;
+            for (const auto& p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
+                if (isRegularPlan(p)) {
+                    ++regularPlansCount;
+                }
+            }
+            TMaybe<double> childCpuTimeMs;
+            if (regularPlansCount == 1) {
+                childCpuTimeMs = effectiveCpuTimeMs;
+            }
             for (auto p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
                 if (!p.GetMapSafe().contains("Operators") && p.GetMapSafe().contains("CTE Name")) {
                     auto precompute = p.GetMapSafe().at("CTE Name").GetStringSafe();
                     if (Precomputes.contains(precompute)) {
-                        planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr));
+                        planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing()));
                     }
-                } else if (p.GetMapSafe().at("Node Type").GetStringSafe().find("Precompute") == TString::npos) {
-                    planInputs.AppendValue(ReconstructImpl(p, 0, taskCount, fromBroadcast, effectiveTableStats));
+                } else if (isRegularPlan(p)) {
+                    planInputs.AppendValue(ReconstructImpl(p, 0, taskCount, fromBroadcast, effectiveTableStats, childCpuTimeMs));
                 }
             }
             result["Plans"] = planInputs;
@@ -2704,7 +2743,7 @@ private:
                 return result;
             }
 
-            return ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr);
+            return ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing());
         }
 
         auto ops = plan.GetMapSafe().at("Operators").GetArraySafe();
@@ -2727,7 +2766,7 @@ private:
                 processedExternalOperators.insert(inputPlanKey);
 
                 auto inputPlan = PlanIndex.at(inputPlanKey);
-                planInputs.push_back( ReconstructImpl(inputPlan, 0, taskCount, inputPlan.GetMapSafe().at("Node Type").GetStringSafe() == "Broadcast", ownTableStats) );
+                planInputs.push_back( ReconstructImpl(inputPlan, 0, taskCount, inputPlan.GetMapSafe().at("Node Type").GetStringSafe() == "Broadcast", ownTableStats, Nothing()) );
             } else if (opInput.GetMapSafe().contains("InternalOperatorId")) {
                 auto inputPlanId = opInput.GetMapSafe().at("InternalOperatorId").GetIntegerSafe();
 
@@ -2736,7 +2775,7 @@ private:
                 }
                 processedInternalOperators.insert(inputPlanId);
 
-                planInputs.push_back( ReconstructImpl(plan, inputPlanId, taskCount, false, inheritedTableStats) );
+                planInputs.push_back( ReconstructImpl(plan, inputPlanId, taskCount, false, inheritedTableStats, Nothing()) );
             }
         }
 
@@ -2769,7 +2808,7 @@ private:
             }
 
             if (Precomputes.contains(maybePrecompute) && planInputs.empty()) {
-                planInputs.push_back(ReconstructImpl(Precomputes.at(maybePrecompute), 0, taskCount, false, nullptr));
+                planInputs.push_back(ReconstructImpl(Precomputes.at(maybePrecompute), 0, taskCount, false, nullptr, Nothing()));
             }
         }
 
@@ -2881,7 +2920,6 @@ private:
             }
 
             if (operatorIndex == 0 && !op.GetMapSafe().contains("A-Rows")) {
-
                 // top level rows/size have to match stage output
                 if (!operatorRows && stats.contains("OutputRows")) {
                     auto outputRows = stats.at("OutputRows");
@@ -2899,21 +2937,11 @@ private:
                     }
                     op["A-Size"] = aSize;
                 }
-
-                // cpu usage available for stage only, so assign it to top level operator
-                if (stats.contains("CpuTimeUs")) {
-                    double opCpuTime;
-
-                    auto& cpuTime = stats.at("CpuTimeUs");
-                    if (cpuTime.IsMap()) {
-                        opCpuTime = cpuTime.GetMapSafe().at("Max").GetDoubleSafe();
-                    } else {
-                        opCpuTime = cpuTime.GetDoubleSafe();
-                    }
-
-                    op["A-SelfCpu"] = opCpuTime / 1000.0;
-                }
             }
+        }
+
+        if (operatorIndex == 0) {
+            ApplyCpuTime(op, effectiveCpuTimeMs);
         }
 
         if (opName == "TableFullScan" && !ownTableStats && inheritedTableStats) {

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2461,10 +2461,14 @@ void SetNonZero(NJson::TJsonValue& node, const TStringBuf& name, T value) {
     }
 }
 
-void BuildPlanIndex(NJson::TJsonValue& plan, THashMap<int, NJson::TJsonValue>& planIndex, THashMap<TString, NJson::TJsonValue>& precomputes) {
+void BuildPlanIndex(
+    const NJson::TJsonValue& plan,
+    THashMap<int, const NJson::TJsonValue*>& planIndex,
+    THashMap<TString, const NJson::TJsonValue*>& precomputes
+) {
     if (plan.GetMapSafe().contains("PlanNodeId")){
         auto id = plan.GetMapSafe().at("PlanNodeId").GetIntegerSafe();
-        planIndex[id] = plan;
+        planIndex[id] = &plan;
     }
 
     if (plan.GetMapSafe().contains("Subplan Name")) {
@@ -2472,14 +2476,14 @@ void BuildPlanIndex(NJson::TJsonValue& plan, THashMap<int, NJson::TJsonValue>& p
 
         auto pos = precomputeName.find("precompute");
         if (pos != TString::npos) {
-            precomputes[precomputeName.substr(pos)] = plan;
+            precomputes[precomputeName.substr(pos)] = &plan;
         } else if (precomputeName.size()>=4 && precomputeName.find("CTE ") != TString::npos) {
-            precomputes[precomputeName.substr(4)] = plan;
+            precomputes[precomputeName.substr(4)] = &plan;
         }
     }
 
     if (plan.GetMapSafe().contains("Plans")) {
-        for (auto p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
+        for (const auto& p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
             BuildPlanIndex(p, planIndex, precomputes);
         }
     }
@@ -2536,8 +2540,8 @@ void CopySimplifiedConnectionFields(const NJson::TJsonValue& from, NJson::TJsonV
 class TQueryPlanReconstructor {
 public:
     TQueryPlanReconstructor(
-        const THashMap<int, NJson::TJsonValue>& planIndex,
-        const THashMap<TString, NJson::TJsonValue>& precomputes
+        const THashMap<int, const NJson::TJsonValue*>& planIndex,
+        const THashMap<TString, const NJson::TJsonValue*>& precomputes
     )
         : PlanIndex(planIndex)
         , Precomputes(precomputes)
@@ -2579,7 +2583,7 @@ private:
             if (stats.contains("Table")) {
                 ownTableStats = &stats.at("Table");
             }
-            if (stats.contains("CpuTimeUs")) {
+            if (operatorIndex == 0 && stats.contains("CpuTimeUs")) {
                 const auto& cpuTime = stats.at("CpuTimeUs");
                 const double cpuTimeUs = cpuTime.IsMap()
                     ? cpuTime.GetMapSafe().at("Max").GetDoubleSafe()
@@ -2664,7 +2668,7 @@ private:
             if (plan.GetMapSafe().contains("CTE Name")) {
                 auto precompute = plan.GetMapSafe().at("CTE Name").GetStringSafe();
                 if (Precomputes.contains(precompute)) {
-                    planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing()));
+                    planInputs.AppendValue(ReconstructImpl(*Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing()));
                 }
             }
 
@@ -2705,21 +2709,23 @@ private:
                 const bool isCte = !childMap.contains("Operators") && childMap.contains("CTE Name");
                 return !isCte && childMap.at("Node Type").GetStringSafe().find("Precompute") == TString::npos;
             };
-            size_t regularPlansCount = 0;
-            for (const auto& p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
-                if (isRegularPlan(p)) {
-                    ++regularPlansCount;
+            TMaybe<double> childCpuTimeMs;
+            if (effectiveCpuTimeMs) {
+                size_t regularPlansCount = 0;
+                for (const auto& p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
+                    if (isRegularPlan(p)) {
+                        ++regularPlansCount;
+                    }
+                }
+                if (regularPlansCount == 1) {
+                    childCpuTimeMs = effectiveCpuTimeMs;
                 }
             }
-            TMaybe<double> childCpuTimeMs;
-            if (regularPlansCount == 1) {
-                childCpuTimeMs = effectiveCpuTimeMs;
-            }
-            for (auto p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
+            for (const auto& p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
                 if (!p.GetMapSafe().contains("Operators") && p.GetMapSafe().contains("CTE Name")) {
                     auto precompute = p.GetMapSafe().at("CTE Name").GetStringSafe();
                     if (Precomputes.contains(precompute)) {
-                        planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing()));
+                        planInputs.AppendValue(ReconstructImpl(*Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing()));
                     }
                 } else if (isRegularPlan(p)) {
                     planInputs.AppendValue(ReconstructImpl(p, 0, taskCount, fromBroadcast, effectiveTableStats, childCpuTimeMs));
@@ -2736,7 +2742,7 @@ private:
                 return result;
             }
 
-            return ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing());
+            return ReconstructImpl(*Precomputes.at(precompute), 0, taskCount, false, nullptr, Nothing());
         }
 
         auto ops = plan.GetMapSafe().at("Operators").GetArraySafe();
@@ -2758,7 +2764,7 @@ private:
                 }
                 processedExternalOperators.insert(inputPlanKey);
 
-                auto inputPlan = PlanIndex.at(inputPlanKey);
+                const auto& inputPlan = *PlanIndex.at(inputPlanKey);
                 planInputs.push_back( ReconstructImpl(inputPlan, 0, taskCount, inputPlan.GetMapSafe().at("Node Type").GetStringSafe() == "Broadcast", ownTableStats, Nothing()) );
             } else if (opInput.GetMapSafe().contains("InternalOperatorId")) {
                 auto inputPlanId = opInput.GetMapSafe().at("InternalOperatorId").GetIntegerSafe();
@@ -2801,7 +2807,7 @@ private:
             }
 
             if (Precomputes.contains(maybePrecompute) && planInputs.empty()) {
-                planInputs.push_back(ReconstructImpl(Precomputes.at(maybePrecompute), 0, taskCount, false, nullptr, Nothing()));
+                planInputs.push_back(ReconstructImpl(*Precomputes.at(maybePrecompute), 0, taskCount, false, nullptr, Nothing()));
             }
         }
 
@@ -2976,8 +2982,8 @@ private:
     }
 
 private:
-    const THashMap<int, NJson::TJsonValue>& PlanIndex;
-    const THashMap<TString, NJson::TJsonValue>& Precomputes;
+    const THashMap<int, const NJson::TJsonValue*>& PlanIndex;
+    const THashMap<TString, const NJson::TJsonValue*>& Precomputes;
     ui32 NodeIDCounter;
     i32 Budget; // Prevent bugs with inf recursion
 };
@@ -3019,15 +3025,17 @@ NJson::TJsonValue SimplifyQueryPlan(NJson::TJsonValue& plan) {
         "CombineByKey"
     };
 
-    THashMap<int, NJson::TJsonValue> planIndex;
-    THashMap<TString, NJson::TJsonValue> precomputes;
+    NJson::TJsonValue reconstructedPlan;
+    {
+        THashMap<int, const NJson::TJsonValue*> planIndex;
+        THashMap<TString, const NJson::TJsonValue*> precomputes;
 
+        BuildPlanIndex(plan, planIndex, precomputes);
 
-    BuildPlanIndex(plan, planIndex, precomputes);
-
-    plan =
-        TQueryPlanReconstructor(planIndex, precomputes)
-            .Reconstruct(plan);
+        TQueryPlanReconstructor reconstructor(planIndex, precomputes);
+        reconstructedPlan = reconstructor.Reconstruct(plan);
+    }
+    plan = std::move(reconstructedPlan);
 
     RemoveRedundantNodes(plan, redundantNodes);
     ComputeCpuTimes(plan);

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2548,23 +2548,10 @@ public:
     NJson::TJsonValue Reconstruct(
         const NJson::TJsonValue& plan
     ) {
-        auto reconstructed = ReconstructImpl(plan, 0, 0, false, nullptr, Nothing());
-        return reconstructed;
+        return ReconstructImpl(plan, 0, 0, false, nullptr, Nothing());
     }
 
 private:
-    static TMaybe<double> GetCpuTimeMs(const NJson::TJsonValue& stats) {
-        if (!stats.GetMapSafe().contains("CpuTimeUs")) {
-            return Nothing();
-        }
-
-        const auto& cpuTime = stats.GetMapSafe().at("CpuTimeUs");
-        const double cpuTimeUs = cpuTime.IsMap()
-            ? cpuTime.GetMapSafe().at("Max").GetDoubleSafe()
-            : cpuTime.GetDoubleSafe();
-        return cpuTimeUs / 1000.0;
-    }
-
     static void ApplyCpuTime(NJson::TJsonValue& op, const TMaybe<double>& cpuTimeMs) {
         if (cpuTimeMs) {
             op["A-SelfCpu"] = *cpuTimeMs;
@@ -2592,7 +2579,13 @@ private:
             if (stats.contains("Table")) {
                 ownTableStats = &stats.at("Table");
             }
-            ownCpuTimeMs = GetCpuTimeMs(plan.GetMapSafe().at("Stats"));
+            if (stats.contains("CpuTimeUs")) {
+                const auto& cpuTime = stats.at("CpuTimeUs");
+                const double cpuTimeUs = cpuTime.IsMap()
+                    ? cpuTime.GetMapSafe().at("Max").GetDoubleSafe()
+                    : cpuTime.GetDoubleSafe();
+                ownCpuTimeMs = cpuTimeUs / 1000.0;
+            }
         }
         const auto effectiveCpuTimeMs = ownCpuTimeMs ? ownCpuTimeMs : inheritedCpuTimeMs;
 

--- a/ydb/core/kqp/opt/rbo/kqp_plan_to_json.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_plan_to_json.cpp
@@ -111,95 +111,83 @@ NJson::TJsonValue GetExplainJsonRec(const TIntrusivePtr<IOperator>& op, TExplain
     return result;
 }
 
-void FindPlanNodes(const NJson::TJsonValue& node, const TString& key, std::vector<NJson::TJsonValue>& results) {
-    if (node.IsArray()) {
-        for (const auto& item: node.GetArray()) {
-            FindPlanNodes(item, key, results);
+struct TOperatorLocation {
+    NJson::TJsonValue* Stage = nullptr;
+    NJson::TJsonValue* Operator = nullptr;
+    int OperatorIndex = 0;
+};
+
+struct TConnectionInfo {
+    bool FromBroadcast = false;
+    int ParentTaskCount = 0;
+};
+
+struct TPlanLookupIndex {
+    THashMap<i64, TOperatorLocation> Operators;
+    THashMap<TString, TConnectionInfo> Connections;
+    TVector<i64> OperatorOrder;
+};
+
+enum class EPlanIndexKind {
+    Execution,
+    Simplified,
+};
+
+void BuildPlanLookupIndex(
+    NJson::TJsonValue& planNode,
+    TPlanLookupIndex& index,
+    EPlanIndexKind kind)
+{
+    if (planNode.IsArray()) {
+        for (auto& item: planNode.GetArraySafe()) {
+            BuildPlanLookupIndex(item, index, kind);
         }
         return;
     }
 
-    if (!node.IsMap()) {
+    if (!planNode.IsMap()) {
         return;
     }
 
-    if (auto* valueNode = node.GetValueByPath(key)) {
-        results.push_back(*valueNode);
-    }
-
-    for (const auto& [_, value]: node.GetMap()) {
-        FindPlanNodes(value, key, results);
-    }
-}
-
-bool FindStageAndOpByOpId(NJson::TJsonValue& planNode, int opId, NJson::TJsonValue*& stage, NJson::TJsonValue*& op, int& operatorIdx) {
-
-    if (planNode.IsArray()) {
-        for (auto& item: planNode.GetArraySafe()) {
-            if (FindStageAndOpByOpId(item, opId, stage, op, operatorIdx)) {
-                return true;
-            }
-        }
-        return false;
-    } else if (planNode.IsMap()) {
-        if (planNode.GetMapSafe().contains("Operators")) {
-            auto& operatorArray = planNode.GetMapSafe().at("Operators").GetArraySafe();
-            for (size_t i=0; i<operatorArray.size(); i++) {
-                auto& item = operatorArray.at(i);
-                auto& itemMap = item.GetMapSafe();
-                auto itemId = itemMap.find("OperatorId");
-                if (itemId != itemMap.end() && itemId->second.GetInteger() == opId) {
-                    operatorIdx = i;
-                    stage = &planNode;
-                    op = &item;
-                    return true;
+    auto& planMap = planNode.GetMapSafe();
+    if (auto operators = planMap.find("Operators"); operators != planMap.end()) {
+        auto& operatorArray = operators->second.GetArraySafe();
+        for (size_t i = 0; i < operatorArray.size(); ++i) {
+            auto& item = operatorArray.at(i);
+            auto& itemMap = item.GetMapSafe();
+            if (auto itemId = itemMap.find("OperatorId"); itemId != itemMap.end()) {
+                const i64 id = itemId->second.GetIntegerSafe();
+                if (kind == EPlanIndexKind::Simplified) {
+                    index.OperatorOrder.push_back(id);
                 }
+                index.Operators.try_emplace(
+                    id,
+                    TOperatorLocation{&planNode, &item, static_cast<int>(i)}
+                );
             }
-        }
-        if (planNode.GetMapSafe().contains("Plans")) {
-            for (auto& item: planNode.GetMapSafe().at("Plans").GetArraySafe()) {
-                if (FindStageAndOpByOpId(item, opId, stage, op, operatorIdx)) {
-                    return true;
-                }
-            }
-            return false;
         }
     }
 
-    return false;
-}
-
-bool FindConnection(NJson::TJsonValue& planNode, const TString& stageGuid, bool& fromBroadcast, int& parentTaskCount) {
-    if (planNode.IsArray()) {
-        for (auto& item: planNode.GetArraySafe()) {
-            if (FindConnection(item, stageGuid, fromBroadcast, parentTaskCount)) {
-                return true;
-            }
-        }
-        return false;
-    } else if (planNode.IsMap()) {
-        const auto& planMap = planNode.GetMapSafe();
+    if (kind == EPlanIndexKind::Execution) {
         if (planMap.contains("PlanNodeType") && planMap.at("PlanNodeType") == "Connection") {
-            const auto& subplan = planMap.at("Plans").GetArraySafe().at(0);
-            if (subplan.GetMapSafe().at("StageGuid") == stageGuid) {
-                fromBroadcast = planMap.at("Node Type") == "Broadcast";
-                if (planMap.contains("Stats") && planMap.at("Stats").GetMapSafe().contains("Tasks")) {
-                    parentTaskCount = planMap.at("Stats").GetMapSafe().at("Tasks").GetIntegerSafe();
-                }
-                return true;
+            auto& subplan = planMap.at("Plans").GetArraySafe().at(0);
+            TConnectionInfo connectionInfo;
+            connectionInfo.FromBroadcast = planMap.at("Node Type") == "Broadcast";
+            if (planMap.contains("Stats") && planMap.at("Stats").GetMapSafe().contains("Tasks")) {
+                connectionInfo.ParentTaskCount = planMap.at("Stats").GetMapSafe().at("Tasks").GetIntegerSafe();
             }
-        }
-        if (planNode.GetMapSafe().contains("Plans")) {
-            for (auto& item: planNode.GetMapSafe().at("Plans").GetArraySafe()) {
-                if (FindConnection(item, stageGuid, fromBroadcast, parentTaskCount)) {
-                    return true;
-                }
-            }
-            return false;
+            index.Connections.try_emplace(
+                subplan.GetMapSafe().at("StageGuid").GetStringSafe(),
+                connectionInfo
+            );
         }
     }
 
-    return false;
+    if (auto plans = planMap.find("Plans"); plans != planMap.end()) {
+        for (auto& item: plans->second.GetArraySafe()) {
+            BuildPlanLookupIndex(item, index, kind);
+        }
+    }
 }
 
 double ComputeCpuTimes(NJson::TJsonValue& plan) {
@@ -236,21 +224,23 @@ void AddStatsToSimplifiedPlan(NJson::TJsonValue& txPlan) {
     auto& simplifiedPlan = txPlan.GetMapSafe().at("SimplifiedPlan");
     auto& execPlan = txPlan.GetMapSafe().at("Plans")[0];
 
-    // Extract all operator ids from SimplifiedPlan and look up stages and operators
-    // in the execution plan
-    std::vector<NJson::TJsonValue> opIds;
-    FindPlanNodes(simplifiedPlan, "OperatorId", opIds);
+    TPlanLookupIndex execPlanIndex;
+    TPlanLookupIndex simplifiedPlanIndex;
+    BuildPlanLookupIndex(simplifiedPlan, simplifiedPlanIndex, EPlanIndexKind::Simplified);
+    execPlanIndex.Operators.reserve(simplifiedPlanIndex.OperatorOrder.size());
+    execPlanIndex.Connections.reserve(simplifiedPlanIndex.OperatorOrder.size());
+    BuildPlanLookupIndex(execPlan, execPlanIndex, EPlanIndexKind::Execution);
 
-    for (auto & idNode : opIds) {
-        int execOperatorIdx;
-        int explainOperatorIdx;
-        NJson::TJsonValue* execPlanStage;
-        NJson::TJsonValue* execPlanOp;
-        NJson::TJsonValue* explainPlanStage;
-        NJson::TJsonValue* explainPlanOp;
+    for (const auto opId : simplifiedPlanIndex.OperatorOrder) {
+        const auto execLocation = execPlanIndex.Operators.find(opId);
+        const auto explainLocation = simplifiedPlanIndex.Operators.find(opId);
+        Y_ENSURE(execLocation != execPlanIndex.Operators.end());
+        Y_ENSURE(explainLocation != simplifiedPlanIndex.Operators.end());
 
-        Y_ENSURE(FindStageAndOpByOpId(execPlan, idNode.GetIntegerSafe(), execPlanStage, execPlanOp, execOperatorIdx));
-        Y_ENSURE(FindStageAndOpByOpId(simplifiedPlan, idNode.GetIntegerSafe(), explainPlanStage, explainPlanOp, explainOperatorIdx));
+        auto* execPlanStage = execLocation->second.Stage;
+        auto* execPlanOp = execLocation->second.Operator;
+        const int execOperatorIdx = execLocation->second.OperatorIndex;
+        auto* explainPlanOp = explainLocation->second.Operator;
 
         if(!execPlanStage->GetMapSafe().contains("Stats")) {
             continue;
@@ -324,10 +314,10 @@ void AddStatsToSimplifiedPlan(NJson::TJsonValue& txPlan) {
 
         if (execOperatorIdx == 0 && !explainPlanOp->GetMapSafe().contains("A-Rows")) {
             // Find enclosing connection to process broadcast correctly
-            bool fromBroadcast = false;
-            int parentTaskCount = 0;
-            TString stageGuid = execPlanStage->GetMapSafe().at("StageGuid").GetStringSafe();
-            FindConnection(execPlan, stageGuid, fromBroadcast, parentTaskCount);
+            const TString stageGuid = execPlanStage->GetMapSafe().at("StageGuid").GetStringSafe();
+            const auto connection = execPlanIndex.Connections.find(stageGuid);
+            const bool fromBroadcast = connection != execPlanIndex.Connections.end() && connection->second.FromBroadcast;
+            const int parentTaskCount = connection == execPlanIndex.Connections.end() ? 0 : connection->second.ParentTaskCount;
             // top level rows/size have to match stage output
             if (!operatorRows && stats.contains("OutputRows")) {
                 auto outputRows = stats.at("OutputRows");

--- a/ydb/core/kqp/opt/rbo/kqp_plan_to_json.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_plan_to_json.cpp
@@ -332,7 +332,7 @@ void AddStatsToSimplifiedPlan(NJson::TJsonValue& txPlan) {
             if (!operatorRows && stats.contains("OutputRows")) {
                 auto outputRows = stats.at("OutputRows");
                 int aRows = outputRows.IsMap() ? outputRows.GetMapSafe().at("Sum").GetIntegerSafe() : outputRows.GetIntegerSafe();
-    
+
                 if (fromBroadcast && parentTaskCount && (aRows % parentTaskCount == 0)) {
                     aRows /= parentTaskCount;
                 }
@@ -346,7 +346,9 @@ void AddStatsToSimplifiedPlan(NJson::TJsonValue& txPlan) {
                 }
                 explainPlanOp->InsertValue("A-Size", aSize);
             }
+        }
 
+        if (execOperatorIdx == 0) {
             // cpu usage available for stage only, so assign it to top level operator
             if (stats.contains("CpuTimeUs")) {
                 double opCpuTime;

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -770,6 +770,139 @@ Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
     UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-Cpu"), simplifiedPlan);
 }
 
+Y_UNIT_TEST(LegacySimplifiedPlanDuplicateIndexesUseLastValue) {
+    const TString plan = R"({
+        "Plan": {
+            "Node Type": "Query",
+            "Plans": [
+                {
+                    "Node Type": "FilterStage",
+                    "Operators": [{
+                        "Name": "Filter",
+                        "Inputs": [{"ExternalPlanNodeId": 7}]
+                    }]
+                },
+                {
+                    "Node Type": "FirstDuplicate",
+                    "PlanNodeId": 7,
+                    "Operators": [{"Name": "FirstDuplicate", "Inputs": []}]
+                },
+                {
+                    "Node Type": "LastDuplicate",
+                    "PlanNodeId": 7,
+                    "Operators": [{"Name": "LastDuplicate", "Inputs": []}]
+                },
+                {
+                    "Node Type": "Precompute",
+                    "Subplan Name": "precompute_duplicate",
+                    "Plans": [{
+                        "Node Type": "FirstPrecompute",
+                        "Operators": [{"Name": "FirstPrecompute", "Inputs": []}]
+                    }]
+                },
+                {
+                    "Node Type": "Precompute",
+                    "Subplan Name": "precompute_duplicate",
+                    "Plans": [{
+                        "Node Type": "LastPrecompute",
+                        "Operators": [{"Name": "LastPrecompute", "Inputs": []}]
+                    }]
+                },
+                {
+                    "Node Type": "CteOwner",
+                    "Plans": [{
+                        "Node Type": "CTE",
+                        "CTE Name": "precompute_duplicate"
+                    }]
+                }
+            ]
+        }
+    })";
+
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
+    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
+    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(FindPlanNodeByKv(filter, "Name", "LastDuplicate").IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(!FindPlanNodeByKv(filter, "Name", "FirstDuplicate").IsDefined(), simplifiedPlan);
+
+    const auto cteOwner = FindPlanNodeByKv(simplifiedPlan, "Node Type", "CteOwner");
+    UNIT_ASSERT_C(cteOwner.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(FindPlanNodeByKv(cteOwner, "Name", "LastPrecompute").IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(!FindPlanNodeByKv(cteOwner, "Name", "FirstPrecompute").IsDefined(), simplifiedPlan);
+}
+
+Y_UNIT_TEST(LegacySimplifiedPlanMultiOperatorCpuOwner) {
+    const TString plan = R"({
+        "Plan": {
+            "Node Type": "Stage",
+            "Stats": {"CpuTimeUs": {"Max": 7000}},
+            "Operators": [
+                {
+                    "Name": "Filter",
+                    "Inputs": [{"InternalOperatorId": 1}]
+                },
+                {
+                    "Name": "Aggregate",
+                    "Inputs": []
+                }
+            ]
+        }
+    })";
+
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
+    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
+    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    AssertCpuValues(filter, 7, 7, simplifiedPlan);
+
+    const auto aggregate = FindPlanNodeByKv(filter, "Name", "Aggregate");
+    UNIT_ASSERT_C(aggregate.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(!aggregate.GetMapSafe().contains("A-SelfCpu"), simplifiedPlan);
+    UNIT_ASSERT_C(!aggregate.GetMapSafe().contains("A-Cpu"), simplifiedPlan);
+}
+
+Y_UNIT_TEST(LegacySimplifiedPlanCpuAbsentAndScriptPlan) {
+    const TString plan = R"({
+        "Plan": {
+            "Node Type": "Query",
+            "Plans": [{
+                "Node Type": "Collect",
+                "Plans": [{
+                    "Node Type": "ScanStage",
+                    "Stats": {
+                        "OutputRows": {"Sum": 6},
+                        "OutputBytes": {"Sum": 48},
+                        "Tasks": 2
+                    },
+                    "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                }]
+            }]
+        }
+    })";
+
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
+    UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-SelfCpu").empty(), simplifiedPlan);
+    UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-Cpu").empty(), simplifiedPlan);
+
+    const auto scan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
+    UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Rows").GetIntegerSafe(), 6, simplifiedPlan);
+    UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Size").GetDoubleSafe(), 48, simplifiedPlan);
+
+    const TVector<const TString> queryPlans = {plan};
+    const auto serializedScriptPlan = SerializeScriptPlan(queryPlans);
+    NJson::TJsonValue scriptPlan;
+    UNIT_ASSERT_C(NJson::ReadJsonTree(serializedScriptPlan, &scriptPlan, true), serializedScriptPlan);
+    UNIT_ASSERT_C(FindPlanNodes(scriptPlan, "A-SelfCpu").empty(), scriptPlan);
+    UNIT_ASSERT_C(FindPlanNodes(scriptPlan, "A-Cpu").empty(), scriptPlan);
+
+    const auto& scriptQuery = scriptPlan.GetMapSafe().at("queries").GetArraySafe().front();
+    const auto& scriptSimplifiedPlan = scriptQuery.GetMapSafe().at("SimplifiedPlan");
+    const auto scriptScan = FindPlanNodeByKv(scriptSimplifiedPlan, "Name", "TableFullScan");
+    UNIT_ASSERT_C(scriptScan.IsDefined(), scriptPlan);
+    UNIT_ASSERT_VALUES_EQUAL_C(scriptScan.GetMapSafe().at("A-Rows").GetIntegerSafe(), 6, scriptPlan);
+    UNIT_ASSERT_VALUES_EQUAL_C(scriptScan.GetMapSafe().at("A-Size").GetDoubleSafe(), 48, scriptPlan);
+}
+
 Y_UNIT_TEST(LegacySimplifiedPlanTableFullScanActualStats) {
     NKikimrConfig::TAppConfig app;
     app.MutableTableServiceConfig()->SetEnableNewRBO(false);

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -10,6 +10,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h>
 
 #include <cstdlib>
+#include <initializer_list>
 
 namespace NKikimr {
 namespace NKqp {
@@ -17,41 +18,38 @@ namespace NKqp {
 using namespace NYdb;
 using namespace NYdb::NTable;
 
-void AddStageCpuStats(NYql::NDqProto::TDqExecutionStats& executionStats, TStringBuf stageGuid, ui64 cpuTimeUs) {
-    auto* stageStats = executionStats.AddStages();
-    stageStats->SetStageGuid(TString(stageGuid));
-    stageStats->MutableCpuTimeUs()->SetMax(cpuTimeUs);
-}
-
-NJson::TJsonValue GetLegacySimplifiedPlan(
-    const TString& plan,
-    const NYql::NDqProto::TDqExecutionStats& executionStats)
-{
+NJson::TJsonValue GetLegacySimplifiedPlan(const TString& plan) {
+    NYql::NDqProto::TDqExecutionStats executionStats;
     NJson::TJsonValue planJson;
     const auto planWithStats = AddExecStatsToTxPlan(plan, executionStats, false);
     UNIT_ASSERT_C(NJson::ReadJsonTree(planWithStats, &planJson, true), planWithStats);
     return planJson.GetMapSafe().at("SimplifiedPlan");
 }
 
-NJson::TJsonValue FindPlanNodeByTypeAndStat(
+NJson::TJsonValue FindPlanNodeByTypeAndStats(
     const NJson::TJsonValue& plan,
     TStringBuf nodeType,
-    TStringBuf statName)
+    std::initializer_list<TStringBuf> statNames)
 {
     if (!plan.IsMap()) {
         return {};
     }
 
     const auto& map = plan.GetMapSafe();
-    if (map.contains("Node Type") && map.at("Node Type").GetStringSafe() == nodeType
-        && map.contains("Stats") && map.at("Stats").GetMapSafe().contains(TString(statName)))
-    {
-        return plan;
+    if (map.contains("Node Type") && map.at("Node Type").GetStringSafe() == nodeType && map.contains("Stats")) {
+        const auto& stats = map.at("Stats").GetMapSafe();
+        bool containsAllStats = true;
+        for (const auto statName : statNames) {
+            containsAllStats &= stats.contains(TString(statName));
+        }
+        if (containsAllStats) {
+            return plan;
+        }
     }
 
     if (map.contains("Plans")) {
         for (const auto& child : map.at("Plans").GetArraySafe()) {
-            auto result = FindPlanNodeByTypeAndStat(child, nodeType, statName);
+            auto result = FindPlanNodeByTypeAndStats(child, nodeType, statNames);
             if (result.IsDefined()) {
                 return result;
             }
@@ -527,6 +525,14 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuWithActualRows) {
         "Plan": {
             "Node Type": "Filter",
             "StageGuid": "stage-1",
+            "Stats": {
+                "Operator": [{
+                    "Type": "Filter",
+                    "Id": "0",
+                    "Rows": {"Sum": 6}
+                }],
+                "CpuTimeUs": {"Max": 7000}
+            },
             "Operators": [{
                 "Name": "Filter",
                 "Id": "0",
@@ -535,12 +541,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuWithActualRows) {
         }
     })";
 
-    NYql::NDqProto::TDqExecutionStats executionStats;
-    AddStageCpuStats(executionStats, "stage-1", 7000);
-    auto* stageStats = executionStats.MutableStages(0);
-    (*stageStats->MutableOperatorFilter())["0"].MutableRows()->SetSum(6);
-
-    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
     const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
     UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
     UNIT_ASSERT_VALUES_EQUAL_C(filter.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
@@ -555,6 +556,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
                 "Plans": [{
                     "Node Type": "Collect",
                     "StageGuid": "collect-stage",
+                    "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Plans": [{
                         "Node Type": "TableFullScan",
                         "Operators": [{"Name": "TableFullScan", "Inputs": []}]
@@ -563,9 +565,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
             }
         })";
 
-        NYql::NDqProto::TDqExecutionStats executionStats;
-        AddStageCpuStats(executionStats, "collect-stage", 7000);
-        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
         const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
         UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
         AssertCpuValues(fullScan, 7, 7, simplifiedPlan);
@@ -578,6 +578,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
                 "Plans": [{
                     "Node Type": "Collect",
                     "StageGuid": "collect-stage",
+                    "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Plans": [
                         {
                             "Node Type": "LeftScan",
@@ -592,9 +593,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
             }
         })";
 
-        NYql::NDqProto::TDqExecutionStats executionStats;
-        AddStageCpuStats(executionStats, "collect-stage", 7000);
-        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
         UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-SelfCpu").empty(), simplifiedPlan);
         UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-Cpu").empty(), simplifiedPlan);
     }
@@ -606,19 +605,18 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
                 "Plans": [{
                     "Node Type": "Collect",
                     "StageGuid": "collect-stage",
+                    "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Plans": [{
                         "Node Type": "TableFullScan",
                         "StageGuid": "scan-stage",
+                        "Stats": {"CpuTimeUs": {"Max": 3000}},
                         "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                     }]
                 }]
             }
         })";
 
-        NYql::NDqProto::TDqExecutionStats executionStats;
-        AddStageCpuStats(executionStats, "collect-stage", 7000);
-        AddStageCpuStats(executionStats, "scan-stage", 3000);
-        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
         const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
         UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
         AssertCpuValues(fullScan, 3, 3, simplifiedPlan);
@@ -631,6 +629,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanSyntheticLookupCpu) {
             "Plan": {
                 "Node Type": "Collect",
                 "StageGuid": "lookup-stage",
+                "Stats": {"CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
                     "Node Type": "TableLookup",
                     "Columns": ["Value"],
@@ -641,9 +640,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanSyntheticLookupCpu) {
             }
         })";
 
-        NYql::NDqProto::TDqExecutionStats executionStats;
-        AddStageCpuStats(executionStats, "lookup-stage", 7000);
-        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
         const auto lookup = FindPlanNodeByKv(simplifiedPlan, "Name", "TableLookup");
         UNIT_ASSERT_C(lookup.IsDefined(), simplifiedPlan);
         AssertCpuValues(lookup, 7, 7, simplifiedPlan);
@@ -654,6 +651,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanSyntheticLookupCpu) {
             "Plan": {
                 "Node Type": "Collect",
                 "StageGuid": "lookup-join-stage",
+                "Stats": {"CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
                     "Node Type": "TableLookupJoin",
                     "Columns": ["Value"],
@@ -663,9 +661,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanSyntheticLookupCpu) {
             }
         })";
 
-        NYql::NDqProto::TDqExecutionStats executionStats;
-        AddStageCpuStats(executionStats, "lookup-join-stage", 7000);
-        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
         const auto lookup = FindPlanNodeByKv(simplifiedPlan, "Name", "Lookup");
         UNIT_ASSERT_C(lookup.IsDefined(), simplifiedPlan);
         AssertCpuValues(lookup, 7, 7, simplifiedPlan);
@@ -681,6 +677,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
                     "Node Type": "Filter",
                     "PlanNodeId": 1,
                     "StageGuid": "filter-stage",
+                    "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Operators": [{
                         "Name": "Filter",
                         "Inputs": [{"ExternalPlanNodeId": 2}]
@@ -689,6 +686,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
                         "Node Type": "TableFullScan",
                         "PlanNodeId": 2,
                         "StageGuid": "scan-stage",
+                        "Stats": {"CpuTimeUs": {"Max": 3000}},
                         "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                     }]
                 },
@@ -703,6 +701,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
                 {
                     "Node Type": "Collect",
                     "StageGuid": "cte-owner-stage",
+                    "Stats": {"CpuTimeUs": {"Max": 11000}},
                     "Plans": [{
                         "Node Type": "CTE",
                         "CTE Name": "precompute_1"
@@ -712,11 +711,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
         }
     })";
 
-    NYql::NDqProto::TDqExecutionStats executionStats;
-    AddStageCpuStats(executionStats, "filter-stage", 7000);
-    AddStageCpuStats(executionStats, "scan-stage", 3000);
-    AddStageCpuStats(executionStats, "cte-owner-stage", 11000);
-    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
 
     const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
     UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
@@ -739,6 +734,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
             "Plans": [{
                 "Node Type": "Collect",
                 "StageGuid": "collect-stage",
+                "Stats": {"CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
                     "Node Type": "Filter",
                     "PlanNodeId": 1,
@@ -756,9 +752,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
         }
     })";
 
-    NYql::NDqProto::TDqExecutionStats executionStats;
-    AddStageCpuStats(executionStats, "collect-stage", 7000);
-    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
 
     const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
     UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
@@ -803,8 +797,11 @@ Y_UNIT_TEST(LegacySimplifiedPlanTableFullScanActualStats) {
     UNIT_ASSERT_VALUES_EQUAL_C(fullScan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, fullScanPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Size"), fullScanPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Size").GetDoubleSafe() > 0, fullScanPlan);
-    UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Cpu"), fullScanPlan);
-    UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Cpu").GetDoubleSafe() >= 0, fullScanPlan);
+    const auto cpuValues = FindPlanNodes(fullScanPlan, "A-Cpu");
+    UNIT_ASSERT_C(!cpuValues.empty(), fullScanPlan);
+    for (const auto& cpu : cpuValues) {
+        UNIT_ASSERT_C(cpu.GetDoubleSafe() >= 0, fullScanPlan);
+    }
 
     const auto limitedPlan = execute(R"(
         SELECT Key, Value1 FROM `/Root/TwoShard` LIMIT 3;
@@ -846,11 +843,11 @@ Y_UNIT_TEST(LegacySimplifiedPlanQueryServiceTableFullScanActualStats) {
         NJson::ReadJsonTree(*result.GetStats()->GetPlan(), &plan, true),
         *result.GetStats()->GetPlan());
     const auto simplifiedPlan = plan.GetMapSafe().at("SimplifiedPlan");
-    const auto collect = FindPlanNodeByTypeAndStat(plan.GetMapSafe().at("Plan"), "Collect", "CpuTimeUs");
+    const auto collect = FindPlanNodeByTypeAndStats(
+        plan.GetMapSafe().at("Plan"), "Collect", {"Table", "CpuTimeUs"});
     UNIT_ASSERT_C(collect.IsDefined(), plan);
     UNIT_ASSERT_C(!collect.GetMapSafe().contains("Operators"), plan);
     const auto& collectStats = collect.GetMapSafe().at("Stats").GetMapSafe();
-    UNIT_ASSERT_C(collectStats.contains("Table"), plan);
     const auto& cpuTime = collectStats.at("CpuTimeUs");
     UNIT_ASSERT_C(cpuTime.IsMap(), plan);
     UNIT_ASSERT_C(cpuTime.GetMapSafe().at("Max").GetDoubleSafe() >= 0, plan);

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -854,7 +854,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanMultiOperatorCpuOwner) {
     UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
     AssertCpuValues(filter, 7, 7, simplifiedPlan);
 
-    const auto aggregate = FindPlanNodeByKv(filter, "Name", "Aggregate");
+    const auto aggregate = FindPlanNodeByKv(simplifiedPlan, "Name", "Aggregate");
     UNIT_ASSERT_C(aggregate.IsDefined(), simplifiedPlan);
     UNIT_ASSERT_C(!aggregate.GetMapSafe().contains("A-SelfCpu"), simplifiedPlan);
     UNIT_ASSERT_C(!aggregate.GetMapSafe().contains("A-Cpu"), simplifiedPlan);

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -796,16 +796,16 @@ Y_UNIT_TEST(LegacySimplifiedPlanDuplicateIndexesUseLastValue) {
                     "Node Type": "Precompute",
                     "Subplan Name": "precompute_duplicate",
                     "Plans": [{
-                        "Node Type": "FirstPrecompute",
-                        "Operators": [{"Name": "FirstPrecompute", "Inputs": []}]
+                        "Node Type": "FirstValue",
+                        "Operators": [{"Name": "FirstValue", "Inputs": []}]
                     }]
                 },
                 {
                     "Node Type": "Precompute",
                     "Subplan Name": "precompute_duplicate",
                     "Plans": [{
-                        "Node Type": "LastPrecompute",
-                        "Operators": [{"Name": "LastPrecompute", "Inputs": []}]
+                        "Node Type": "LastValue",
+                        "Operators": [{"Name": "LastValue", "Inputs": []}]
                     }]
                 },
                 {
@@ -827,8 +827,8 @@ Y_UNIT_TEST(LegacySimplifiedPlanDuplicateIndexesUseLastValue) {
 
     const auto cteOwner = FindPlanNodeByKv(simplifiedPlan, "Node Type", "CteOwner");
     UNIT_ASSERT_C(cteOwner.IsDefined(), simplifiedPlan);
-    UNIT_ASSERT_C(FindPlanNodeByKv(cteOwner, "Name", "LastPrecompute").IsDefined(), simplifiedPlan);
-    UNIT_ASSERT_C(!FindPlanNodeByKv(cteOwner, "Name", "FirstPrecompute").IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(FindPlanNodeByKv(cteOwner, "Name", "LastValue").IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(!FindPlanNodeByKv(cteOwner, "Name", "FirstValue").IsDefined(), simplifiedPlan);
 }
 
 Y_UNIT_TEST(LegacySimplifiedPlanMultiOperatorCpuOwner) {

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -713,11 +713,14 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
 
-    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
+    const auto filterNode = FindPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
+    UNIT_ASSERT_C(filterNode.IsDefined(), simplifiedPlan);
+
+    const auto filter = FindPlanNodeByKv(filterNode, "Name", "Filter");
     UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
     AssertCpuValues(filter, 7, 10, simplifiedPlan);
 
-    const auto scan = FindPlanNodeByKv(filter, "Name", "TableFullScan");
+    const auto scan = FindPlanNodeByKv(filterNode, "Name", "TableFullScan");
     UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
     AssertCpuValues(scan, 3, 3, simplifiedPlan);
 
@@ -754,11 +757,14 @@ Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
 
-    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
+    const auto filterNode = FindPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
+    UNIT_ASSERT_C(filterNode.IsDefined(), simplifiedPlan);
+
+    const auto filter = FindPlanNodeByKv(filterNode, "Name", "Filter");
     UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
     AssertCpuValues(filter, 7, 7, simplifiedPlan);
 
-    const auto scan = FindPlanNodeByKv(filter, "Name", "TableFullScan");
+    const auto scan = FindPlanNodeByKv(filterNode, "Name", "TableFullScan");
     UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
     UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-SelfCpu"), simplifiedPlan);
     UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-Cpu"), simplifiedPlan);

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -59,6 +59,16 @@ NJson::TJsonValue FindPlanNodeByTypeAndStats(
     return {};
 }
 
+NJson::TJsonValue FindRequiredPlanNodeByKv(
+    const NJson::TJsonValue& plan,
+    const TString& key,
+    const TString& value)
+{
+    auto node = FindPlanNodeByKv(plan, key, value);
+    UNIT_ASSERT_C(node.IsDefined(), plan);
+    return node;
+}
+
 void AssertCpuValues(
     const NJson::TJsonValue& node,
     double expectedSelfCpu,
@@ -69,6 +79,11 @@ void AssertCpuValues(
     UNIT_ASSERT_C(node.GetMapSafe().contains("A-Cpu"), plan);
     UNIT_ASSERT_VALUES_EQUAL_C(node.GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), expectedSelfCpu, plan);
     UNIT_ASSERT_VALUES_EQUAL_C(node.GetMapSafe().at("A-Cpu").GetDoubleSafe(), expectedCpu, plan);
+}
+
+void AssertNoCpuValues(const NJson::TJsonValue& node, const NJson::TJsonValue& plan) {
+    UNIT_ASSERT_C(FindPlanNodes(node, "A-SelfCpu").empty(), plan);
+    UNIT_ASSERT_C(FindPlanNodes(node, "A-Cpu").empty(), plan);
 }
 
 Y_UNIT_TEST_SUITE(KqpStats) {
@@ -523,27 +538,17 @@ Y_UNIT_TEST(RequestUnitForExecute) {
 Y_UNIT_TEST(LegacySimplifiedPlanCpuWithActualRows) {
     const TString plan = R"({
         "Plan": {
-            "Node Type": "Filter",
-            "StageGuid": "stage-1",
+            "Node Type": "Filter", "StageGuid": "stage-1",
             "Stats": {
-                "Operator": [{
-                    "Type": "Filter",
-                    "Id": "0",
-                    "Rows": {"Sum": 6}
-                }],
+                "Operator": [{"Type": "Filter", "Id": "0", "Rows": {"Sum": 6}}],
                 "CpuTimeUs": {"Max": 7000}
             },
-            "Operators": [{
-                "Name": "Filter",
-                "Id": "0",
-                "Inputs": []
-            }]
+            "Operators": [{"Name": "Filter", "Id": "0", "Inputs": []}]
         }
     })";
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
-    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    const auto filter = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "Filter");
     UNIT_ASSERT_VALUES_EQUAL_C(filter.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
     AssertCpuValues(filter, 7, 7, simplifiedPlan);
 }
@@ -554,20 +559,17 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
             "Plan": {
                 "Node Type": "Query",
                 "Plans": [{
-                    "Node Type": "Collect",
-                    "StageGuid": "collect-stage",
+                    "Node Type": "Collect", "StageGuid": "collect-stage",
                     "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Plans": [{
-                        "Node Type": "TableFullScan",
-                        "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                        "Node Type": "TableFullScan", "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                     }]
                 }]
             }
         })";
 
         const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-        const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
-        UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
+        const auto fullScan = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
         AssertCpuValues(fullScan, 7, 7, simplifiedPlan);
     }
 
@@ -576,17 +578,14 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
             "Plan": {
                 "Node Type": "Query",
                 "Plans": [{
-                    "Node Type": "Collect",
-                    "StageGuid": "collect-stage",
+                    "Node Type": "Collect", "StageGuid": "collect-stage",
                     "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Plans": [
                         {
-                            "Node Type": "LeftScan",
-                            "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                            "Node Type": "LeftScan", "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                         },
                         {
-                            "Node Type": "RightScan",
-                            "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                            "Node Type": "RightScan", "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                         }
                     ]
                 }]
@@ -594,8 +593,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
         })";
 
         const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-        UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-SelfCpu").empty(), simplifiedPlan);
-        UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-Cpu").empty(), simplifiedPlan);
+        AssertNoCpuValues(simplifiedPlan, simplifiedPlan);
     }
 
     {
@@ -603,12 +601,10 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
             "Plan": {
                 "Node Type": "Query",
                 "Plans": [{
-                    "Node Type": "Collect",
-                    "StageGuid": "collect-stage",
+                    "Node Type": "Collect", "StageGuid": "collect-stage",
                     "Stats": {"CpuTimeUs": {"Max": 7000}},
                     "Plans": [{
-                        "Node Type": "TableFullScan",
-                        "StageGuid": "scan-stage",
+                        "Node Type": "TableFullScan", "StageGuid": "scan-stage",
                         "Stats": {"CpuTimeUs": {"Max": 3000}},
                         "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                     }]
@@ -617,8 +613,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
         })";
 
         const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-        const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
-        UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
+        const auto fullScan = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
         AssertCpuValues(fullScan, 3, 3, simplifiedPlan);
     }
 }
@@ -627,43 +622,35 @@ Y_UNIT_TEST(LegacySimplifiedPlanSyntheticLookupCpu) {
     {
         const TString plan = R"({
             "Plan": {
-                "Node Type": "Collect",
-                "StageGuid": "lookup-stage",
+                "Node Type": "Collect", "StageGuid": "lookup-stage",
                 "Stats": {"CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
-                    "Node Type": "TableLookup",
-                    "Columns": ["Value"],
-                    "LookupKeyColumns": ["Key"],
-                    "Table": "/Root/t1",
+                    "Node Type": "TableLookup", "Table": "/Root/t1",
+                    "Columns": ["Value"], "LookupKeyColumns": ["Key"],
                     "Plans": []
                 }]
             }
         })";
 
         const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-        const auto lookup = FindPlanNodeByKv(simplifiedPlan, "Name", "TableLookup");
-        UNIT_ASSERT_C(lookup.IsDefined(), simplifiedPlan);
+        const auto lookup = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "TableLookup");
         AssertCpuValues(lookup, 7, 7, simplifiedPlan);
     }
 
     {
         const TString plan = R"({
             "Plan": {
-                "Node Type": "Collect",
-                "StageGuid": "lookup-join-stage",
+                "Node Type": "Collect", "StageGuid": "lookup-join-stage",
                 "Stats": {"CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
-                    "Node Type": "TableLookupJoin",
-                    "Columns": ["Value"],
-                    "LookupKeyColumns": ["Key"],
-                    "Table": "/Root/t1"
+                    "Node Type": "TableLookupJoin", "Table": "/Root/t1",
+                    "Columns": ["Value"], "LookupKeyColumns": ["Key"]
                 }]
             }
         })";
 
         const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-        const auto lookup = FindPlanNodeByKv(simplifiedPlan, "Name", "Lookup");
-        UNIT_ASSERT_C(lookup.IsDefined(), simplifiedPlan);
+        const auto lookup = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "Lookup");
         AssertCpuValues(lookup, 7, 7, simplifiedPlan);
     }
 }
@@ -674,38 +661,26 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
             "Node Type": "Query",
             "Plans": [
                 {
-                    "Node Type": "Filter",
-                    "PlanNodeId": 1,
-                    "StageGuid": "filter-stage",
+                    "Node Type": "Filter", "PlanNodeId": 1, "StageGuid": "filter-stage",
                     "Stats": {"CpuTimeUs": {"Max": 7000}},
-                    "Operators": [{
-                        "Name": "Filter",
-                        "Inputs": [{"ExternalPlanNodeId": 2}]
-                    }],
+                    "Operators": [{"Name": "Filter", "Inputs": [{"ExternalPlanNodeId": 2}]}],
                     "Plans": [{
-                        "Node Type": "TableFullScan",
-                        "PlanNodeId": 2,
-                        "StageGuid": "scan-stage",
+                        "Node Type": "TableFullScan", "PlanNodeId": 2, "StageGuid": "scan-stage",
                         "Stats": {"CpuTimeUs": {"Max": 3000}},
                         "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                     }]
                 },
                 {
-                    "Node Type": "Precompute",
-                    "Subplan Name": "precompute_1",
+                    "Node Type": "Precompute", "Subplan Name": "precompute_1",
                     "Plans": [{
                         "Node Type": "TableRangeScan",
                         "Operators": [{"Name": "TableRangeScan", "Inputs": []}]
                     }]
                 },
                 {
-                    "Node Type": "Collect",
-                    "StageGuid": "cte-owner-stage",
+                    "Node Type": "Collect", "StageGuid": "cte-owner-stage",
                     "Stats": {"CpuTimeUs": {"Max": 11000}},
-                    "Plans": [{
-                        "Node Type": "CTE",
-                        "CTE Name": "precompute_1"
-                    }]
+                    "Plans": [{"Node Type": "CTE", "CTE Name": "precompute_1"}]
                 }
             ]
         }
@@ -713,21 +688,16 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
 
-    const auto filterNode = FindPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
-    UNIT_ASSERT_C(filterNode.IsDefined(), simplifiedPlan);
+    const auto filterNode = FindRequiredPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
 
-    const auto filter = FindPlanNodeByKv(filterNode, "Name", "Filter");
-    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    const auto filter = FindRequiredPlanNodeByKv(filterNode, "Name", "Filter");
     AssertCpuValues(filter, 7, 10, simplifiedPlan);
 
-    const auto scan = FindPlanNodeByKv(filterNode, "Name", "TableFullScan");
-    UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
+    const auto scan = FindRequiredPlanNodeByKv(filterNode, "Name", "TableFullScan");
     AssertCpuValues(scan, 3, 3, simplifiedPlan);
 
-    const auto precomputeScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableRangeScan");
-    UNIT_ASSERT_C(precomputeScan.IsDefined(), simplifiedPlan);
-    UNIT_ASSERT_C(FindPlanNodes(precomputeScan, "A-SelfCpu").empty(), simplifiedPlan);
-    UNIT_ASSERT_C(FindPlanNodes(precomputeScan, "A-Cpu").empty(), simplifiedPlan);
+    const auto precomputeScan = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "TableRangeScan");
+    AssertNoCpuValues(precomputeScan, simplifiedPlan);
 }
 
 Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
@@ -735,19 +705,13 @@ Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
         "Plan": {
             "Node Type": "Query",
             "Plans": [{
-                "Node Type": "Collect",
-                "StageGuid": "collect-stage",
+                "Node Type": "Collect", "StageGuid": "collect-stage",
                 "Stats": {"CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
-                    "Node Type": "Filter",
-                    "PlanNodeId": 1,
-                    "Operators": [{
-                        "Name": "Filter",
-                        "Inputs": [{"ExternalPlanNodeId": 2}]
-                    }],
+                    "Node Type": "Filter", "PlanNodeId": 1,
+                    "Operators": [{"Name": "Filter", "Inputs": [{"ExternalPlanNodeId": 2}]}],
                     "Plans": [{
-                        "Node Type": "TableFullScan",
-                        "PlanNodeId": 2,
+                        "Node Type": "TableFullScan", "PlanNodeId": 2,
                         "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                     }]
                 }]
@@ -757,17 +721,13 @@ Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
 
-    const auto filterNode = FindPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
-    UNIT_ASSERT_C(filterNode.IsDefined(), simplifiedPlan);
+    const auto filterNode = FindRequiredPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
 
-    const auto filter = FindPlanNodeByKv(filterNode, "Name", "Filter");
-    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    const auto filter = FindRequiredPlanNodeByKv(filterNode, "Name", "Filter");
     AssertCpuValues(filter, 7, 7, simplifiedPlan);
 
-    const auto scan = FindPlanNodeByKv(filterNode, "Name", "TableFullScan");
-    UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
-    UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-SelfCpu"), simplifiedPlan);
-    UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-Cpu"), simplifiedPlan);
+    const auto scan = FindRequiredPlanNodeByKv(filterNode, "Name", "TableFullScan");
+    AssertNoCpuValues(scan, simplifiedPlan);
 }
 
 Y_UNIT_TEST(LegacySimplifiedPlanDuplicateIndexesUseLastValue) {
@@ -777,56 +737,42 @@ Y_UNIT_TEST(LegacySimplifiedPlanDuplicateIndexesUseLastValue) {
             "Plans": [
                 {
                     "Node Type": "FilterStage",
-                    "Operators": [{
-                        "Name": "Filter",
-                        "Inputs": [{"ExternalPlanNodeId": 7}]
-                    }]
+                    "Operators": [{"Name": "Filter", "Inputs": [{"ExternalPlanNodeId": 7}]}]
                 },
                 {
-                    "Node Type": "FirstDuplicate",
-                    "PlanNodeId": 7,
+                    "Node Type": "FirstDuplicate", "PlanNodeId": 7,
                     "Operators": [{"Name": "FirstDuplicate", "Inputs": []}]
                 },
                 {
-                    "Node Type": "LastDuplicate",
-                    "PlanNodeId": 7,
+                    "Node Type": "LastDuplicate", "PlanNodeId": 7,
                     "Operators": [{"Name": "LastDuplicate", "Inputs": []}]
                 },
                 {
-                    "Node Type": "Precompute",
-                    "Subplan Name": "precompute_duplicate",
+                    "Node Type": "Precompute", "Subplan Name": "precompute_duplicate",
                     "Plans": [{
-                        "Node Type": "FirstValue",
-                        "Operators": [{"Name": "FirstValue", "Inputs": []}]
+                        "Node Type": "FirstValue", "Operators": [{"Name": "FirstValue", "Inputs": []}]
                     }]
                 },
                 {
-                    "Node Type": "Precompute",
-                    "Subplan Name": "precompute_duplicate",
+                    "Node Type": "Precompute", "Subplan Name": "precompute_duplicate",
                     "Plans": [{
-                        "Node Type": "LastValue",
-                        "Operators": [{"Name": "LastValue", "Inputs": []}]
+                        "Node Type": "LastValue", "Operators": [{"Name": "LastValue", "Inputs": []}]
                     }]
                 },
                 {
                     "Node Type": "CteOwner",
-                    "Plans": [{
-                        "Node Type": "CTE",
-                        "CTE Name": "precompute_duplicate"
-                    }]
+                    "Plans": [{"Node Type": "CTE", "CTE Name": "precompute_duplicate"}]
                 }
             ]
         }
     })";
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
-    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    const auto filter = FindRequiredPlanNodeByKv(simplifiedPlan, "Node Type", "Filter");
     UNIT_ASSERT_C(FindPlanNodeByKv(filter, "Name", "LastDuplicate").IsDefined(), simplifiedPlan);
     UNIT_ASSERT_C(!FindPlanNodeByKv(filter, "Name", "FirstDuplicate").IsDefined(), simplifiedPlan);
 
-    const auto cteOwner = FindPlanNodeByKv(simplifiedPlan, "Node Type", "CteOwner");
-    UNIT_ASSERT_C(cteOwner.IsDefined(), simplifiedPlan);
+    const auto cteOwner = FindRequiredPlanNodeByKv(simplifiedPlan, "Node Type", "CteOwner");
     UNIT_ASSERT_C(FindPlanNodeByKv(cteOwner, "Name", "LastValue").IsDefined(), simplifiedPlan);
     UNIT_ASSERT_C(!FindPlanNodeByKv(cteOwner, "Name", "FirstValue").IsDefined(), simplifiedPlan);
 }
@@ -837,27 +783,18 @@ Y_UNIT_TEST(LegacySimplifiedPlanMultiOperatorCpuOwner) {
             "Node Type": "Stage",
             "Stats": {"CpuTimeUs": {"Max": 7000}},
             "Operators": [
-                {
-                    "Name": "Filter",
-                    "Inputs": [{"InternalOperatorId": 1}]
-                },
-                {
-                    "Name": "Aggregate",
-                    "Inputs": []
-                }
+                {"Name": "Filter", "Inputs": [{"InternalOperatorId": 1}]},
+                {"Name": "Aggregate", "Inputs": []}
             ]
         }
     })";
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
-    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    const auto filter = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "Filter");
     AssertCpuValues(filter, 7, 7, simplifiedPlan);
 
-    const auto aggregate = FindPlanNodeByKv(simplifiedPlan, "Name", "Aggregate");
-    UNIT_ASSERT_C(aggregate.IsDefined(), simplifiedPlan);
-    UNIT_ASSERT_C(!aggregate.GetMapSafe().contains("A-SelfCpu"), simplifiedPlan);
-    UNIT_ASSERT_C(!aggregate.GetMapSafe().contains("A-Cpu"), simplifiedPlan);
+    const auto aggregate = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "Aggregate");
+    AssertNoCpuValues(aggregate, simplifiedPlan);
 }
 
 Y_UNIT_TEST(LegacySimplifiedPlanCpuAbsentAndScriptPlan) {
@@ -868,11 +805,7 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuAbsentAndScriptPlan) {
                 "Node Type": "Collect",
                 "Plans": [{
                     "Node Type": "ScanStage",
-                    "Stats": {
-                        "OutputRows": {"Sum": 6},
-                        "OutputBytes": {"Sum": 48},
-                        "Tasks": 2
-                    },
+                    "Stats": {"OutputRows": {"Sum": 6}, "OutputBytes": {"Sum": 48}, "Tasks": 2},
                     "Operators": [{"Name": "TableFullScan", "Inputs": []}]
                 }]
             }]
@@ -880,11 +813,9 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuAbsentAndScriptPlan) {
     })";
 
     const auto simplifiedPlan = GetLegacySimplifiedPlan(plan);
-    UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-SelfCpu").empty(), simplifiedPlan);
-    UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-Cpu").empty(), simplifiedPlan);
+    AssertNoCpuValues(simplifiedPlan, simplifiedPlan);
 
-    const auto scan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
-    UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
+    const auto scan = FindRequiredPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
     UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Rows").GetIntegerSafe(), 6, simplifiedPlan);
     UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Size").GetDoubleSafe(), 48, simplifiedPlan);
 
@@ -892,13 +823,11 @@ Y_UNIT_TEST(LegacySimplifiedPlanCpuAbsentAndScriptPlan) {
     const auto serializedScriptPlan = SerializeScriptPlan(queryPlans);
     NJson::TJsonValue scriptPlan;
     UNIT_ASSERT_C(NJson::ReadJsonTree(serializedScriptPlan, &scriptPlan, true), serializedScriptPlan);
-    UNIT_ASSERT_C(FindPlanNodes(scriptPlan, "A-SelfCpu").empty(), scriptPlan);
-    UNIT_ASSERT_C(FindPlanNodes(scriptPlan, "A-Cpu").empty(), scriptPlan);
+    AssertNoCpuValues(scriptPlan, scriptPlan);
 
     const auto& scriptQuery = scriptPlan.GetMapSafe().at("queries").GetArraySafe().front();
     const auto& scriptSimplifiedPlan = scriptQuery.GetMapSafe().at("SimplifiedPlan");
-    const auto scriptScan = FindPlanNodeByKv(scriptSimplifiedPlan, "Name", "TableFullScan");
-    UNIT_ASSERT_C(scriptScan.IsDefined(), scriptPlan);
+    const auto scriptScan = FindRequiredPlanNodeByKv(scriptSimplifiedPlan, "Name", "TableFullScan");
     UNIT_ASSERT_VALUES_EQUAL_C(scriptScan.GetMapSafe().at("A-Rows").GetIntegerSafe(), 6, scriptPlan);
     UNIT_ASSERT_VALUES_EQUAL_C(scriptScan.GetMapSafe().at("A-Size").GetDoubleSafe(), 48, scriptPlan);
 }

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/base/hive.h>
+#include <ydb/core/kqp/opt/kqp_query_plan.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
@@ -15,6 +16,62 @@ namespace NKqp {
 
 using namespace NYdb;
 using namespace NYdb::NTable;
+
+void AddStageCpuStats(NYql::NDqProto::TDqExecutionStats& executionStats, TStringBuf stageGuid, ui64 cpuTimeUs) {
+    auto* stageStats = executionStats.AddStages();
+    stageStats->SetStageGuid(TString(stageGuid));
+    stageStats->MutableCpuTimeUs()->SetMax(cpuTimeUs);
+}
+
+NJson::TJsonValue GetLegacySimplifiedPlan(
+    const TString& plan,
+    const NYql::NDqProto::TDqExecutionStats& executionStats)
+{
+    NJson::TJsonValue planJson;
+    const auto planWithStats = AddExecStatsToTxPlan(plan, executionStats, false);
+    UNIT_ASSERT_C(NJson::ReadJsonTree(planWithStats, &planJson, true), planWithStats);
+    return planJson.GetMapSafe().at("SimplifiedPlan");
+}
+
+NJson::TJsonValue FindPlanNodeByTypeAndStat(
+    const NJson::TJsonValue& plan,
+    TStringBuf nodeType,
+    TStringBuf statName)
+{
+    if (!plan.IsMap()) {
+        return {};
+    }
+
+    const auto& map = plan.GetMapSafe();
+    if (map.contains("Node Type") && map.at("Node Type").GetStringSafe() == nodeType
+        && map.contains("Stats") && map.at("Stats").GetMapSafe().contains(TString(statName)))
+    {
+        return plan;
+    }
+
+    if (map.contains("Plans")) {
+        for (const auto& child : map.at("Plans").GetArraySafe()) {
+            auto result = FindPlanNodeByTypeAndStat(child, nodeType, statName);
+            if (result.IsDefined()) {
+                return result;
+            }
+        }
+    }
+
+    return {};
+}
+
+void AssertCpuValues(
+    const NJson::TJsonValue& node,
+    double expectedSelfCpu,
+    double expectedCpu,
+    const NJson::TJsonValue& plan)
+{
+    UNIT_ASSERT_C(node.GetMapSafe().contains("A-SelfCpu"), plan);
+    UNIT_ASSERT_C(node.GetMapSafe().contains("A-Cpu"), plan);
+    UNIT_ASSERT_VALUES_EQUAL_C(node.GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), expectedSelfCpu, plan);
+    UNIT_ASSERT_VALUES_EQUAL_C(node.GetMapSafe().at("A-Cpu").GetDoubleSafe(), expectedCpu, plan);
+}
 
 Y_UNIT_TEST_SUITE(KqpStats) {
 
@@ -465,6 +522,254 @@ Y_UNIT_TEST(RequestUnitForExecute) {
     }
 }
 
+Y_UNIT_TEST(LegacySimplifiedPlanCpuWithActualRows) {
+    const TString plan = R"({
+        "Plan": {
+            "Node Type": "Filter",
+            "StageGuid": "stage-1",
+            "Operators": [{
+                "Name": "Filter",
+                "Id": "0",
+                "Inputs": []
+            }]
+        }
+    })";
+
+    NYql::NDqProto::TDqExecutionStats executionStats;
+    AddStageCpuStats(executionStats, "stage-1", 7000);
+    auto* stageStats = executionStats.MutableStages(0);
+    (*stageStats->MutableOperatorFilter())["0"].MutableRows()->SetSum(6);
+
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
+    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_VALUES_EQUAL_C(filter.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
+    AssertCpuValues(filter, 7, 7, simplifiedPlan);
+}
+
+Y_UNIT_TEST(LegacySimplifiedPlanStructuralCpu) {
+    {
+        const TString plan = R"({
+            "Plan": {
+                "Node Type": "Query",
+                "Plans": [{
+                    "Node Type": "Collect",
+                    "StageGuid": "collect-stage",
+                    "Plans": [{
+                        "Node Type": "TableFullScan",
+                        "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                    }]
+                }]
+            }
+        })";
+
+        NYql::NDqProto::TDqExecutionStats executionStats;
+        AddStageCpuStats(executionStats, "collect-stage", 7000);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
+        UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
+        AssertCpuValues(fullScan, 7, 7, simplifiedPlan);
+    }
+
+    {
+        const TString plan = R"({
+            "Plan": {
+                "Node Type": "Query",
+                "Plans": [{
+                    "Node Type": "Collect",
+                    "StageGuid": "collect-stage",
+                    "Plans": [
+                        {
+                            "Node Type": "LeftScan",
+                            "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                        },
+                        {
+                            "Node Type": "RightScan",
+                            "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                        }
+                    ]
+                }]
+            }
+        })";
+
+        NYql::NDqProto::TDqExecutionStats executionStats;
+        AddStageCpuStats(executionStats, "collect-stage", 7000);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-SelfCpu").empty(), simplifiedPlan);
+        UNIT_ASSERT_C(FindPlanNodes(simplifiedPlan, "A-Cpu").empty(), simplifiedPlan);
+    }
+
+    {
+        const TString plan = R"({
+            "Plan": {
+                "Node Type": "Query",
+                "Plans": [{
+                    "Node Type": "Collect",
+                    "StageGuid": "collect-stage",
+                    "Plans": [{
+                        "Node Type": "TableFullScan",
+                        "StageGuid": "scan-stage",
+                        "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                    }]
+                }]
+            }
+        })";
+
+        NYql::NDqProto::TDqExecutionStats executionStats;
+        AddStageCpuStats(executionStats, "collect-stage", 7000);
+        AddStageCpuStats(executionStats, "scan-stage", 3000);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
+        UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
+        AssertCpuValues(fullScan, 3, 3, simplifiedPlan);
+    }
+}
+
+Y_UNIT_TEST(LegacySimplifiedPlanSyntheticLookupCpu) {
+    {
+        const TString plan = R"({
+            "Plan": {
+                "Node Type": "Collect",
+                "StageGuid": "lookup-stage",
+                "Plans": [{
+                    "Node Type": "TableLookup",
+                    "Columns": ["Value"],
+                    "LookupKeyColumns": ["Key"],
+                    "Table": "/Root/t1",
+                    "Plans": []
+                }]
+            }
+        })";
+
+        NYql::NDqProto::TDqExecutionStats executionStats;
+        AddStageCpuStats(executionStats, "lookup-stage", 7000);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto lookup = FindPlanNodeByKv(simplifiedPlan, "Name", "TableLookup");
+        UNIT_ASSERT_C(lookup.IsDefined(), simplifiedPlan);
+        AssertCpuValues(lookup, 7, 7, simplifiedPlan);
+    }
+
+    {
+        const TString plan = R"({
+            "Plan": {
+                "Node Type": "Collect",
+                "StageGuid": "lookup-join-stage",
+                "Plans": [{
+                    "Node Type": "TableLookupJoin",
+                    "Columns": ["Value"],
+                    "LookupKeyColumns": ["Key"],
+                    "Table": "/Root/t1"
+                }]
+            }
+        })";
+
+        NYql::NDqProto::TDqExecutionStats executionStats;
+        AddStageCpuStats(executionStats, "lookup-join-stage", 7000);
+        const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+        const auto lookup = FindPlanNodeByKv(simplifiedPlan, "Name", "Lookup");
+        UNIT_ASSERT_C(lookup.IsDefined(), simplifiedPlan);
+        AssertCpuValues(lookup, 7, 7, simplifiedPlan);
+    }
+}
+
+Y_UNIT_TEST(LegacySimplifiedPlanCpuBoundariesAndCumulativeValue) {
+    const TString plan = R"({
+        "Plan": {
+            "Node Type": "Query",
+            "Plans": [
+                {
+                    "Node Type": "Filter",
+                    "PlanNodeId": 1,
+                    "StageGuid": "filter-stage",
+                    "Operators": [{
+                        "Name": "Filter",
+                        "Inputs": [{"ExternalPlanNodeId": 2}]
+                    }],
+                    "Plans": [{
+                        "Node Type": "TableFullScan",
+                        "PlanNodeId": 2,
+                        "StageGuid": "scan-stage",
+                        "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                    }]
+                },
+                {
+                    "Node Type": "Precompute",
+                    "Subplan Name": "precompute_1",
+                    "Plans": [{
+                        "Node Type": "TableRangeScan",
+                        "Operators": [{"Name": "TableRangeScan", "Inputs": []}]
+                    }]
+                },
+                {
+                    "Node Type": "Collect",
+                    "StageGuid": "cte-owner-stage",
+                    "Plans": [{
+                        "Node Type": "CTE",
+                        "CTE Name": "precompute_1"
+                    }]
+                }
+            ]
+        }
+    })";
+
+    NYql::NDqProto::TDqExecutionStats executionStats;
+    AddStageCpuStats(executionStats, "filter-stage", 7000);
+    AddStageCpuStats(executionStats, "scan-stage", 3000);
+    AddStageCpuStats(executionStats, "cte-owner-stage", 11000);
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+
+    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
+    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    AssertCpuValues(filter, 7, 10, simplifiedPlan);
+
+    const auto scan = FindPlanNodeByKv(filter, "Name", "TableFullScan");
+    UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
+    AssertCpuValues(scan, 3, 3, simplifiedPlan);
+
+    const auto precomputeScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableRangeScan");
+    UNIT_ASSERT_C(precomputeScan.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(FindPlanNodes(precomputeScan, "A-SelfCpu").empty(), simplifiedPlan);
+    UNIT_ASSERT_C(FindPlanNodes(precomputeScan, "A-Cpu").empty(), simplifiedPlan);
+}
+
+Y_UNIT_TEST(LegacySimplifiedPlanInheritedCpuStopsAtExternalEdge) {
+    const TString plan = R"({
+        "Plan": {
+            "Node Type": "Query",
+            "Plans": [{
+                "Node Type": "Collect",
+                "StageGuid": "collect-stage",
+                "Plans": [{
+                    "Node Type": "Filter",
+                    "PlanNodeId": 1,
+                    "Operators": [{
+                        "Name": "Filter",
+                        "Inputs": [{"ExternalPlanNodeId": 2}]
+                    }],
+                    "Plans": [{
+                        "Node Type": "TableFullScan",
+                        "PlanNodeId": 2,
+                        "Operators": [{"Name": "TableFullScan", "Inputs": []}]
+                    }]
+                }]
+            }]
+        }
+    })";
+
+    NYql::NDqProto::TDqExecutionStats executionStats;
+    AddStageCpuStats(executionStats, "collect-stage", 7000);
+    const auto simplifiedPlan = GetLegacySimplifiedPlan(plan, executionStats);
+
+    const auto filter = FindPlanNodeByKv(simplifiedPlan, "Name", "Filter");
+    UNIT_ASSERT_C(filter.IsDefined(), simplifiedPlan);
+    AssertCpuValues(filter, 7, 7, simplifiedPlan);
+
+    const auto scan = FindPlanNodeByKv(filter, "Name", "TableFullScan");
+    UNIT_ASSERT_C(scan.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-SelfCpu"), simplifiedPlan);
+    UNIT_ASSERT_C(!scan.GetMapSafe().contains("A-Cpu"), simplifiedPlan);
+}
+
 Y_UNIT_TEST(LegacySimplifiedPlanTableFullScanActualStats) {
     NKikimrConfig::TAppConfig app;
     app.MutableTableServiceConfig()->SetEnableNewRBO(false);
@@ -498,6 +803,8 @@ Y_UNIT_TEST(LegacySimplifiedPlanTableFullScanActualStats) {
     UNIT_ASSERT_VALUES_EQUAL_C(fullScan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, fullScanPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Size"), fullScanPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Size").GetDoubleSafe() > 0, fullScanPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Cpu"), fullScanPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Cpu").GetDoubleSafe() >= 0, fullScanPlan);
 
     const auto limitedPlan = execute(R"(
         SELECT Key, Value1 FROM `/Root/TwoShard` LIMIT 3;
@@ -539,12 +846,23 @@ Y_UNIT_TEST(LegacySimplifiedPlanQueryServiceTableFullScanActualStats) {
         NJson::ReadJsonTree(*result.GetStats()->GetPlan(), &plan, true),
         *result.GetStats()->GetPlan());
     const auto simplifiedPlan = plan.GetMapSafe().at("SimplifiedPlan");
+    const auto collect = FindPlanNodeByTypeAndStat(plan.GetMapSafe().at("Plan"), "Collect", "CpuTimeUs");
+    UNIT_ASSERT_C(collect.IsDefined(), plan);
+    UNIT_ASSERT_C(!collect.GetMapSafe().contains("Operators"), plan);
+    const auto& collectStats = collect.GetMapSafe().at("Stats").GetMapSafe();
+    UNIT_ASSERT_C(collectStats.contains("Table"), plan);
+    const auto& cpuTime = collectStats.at("CpuTimeUs");
+    UNIT_ASSERT_C(cpuTime.IsMap(), plan);
+    UNIT_ASSERT_C(cpuTime.GetMapSafe().at("Max").GetDoubleSafe() >= 0, plan);
+
     const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
     UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Rows"), simplifiedPlan);
     UNIT_ASSERT_VALUES_EQUAL_C(fullScan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Size"), simplifiedPlan);
     UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Size").GetDoubleSafe() > 0, simplifiedPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Cpu"), simplifiedPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Cpu").GetDoubleSafe() >= 0, simplifiedPlan);
 }
 
 Y_UNIT_TEST(StatsProfile) {

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -10,7 +10,6 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h>
 
 #include <cstdlib>
-#include <initializer_list>
 
 namespace NKikimr {
 namespace NKqp {
@@ -24,39 +23,6 @@ NJson::TJsonValue GetLegacySimplifiedPlan(const TString& plan) {
     const auto planWithStats = AddExecStatsToTxPlan(plan, executionStats, false);
     UNIT_ASSERT_C(NJson::ReadJsonTree(planWithStats, &planJson, true), planWithStats);
     return planJson.GetMapSafe().at("SimplifiedPlan");
-}
-
-NJson::TJsonValue FindPlanNodeByTypeAndStats(
-    const NJson::TJsonValue& plan,
-    TStringBuf nodeType,
-    std::initializer_list<TStringBuf> statNames)
-{
-    if (!plan.IsMap()) {
-        return {};
-    }
-
-    const auto& map = plan.GetMapSafe();
-    if (map.contains("Node Type") && map.at("Node Type").GetStringSafe() == nodeType && map.contains("Stats")) {
-        const auto& stats = map.at("Stats").GetMapSafe();
-        bool containsAllStats = true;
-        for (const auto statName : statNames) {
-            containsAllStats &= stats.contains(TString(statName));
-        }
-        if (containsAllStats) {
-            return plan;
-        }
-    }
-
-    if (map.contains("Plans")) {
-        for (const auto& child : map.at("Plans").GetArraySafe()) {
-            auto result = FindPlanNodeByTypeAndStats(child, nodeType, statNames);
-            if (result.IsDefined()) {
-                return result;
-            }
-        }
-    }
-
-    return {};
 }
 
 NJson::TJsonValue FindRequiredPlanNodeByKv(
@@ -911,14 +877,6 @@ Y_UNIT_TEST(LegacySimplifiedPlanQueryServiceTableFullScanActualStats) {
         NJson::ReadJsonTree(*result.GetStats()->GetPlan(), &plan, true),
         *result.GetStats()->GetPlan());
     const auto simplifiedPlan = plan.GetMapSafe().at("SimplifiedPlan");
-    const auto collect = FindPlanNodeByTypeAndStats(
-        plan.GetMapSafe().at("Plan"), "Collect", {"Table", "CpuTimeUs"});
-    UNIT_ASSERT_C(collect.IsDefined(), plan);
-    UNIT_ASSERT_C(!collect.GetMapSafe().contains("Operators"), plan);
-    const auto& collectStats = collect.GetMapSafe().at("Stats").GetMapSafe();
-    const auto& cpuTime = collectStats.at("CpuTimeUs");
-    UNIT_ASSERT_C(cpuTime.IsMap(), plan);
-    UNIT_ASSERT_C(cpuTime.GetMapSafe().at("Max").GetDoubleSafe() >= 0, plan);
 
     const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
     UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -986,6 +986,47 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         UNIT_ASSERT_C(!disjointReadOp->GetMapSafe().contains("ReadRangesPointPrefixLen"), disjointPlan);
     }
 
+    Y_UNIT_TEST(ExplainAnalyzeSimplifiedPlanCpuWithActualRows) {
+        const TString txPlan = R"({
+            "Plans": [{
+                "Node Type": "TableFullScan",
+                "StageGuid": "stage-1",
+                "Operators": [{
+                    "Name": "TableFullScan",
+                    "OperatorId": 1
+                }],
+                "Stats": {
+                    "Table": [{
+                        "Path": "/Root/t1",
+                        "ReadRows": {"Sum": 6},
+                        "ReadBytes": {"Sum": 64}
+                    }],
+                    "CpuTimeUs": {"Max": 7000}
+                }
+            }],
+            "SimplifiedPlan": {
+                "Node Type": "TableFullScan",
+                "Operators": [{
+                    "Name": "TableFullScan",
+                    "OperatorId": 1,
+                    "Table": "/Root/t1"
+                }]
+            }
+        })";
+
+        NKqpProto::TKqpStatsQuery queryStats;
+        const TVector<const TString> txPlans = {txPlan};
+        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* fullScan = FindOperatorByStringField(simplifiedPlan, "Name", "TableFullScan");
+        UNIT_ASSERT_C(fullScan, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, plan);
+        UNIT_ASSERT_C(fullScan->GetMapSafe().contains("A-SelfCpu"), plan);
+        UNIT_ASSERT_C(fullScan->GetMapSafe().contains("A-Cpu"), plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
+    }
+
     Y_UNIT_TEST(ExplainAnalyzeRangePushdown) {
         TExplainPlanTestContext testContext;
         BulkUpsertExplainPlanTestRows(testContext.GetKikimr());

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -1027,6 +1027,172 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
     }
 
+    Y_UNIT_TEST(ExplainAnalyzeDuplicateOperatorIdUsesFirstMatch) {
+        const TString txPlan = R"({
+            "Plans": [{
+                "Node Type": "FirstExec",
+                "StageGuid": "stage-first",
+                "Operators": [{"Name": "FirstExec", "OperatorId": 7}],
+                "Stats": {
+                    "OutputRows": {"Sum": 6},
+                    "OutputBytes": {"Sum": 60},
+                    "CpuTimeUs": {"Max": 7000}
+                },
+                "Plans": [{
+                    "Node Type": "SecondExec",
+                    "StageGuid": "stage-second",
+                    "Operators": [{"Name": "SecondExec", "OperatorId": 7}],
+                    "Stats": {
+                        "OutputRows": {"Sum": 11},
+                        "OutputBytes": {"Sum": 110},
+                        "CpuTimeUs": {"Max": 11000}
+                    }
+                }]
+            }],
+            "SimplifiedPlan": {
+                "Node Type": "First",
+                "Operators": [{"Name": "First", "OperatorId": 7}],
+                "Plans": [{
+                    "Node Type": "Second",
+                    "Operators": [{"Name": "Second", "OperatorId": 7}]
+                }]
+            }
+        })";
+
+        NKqpProto::TKqpStatsQuery queryStats;
+        const TVector<const TString> txPlans = {txPlan};
+        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* first = FindOperatorByStringField(simplifiedPlan, "Name", "First");
+        const auto* second = FindOperatorByStringField(simplifiedPlan, "Name", "Second");
+
+        UNIT_ASSERT_C(first, plan);
+        UNIT_ASSERT_C(second, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-Size").GetDoubleSafe(), 60, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
+        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-Rows"), plan);
+        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-Size"), plan);
+        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-SelfCpu"), plan);
+        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-Cpu"), plan);
+    }
+
+    Y_UNIT_TEST(ExplainAnalyzeMissingExecutionOperatorIdFails) {
+        const TString txPlan = R"({
+            "Plans": [{
+                "Node Type": "Exec",
+                "StageGuid": "stage-1",
+                "Operators": [{"Name": "Exec", "OperatorId": 1}]
+            }],
+            "SimplifiedPlan": {
+                "Node Type": "Missing",
+                "Operators": [{"Name": "Missing", "OperatorId": 2}]
+            }
+        })";
+
+        NKqpProto::TKqpStatsQuery queryStats;
+        const TVector<const TString> txPlans = {txPlan};
+        UNIT_ASSERT_EXCEPTION(SerializeRBOAnalyzePlan(txPlans, queryStats), yexception);
+    }
+
+    Y_UNIT_TEST(ExplainAnalyzeBroadcastStatsUseParentTaskCount) {
+        const TString txPlan = R"({
+            "Plans": [{
+                "Node Type": "Broadcast",
+                "PlanNodeType": "Connection",
+                "Stats": {"Tasks": 4},
+                "Plans": [{
+                    "Node Type": "Scan",
+                    "StageGuid": "stage-1",
+                    "Operators": [{"Name": "Scan", "OperatorId": 1}],
+                    "Stats": {
+                        "OutputRows": {"Sum": 8},
+                        "OutputBytes": {"Sum": 80},
+                        "CpuTimeUs": {"Max": 7000}
+                    }
+                }]
+            }],
+            "SimplifiedPlan": {
+                "Node Type": "Scan",
+                "Operators": [{"Name": "Scan", "OperatorId": 1}]
+            }
+        })";
+
+        NKqpProto::TKqpStatsQuery queryStats;
+        const TVector<const TString> txPlans = {txPlan};
+        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* scan = FindOperatorByStringField(simplifiedPlan, "Name", "Scan");
+
+        UNIT_ASSERT_C(scan, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-Rows").GetDoubleSafe(), 2, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-Size").GetDoubleSafe(), 20, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
+    }
+
+    Y_UNIT_TEST(ExplainAnalyzeMultiOperatorCpuUsesTopOperator) {
+        const TString txPlan = R"({
+            "Plans": [{
+                "Node Type": "Stage",
+                "StageGuid": "stage-1",
+                "Operators": [
+                    {"Name": "Top", "OperatorId": 1},
+                    {"Name": "Inner", "OperatorId": 2}
+                ],
+                "Stats": {"CpuTimeUs": {"Max": 7000}}
+            }],
+            "SimplifiedPlan": {
+                "Node Type": "Top",
+                "Operators": [{"Name": "Top", "OperatorId": 1}],
+                "Plans": [{
+                    "Node Type": "Inner",
+                    "Operators": [{"Name": "Inner", "OperatorId": 2}]
+                }]
+            }
+        })";
+
+        NKqpProto::TKqpStatsQuery queryStats;
+        const TVector<const TString> txPlans = {txPlan};
+        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* top = FindOperatorByStringField(simplifiedPlan, "Name", "Top");
+        const auto* inner = FindOperatorByStringField(simplifiedPlan, "Name", "Inner");
+
+        UNIT_ASSERT_C(top, plan);
+        UNIT_ASSERT_C(inner, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(top->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(top->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
+        UNIT_ASSERT_C(!inner->GetMapSafe().contains("A-SelfCpu"), plan);
+        UNIT_ASSERT_C(!inner->GetMapSafe().contains("A-Cpu"), plan);
+    }
+
+    Y_UNIT_TEST(ExplainAnalyzeCpuAbsentDoesNotAddCpuFields) {
+        const TString txPlan = R"({
+            "Plans": [{
+                "Node Type": "Scan",
+                "StageGuid": "stage-1",
+                "Operators": [{"Name": "Scan", "OperatorId": 1}],
+                "Stats": {"OutputRows": {"Sum": 6}}
+            }],
+            "SimplifiedPlan": {
+                "Node Type": "Scan",
+                "Operators": [{"Name": "Scan", "OperatorId": 1}]
+            }
+        })";
+
+        NKqpProto::TKqpStatsQuery queryStats;
+        const TVector<const TString> txPlans = {txPlan};
+        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* scan = FindOperatorByStringField(simplifiedPlan, "Name", "Scan");
+
+        UNIT_ASSERT_C(scan, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, plan);
+        UNIT_ASSERT_C(!scan->GetMapSafe().contains("A-SelfCpu"), plan);
+        UNIT_ASSERT_C(!scan->GetMapSafe().contains("A-Cpu"), plan);
+    }
+
     Y_UNIT_TEST(ExplainAnalyzeRangePushdown) {
         TExplainPlanTestContext testContext;
         BulkUpsertExplainPlanTestRows(testContext.GetKikimr());

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -311,6 +311,36 @@ NJson::TJsonValue GetSimplifiedPlan(const TString& plan) {
     return simplifiedPlan->second;
 }
 
+NJson::TJsonValue GetRboAnalyzeSimplifiedPlan(const TString& txPlan) {
+    NKqpProto::TKqpStatsQuery queryStats;
+    return GetSimplifiedPlan(SerializeRBOAnalyzePlan(TVector<const TString>{txPlan}, queryStats));
+}
+
+const NJson::TJsonValue& FindRequiredOperatorByStringField(
+    const NJson::TJsonValue& plan,
+    const TString& fieldName,
+    const TString& fieldValue)
+{
+    const auto* op = FindOperatorByStringField(plan, fieldName, fieldValue);
+    UNIT_ASSERT_C(op, plan);
+    return *op;
+}
+
+void AssertRboCpuValues(
+    const NJson::TJsonValue& op,
+    double expectedSelfCpu,
+    double expectedCpu,
+    const NJson::TJsonValue& plan)
+{
+    UNIT_ASSERT_VALUES_EQUAL_C(op.GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), expectedSelfCpu, plan);
+    UNIT_ASSERT_VALUES_EQUAL_C(op.GetMapSafe().at("A-Cpu").GetDoubleSafe(), expectedCpu, plan);
+}
+
+void AssertNoRboCpuValues(const NJson::TJsonValue& op, const NJson::TJsonValue& plan) {
+    UNIT_ASSERT_C(!op.GetMapSafe().contains("A-SelfCpu"), plan);
+    UNIT_ASSERT_C(!op.GetMapSafe().contains("A-Cpu"), plan);
+}
+
 TIntrusivePtr<TOpRead> MakeTestRead(const TVector<TInfoUnit>& outputIUs, TPositionHandle pos) {
     TVector<TString> columns;
     columns.reserve(outputIUs.size());
@@ -989,105 +1019,65 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
     Y_UNIT_TEST(ExplainAnalyzeSimplifiedPlanCpuWithActualRows) {
         const TString txPlan = R"({
             "Plans": [{
-                "Node Type": "TableFullScan",
-                "StageGuid": "stage-1",
-                "Operators": [{
-                    "Name": "TableFullScan",
-                    "OperatorId": 1
-                }],
+                "Node Type": "TableFullScan", "StageGuid": "stage-1",
+                "Operators": [{"Name": "TableFullScan", "OperatorId": 1}],
                 "Stats": {
-                    "Table": [{
-                        "Path": "/Root/t1",
-                        "ReadRows": {"Sum": 6},
-                        "ReadBytes": {"Sum": 64}
-                    }],
+                    "Table": [{"Path": "/Root/t1", "ReadRows": {"Sum": 6}, "ReadBytes": {"Sum": 64}}],
                     "CpuTimeUs": {"Max": 7000}
                 }
             }],
             "SimplifiedPlan": {
                 "Node Type": "TableFullScan",
-                "Operators": [{
-                    "Name": "TableFullScan",
-                    "OperatorId": 1,
-                    "Table": "/Root/t1"
-                }]
+                "Operators": [{"Name": "TableFullScan", "OperatorId": 1, "Table": "/Root/t1"}]
             }
         })";
 
-        NKqpProto::TKqpStatsQuery queryStats;
-        const TVector<const TString> txPlans = {txPlan};
-        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
-        const auto simplifiedPlan = GetSimplifiedPlan(plan);
-        const auto* fullScan = FindOperatorByStringField(simplifiedPlan, "Name", "TableFullScan");
-        UNIT_ASSERT_C(fullScan, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, plan);
-        UNIT_ASSERT_C(fullScan->GetMapSafe().contains("A-SelfCpu"), plan);
-        UNIT_ASSERT_C(fullScan->GetMapSafe().contains("A-Cpu"), plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(fullScan->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
+        const auto simplifiedPlan = GetRboAnalyzeSimplifiedPlan(txPlan);
+        const auto& fullScan = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "TableFullScan");
+        UNIT_ASSERT_VALUES_EQUAL_C(fullScan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
+        AssertRboCpuValues(fullScan, 7, 7, simplifiedPlan);
     }
 
     Y_UNIT_TEST(ExplainAnalyzeDuplicateOperatorIdUsesFirstMatch) {
         const TString txPlan = R"({
             "Plans": [{
-                "Node Type": "FirstExec",
-                "StageGuid": "stage-first",
+                "Node Type": "FirstExec", "StageGuid": "stage-first",
                 "Operators": [{"Name": "FirstExec", "OperatorId": 7}],
-                "Stats": {
-                    "OutputRows": {"Sum": 6},
-                    "OutputBytes": {"Sum": 60},
-                    "CpuTimeUs": {"Max": 7000}
-                },
+                "Stats": {"OutputRows": {"Sum": 6}, "OutputBytes": {"Sum": 60}, "CpuTimeUs": {"Max": 7000}},
                 "Plans": [{
-                    "Node Type": "SecondExec",
-                    "StageGuid": "stage-second",
+                    "Node Type": "SecondExec", "StageGuid": "stage-second",
                     "Operators": [{"Name": "SecondExec", "OperatorId": 7}],
-                    "Stats": {
-                        "OutputRows": {"Sum": 11},
-                        "OutputBytes": {"Sum": 110},
-                        "CpuTimeUs": {"Max": 11000}
-                    }
+                    "Stats": {"OutputRows": {"Sum": 11}, "OutputBytes": {"Sum": 110}, "CpuTimeUs": {"Max": 11000}}
                 }]
             }],
             "SimplifiedPlan": {
-                "Node Type": "First",
-                "Operators": [{"Name": "First", "OperatorId": 7}],
+                "Node Type": "First", "Operators": [{"Name": "First", "OperatorId": 7}],
                 "Plans": [{
-                    "Node Type": "Second",
-                    "Operators": [{"Name": "Second", "OperatorId": 7}]
+                    "Node Type": "Second", "Operators": [{"Name": "Second", "OperatorId": 7}]
                 }]
             }
         })";
 
-        NKqpProto::TKqpStatsQuery queryStats;
-        const TVector<const TString> txPlans = {txPlan};
-        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
-        const auto simplifiedPlan = GetSimplifiedPlan(plan);
-        const auto* first = FindOperatorByStringField(simplifiedPlan, "Name", "First");
-        const auto* second = FindOperatorByStringField(simplifiedPlan, "Name", "Second");
+        const auto simplifiedPlan = GetRboAnalyzeSimplifiedPlan(txPlan);
+        const auto& first = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "First");
+        const auto& second = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "Second");
 
-        UNIT_ASSERT_C(first, plan);
-        UNIT_ASSERT_C(second, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-Size").GetDoubleSafe(), 60, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(first->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
-        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-Rows"), plan);
-        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-Size"), plan);
-        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-SelfCpu"), plan);
-        UNIT_ASSERT_C(!second->GetMapSafe().contains("A-Cpu"), plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(first.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
+        UNIT_ASSERT_VALUES_EQUAL_C(first.GetMapSafe().at("A-Size").GetDoubleSafe(), 60, simplifiedPlan);
+        AssertRboCpuValues(first, 7, 7, simplifiedPlan);
+        UNIT_ASSERT_C(!second.GetMapSafe().contains("A-Rows"), simplifiedPlan);
+        UNIT_ASSERT_C(!second.GetMapSafe().contains("A-Size"), simplifiedPlan);
+        AssertNoRboCpuValues(second, simplifiedPlan);
     }
 
     Y_UNIT_TEST(ExplainAnalyzeMissingExecutionOperatorIdFails) {
         const TString txPlan = R"({
             "Plans": [{
-                "Node Type": "Exec",
-                "StageGuid": "stage-1",
+                "Node Type": "Exec", "StageGuid": "stage-1",
                 "Operators": [{"Name": "Exec", "OperatorId": 1}]
             }],
             "SimplifiedPlan": {
-                "Node Type": "Missing",
-                "Operators": [{"Name": "Missing", "OperatorId": 2}]
+                "Node Type": "Missing", "Operators": [{"Name": "Missing", "OperatorId": 2}]
             }
         })";
 
@@ -1099,43 +1089,31 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
     Y_UNIT_TEST(ExplainAnalyzeBroadcastStatsUseParentTaskCount) {
         const TString txPlan = R"({
             "Plans": [{
-                "Node Type": "Broadcast",
-                "PlanNodeType": "Connection",
+                "Node Type": "Broadcast", "PlanNodeType": "Connection",
                 "Stats": {"Tasks": 4},
                 "Plans": [{
-                    "Node Type": "Scan",
-                    "StageGuid": "stage-1",
+                    "Node Type": "Scan", "StageGuid": "stage-1",
                     "Operators": [{"Name": "Scan", "OperatorId": 1}],
-                    "Stats": {
-                        "OutputRows": {"Sum": 8},
-                        "OutputBytes": {"Sum": 80},
-                        "CpuTimeUs": {"Max": 7000}
-                    }
+                    "Stats": {"OutputRows": {"Sum": 8}, "OutputBytes": {"Sum": 80}, "CpuTimeUs": {"Max": 7000}}
                 }]
             }],
             "SimplifiedPlan": {
-                "Node Type": "Scan",
-                "Operators": [{"Name": "Scan", "OperatorId": 1}]
+                "Node Type": "Scan", "Operators": [{"Name": "Scan", "OperatorId": 1}]
             }
         })";
 
-        NKqpProto::TKqpStatsQuery queryStats;
-        const TVector<const TString> txPlans = {txPlan};
-        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
-        const auto simplifiedPlan = GetSimplifiedPlan(plan);
-        const auto* scan = FindOperatorByStringField(simplifiedPlan, "Name", "Scan");
+        const auto simplifiedPlan = GetRboAnalyzeSimplifiedPlan(txPlan);
+        const auto& scan = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "Scan");
 
-        UNIT_ASSERT_C(scan, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-Rows").GetDoubleSafe(), 2, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-Size").GetDoubleSafe(), 20, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 2, simplifiedPlan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Size").GetDoubleSafe(), 20, simplifiedPlan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, simplifiedPlan);
     }
 
     Y_UNIT_TEST(ExplainAnalyzeMultiOperatorCpuUsesTopOperator) {
         const TString txPlan = R"({
             "Plans": [{
-                "Node Type": "Stage",
-                "StageGuid": "stage-1",
+                "Node Type": "Stage", "StageGuid": "stage-1",
                 "Operators": [
                     {"Name": "Top", "OperatorId": 1},
                     {"Name": "Inner", "OperatorId": 2}
@@ -1143,54 +1121,38 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
                 "Stats": {"CpuTimeUs": {"Max": 7000}}
             }],
             "SimplifiedPlan": {
-                "Node Type": "Top",
-                "Operators": [{"Name": "Top", "OperatorId": 1}],
+                "Node Type": "Top", "Operators": [{"Name": "Top", "OperatorId": 1}],
                 "Plans": [{
-                    "Node Type": "Inner",
-                    "Operators": [{"Name": "Inner", "OperatorId": 2}]
+                    "Node Type": "Inner", "Operators": [{"Name": "Inner", "OperatorId": 2}]
                 }]
             }
         })";
 
-        NKqpProto::TKqpStatsQuery queryStats;
-        const TVector<const TString> txPlans = {txPlan};
-        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
-        const auto simplifiedPlan = GetSimplifiedPlan(plan);
-        const auto* top = FindOperatorByStringField(simplifiedPlan, "Name", "Top");
-        const auto* inner = FindOperatorByStringField(simplifiedPlan, "Name", "Inner");
+        const auto simplifiedPlan = GetRboAnalyzeSimplifiedPlan(txPlan);
+        const auto& top = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "Top");
+        const auto& inner = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "Inner");
 
-        UNIT_ASSERT_C(top, plan);
-        UNIT_ASSERT_C(inner, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(top->GetMapSafe().at("A-SelfCpu").GetDoubleSafe(), 7, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(top->GetMapSafe().at("A-Cpu").GetDoubleSafe(), 7, plan);
-        UNIT_ASSERT_C(!inner->GetMapSafe().contains("A-SelfCpu"), plan);
-        UNIT_ASSERT_C(!inner->GetMapSafe().contains("A-Cpu"), plan);
+        AssertRboCpuValues(top, 7, 7, simplifiedPlan);
+        AssertNoRboCpuValues(inner, simplifiedPlan);
     }
 
     Y_UNIT_TEST(ExplainAnalyzeCpuAbsentDoesNotAddCpuFields) {
         const TString txPlan = R"({
             "Plans": [{
-                "Node Type": "Scan",
-                "StageGuid": "stage-1",
+                "Node Type": "Scan", "StageGuid": "stage-1",
                 "Operators": [{"Name": "Scan", "OperatorId": 1}],
                 "Stats": {"OutputRows": {"Sum": 6}}
             }],
             "SimplifiedPlan": {
-                "Node Type": "Scan",
-                "Operators": [{"Name": "Scan", "OperatorId": 1}]
+                "Node Type": "Scan", "Operators": [{"Name": "Scan", "OperatorId": 1}]
             }
         })";
 
-        NKqpProto::TKqpStatsQuery queryStats;
-        const TVector<const TString> txPlans = {txPlan};
-        const auto plan = SerializeRBOAnalyzePlan(txPlans, queryStats);
-        const auto simplifiedPlan = GetSimplifiedPlan(plan);
-        const auto* scan = FindOperatorByStringField(simplifiedPlan, "Name", "Scan");
+        const auto simplifiedPlan = GetRboAnalyzeSimplifiedPlan(txPlan);
+        const auto& scan = FindRequiredOperatorByStringField(simplifiedPlan, "Name", "Scan");
 
-        UNIT_ASSERT_C(scan, plan);
-        UNIT_ASSERT_VALUES_EQUAL_C(scan->GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, plan);
-        UNIT_ASSERT_C(!scan->GetMapSafe().contains("A-SelfCpu"), plan);
-        UNIT_ASSERT_C(!scan->GetMapSafe().contains("A-Cpu"), plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(scan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
+        AssertNoRboCpuValues(scan, simplifiedPlan);
     }
 
     Y_UNIT_TEST(ExplainAnalyzeRangePushdown) {


### PR DESCRIPTION
### Changelog entry

Fixed missing `A-Cpu` in legacy and new-RBO Explain Analyze plans when actual rows are already present or stage statistics belong to a structural legacy node.

### Description for reviewers

#46498 and #46920 restored legacy scan rows/bytes and intentionally left CPU out of scope.

The remaining gap has two parts:

- both serializers assign stage CPU inside the `!A-Rows` fallback, so an operator that already has actual rows loses `A-SelfCpu` and cumulative `A-Cpu`;
- in the legacy QueryService shape, stage statistics can live on a no-operator `Collect`, and ordinary recursion drops CPU before the first visible operator.

This change assigns `CpuTimeUs.Max / 1000` independently of the rows fallback in both serializers. Legacy reconstruction also carries CPU through a unary structural node exactly once, with local priority and resets at fan-out, CTE/precompute, and external-stage boundaries. The existing stage-level attribution and cumulative calculation are unchanged.

### Before and after

The lookup changes keep this path linear: Legacy indexes keep non-owning node views, and new RBO builds per-call operator and connection indexes.

| Before | After |
| :---: | :---: |
| <img width="700" height="680" alt="Before: CPU coupled to rows and repeated plan scans" src="https://github.com/user-attachments/assets/7c34c636-c29e-4c6f-aaa8-2f3181fc2211" /> | <img width="700" height="680" alt="After: independent CPU attribution and indexed plan lookup" src="https://github.com/user-attachments/assets/a9f00803-6425-460f-8340-53e407d87406" /> |

Deterministic fixtures cover existing `A-Rows`, unary propagation, fan-out, local priority, boundaries, cumulative CPU, synthetic lookups, and new RBO. The QueryService regression first asserts raw CPU ownership on the structural `Collect`, then checks numeric simplified `A-Cpu`.

Related: #2325  
UI context: ydb-platform/ydb-embedded-ui#4058