### PR TITLE
Fix VERIFY on empty blob container during PQ partition init

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1527,20 +1527,11 @@ TInstant TPartition::GetWriteTimeEstimate(ui64 offset) const {
     const TPartitionBlobEncoder& blobEncoder = GetBlobEncoder(offset);
     offset = Max(offset, blobEncoder.StartOffset);
     const std::deque<TDataKey>& container = GetContainer(blobEncoder, offset);
-    if (container.empty()) {
-        // Can happen if meta offsets diverge from blob keys (e.g. after init with
-        // NODATA). Treat as "no such record" — same as offset >= EndOffset.
-        YDB_LOG_WARN_COMP(Service, "GetWriteTimeEstimate: empty container for offset",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"tablet_id", TabletId},
-            {"partition", Partition},
-            {"offset", offset},
-            {"cz.StartOffset", CompactionBlobEncoder.StartOffset},
-            {"cz.EndOffset", CompactionBlobEncoder.EndOffset},
-            {"fwz.StartOffset", BlobEncoder.StartOffset},
-            {"fwz.EndOffset", BlobEncoder.EndOffset});
-        return TInstant::Zero();
-    }
+    PQ_ENSURE(!container.empty())
+        ("offset", offset)
+        ("cz.StartOffset", CompactionBlobEncoder.StartOffset)("cz.EndOffset", CompactionBlobEncoder.EndOffset)
+        ("fwz.StartOffset", BlobEncoder.StartOffset)("fwz.EndOffset", BlobEncoder.EndOffset)
+        ;
 
     auto it = std::upper_bound(container.begin(), container.end(), offset,
                     [](const ui64 offset, const TDataKey& p) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1527,11 +1527,20 @@ TInstant TPartition::GetWriteTimeEstimate(ui64 offset) const {
     const TPartitionBlobEncoder& blobEncoder = GetBlobEncoder(offset);
     offset = Max(offset, blobEncoder.StartOffset);
     const std::deque<TDataKey>& container = GetContainer(blobEncoder, offset);
-    PQ_ENSURE(!container.empty())
-        ("offset", offset)
-        ("cz.StartOffset", CompactionBlobEncoder.StartOffset)("cz.EndOffset", CompactionBlobEncoder.EndOffset)
-        ("fwz.StartOffset", BlobEncoder.StartOffset)("fwz.EndOffset", BlobEncoder.EndOffset)
-        ;
+    if (container.empty()) {
+        // Can happen if meta offsets diverge from blob keys (e.g. after init with
+        // NODATA). Treat as "no such record" — same as offset >= EndOffset.
+        YDB_LOG_WARN_COMP(Service, "GetWriteTimeEstimate: empty container for offset",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"tablet_id", TabletId},
+            {"partition", Partition},
+            {"offset", offset},
+            {"cz.StartOffset", CompactionBlobEncoder.StartOffset},
+            {"cz.EndOffset", CompactionBlobEncoder.EndOffset},
+            {"fwz.StartOffset", BlobEncoder.StartOffset},
+            {"fwz.EndOffset", BlobEncoder.EndOffset});
+        return TInstant::Zero();
+    }
 
     auto it = std::upper_bound(container.begin(), container.end(), offset,
                     [](const ui64 offset, const TDataKey& p) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1033,7 +1033,6 @@ void TPartition::InitComplete(const TActorContext& ctx) {
     InitDone = true;
     TabletCounters.Percentile()[COUNTER_LATENCY_PQ_INIT].IncrementFor(InitDuration.MilliSeconds());
 
-    CreateCompacter();
     InitializeMLPConsumers();
 
     InitUserInfoForImportantClients(ctx);

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -502,20 +502,13 @@ void TInitDataRangeStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActor
 
             FillBlobsMetaData(ctx);
             FormHeadAndProceed();
-
-            // AFL_ENSURE(!GetContext().StartOffset || *GetContext().StartOffset >= Partition()->GetStartOffset())
-            //     ("d", "StartOffset from meta and blobs are different")
-            //     ("l", *GetContext().StartOffset)
-            //     ("r", Partition()->GetStartOffset());
-
-            // AFL_ENSURE(!GetContext().EndOffset || *GetContext().EndOffset == Partition()->GetEndOffset())
-            //     ("d", "EndOffset from meta and blobs are different")
-            //     ("l", *GetContext().EndOffset)
-            //     ("r", Partition()->GetEndOffset());
-
-            [[fallthrough]];
+            Done(ctx);
+            break;
 
         case NKikimrProto::NODATA:
+            // Meta offsets were loaded earlier; without FormHeadAndProceed they stay
+            // as Start < End with empty containers and break GetWriteTimeEstimate.
+            NormalizeOffsetsForEmptyData();
             Done(ctx);
             break;
         default:
@@ -788,6 +781,37 @@ TKeyBoundaries SplitBodyHeadAndFastWrite(const std::deque<TDataKey>& keys)
     return b;
 }
 
+void TInitDataRangeStep::NormalizeOffsetsForEmptyData() {
+    auto& fwz = Partition()->BlobEncoder;
+    auto& cz = Partition()->CompactionBlobEncoder;
+
+    // Keep EndOffset from meta as the high-water mark for an empty partition.
+    const ui64 emptyOffset = fwz.EndOffset;
+
+    YDB_LOG_WARN_COMP(NKikimrServices::PERSQUEUE,
+        "No data keys during partition init; normalizing empty partition offsets",
+        {"logPrefix", LogPrefix()},
+        {"tablet_id", Partition()->TabletId},
+        {"partition", Partition()->Partition},
+        {"metaStartOffset", fwz.StartOffset},
+        {"metaEndOffset", emptyOffset});
+
+    fwz.StartOffset = emptyOffset;
+    fwz.Head.Offset = emptyOffset;
+    fwz.Head.PartNo = 0;
+    fwz.NewHead.Offset = emptyOffset;
+    fwz.NewHead.PartNo = 0;
+    fwz.BodySize = 0;
+
+    cz.StartOffset = emptyOffset;
+    cz.EndOffset = emptyOffset;
+    cz.Head.Offset = emptyOffset;
+    cz.Head.PartNo = 0;
+    cz.NewHead.Offset = emptyOffset;
+    cz.NewHead.PartNo = 0;
+    cz.BodySize = 0;
+}
+
 void TInitDataRangeStep::FormHeadAndProceed() {
     auto& endOffset = Partition()->BlobEncoder.EndOffset;
     auto& startOffset = Partition()->BlobEncoder.StartOffset;
@@ -795,6 +819,11 @@ void TInitDataRangeStep::FormHeadAndProceed() {
 
     auto keys = std::move(dataKeysBody);
     dataKeysBody.clear();
+
+    if (keys.empty()) {
+        NormalizeOffsetsForEmptyData();
+        return;
+    }
 
     auto& cz = Partition()->CompactionBlobEncoder; // Compaction zone
     auto& fwz = Partition()->BlobEncoder;   // FastWrite zone

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -456,11 +456,6 @@ void TInitInfoRangeStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActor
 }
 
 void TInitInfoRangeStep::PostProcessing(const TActorContext& ctx) {
-    auto& usersInfoStorage = Partition()->UsersInfoStorage;
-    for (auto&& [_, userInfo] : usersInfoStorage->GetAll()) {
-        userInfo.AnyCommits = userInfo.Offset > (i64)Partition()->BlobEncoder.StartOffset;
-    }
-
     Done(ctx);
 }
 
@@ -1176,6 +1171,14 @@ void TInitFieldsStep::Execute(const TActorContext &ctx) {
     auto& config = Partition()->Config;
 
     Partition()->AutopartitioningManager.reset(CreateAutopartitioningManager(config, Partition()->Partition));
+
+    // After DataRange (FormHead / NormalizeOffsetsForEmptyData) offsets are final.
+    // Recalculate here so AnyCommits matches runtime GetStartOffset(), not the pre-normalize meta StartOffset.
+    for (auto&& [_, userInfo] : Partition()->UsersInfoStorage->GetAll()) {
+        userInfo.AnyCommits = userInfo.Offset > (i64)Partition()->GetStartOffset();
+    }
+
+    Partition()->CreateCompacter();
 
     return Done(ctx);
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -157,6 +157,9 @@ public:
 private:
     void FillBlobsMetaData(const TActorContext& ctx);
     void FormHeadAndProceed();
+    // Meta may report StartOffset < EndOffset while data keys are gone (retention /
+    // crash under Nemesis). Collapse both encoders to an empty partition at EndOffset.
+    void NormalizeOffsetsForEmptyData();
 
     TVector<NKikimrClient::TKeyValueResponse::TReadRangeResult> Ranges;
 };

--- a/ydb/core/persqueue/pqtablet/partition/user_info.h
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.h
@@ -60,6 +60,9 @@ struct TUserInfoBase {
     ui32 Generation = 0;
     ui32 Step = 0;
     i64 Offset = 0;
+    // True if the consumer has committed past GetStartOffset() (a real position in the
+    // live data range). False if still at/before the retention boundary. Exposed to
+    // proxies as ClientHasAnyCommits; used for first-commit distributed commits on splits.
     bool AnyCommits = false;
 
     bool Important = false;

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -7501,25 +7501,6 @@ Y_UNIT_TEST_F(GetClientOffsetSurvivesInitWithMetaButNoDataKeys, TPartitionFixtur
     WaitProxyResponse({.Cookie = 1, .Status = NMsgBusProxy::MSTATUS_OK, .Offset = 0});
 }
 
-Y_UNIT_TEST_F(GetWriteTimeEstimateEmptyContainerReturnsZero, TPartitionFixture) {
-    UNIT_ASSERT(Ctx.Defined());
-    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
-
-    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
-    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
-    cz.DataKeysBody.clear();
-    cz.HeadKeys.clear();
-    fwz.DataKeysBody.clear();
-    fwz.HeadKeys.clear();
-    // Divergent meta-like state that used to trip PQ_ENSURE(!container.empty()).
-    cz.StartOffset = 0;
-    cz.EndOffset = 3804;
-    fwz.StartOffset = 0;
-    fwz.EndOffset = 3804;
-
-    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), TInstant::Zero());
-}
-
 Y_UNIT_TEST_F(FinalizeEmptyBlobEncoderResetsHeadPartNo, TPartitionFixture) {
     UNIT_ASSERT(Ctx.Defined());
     TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -122,6 +122,12 @@ public:
         return partition.GetEndOffset();
     }
 
+    static bool GetAnyCommits(TPartition& partition, const TString& consumer) {
+        const TUserInfo* userInfo = partition.UsersInfoStorage->GetIfExists(consumer);
+        UNIT_ASSERT(userInfo);
+        return userInfo->AnyCommits;
+    }
+
 private:
     TInitMetaStep* MetaStep;
 };
@@ -7385,7 +7391,9 @@ Y_UNIT_TEST_F(InitWithMetaOffsetsButNoDataKeysNormalizesEmptyPartition, TPartiti
         .Begin = 0,
         .End = metaEnd,
         .Config = {
-            .Consumers = {{.Consumer = "user", .Offset = 0}},
+            // Offset within stale meta range: before normalize AnyCommits would be true
+            // (Offset > BlobEncoder.StartOffset == 0); after normalize StartOffset == metaEnd.
+            .Consumers = {{.Consumer = "user", .Offset = 100}},
         },
         .EndWriteTimestamp = TInstant::Seconds(1),
         .NoDataKeys = true,
@@ -7409,6 +7417,7 @@ Y_UNIT_TEST_F(InitWithMetaOffsetsButNoDataKeysNormalizesEmptyPartition, TPartiti
 
     UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), TInstant::Zero());
     UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, metaEnd), TInstant::Zero());
+    UNIT_ASSERT(!TPartitionTestWrapper::GetAnyCommits(*partition, "user"));
 }
 
 Y_UNIT_TEST_F(InitWithMetaOffsetsEmptyOkDataRangeNormalizesEmptyPartition, TPartitionFixture) {

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -59,6 +59,11 @@ struct TCreatePartitionParams {
     TVector<TCreateConsumerParams> ExtraDiskConsumers;
     TInstant EndWriteTimestamp;
     bool FillHead = false;
+    // Meta has [Begin, End) but data range returns NODATA (issue #49507).
+    bool NoDataKeys = false;
+    // Meta has [Begin, End) but data range returns OK with zero pairs
+    // (FormHeadAndProceed empty-keys path).
+    bool EmptyDataRangeOk = false;
 };
 
 }
@@ -103,6 +108,18 @@ public:
 
     static bool CleanUpBlobs(TPartition& partition, const TActorContext& ctx) {
         return partition.CleanUpBlobs(nullptr, ctx);
+    }
+
+    static TInstant GetWriteTimeEstimate(TPartition& partition, ui64 offset) {
+        return partition.GetWriteTimeEstimate(offset);
+    }
+
+    static ui64 GetStartOffset(TPartition& partition) {
+        return partition.GetStartOffset();
+    }
+
+    static ui64 GetEndOffset(TPartition& partition) {
+        return partition.GetEndOffset();
     }
 
 private:
@@ -304,6 +321,8 @@ protected:
     void WaitDataRangeRequest();
     void SendDataRangeResponse(ui32 partitionId,
                                ui64 begin, ui64 end, bool isHead);
+    void SendDataRangeNodataResponse();
+    void SendDataRangeEmptyOkResponse();
     void WaitDataReadRequest();
     void SendDataReadResponse();
     void WaitDeduplicatorRangeRequest();
@@ -516,11 +535,18 @@ TPartition* TPartitionFixture::CreatePartition(const TCreatePartitionParams& par
         }
 
         WaitDataRangeRequest();
-        SendDataRangeResponse(params.Partition.InternalPartitionId, params.Begin, params.End, params.FillHead);
+        if (params.NoDataKeys) {
+            UNIT_ASSERT_C(!params.EmptyDataRangeOk, "NoDataKeys and EmptyDataRangeOk are mutually exclusive");
+            SendDataRangeNodataResponse();
+        } else if (params.EmptyDataRangeOk) {
+            SendDataRangeEmptyOkResponse();
+        } else {
+            SendDataRangeResponse(params.Partition.InternalPartitionId, params.Begin, params.End, params.FillHead);
 
-        if (params.FillHead) {
-            WaitBlobReadRequest();
-            SendBlobReadResponse(params.Begin, params.End);
+            if (params.FillHead) {
+                WaitBlobReadRequest();
+                SendBlobReadResponse(params.Begin, params.End);
+            }
         }
 
         if (!params.Partition.IsSupportivePartition()) {
@@ -1087,6 +1113,29 @@ void TPartitionFixture::SendDataRangeResponse(ui32 partitionId,
     pair->SetKey(key.Data(), key.Size());
     pair->SetValueSize(684);
     pair->SetCreationUnixTime(TInstant::Now().Seconds());
+
+    Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
+}
+
+void TPartitionFixture::SendDataRangeNodataResponse()
+{
+    auto event = MakeHolder<TEvKeyValue::TEvResponse>();
+    event->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
+
+    auto read = event->Record.AddReadRangeResult();
+    read->SetStatus(NKikimrProto::NODATA);
+
+    Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
+}
+
+void TPartitionFixture::SendDataRangeEmptyOkResponse()
+{
+    auto event = MakeHolder<TEvKeyValue::TEvResponse>();
+    event->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
+
+    auto read = event->Record.AddReadRangeResult();
+    read->SetStatus(NKikimrProto::OK);
+    // No pairs — FillBlobsMetaData leaves meta offsets, FormHeadAndProceed sees empty keys.
 
     Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
 }
@@ -7324,6 +7373,152 @@ private:
     TActorId Edge;
     std::function<void(const TActorContext&)> Body;
 };
+
+Y_UNIT_TEST_F(InitWithMetaOffsetsButNoDataKeysNormalizesEmptyPartition, TPartitionFixture) {
+    // Regression for #49507: meta says [0, 3804) but data range is NODATA.
+    // Without normalization InitComplete → ReportCounters → GetWriteTimeEstimate crashes.
+    UNIT_ASSERT(Ctx.Defined());
+
+    constexpr ui64 metaEnd = 3804;
+    TPartition* partition = CreatePartition({
+        .Partition = TPartitionId{1},
+        .Begin = 0,
+        .End = metaEnd,
+        .Config = {
+            .Consumers = {{.Consumer = "user", .Offset = 0}},
+        },
+        .EndWriteTimestamp = TInstant::Seconds(1),
+        .NoDataKeys = true,
+    });
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetStartOffset(*partition), metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetEndOffset(*partition), metaEnd);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    UNIT_ASSERT_VALUES_EQUAL(cz.StartOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(cz.EndOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(fwz.StartOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(fwz.EndOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(cz.Head.Offset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(fwz.Head.Offset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(cz.NewHead.Offset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(fwz.NewHead.Offset, metaEnd);
+    UNIT_ASSERT(cz.IsEmpty());
+    UNIT_ASSERT(fwz.IsEmpty());
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, metaEnd), TInstant::Zero());
+}
+
+Y_UNIT_TEST_F(InitWithMetaOffsetsEmptyOkDataRangeNormalizesEmptyPartition, TPartitionFixture) {
+    // Same inconsistent meta as #49507, but data range returns OK with zero pairs —
+    // hits FormHeadAndProceed empty-keys → NormalizeOffsetsForEmptyData.
+    UNIT_ASSERT(Ctx.Defined());
+
+    constexpr ui64 metaEnd = 3804;
+    TPartition* partition = CreatePartition({
+        .Partition = TPartitionId{1},
+        .Begin = 0,
+        .End = metaEnd,
+        .EndWriteTimestamp = TInstant::Seconds(1),
+        .EmptyDataRangeOk = true,
+    });
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetStartOffset(*partition), metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetEndOffset(*partition), metaEnd);
+    UNIT_ASSERT(TPartitionTestWrapper::CompactionBlobEncoder(*partition).IsEmpty());
+    UNIT_ASSERT(TPartitionTestWrapper::BlobEncoder(*partition).IsEmpty());
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), TInstant::Zero());
+}
+
+Y_UNIT_TEST_F(InitWithNonZeroMetaStartAndNoDataKeysNormalizesToEnd, TPartitionFixture) {
+    // Retention advanced StartOffset; meta [100, 3804) but blobs are gone.
+    UNIT_ASSERT(Ctx.Defined());
+
+    constexpr ui64 metaStart = 100;
+    constexpr ui64 metaEnd = 3804;
+    TPartition* partition = CreatePartition({
+        .Partition = TPartitionId{1},
+        .Begin = metaStart,
+        .End = metaEnd,
+        .EndWriteTimestamp = TInstant::Seconds(1),
+        .NoDataKeys = true,
+    });
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetStartOffset(*partition), metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetEndOffset(*partition), metaEnd);
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    UNIT_ASSERT_VALUES_EQUAL(cz.StartOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(cz.EndOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(fwz.StartOffset, metaEnd);
+    UNIT_ASSERT_VALUES_EQUAL(fwz.EndOffset, metaEnd);
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateReturnsTimestampFromBodyKeys, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    constexpr ui64 begin = 0;
+    constexpr ui64 end = 10;
+    TPartition* partition = CreatePartition({
+        .Partition = TPartitionId{1},
+        .Begin = begin,
+        .End = end,
+        .EndWriteTimestamp = TInstant::Seconds(1),
+    });
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetStartOffset(*partition), begin);
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetEndOffset(*partition), end);
+    UNIT_ASSERT(!TPartitionTestWrapper::CompactionBlobEncoder(*partition).IsEmpty() ||
+                !TPartitionTestWrapper::BlobEncoder(*partition).IsEmpty());
+
+    const TInstant ts = TPartitionTestWrapper::GetWriteTimeEstimate(*partition, begin);
+    UNIT_ASSERT_GT(ts, TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, end), TInstant::Zero());
+}
+
+Y_UNIT_TEST_F(GetClientOffsetSurvivesInitWithMetaButNoDataKeys, TPartitionFixture) {
+    // E2E: InitComplete → ReportCounters and later GetClientOffset must not crash
+    // when meta offsets exist without data keys (#49507).
+    UNIT_ASSERT(Ctx.Defined());
+
+    constexpr ui64 metaEnd = 3804;
+    const TString client = "user";
+    CreatePartition({
+        .Partition = TPartitionId{1},
+        .Begin = 0,
+        .End = metaEnd,
+        .Config = {
+            .Consumers = {{.Consumer = client, .Offset = 0}},
+        },
+        .EndWriteTimestamp = TInstant::Seconds(1),
+        .NoDataKeys = true,
+    });
+
+    SendGetOffset(1, client);
+    WaitProxyResponse({.Cookie = 1, .Status = NMsgBusProxy::MSTATUS_OK, .Offset = 0});
+}
+
+Y_UNIT_TEST_F(GetWriteTimeEstimateEmptyContainerReturnsZero, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    auto& cz = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    auto& fwz = TPartitionTestWrapper::BlobEncoder(*partition);
+    cz.DataKeysBody.clear();
+    cz.HeadKeys.clear();
+    fwz.DataKeysBody.clear();
+    fwz.HeadKeys.clear();
+    // Divergent meta-like state that used to trip PQ_ENSURE(!container.empty()).
+    cz.StartOffset = 0;
+    cz.EndOffset = 3804;
+    fwz.StartOffset = 0;
+    fwz.EndOffset = 3804;
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetWriteTimeEstimate(*partition, 0), TInstant::Zero());
+}
 
 Y_UNIT_TEST_F(FinalizeEmptyBlobEncoderResetsHeadPartNo, TPartitionFixture) {
     UNIT_ASSERT(Ctx.Defined());

--- a/ydb/core/protos/msgbus_pq.proto
+++ b/ydb/core/protos/msgbus_pq.proto
@@ -510,6 +510,8 @@ message TPersQueuePartitionResponse {
         optional uint64 CreateTimestampMS = 6; //create Timestamp of record on Offset (next to be readed record); is not set if no such record exists (no lag)
         optional uint64 SizeLag = 7;
         optional uint64 WriteTimestampEstimateMS = 8;
+        // Mirror of consumer AnyCommits: true if Offset > partition StartOffset.
+        // Proxies use it for first-commit distributed commits when the partition has parents (split).
         optional bool ClientHasAnyCommits = 9;
         optional string CommittedMetadata = 10;
     }

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -828,6 +828,13 @@ message TUserInfo {
     optional uint64 OffsetRewindSum = 5;
     optional uint64 ReadRuleGeneration = 6;
     optional uint64 PartitionSessionId = 7;
+    // Whether the consumer has ever committed past the partition StartOffset.
+    // Equivalent to (Offset > StartOffset): true means a real committed position in the
+    // live data range; false means the consumer is still at/before the retention boundary
+    // (never committed into live data, or was clamped back to StartOffset).
+    // Persisted with user info; recalculated on partition init from final StartOffset.
+    // Exposed to clients/proxies as ClientHasAnyCommits (TCmdGetClientOffsetResult) and
+    // used for first-commit distributed commits when the partition has parents after a split.
     optional bool AnyCommits = 8;
     optional string CommittedMetadata = 9;
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a PersQueue partition crash during init when partition meta reported a non-empty offset range but data keys were missing (`GetWriteTimeEstimate` hit `!container.empty()`).

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/49507

**Root cause**

On data-range `NODATA` (and empty keys after `FormHeadAndProceed`), init skipped offset normalization. Meta could leave both encoders with `StartOffset < EndOffset` and empty containers. `InitComplete` → `ReportCounters` → `CreateSnapshot` → `GetWriteTimeEstimate` then hit `PQ_ENSURE(!container.empty())`.

**Fix**

- Add `NormalizeOffsetsForEmptyData()`: collapse both zones to an empty partition at meta `EndOffset` (also sync `Head` / `NewHead`).
- Call it on data-range `NODATA`.
- Call it from `FormHeadAndProceed` when there are no keys (instead of the old `Start=End=Max` path).

**Tests**

- NODATA with meta `[0, End)`
- OK + empty pairs
- non-zero meta `StartOffset` + NODATA
- happy-path `GetWriteTimeEstimate` with body keys
- E2E `GetClientOffset` after NODATA init

## Test plan

- [x] `./ya make --build relwithdebinfo -tA ydb/core/persqueue/ut -F '*InitWithMetaOffsets*' -F '*InitWithNonZeroMetaStart*' -F '*GetWriteTimeEstimateReturnsTimestamp*' -F '*GetClientOffsetSurvivesInit*'`