### PR TITLE
Disable renames for TableStore tables

### DIFF
--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -5497,5 +5497,102 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         }
     }
 
+    Y_UNIT_TEST(MovingTableStoreTablesNotSupported) {
+        auto settings = TKikimrSettings().SetWithSampleTables(false);
+        TKikimrRunner kikimr(settings);
+
+        auto queryClient = kikimr.GetQueryClient();
+
+        {
+            auto status = queryClient.ExecuteQuery(R"(
+                CREATE TABLESTORE `/Root/TableStore` (
+                    timestamp Timestamp NOT NULL,
+                    uid Utf8 NOT NULL,
+                    value Int32,
+                    PRIMARY KEY (timestamp, uid)
+                )
+                WITH (
+                    STORE = COLUMN,
+                    PARTITION_COUNT=1
+                );
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        }
+
+        {
+            auto status = queryClient.ExecuteQuery(R"(
+                CREATE TABLE `/Root/TableStore/InStoreTable` (
+                    timestamp Timestamp NOT NULL,
+                    uid Utf8 NOT NULL,
+                    value Int32,
+                    PRIMARY KEY (timestamp, uid)
+                )
+                PARTITION BY HASH(timestamp)
+                WITH (
+                    STORE = COLUMN,
+                    PARTITION_COUNT=1
+                );
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        }
+
+        {
+            auto status = queryClient.ExecuteQuery(R"(
+                CREATE TABLE `/Root/StandaloneTable` (
+                    timestamp Timestamp NOT NULL,
+                    uid Utf8 NOT NULL,
+                    value Int32,
+                    PRIMARY KEY (timestamp, uid)
+                )
+                PARTITION BY HASH(timestamp)
+                WITH (
+                    STORE = COLUMN,
+                    PARTITION_COUNT=1
+                );
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        }
+
+        // Case 1: Move in-store table within the TABLESTORE — should fail
+        {
+            auto status = queryClient.ExecuteQuery(R"(
+                ALTER TABLE `/Root/TableStore/InStoreTable` RENAME TO `/Root/TableStore/InStoreTable_renamed`;
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!status.IsSuccess(), "Moving tables inside a TABLESTORE should fail");
+        }
+
+        // Case 2: Move in-store table out of the TABLESTORE — should fail
+        {
+            auto status = queryClient.ExecuteQuery(R"(
+                ALTER TABLE `/Root/TableStore/InStoreTable` RENAME TO `/Root/InStoreTable_moved`;
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!status.IsSuccess(), "Moving tables from a TABLESTORE should fail");
+        }
+
+        // Case 3: Move standalone table into the TABLESTORE — should fail
+        {
+            auto status = queryClient.ExecuteQuery(R"(
+                ALTER TABLE `/Root/StandaloneTable` RENAME TO `/Root/TableStore/MovedTable`;
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!status.IsSuccess(), "Moving tables into a TABLESTORE should fail");
+        }
+
+        // Verify the in-store table is still accessible (all moves were rejected)
+        {
+            auto it = queryClient.ExecuteQuery(R"(
+                SELECT * FROM `/Root/TableStore/InStoreTable`;
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+        }
+
+        // Verify the renamed standalone table is accessible
+        {
+            auto it = queryClient.ExecuteQuery(R"(
+                SELECT * FROM `/Root/StandaloneTable`;
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+        }
+    }
+
 }
 }

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -5585,7 +5585,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
         }
 
-        // Verify the renamed standalone table is accessible
+        // Verify the standalone table is still accessible (move was rejected)
         {
             auto it = queryClient.ExecuteQuery(R"(
                 SELECT * FROM `/Root/StandaloneTable`;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -820,6 +820,12 @@ public:
             if (!srcPath->IsTable() && !srcPath->IsColumnTable()) {
                 result->SetError(NKikimrScheme::StatusPreconditionFailed, "Cannot move non-tables");
             }
+            if (srcPath->IsColumnTable() && srcPath.Parent()->IsOlapStore()) {
+                result->SetError(NKikimrScheme::StatusPreconditionFailed,
+                    "Moving tables inside a TABLESTORE is not supported");
+                return result;
+            }
+
             TPath::TChecker checks = srcPath.Check();
             checks
                 .NotEmpty()
@@ -841,6 +847,11 @@ public:
 
         TPath dstPath = TPath::ResolveWithInactive(OperationId, dstPathStr, context.SS);
         TPath dstParent = dstPath.Parent();
+        if (dstParent->IsOlapStore()) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed,
+                "Moving tables into a TABLESTORE is not supported");
+            return result;
+        }
 
         {
             TPath::TChecker checks = dstParent.Check();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -847,11 +847,6 @@ public:
 
         TPath dstPath = TPath::ResolveWithInactive(OperationId, dstPathStr, context.SS);
         TPath dstParent = dstPath.Parent();
-        if (dstParent->IsOlapStore()) {
-            result->SetError(NKikimrScheme::StatusPreconditionFailed,
-                "Moving tables into a TABLESTORE is not supported");
-            return result;
-        }
 
         {
             TPath::TChecker checks = dstParent.Check();
@@ -863,6 +858,12 @@ public:
 
             if (!checks) {
                 result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+
+            if (dstParent->IsOlapStore()) {
+                result->SetError(NKikimrScheme::StatusPreconditionFailed,
+                "Moving tables into a TABLESTORE is not supported");
                 return result;
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -822,7 +822,7 @@ public:
             }
             if (srcPath->IsColumnTable() && srcPath.Parent()->IsOlapStore()) {
                 result->SetError(NKikimrScheme::StatusPreconditionFailed,
-                    "Moving tables inside a TABLESTORE is not supported");
+                    "TABLESTORE tables cannot be renamed or moved");
                 return result;
             }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Падало в SS на попытке переименования таблицы в TableStore. Поскольку TableStore мы не релизили, и возможность переименовывать там таблицы сейчас никому не нужно, проще запретить, чем поддерживать

...
