### PR TITLE
[HashJoin] fix void columns handling

### DIFF
--- a/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
@@ -1245,6 +1245,81 @@ Y_UNIT_TEST_SUITE(KqpBlockHashJoin) {
             R"([[0;0];[1;1];[2;2]])"
         );
     }
+
+    Y_UNIT_TEST(RegressionCountStarOverJoin) {
+        TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);
+        auto* ts = settings.AppConfig.MutableTableServiceConfig();
+        ts->SetEnableNewRBO(true);
+        ts->SetEnableFallbackToYqlOptimizer(true);
+        ts->SetAllowOlapDataQuery(true);
+        ts->SetEnableOlapSink(true);
+        ts->SetUseBlockHashJoin(true);
+        TKikimrRunner kikimr(settings);
+
+        auto queryClient = kikimr.GetQueryClient();
+        {
+            auto status = queryClient.ExecuteQuery(
+                R"(
+                    CREATE TABLE `/Root/count_target` (
+                        a Int64 NOT NULL,
+                        PRIMARY KEY (a)
+                    ) WITH (STORE = COLUMN);
+
+                    CREATE TABLE `/Root/count_source` (
+                        a Int64 NOT NULL,
+                        PRIMARY KEY (a)
+                    ) WITH (STORE = COLUMN);
+                )",
+                NYdb::NQuery::TTxControl::NoTx()
+            ).GetValueSync();
+            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        }
+        {
+            auto status = queryClient.ExecuteQuery(
+                R"(
+                    INSERT INTO `/Root/count_target` (a) VALUES (0), (1), (2), (3);
+                    INSERT INTO `/Root/count_source` (a) VALUES (1), (2), (3), (4);
+                )",
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx()
+            ).GetValueSync();
+            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        }
+
+        const TString query = R"(
+            PRAGMA ydb.CostBasedOptimizationLevel = '0';
+            PRAGMA ydb.HashJoinMode = 'grace';
+            PRAGMA ydb.UseBlockHashJoin = 'true';
+            SELECT COUNT(*)
+            FROM `/Root/count_target` AS t
+            INNER JOIN `/Root/count_source` AS s ON t.a = s.a;
+        )";
+
+        {
+            auto explain = queryClient.ExecuteQuery(
+                query,
+                NYdb::NQuery::TTxControl::NoTx(),
+                NYdb::NQuery::TExecuteQuerySettings().ExecMode(NYdb::NQuery::EExecMode::Explain)
+            ).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explain.GetStatus(), EStatus::SUCCESS, explain.GetIssues().ToString());
+            auto astOpt = explain.GetStats()->GetAst();
+            UNIT_ASSERT(astOpt.has_value());
+            const TString ast(*astOpt);
+            UNIT_ASSERT_C(
+                ast.Contains("BlockHashJoin") || ast.Contains("DqBlockHashJoin"),
+                TStringBuilder() << "Expected BlockHashJoin. AST: " << ast
+            );
+        }
+
+        auto result = queryClient.ExecuteQuery(
+            query,
+            NYdb::NQuery::TTxControl::NoTx()
+        ).GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(
+            FormatResultSetYson(result.GetResultSet(0)),
+            R"([[3u]])"
+        );
+    }
 }
 
 } // namespace NKqp

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
@@ -242,6 +242,7 @@ public:
 
     TVector<const ui8*> GetNullBitmapConst(std::shared_ptr<arrow::ArrayData> array, TVector<std::shared_ptr<arrow::Buffer>>& nullBitmapRelocationBuffer) override {
         if constexpr (IsNull) {
+            auto bitmap = NYql::NUdf::MakeDenseFalseBitmap(array->length, Pool_);
             nullBitmapRelocationBuffer.push_back(bitmap);
             return {bitmap->data()};
         } else {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
@@ -224,6 +224,9 @@ protected:
     std::shared_ptr<arrow::DataType> ArrowType_;
 };
 
+// singular types (Void, Null, EmptyList, EmptyDict) have no payload buffer
+// DataSize == 0 --> tuple pack/unpack skips them
+template <bool IsNull>
 class TSingularColumnDataExtractor : public IColumnDataExtractor {
 public:
     TSingularColumnDataExtractor(const NYql::NUdf::TType* type, arrow::MemoryPool* pool) {
@@ -231,7 +234,8 @@ public:
     }
 
     TVector<const ui8*> GetColumnsDataConst(std::shared_ptr<arrow::ArrayData> array) override {
-        return {array->GetValues<ui8>(0)};
+        Y_UNUSED(array);
+        return {nullptr};
     }
 
     TVector<const ui8*> GetNullBitmapConst(std::shared_ptr<arrow::ArrayData> array, TVector<std::shared_ptr<arrow::Buffer>>& nullBitmapRelocationBuffer) override {
@@ -241,7 +245,8 @@ public:
     }
 
     TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
-        return {array->GetMutableValues<ui8>(0)};
+        Y_UNUSED(array);
+        return {nullptr};
     }
 
     TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
@@ -250,7 +255,7 @@ public:
     }
 
     ui32 GetElementSize() override {
-        return 1; // or 0?
+        return 0;
     }
 
     NPackedTuple::EColumnSizeType GetElementSizeType() override {
@@ -259,7 +264,7 @@ public:
 
     std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
         Y_UNUSED(bytes);
-        return arrow::ArrayData::Make(arrow::null(), len, {nullptr}, len);
+        return NYql::NUdf::MakeSingularArray(IsNull, len);
     }
 
     void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
@@ -607,7 +612,8 @@ struct TColumnDataExtractorTraits {
     using TResource = TResourceColumnDataExtractor<Nullable>;
     template<typename TTzDate, bool Nullable>
     using TTzDateReader = TTzDateColumnDataExtractor<TTzDate, Nullable>;
-    using TSingular = TSingularColumnDataExtractor;
+    template <bool IsNull>
+    using TSingular = TSingularColumnDataExtractor<IsNull>;
 
     constexpr static bool PassType = true;
 
@@ -622,8 +628,7 @@ struct TColumnDataExtractorTraits {
 
     template <bool IsNull>
     static TResult::TPtr MakeSingular(const NYql::NUdf::TType* type, arrow::MemoryPool* pool) {
-        Y_UNUSED(IsNull);
-        return std::make_unique<TSingular>(type, pool);
+        return std::make_unique<TSingular<IsNull>>(type, pool);
     }
 
     static TResult::TPtr MakeResource(bool isOptional, const NYql::NUdf::TType* type, arrow::MemoryPool* pool) {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
@@ -229,8 +229,10 @@ protected:
 template <bool IsNull>
 class TSingularColumnDataExtractor : public IColumnDataExtractor {
 public:
-    TSingularColumnDataExtractor(const NYql::NUdf::TType* type, arrow::MemoryPool* pool) {
-        Y_UNUSED(type, pool);
+    TSingularColumnDataExtractor(const NYql::NUdf::TType* type, arrow::MemoryPool* pool)
+        : Pool_(pool)
+    {
+        Y_UNUSED(type);
     }
 
     TVector<const ui8*> GetColumnsDataConst(std::shared_ptr<arrow::ArrayData> array) override {
@@ -239,9 +241,13 @@ public:
     }
 
     TVector<const ui8*> GetNullBitmapConst(std::shared_ptr<arrow::ArrayData> array, TVector<std::shared_ptr<arrow::Buffer>>& nullBitmapRelocationBuffer) override {
-        Y_UNUSED(array);
-        Y_UNUSED(nullBitmapRelocationBuffer);
-        return {nullptr};
+        if constexpr (IsNull) {
+            nullBitmapRelocationBuffer.push_back(bitmap);
+            return {bitmap->data()};
+        } else {
+            Y_UNUSED(array, nullBitmapRelocationBuffer);
+            return {nullptr};
+        }
     }
 
     TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
@@ -270,6 +276,9 @@ public:
     void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
         extractors.push_back(this);
     }
+
+private:
+    arrow::MemoryPool* Pool_;
 };
 
 template <typename TStringType, bool Nullable>

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/scalar_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/scalar_layout_converter.cpp
@@ -11,6 +11,7 @@
 #include <yql/essentials/public/udf/udf_type_inspection.h>
 #include <yql/essentials/public/udf/udf_value.h>
 #include <yql/essentials/public/udf/udf_value_builder.h>
+#include <yql/essentials/public/udf/udf_value_utils.h>
 #include <yql/essentials/utils/yql_panic.h>
 
 #include <util/generic/guid.h>
@@ -221,6 +222,7 @@ protected:
     TType* Type_;
 };
 
+template <bool IsNull>
 class TSingularColumnDataExtractor : public IColumnDataExtractor {
 public:
     TSingularColumnDataExtractor(TType* type) {
@@ -228,10 +230,17 @@ public:
     }
 
     void ExtractForPack(const NYql::NUdf::TUnboxedValue& value, TVector<const ui8*>& columnsData, TVector<const ui8*>& columnsNullBitmap, TVector<TVector<ui8>>& tempStorage) override {
-        Y_UNUSED(value, tempStorage);
-        // skip the payload pointer entirely
+        Y_UNUSED(value);
         columnsData.push_back(nullptr);
-        columnsNullBitmap.push_back(nullptr);
+
+        if constexpr (IsNull) {
+            auto& bitmapStorage = tempStorage.emplace_back(1);
+            bitmapStorage[0] = 0; // null
+            columnsNullBitmap.push_back(bitmapStorage.data());
+        } else {
+            Y_UNUSED(tempStorage);
+            columnsNullBitmap.push_back(nullptr);
+        }
     }
 
     void ExtractForPackBatch(const NYql::NUdf::TUnboxedValue* values, ui32 count, TVector<const ui8*>& columnsData, TVector<const ui8*>& columnsNullBitmap, TVector<TVector<ui8>>& tempStorage) override {
@@ -243,7 +252,7 @@ public:
 
     NYql::NUdf::TUnboxedValue CreateFromUnpack(ui8** columnsData, ui8** columnsNullBitmap, ui32 tupleIndex, [[maybe_unused]] const THolderFactory& holderFactory) override {
         Y_UNUSED(columnsData, columnsNullBitmap, tupleIndex, holderFactory);
-        return NYql::NUdf::TUnboxedValuePod::Void();
+        return NYql::NUdf::CreateSingularUnboxedValuePod<IsNull>();
     }
 
     ui32 GetElementSize() override {
@@ -602,7 +611,8 @@ struct TColumnDataExtractorTraits {
     using TResource = TResourceColumnDataExtractor<Nullable>;
     template<typename TTzDate, bool Nullable>
     using TTzDateReader = TTzDateColumnDataExtractor<TTzDate, Nullable>;
-    using TSingular = TSingularColumnDataExtractor;
+    template <bool IsNull>
+    using TSingular = TSingularColumnDataExtractor<IsNull>;
 
     constexpr static bool PassType = false;
 
@@ -617,8 +627,7 @@ struct TColumnDataExtractorTraits {
 
     template <bool IsNull>
     static TResult::TPtr MakeSingular(TType* type) {
-        Y_UNUSED(IsNull);
-        return std::make_unique<TSingular>(type);
+        return std::make_unique<TSingular<IsNull>>(type);
     }
 
     static TResult::TPtr MakeResource(bool isOptional, TType* type) {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/scalar_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/scalar_layout_converter.cpp
@@ -228,11 +228,9 @@ public:
     }
 
     void ExtractForPack(const NYql::NUdf::TUnboxedValue& value, TVector<const ui8*>& columnsData, TVector<const ui8*>& columnsNullBitmap, TVector<TVector<ui8>>& tempStorage) override {
-        Y_UNUSED(value);
-        auto& dataStorage = tempStorage.emplace_back(1);
-        dataStorage[0] = 0;
-
-        columnsData.push_back(dataStorage.data());
+        Y_UNUSED(value, tempStorage);
+        // skip the payload pointer entirely
+        columnsData.push_back(nullptr);
         columnsNullBitmap.push_back(nullptr);
     }
 
@@ -249,7 +247,7 @@ public:
     }
 
     ui32 GetElementSize() override {
-        return 1;
+        return 0;
     }
 
     NPackedTuple::EColumnSizeType GetElementSizeType() override {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -340,6 +340,8 @@ TTupleLayoutFallback::TTupleLayoutFallback(
     for (auto &col : Columns) {
         if (col.SizeType == EColumnSizeType::Variable) {
             VariableColumns.push_back(col);
+        } else if (col.DataSize == 0) {
+            // singular types (void/null...) no payload bytes to pack/unpack
         } else if (IsPowerOf2(col.DataSize) &&
                    col.DataSize < (1u << FixedPOTColumns_.size())) {
             FixedPOTColumns_[CountTrailingZeroBits(col.DataSize)].push_back(
@@ -366,13 +368,23 @@ TTupleLayoutSIMD<TTraits>::TTupleLayoutSIMD(
     std::vector<const TColumnDesc *> fallback_cols;
     std::queue<const TColumnDesc *> next_cols;
 
+    auto packableFixedPrefix = [](const std::vector<TColumnDesc> &columns) {
+        std::vector<TColumnDesc> result;
+        for (const auto &col : columns) {
+            if (col.SizeType != EColumnSizeType::Fixed) {
+                break;
+            }
+            if (col.DataSize != 0) {
+                result.push_back(col);
+            }
+        }
+        return result;
+    };
+    const auto packableKeyColumns = packableFixedPrefix(KeyColumns);
+    const auto packablePayloadColumns = packableFixedPrefix(PayloadColumns);
+
     size_t fixed_cols_left =
-        KeyColumnsFixedNum +
-        std::accumulate(PayloadColumns.begin(), PayloadColumns.end(), 0ul,
-                        [](size_t prev, const auto &col) {
-                            return prev +
-                                   (col.SizeType == EColumnSizeType::Fixed);
-                        });
+        packableKeyColumns.size() + packablePayloadColumns.size();
 
     const auto small_tuple_packing = [&](const std::vector<TColumnDesc>
                                              &columns) {
@@ -520,16 +532,16 @@ TTupleLayoutSIMD<TTraits>::TTupleLayoutSIMD(
     };
 
     if (max_simd_tuple_size) {
-        small_tuple_packing(KeyColumns);
-        small_tuple_packing(PayloadColumns);
+        small_tuple_packing(packableKeyColumns);
+        small_tuple_packing(packablePayloadColumns);
 
         while (!next_cols.empty()) {
             fallback_cols.push_back(next_cols.front());
             next_cols.pop();
         }
     } else {
-        transpose_packing(KeyColumns, 0);
-        transpose_packing(PayloadColumns, 1);
+        transpose_packing(packableKeyColumns, 0);
+        transpose_packing(packablePayloadColumns, 1);
     }
 
     for (const auto col_desc_p : fallback_cols) {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
@@ -5,6 +5,7 @@
 #include <yql/essentials/public/udf/arrow/block_builder.h>
 #include <yql/essentials/public/udf/arrow/block_reader.h>
 #include <yql/essentials/public/udf/arrow/memory_pool.h>
+#include <yql/essentials/public/udf/arrow/util.h>
 #include <yql/essentials/minikql/mkql_type_builder.h>
 #include <yql/essentials/minikql/mkql_function_registry.h>
 #include <yql/essentials/minikql/mkql_program_builder.h>
@@ -540,6 +541,57 @@ Y_UNIT_TEST_SUITE(TBlockLayoutConverterTest) {
 
         TBlockItem item2 = reader->GetItem(col, 2);
         UNIT_ASSERT_C(!item2, "Row 2 must be NULL");
+    }
+
+    Y_UNIT_TEST(TestSingularColumns) {
+        TBlockLayoutConverterTestData data;
+
+        const auto int64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, false);
+        auto* const voidType = data.Env.GetTypeOfVoidLazy();
+        TVector<NKikimr::NMiniKQL::TType*> types{int64Type, voidType, voidType};
+        TVector<NPackedTuple::EColumnRole> roles{
+            NPackedTuple::EColumnRole::Key, NPackedTuple::EColumnRole::Key,
+            NPackedTuple::EColumnRole::Payload};
+
+        constexpr size_t testSize = 137;
+
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), int64Type, *data.ArrowPool, testSize, nullptr);
+        for (size_t i = 0; i < testSize; i++) {
+            builder->Add(TBlockItem(i));
+        }
+        auto keyDatum = builder->Build(true);
+        Y_ENSURE(keyDatum.is_array());
+
+        TVector<arrow::Datum> columns{
+            keyDatum,
+            arrow::Datum(NYql::NUdf::MakeSingularArray(/*isNull=*/false, testSize)),
+            arrow::Datum(NYql::NUdf::MakeSingularArray(/*isNull=*/false, testSize))};
+
+        TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), columns.size(), "Expected same columns count after conversion");
+
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), int64Type);
+        const auto& keyBefore = columns.front().array();
+        const auto& keyAfter = columnsAfterConversion.front().array();
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*keyBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*keyAfter, elemIdx);
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<i64>(), rhs.Get<i64>(), "Expected the same data after conversion");
+        }
+
+        for (size_t colIdx = 1; colIdx < columns.size(); ++colIdx) {
+            const auto& before = columns[colIdx].array();
+            const auto& after = columnsAfterConversion[colIdx].array();
+            UNIT_ASSERT_VALUES_EQUAL_C(after->length, before->length, "Expected the same length after conversion");
+            UNIT_ASSERT_C(after->type->Equals(*before->type), "Expected the same arrow type after conversion");
+        }
     }
 
     Y_UNIT_TEST(TestBuckets) {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
@@ -594,6 +594,43 @@ Y_UNIT_TEST_SUITE(TBlockLayoutConverterTest) {
         }
     }
 
+    // singular null has DataSize == 0
+    // without packing its allnull validity bitmap
+    // two Null keys compare equal and would match in the join.
+    Y_UNIT_TEST(TestSingularNullKeyPackedAsNull) {
+        TBlockLayoutConverterTestData data;
+
+        auto* const nullType = data.Env.GetTypeOfNullLazy();
+        TVector<NKikimr::NMiniKQL::TType*> types{nullType};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        constexpr size_t testSize = 17;
+
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+        TVector<arrow::Datum> columns{
+            arrow::Datum(NYql::NUdf::MakeSingularArray(/*isNull=*/true, testSize))};
+
+        TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL(packRes.NTuples, testSize);
+
+        const auto* layout = converter->GetTupleLayout();
+        UNIT_ASSERT_VALUES_EQUAL(layout->KeyColumnsNum, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(layout->Columns[0].DataSize, 0u);
+
+        for (size_t row = 0; row < testSize; ++row) {
+            const ui8* tuple = packRes.PackedTuples.data() + row * layout->TotalRowSize;
+            const ui8 bit = (tuple[layout->BitmaskOffset] >> 0) & 1u;
+            UNIT_ASSERT_VALUES_EQUAL_C(bit, 0u, "Null key column must be packed as NULL");
+        }
+
+        const ui8* row0 = packRes.PackedTuples.data();
+        const ui8* row1 = packRes.PackedTuples.data() + layout->TotalRowSize;
+        UNIT_ASSERT_C(
+            !layout->KeysEqual(row0, packRes.Overflow.data(), row1, packRes.Overflow.data()),
+            "Null keys must not compare equal");
+    }
+
     Y_UNIT_TEST(TestBuckets) {
         TBlockLayoutConverterTestData data;
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/scalar_layout_converter_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/scalar_layout_converter_ut.cpp
@@ -737,4 +737,42 @@ Y_UNIT_TEST_SUITE(TScalarLayoutConverterTest) {
             }
         }
     }
+
+    Y_UNIT_TEST(TestSingularNullKeyPackedAsNull) {
+        TScalarLayoutConverterTestData data;
+
+        auto* const nullType = data.Env.GetTypeOfNullLazy();
+        TVector<NKikimr::NMiniKQL::TType*> types{nullType};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        constexpr size_t testSize = 17;
+        auto converter = MakeScalarLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.HolderFactory);
+
+        NYql::NUdf::TUnboxedValue nullValue;
+        TPackResult packRes;
+        for (size_t i = 0; i < testSize; ++i) {
+            converter->Pack(&nullValue, packRes);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(packRes.NTuples, testSize);
+
+        const auto* layout = converter->GetTupleLayout();
+        UNIT_ASSERT_VALUES_EQUAL(layout->KeyColumnsNum, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(layout->Columns[0].DataSize, 0u);
+
+        for (size_t row = 0; row < testSize; ++row) {
+            const ui8* tuple = packRes.PackedTuples.data() + row * layout->TotalRowSize;
+            const ui8 bit = (tuple[layout->BitmaskOffset] >> 0) & 1u;
+            UNIT_ASSERT_VALUES_EQUAL_C(bit, 0u, "Null key column must be packed as NULL");
+
+            NYql::NUdf::TUnboxedValue unpacked[1];
+            converter->Unpack(packRes, row, unpacked);
+            UNIT_ASSERT_C(!unpacked[0].HasValue(), "Unpack must restore Null, not Void");
+        }
+
+        const ui8* row0 = packRes.PackedTuples.data();
+        const ui8* row1 = packRes.PackedTuples.data() + layout->TotalRowSize;
+        UNIT_ASSERT_C(
+            !layout->KeysEqual(row0, packRes.Overflow.data(), row1, packRes.Overflow.data()),
+            "Null keys must not compare equal");
+    }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->
Singular columns (void/null/...) were already handled by the block layout converter, but inconsistently with the Arrow representation: singular arrays have no data buffer (nullptr), while the converter treated them as fixed-size and packing dereferenced that null pointer, e.g. when COUNT(*) feeds a Void payload through BlockHashJoin.

This change makes singular columns zero-sized so tuple pack/unpack skips their payload entirely.
...
