### PR TITLE
Store TFragmentedBuffer fragments in a sorted inline vector

### DIFF
--- a/ydb/core/util/fragmented_buffer.cpp
+++ b/ydb/core/util/fragmented_buffer.cpp
@@ -25,6 +25,10 @@ void TFragmentedBuffer::Write(ui32 begin, const char* buffer, ui32 size) {
 }
 
 void TFragmentedBuffer::Write(ui32 begin, TRope&& data) {
+    if (!data) {
+        return;
+    }
+
     // index of the fragment that is going to hold the written data; iterators do not survive the
     // insertion below, so everything here is index-based
     size_t idx = UpperBound(begin);

--- a/ydb/core/util/fragmented_buffer.cpp
+++ b/ydb/core/util/fragmented_buffer.cpp
@@ -6,18 +6,18 @@
 namespace NKikimr {
 
 bool TFragmentedBuffer::IsMonolith() const {
-    return (BufferForOffset.size() == 1 && BufferForOffset.begin()->first == 0);
+    return (BufferForOffset.size() == 1 && BufferForOffset.front().first == 0);
 }
 
 TRope TFragmentedBuffer::GetMonolith() {
     Y_ABORT_UNLESS(IsMonolith());
-    return BufferForOffset.begin()->second;
+    return BufferForOffset.front().second;
 }
 
 void TFragmentedBuffer::SetMonolith(TRope&& data) {
     Y_ABORT_UNLESS(data);
     BufferForOffset.clear();
-    BufferForOffset[0] = std::move(data);
+    BufferForOffset.emplace_back(0, std::move(data));
 }
 
 void TFragmentedBuffer::Write(ui32 begin, const char* buffer, ui32 size) {
@@ -25,10 +25,13 @@ void TFragmentedBuffer::Write(ui32 begin, const char* buffer, ui32 size) {
 }
 
 void TFragmentedBuffer::Write(ui32 begin, TRope&& data) {
-    auto it = BufferForOffset.upper_bound(begin);
-    if (it != BufferForOffset.begin()) {
-        auto& [prevOffset, prevRope] = *--it;
+    // index of the fragment that is going to hold the written data; iterators do not survive the
+    // insertion below, so everything here is index-based
+    size_t idx = UpperBound(begin);
+    if (idx) {
+        auto& [prevOffset, prevRope] = BufferForOffset[idx - 1];
         if (begin <= prevOffset + prevRope.size()) {
+            --idx; // the preceding fragment touches the written range, so it absorbs the data
             const ui32 overlap = prevOffset + prevRope.size() - begin;
             if (data.size() < overlap) {
                 const ui32 offset = begin - prevOffset;
@@ -38,27 +41,25 @@ void TFragmentedBuffer::Write(ui32 begin, TRope&& data) {
                 prevRope.EraseBack(overlap);
                 prevRope.Insert(prevRope.End(), std::exchange(data, {}));
             }
-        } else {
-            ++it;
         }
     }
 
     if (data) {
-        it = BufferForOffset.try_emplace(it, begin, std::move(data));
+        BufferForOffset.emplace(BufferForOffset.begin() + idx, begin, std::move(data));
     }
 
     // consume or join succeeding intervals
-    auto& [prevOffset, prevRope] = *it++;
-    const ui32 end = prevOffset + prevRope.size();
-    auto endIt = BufferForOffset.upper_bound(end);
-    Y_DEBUG_ABORT_UNLESS(endIt != BufferForOffset.begin());
-    auto& [lastOffset, lastRope] = *std::prev(endIt);
+    const ui32 end = BufferForOffset[idx].first + BufferForOffset[idx].second.size();
+    const size_t endIdx = UpperBound(end);
+    Y_DEBUG_ABORT_UNLESS(endIdx != 0);
+    auto& [lastOffset, lastRope] = BufferForOffset[endIdx - 1];
     const ui32 bytesToCut = end - lastOffset;
     if (bytesToCut < lastRope.size()) {
         lastRope.EraseFront(bytesToCut);
-        prevRope.Insert(prevRope.End(), std::move(lastRope));
+        auto& rope = BufferForOffset[idx].second;
+        rope.Insert(rope.End(), std::move(lastRope));
     }
-    BufferForOffset.erase(it, endIt);
+    BufferForOffset.erase(BufferForOffset.begin() + idx + 1, BufferForOffset.begin() + endIdx);
 }
 
 void TFragmentedBuffer::Read(ui32 begin, char* buffer, ui32 size) const {
@@ -68,11 +69,11 @@ void TFragmentedBuffer::Read(ui32 begin, char* buffer, ui32 size) const {
 TRope TFragmentedBuffer::Read(ui32 begin, ui32 size) const {
     // X....Y X.....Y X'.....Y'
     //        b.b.e.e
-    auto it = BufferForOffset.upper_bound(begin);
-    Y_ABORT_UNLESS(it != BufferForOffset.begin());
-    --it;
-    Y_ABORT_UNLESS(it->first <= begin && begin + size <= it->first + it->second.size());
-    const auto iter = it->second.begin() + (begin - it->first);
+    const size_t idx = UpperBound(begin);
+    Y_ABORT_UNLESS(idx != 0);
+    const auto& [offset, rope] = BufferForOffset[idx - 1];
+    Y_ABORT_UNLESS(offset <= begin && begin + size <= offset + rope.size());
+    const auto iter = rope.begin() + (begin - offset);
     return {iter, iter + size};
 }
 

--- a/ydb/core/util/fragmented_buffer.h
+++ b/ydb/core/util/fragmented_buffer.h
@@ -2,13 +2,25 @@
 #include "defs.h"
 
 #include <ydb/library/actors/util/rope.h>
-#include <util/generic/map.h>
+#include <library/cpp/containers/stack_vector/stack_vec.h>
+#include <algorithm>
+#include <utility>
 #include "interval_set.h"
 
 namespace NKikimr {
 
 class TFragmentedBuffer {
-    TMap<ui32, TRope> BufferForOffset;
+    // Fragments sorted by offset, non-overlapping and never adjacent-and-joinable (Write()
+    // coalesces them). One fragment is the overwhelmingly common case -- the Put path stores
+    // exactly one via SetMonolith -- so keep it inline and never touch the heap. Fragment counts
+    // stay tiny even on partial-range Gets, so a contiguous array beats a tree everywhere.
+    TStackVec<std::pair<ui32, TRope>, 1> BufferForOffset;
+
+    // Index of the first fragment with offset > begin, mirroring TMap::upper_bound.
+    size_t UpperBound(ui32 begin) const {
+        return std::upper_bound(BufferForOffset.begin(), BufferForOffset.end(), begin,
+            [](ui32 value, const auto& item) { return value < item.first; }) - BufferForOffset.begin();
+    }
 
 public:
     bool IsMonolith() const;

--- a/ydb/core/util/fragmented_buffer_ut.cpp
+++ b/ydb/core/util/fragmented_buffer_ut.cpp
@@ -121,6 +121,20 @@ Y_UNIT_TEST_SUITE(TFragmentedBufferTest) {
         UNIT_ASSERT_VALUES_EQUAL(fb.Read(0, 26).ConvertToString(), "ABCDefghijklmnopqrstuvWXYZ");
     }
 
+    Y_UNIT_TEST(TestEmptyWriteIsNoOp) {
+        TFragmentedBuffer fb;
+
+        fb.Write(10, nullptr, 0);
+        UNIT_ASSERT(!fb);
+
+        fb.Write(10, "ABC", 3);
+        TRope empty;
+        fb.Write(20, std::move(empty));
+
+        UNIT_ASSERT_VALUES_EQUAL(fb.Print(), "{[10, 13)}");
+        UNIT_ASSERT_VALUES_EQUAL(fb.Read(10, 3).ConvertToString(), "ABC");
+    }
+
     Y_UNIT_TEST(TestIsNotMonolith) {
         const char *data2 = "234";
         const char *data3v2 = "5";

--- a/ydb/core/util/fragmented_buffer_ut.cpp
+++ b/ydb/core/util/fragmented_buffer_ut.cpp
@@ -104,6 +104,23 @@ Y_UNIT_TEST_SUITE(TFragmentedBufferTest) {
 
     }
 
+    Y_UNIT_TEST(TestOutOfOrderFragmentsAndMultiMerge) {
+        TFragmentedBuffer fb;
+
+        // Exceed the inline capacity and insert at the beginning and in the middle.
+        fb.Write(20, "UVWXYZ", 6);
+        fb.Write(0, "ABCDEF", 6);
+        fb.Write(10, "KLMNOP", 6);
+        UNIT_ASSERT_VALUES_EQUAL(fb.Print(), "{[0, 6) U [10, 16) U [20, 26)}");
+        UNIT_ASSERT_VALUES_EQUAL(fb.GetTotalSize(), 18);
+
+        // Merge all three fragments, preserving the prefix and the non-overwritten suffix.
+        fb.Write(4, "efghijklmnopqrstuv", 18);
+        UNIT_ASSERT(fb.IsMonolith());
+        UNIT_ASSERT_VALUES_EQUAL(fb.GetTotalSize(), 26);
+        UNIT_ASSERT_VALUES_EQUAL(fb.Read(0, 26).ConvertToString(), "ABCDefghijklmnopqrstuvWXYZ");
+    }
+
     Y_UNIT_TEST(TestIsNotMonolith) {
         const char *data2 = "234";
         const char *data3v2 = "5";


### PR DESCRIPTION
### Description for reviewers 

TFragmentedBuffer was a TMap<ui32, TRope>, and TBlobState holds seven of them per blob (Whole plus TypicalPartsInBlob parts), all constructed by TBlobState::Init whether or not they are ever written. On the Put path each buffer that is used holds exactly one fragment, put there by SetMonolith -- so that is seven red-black trees built and torn down, plus a heap node per used tree, to store at most seven single entries.

Replace the tree with a TStackVec<std::pair<ui32, TRope>, 1> kept sorted by offset. Every algorithm in the class relied only on offset ordering, so this is semantically a drop-in; fragment counts are tiny (one on Put, a handful on partial-range Gets), so a contiguous array beats a tree on every operation and the common case stops allocating.

Write() is rewritten index-based, since vector iterators -- unlike TMap ones -- do not survive the insertion in the middle of it.

Worth ~1.8% of CPU on a 4KB-blob Put workload, plus the reduced tcmalloc pressure from dropping seven allocations per blob.

Related to https://github.com/ydb-platform/ydb/issues/49294