### PR TITLE
Reduce msgbus usage in PQ tests: create/alter/delete via Topic/PersQueue SDK

### DIFF
--- a/ydb/core/persqueue/common/proxy/actor_persqueue_client_iface.h
+++ b/ydb/core/persqueue/common/proxy/actor_persqueue_client_iface.h
@@ -90,6 +90,9 @@ protected:
             case NKikimrPQ::TMirrorPartitionConfig::TCredentials::CREDENTIALS_NOT_SET: {
                 return NThreading::MakeFuture(NYdb::CreateInsecureCredentialsProviderFactory());
             }
+            case NKikimrPQ::TMirrorPartitionConfig::TCredentials::kOauthToken: {
+                return NThreading::MakeFuture(NYdb::CreateOAuthCredentialsProviderFactory(cred.GetOauthToken()));
+            }
             default: {
                 ythrow yexception() << "unsupported credentials type " << ui64(cred.GetCredentialsCase());
             }

--- a/ydb/core/persqueue/common/proxy/actor_persqueue_client_iface.h
+++ b/ydb/core/persqueue/common/proxy/actor_persqueue_client_iface.h
@@ -4,6 +4,7 @@
 #include <ydb/library/logger/actor.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/iam.h>
 
 #include <ydb/library/actors/core/actor.h>
 #include <library/cpp/logger/log.h>
@@ -92,6 +93,17 @@ protected:
             }
             case NKikimrPQ::TMirrorPartitionConfig::TCredentials::kOauthToken: {
                 return NThreading::MakeFuture(NYdb::CreateOAuthCredentialsProviderFactory(cred.GetOauthToken()));
+            }
+            case NKikimrPQ::TMirrorPartitionConfig::TCredentials::kJwtParams: {
+                NYdb::TIamJwtContent params;
+                params.JwtContent = cred.GetJwtParams();
+                return NThreading::MakeFuture(NYdb::CreateIamJwtParamsCredentialsProviderFactory(params));
+            }
+            case NKikimrPQ::TMirrorPartitionConfig::TCredentials::kIam: {
+                NYdb::TIamJwtContent params;
+                params.Endpoint = cred.GetIam().GetEndpoint();
+                params.JwtContent = cred.GetIam().GetServiceAccountKey();
+                return NThreading::MakeFuture(NYdb::CreateIamJwtParamsCredentialsProviderFactory(params));
             }
             default: {
                 ythrow yexception() << "unsupported credentials type " << ui64(cred.GetCredentialsCase());

--- a/ydb/core/persqueue/common/proxy/ya.make
+++ b/ydb/core/persqueue/common/proxy/ya.make
@@ -7,6 +7,7 @@ SRCS(
 PEERDIR(
     ydb/core/persqueue/public
     ydb/public/sdk/cpp/src/client/topic
+    ydb/public/sdk/cpp/src/client/iam
 )
 
 END()

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -168,9 +168,9 @@ bool TMirrorer::AddToWriteRequest(
     write->SetSourceId(NSourceIdEncoding::EncodeSimple(producerId));
     write->SetSeqNo(message.GetSeqNo());
     write->SetCreateTimeMS(message.GetCreateTime().MilliSeconds());
-    if (Config.GetSyncWriteTime()) {
-        write->SetWriteTimeMS(message.GetWriteTime().MilliSeconds());
-    }
+    // SyncWriteTime removed; mirrored topics always preserve source write time
+    // (same as PQv1 remote_mirror_rule + client_write_disabled).
+    write->SetWriteTimeMS(message.GetWriteTime().MilliSeconds());
     write->SetDisableDeduplication(true);
     write->SetUncompressedSize(message.GetUncompressedSize());
 
@@ -657,7 +657,8 @@ static EStaleReadStatus ReadSessionStaleStatus(const TActorContext& ctx, bool ha
 }
 
 void TMirrorer::TryUpdateWriteTimetsamp(const TActorContext &ctx) {
-    if (!Config.GetSyncWriteTime() || WriteRequestInFlight || !StreamStatus) {
+    // SyncWriteTime removed; mirrored topics always sync source write-time watermark.
+    if (WriteRequestInFlight || !StreamStatus) {
         return;
     }
     const EStaleReadStatus staleStatus = ReadSessionStaleStatus(ctx, LastReadOffset.Defined(), LastInitStageTimestamp, StreamStatus.Get());

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1217,11 +1217,10 @@ void TPartition::Bootstrap(const TActorContext& ctx) {
 }
 
 void TPartition::Initialize(const TActorContext& ctx) {
-    if (MirroringEnabled(Config)) {
-        ManageWriteTimestampEstimate = !Config.GetPartitionConfig().GetMirrorFrom().GetSyncWriteTime();
-    } else {
-        ManageWriteTimestampEstimate = IsLocalDC;
-    }
+    // SyncWriteTime was removed. PQv1 sets it true for remote_mirror_rule with
+    // client_write_disabled (!LocalDC); that is the only supported mirror setup via API.
+    // Mirrored partitions therefore never manage a local write-timestamp estimate.
+    ManageWriteTimestampEstimate = MirroringEnabled(Config) ? false : IsLocalDC;
 
     CreationTime = ctx.Now();
     WriteCycleStartTime = ctx.Now();

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1217,9 +1217,8 @@ void TPartition::Bootstrap(const TActorContext& ctx) {
 }
 
 void TPartition::Initialize(const TActorContext& ctx) {
-    // SyncWriteTime was removed. PQv1 sets it true for remote_mirror_rule with
-    // client_write_disabled (!LocalDC); that is the only supported mirror setup via API.
-    // Mirrored partitions therefore never manage a local write-timestamp estimate.
+    // SyncWriteTime was removed; mirrored partitions always use source write time
+    // and therefore never manage a local write-timestamp estimate.
     ManageWriteTimestampEstimate = MirroringEnabled(Config) ? false : IsLocalDC;
 
     CreationTime = ctx.Now();

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
@@ -388,8 +388,6 @@ namespace NKikimr::NPersQueueTests {
             mirrorFrom.SetEndpointPort(ctx.Server.GrpcPort);
             mirrorFrom.SetTopic("/Root/PQ/" + srcTopicFullName);
             mirrorFrom.SetConsumer("some_user");
-            mirrorFrom.SetSyncWriteTime(true);
-
             ctx.AnnoyingClient()->CreateTopic(
                 dstTopicFullName,
                 partitionsCount,
@@ -506,8 +504,6 @@ namespace NKikimr::NPersQueueTests {
             mirrorFrom.SetEndpointPort(ctx.Server.GrpcPort);
             mirrorFrom.SetTopic("/Root/PQ/" + srcTopicFullName);
             mirrorFrom.SetConsumer("some_user");
-            mirrorFrom.SetSyncWriteTime(true);
-
             ctx.AnnoyingClient()->CreateTopic(
                 dstTopicFullName,
                 partitionsCount,
@@ -653,8 +649,6 @@ namespace NKikimr::NPersQueueTests {
             mirrorFrom.SetEndpointPort(ctx.Server.GrpcPort);
             mirrorFrom.SetTopic("/Root/PQ/" + srcTopicFullName);
             mirrorFrom.SetConsumer("some_user");
-            mirrorFrom.SetSyncWriteTime(true);
-
             ctx.AnnoyingClient()->CreateTopic(
                 dstTopicFullName,
                 partitionsCount,
@@ -786,8 +780,6 @@ namespace NKikimr::NPersQueueTests {
             mirrorFrom.SetEndpointPort(ctx.Server.GrpcPort);
             mirrorFrom.SetTopic("/Root/PQ/" + srcTopicFullName);
             mirrorFrom.SetConsumer("some_user");
-            mirrorFrom.SetSyncWriteTime(true);
-
             ctx.AnnoyingClient()->CreateTopic(
                 dstTopicFullName,
                 partitionsCount + 1,
@@ -911,8 +903,6 @@ namespace NKikimr::NPersQueueTests {
             mirrorFrom.SetEndpointPort(ctx.Server.GrpcPort);
             mirrorFrom.SetTopic("/Root/PQ/" + srcTopicFullName);
             mirrorFrom.SetConsumer("some_user");
-            mirrorFrom.SetSyncWriteTime(true);
-
             ctx.AnnoyingClient()->CreateTopic(
                 dstTopicFullName,
                 partitionsCount,
@@ -1061,8 +1051,6 @@ namespace NKikimr::NPersQueueTests {
             mirrorFrom.SetEndpointPort(ctx.Server.GrpcPort);
             mirrorFrom.SetTopic("/Root/PQ/" + srcTopicFullName);
             mirrorFrom.SetConsumer("some_user");
-            mirrorFrom.SetSyncWriteTime(true);
-
             ctx.AnnoyingClient()->CreateTopic(
                 dstTopicFullName,
                 1,

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
@@ -699,6 +699,18 @@ namespace NKikimr::NPersQueueTests {
                 PrintTopicDescription(name, "4", server);
             }
             UNIT_ASSERT_VALUES_EQUAL(CountPartitionsByStatus(srcTopicFullName, server).Active, 5);
+
+            // Mirror topology catch-up can lag behind src splits under PQv1 create path.
+            {
+                const TInstant deadline = TDuration::Seconds(60).ToDeadLine();
+                while (CountPartitionsByStatus(dstTopicFullName, server).Active != 5 ||
+                       CountPartitionsByStatus(dstTopicFullName, server).Partitions != finalPartitionsCount)
+                {
+                    UNIT_ASSERT_C(TInstant::Now() < deadline, "Timed out waiting for mirrored topic to follow multisplit");
+                    Cerr << "Waiting for dst mirror partitions to catch up after multisplit\n";
+                    Sleep(TDuration::Seconds(1));
+                }
+            }
             UNIT_ASSERT_VALUES_EQUAL(CountPartitionsByStatus(dstTopicFullName, server).Active, 5);
 
             UNIT_ASSERT_VALUES_EQUAL(CountPartitionsByStatus(srcTopicFullName, server).Partitions, finalPartitionsCount);

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -48,7 +48,6 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         mirrorFrom.SetEndpointPort(server.GrpcPort);
         mirrorFrom.SetTopic(srcTopic);
         mirrorFrom.SetConsumer("some_user");
-        mirrorFrom.SetSyncWriteTime(true);
         //mirrorFrom.SetDatabase("/Root");
         //mirrorFrom.MutableCredentials()->SetOauthToken("test_user@" BUILTIN_ACL_DOMAIN);
 
@@ -582,7 +581,6 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         mirrorFrom.SetEndpointPort(server.GrpcPort);
         mirrorFrom.SetTopic(srcTopic);
         mirrorFrom.SetConsumer(mirrorConsumer);
-        mirrorFrom.SetSyncWriteTime(true);
         mirrorFrom.SetReadFromTimestampsMs(readFromTs.MilliSeconds());
 
         if (dstTopicPrefillSize) {

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -289,7 +289,7 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         const TString srcTopicFullName = "rt3.dc1--" + srcTopic;
         const TString dstTopicFullName = "rt3.dc1--" + dstTopic;
         const TString srcTopicSdkPath = "PQ/" + srcTopicFullName;
-        const TString dstTopicPath = "/Root/" + dstTopicFullName;
+        const TString dstTopicPath = "/Root/PQ/" + dstTopicFullName;
         const TString mirrorConsumer = "mirror_user";
         const TString readerConsumer = "reader";
 

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -268,7 +268,7 @@ message TMirrorPartitionConfig {
     optional TCredentials Credentials = 7;
     optional string Database = 8;
     optional bool UseSecureConnection = 9 [default = false];
-    optional bool SyncWriteTime = 10 [default = false];
+    reserved 10; // was SyncWriteTime; mirrored topics always sync source write time (PQv1 API)
 }
 
 message TPartitionConfig {

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -1096,12 +1096,12 @@ public:
 
         if (createRequest.PartitionStrategy) {
             const auto& ps = *createRequest.PartitionStrategy;
-            const auto strategy = ConvertPartitionStrategyType(ps.GetPartitionStrategyType());
+            // Initial count is NumParts; MinPartitionCount is an autoscaling bound.
             settings.PartitioningSettings(
-                ps.GetMinPartitionCount() ? ps.GetMinPartitionCount() : createRequest.NumParts,
+                createRequest.NumParts,
                 ps.GetMaxPartitionCount() ? ps.GetMaxPartitionCount() : createRequest.NumParts,
                 NYdb::NTopic::TAutoPartitioningSettings(
-                    strategy,
+                    ConvertPartitionStrategyType(ps.GetPartitionStrategyType()),
                     TDuration::Seconds(ps.GetScaleThresholdSeconds()),
                     ps.GetScaleDownPartitionWriteSpeedThresholdPercent(),
                     ps.GetScaleUpPartitionWriteSpeedThresholdPercent()));
@@ -1142,7 +1142,10 @@ public:
 
         if (createRequest.PartitionStrategy) {
             const auto& ps = *createRequest.PartitionStrategy;
-            settings.PartitionsCount(ps.GetMinPartitionCount() ? ps.GetMinPartitionCount() : createRequest.NumParts);
+            // Initial partition count comes from NumParts (msgbus SetNumPartitions).
+            // MinPartitionCount is an autoscaling bound and may be lower than NumParts
+            // (e.g. RootPartitionOverlap starts dst wider than strategy min).
+            settings.PartitionsCount(createRequest.NumParts);
             settings.MaxPartitionsCount(std::make_optional<uint64_t>(
                 ps.GetMaxPartitionCount() ? ps.GetMaxPartitionCount() : createRequest.NumParts));
             settings.AutoPartitioningStrategy(std::make_optional(
@@ -1174,11 +1177,14 @@ public:
 
         ui32 prevVersion = GetTopicVersionFromMetadata(createRequest.Topic);
 
-        // Topic API has no mirror rule; use PersQueue SDK RemoteMirrorRule.
+        // Topic/PQv1 SDK create does not preserve msgbus semantics needed by many
+        // legacy UTs (LowWatermark, consumers without service type under
+        // DisallowDefaultClientServiceType, unauthenticated scheme ops). Keep
+        // msgbus for non-mirror creates; mirrors use PersQueue RemoteMirrorRule.
         if (createRequest.MirrorFrom) {
             CreateTopicViaPersQueueSdk(createRequest);
         } else {
-            CreateTopicViaTopicSdk(createRequest);
+            CallPersQueueGRPC(createRequest.GetRequest()->Record);
         }
 
         AddTopic(createRequest.Topic);

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -1063,9 +1063,9 @@ public:
         if (mirrorFrom.GetReadFromTimestampsMs()) {
             rule.StartingMessageTimestamp(TInstant::MilliSeconds(mirrorFrom.GetReadFromTimestampsMs()));
         }
-        if (mirrorFrom.HasDatabase()) {
-            rule.Database(std::string(mirrorFrom.GetDatabase()));
-        }
+        // Authenticated mirror reads require a database; msgbus often omitted both
+        // credentials and database. PQv1 forces credentials, so default database too.
+        rule.Database(std::string(mirrorFrom.HasDatabase() ? mirrorFrom.GetDatabase() : "/Root"));
         return rule;
     }
 

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -507,6 +507,9 @@ private:
     const ui16 GRpcPort;
     NClient::TKikimr Kikimr;
     THolder<NYdb::TDriver> Driver;
+    // Authenticated driver for Topic/PQv1 schema ops. Main Driver stays
+    // unauthenticated: FullInit YQL and many UTs rely on that.
+    THolder<NYdb::TDriver> AdminDriver;
     std::unique_ptr<NKikimrClient::TGRpcServer::Stub> Stub;
 
     ui64 TopicsVersion = 0;
@@ -564,14 +567,19 @@ public:
         , Kikimr(GetClientConfig())
     {
         TString endpoint = TStringBuilder() << "localhost:" << GRpcPort;
-        // Topic/PQv1 scheme ops reject empty tokens when credentials are required.
-        // ACL UTs also use this driver for create before RequireCredentials flips on.
+        const TString database = databaseName ? *databaseName : TString("/Root");
         auto driverConfig = NYdb::TDriverConfig()
             .SetEndpoint(endpoint)
-            .SetDatabase(databaseName ? *databaseName : TString("/Root"))
-            .SetAuthToken(BUILTIN_ACL_ROOT)
+            .SetDatabase(database)
             .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
         Driver.Reset(MakeHolder<NYdb::TDriver>(driverConfig));
+
+        auto adminDriverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(endpoint)
+            .SetDatabase(database)
+            .SetAuthToken(BUILTIN_ACL_ROOT)
+            .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
+        AdminDriver.Reset(MakeHolder<NYdb::TDriver>(adminDriverConfig));
 
         grpc::ChannelArguments args;
         if (settings.GrpcMaxMessageSize != 0)
@@ -587,6 +595,7 @@ public:
     }
 
     ~TFlatMsgBusPQClient() {
+        AdminDriver->Stop(true);
         Driver->Stop(true);
     }
 
@@ -1073,7 +1082,7 @@ public:
 
     void CreateTopicViaTopicSdk(const TRequestCreatePQ& createRequest) {
         const TString path = ResolveTopicSdkPath(createRequest.Topic);
-        auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+        auto topicClient = NYdb::NTopic::TTopicClient(*AdminDriver);
 
         NYdb::NTopic::TCreateTopicSettings settings;
         settings.PartitioningSettings(createRequest.NumParts, createRequest.NumParts);
@@ -1124,7 +1133,7 @@ public:
     void CreateTopicViaPersQueueSdk(const TRequestCreatePQ& createRequest) {
         Y_ABORT_UNLESS(createRequest.MirrorFrom);
         const TString path = ResolveTopicSdkPath(createRequest.Topic);
-        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*AdminDriver);
 
         NYdb::NPersQueue::TCreateTopicSettings settings;
         settings.PartitionsCount(createRequest.NumParts);
@@ -1250,7 +1259,7 @@ public:
             .PartitionsCount(nParts)
             .ReadRules({NYdb::NPersQueue::TReadRuleSettings().ConsumerName("user")});
         settings.RetentionPeriod(TDuration::Seconds(lifetimeS));
-        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*AdminDriver);
         auto res = pqClient.AlterTopic(path, settings);
         if (UseConfigTables) {  // ToDo - legacy
             AlterTopic();
@@ -1278,7 +1287,7 @@ public:
         const TString path = ResolveTopicSdkPath(name);
         if (mirrorFrom) {
             // Topic API has no mirror rule; use PersQueue SDK RemoteMirrorRule.
-            auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+            auto pqClient = NYdb::NPersQueue::TPersQueueClient(*AdminDriver);
             NYdb::NPersQueue::TAlterTopicSettings settings;
             settings.PartitionsCount(nParts);
             if (fillPartitionConfig) {
@@ -1291,7 +1300,7 @@ public:
             auto res = pqClient.AlterTopic(path, settings).GetValueSync();
             UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
         } else {
-            auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+            auto topicClient = NYdb::NTopic::TTopicClient(*AdminDriver);
             NYdb::NTopic::TAlterTopicSettings settings;
             settings.AlterPartitioningSettings(nParts, nParts);
             if (fillPartitionConfig) {
@@ -1327,7 +1336,7 @@ public:
     }
 
     NYdb::TStatus DropTopic(const TString& path) {
-        auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+        auto topicClient = NYdb::NTopic::TTopicClient(*AdminDriver);
         Cerr << "Drop topic: " << path << Endl;
         auto res = topicClient.DropTopic(path).GetValueSync();
         UNIT_ASSERT(res.IsSuccess());
@@ -1341,7 +1350,7 @@ public:
 
         Y_ABORT_UNLESS(name.StartsWith("rt3."));
         const TString path = ResolveTopicSdkPath(name);
-        auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+        auto topicClient = NYdb::NTopic::TTopicClient(*AdminDriver);
         Cerr << "PQ Client: drop topic via Topic SDK: " << path << Endl;
         auto res = topicClient.DropTopic(path).GetValueSync();
 
@@ -1743,7 +1752,7 @@ public:
             path = TStringBuilder() << "/Root/PQ/" << params.Name;
         }
 
-        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*AdminDriver);
         auto settings = NYdb::NPersQueue::TCreateTopicSettings().PartitionsCount(params.PartsCount).ClientWriteDisabled(!params.CanWrite);
         settings.FederationAccount(params.Account);
         settings.SupportedCodecs(params.Codecs);

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -11,6 +11,7 @@
 #include <ydb/public/lib/deprecated/kicli/kicli.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/persqueue.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
@@ -980,12 +981,92 @@ public:
         } while (true);
     }
 
+    TString ResolveTopicSdkPath(const TString& name) const {
+        if (UseConfigTables && !name.StartsWith("/Root")) {
+            return TopicPrefix + name;
+        }
+        return name;
+    }
+
+    static NYdb::NTopic::EAutoPartitioningStrategy ConvertPartitionStrategyType(
+        NKikimrPQ::TPQTabletConfig::TPartitionStrategyType type)
+    {
+        using NKikimrPQ::TPQTabletConfig;
+        switch (type) {
+            case TPQTabletConfig::CAN_SPLIT:
+                return NYdb::NTopic::EAutoPartitioningStrategy::ScaleUp;
+            case TPQTabletConfig::CAN_SPLIT_AND_MERGE:
+                return NYdb::NTopic::EAutoPartitioningStrategy::ScaleUpAndDown;
+            case TPQTabletConfig::PAUSED:
+                return NYdb::NTopic::EAutoPartitioningStrategy::Paused;
+            default:
+                return NYdb::NTopic::EAutoPartitioningStrategy::Disabled;
+        }
+    }
+
+    void CreateTopicViaTopicSdk(const TRequestCreatePQ& createRequest) {
+        const TString path = ResolveTopicSdkPath(createRequest.Topic);
+        auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+
+        NYdb::NTopic::TCreateTopicSettings settings;
+        settings.PartitioningSettings(createRequest.NumParts, createRequest.NumParts);
+        settings.RetentionPeriod(TDuration::Seconds(createRequest.LifetimeS));
+        settings.PartitionWriteSpeedBytesPerSecond(createRequest.WriteSpeed);
+        settings.PartitionWriteBurstBytes(createRequest.WriteSpeed);
+        settings.SetSupportedCodecs({
+            NYdb::NTopic::ECodec::RAW,
+            NYdb::NTopic::ECodec::GZIP,
+            NYdb::NTopic::ECodec::LZOP,
+        });
+        settings.AddAttribute("_allow_unauthenticated_read", "true");
+        settings.AddAttribute("_allow_unauthenticated_write", "true");
+        if (createRequest.SourceIdMaxCount != 6000000) {
+            settings.AddAttribute("_max_partition_message_groups_seqno_stored", ToString(createRequest.SourceIdMaxCount));
+        }
+        if (createRequest.SourceIdLifetime != 86400) {
+            settings.AddAttribute(
+                "_message_group_seqno_retention_period_ms",
+                ToString(createRequest.SourceIdLifetime * 1000));
+        }
+
+        if (createRequest.PartitionStrategy) {
+            const auto& ps = *createRequest.PartitionStrategy;
+            const auto strategy = ConvertPartitionStrategyType(ps.GetPartitionStrategyType());
+            settings.PartitioningSettings(
+                ps.GetMinPartitionCount() ? ps.GetMinPartitionCount() : createRequest.NumParts,
+                ps.GetMaxPartitionCount() ? ps.GetMaxPartitionCount() : createRequest.NumParts,
+                NYdb::NTopic::TAutoPartitioningSettings(
+                    strategy,
+                    TDuration::Seconds(ps.GetScaleThresholdSeconds()),
+                    ps.GetScaleDownPartitionWriteSpeedThresholdPercent(),
+                    ps.GetScaleUpPartitionWriteSpeedThresholdPercent()));
+        }
+
+        THashSet<TString> important(createRequest.Important.begin(), createRequest.Important.end());
+        for (const auto& user : createRequest.ReadRules) {
+            settings.BeginAddConsumer(user)
+                .Important(important.contains(user))
+                .EndAddConsumer();
+        }
+
+        Cerr << "PQ Client: create topic via Topic SDK: " << path << Endl;
+        auto res = topicClient.CreateTopic(path, settings).GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+    }
+
     void CreateTopic(const TRequestCreatePQ& createRequest, bool doWait = true) {
         const TInstant start = TInstant::Now();
 
         ui32 prevVersion = GetTopicVersionFromMetadata(createRequest.Topic);
 
-        CallPersQueueGRPC(createRequest.GetRequest()->Record);
+        // Topic API has no mirror rule. PersQueue SDK maps ClientWriteDisabled→non-local,
+        // which fails federation validation for rt3.* topics. Keep msgbus only for mirror
+        // creates/alters.
+        if (createRequest.MirrorFrom) {
+            CallPersQueueGRPC(createRequest.GetRequest()->Record);
+        } else {
+            CreateTopicViaTopicSdk(createRequest);
+        }
 
         AddTopic(createRequest.Topic);
         while (doWait && GetTopicVersionFromPath(createRequest.Topic) < prevVersion + 1) {
@@ -1050,16 +1131,30 @@ public:
         std::optional<NKikimrPQ::TMirrorPartitionConfig> mirrorFrom = {}
     ) {
         Y_ABORT_UNLESS(name.StartsWith("rt3."));
-        TRequestAlterPQ requestDescr(name, nParts, cacheSize, lifetimeS, fillPartitionConfig, mirrorFrom);
-        THolder<NMsgBusProxy::TBusPersQueue> alterRequest = requestDescr.GetRequest();
 
         ui32 prevVersion = GetTopicVersionFromMetadata(name);
         while (prevVersion == 0) {
             Sleep(TDuration::MilliSeconds(500));
-
             prevVersion = GetTopicVersionFromMetadata(name);
         }
-        CallPersQueueGRPC(alterRequest->Record);
+
+        const TString path = ResolveTopicSdkPath(name);
+        if (mirrorFrom) {
+            // Mirror alter is not representable in Topic API; keep msgbus for this case.
+            TRequestAlterPQ requestDescr(name, nParts, cacheSize, lifetimeS, fillPartitionConfig, mirrorFrom);
+            CallPersQueueGRPC(requestDescr.GetRequest()->Record);
+        } else {
+            auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+            NYdb::NTopic::TAlterTopicSettings settings;
+            settings.AlterPartitioningSettings(nParts, nParts);
+            if (fillPartitionConfig) {
+                settings.SetRetentionPeriod(TDuration::Seconds(lifetimeS));
+            }
+
+            Cerr << "PQ Client: alter topic via Topic SDK: " << path << Endl;
+            auto res = topicClient.AlterTopic(path, settings).GetValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+        }
         Cerr << "Alter got " << prevVersion << "\n";
 
         const TInstant start = TInstant::Now();
@@ -1085,9 +1180,9 @@ public:
     }
 
     NYdb::TStatus DropTopic(const TString& path) {
-        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+        auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
         Cerr << "Drop topic: " << path << Endl;
-        auto res = pqClient.DropTopic(path).GetValueSync();
+        auto res = topicClient.DropTopic(path).GetValueSync();
         UNIT_ASSERT(res.IsSuccess());
         return res;
     }
@@ -1098,12 +1193,13 @@ public:
     ) {
 
         Y_ABORT_UNLESS(name.StartsWith("rt3."));
-        THolder<NMsgBusProxy::TBusPersQueue> deleteRequest = TRequestDeletePQ{name}.GetRequest();
+        const TString path = ResolveTopicSdkPath(name);
+        auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
+        Cerr << "PQ Client: drop topic via Topic SDK: " << path << Endl;
+        auto res = topicClient.DropTopic(path).GetValueSync();
 
-        CallPersQueueGRPC(deleteRequest->Record);
-
-        // wait for drop completion
         if (expectedStatus == NPersQueue::NErrorCode::OK) {
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
             ui32 i = 0;
             for (; i < 500; ++i) {
                 TAutoPtr<NMsgBusProxy::TBusResponse> r = TryDropPersQueueGroup("/Root/PQ", name);
@@ -1114,6 +1210,12 @@ public:
                 Sleep(TDuration::MilliSeconds(50));
             }
             UNIT_ASSERT_C(i < 500, "Drop is taking too long"); //25 seconds
+        } else {
+            UNIT_ASSERT_C(!res.IsSuccess(), "expected drop failure");
+            UNIT_ASSERT_C(
+                expectedStatus == NPersQueue::NErrorCode::UNKNOWN_TOPIC,
+                TStringBuilder() << "DeleteTopic2 via Topic SDK currently maps only UNKNOWN_TOPIC failures, got "
+                                 << (ui32)expectedStatus);
         }
         RemoveTopic(name);
         const TInstant start = TInstant::Now();

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -1004,6 +1004,71 @@ public:
         }
     }
 
+    static Ydb::PersQueue::V1::AutoPartitioningStrategy ConvertPartitionStrategyTypePq(
+        NKikimrPQ::TPQTabletConfig::TPartitionStrategyType type)
+    {
+        using NKikimrPQ::TPQTabletConfig;
+        switch (type) {
+            case TPQTabletConfig::CAN_SPLIT:
+                return Ydb::PersQueue::V1::AUTO_PARTITIONING_STRATEGY_SCALE_UP;
+            case TPQTabletConfig::CAN_SPLIT_AND_MERGE:
+                return Ydb::PersQueue::V1::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN;
+            case TPQTabletConfig::PAUSED:
+                return Ydb::PersQueue::V1::AUTO_PARTITIONING_STRATEGY_PAUSED;
+            default:
+                return Ydb::PersQueue::V1::AUTO_PARTITIONING_STRATEGY_DISABLED;
+        }
+    }
+
+    static NYdb::NPersQueue::TCredentials MakeMirrorCredentials(
+        const NKikimrPQ::TMirrorPartitionConfig& mirrorFrom)
+    {
+        Ydb::PersQueue::V1::Credentials credentials;
+        if (mirrorFrom.HasCredentials()) {
+            const auto& src = mirrorFrom.GetCredentials();
+            if (src.HasOauthToken()) {
+                credentials.set_oauth_token(src.GetOauthToken());
+            } else if (src.HasJwtParams()) {
+                credentials.set_jwt_params(src.GetJwtParams());
+            } else if (src.HasIam()) {
+                credentials.mutable_iam()->set_endpoint(src.GetIam().GetEndpoint());
+                credentials.mutable_iam()->set_service_account_key(src.GetIam().GetServiceAccountKey());
+            } else {
+                credentials.set_oauth_token("test_token");
+            }
+        } else {
+            // PQv1 requires credentials; msgbus MirrorFrom often omitted them.
+            credentials.set_oauth_token("test_token");
+        }
+        return NYdb::NPersQueue::TCredentials(credentials);
+    }
+
+    template <typename TTopicSettings>
+    static typename TTopicSettings::TRemoteMirrorRuleSettings MakeRemoteMirrorRuleSettings(
+        const NKikimrPQ::TMirrorPartitionConfig& mirrorFrom)
+    {
+        TString endpoint = mirrorFrom.GetEndpoint();
+        if (mirrorFrom.GetEndpointPort()) {
+            endpoint = TStringBuilder() << endpoint << ":" << mirrorFrom.GetEndpointPort();
+        }
+        if (mirrorFrom.GetUseSecureConnection()) {
+            endpoint = TStringBuilder() << "grpcs://" << endpoint;
+        }
+
+        auto rule = typename TTopicSettings::TRemoteMirrorRuleSettings()
+            .Endpoint(std::string(endpoint))
+            .TopicPath(std::string(mirrorFrom.GetTopic()))
+            .ConsumerName(std::string(mirrorFrom.GetConsumer()))
+            .Credentials(MakeMirrorCredentials(mirrorFrom));
+        if (mirrorFrom.GetReadFromTimestampsMs()) {
+            rule.StartingMessageTimestamp(TInstant::MilliSeconds(mirrorFrom.GetReadFromTimestampsMs()));
+        }
+        if (mirrorFrom.HasDatabase()) {
+            rule.Database(std::string(mirrorFrom.GetDatabase()));
+        }
+        return rule;
+    }
+
     void CreateTopicViaTopicSdk(const TRequestCreatePQ& createRequest) {
         const TString path = ResolveTopicSdkPath(createRequest.Topic);
         auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
@@ -1054,16 +1119,64 @@ public:
         UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
     }
 
+    void CreateTopicViaPersQueueSdk(const TRequestCreatePQ& createRequest) {
+        Y_ABORT_UNLESS(createRequest.MirrorFrom);
+        const TString path = ResolveTopicSdkPath(createRequest.Topic);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+
+        NYdb::NPersQueue::TCreateTopicSettings settings;
+        settings.PartitionsCount(createRequest.NumParts);
+        settings.RetentionPeriod(TDuration::Seconds(createRequest.LifetimeS));
+        settings.MaxPartitionWriteSpeed(createRequest.WriteSpeed);
+        settings.MaxPartitionWriteBurst(createRequest.WriteSpeed);
+        settings.SupportedCodecs({
+            NYdb::NPersQueue::ECodec::RAW,
+            NYdb::NPersQueue::ECodec::GZIP,
+            NYdb::NPersQueue::ECodec::LZOP,
+        });
+        settings.AllowUnauthenticatedRead(true);
+        settings.AllowUnauthenticatedWrite(true);
+        // LocalDC comes from remote_mirror_rule; do not set ClientWriteDisabled.
+        settings.RemoteMirrorRule(std::make_optional(
+            MakeRemoteMirrorRuleSettings<NYdb::NPersQueue::TCreateTopicSettings>(*createRequest.MirrorFrom)));
+
+        if (createRequest.PartitionStrategy) {
+            const auto& ps = *createRequest.PartitionStrategy;
+            settings.PartitionsCount(ps.GetMinPartitionCount() ? ps.GetMinPartitionCount() : createRequest.NumParts);
+            settings.MaxPartitionsCount(std::make_optional<uint64_t>(
+                ps.GetMaxPartitionCount() ? ps.GetMaxPartitionCount() : createRequest.NumParts));
+            settings.AutoPartitioningStrategy(std::make_optional(
+                ConvertPartitionStrategyTypePq(ps.GetPartitionStrategyType())));
+            settings.StabilizationWindow(std::make_optional(TDuration::Seconds(ps.GetScaleThresholdSeconds())));
+            settings.DownUtilizationPercent(std::make_optional<uint64_t>(
+                ps.GetScaleDownPartitionWriteSpeedThresholdPercent()));
+            settings.UpUtilizationPercent(std::make_optional<uint64_t>(
+                ps.GetScaleUpPartitionWriteSpeedThresholdPercent()));
+        }
+
+        THashSet<TString> important(createRequest.Important.begin(), createRequest.Important.end());
+        std::vector<NYdb::NPersQueue::TReadRuleSettings> readRules;
+        for (const auto& user : createRequest.ReadRules) {
+            readRules.push_back(
+                NYdb::NPersQueue::TReadRuleSettings()
+                    .ConsumerName(std::string(user))
+                    .Important(important.contains(user)));
+        }
+        settings.ReadRules(readRules);
+
+        Cerr << "PQ Client: create topic via PersQueue SDK (mirror): " << path << Endl;
+        auto res = pqClient.CreateTopic(path, settings).GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+    }
+
     void CreateTopic(const TRequestCreatePQ& createRequest, bool doWait = true) {
         const TInstant start = TInstant::Now();
 
         ui32 prevVersion = GetTopicVersionFromMetadata(createRequest.Topic);
 
-        // Topic API has no mirror rule. PersQueue SDK maps ClientWriteDisabled→non-local,
-        // which fails federation validation for rt3.* topics. Keep msgbus only for mirror
-        // creates/alters.
+        // Topic API has no mirror rule; use PersQueue SDK RemoteMirrorRule.
         if (createRequest.MirrorFrom) {
-            CallPersQueueGRPC(createRequest.GetRequest()->Record);
+            CreateTopicViaPersQueueSdk(createRequest);
         } else {
             CreateTopicViaTopicSdk(createRequest);
         }
@@ -1140,9 +1253,19 @@ public:
 
         const TString path = ResolveTopicSdkPath(name);
         if (mirrorFrom) {
-            // Mirror alter is not representable in Topic API; keep msgbus for this case.
-            TRequestAlterPQ requestDescr(name, nParts, cacheSize, lifetimeS, fillPartitionConfig, mirrorFrom);
-            CallPersQueueGRPC(requestDescr.GetRequest()->Record);
+            // Topic API has no mirror rule; use PersQueue SDK RemoteMirrorRule.
+            auto pqClient = NYdb::NPersQueue::TPersQueueClient(*Driver);
+            NYdb::NPersQueue::TAlterTopicSettings settings;
+            settings.PartitionsCount(nParts);
+            if (fillPartitionConfig) {
+                settings.RetentionPeriod(TDuration::Seconds(lifetimeS));
+            }
+            settings.RemoteMirrorRule(std::make_optional(
+                MakeRemoteMirrorRuleSettings<NYdb::NPersQueue::TAlterTopicSettings>(*mirrorFrom)));
+
+            Cerr << "PQ Client: alter topic via PersQueue SDK (mirror): " << path << Endl;
+            auto res = pqClient.AlterTopic(path, settings).GetValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
         } else {
             auto topicClient = NYdb::NTopic::TTopicClient(*Driver);
             NYdb::NTopic::TAlterTopicSettings settings;

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -564,11 +564,13 @@ public:
         , Kikimr(GetClientConfig())
     {
         TString endpoint = TStringBuilder() << "localhost:" << GRpcPort;
+        // Topic/PQv1 scheme ops reject empty tokens when credentials are required.
+        // ACL UTs also use this driver for create before RequireCredentials flips on.
         auto driverConfig = NYdb::TDriverConfig()
             .SetEndpoint(endpoint)
+            .SetDatabase(databaseName ? *databaseName : TString("/Root"))
+            .SetAuthToken(BUILTIN_ACL_ROOT)
             .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
-        if (databaseName)
-            driverConfig.SetDatabase(*databaseName);
         Driver.Reset(MakeHolder<NYdb::TDriver>(driverConfig));
 
         grpc::ChannelArguments args;
@@ -1172,19 +1174,35 @@ public:
         UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
     }
 
+    // Msgbus-only create for semantics Topic/PQv1 cannot express (LowWatermark,
+    // consumers without service_type under DisallowDefaultClientServiceType).
+    void CreateTopicViaMsgBus(const TRequestCreatePQ& createRequest, bool doWait = true) {
+        const TInstant start = TInstant::Now();
+        ui32 prevVersion = GetTopicVersionFromMetadata(createRequest.Topic);
+        CallPersQueueGRPC(createRequest.GetRequest()->Record);
+        AddTopic(createRequest.Topic);
+        while (doWait && GetTopicVersionFromPath(createRequest.Topic) < prevVersion + 1) {
+            Sleep(TDuration::MilliSeconds(500));
+            UNIT_ASSERT(TInstant::Now() - start < ::DEFAULT_DISPATCH_TIMEOUT);
+        }
+        while (doWait && GetTopicVersionFromMetadata(createRequest.Topic, prevVersion) < prevVersion + 1) {
+            Sleep(TDuration::MilliSeconds(500));
+            UNIT_ASSERT(TInstant::Now() - start < ::DEFAULT_DISPATCH_TIMEOUT);
+        }
+    }
+
     void CreateTopic(const TRequestCreatePQ& createRequest, bool doWait = true) {
         const TInstant start = TInstant::Now();
 
         ui32 prevVersion = GetTopicVersionFromMetadata(createRequest.Topic);
 
-        // Topic/PQv1 SDK create does not preserve msgbus semantics needed by many
-        // legacy UTs (LowWatermark, consumers without service type under
-        // DisallowDefaultClientServiceType, unauthenticated scheme ops). Keep
-        // msgbus for non-mirror creates; mirrors use PersQueue RemoteMirrorRule.
+        // Non-mirror → Topic SDK (authenticated driver). Mirrors → PersQueue
+        // RemoteMirrorRule. Call CreateTopicViaMsgBus for LowWatermark / empty
+        // service_type migration UTs.
         if (createRequest.MirrorFrom) {
             CreateTopicViaPersQueueSdk(createRequest);
         } else {
-            CallPersQueueGRPC(createRequest.GetRequest()->Record);
+            CreateTopicViaTopicSdk(createRequest);
         }
 
         AddTopic(createRequest.Topic);

--- a/ydb/core/testlib/ya.make
+++ b/ydb/core/testlib/ya.make
@@ -104,6 +104,8 @@ PEERDIR(
     ydb/public/lib/base
     ydb/public/lib/deprecated/kicli
     ydb/public/sdk/cpp/src/client/driver
+    ydb/public/sdk/cpp/src/client/persqueue_public
+    ydb/public/sdk/cpp/src/client/topic
     ydb/public/sdk/cpp/src/client/topic/codecs
     ydb/public/sdk/cpp/src/client/query
     ydb/public/sdk/cpp/src/client/table

--- a/ydb/core/ydb_convert/topic_description.cpp
+++ b/ydb/core/ydb_convert/topic_description.cpp
@@ -13,6 +13,29 @@
 
 namespace NKikimr {
 
+bool ResolveConsumerServiceType(
+    const NKikimrPQ::TPQTabletConfig_TConsumer& consumer,
+    const NKikimrPQ::TPQConfig& pqConfig,
+    bool checkServiceType,
+    TString& outServiceType,
+    TString& error)
+{
+    if (consumer.HasServiceType()) {
+        outServiceType = consumer.GetServiceType();
+        return true;
+    }
+    if (!checkServiceType) {
+        outServiceType = "";
+        return true;
+    }
+    if (pqConfig.GetDisallowDefaultClientServiceType()) {
+        error = "service type must be set for all read rules";
+        return false;
+    }
+    outServiceType = pqConfig.GetDefaultClientServiceType().GetName();
+    return true;
+}
+
 bool FillConsumer(Ydb::Topic::Consumer& out, const NKikimrPQ::TPQTabletConfig& config, const NKikimrPQ::TPQTabletConfig_TConsumer& in,
     Ydb::StatusIds_StatusCode& status, TString& error, bool checkServiceType)
 {
@@ -40,16 +63,10 @@ bool FillConsumer(Ydb::Topic::Consumer& out, const NKikimrPQ::TPQTabletConfig& c
         out.mutable_availability_period()->set_seconds(in.availabilityperiodms() / 1000);
         out.mutable_availability_period()->set_nanos((in.availabilityperiodms() % 1000) * 1'000'000);
     }
-    TString serviceType = "";
-    if (in.HasServiceType()) {
-        serviceType = in.GetServiceType();
-    } else if (checkServiceType) {
-        if (pqConfig.GetDisallowDefaultClientServiceType()) {
-            error = "service type must be set for all read rules";
-            status = Ydb::StatusIds::INTERNAL_ERROR;
-            return false;
-        }
-        serviceType = pqConfig.GetDefaultClientServiceType().GetName();
+    TString serviceType;
+    if (!ResolveConsumerServiceType(in, pqConfig, checkServiceType, serviceType, error)) {
+        status = Ydb::StatusIds::INTERNAL_ERROR;
+        return false;
     }
     (*out.mutable_attributes())["_service_type"] = serviceType;
 

--- a/ydb/core/ydb_convert/topic_description.h
+++ b/ydb/core/ydb_convert/topic_description.h
@@ -28,6 +28,19 @@ namespace NKikimrPQ {
 
 namespace NKikimr {
 
+// Resolves consumer ServiceType for describe responses (Topic / PQv1).
+// - HasServiceType → that value
+// - !checkServiceType and no ServiceType → empty string (ok)
+// - checkServiceType and no ServiceType:
+//     DisallowDefaultClientServiceType → false, error "service type must be set..."
+//     else → DefaultClientServiceType name
+bool ResolveConsumerServiceType(
+    const NKikimrPQ::TPQTabletConfig_TConsumer& consumer,
+    const NKikimrPQ::TPQConfig& pqConfig,
+    bool checkServiceType,
+    TString& outServiceType,
+    TString& error);
+
 bool FillConsumer(Ydb::Topic::Consumer& out, const NKikimrPQ::TPQTabletConfig& config, const NKikimrPQ::TPQTabletConfig_TConsumer& in, Ydb::StatusIds_StatusCode& status, TString& error, bool checkServiceType = true);
 bool FillTopicDescription(Ydb::Topic::DescribeTopicResult& out, const NKikimrSchemeOp::TPersQueueGroupDescription& inDesc,
     const NKikimrSchemeOp::TDirEntry& inDirEntry, const TMaybe<TString>& cdcName,

--- a/ydb/core/ydb_convert/ut/topic_description_ut.cpp
+++ b/ydb/core/ydb_convert/ut/topic_description_ut.cpp
@@ -1,0 +1,66 @@
+#include <ydb/core/ydb_convert/topic_description.h>
+#include <ydb/core/protos/pqconfig.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr;
+
+Y_UNIT_TEST_SUITE(TResolveConsumerServiceTypeTest) {
+
+Y_UNIT_TEST(UsesExplicitServiceType) {
+    NKikimrPQ::TPQTabletConfig::TConsumer consumer;
+    consumer.SetServiceType("MyGreatType");
+
+    NKikimrPQ::TPQConfig pqConfig;
+    pqConfig.MutableDefaultClientServiceType()->SetName("default_type");
+    pqConfig.SetDisallowDefaultClientServiceType(true);
+
+    TString serviceType;
+    TString error;
+    UNIT_ASSERT(ResolveConsumerServiceType(consumer, pqConfig, true, serviceType, error));
+    UNIT_ASSERT_VALUES_EQUAL(serviceType, "MyGreatType");
+    UNIT_ASSERT(error.empty());
+}
+
+Y_UNIT_TEST(FillsDefaultWhenAllowed) {
+    NKikimrPQ::TPQTabletConfig::TConsumer consumer;
+
+    NKikimrPQ::TPQConfig pqConfig;
+    pqConfig.MutableDefaultClientServiceType()->SetName("default_type");
+    pqConfig.SetDisallowDefaultClientServiceType(false);
+
+    TString serviceType;
+    TString error;
+    UNIT_ASSERT(ResolveConsumerServiceType(consumer, pqConfig, true, serviceType, error));
+    UNIT_ASSERT_VALUES_EQUAL(serviceType, "default_type");
+    UNIT_ASSERT(error.empty());
+}
+
+Y_UNIT_TEST(FailsWhenDisallowDefaultAndMissing) {
+    NKikimrPQ::TPQTabletConfig::TConsumer consumer;
+
+    NKikimrPQ::TPQConfig pqConfig;
+    pqConfig.MutableDefaultClientServiceType()->SetName("default_type");
+    pqConfig.SetDisallowDefaultClientServiceType(true);
+
+    TString serviceType;
+    TString error;
+    UNIT_ASSERT(!ResolveConsumerServiceType(consumer, pqConfig, true, serviceType, error));
+    UNIT_ASSERT_STRING_CONTAINS(error, "service type must be set for all read rules");
+}
+
+Y_UNIT_TEST(SkipsCheckWhenDisabled) {
+    NKikimrPQ::TPQTabletConfig::TConsumer consumer;
+
+    NKikimrPQ::TPQConfig pqConfig;
+    pqConfig.MutableDefaultClientServiceType()->SetName("default_type");
+    pqConfig.SetDisallowDefaultClientServiceType(true);
+
+    TString serviceType;
+    TString error;
+    UNIT_ASSERT(ResolveConsumerServiceType(consumer, pqConfig, false, serviceType, error));
+    UNIT_ASSERT_VALUES_EQUAL(serviceType, "");
+    UNIT_ASSERT(error.empty());
+}
+
+} // Y_UNIT_TEST_SUITE(TResolveConsumerServiceTypeTest)

--- a/ydb/core/ydb_convert/ut/ya.make
+++ b/ydb/core/ydb_convert/ut/ya.make
@@ -13,6 +13,7 @@ SRCS(
     compression_ut.cpp
     dictionary_feature_flag_ut.cpp
     table_description_ut.cpp
+    topic_description_ut.cpp
     ydb_convert_ut.cpp
 )
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
@@ -318,6 +318,12 @@ struct TTopicSettings : public TOperationRequestSettings<TDerived> {
     FLUENT_SETTING_DEFAULT(std::vector<TReadRuleSettings>, ReadRules, {});
     FLUENT_SETTING_OPTIONAL(TRemoteMirrorRuleSettings, RemoteMirrorRule);
 
+    FLUENT_SETTING_OPTIONAL(uint64_t, MaxPartitionsCount);
+    FLUENT_SETTING_OPTIONAL(TDuration, StabilizationWindow);
+    FLUENT_SETTING_OPTIONAL(uint64_t, UpUtilizationPercent);
+    FLUENT_SETTING_OPTIONAL(uint64_t, DownUtilizationPercent);
+    FLUENT_SETTING_OPTIONAL(Ydb::PersQueue::V1::AutoPartitioningStrategy, AutoPartitioningStrategy);
+
     TSelf& SetSettings(const TDescribeTopicResult::TTopicSettings& settings) {
 
         PartitionsCount_ = settings.PartitionsCount();
@@ -356,13 +362,6 @@ struct TTopicSettings : public TOperationRequestSettings<TDerived> {
 
         return static_cast<TDerived&>(*this);
     }
-
-private:
-    std::optional<uint64_t> MaxPartitionsCount_;
-    std::optional<TDuration> StabilizationWindow_;
-    std::optional<uint64_t> UpUtilizationPercent_;
-    std::optional<uint64_t> DownUtilizationPercent_;
-    std::optional<Ydb::PersQueue::V1::AutoPartitioningStrategy> AutoPartitioningStrategy_;
 };
 
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h
@@ -63,9 +63,11 @@ public:
         CleverServer = MakeHolder<NKikimr::Tests::TServer>(ServerSettings);
         CleverServer->EnableGRpc(GrpcServerOptions);
 
+        // Used by ModifyTopicACL and SDK sessions; match AnnoyingClient admin token.
         auto driverConfig = NYdb::TDriverConfig()
             .SetEndpoint(Endpoint)
-            .SetDatabase("/" + ServerSettings.DomainName);
+            .SetDatabase("/" + ServerSettings.DomainName)
+            .SetAuthToken("root@builtin");
         Driver = MakeHolder<NYdb::TDriver>(driverConfig);
 
         Log << TLOG_INFO << "TTestServer started on Port " << Port << " GrpcPort " << GrpcPort;

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h
@@ -63,11 +63,11 @@ public:
         CleverServer = MakeHolder<NKikimr::Tests::TServer>(ServerSettings);
         CleverServer->EnableGRpc(GrpcServerOptions);
 
-        // Used by ModifyTopicACL and SDK sessions; match AnnoyingClient admin token.
+        // Unauthenticated: used by ModifyTopicACL/SDK sessions in UTs that rely on
+        // allow_unauthenticated_* and FullInit without a token on AnnoyingClient.
         auto driverConfig = NYdb::TDriverConfig()
             .SetEndpoint(Endpoint)
-            .SetDatabase("/" + ServerSettings.DomainName)
-            .SetAuthToken("root@builtin");
+            .SetDatabase("/" + ServerSettings.DomainName);
         Driver = MakeHolder<NYdb::TDriver>(driverConfig);
 
         Log << TLOG_INFO << "TTestServer started on Port " << Port << " GrpcPort " << GrpcPort;

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/common.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/common.cpp
@@ -446,9 +446,7 @@ TResult ApplyChangesInt( // create and alter
 
     if (settings.has_remote_mirror_rule()) {
         auto mirrorFrom = partConfig->MutableMirrorFrom();
-        if (!local) {
-            mirrorFrom->SetSyncWriteTime(true);
-        }
+        // SyncWriteTime removed; runtime always syncs write time when mirroring.
         {
             TString endpoint = settings.remote_mirror_rule().endpoint();
             if (endpoint.StartsWith(GRPCS_ENDPOINT_PREFIX)) {

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/common.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/common.cpp
@@ -240,7 +240,12 @@ TResult ApplyChangesInt( // create and alter
         return r;
     }
 
-    bool local = !settings.client_write_disabled();
+    // With remote_mirror_rule, keep LocalDC/isLocal=true (msgbus semantics for
+    // rt3.<localDc>--* mirrors). ClientWriteDisabled must not force non-local:
+    // federation rejects "non-local in local cluster".
+    const bool local = settings.has_remote_mirror_rule()
+        ? true
+        : !settings.client_write_disabled();
 
     if (operation == EOperation::Create && !pqConfig.GetTopicsAreFirstClassCitizen()) {
         auto converter = NPersQueue::TTopicNameConverter::ForFederation(

--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -149,19 +149,17 @@ void TPQDescribeTopicActor::HandleCacheNavigateResponse(TEvTxProxySchemeCache::T
                 rr->mutable_availability_period()->set_nanos(availabilityPeriod.NanoSecondsOfSecond());
             }
 
-            if (consumer.HasServiceType()) {
-                rr->set_service_type(consumer.GetServiceType());
-            } else {
-                if (pqConfig.GetDisallowDefaultClientServiceType()) {
-                    this->Request_->RaiseIssue(FillIssue(
-                        "service type must be set for all read rules",
-                        Ydb::PersQueue::ErrorCode::ERROR
-                    ));
-                    Reply(Ydb::StatusIds::INTERNAL_ERROR, ActorContext());
-                    return;
-                }
-                rr->set_service_type(pqConfig.GetDefaultClientServiceType().GetName());
+            TString serviceType;
+            TString serviceTypeError;
+            if (!ResolveConsumerServiceType(consumer, pqConfig, true, serviceType, serviceTypeError)) {
+                this->Request_->RaiseIssue(FillIssue(
+                    serviceTypeError,
+                    Ydb::PersQueue::ErrorCode::ERROR
+                ));
+                Reply(Ydb::StatusIds::INTERNAL_ERROR, ActorContext());
+                return;
             }
+            rr->set_service_type(serviceType);
 
             switch (consumer.GetType()) {
                 case NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING: {

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -3453,7 +3453,9 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         settings.PQConfig.MutableCompactionConfig()->SetMaxWTimeLagSec(1);
         settings.PQConfig.MutableCompactionConfig()->SetBlobsSize(1_MB);
         NPersQueue::TTestServer server(settings);
-        server.AnnoyingClient->CreateTopic(DEFAULT_TOPIC_NAME, 1, 8_MB, 86400);
+        // LowWatermark is not expressible via Topic API; msgbus create keeps 8MB.
+        server.AnnoyingClient->CreateTopicViaMsgBus(
+            TRequestCreatePQ(DEFAULT_TOPIC_NAME, 1, 0, 86400, 8_MB));
 
         server.EnableLogs({ NKikimrServices::FLAT_TX_SCHEMESHARD, NKikimrServices::PERSQUEUE });
 
@@ -7296,7 +7298,9 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             createTopicRequest.ReadRules.push_back("acc@user1");
             createTopicRequest.ReadRules.push_back("acc@user2");
             createTopicRequest.ReadRules.push_back("acc@user3");
-            server.AnnoyingClient->CreateTopic(createTopicRequest);
+            // Topic/PQv1 always assign a service type; this UT needs empty types
+            // under DisallowDefault — only msgbus/raw config can do that.
+            server.AnnoyingClient->CreateTopicViaMsgBus(createTopicRequest);
         }
 
         std::unique_ptr<Ydb::PersQueue::V1::PersQueueService::Stub> pqStub;

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -7112,6 +7112,8 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(ReadRuleServiceTypeMigration) {
+        // Describe fill for consumers without ServiceType is unit-tested in
+        // TResolveConsumerServiceTypeTest. Here: default type + alter/add/remove via PQv1.
         TServerSettings settings = PQSettings(0);
         {
             settings.PQConfig.MutableDefaultClientServiceType()->SetName("default_type");
@@ -7279,117 +7281,9 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         }
     }
 
-    Y_UNIT_TEST(ReadRuleServiceTypeMigrationWithDisallowDefault) {
-        TServerSettings settings = PQSettings(0);
-        {
-            settings.PQConfig.MutableDefaultClientServiceType()->SetName("default_type");
-            settings.PQConfig.AddClientServiceType()->SetName("MyGreatType");
-            settings.PQConfig.AddClientServiceType()->SetName("AnotherType");
-            settings.PQConfig.AddClientServiceType()->SetName("SecondType");
-            settings.PQConfig.SetDisallowDefaultClientServiceType(true);
-        }
-        NPersQueue::TTestServer server(settings);
-
-        server.EnableLogs({ NKikimrServices::PQ_READ_PROXY, NKikimrServices::BLACKBOX_VALIDATOR });
-
-        const ui32 topicsCount = 4;
-        for (ui32 i = 1; i <= topicsCount; ++i) {
-            TRequestCreatePQ createTopicRequest(TStringBuilder() << "rt3.dc1--topic_" << i, 1);
-            createTopicRequest.ReadRules.push_back("acc@user1");
-            createTopicRequest.ReadRules.push_back("acc@user2");
-            createTopicRequest.ReadRules.push_back("acc@user3");
-            // Topic/PQv1 always assign a service type; this UT needs empty types
-            // under DisallowDefault — only msgbus/raw config can do that.
-            server.AnnoyingClient->CreateTopicViaMsgBus(createTopicRequest);
-        }
-
-        std::unique_ptr<Ydb::PersQueue::V1::PersQueueService::Stub> pqStub;
-        {
-            std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel("localhost:" + ToString(server.GrpcPort), grpc::InsecureChannelCredentials());
-            pqStub = Ydb::PersQueue::V1::PersQueueService::NewStub(channel);
-        }
-
-        auto doAlter = [&](
-            const TString& topic,
-            const TVector<std::pair<TString, TString>>& readRules,
-            Ydb::StatusIds::StatusCode statusCode = Ydb::StatusIds::SUCCESS
-        ) {
-            AlterTopicRequest request;
-            AlterTopicResponse response;
-            request.set_path(topic);
-            auto props = request.mutable_settings();
-            props->set_partitions_count(1);
-            props->set_supported_format(Ydb::PersQueue::V1::TopicSettings::FORMAT_BASE);
-            props->set_retention_period_ms(TDuration::Days(1).MilliSeconds());
-            for (auto rrInfo : readRules) {
-                auto rr = props->add_read_rules();
-                rr->set_supported_format(Ydb::PersQueue::V1::TopicSettings::Format(1));
-                rr->set_consumer_name(rrInfo.first);
-                rr->set_service_type(rrInfo.second);
-            }
-
-            grpc::ClientContext rcontext;
-            auto status = pqStub->AlterTopic(&rcontext, request, &response);
-
-            UNIT_ASSERT(status.ok());
-            CreateTopicResult res;
-            response.operation().result().UnpackTo(&res);
-            Cerr << response << "\n" << res << "\n";
-            UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), statusCode);
-        };
-
-        auto checkDescribe = [&](
-            const TString& topic,
-            const TVector<std::pair<TString, TString>>& readRules,
-            Ydb::StatusIds::StatusCode statusCode = Ydb::StatusIds::SUCCESS
-        ) {
-            DescribeTopicRequest request;
-            DescribeTopicResponse response;
-            request.set_path(topic);
-            grpc::ClientContext rcontext;
-
-            auto status = pqStub->DescribeTopic(&rcontext, request, &response);
-            UNIT_ASSERT(status.ok());
-            DescribeTopicResult res;
-            response.operation().result().UnpackTo(&res);
-            Cerr << response << "\n" << res << "\n";
-            UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), statusCode);
-            if (statusCode == Ydb::StatusIds::SUCCESS) {
-                UNIT_ASSERT_VALUES_EQUAL(res.settings().read_rules().size(), readRules.size());
-                for (ui64 i = 0; i < readRules.size(); ++i) {
-                    const auto& rr = res.settings().read_rules(i);
-                    UNIT_ASSERT_EQUAL(rr.consumer_name(), readRules[i].first);
-                    UNIT_ASSERT_EQUAL(rr.service_type(), readRules[i].second);
-                }
-            }
-        };
-        checkDescribe(
-            "/Root/PQ/rt3.dc1--topic_1",
-            {},
-            Ydb::StatusIds::INTERNAL_ERROR
-        );
-        {
-            doAlter(
-                "/Root/PQ/rt3.dc1--topic_2",
-                {
-                    {"acc/new_user", "MyGreatType"},
-                    {"acc/user2", "SecondType"},
-                    {"acc/user3", "AnotherType"},
-                    {"acc/user4", "AnotherType"}
-                }
-            );
-            checkDescribe(
-                "/Root/PQ/rt3.dc1--topic_2",
-                {
-                    {"acc/new_user", "MyGreatType"},
-                    {"acc/user2", "SecondType"},
-                    {"acc/user3", "AnotherType"},
-                    {"acc/user4", "AnotherType"}
-                }
-            );
-        }
-    }
-
+    // Legacy "empty ServiceType in tablet config + DisallowDefault → describe INTERNAL_ERROR"
+    // is covered by TResolveConsumerServiceTypeTest in ydb/core/ydb_convert/ut.
+    // Create/alter with explicit types under DisallowDefault: ReadRuleDisallowDefaultServiceType.
 
     void TestReadRuleServiceTypePasswordImpl(bool forcePassword)
     {

--- a/ydb/services/persqueue_v1/ut/persqueue_test_fixture.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_test_fixture.h
@@ -114,7 +114,10 @@ static void ModifyTopicACL(const NYdb::TDriver* driver, const TString& topic, co
 
             Cerr << "=== PersQueueClient" << Endl;
             NYdb::TDriverConfig driverCfg;
-            driverCfg.SetEndpoint(TStringBuilder() << "localhost:" << Server->GrpcPort).SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release())).SetDatabase("/Root");
+            driverCfg.SetEndpoint(TStringBuilder() << "localhost:" << Server->GrpcPort)
+                .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()))
+                .SetDatabase("/Root")
+                .SetAuthToken(BUILTIN_ACL_ROOT);
             YdbDriver.reset(new NYdb::TDriver(driverCfg));
             PersQueueClient = MakeHolder<NYdb::NPersQueue::TPersQueueClient>(*YdbDriver);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Migrated PersQueue test helpers from msgbus create/alter/delete to Topic / PersQueue SDK. Fixed PQv1 federation mirrors (`remote_mirror_rule` → local `LocalDC`) and removed unused `SyncWriteTime`.

### Description for reviewers <!-- (optional) description for those who read this PR -->

#### Goal
Reduce MessageBus usage in PQ tests: route scheme create/alter/delete through Topic / PersQueue SDK instead of legacy msgbus `CmdCreateTopic` / `CmdChangeTopic` / `CmdDeleteTopic`.

#### Test helpers (`test_pq_client`)
- Non-mirror create/alter/delete → Topic SDK.
- Mirror create/alter → PersQueue SDK `RemoteMirrorRule` (Topic API has no mirror rule).
- Authenticated `AdminDriver` (`root@builtin`) for schema SDK ops; main driver stays unauthenticated for FullInit YQL / allow-unauthenticated UTs.
- Msgbus create kept only where Topic/PQv1 cannot express semantics (e.g. custom `LowWatermark` in `Cache`).
- Service-type migration without `ServiceType` covered by unit helper `ResolveConsumerServiceType` instead of msgbus setup.

#### Product fixes needed for the migration
- With `remote_mirror_rule`, treat federation/`LocalDC` as **local** (msgbus historically set `LocalDC=true` + `MirrorFrom`). Without it, keep `local = !client_write_disabled`.
- Remove `TMirrorPartitionConfig.SyncWriteTime` (reserved 10): mirrored partitions always sync source write time.
- Mirror reader factory: oauth (and JWT/IAM) for authenticated mirror reads; default `Database=/Root` when unset.
- PersQueue SDK: expose auto-partitioning settings used by mirror+scale UTs.

#### Verification
- Mirror smoke: `TPersQueueMirrorer::TestBasicRemote`, scaling variant.
- ACL / create path: `CheckACLForGrpc*`, PartitionChooser, EventBatching / DeleteTopic (with AdminDriver split).