### PR TITLE
Avoid timer variant overhead in BS queue items

### DIFF
--- a/ydb/core/blobstorage/backpressure/common.h
+++ b/ydb/core/blobstorage/backpressure/common.h
@@ -6,35 +6,28 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
 
 namespace NKikimr::NBsQueue {
 
-// Special timer for debug purposes, which works with virtual time of TTestActorSystem
-struct TActivationContextTimer {
-    TActivationContextTimer()
-        : CreationTimestamp(NActors::TActivationContext::Monotonic())
-    {}
-
-    double Passed() const {
-        return (NActors::TActivationContext::Monotonic() - CreationTimestamp).SecondsFloat();
-    }
-
-    TMonotonic CreationTimestamp;
-};
-
 struct TBSQueueTimer {
+    const bool UseActorSystemTime;
+    ui64 Timestamp;
+
     TBSQueueTimer(bool useActorSystemTime)
+        : UseActorSystemTime(useActorSystemTime)
     {
         if (useActorSystemTime) {
-            Timer.emplace<TActivationContextTimer>();
+            Timestamp = NActors::TActivationContext::Monotonic().GetValue();
         } else {
-            Timer.emplace<THPTimer>();
+            NHPTimer::STime start;
+            NHPTimer::GetTime(&start);
+            Timestamp = static_cast<ui64>(start);
         }
     }
 
-    std::variant<THPTimer, TActivationContextTimer> Timer;
-
     double Passed() const {
-        return std::visit([](const auto& timer) -> double {
-            return timer.Passed();
-        }, Timer);
+        if (UseActorSystemTime) {
+            return (NActors::TActivationContext::Monotonic() - TMonotonic::FromValue(Timestamp)).SecondsFloat();
+        }
+        NHPTimer::STime start = static_cast<NHPTimer::STime>(Timestamp);
+        return NHPTimer::GetTimePassed(&start);
     }
 };
 

--- a/ydb/core/blobstorage/backpressure/common_ut.cpp
+++ b/ydb/core/blobstorage/backpressure/common_ut.cpp
@@ -1,0 +1,73 @@
+#include "common.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/testlib/actors/test_runtime.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NBsQueue {
+namespace {
+
+using namespace NActors;
+
+TTestActorRuntime::TEgg MakeTestRuntimeEgg() {
+    return {new TAppData(0, 0, 0, 0, {}, nullptr, nullptr, nullptr, nullptr), nullptr, nullptr, {}, {}};
+}
+
+class TVirtualTimerActor : public TActor<TVirtualTimerActor> {
+public:
+    explicit TVirtualTimerActor(TActorId replyTo)
+        : TActor(&TVirtualTimerActor::StateFunc)
+        , ReplyTo(replyTo)
+    {}
+
+private:
+    STFUNC(StateFunc) {
+        switch (ev->GetTypeRewrite()) {
+            case TEvents::THelloWorld::Ping:
+                Timer.ConstructInPlace(true);
+                Schedule(TDuration::Seconds(5), new TEvents::TEvWakeup);
+                break;
+
+            case TEvents::TSystem::Wakeup:
+                Send(ReplyTo, new TEvents::TEvWakeup(TDuration::Seconds(Timer->Passed()).MicroSeconds()));
+                PassAway();
+                break;
+        }
+    }
+
+    const TActorId ReplyTo;
+    TMaybe<TBSQueueTimer> Timer;
+};
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(TBSQueueTimerTest) {
+    Y_UNIT_TEST(HighPrecisionTimer) {
+        TBSQueueTimer timer(false);
+        Sleep(TDuration::MilliSeconds(1));
+        const double first = timer.Passed();
+        Sleep(TDuration::MilliSeconds(1));
+        const double second = timer.Passed();
+
+        UNIT_ASSERT_C(first > 0, first);
+        UNIT_ASSERT_C(second >= first, first << " " << second);
+        UNIT_ASSERT_VALUES_EQUAL(sizeof(timer), 16);
+    }
+
+    Y_UNIT_TEST(ActorSystemTimerUsesVirtualTime) {
+        TTestActorRuntime runtime;
+        runtime.Initialize(MakeTestRuntimeEgg());
+        runtime.SetScheduledEventsSelectorFunc(&TTestActorRuntimeBase::CollapsedTimeScheduledEventsSelector);
+
+        const TActorId edge = runtime.AllocateEdgeActor();
+        const TActorId actor = runtime.Register(new TVirtualTimerActor(edge));
+        runtime.EnableScheduleForActor(actor);
+        runtime.Send(new IEventHandle(actor, edge, new TEvents::TEvPing));
+
+        const auto result = runtime.GrabEdgeEvent<TEvents::TEvWakeup>(edge, TDuration::Seconds(10));
+        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Tag, TDuration::Seconds(5).MicroSeconds());
+    }
+}
+
+} // namespace NKikimr::NBsQueue

--- a/ydb/core/blobstorage/backpressure/common_ut.cpp
+++ b/ydb/core/blobstorage/backpressure/common_ut.cpp
@@ -16,9 +16,10 @@ TTestActorRuntime::TEgg MakeTestRuntimeEgg() {
 
 class TVirtualTimerActor : public TActor<TVirtualTimerActor> {
 public:
-    explicit TVirtualTimerActor(TActorId replyTo)
+    TVirtualTimerActor(TActorId replyTo, double& passed)
         : TActor(&TVirtualTimerActor::StateFunc)
         , ReplyTo(replyTo)
+        , Passed(passed)
     {}
 
 private:
@@ -30,13 +31,15 @@ private:
                 break;
 
             case TEvents::TSystem::Wakeup:
-                Send(ReplyTo, new TEvents::TEvWakeup(TDuration::Seconds(Timer->Passed()).MicroSeconds()));
+                Passed = Timer->Passed();
+                Send(ReplyTo, new TEvents::TEvWakeup);
                 PassAway();
                 break;
         }
     }
 
     const TActorId ReplyTo;
+    double& Passed;
     TMaybe<TBSQueueTimer> Timer;
 };
 
@@ -61,12 +64,13 @@ Y_UNIT_TEST_SUITE(TBSQueueTimerTest) {
         runtime.SetScheduledEventsSelectorFunc(&TTestActorRuntimeBase::CollapsedTimeScheduledEventsSelector);
 
         const TActorId edge = runtime.AllocateEdgeActor();
-        const TActorId actor = runtime.Register(new TVirtualTimerActor(edge));
+        double passed = 0;
+        const TActorId actor = runtime.Register(new TVirtualTimerActor(edge, passed));
         runtime.EnableScheduleForActor(actor);
         runtime.Send(new IEventHandle(actor, edge, new TEvents::TEvPing));
 
-        const auto result = runtime.GrabEdgeEvent<TEvents::TEvWakeup>(edge, TDuration::Seconds(10));
-        UNIT_ASSERT_VALUES_EQUAL(result->Get()->Tag, TDuration::Seconds(5).MicroSeconds());
+        runtime.GrabEdgeEvent<TEvents::TEvWakeup>(edge, TDuration::Seconds(10));
+        UNIT_ASSERT_DOUBLES_EQUAL(passed, 5.0, 1e-5);
     }
 }
 

--- a/ydb/core/blobstorage/backpressure/ut/ya.make
+++ b/ydb/core/blobstorage/backpressure/ut/ya.make
@@ -9,9 +9,11 @@ PEERDIR(
     library/cpp/svnversion
     ydb/core/base
     ydb/core/blobstorage/dsproxy/mock
+    ydb/core/testlib/actors
 )
 
 SRCS(
+    common_ut.cpp
     queue_backpressure_client_ut.cpp
     queue_backpressure_server_ut.cpp
 )


### PR DESCRIPTION
### Description for reviewers 

Store the timer source and raw start timestamp directly in TBSQueueTimer. The source is fixed per queue, so this avoids `std::visit` dispatch on every `Passed()` call while preserving virtual actor-system time in tests.

Related to https://github.com/ydb-platform/ydb/issues/49294
