### PR TITLE
Stop shared topic asyncio loop in stress workloads before exit

### DIFF
--- a/ydb/tests/stress/common/common.py
+++ b/ydb/tests/stress/common/common.py
@@ -11,6 +11,41 @@ ydb.interceptor.monkey_patch_event_handler()
 logger = logging.getLogger(__name__)
 
 
+def shutdown_shared_topic_event_loop(timeout: Optional[float] = 30) -> None:
+    """
+    Stop the process-wide YDB topic asyncio loop thread before interpreter exit.
+
+    Sync topic clients leave "Common ydb topic event loop" in run_forever()/epoll
+    after writer/reader close; joining it avoids a TSan race with Py_FinalizeEx
+    (ydb-platform/ydb#40952). Prefer SDK helper when available (after python-sdk sync).
+    """
+    try:
+        from ydb._topic_common import common as topic_common
+    except ImportError:
+        return
+
+    shutdown = getattr(topic_common, "_shutdown_shared_event_loop", None)
+    if shutdown is not None:
+        shutdown(timeout=timeout)
+        return
+
+    loop = getattr(topic_common, "_shared_event_loop", None)
+    if loop is not None:
+        try:
+            if loop.is_running():
+                loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError:
+            logger.debug("Shared topic event loop already stopped", exc_info=True)
+        topic_common._shared_event_loop = None
+
+    for thread in threading.enumerate():
+        if thread.name == "Common ydb topic event loop" and thread.is_alive():
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                logger.warning("Shared ydb topic event loop thread did not stop in time")
+            break
+
+
 class YdbClient:
     def __init__(self, endpoint, database, use_query_service=False, sessions=100):
         self.driver = ydb.Driver(endpoint=endpoint, database=database, oauth=None)

--- a/ydb/tests/stress/kafka/workload/__init__.py
+++ b/ydb/tests/stress/kafka/workload/__init__.py
@@ -408,5 +408,8 @@ class Workload(unittest.TestCase):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.driver is not None:
             self.driver.stop()
+        from ydb.tests.stress.common.common import shutdown_shared_topic_event_loop
+
+        shutdown_shared_topic_event_loop()
         for tmp_dir in self.tmp_dirs:
             shutil.rmtree(tmp_dir)

--- a/ydb/tests/stress/streaming/workload/__init__.py
+++ b/ydb/tests/stress/streaming/workload/__init__.py
@@ -259,3 +259,6 @@ class Workload():
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.pool.stop()
         self.driver.stop()
+        from ydb.tests.stress.common.common import shutdown_shared_topic_event_loop
+
+        shutdown_shared_topic_event_loop()

--- a/ydb/tests/stress/transfer/workload/__init__.py
+++ b/ydb/tests/stress/transfer/workload/__init__.py
@@ -137,3 +137,6 @@ class Workload(unittest.TestCase):
 
         self.pool.stop()
         self.driver.stop()
+        from ydb.tests.stress.common.common import shutdown_shared_topic_event_loop
+
+        shutdown_shared_topic_event_loop()


### PR DESCRIPTION
## Summary
- Fixes TSan race from https://github.com/ydb-platform/ydb/issues/40952 in stress binaries that use sync topic clients (`kafka`, `streaming`, `transfer`): after `driver.stop()`, stop/join the leftover `"Common ydb topic event loop"` thread before process exit.
- Adds `shutdown_shared_topic_event_loop()` helper that prefers `ydb._topic_common.common._shutdown_shared_event_loop` (after python-sdk sync) and falls back to stop+join by thread name on current contrib.
- No changes under `contrib/python/ydb` (synced from elsewhere). SDK-side fix: https://github.com/ydb-platform/ydb-python-sdk/pull/874

## Test plan
- [ ] Confirm SDK PR #874 merged and/or fallback path stops the shared loop thread
- [ ] Re-run release-tsan stress for `streaming` / `transfer` / `kafka` and check that `Py_FinalizeEx` / `free_threadstate` vs `drop_gil` race is gone


Made with [Cursor](https://cursor.com)