### PR TITLE
[Backport stable-26-2] Fix ASAN leak in Topic/PersQueue read session teardown

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
@@ -6,6 +6,8 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
 
+#include <util/generic/scope.h>
+
 using namespace NYdb::NConsoleClient;
 
 void TTopicWorkloadReader::RetryableReaderLoop(const TTopicWorkloadReaderParams& params) {
@@ -64,6 +66,12 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
         NYdb::NTopic::TPartitionSession::TPtr Stream;
     };
     THashMap<std::pair<TString, ui64>, TPartitionStreamState> streamState;
+    Y_DEFER {
+        streamState.clear();
+        if (!readSession->Close(TDuration::Seconds(5))) {
+            WRITE_LOG(params.Log, ELogPriority::TLOG_WARNING, "Reader session was not gracefully closed.");
+        }
+    };
 
     TInstant LastPartitionStatusRequestTime = TInstant::Zero();
 
@@ -148,6 +156,11 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
         if (txSupport) {
             TryCommitTx(params, txSupport, commitTime, stopPartitionSessionEvents);
         }
+    }
+
+    if (txSupport) {
+        TryCommitTableChanges(params, txSupport);
+        GracefullShutdown(stopPartitionSessionEvents);
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
@@ -59,7 +59,28 @@ TReadSession::~TReadSession() {
     }
 
     Abort();
+
+    std::vector<TSingleClusterReadSessionImpl::TPtr> sessions;
+    {
+        std::lock_guard guard(Lock);
+        sessions.reserve(ClusterSessions.size());
+        for (auto& [_, sessionInfo] : ClusterSessions) {
+            if (sessionInfo.Session) {
+                sessions.push_back(sessionInfo.Session);
+            }
+        }
+    }
+
+    const TInstant closeDeadline = TInstant::Now() + TDuration::Seconds(5);
+    for (const auto& session : sessions) {
+        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session destroy timeout");
+        }
+    }
     ClearAllEvents();
+    for (const auto& session : sessions) {
+        session->ClearAllPartitionStreamEvents();
+    }
 
     for (const auto& ctx : CbContexts) {
         ctx->Cancel();
@@ -352,6 +373,12 @@ bool TReadSession::Close(TDuration timeout) {
         // Log final counters.
         CountersLogger->Stop();
     }
+    {
+        std::lock_guard guard(Lock);
+        if (DumpCountersContext) {
+            DumpCountersContext->Cancel();
+        }
+    }
 
     std::vector<TSingleClusterReadSessionImpl::TPtr> sessions;
     NThreading::TPromise<bool> promise = NThreading::NewPromise<bool>();
@@ -362,6 +389,8 @@ bool TReadSession::Close(TDuration timeout) {
         }
     };
 
+    std::vector<TCallbackContextPtr> cbContextsToCancel;
+    std::shared_ptr<TCallbackContext<TCountersLogger>> dumpCountersContextToCancel;
     TDeferredActions deferred;
     {
         std::lock_guard guard(Lock);
@@ -395,9 +424,11 @@ bool TReadSession::Close(TDuration timeout) {
 
     auto timeoutContext = Connections->CreateContext();
     if (!timeoutContext) {
+        std::lock_guard guard(Lock);
         AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
         return false;
     }
+    const TInstant closeDeadline = TInstant::Now() + timeout;
     Connections->ScheduleCallback(timeout,
                                   std::move(timeoutCallback),
                                   timeoutContext);
@@ -422,8 +453,30 @@ bool TReadSession::Close(TDuration timeout) {
         EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
     }
 
-    std::lock_guard guard(Lock);
-    Aborting = true; // Set abort flag for doing nothing on destructor.
+    {
+        std::lock_guard guard(Lock);
+        Aborting = true; // Set abort flag for doing nothing on destructor.
+        cbContextsToCancel = CbContexts;
+        dumpCountersContextToCancel = DumpCountersContext;
+    }
+
+    for (const auto& session : sessions) {
+        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+        }
+    }
+    ClearAllEvents();
+    for (const auto& session : sessions) {
+        session->ClearAllPartitionStreamEvents();
+    }
+
+    for (const auto& ctx : cbContextsToCancel) {
+        ctx->Cancel();
+    }
+    if (dumpCountersContextToCancel) {
+        dumpCountersContextToCancel->Cancel();
+    }
+
     return result;
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -40,7 +40,20 @@ TReadSession::~TReadSession() {
     Close(TDuration::Zero());
 
     Abort(EStatus::ABORTED, "Aborted");
-    ClearAllEvents();
+    if (CbContext) {
+        if (auto session = CbContext->LockShared()) {
+            const TInstant closeDeadline = TInstant::Now() + TDuration::Seconds(5);
+            if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+                LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session destroy timeout");
+            }
+            ClearAllEvents();
+            session->ClearAllPartitionStreamEvents();
+        } else {
+            ClearAllEvents();
+        }
+    } else {
+        ClearAllEvents();
+    }
 
     if (CbContext) {
         CbContext->Cancel();
@@ -191,57 +204,77 @@ bool TReadSession::Close(TDuration timeout) {
         promise.TrySetValue(true);
     };
 
-    TDeferredActions<false> deferred;
-    with_lock(Lock) {
-        if (Closing || Aborting) {
-            return false;
-        }
-
-        if (!timeout) {
-            AbortImpl(EStatus::ABORTED, "Close with zero timeout", deferred);
-            return false;
-        }
-
-        Closing = true;
-        session = CbContext->TryGet();
-    }
-    session->Close(callback);
-
-    callback(); // For the case when there are no subsessions yet.
-
-    auto timeoutCallback = [=](bool) mutable {
-        promise.TrySetValue(false);
-    };
-
-    auto timeoutContext = Connections->CreateContext();
-    if (!timeoutContext) {
-        AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
-        return false;
-    }
-    Connections->ScheduleCallback(timeout,
-                                  std::move(timeoutCallback),
-                                  timeoutContext);
-
-    // Wait.
-    NThreading::TFuture<bool> resultFuture = promise.GetFuture();
-    const bool result = resultFuture.GetValueSync();
-    if (result) {
-        Cancel(timeoutContext);
-
-        NYdb::NIssue::TIssues issues;
-        issues.AddIssue("Session was gracefully closed");
-        EventsQueue->Close(TSessionClosedEvent(EStatus::SUCCESS, std::move(issues)), deferred);
-    } else {
-        ++*Settings.Counters_->Errors;
-        session->Abort();
-
-        NYdb::NIssue::TIssues issues;
-        issues.AddIssue(TStringBuilder() << "Session was closed after waiting " << timeout);
-        EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
-    }
+    std::shared_ptr<TCallbackContext<TSingleClusterReadSessionImpl<false>>> cbContextToCancel;
+    std::shared_ptr<TCallbackContext<TCountersLogger<false>>> dumpCountersContextToCancel;
+    TInstant closeDeadline;
+    bool result = false;
     {
-        std::lock_guard guard(Lock);
-        Aborting = true; // Set abort flag for doing nothing on destructor.
+        TDeferredActions<false> deferred;
+        with_lock(Lock) {
+            if (Closing || Aborting) {
+                return false;
+            }
+
+            if (!timeout) {
+                AbortImpl(EStatus::ABORTED, "Close with zero timeout", deferred);
+                return false;
+            }
+
+            Closing = true;
+            session = CbContext->TryGet();
+        }
+        session->Close(callback);
+
+        callback(); // For the case when there are no subsessions yet.
+
+        auto timeoutCallback = [=](bool) mutable {
+            promise.TrySetValue(false);
+        };
+
+        auto timeoutContext = Connections->CreateContext();
+        if (!timeoutContext) {
+            AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
+            return false;
+        }
+        closeDeadline = TInstant::Now() + timeout;
+        Connections->ScheduleCallback(timeout,
+                                      std::move(timeoutCallback),
+                                      timeoutContext);
+
+        // Wait.
+        NThreading::TFuture<bool> resultFuture = promise.GetFuture();
+        result = resultFuture.GetValueSync();
+        if (result) {
+            Cancel(timeoutContext);
+
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue("Session was gracefully closed");
+            EventsQueue->Close(TSessionClosedEvent(EStatus::SUCCESS, std::move(issues)), deferred);
+        } else {
+            ++*Settings.Counters_->Errors;
+            session->Abort();
+
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue(TStringBuilder() << "Session was closed after waiting " << timeout);
+            EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
+        }
+        {
+            std::lock_guard guard(Lock);
+            Aborting = true; // Set abort flag for doing nothing on destructor.
+            cbContextToCancel = CbContext;
+            dumpCountersContextToCancel = DumpCountersContext;
+        }
+        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+        }
+        ClearAllEvents();
+        session->ClearAllPartitionStreamEvents();
+    }
+    if (cbContextToCancel) {
+        cbContextToCancel->Cancel();
+    }
+    if (dumpCountersContextToCancel) {
+        dumpCountersContextToCancel->Cancel();
     }
     return result;
 }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -247,8 +247,9 @@ public:
     i64 StartDecompressionTasks(const typename IExecutor::TPtr& executor,
                                 i64 availableMemory,
                                 TDeferredActions<UseMigrationProtocol>& deferred);
-    void PlanDecompressionTasks(double averageCompressionRatio,
-                                TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream);
+    bool PlanDecompressionTasks(double averageCompressionRatio,
+                                TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
+                                TDeferredActions<UseMigrationProtocol>& deferred);
 
     void OnDestroyReadSession();
 
@@ -602,6 +603,7 @@ public:
                            TReadSessionEventsQueue<UseMigrationProtocol>& queue,
                            TDeferredActions<UseMigrationProtocol>& deferred);
     void DeleteNotReadyTail(TDeferredActions<UseMigrationProtocol>& deferred);
+    void Cleanup(TDeferredActions<UseMigrationProtocol>& deferred);
 
     void GetDataEventImpl(TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
                           size_t& maxEventsCount,
@@ -936,6 +938,9 @@ public:
         }
 
         // Delayed deletion is necessary to avoid deadlock with PushEvent
+        for (auto& queue : deferredDelete) {
+            queue.Cleanup(deferred);
+        }
         deferredDelete.clear();
 
         TReadSessionEventInfo<UseMigrationProtocol> info(event);
@@ -1242,7 +1247,7 @@ public:
     void OnUserRetrievedEvent(i64 decompressedSize, size_t messagesCount) override;
 
     void Abort();
-    void AbortImpl();
+    void AbortImpl(TDeferredActions<UseMigrationProtocol>* deferred = nullptr);
     void Close(std::function<void()> callback);
     void AbortSession(TASessionClosedEvent<UseMigrationProtocol>&& closeEvent);
 
@@ -1311,6 +1316,7 @@ private:
     void OnConnectTimeout(const NYdbGrpc::IQueueClientContextPtr& connectTimeoutContext);
     void OnConnect(TPlainStatus&&, typename IProcessor::TPtr&&, const NYdbGrpc::IQueueClientContextPtr& connectContext);
     void DestroyAllPartitionStreamsImpl(TDeferredActions<UseMigrationProtocol>& deferred); // Destroy all streams before setting new connection // Assumes that we're under lock.
+    void CleanupDecompressionQueueImpl(TDeferredActions<UseMigrationProtocol>& deferred); // Assumes that we're under lock.
 
     // Initing.
     inline void InitImpl(TDeferredActions<UseMigrationProtocol>& deferred); // Assumes that we're under lock.
@@ -1352,7 +1358,7 @@ private:
 
     bool GetRangesMode() const;
 
-    void CallCloseCallbackImpl();
+    void CallCloseCallbackImpl(TDeferredActions<UseMigrationProtocol>* deferred = nullptr);
 
     void UpdateMemoryUsageStatisticsImpl();
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -27,7 +27,9 @@
 #include <util/digest/numeric.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <deque>
+#include <mutex>
 #include <vector>
 
 
@@ -1230,6 +1232,9 @@ public:
     void Commit(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, ui64 startOffset, ui64 endOffset);
 
     void OnCreateNewDecompressionTask();
+    void OnDecompressionTaskFinished();
+    bool WaitAllDecompressionTasks(TInstant deadline) const;
+    void ClearAllPartitionStreamEvents();
     void OnDecompressionInfoDestroy(i64 compressedSize, i64 decompressedSize, i64 messagesCount, i64 serverBytesSize);
     void OnDecompressionInfoDestroyImpl(i64 compressedSize,
                                         i64 decompressedSize,
@@ -1513,6 +1518,8 @@ private:
     bool Closing = false;
     std::function<void()> CloseCallback;
     std::atomic<int> DecompressionTasksInflight = 0;
+    mutable std::mutex DecompressionTasksInflightMutex;
+    mutable std::condition_variable DecompressionTasksInflightCondVar;
     i64 ReadSizeBudget;
     i64 ReadSizeServerDelta = 0;
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -256,7 +256,7 @@ void TRawPartitionStreamEventQueue<UseMigrationProtocol>::Cleanup(TDeferredActio
 
         auto& dataEvent = event.GetDataEvent();
         if (event.IsReady() || !dataEvent.SetAbandoned()) {
-            accumulator.Add(dataEvent.GetParent(), dataEvent.GetDataSize(), dataEvent.GetMessageCount());
+            accumulator.Add(dataEvent.GetParent(), dataEvent.GetDataSize());
         } else {
             infos.push_back(dataEvent.GetParent());
         }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -25,6 +25,7 @@
 #include <util/stream/mem.h>
 
 #include <atomic>
+#include <chrono>
 #include <utility>
 #include <variant>
 
@@ -1859,6 +1860,56 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnCreateNewDecompressi
 }
 
 template<bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDecompressionTaskFinished() {
+    Y_ABORT_UNLESS(DecompressionTasksInflight > 0);
+    if (--DecompressionTasksInflight == 0) {
+        DecompressionTasksInflightCondVar.notify_all();
+    }
+}
+
+template<bool UseMigrationProtocol>
+bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::WaitAllDecompressionTasks(TInstant deadline) const {
+    const TDuration timeout = deadline - TInstant::Now();
+    if (timeout <= TDuration::Zero()) {
+        return DecompressionTasksInflight.load() == 0;
+    }
+
+    std::unique_lock guard(DecompressionTasksInflightMutex);
+    return DecompressionTasksInflightCondVar.wait_for(
+        guard,
+        std::chrono::microseconds(timeout.MicroSeconds()),
+        [&] {
+            return DecompressionTasksInflight.load() == 0;
+        });
+}
+
+template<bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ClearAllPartitionStreamEvents() {
+    TDeferredActions<UseMigrationProtocol> deferred;
+    std::vector<TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>>> streams;
+    std::vector<TRawPartitionStreamEventQueue<UseMigrationProtocol>> deferredDelete;
+    {
+        std::lock_guard guard(Lock);
+        streams.reserve(PartitionStreams.size());
+        for (auto& [_, partitionStream] : PartitionStreams) {
+            streams.push_back(partitionStream);
+        }
+    }
+
+    deferredDelete.reserve(streams.size());
+    for (auto& stream : streams) {
+        std::lock_guard guard(stream->GetLock());
+        if (stream->HasEvents()) {
+            deferredDelete.push_back(stream->ExtractQueue());
+        }
+    }
+
+    for (auto& queue : deferredDelete) {
+        queue.Cleanup(deferred);
+    }
+}
+
+template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDecompressionInfoDestroy(i64 compressedSize, i64 decompressedSize, i64 messagesCount, i64 serverBytesSize)
 {
 
@@ -1887,9 +1938,6 @@ template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDataDecompressed(i64 sourceSize, i64 estimatedDecompressedSize, i64 decompressedSize, size_t messagesCount, i64 serverBytesSize) {
 
     TDeferredActions<UseMigrationProtocol> deferred;
-
-    Y_ABORT_UNLESS(DecompressionTasksInflight > 0);
-    --DecompressionTasksInflight;
 
     *Settings.Counters_->BytesRead += decompressedSize;
     *Settings.Counters_->BytesReadCompressed += sourceSize;
@@ -3333,6 +3381,10 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
     if (bool expected = false; !Ready->Abandoned.compare_exchange_strong(expected, true)) {
         // Message is dropped due to partition stream cancellation, we should release decompressed memory
         parent->OnUserRetrievedEvent(DecompressedSize, messagesProcessed);
+    }
+
+    if (auto session = parent->CbContext->LockShared()) {
+        session->OnDecompressionTaskFinished();
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -242,6 +242,38 @@ void TRawPartitionStreamEventQueue<UseMigrationProtocol>::DeleteNotReadyTail(TDe
     swap(ready, NotReady);
 }
 
+template<bool UseMigrationProtocol>
+void TRawPartitionStreamEventQueue<UseMigrationProtocol>::Cleanup(TDeferredActions<UseMigrationProtocol>& deferred)
+{
+    std::vector<TDataDecompressionInfoPtr<UseMigrationProtocol>> infos;
+    TUserRetrievedEventsInfoAccumulator<UseMigrationProtocol> accumulator;
+
+    auto cleanupEvent = [&](TRawPartitionStreamEvent<UseMigrationProtocol>& event) {
+        if (!event.IsDataEvent()) {
+            return;
+        }
+
+        auto& dataEvent = event.GetDataEvent();
+        if (event.IsReady() || !dataEvent.SetAbandoned()) {
+            accumulator.Add(dataEvent.GetParent(), dataEvent.GetDataSize(), dataEvent.GetMessageCount());
+        } else {
+            infos.push_back(dataEvent.GetParent());
+        }
+    };
+
+    for (auto& event : Ready) {
+        cleanupEvent(event);
+    }
+    for (auto& event : NotReady) {
+        cleanupEvent(event);
+    }
+
+    deferred.DeferDestroyDecompressionInfos(std::move(infos));
+    deferred.DeferOnUserRetrievedEvent(std::move(accumulator));
+    Ready.clear();
+    NotReady.clear();
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TDecompressionQueueItem
 
@@ -428,6 +460,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::BreakConnectionAndReco
 
 template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnConnectTimeout(const NYdbGrpc::IQueueClientContextPtr& connectTimeoutContext) {
+    TDeferredActions<UseMigrationProtocol> deferred;
     {
         std::lock_guard guard(Lock);
         if (ConnectTimeoutContext == connectTimeoutContext) {
@@ -437,7 +470,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnConnectTimeout(const
             ConnectDelayContext = nullptr;
 
             if (Closing || Aborting) {
-                CallCloseCallbackImpl();
+                CallCloseCallbackImpl(&deferred);
                 return;
             }
         } else {
@@ -466,7 +499,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnConnect(
             ConnectDelayContext = nullptr;
 
             if (Closing || Aborting) {
-                CallCloseCallbackImpl();
+                CallCloseCallbackImpl(&deferred);
                 return;
             }
 
@@ -745,7 +778,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStream
                                 deferred);
     }
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
     TClientMessage<UseMigrationProtocol> req;
@@ -895,7 +928,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ReadFromProcessorImpl(
     }
     if (Closing && !HasCommitsInflightImpl()) {
         Processor->Cancel();
-        CallCloseCallbackImpl();
+        CallCloseCallbackImpl(&deferred);
         return;
     }
 
@@ -1114,8 +1147,11 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
                                                                                 Settings.Decompress_);
         Y_ABORT_UNLESS(decompressionInfo);
 
-        decompressionInfo->PlanDecompressionTasks(AverageCompressionRatio,
-                                                  partitionStream);
+        if (!decompressionInfo->PlanDecompressionTasks(AverageCompressionRatio,
+                                                       partitionStream,
+                                                       deferred)) {
+            return;
+        }
 
         DecompressionQueue.emplace_back(decompressionInfo, partitionStream);
         StartDecompressionTasksImpl(deferred);
@@ -1151,7 +1187,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
                  currentPartitionStream, NPersQueue::TReadSessionEvent::TPartitionStreamClosedEvent::EReason::Lost),
             deferred);
         if (!pushRes) {
-            AbortImpl();
+            AbortImpl(&deferred);
             return;
         }
     }
@@ -1163,7 +1199,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
         NPersQueue::TReadSessionEvent::TCreatePartitionStreamEvent(partitionStream, msg.read_offset(), msg.end_offset()),
         deferred);
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
 }
@@ -1197,7 +1233,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
     }
 
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
 
@@ -1226,7 +1262,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
                                                   partitionStream, partitionStream->GetMaxCommittedOffset()),
                                               deferred);
         if (!pushRes) {
-            AbortImpl();
+            AbortImpl(&deferred);
             return;
         }
     }
@@ -1241,7 +1277,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
                 NPersQueue::TReadSessionEvent::TCommitAcknowledgementEvent(partitionStream, rangeProto.end_offset()),
                 deferred);
             if (!pushRes) {
-                AbortImpl();
+                AbortImpl(&deferred);
                 return;
             }
         }
@@ -1266,7 +1302,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
                                               msg.end_offset(), TInstant::MilliSeconds(msg.write_watermark_ms())),
                                           deferred);
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
 }
@@ -1357,8 +1393,11 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
         serverBytesSize = 0;
         Y_ABORT_UNLESS(decompressionInfo);
 
-        decompressionInfo->PlanDecompressionTasks(AverageCompressionRatio,
-                                                  partitionStream);
+        if (!decompressionInfo->PlanDecompressionTasks(AverageCompressionRatio,
+                                                       partitionStream,
+                                                       deferred)) {
+            return;
+        }
         DecompressionQueue.emplace_back(decompressionInfo, partitionStream);
         StartDecompressionTasksImpl(deferred);
     }
@@ -1401,7 +1440,7 @@ inline void TSingleClusterReadSessionImpl<false>::StopPartitionSessionImpl(
     }
 
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
     }
 }
 
@@ -1535,7 +1574,7 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
             deferred);
 
         if (!pushRes) {
-            AbortImpl();
+            AbortImpl(&deferred);
             return;
         }
     }
@@ -1560,7 +1599,7 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
         deferred);
 
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
 }
@@ -1673,7 +1712,7 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
             TReadSessionEvent::TEndPartitionSessionEvent(std::move(partitionStream), std::move(adjacentPartitionIds), std::move(childPartitionIds)),
             deferred);
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
 }
@@ -1697,7 +1736,7 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
                                         partitionStream, rangeProto.committed_offset()),
                                    deferred);
             if (!pushRes) {
-                AbortImpl();
+                AbortImpl(&deferred);
                 return;
             }
         }
@@ -1725,7 +1764,7 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
                                     msg.write_time_high_watermark()))),
                            deferred);
     if (!pushRes) {
-        AbortImpl();
+        AbortImpl(&deferred);
         return;
     }
 }
@@ -1788,12 +1827,30 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::DestroyAllPartitionStr
                                 TClosedEvent(std::move(partitionStream), TClosedEvent::EReason::ConnectionLost),
                                deferred);
         if (!pushRes) {
-            AbortImpl();
+            AbortImpl(&deferred);
             return;
         }
     }
     PartitionStreams.clear();
     CookieMapping.ClearMapping();
+}
+
+template<bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::CleanupDecompressionQueueImpl(TDeferredActions<UseMigrationProtocol>& deferred) {
+    Y_ABORT_UNLESS(Lock.IsLocked());
+
+    if (DecompressionQueue.empty()) {
+        return;
+    }
+
+    std::vector<TDataDecompressionInfoPtr<UseMigrationProtocol>> infos;
+    infos.reserve(DecompressionQueue.size());
+    for (auto& item : DecompressionQueue) {
+        infos.push_back(item.BatchInfo);
+    }
+    DecompressionQueue.clear();
+
+    deferred.DeferDestroyDecompressionInfos(std::move(infos));
 }
 
 template<bool UseMigrationProtocol>
@@ -1893,8 +1950,9 @@ template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::Abort() {
     LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "Abort session to cluster");
 
+    TDeferredActions<UseMigrationProtocol> deferred;
     std::lock_guard guard(Lock);
-    AbortImpl();
+    AbortImpl(&deferred);
 }
 
 template<bool UseMigrationProtocol>
@@ -1907,12 +1965,12 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::AbortSession(TASession
 
 
 template<bool UseMigrationProtocol>
-void TSingleClusterReadSessionImpl<UseMigrationProtocol>::AbortImpl() {
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::AbortImpl(TDeferredActions<UseMigrationProtocol>* deferred) {
     Y_ABORT_UNLESS(Lock.IsLocked());
 
     if (!Aborting) {
         Aborting = true;
-        CallCloseCallbackImpl();
+        CallCloseCallbackImpl(deferred);
 
         // Cancel(ClientContext); // Don't cancel, because this is used only as factory for other contexts.
         Cancel(ConnectContext);
@@ -1930,13 +1988,19 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::AbortImpl() {
             }
         }
     }
+
+    if (deferred) {
+        CleanupDecompressionQueueImpl(*deferred);
+    }
 }
 
 template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::Close(std::function<void()> callback) {
+    TDeferredActions<UseMigrationProtocol> deferred;
     std::lock_guard guard(Lock);
     if (Aborting) {
         callback();
+        return;
     }
 
     if (!Closing) {
@@ -1949,27 +2013,31 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::Close(std::function<vo
         Cancel(ConnectDelayContext);
 
         if (!Processor) {
-            CallCloseCallbackImpl();
+            CallCloseCallbackImpl(&deferred);
         } else {
             if (!HasCommitsInflightImpl()) {
                 Processor->Cancel();
-                CallCloseCallbackImpl();
+                CallCloseCallbackImpl(&deferred);
             }
         }
     }
 
-    AbortImpl();
+    AbortImpl(&deferred);
 }
 
 template<bool UseMigrationProtocol>
-void TSingleClusterReadSessionImpl<UseMigrationProtocol>::CallCloseCallbackImpl() {
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::CallCloseCallbackImpl(TDeferredActions<UseMigrationProtocol>* deferred) {
     Y_ABORT_UNLESS(Lock.IsLocked());
 
     if (CloseCallback) {
         CloseCallback();
         CloseCallback = {};
     }
-    AbortImpl();
+    if (!Aborting) {
+        AbortImpl(deferred);
+    } else if (deferred) {
+        CleanupDecompressionQueueImpl(*deferred);
+    }
 }
 
 template<bool UseMigrationProtocol>
@@ -2791,14 +2859,24 @@ void TReadSessionEventsQueue<UseMigrationProtocol>::GetDataEventCallbackSettings
 
 template<bool UseMigrationProtocol>
 void TReadSessionEventsQueue<UseMigrationProtocol>::ClearAllEvents() {
-    std::lock_guard<std::mutex> guard(TParent::Mutex);
-    while (!TParent::Events.empty()) {
-        auto& event = TParent::Events.front();
-        if (event.PartitionStream && event.PartitionStream->HasEvents()) {
-            event.PartitionStream->PopEvent();
+    TDeferredActions<UseMigrationProtocol> deferred;
+    std::vector<TRawPartitionStreamEventQueue<UseMigrationProtocol>> deferredDelete;
+    {
+        std::lock_guard<std::mutex> guard(TParent::Mutex);
+        deferredDelete.reserve(TParent::Events.size());
+        while (!TParent::Events.empty()) {
+            auto& event = TParent::Events.front();
+            if (!event.IsEmpty()) {
+                deferredDelete.push_back(event.PartitionStream->ExtractQueue());
+            }
+            TParent::Events.pop();
         }
-        TParent::Events.pop();
     }
+
+    for (auto& queue : deferredDelete) {
+        queue.Cleanup(deferred);
+    }
+    deferredDelete.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2950,8 +3028,9 @@ i64 TDataDecompressionInfo<UseMigrationProtocol>::StartDecompressionTasks(
 }
 
 template<bool UseMigrationProtocol>
-void TDataDecompressionInfo<UseMigrationProtocol>::PlanDecompressionTasks(double averageCompressionRatio,
-                                                                          TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream) {
+bool TDataDecompressionInfo<UseMigrationProtocol>::PlanDecompressionTasks(double averageCompressionRatio,
+                                                                          TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
+                                                                          TDeferredActions<UseMigrationProtocol>& deferred) {
     constexpr size_t TASK_LIMIT = 512_KB;
 
     auto session = CbContext->LockShared();
@@ -2981,8 +3060,9 @@ void TDataDecompressionInfo<UseMigrationProtocol>::PlanDecompressionTasks(double
                                                      ReadyThresholds.back().Ready,
                                                      ReadyThresholds.back().Abandoned);
             if (!pushRes) {
-                session->AbortImpl();
-                return;
+                deferred.DeferDestroyDecompressionInfos({TDataDecompressionInfo::shared_from_this()});
+                session->AbortImpl(&deferred);
+                return false;
             }
         }
 
@@ -3006,6 +3086,8 @@ void TDataDecompressionInfo<UseMigrationProtocol>::PlanDecompressionTasks(double
     } else {
         ReadyThresholds.pop_back(); // Revert.
     }
+
+    return true;
 }
 
 template <bool UseMigrationProtocol>

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -1229,7 +1229,7 @@ inline void TSingleClusterReadSessionImpl<true>::OnReadDoneImpl(
     } else {
         pushRes = EventsQueue->PushEvent(
             partitionStream,
-            NPersQueue::TReadSessionEvent::TDestroyPartitionStreamEvent(std::move(partitionStream), msg.commit_offset()),
+            NPersQueue::TReadSessionEvent::TDestroyPartitionStreamEvent(partitionStream, msg.commit_offset()),
             deferred);
     }
 
@@ -1425,7 +1425,7 @@ inline void TSingleClusterReadSessionImpl<false>::StopPartitionSessionImpl(
         pushRes = EventsQueue->PushEvent(
             partitionStream,
             // TODO(qyryq) Is it safe to use GetMaxCommittedOffset here instead of StopPartitionSessionRequest.commmitted_offset?
-            TReadSessionEvent::TStopPartitionSessionEvent(std::move(partitionStream), committedOffset),
+            TReadSessionEvent::TStopPartitionSessionEvent(partitionStream, committedOffset),
             deferred);
     } else {
         // partitionStream->ConfirmDestroy();
@@ -1710,7 +1710,7 @@ inline void TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(
 
     bool pushRes = EventsQueue->PushEvent(
             partitionStream,
-            TReadSessionEvent::TEndPartitionSessionEvent(std::move(partitionStream), std::move(adjacentPartitionIds), std::move(childPartitionIds)),
+            TReadSessionEvent::TEndPartitionSessionEvent(partitionStream, std::move(adjacentPartitionIds), std::move(childPartitionIds)),
             deferred);
     if (!pushRes) {
         AbortImpl(&deferred);
@@ -1825,7 +1825,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::DestroyAllPartitionStr
 
     for (auto&& [key, partitionStream] : PartitionStreams) {
         bool pushRes = EventsQueue->PushEvent(partitionStream,
-                                TClosedEvent(std::move(partitionStream), TClosedEvent::EReason::ConnectionLost),
+                                TClosedEvent(partitionStream, TClosedEvent::EReason::ConnectionLost),
                                deferred);
         if (!pushRes) {
             AbortImpl(&deferred);


### PR DESCRIPTION
## Summary
- Reopens the SDK ASAN leak backport previously attempted in #47778 (branches were deleted after close).
- Backports the full dependency chain for #48054 / LOGBROKER-10550:
  - #45159 — shared read-session cleanup
  - #46748 — `WaitAllDecompressionTasks` / `ClearAllPartitionStreamEvents` + topic workload explicit `Close(5s)`
  - #46840 — fix VERIFY on shutdown (`std::move(partitionStream)` into events)
  - #47727 — PersQueue wrapper teardown cleanup
  - tiny adaptation for older `TUserRetrievedEventsInfoAccumulator::Add` API on 26-2

Fixes #48054

## Test plan
- [x] Local build of `topic/impl`, `persqueue_public/impl`, topic workload
- [ ] PR CI relwithdebinfo / release-asan
- [ ] Confirm previous non-blocking ASAN VERIFYs in `sqs_topic_ut` are gone (expected after #46840)
- [ ] Stress topic workload ASAN no longer reports `TDataDecompressionInfo` leak (#48054)