### PR TITLE
Introduce chunk reserve for static group in PDisk

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -811,24 +811,62 @@ private:
         // the log, which is a way more dangerous kind of starvation
         const i64 maxTotal = Params.SeparateCommonLog ? pool * (i64)Params.StaticGroupChunkReservePerMille / 1000 : 0;
 
+        TStackVec<i64, 8> desired(StaticOwners.size());
         i64 desiredTotal = 0;
-        for (const TStaticOwnerInfo &info : StaticOwners) {
-            desiredTotal += GetDesiredStaticReserve(info);
+        for (size_t idx = 0; idx < StaticOwners.size(); ++idx) {
+            desired[idx] = GetDesiredStaticReserve(StaticOwners[idx]);
+            desiredTotal += desired[idx];
+        }
+        if (desiredTotal > maxTotal) {
+            for (i64 &value : desired) {
+                value = value * maxTotal / desiredTotal;
+            }
+        }
+
+        // Give back everything that is not needed anymore before taking anything. Otherwise a reserve that has to
+        // grow is limited by the free space of the shared quota while the space it needs is still held by another
+        // owner of the very same list, and the surplus released later in the pass is left for the dynamic owners
+        // to grab.
+        for (size_t idx = 0; idx < StaticOwners.size(); ++idx) {
+            ShrinkStaticReserve(StaticOwners[idx].OwnerId, desired[idx]);
+        }
+
+        i64 deficitTotal = 0;
+        for (size_t idx = 0; idx < StaticOwners.size(); ++idx) {
+            deficitTotal += GetStaticReserveDeficit(StaticOwners[idx].OwnerId, desired[idx]);
+        }
+        if (deficitTotal) {
+            const i64 available = Max<i64>(SharedQuota->GetFree(), 0);
+            if (deficitTotal > available) {
+                // There is not enough space for everybody, split it proportionally to what each owner is missing,
+                // so that the first owner of the list can not take it all
+                for (size_t idx = 0; idx < StaticOwners.size(); ++idx) {
+                    GrowStaticReserve(StaticOwners[idx].OwnerId,
+                            GetStaticReserveDeficit(StaticOwners[idx].OwnerId, desired[idx]) * available / deficitTotal);
+                }
+            }
+            // Either every deficit fits into the shared quota, or these are the few chunks lost to the rounding above
+            for (size_t idx = 0; idx < StaticOwners.size(); ++idx) {
+                GrowStaticReserve(StaticOwners[idx].OwnerId,
+                        GetStaticReserveDeficit(StaticOwners[idx].OwnerId, desired[idx]));
+            }
         }
 
         IsStaticReserveDirty = false;
-        for (ui64 idx = 0; idx < StaticOwners.size();) {
+        for (size_t idx = 0; idx < StaticOwners.size();) {
             const TStaticOwnerInfo &info = StaticOwners[idx];
-            i64 desired = GetDesiredStaticReserve(info);
-            if (desiredTotal > maxTotal) {
-                desired = desired * maxTotal / desiredTotal;
+            const i64 current = StaticReserve->GetHardLimit(info.OwnerId);
+            if (current != desired[idx]) {
+                // There was not enough free space in the shared quota for the whole reserve, try again as soon as
+                // some chunks are released
+                IsStaticReserveDirty = true;
             }
-            SetStaticReserve(info.OwnerId, desired);
-
-            if (!info.IsActive && StaticReserve->GetHardLimit(info.OwnerId) == 0) {
+            if (!info.IsActive && current == 0) {
                 StaticReserve->RemoveReserveOwner(info.OwnerId);
                 StaticOwners[idx] = StaticOwners.back();
                 StaticOwners.pop_back();
+                desired[idx] = desired.back();
+                desired.pop_back();
             } else {
                 ++idx;
             }
@@ -839,29 +877,28 @@ private:
         return info.IsActive ? OwnerQuota->GetHardLimit(info.OwnerId) : 0;
     }
 
-    // Moves chunks between the shared quota and the private reserve of a static group owner. Neither of the two is
-    // ever left with negative free space, so an overused disk just gets a smaller reserve, and the reserve grows
-    // back as soon as the chunks are released.
-    void SetStaticReserve(TOwner owner, i64 desired) {
+    i64 GetStaticReserveDeficit(TOwner owner, i64 desired) const {
+        return Max<i64>(desired - StaticReserve->GetHardLimit(owner), 0);
+    }
+
+    // Returns the unused part of a reserve to the shared quota. The reserve is never left with negative free space,
+    // so a reserve the owner still holds chunks of shrinks only as those chunks are released.
+    void ShrinkStaticReserve(TOwner owner, i64 desired) {
         const i64 current = StaticReserve->GetHardLimit(owner);
-        i64 granted = current;
-        if (desired > current) {
-            const i64 increment = Min(desired - current, Max<i64>(SharedQuota->GetFree(), 0));
-            if (increment) {
-                granted = current + increment;
-                SharedQuota->ForceHardLimit(SharedQuota->GetHardLimit() - increment, ChunkLimits);
-                StaticReserve->ForceHardLimit(owner, granted);
-            }
-        } else if (desired < current) {
-            const i64 decrement = Min(current - desired, Max<i64>(StaticReserve->GetFree(owner), 0));
-            if (decrement) {
-                granted = current - decrement;
-                StaticReserve->ForceHardLimit(owner, granted);
-                SharedQuota->ForceHardLimit(SharedQuota->GetHardLimit() + decrement, ChunkLimits);
-            }
+        const i64 decrement = Min(current - desired, Max<i64>(StaticReserve->GetFree(owner), 0));
+        if (decrement > 0) {
+            StaticReserve->ForceHardLimit(owner, current - decrement);
+            SharedQuota->ForceHardLimit(SharedQuota->GetHardLimit() + decrement, ChunkLimits);
         }
-        if (granted != desired) {
-            IsStaticReserveDirty = true;
+    }
+
+    // Takes free space of the shared quota into a reserve. The shared quota is never left with negative free space,
+    // so an overused disk just gets a smaller reserve, and the reserve grows as soon as the chunks are released.
+    void GrowStaticReserve(TOwner owner, i64 increment) {
+        increment = Min(increment, Max<i64>(SharedQuota->GetFree(), 0));
+        if (increment > 0) {
+            SharedQuota->ForceHardLimit(SharedQuota->GetHardLimit() - increment, ChunkLimits);
+            StaticReserve->ForceHardLimit(owner, StaticReserve->GetHardLimit(owner) + increment);
         }
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -155,12 +155,37 @@ public:
         return inc;
     }
 
+    // Registers an owner with an externally managed quota, i.e. without redistributing Total between the owners.
+    void AddReserveOwner(TOwner id, TVDiskID vdiskId, TString name) {
+        TQuotaRecord &record = QuotaForOwner[id];
+        Y_VERIFY(record.GetHardLimit() == 0);
+        Y_VERIFY(record.GetFree() == 0);
+        record.SetName(name);
+        record.SetVDiskId(vdiskId);
+        ActiveOwnerIds.push_back(id);
+    }
+
+    void RemoveReserveOwner(TOwner id) {
+        for (ui64 idx = 0; idx < ActiveOwnerIds.size(); ++idx) {
+            if (ActiveOwnerIds[idx] == id) {
+                ActiveOwnerIds[idx] = ActiveOwnerIds.back();
+                ActiveOwnerIds.pop_back();
+                break;
+            }
+        }
+        QuotaForOwner[id] = TQuotaRecord{};
+    }
+
     i64 GetHardLimit(TOwner id) const {
         return QuotaForOwner[id].GetHardLimit();
     }
 
     i64 GetFree(TOwner id) const {
         return QuotaForOwner[id].GetFree();
+    }
+
+    i64 GetAllocatableFree(TOwner id) const {
+        return QuotaForOwner[id].GetAllocatableFree();
     }
 
     i64 GetUsed(TOwner id) const {
@@ -278,11 +303,28 @@ class TChunkTracker {
 
 using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
 
+    struct TStaticOwnerInfo {
+        TOwner OwnerId;
+        // Becomes false when the owner is removed while it still holds chunks of its reserve. Such a reserve is
+        // returned to the shared quota as the chunks are released.
+        bool IsActive;
+    };
+
     THolder<TPerOwnerQuotaTracker> GlobalQuota;
     THolder<TQuotaRecord> SharedQuota;
     THolder<TPerOwnerQuotaTracker> OwnerQuota;
+    // Private chunk reserve of each static group owner, carved out of SharedQuota
+    THolder<TPerOwnerQuotaTracker> StaticReserve;
+    TStackVec<TStaticOwnerInfo, 8> StaticOwners;
     TKeeperParams Params;
     TColorLimits ColorLimits;
+    TColorLimits ChunkLimits;
+
+    // Set while the reserve of some owner differs from the desired one, i.e. while there is a reason to recalculate
+    // the reserve as soon as chunks are released
+    bool IsStaticReserveDirty = false;
+    // Set while Reset is replaying the initial allocations, those must be done against the whole chunk pool
+    bool IsStaticReserveSuppressed = false;
 
     TColor::E ColorBorder = NKikimrBlobStorage::TPDiskSpaceColor::GREEN;
     double ColorBorderOccupancy = 0;
@@ -302,6 +344,7 @@ public:
         : GlobalQuota(new TPerOwnerQuotaTracker())
         , SharedQuota(new TQuotaRecord())
         , OwnerQuota(new TPerOwnerQuotaTracker())
+        , StaticReserve(new TPerOwnerQuotaTracker())
     {}
 
     bool Reset(const TKeeperParams &params, const TColorLimits &limits, TString &outErrorReason) {
@@ -364,9 +407,17 @@ public:
 
         SharedQuota->SetName("SharedQuota");
         TColorLimits chunkLimits = TColorLimits::MakeChunkLimits(params.ChunkBaseLimit);
+        ChunkLimits = chunkLimits;
         SharedQuota->ForceHardLimit(GlobalQuota->GetHardLimit(OwnerBeginUser), chunkLimits);
         OwnerQuota->Reset(GlobalQuota->GetHardLimit(OwnerBeginUser), chunkLimits);
         OwnerQuota->SetExpectedOwnerSettings(params.ExpectedOwnerCount, params.ExpectedOwnerSize);
+
+        // The initial allocations below must be replayed against the whole chunk pool, the reserve of the static
+        // group owners is carved out of the free space that is left after that.
+        StaticReserve->Reset(0, chunkLimits);
+        StaticOwners.clear();
+        IsStaticReserveDirty = false;
+        IsStaticReserveSuppressed = true;
 
         for (auto& [ownerId, ownerInfo] : params.OwnersInfo) {
             i64 chunks = ownerInfo.ChunksOwned;
@@ -397,22 +448,37 @@ public:
 
         ColorBorder = params.SpaceColorBorder;
         ColorBorderOccupancy = OwnerQuota->GetOccupancyForColor(ColorBorder);
+
+        IsStaticReserveSuppressed = false;
+        RecomputeStaticReserve();
         return true;
     }
 
     void AddOwner(TOwner owner, TVDiskID vdiskId, ui32 weight = 1) {
         Y_VERIFY(IsOwnerUser(owner));
         OwnerQuota->AddOwner(owner, vdiskId, weight);
+        if (IsStaticGroupVDisk(vdiskId)) {
+            StaticReserve->AddReserveOwner(owner, vdiskId, TStringBuilder() << "StaticReserve Owner# " << owner);
+            StaticOwners.push_back({.OwnerId = owner, .IsActive = true});
+        }
+        RecomputeStaticReserve();
     }
 
     void SetOwnerWeight(TOwner owner, ui32 weight) {
         Y_VERIFY(IsOwnerUser(owner));
         OwnerQuota->SetOwnerWeight(owner, weight);
+        RecomputeStaticReserve();
     }
 
     void RemoveOwner(TOwner owner) {
         Y_VERIFY(IsOwnerUser(owner));
+        for (TStaticOwnerInfo &info : StaticOwners) {
+            if (info.OwnerId == owner) {
+                info.IsActive = false;
+            }
+        }
         OwnerQuota->RemoveOwner(owner);
+        RecomputeStaticReserve();
     }
 
     ui32 GetOwnerWeight(TOwner owner) {
@@ -454,23 +520,35 @@ public:
         return OwnerQuota->GetUsed(owner);
     }
 
+    // Private chunk reserve of a static group owner, 0 for all the other owners
+    i64 GetOwnerStaticReserve(TOwner owner) const {
+        return StaticReserve->GetHardLimit(owner);
+    }
+
+    i64 GetOwnerStaticReserveUsed(TOwner owner) const {
+        return StaticReserve->GetUsed(owner);
+    }
+
     i64 GetLogChunkCount() const {
         return GlobalQuota->GetUsed(OwnerSystem);
     }
 
     /////////////////////////////////////////////////////
     // for used space monitoring
+    // The reserve of the static group owners is a part of the user chunk pool, so it is included into the disk-wide
+    // numbers below
     i64 GetTotalUsed() const {
-        return SharedQuota->GetUsed();
+        return SharedQuota->GetUsed() + GetStaticReserveUsed();
     }
 
     i64 GetTotalHardLimit() const {
-        return SharedQuota->GetHardLimit();
+        return SharedQuota->GetHardLimit() + GetStaticReserveHardLimit();
     }
 
     TColor::E GetPDiskCapacityAlert() const {
         double occupancy;
-        TColor::E sharedColor = SharedQuota->EstimateSpaceColor(0, &occupancy);
+        TColor::E sharedColor = NPDisk::EstimateSpaceColor(ChunkLimits, SharedQuota->GetFree() + GetStaticReserveFree(),
+                GetTotalHardLimit(), &occupancy);
         if (Params.SeparateCommonLog) {
             TColor::E commonLogColor = GlobalQuota->EstimateSpaceColor(OwnerSystem, 0, &occupancy);
             return Max(sharedColor, commonLogColor);
@@ -483,7 +561,8 @@ public:
     i64 GetOwnerFree(TOwner owner, bool personal) const {
         if (IsOwnerUser(owner)) {
             // See CLOUDINC-1822: OwnerQuota->GetFree(owner) broke group balancing in Hive and was replaced by SharedQuota
-            return personal ? OwnerQuota->GetFree(owner) : SharedQuota->GetFree();
+            // A static group owner can also allocate from its private reserve
+            return personal ? OwnerQuota->GetFree(owner) : SharedQuota->GetFree() + StaticReserve->GetFree(owner);
         } else {
             switch (owner) {
                 case OwnerCommonStaticLog:
@@ -518,12 +597,22 @@ public:
     // Estimate status flags after allocation of allocatinoSize
     TColor::E EstimateSpaceColor(TOwner owner, i64 allocationSize, double *occupancy) const {
         if (IsOwnerUser(owner)) {
-            double ownerOccupancy, sharedOccupancy;
+            double ownerOccupancy, poolOccupancy;
+            TColor::E poolColor;
+            if (HasStaticReserve(owner)) {
+                // A static group owner allocates from the shared quota and from its private reserve, both of them
+                // make up the pool it sees
+                poolColor = NPDisk::EstimateSpaceColor(ChunkLimits,
+                        SharedQuota->GetFree() + StaticReserve->GetFree(owner) - allocationSize,
+                        SharedQuota->GetHardLimit() + StaticReserve->GetHardLimit(owner), &poolOccupancy);
+            } else {
+                poolColor = SharedQuota->EstimateSpaceColor(allocationSize, &poolOccupancy);
+            }
             TColor::E ret = Min(ColorBorder, OwnerQuota->EstimateSpaceColor(owner, allocationSize, &ownerOccupancy));
-            ret = Max(ret, SharedQuota->EstimateSpaceColor(allocationSize, &sharedOccupancy));
+            ret = Max(ret, poolColor);
             *occupancy = Max(
                 Min(ColorBorderOccupancy, ownerOccupancy), // owner occupancy can't exceed its color border top value
-                sharedOccupancy
+                poolOccupancy
             );
             return ret;
         } else {
@@ -562,6 +651,16 @@ public:
             if (SharedQuota->TryAllocate(count, outErrorReason)) {
                 return true;
             }
+            // A static group owner takes what is left in the shared quota and the rest from its private reserve
+            if (HasStaticReserve(owner)) {
+                i64 fromShared = SharedQuota->GetAllocatableFree();
+                if (StaticReserve->TryAllocate(owner, count - fromShared, outErrorReason)) {
+                    if (fromShared == 0 || SharedQuota->TryAllocate(fromShared, outErrorReason)) {
+                        return true;
+                    }
+                    StaticReserve->Release(owner, count - fromShared);
+                }
+            }
             OwnerQuota->Release(owner, count);
             return false;
         } else {
@@ -596,7 +695,19 @@ public:
     void Release(TOwner owner, i64 count) {
         if (IsOwnerUser(owner)) {
             OwnerQuota->Release(owner, count);
-            SharedQuota->Release(count);
+            // Refill the private reserve of the static group owner first to restore its protection
+            i64 usedReserve = StaticReserve->GetUsed(owner);
+            i64 releaseReserve = Min(usedReserve, count);
+            if (releaseReserve) {
+                StaticReserve->Release(owner, releaseReserve);
+            }
+            i64 releaseShared = count - releaseReserve;
+            if (releaseShared) {
+                SharedQuota->Release(releaseShared);
+            }
+            if (IsStaticReserveDirty) {
+                RecomputeStaticReserve();
+            }
         } else {
             switch (owner) {
                 case OwnerCommonStaticLog:
@@ -631,6 +742,10 @@ public:
         GlobalQuota->PrintHTML(str, nullptr, nullptr, nullptr);
         str << "<h4>OwnerQuota</h4>";
         OwnerQuota->PrintHTML(str, SharedQuota.Get(), &ColorBorder, &ColorBorderOccupancy);
+        if (!StaticOwners.empty()) {
+            str << "<h4>StaticReserve</h4>";
+            StaticReserve->PrintHTML(str, nullptr, nullptr, nullptr);
+        }
     }
 
     ui32 ColorFlagLimit(TOwner owner, NKikimrBlobStorage::TPDiskSpaceColor::E color) const {
@@ -656,22 +771,126 @@ public:
     void SetExpectedOwnerCount(size_t newOwnerCount) {
         Params.ExpectedOwnerCount = newOwnerCount;
         OwnerQuota->SetExpectedOwnerCount(newOwnerCount);
+        RecomputeStaticReserve();
     }
 
     void SetExpectedOwnerSize(i64 newOwnerSize) {
         Params.ExpectedOwnerSize = newOwnerSize;
         OwnerQuota->SetExpectedOwnerSize(newOwnerSize);
+        RecomputeStaticReserve();
     }
 
     void SetExpectedOwnerSettings(size_t newOwnerCount, i64 newOwnerSize) {
         Params.ExpectedOwnerCount = newOwnerCount;
         Params.ExpectedOwnerSize = newOwnerSize;
         OwnerQuota->SetExpectedOwnerSettings(newOwnerCount, newOwnerSize);
+        RecomputeStaticReserve();
     }
 
     void SetColorBorder(NKikimrBlobStorage::TPDiskSpaceColor::E colorBorder) {
         ColorBorder = colorBorder;
         ColorBorderOccupancy = OwnerQuota->GetOccupancyForColor(ColorBorder);
+    }
+
+    void SetStaticGroupChunkReservePerMille(ui32 perMille) {
+        Params.StaticGroupChunkReservePerMille = perMille;
+        RecomputeStaticReserve();
+    }
+
+private:
+    // A static group owner must keep working even when its neighbours from dynamic groups have eaten the whole
+    // shared quota, otherwise the tablets living in the static group take the whole cluster down. Each of them gets
+    // a private chunk reserve of its personal quota size, carved out of the shared quota.
+    void RecomputeStaticReserve() {
+        if (IsStaticReserveSuppressed || StaticOwners.empty()) {
+            return;
+        }
+
+        const i64 pool = GlobalQuota->GetHardLimit(OwnerBeginUser);
+        // On a disk where the common log shares the chunk pool with the owners a reserve would be taken away from
+        // the log, which is a way more dangerous kind of starvation
+        const i64 maxTotal = Params.SeparateCommonLog ? pool * (i64)Params.StaticGroupChunkReservePerMille / 1000 : 0;
+
+        i64 desiredTotal = 0;
+        for (const TStaticOwnerInfo &info : StaticOwners) {
+            desiredTotal += GetDesiredStaticReserve(info);
+        }
+
+        IsStaticReserveDirty = false;
+        for (ui64 idx = 0; idx < StaticOwners.size();) {
+            const TStaticOwnerInfo &info = StaticOwners[idx];
+            i64 desired = GetDesiredStaticReserve(info);
+            if (desiredTotal > maxTotal) {
+                desired = desired * maxTotal / desiredTotal;
+            }
+            SetStaticReserve(info.OwnerId, desired);
+
+            if (!info.IsActive && StaticReserve->GetHardLimit(info.OwnerId) == 0) {
+                StaticReserve->RemoveReserveOwner(info.OwnerId);
+                StaticOwners[idx] = StaticOwners.back();
+                StaticOwners.pop_back();
+            } else {
+                ++idx;
+            }
+        }
+    }
+
+    i64 GetDesiredStaticReserve(const TStaticOwnerInfo &info) const {
+        return info.IsActive ? OwnerQuota->GetHardLimit(info.OwnerId) : 0;
+    }
+
+    // Moves chunks between the shared quota and the private reserve of a static group owner. Neither of the two is
+    // ever left with negative free space, so an overused disk just gets a smaller reserve, and the reserve grows
+    // back as soon as the chunks are released.
+    void SetStaticReserve(TOwner owner, i64 desired) {
+        const i64 current = StaticReserve->GetHardLimit(owner);
+        i64 granted = current;
+        if (desired > current) {
+            const i64 increment = Min(desired - current, Max<i64>(SharedQuota->GetFree(), 0));
+            if (increment) {
+                granted = current + increment;
+                SharedQuota->ForceHardLimit(SharedQuota->GetHardLimit() - increment, ChunkLimits);
+                StaticReserve->ForceHardLimit(owner, granted);
+            }
+        } else if (desired < current) {
+            const i64 decrement = Min(current - desired, Max<i64>(StaticReserve->GetFree(owner), 0));
+            if (decrement) {
+                granted = current - decrement;
+                StaticReserve->ForceHardLimit(owner, granted);
+                SharedQuota->ForceHardLimit(SharedQuota->GetHardLimit() + decrement, ChunkLimits);
+            }
+        }
+        if (granted != desired) {
+            IsStaticReserveDirty = true;
+        }
+    }
+
+    bool HasStaticReserve(TOwner owner) const {
+        return StaticReserve->GetHardLimit(owner) > 0;
+    }
+
+    i64 GetStaticReserveHardLimit() const {
+        i64 total = 0;
+        for (const TStaticOwnerInfo &info : StaticOwners) {
+            total += StaticReserve->GetHardLimit(info.OwnerId);
+        }
+        return total;
+    }
+
+    i64 GetStaticReserveUsed() const {
+        i64 total = 0;
+        for (const TStaticOwnerInfo &info : StaticOwners) {
+            total += StaticReserve->GetUsed(info.OwnerId);
+        }
+        return total;
+    }
+
+    i64 GetStaticReserveFree() const {
+        i64 total = 0;
+        for (const TStaticOwnerInfo &info : StaticOwners) {
+            total += StaticReserve->GetFree(info.OwnerId);
+        }
+        return total;
     }
 };
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
@@ -57,6 +57,7 @@ constexpr ui64 SmallDiskSizeLogBoundary = 200ull * (1 << 30);
 constexpr ui64 TinyDiskSizeLogBoundary = 8ull * (1 << 30);
 constexpr i64 MaxCommonLogChunks = 200; // default, can also be set from ICB
 constexpr i64 CommonStaticLogChunks = 70; // default, can also be set from ICB
+constexpr ui32 StaticGroupChunkReservePerMille = 500; // default, can also be set from ICB
 constexpr i64 TinyDiskMaxCommonLogChunks = 20;
 constexpr i64 TinyDiskCommonStaticLogChunks = 5;
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "defs.h"
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/blobstorage_tablet_types.h>
+#include <ydb/core/blobstorage/base/blobstorage_vdiskid.h>
 #include <ydb/core/blobstorage/crypto/default.h>
 #include <ydb/core/protos/blobstorage_base.pb.h>
 
@@ -72,6 +74,13 @@ namespace NKikimr {
                 , OwnerRound(ownerRound)
             {}
         };
+
+        inline bool IsStaticGroupVDisk(const TVDiskID &vdiskId) {
+            if (vdiskId == TVDiskID::InvalidId) {
+                return false;
+            }
+            return TGroupID(vdiskId.GroupID).ConfigurationType() == EGroupConfigurationType::Static;
+        }
 
         // using TLogPosition = std::pair<TChunkIdx, ui32>;
         struct TLogPosition {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -79,6 +79,10 @@ TPDisk::TPDisk(std::shared_ptr<TPDiskCtx> pCtx, const TIntrusivePtr<TPDiskConfig
     // 2 - YellowStop
     SemiStrictSpaceIsolation = TControlWrapper(0, 0, 2);
     SemiStrictSpaceIsolationCached = 0;
+
+    // Upper bound for the chunk reserve of the static group owners, in permille of the user chunk pool
+    StaticGroupChunkReservePerMille = TControlWrapper(NPDisk::StaticGroupChunkReservePerMille, 0, 1000);
+    StaticGroupChunkReservePerMilleCached = StaticGroupChunkReservePerMille;
     ForcedPDiskSpaceColor = TControlWrapper(0, 0, 60);
 
     if (Cfg->SectorMap) {
@@ -3118,6 +3122,8 @@ bool TPDisk::Initialize() {
             TControlBoard::RegisterSharedControl(UseNoopSchedulerSSD, icb->PDiskControls.UseNoopSchedulerSSD);
             REGISTER_LOCAL_CONTROL(ChunkBaseLimitPerMille);
             TControlBoard::RegisterSharedControl(SemiStrictSpaceIsolation, icb->PDiskControls.SemiStrictSpaceIsolation);
+            TControlBoard::RegisterSharedControl(StaticGroupChunkReservePerMille,
+                    icb->PDiskControls.StaticGroupChunkReservePerMille);
             if (Cfg->FeatureFlags.GetEnablePDiskSpaceColorOverride()) {
                 REGISTER_LOCAL_CONTROL(ForcedPDiskSpaceColor);
             }
@@ -4253,6 +4259,11 @@ void TPDisk::Update() {
             TColor::E colorBorder = GetColorBorderIcb();
             Keeper.SetColorBorder(colorBorder);
             SemiStrictSpaceIsolationCached = currentIsolation;
+        }
+
+        if (i64 currentReserve = StaticGroupChunkReservePerMille; currentReserve != StaticGroupChunkReservePerMilleCached) {
+            Keeper.SetStaticGroupChunkReservePerMille(static_cast<ui32>(currentReserve));
+            StaticGroupChunkReservePerMilleCached = currentReserve;
         }
 
         if (!PDiskCategory.IsSolidState()) { // HDD

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -113,6 +113,8 @@ public:
     TControlWrapper ChunkBaseLimitPerMille;
     TControlWrapper SemiStrictSpaceIsolation;
     i64 SemiStrictSpaceIsolationCached = 0;
+    TControlWrapper StaticGroupChunkReservePerMille;
+    i64 StaticGroupChunkReservePerMilleCached = 0;
     TControlWrapper ForcedPDiskSpaceColor;
     NKikimrBlobStorage::TPDiskSpaceColor::E GetColorBorderIcb() {
         using TColor = NKikimrBlobStorage::TPDiskSpaceColor;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -1742,6 +1742,8 @@ void TPDisk::ProcessReadLogResult(const NPDisk::TEvReadLogResult &evReadLogResul
                 InitializeKeeperLogParams(params, Cfg, Format);
 
                 params.SpaceColorBorder = GetColorBorderIcb();
+                StaticGroupChunkReservePerMilleCached = StaticGroupChunkReservePerMille;
+                params.StaticGroupChunkReservePerMille = static_cast<ui32>(StaticGroupChunkReservePerMilleCached);
                 ui64 chunkBaseLimitIcb = ChunkBaseLimitPerMille;
                 if (chunkBaseLimitIcb) {
                     params.ChunkBaseLimit = std::clamp(chunkBaseLimitIcb,

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
@@ -227,6 +227,10 @@ public:
         ChunkTracker.SetColorBorder(colorBorder);
     }
 
+    void SetStaticGroupChunkReservePerMille(ui32 perMille) {
+        ChunkTracker.SetStaticGroupChunkReservePerMille(perMille);
+    }
+
     //
     // GUI
     //

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper_params.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper_params.h
@@ -55,6 +55,10 @@ struct TKeeperParams {
 
     // Free chunk permille that triggers Cyan color (e.g. 100 is 10%). Between 130 (default) and 13.
     ui32 ChunkBaseLimit = 130;
+
+    // Upper bound for the total chunk reserve of static group owners, in permille of the user chunk pool.
+    // 0 disables the reserve.
+    ui32 StaticGroupChunkReservePerMille = NPDisk::StaticGroupChunkReservePerMille;
 };
 
 } // NPDisk

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_quota_record.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_quota_record.h
@@ -113,6 +113,11 @@ public:
         return AtomicSub(Free, count) > AtomicGet(Black);
     }
 
+    // The largest count TryAllocate can satisfy right now
+    i64 GetAllocatableFree() const {
+        return Max<i64>(0, AtomicGet(Free) - AtomicGet(Black) - 1);
+    }
+
     // Called only from the main thread
     bool TryAllocate(i64 count, TString &outErrorReason) {
         Y_VERIFY(count > 0);
@@ -204,6 +209,48 @@ public:
         }
     }
 };
+
+// The same ladder as TQuotaRecord::EstimateSpaceColor, for a pool that is a sum of several quota records
+inline NKikimrBlobStorage::TPDiskSpaceColor::E EstimateSpaceColor(const TColorLimits &limits, i64 free, i64 hardLimit,
+        double *occupancy) {
+    using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+
+    if (hardLimit) {
+        *occupancy = (double)Max<i64>(0, hardLimit - free) / hardLimit;
+    } else {
+        *occupancy = 1.0;
+    }
+
+    i64 value = 0;
+    i64 border[8];
+    size_t idx = 0;
+#define CALCULATE_COLOR(NAME) \
+    value = Max(value, limits.NAME.CalculateQuota(hardLimit)); \
+    border[idx++] = value; \
+    ++value;
+    DISK_SPACE_COLORS(CALCULATE_COLOR)
+#undef CALCULATE_COLOR
+
+    if (free > border[7]) {
+        return TColor::GREEN;
+    } else if (free > border[6]) {
+        return TColor::CYAN;
+    } else if (free > border[5]) {
+        return TColor::LIGHT_YELLOW;
+    } else if (free > border[4]) {
+        return TColor::YELLOW;
+    } else if (free > border[3]) {
+        return TColor::LIGHT_ORANGE;
+    } else if (free > border[2]) {
+        return TColor::PRE_ORANGE;
+    } else if (free > border[1]) {
+        return TColor::ORANGE;
+    } else if (free > border[0]) {
+        return TColor::RED;
+    } else {
+        return TColor::BLACK;
+    }
+}
 
 } // NPDisk
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
@@ -2,6 +2,7 @@
 #include "defs.h"
 
 #include "blobstorage_pdisk.h"
+#include "blobstorage_pdisk_defs.h"
 #include "blobstorage_pdisk_logreader_base.h"
 #include "blobstorage_pdisk_tools.h"
 
@@ -110,10 +111,7 @@ struct TOwnerData {
     {}
 
     bool IsStaticGroupOwner() const {
-        if (VDiskId == TVDiskID::InvalidId) {
-            return false;
-        }
-        return TGroupID(VDiskId.GroupID).ConfigurationType() == EGroupConfigurationType::Static;
+        return IsStaticGroupVDisk(VDiskId);
     }
 
     bool IsNextLsnOk(const ui64 lsn) const {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -1889,6 +1889,13 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         auto pdiskConfig = testCtx.GetPDiskConfig();
         using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
         pdiskConfig->SpaceColorBorder = TColor::ORANGE;
+
+        // TVDiskMock creates VDisks of static groups, turn off their chunk reserve to measure the shared quota alone
+        TControlWrapper staticGroupChunkReservePerMille(0, 0, 1000);
+        TControlBoard::RegisterSharedControl(staticGroupChunkReservePerMille,
+                testCtx.GetRuntime()->GetAppData().Icb->PDiskControls.StaticGroupChunkReservePerMille);
+        staticGroupChunkReservePerMille = 0;
+
         testCtx.UpdateConfigRecreatePDisk(pdiskConfig);
         // The actual value of SharedQuota.HardLimit is initialized in TActorTestContext
         // with quite a complex formula. The value used here was obtained experimentally.
@@ -2105,6 +2112,46 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         UNIT_ASSERT_VALUES_EQUAL(expectedHardLimitChunks, 3u);
         UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->TotalChunks, expectedHardLimitChunks);
         UNIT_ASSERT_LE(ui64(evCheckSpaceResult->TotalChunks) * formatChunkSize, expectedSlotSize);
+    }
+
+    Y_UNIT_TEST(StaticGroupChunkReserve) {
+        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+
+        TActorTestContext testCtx({});
+
+        // TVDiskMock makes a group id with the top bit clear, i.e. a static group, unless asked otherwise
+        TVDiskMock staticVDisk(&testCtx);
+        TVDiskMock dynamicVDisk(&testCtx, true);
+        staticVDisk.InitFull();
+        dynamicVDisk.InitFull();
+
+        // Let the neighbour from the dynamic group take everything it can
+        ui32 dynamicChunks = 0;
+        for (;;) {
+            const auto reserveResult = testCtx.TestResponse<NPDisk::TEvChunkReserveResult>(
+                new NPDisk::TEvChunkReserve(dynamicVDisk.PDiskParams->Owner, dynamicVDisk.PDiskParams->OwnerRound, 1));
+            if (reserveResult->Status != NKikimrProto::OK) {
+                UNIT_ASSERT_VALUES_EQUAL(reserveResult->Status, NKikimrProto::OUT_OF_SPACE);
+                break;
+            }
+            ++dynamicChunks;
+        }
+        UNIT_ASSERT_GT(dynamicChunks, 0);
+
+        auto dynamicSpace = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
+            new NPDisk::TEvCheckSpace(dynamicVDisk.PDiskParams->Owner, dynamicVDisk.PDiskParams->OwnerRound),
+            NKikimrProto::OK);
+        UNIT_ASSERT_GE(StatusFlagToSpaceColor(dynamicSpace->StatusFlags), TColor::ORANGE);
+
+        // The VDisk of the static group keeps allocating and committing chunks and still reports free space
+        staticVDisk.ReserveChunk();
+        staticVDisk.CommitReservedChunks();
+
+        auto staticSpace = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
+            new NPDisk::TEvCheckSpace(staticVDisk.PDiskParams->Owner, staticVDisk.PDiskParams->OwnerRound),
+            NKikimrProto::OK);
+        UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(staticSpace->StatusFlags), TColor::GREEN);
+        UNIT_ASSERT_GT(staticSpace->FreeChunks, 0);
     }
 
     Y_UNIT_TEST(PDiskCapacityAlertWithFullCommonLog) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_chunk_tracker.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_chunk_tracker.cpp
@@ -18,6 +18,18 @@ namespace NKikimr {
 
 Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
 
+    static TVDiskID MakeVDiskId(EGroupConfigurationType type, ui32 groupLocalId) {
+        return TVDiskID(TGroupID(type, 1, groupLocalId).GetRaw(), 1, TVDiskIdShort(0, 0, 0));
+    }
+
+    static TVDiskID DynamicVDiskId(ui32 groupLocalId = 1) {
+        return MakeVDiskId(EGroupConfigurationType::Dynamic, groupLocalId);
+    }
+
+    static TVDiskID StaticVDiskId(ui32 groupLocalId = 1) {
+        return MakeVDiskId(EGroupConfigurationType::Static, groupLocalId);
+    }
+
     Y_UNIT_TEST(AddRemove) {
         using namespace NPDisk;
 
@@ -38,14 +50,14 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(OwnerSystemReserve), 5);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 60);
 
-        chunkTracker.AddOwner(101, TVDiskID());
+        chunkTracker.AddOwner(101, DynamicVDiskId());
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 30);
 
-        chunkTracker.AddOwner(102, TVDiskID());
+        chunkTracker.AddOwner(102, DynamicVDiskId());
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 30);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(102), 30);
 
-        chunkTracker.AddOwner(103, TVDiskID());
+        chunkTracker.AddOwner(103, DynamicVDiskId());
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 20);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(102), 20);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(103), 20);
@@ -81,7 +93,7 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_C(ok, errorReason);
 
         TOwner owner1 = NPDisk::EOwner::OwnerBeginUser + 1;
-        chunkTracker.AddOwner(owner1, TVDiskID());
+        chunkTracker.AddOwner(owner1, DynamicVDiskId());
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(owner1), 100);
 
@@ -94,7 +106,7 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_EQUAL_X(chunkTracker.EstimateSpaceColor(owner1, 1, &occupancy), TColor::LIGHT_YELLOW);
 
         TOwner owner2 = NPDisk::EOwner::OwnerBeginUser + 2;
-        chunkTracker.AddOwner(owner2, TVDiskID());
+        chunkTracker.AddOwner(owner2, DynamicVDiskId());
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(owner1), 50);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(owner2), 50);
 
@@ -123,14 +135,14 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_C(ok, errorReason);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 80);
 
-        chunkTracker.AddOwner(101, TVDiskID(), 1);
+        chunkTracker.AddOwner(101, DynamicVDiskId(), 1);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 20);
 
-        chunkTracker.AddOwner(102, TVDiskID(), 2);
+        chunkTracker.AddOwner(102, DynamicVDiskId(), 2);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 20);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(102), 40);
 
-        chunkTracker.AddOwner(103, TVDiskID(), 5);
+        chunkTracker.AddOwner(103, DynamicVDiskId(), 5);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 10);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(102), 20);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(103), 50);
@@ -148,7 +160,7 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         TString errorReason;
         UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 10);
-        chunkTracker.AddOwner(101, TVDiskID(), 1);
+        chunkTracker.AddOwner(101, DynamicVDiskId(), 1);
 
         // The owner quota is force-allocated before the shared quota check.
         // When the shared quota rejects the request, the owner quota accounting
@@ -178,10 +190,10 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_C(ok, errorReason);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
 
-        chunkTracker.AddOwner(101, TVDiskID(), 1);
+        chunkTracker.AddOwner(101, DynamicVDiskId(), 1);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 30);
 
-        chunkTracker.AddOwner(102, TVDiskID(), 2);
+        chunkTracker.AddOwner(102, DynamicVDiskId(), 2);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 30);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(102), 30);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerWeight(102), 1);
@@ -206,7 +218,7 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
 
         TString errorReason;
         UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
-        chunkTracker.AddOwner(101, TVDiskID(), 1);
+        chunkTracker.AddOwner(101, DynamicVDiskId(), 1);
 
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 30);
 
@@ -239,12 +251,170 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
 
         TString errorReason;
         UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
-        chunkTracker.AddOwner(101, TVDiskID(), 1);
+        chunkTracker.AddOwner(101, DynamicVDiskId(), 1);
         chunkTracker.SetExpectedOwnerSettings(4, 30);
 
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 30);
         UNIT_ASSERT_C(chunkTracker.TryAllocate(101, 28, errorReason), errorReason);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerUsed(101), 28);
+    }
+
+    Y_UNIT_TEST(StaticGroupOwnerUsesReserveWhenSharedQuotaIsExhausted) {
+        using namespace NPDisk;
+        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+
+        TChunkTracker chunkTracker;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 4,
+        };
+
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+
+        TOwner staticOwner = 101;
+        TOwner dynamicOwner = 102;
+        chunkTracker.AddOwner(staticOwner, StaticVDiskId());
+        chunkTracker.AddOwner(dynamicOwner, DynamicVDiskId());
+
+        // The reserve is the personal quota of the static group owner, carved out of the shared quota. The personal
+        // quota of the neighbours is not affected.
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 25);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(dynamicOwner), 0);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(dynamicOwner), 25);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+
+        // Let the neighbour from the dynamic group eat the whole shared quota
+        while (chunkTracker.TryAllocate(dynamicOwner, 1, errorReason)) {
+        }
+
+        // The static group owner keeps working and does not report the shared quota exhaustion
+        double occupancy;
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetSpaceColor(staticOwner, &occupancy), TColor::GREEN);
+        UNIT_ASSERT_C(chunkTracker.TryAllocate(staticOwner, 20, errorReason), errorReason);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerUsed(staticOwner), 20);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserveUsed(staticOwner), 20);
+
+        // Once the reserve is used up the static group owner is stopped as well
+        while (chunkTracker.TryAllocate(staticOwner, 1, errorReason)) {
+        }
+        UNIT_ASSERT(chunkTracker.GetSpaceColor(staticOwner, &occupancy) >= TColor::ORANGE);
+    }
+
+    Y_UNIT_TEST(StaticGroupReserveIsRefilledBeforeSharedQuota) {
+        using namespace NPDisk;
+
+        TChunkTracker chunkTracker;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 4,
+        };
+
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+
+        TOwner staticOwner = 101;
+        TOwner dynamicOwner = 102;
+        chunkTracker.AddOwner(staticOwner, StaticVDiskId());
+        chunkTracker.AddOwner(dynamicOwner, DynamicVDiskId());
+
+        // Allocate a chunk from the shared quota, then exhaust it and take one more chunk from the reserve
+        UNIT_ASSERT_C(chunkTracker.TryAllocate(staticOwner, 1, errorReason), errorReason);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserveUsed(staticOwner), 0);
+        while (chunkTracker.TryAllocate(dynamicOwner, 1, errorReason)) {
+        }
+        UNIT_ASSERT_C(chunkTracker.TryAllocate(staticOwner, 1, errorReason), errorReason);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserveUsed(staticOwner), 1);
+
+        // The reserve must be restored first, so that the protection is available for the next allocation
+        chunkTracker.Release(staticOwner, 2);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserveUsed(staticOwner), 0);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerUsed(staticOwner), 0);
+    }
+
+    Y_UNIT_TEST(StaticGroupReserveFollowsPersonalQuota) {
+        using namespace NPDisk;
+
+        TChunkTracker chunkTracker;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 4,
+        };
+
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+
+        TOwner staticOwner = 101;
+        chunkTracker.AddOwner(staticOwner, StaticVDiskId());
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 25);
+
+        chunkTracker.SetOwnerWeight(staticOwner, 2);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 50);
+
+        chunkTracker.SetExpectedOwnerSettings(2, 0);
+        chunkTracker.SetOwnerWeight(staticOwner, 1);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 50);
+
+        chunkTracker.SetExpectedOwnerSettings(4, 10);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 10);
+
+        // The whole reserve is returned to the shared quota when the owner is gone
+        chunkTracker.RemoveOwner(staticOwner);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 0);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerFree(staticOwner, false), 100);
+    }
+
+    Y_UNIT_TEST(StaticGroupReserveGrowsAsChunksAreReleased) {
+        using namespace NPDisk;
+
+        TChunkTracker chunkTracker;
+        TOwner staticOwner = 101;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 4,
+        };
+        params.OwnersInfo[staticOwner] = {
+            .ChunksOwned = 95,
+            .VDiskId = StaticVDiskId(),
+            .Weight = 1,
+        };
+
+        // An overused disk must start up, the reserve is just smaller than the personal quota
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 5);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+
+        chunkTracker.Release(staticOwner, 20);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 25);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+    }
+
+    Y_UNIT_TEST(StaticGroupReserveIsCappedAndCanBeDisabled) {
+        using namespace NPDisk;
+
+        TChunkTracker chunkTracker;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 0,
+        };
+
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+
+        // The only owner of the disk has the whole pool as its personal quota, the cap keeps the shared quota alive
+        TOwner staticOwner = 101;
+        chunkTracker.AddOwner(staticOwner, StaticVDiskId());
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(staticOwner), 100);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 50);
+
+        chunkTracker.SetStaticGroupChunkReservePerMille(100);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 10);
+
+        chunkTracker.SetStaticGroupChunkReservePerMille(0);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(staticOwner), 0);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
     }
 
     Y_UNIT_TEST(ZeroWeight) {
@@ -263,7 +433,7 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_C(ok, errorReason);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 50);
 
-        chunkTracker.AddOwner(101, TVDiskID(), 1);
+        chunkTracker.AddOwner(101, DynamicVDiskId(), 1);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetNumActiveSlots(), 1);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 50);
 
@@ -272,7 +442,7 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetNumActiveSlots(), 1);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 50);
 
-        chunkTracker.AddOwner(102, TVDiskID(), 0);
+        chunkTracker.AddOwner(102, DynamicVDiskId(), 0);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetNumActiveSlots(), 2);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(101), 25);
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(102), 25);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_chunk_tracker.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_chunk_tracker.cpp
@@ -391,6 +391,82 @@ Y_UNIT_TEST_SUITE(TChunkTrackerTest) {
         UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
     }
 
+    Y_UNIT_TEST(StaticGroupReservesAreRebalancedWhenSharedQuotaIsFull) {
+        using namespace NPDisk;
+
+        TChunkTracker chunkTracker;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 4,
+        };
+
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+
+        TOwner firstStatic = 101;
+        TOwner secondStatic = 102;
+        TOwner dynamicOwner = 103;
+        chunkTracker.AddOwner(firstStatic, StaticVDiskId(1));
+        chunkTracker.AddOwner(secondStatic, StaticVDiskId(2));
+        chunkTracker.AddOwner(dynamicOwner, DynamicVDiskId(3));
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(firstStatic), 25);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(secondStatic), 25);
+
+        // Leave the shared quota with no free space at all
+        while (chunkTracker.TryAllocate(dynamicOwner, 1, errorReason)) {
+        }
+
+        // The first owner needs a bigger reserve while the second one has a surplus. The surplus must reach the
+        // reserve of the first owner instead of being left in the shared quota for the dynamic owner to grab,
+        // no matter which of the two comes first in the list
+        chunkTracker.SetOwnerWeight(firstStatic, 3);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(firstStatic), 60);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerHardLimit(secondStatic), 20);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(firstStatic), 37);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(secondStatic), 12);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+
+        // The rebalanced reserve is usable right away, while the dynamic owner is still holding the shared quota
+        UNIT_ASSERT_C(chunkTracker.TryAllocate(firstStatic, 30, errorReason), errorReason);
+    }
+
+    Y_UNIT_TEST(StaticGroupReserveDeficitIsSplitBetweenOwners) {
+        using namespace NPDisk;
+
+        TChunkTracker chunkTracker;
+        TOwner firstStatic = 101;
+        TOwner secondStatic = 102;
+        TKeeperParams params {
+            .TotalChunks = 205 /*system*/ + 100,
+            .ExpectedOwnerCount = 4,
+        };
+        params.OwnersInfo[firstStatic] = {
+            .ChunksOwned = 45,
+            .VDiskId = StaticVDiskId(1),
+            .Weight = 1,
+        };
+        params.OwnersInfo[secondStatic] = {
+            .ChunksOwned = 45,
+            .VDiskId = StaticVDiskId(2),
+            .Weight = 1,
+        };
+
+        TString errorReason;
+        UNIT_ASSERT_C(chunkTracker.Reset(params, TColorLimits::MakeLogLimits(), errorReason), errorReason);
+
+        // Both owners are 25 chunks short while only 10 chunks of the pool are free, the free space is split
+        // between them instead of being given away to the first owner of the list
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(firstStatic), 5);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(secondStatic), 5);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+
+        // The reserves keep growing evenly as the chunks are released
+        chunkTracker.Release(firstStatic, 20);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(firstStatic), 15);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetOwnerStaticReserve(secondStatic), 15);
+        UNIT_ASSERT_EQUAL_X(chunkTracker.GetTotalHardLimit(), 100);
+    }
+
     Y_UNIT_TEST(StaticGroupReserveIsCappedAndCanBeDisabled) {
         using namespace NPDisk;
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_color_limits.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_color_limits.cpp
@@ -177,8 +177,10 @@ Y_UNIT_TEST_SUITE(TColorLimitsTest) {
             TOwner owner1 = NPDisk::EOwner::OwnerBeginUser + 1;
             TOwner owner2 = NPDisk::EOwner::OwnerBeginUser + 2;
 
-            chunkTracker.AddOwner(owner1, TVDiskID());
-            chunkTracker.AddOwner(owner2, TVDiskID());
+            TVDiskID vdiskId1(TGroupID(EGroupConfigurationType::Dynamic, 1, 1).GetRaw(), 1, TVDiskIdShort(0, 0, 0));
+            TVDiskID vdiskId2(TGroupID(EGroupConfigurationType::Dynamic, 1, 2).GetRaw(), 1, TVDiskIdShort(0, 0, 0));
+            chunkTracker.AddOwner(owner1, vdiskId1);
+            chunkTracker.AddOwner(owner2, vdiskId2);
 
             double occupancy;
             // consume 100% of personal quota and 50% of common quota

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2183,6 +2183,11 @@ message TImmediateControlsConfig {
             MinValue: 0,
             MaxValue: 1000000,
             DefaultValue: 0 }];
+        optional uint64 StaticGroupChunkReservePerMille = 8 [(ControlOptions) = {
+            Description: "Upper bound for the chunk reserve of the static group VDisks, in permille of the user chunk pool of the PDisk. 0 disables the reserve",
+            MinValue: 0,
+            MaxValue: 1000,
+            DefaultValue: 500 }];
     }
 
     message TBlobStorageControllerControls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce chunk reserve for static group in PDisk

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch introduces static group chunk reserve as it is already done for log chunks. The main idea is to prevent cluster from failing when PDisk gets used too much.
