### PR TITLE
[spilling] Don't create spilling directories recursively to avoid multiuser issues

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -286,14 +286,9 @@ public:
         ResourcePoolsCache.UpdateConfig(FeatureFlags, WorkloadManagerConfig, ActorContext());
 
         if (auto& cfg = TableServiceConfig.GetSpillingServiceConfig().GetLocalFileConfig(); cfg.GetEnable()) {
-            TString spillingRoot = cfg.GetRoot();
-            if (spillingRoot.empty()) {
-                spillingRoot = NYql::NDq::GetDefaultSpillingRoot();
-            }
-
             SpillingService = TActivationContext::Register(NYql::NDq::CreateDqLocalFileSpillingService(
                 NYql::NDq::TFileSpillingServiceConfig{
-                    .Root = spillingRoot,
+                    .Root = cfg.GetRoot(),
                     .MaxTotalSize = cfg.GetMaxTotalSize(),
                     .IoThreadPoolWorkersCount = cfg.GetIoThreadPool().GetWorkersCount(),
                     .IoThreadPoolQueueSize = cfg.GetIoThreadPool().GetQueueSize(),

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -288,7 +288,7 @@ public:
         if (auto& cfg = TableServiceConfig.GetSpillingServiceConfig().GetLocalFileConfig(); cfg.GetEnable()) {
             TString spillingRoot = cfg.GetRoot();
             if (spillingRoot.empty()) {
-                spillingRoot = NYql::NDq::GetTmpSpillingRootForCurrentUser();
+                spillingRoot = NYql::NDq::GetDefaultSpillingRoot();
             }
 
             SpillingService = TActivationContext::Register(NYql::NDq::CreateDqLocalFileSpillingService(

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -70,8 +70,6 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/resource/resource.h>
 
-#include <util/folder/dirut.h>
-
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KQP_PROXY
 
 namespace NKikimr::NKqp {
@@ -291,7 +289,6 @@ public:
             TString spillingRoot = cfg.GetRoot();
             if (spillingRoot.empty()) {
                 spillingRoot = NYql::NDq::GetTmpSpillingRootForCurrentUser();
-                MakeDirIfNotExist(spillingRoot);
             }
 
             SpillingService = TActivationContext::Register(NYql::NDq::CreateDqLocalFileSpillingService(

--- a/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_block_hash_join_ut.cpp
@@ -2,6 +2,8 @@
 #include <counters/kqp_counters.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 
+#include <util/folder/dirut.h>
+
 namespace NKikimr {
 namespace NKqp {
 
@@ -26,6 +28,7 @@ NKikimrConfig::TAppConfig AppCfgLowComputeLimits(double reasonableTreshold, bool
     auto* spilling = ts->MutableSpillingServiceConfig()->MutableLocalFileConfig();
 
     spilling->SetRoot("./spilling/");
+    MakeDirIfNotExist("./spilling");
     if (limitFileSize) {
         spilling->SetMaxTotalSize(1);
     }

--- a/ydb/core/kqp/ut/query/kqp_explain_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_explain_ut.cpp
@@ -3,6 +3,8 @@
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>
 
+#include <util/folder/dirut.h>
+
 namespace NKikimr {
 namespace NKqp {
 
@@ -400,6 +402,7 @@ Y_UNIT_TEST_SUITE(KqpExplain) {
         auto* spilling = appCfg.MutableTableServiceConfig()->MutableSpillingServiceConfig()->MutableLocalFileConfig();
         spilling->SetEnable(true);
         spilling->SetRoot("./spilling/");
+        MakeDirIfNotExist("./spilling");
         auto kikimr = DefaultKikimrRunner({}, appCfg);
 
         auto db = kikimr.GetTableClient();

--- a/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp
+++ b/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>
 
+#include <util/folder/dirut.h>
 #include <util/system/fs.h>
 
 namespace NKikimr {
@@ -30,6 +31,7 @@ NKikimrConfig::TAppConfig AppCfg() {
     auto* spilling = appCfg.MutableTableServiceConfig()->MutableSpillingServiceConfig()->MutableLocalFileConfig();
     spilling->SetEnable(true);
     spilling->SetRoot("./spilling/");
+    MakeDirIfNotExist("./spilling");
 
     return appCfg;
 }
@@ -50,6 +52,7 @@ NKikimrConfig::TAppConfig AppCfgLowComputeLimits(double reasonableTreshold, bool
 
     spilling->SetEnable(enableSpilling);
     spilling->SetRoot("./spilling/");
+    MakeDirIfNotExist("./spilling");
     if (limitFileSize) {
         spilling->SetMaxTotalSize(1);
     }

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -238,10 +238,10 @@ public:
 
     void Bootstrap() {
         SpillingRoot_ = Config_.Root ? TFsPath(Config_.Root) : GetDefaultSpillingRoot();
-        Root_ = SpillingRoot_ / MakeSpillingNodeDirName(SelfId().NodeId(), Username_, Config_.SpillingSessionId);
-        LOG_I("Init DQ local file spilling service at " << Root_ << ", actor: " << SelfId());
+        SessionRoot_ = SpillingRoot_ / MakeSpillingNodeDirName(SelfId().NodeId(), Username_, Config_.SpillingSessionId);
+        LOG_I("Init DQ local file spilling service at " << SessionRoot_ << ", actor: " << SelfId());
 
-        CreateRoot(MaxStartupRetries);
+        CreateSessionRoot(MaxStartupRetries);
     }
 
     static constexpr char ActorName[] = "DQ_LOCAL_FILE_SPILLING_SERVICE";
@@ -251,21 +251,21 @@ protected:
         IoThreadPool_->Stop();
         IActor::PassAway();
         if (Config_.CleanupOnShutdown) {
-            Root_.ForceDelete();
+            SessionRoot_.ForceDelete();
         }
     }
 
 private:
-    void CreateRoot(ui32 retriesLeft) {
+    void CreateSessionRoot(ui32 retriesLeft) {
         try {
-            if (Root_.IsSymlink()) {
-                throw TIoException() << Root_ << " is a symlink, can not start Spilling Service";
+            if (SessionRoot_.IsSymlink()) {
+                throw TIoException() << SessionRoot_ << " is a symlink, can not start Spilling Service";
             }
-            Root_.ForceDelete();
-            // Config_.Root must already exist, create only the per-node directory inside it
-            Root_.MkDir(DIR_MODE);
+            SessionRoot_.ForceDelete();
+            // SpillingRoot_ must already exist, create only the directory of this session inside it
+            SessionRoot_.MkDir(DIR_MODE);
         } catch (const yexception& e) {
-            const TString root = Root_.GetPath();
+            const TString root = SessionRoot_.GetPath();
             if (retriesLeft > 0) {
                 LOG_E("Cannot start DQ local file spilling service at " << root << ": " << e.what() << ". Retry "
                     << (MaxStartupRetries - retriesLeft + 1) << "/" << MaxStartupRetries
@@ -288,7 +288,7 @@ private:
             hFunc(NMon::TEvHttpInfo, HandleWork);
             cFunc(TEvents::TEvPoison::EventType, PassAway);
             case TEvPrivate::TEvRetryStart::EventType:
-                CreateRoot(ev->Get<TEvPrivate::TEvRetryStart>()->RetriesLeft);
+                CreateSessionRoot(ev->Get<TEvPrivate::TEvRetryStart>()->RetriesLeft);
                 break;
             default:
                 LOG_E("DQ local file spilling service is not started, send error to client " << ev->Sender);
@@ -464,7 +464,7 @@ private:
             fd.Parts.emplace(msg.BlobId, fp);
 
             auto fname = TStringBuilder() << fd.TxId << "_" << fd.Description << "_" << fd.NextPartListIndex++;
-            fp->FileName = (Root_ / fname).GetPath();
+            fp->FileName = (SessionRoot_ / fname).GetPath();
 
             LOG_D("[Write] create new FilePart " << fp->FileName);
             newFile = true;
@@ -1112,8 +1112,10 @@ private:
 
     const TFileSpillingServiceConfig Config_;
     const TString Username_ = GetUsername();
+    // Root of all spilling directories, either configured or the default one.
     TFsPath SpillingRoot_;
-    TFsPath Root_;
+    // Directory of this Spilling Service session inside SpillingRoot_, where the spilling files go.
+    TFsPath SessionRoot_;
     TIntrusivePtr<TSpillingCounters> Counters_;
 
     THolder<IThreadPool> IoThreadPool_;

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -237,8 +237,8 @@ public:
     }
 
     void Bootstrap() {
-        Root_ = Config_.Root;
-        Root_ /= MakeSpillingNodeDirName(SelfId().NodeId(), Username_, Config_.SpillingSessionId);
+        SpillingRoot_ = Config_.Root ? TFsPath(Config_.Root) : GetDefaultSpillingRoot();
+        Root_ = SpillingRoot_ / MakeSpillingNodeDirName(SelfId().NodeId(), Username_, Config_.SpillingSessionId);
         LOG_I("Init DQ local file spilling service at " << Root_ << ", actor: " << SelfId());
 
         CreateRoot(MaxStartupRetries);
@@ -278,7 +278,7 @@ private:
         }
 
         Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(
-            Config_.Root, SelfId().NodeId(), Username_, Config_.SpillingSessionId));
+            SpillingRoot_, SelfId().NodeId(), Username_, Config_.SpillingSessionId));
 
         Become(&TDqLocalFileSpillingService::WorkState);
     }
@@ -801,14 +801,15 @@ private:
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
         try {
-            // Current format.
+            // Current format: <root>/spilling-tmp-<nodeId>-<sessionId>-<username>.
             RemoveOwnDirs(root, msg);
 
-            // Old format, when Root was configured.
+            // Old format with a configured Root: <root>/node_<nodeId>_<sessionId>.
             RemoveOwnOldFormatDirs(root, msg.NodeId);
 
-            // Old format, when Root was empty and the default root was $TMP/spilling-tmp-<username>.
-            RemoveOwnOldFormatDirs(root / (TStringBuilder() << SpillingDirPrefix << msg.Username), msg.NodeId);
+            // Old format with an empty Root: $TMP/spilling-tmp-<username>/node_<nodeId>_<sessionId>.
+            RemoveOwnOldFormatDirs(
+                GetDefaultSpillingRoot() / (TStringBuilder() << SpillingDirPrefix << msg.Username), msg.NodeId);
         } catch (const yexception& e) {
             LOG_E("[RemoveOldTmp] removing failed due to: " << e.what());
         }
@@ -831,11 +832,16 @@ private:
     }
 
     void RemoveOwnOldFormatDirs(const TFsPath& dir, ui32 nodeId) {
-        const TString nodeIdString = ToString(nodeId);
+        const TString prefix = TStringBuilder() << "node_" << nodeId << "_";
 
         RemoveMatchingChildren(dir, [&](TStringBuf dirName) {
-            TStringBuf rest = dirName;
-            return rest.SkipPrefix("node_") && rest.NextTok('_') == nodeIdString && !rest.empty();
+            TStringBuf sessionId = dirName;
+            if (!sessionId.SkipPrefix(prefix)) {
+                return false;
+            }
+
+            TGUID guid;
+            return GetGuid(sessionId, guid);
         });
     }
 
@@ -1106,6 +1112,7 @@ private:
 
     const TFileSpillingServiceConfig Config_;
     const TString Username_ = GetUsername();
+    TFsPath SpillingRoot_;
     TFsPath Root_;
     TIntrusivePtr<TSpillingCounters> Counters_;
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -257,7 +257,10 @@ private:
                 throw TIoException() << Root_ << " is a symlink, can not start Spilling Service";
             }
             Root_.ForceDelete();
-            Root_.MkDirs(DIR_MODE);
+            // root must already exist
+            // create only the per-node subdirectory inside it
+            // dont create the directories recursively to avoid multiuser errors
+            Root_.MkDir(DIR_MODE);
         } catch (const yexception& e) {
             const TString root = Root_.GetPath();
             if (retriesLeft > 0) {

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -237,7 +237,6 @@ public:
     }
 
     void Bootstrap() {
-        Username_ = GetUsername();
         Root_ = Config_.Root;
         Root_ /= MakeSpillingNodeDirName(SelfId().NodeId(), Username_, Config_.SpillingSessionId);
         LOG_I("Init DQ local file spilling service at " << Root_ << ", actor: " << SelfId());
@@ -263,8 +262,7 @@ private:
                 throw TIoException() << Root_ << " is a symlink, can not start Spilling Service";
             }
             Root_.ForceDelete();
-            // Config_.Root must already exist
-            // create only spilling-tmp-<nodeId>-<username>-<sessionId> inside it
+            // Config_.Root must already exist, create only the per-node directory inside it
             Root_.MkDir(DIR_MODE);
         } catch (const yexception& e) {
             const TString root = Root_.GetPath();
@@ -804,62 +802,55 @@ private:
 
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
-        const auto isOwnNewFormatDir = [&](const TString& dirName) -> bool {
-            // spilling-tmp-<nodeId>-<username>-<sessionId>
+        // node_<nodeId>_<sessionId>
+        const auto isOwnOldFormatDir = [&](TStringBuf dirName) {
             TStringBuf rest = dirName;
-            if (!rest.SkipPrefix("spilling-tmp-")) {
-                return false;
-            }
-            const auto id = rest.NextTok('-');
-            return id == nodeIdString && !rest.empty() && dirName != currentDirName;
+            return rest.SkipPrefix("node_") && rest.NextTok('_') == nodeIdString && !rest.empty();
         };
 
-        const auto isOwnOldFormatDir = [&](const TString& dirName) -> bool {
-            // node_<nodeId>_<sessionId>
+        // spilling-tmp-<nodeId>-<username>-<sessionId>
+        const auto isOwnDir = [&](TStringBuf dirName) {
             TStringBuf rest = dirName;
-            if (!rest.SkipPrefix("node_")) {
-                return false;
+            if (!rest.SkipPrefix(SpillingDirPrefix)) {
+                return isOwnOldFormatDir(dirName);
             }
-            const auto id = rest.NextTok('_');
-            return id == nodeIdString && !rest.empty();
+            return rest.NextTok('-') == nodeIdString && !rest.empty() && dirName != currentDirName;
         };
 
         try {
-            RemoveMatchingChildren(root, isOwnNewFormatDir);
-            RemoveMatchingChildren(root, isOwnOldFormatDir);
+            RemoveMatchingChildren(root, isOwnDir);
 
-            // Legacy default root: $TMP/spilling-tmp-<username>. Other nodes may still
-            // write there during a rolling upgrade, so drop only this node's node_* dirs.
-            const TFsPath legacyRoot = TFsPath{GetSystemTempDir()} / ("spilling-tmp-" + msg.Username);
-            if (!(legacyRoot == root)) {
-                RemoveMatchingChildren(legacyRoot, isOwnOldFormatDir);
-            }
+            // Legacy default root shared by all nodes of this user: other nodes may still
+            // write there during a rolling upgrade, so drop only this node's directories.
+            RemoveMatchingChildren(TFsPath{GetSystemTempDir()} / (TStringBuilder() << SpillingDirPrefix << msg.Username),
+                isOwnOldFormatDir);
         } catch (const yexception& e) {
             LOG_E("[RemoveOldTmp] removing failed due to: " << e.what());
         }
     }
 
-    template <typename TPred>
-    void RemoveMatchingChildren(const TFsPath& dir, TPred isOldTmp) {
-        if (!dir.Exists() || !dir.IsDirectory()) {
+    template <typename TPredicate>
+    void RemoveMatchingChildren(const TFsPath& dir, const TPredicate& shouldRemove) {
+        if (!dir.IsDirectory()) {
             return;
         }
 
         TDirIterator iter(dir, TDirIterator::TOptions().SetMaxLevel(1));
-        TVector<TString> oldTmps;
+
+        TVector<TString> toRemove;
         for (const auto& dirEntry : iter) {
             if (dirEntry.fts_info == FTS_DP) {
                 continue;
             }
 
-            const auto dirName = dirEntry.fts_name;
-            if (isOldTmp(dirName)) {
+            const TStringBuf dirName = dirEntry.fts_name;
+            if (shouldRemove(dirName)) {
                 LOG_D("[RemoveOldTmp] found old temporary at " << (dir / dirName));
-                oldTmps.emplace_back(dirName);
+                toRemove.emplace_back(dirName);
             }
         }
 
-        for (const auto& dirName : oldTmps) {
+        for (const auto& dirName : toRemove) {
             (dir / dirName).ForceDelete();
         }
     }
@@ -1100,7 +1091,7 @@ private:
     static constexpr TDuration StartupRetryDelay = TDuration::Seconds(1);
 
     const TFileSpillingServiceConfig Config_;
-    TString Username_;
+    const TString Username_ = GetUsername();
     TFsPath Root_;
     TIntrusivePtr<TSpillingCounters> Counters_;
 
@@ -1112,7 +1103,7 @@ private:
 
 } // anonymous namespace
 
-TFsPath GetTmpSpillingRootForCurrentUser() {
+TFsPath GetDefaultSpillingRoot() {
     return TFsPath{GetSystemTempDir()};
 }
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -204,10 +204,10 @@ private:
         struct TEvRemoveOldTmp : public TEventLocal<TEvRemoveOldTmp, EvRemoveOldTmp> {
             TFsPath TmpRoot;
             ui32 NodeId;
-            TString SpillingSessionId;
+            TString Username;
 
-            TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString spillingSessionId)
-                : TmpRoot(std::move(tmpRoot)), NodeId(nodeId), SpillingSessionId(std::move(spillingSessionId)) {}
+            TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString username)
+                : TmpRoot(std::move(tmpRoot)), NodeId(nodeId), Username(std::move(username)) {}
         };
 
         struct TEvRetryStart : public TEventLocal<TEvRetryStart, EvRetryStart> {
@@ -232,8 +232,9 @@ public:
     }
 
     void Bootstrap() {
+        Username_ = GetUsername();
         Root_ = Config_.Root;
-        Root_ /= (TStringBuilder() << NodePrefix_ << "_" << SelfId().NodeId() << "_" << Config_.SpillingSessionId);
+        Root_ /= MakeSpillingNodeDirName(SelfId().NodeId(), Username_);
         LOG_I("Init DQ local file spilling service at " << Root_ << ", actor: " << SelfId());
 
         CreateRoot(MaxStartupRetries);
@@ -257,9 +258,8 @@ private:
                 throw TIoException() << Root_ << " is a symlink, can not start Spilling Service";
             }
             Root_.ForceDelete();
-            // root must already exist
-            // create only the per-node subdirectory inside it
-            // dont create the directories recursively to avoid multiuser errors
+            // Config_.Root must already exist
+            // create only spilling-tmp-<nodeId>-<username> inside it
             Root_.MkDir(DIR_MODE);
         } catch (const yexception& e) {
             const TString root = Root_.GetPath();
@@ -274,7 +274,7 @@ private:
             Y_ABORT("Cannot start DQ local file spilling service at %s: %s", root.c_str(), e.what());
         }
 
-        Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(Config_.Root, SelfId().NodeId(), Config_.SpillingSessionId));
+        Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(Config_.Root, SelfId().NodeId(), Username_));
 
         Become(&TDqLocalFileSpillingService::WorkState);
     }
@@ -794,20 +794,19 @@ private:
         const auto& msg = *ev->Get();
         const auto& root = msg.TmpRoot;
         const auto nodeIdString = ToString(msg.NodeId);
-        const auto& sessionId = msg.SpillingSessionId;
-        const auto& nodePrefix = this->NodePrefix_;
+        const auto currentDirName = MakeSpillingNodeDirName(msg.NodeId, msg.Username);
+        const auto newPrefix = TStringBuilder() << "spilling-tmp-" << nodeIdString << "-";
+        const auto oldPrefix = TStringBuilder() << "node_" << nodeIdString << "_";
 
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
-        const auto isDirOldTmp = [&nodePrefix, &nodeIdString, &sessionId](const TString& dirName) -> bool {
-            // dirName: node_<nodeId>_<sessionId>
-            TVector<TString> parts;
-            StringSplitter(dirName).Split('_').Limit(3).Collect(&parts);
-
-            if (parts.size() < 3) {
-                return false;
+        const auto isDirOldTmp = [&](const TString& dirName) -> bool {
+            // New format: spilling-tmp-<nodeId>-<username>
+            if (dirName.StartsWith(newPrefix)) {
+                return dirName != currentDirName;
             }
-            return parts[0] == nodePrefix && parts[1] == nodeIdString && parts[2] != sessionId;
+            // Old format: node_<nodeId>_<sessionId>
+            return dirName.StartsWith(oldPrefix);
         };
 
         try {
@@ -1070,7 +1069,7 @@ private:
     static constexpr TDuration StartupRetryDelay = TDuration::Seconds(1);
 
     const TFileSpillingServiceConfig Config_;
-    const TString NodePrefix_ = "node";
+    TString Username_;
     TFsPath Root_;
     TIntrusivePtr<TSpillingCounters> Counters_;
 
@@ -1083,9 +1082,7 @@ private:
 } // anonymous namespace
 
 TFsPath GetTmpSpillingRootForCurrentUser() {
-    auto root = TFsPath{GetSystemTempDir()};
-    root /= "spilling-tmp-" + GetUsername();
-    return root;
+    return TFsPath{GetSystemTempDir()};
 }
 
 IActor* CreateDqLocalFileSpillingActor(TTxId txId, const TString& details, const TActorId& client,

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -205,9 +205,14 @@ private:
             TFsPath TmpRoot;
             ui32 NodeId;
             TString Username;
+            TString SpillingSessionId;
 
-            TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString username)
-                : TmpRoot(std::move(tmpRoot)), NodeId(nodeId), Username(std::move(username)) {}
+            TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString username, TString spillingSessionId)
+                : TmpRoot(std::move(tmpRoot))
+                , NodeId(nodeId)
+                , Username(std::move(username))
+                , SpillingSessionId(std::move(spillingSessionId))
+            {}
         };
 
         struct TEvRetryStart : public TEventLocal<TEvRetryStart, EvRetryStart> {
@@ -234,7 +239,7 @@ public:
     void Bootstrap() {
         Username_ = GetUsername();
         Root_ = Config_.Root;
-        Root_ /= MakeSpillingNodeDirName(SelfId().NodeId(), Username_);
+        Root_ /= MakeSpillingNodeDirName(SelfId().NodeId(), Username_, Config_.SpillingSessionId);
         LOG_I("Init DQ local file spilling service at " << Root_ << ", actor: " << SelfId());
 
         CreateRoot(MaxStartupRetries);
@@ -259,7 +264,7 @@ private:
             }
             Root_.ForceDelete();
             // Config_.Root must already exist
-            // create only spilling-tmp-<nodeId>-<username> inside it
+            // create only spilling-tmp-<nodeId>-<username>-<sessionId> inside it
             Root_.MkDir(DIR_MODE);
         } catch (const yexception& e) {
             const TString root = Root_.GetPath();
@@ -274,7 +279,8 @@ private:
             Y_ABORT("Cannot start DQ local file spilling service at %s: %s", root.c_str(), e.what());
         }
 
-        Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(Config_.Root, SelfId().NodeId(), Username_));
+        Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(
+            Config_.Root, SelfId().NodeId(), Username_, Config_.SpillingSessionId));
 
         Become(&TDqLocalFileSpillingService::WorkState);
     }
@@ -794,42 +800,67 @@ private:
         const auto& msg = *ev->Get();
         const auto& root = msg.TmpRoot;
         const auto nodeIdString = ToString(msg.NodeId);
-        const auto currentDirName = MakeSpillingNodeDirName(msg.NodeId, msg.Username);
-        const auto newPrefix = TStringBuilder() << "spilling-tmp-" << nodeIdString << "-";
-        const auto oldPrefix = TStringBuilder() << "node_" << nodeIdString << "_";
+        const auto currentDirName = MakeSpillingNodeDirName(msg.NodeId, msg.Username, msg.SpillingSessionId);
 
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
-        const auto isDirOldTmp = [&](const TString& dirName) -> bool {
-            // New format: spilling-tmp-<nodeId>-<username>
-            if (dirName.StartsWith(newPrefix)) {
-                return dirName != currentDirName;
+        const auto isOwnNewFormatDir = [&](const TString& dirName) -> bool {
+            // spilling-tmp-<nodeId>-<username>-<sessionId>
+            TStringBuf rest = dirName;
+            if (!rest.SkipPrefix("spilling-tmp-")) {
+                return false;
             }
-            // Old format: node_<nodeId>_<sessionId>
-            return dirName.StartsWith(oldPrefix);
+            const auto id = rest.NextTok('-');
+            return id == nodeIdString && !rest.empty() && dirName != currentDirName;
+        };
+
+        const auto isOwnOldFormatDir = [&](const TString& dirName) -> bool {
+            // node_<nodeId>_<sessionId>
+            TStringBuf rest = dirName;
+            if (!rest.SkipPrefix("node_")) {
+                return false;
+            }
+            const auto id = rest.NextTok('_');
+            return id == nodeIdString && !rest.empty();
         };
 
         try {
-            TDirIterator iter(root, TDirIterator::TOptions().SetMaxLevel(1));
+            RemoveMatchingChildren(root, isOwnNewFormatDir);
+            RemoveMatchingChildren(root, isOwnOldFormatDir);
 
-            TVector<TString> oldTmps;
-            for (const auto& dirEntry : iter) {
-                if (dirEntry.fts_info == FTS_DP) {
-                    continue;
-                }
-
-                const auto dirName = dirEntry.fts_name;
-                if (isDirOldTmp(dirName)) {
-                    LOG_D("[RemoveOldTmp] found old temporary at " << (root / dirName));
-                    oldTmps.emplace_back(std::move(dirName));
-                }
-            }
-
-            for (const auto& dirName : oldTmps) {
-                (root / dirName).ForceDelete();
+            // Legacy default root: $TMP/spilling-tmp-<username>. Other nodes may still
+            // write there during a rolling upgrade, so drop only this node's node_* dirs.
+            const TFsPath legacyRoot = TFsPath{GetSystemTempDir()} / ("spilling-tmp-" + msg.Username);
+            if (!(legacyRoot == root)) {
+                RemoveMatchingChildren(legacyRoot, isOwnOldFormatDir);
             }
         } catch (const yexception& e) {
             LOG_E("[RemoveOldTmp] removing failed due to: " << e.what());
+        }
+    }
+
+    template <typename TPred>
+    void RemoveMatchingChildren(const TFsPath& dir, TPred isOldTmp) {
+        if (!dir.Exists() || !dir.IsDirectory()) {
+            return;
+        }
+
+        TDirIterator iter(dir, TDirIterator::TOptions().SetMaxLevel(1));
+        TVector<TString> oldTmps;
+        for (const auto& dirEntry : iter) {
+            if (dirEntry.fts_info == FTS_DP) {
+                continue;
+            }
+
+            const auto dirName = dirEntry.fts_name;
+            if (isOldTmp(dirName)) {
+                LOG_D("[RemoveOldTmp] found old temporary at " << (dir / dirName));
+                oldTmps.emplace_back(dirName);
+            }
+        }
+
+        for (const auto& dirName : oldTmps) {
+            (dir / dirName).ForceDelete();
         }
     }
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -802,28 +802,25 @@ private:
 
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
-        // node_<nodeId>_<sessionId>
+        // Old format when Root was configured: spilling_root/node_<nodeId>_<sessionId>
         const auto isOwnOldFormatDir = [&](TStringBuf dirName) {
             TStringBuf rest = dirName;
             return rest.SkipPrefix("node_") && rest.NextTok('_') == nodeIdString && !rest.empty();
         };
 
-        // spilling-tmp-<nodeId>-<username>-<sessionId>
+        // New format: spilling_root/spilling-tmp-<nodeId>-<username>-<sessionId>
+        const TString ownPrefix = MakeSpillingNodeDirName(msg.NodeId, msg.Username, {});
         const auto isOwnDir = [&](TStringBuf dirName) {
-            TStringBuf rest = dirName;
-            if (!rest.SkipPrefix(SpillingDirPrefix)) {
-                return isOwnOldFormatDir(dirName);
+            if (dirName.StartsWith(ownPrefix)) {
+                return dirName != currentDirName;
             }
-            return rest.NextTok('-') == nodeIdString && !rest.empty() && dirName != currentDirName;
+            return isOwnOldFormatDir(dirName);
         };
 
         try {
             RemoveMatchingChildren(root, isOwnDir);
-
-            // Legacy default root shared by all nodes of this user: other nodes may still
-            // write there during a rolling upgrade, so drop only this node's directories.
-            RemoveMatchingChildren(TFsPath{GetSystemTempDir()} / (TStringBuilder() << SpillingDirPrefix << msg.Username),
-                isOwnOldFormatDir);
+            // Old format when Root was empty: $TMP/spilling-tmp-<username>/node_<nodeId>_<sessionId>
+            RemoveMatchingChildren(root / (TStringBuilder() << SpillingDirPrefix << msg.Username), isOwnOldFormatDir);
         } catch (const yexception& e) {
             LOG_E("[RemoveOldTmp] removing failed due to: " << e.what());
         }
@@ -851,7 +848,11 @@ private:
         }
 
         for (const auto& dirName : toRemove) {
-            (dir / dirName).ForceDelete();
+            try {
+                (dir / dirName).ForceDelete();
+            } catch (const yexception& e) {
+                LOG_E("[RemoveOldTmp] failed to remove " << (dir / dirName) << ": " << e.what());
+            }
         }
     }
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -797,33 +797,46 @@ private:
     void HandleWork(TEvPrivate::TEvRemoveOldTmp::TPtr& ev) {
         const auto& msg = *ev->Get();
         const auto& root = msg.TmpRoot;
-        const auto nodeIdString = ToString(msg.NodeId);
-        const auto currentDirName = MakeSpillingNodeDirName(msg.NodeId, msg.Username, msg.SpillingSessionId);
 
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
-        // Old format when Root was configured: spilling_root/node_<nodeId>_<sessionId>
-        const auto isOwnOldFormatDir = [&](TStringBuf dirName) {
-            TStringBuf rest = dirName;
-            return rest.SkipPrefix("node_") && rest.NextTok('_') == nodeIdString && !rest.empty();
-        };
-
-        // New format: spilling_root/spilling-tmp-<nodeId>-<username>-<sessionId>
-        const TString ownPrefix = MakeSpillingNodeDirName(msg.NodeId, msg.Username, {});
-        const auto isOwnDir = [&](TStringBuf dirName) {
-            if (dirName.StartsWith(ownPrefix)) {
-                return dirName != currentDirName;
-            }
-            return isOwnOldFormatDir(dirName);
-        };
-
         try {
-            RemoveMatchingChildren(root, isOwnDir);
-            // Old format when Root was empty: $TMP/spilling-tmp-<username>/node_<nodeId>_<sessionId>
-            RemoveMatchingChildren(root / (TStringBuilder() << SpillingDirPrefix << msg.Username), isOwnOldFormatDir);
+            // Current format.
+            RemoveOwnDirs(root, msg);
+
+            // Old format, when Root was configured.
+            RemoveOwnOldFormatDirs(root, msg.NodeId);
+
+            // Old format, when Root was empty and the default root was $TMP/spilling-tmp-<username>.
+            RemoveOwnOldFormatDirs(root / (TStringBuilder() << SpillingDirPrefix << msg.Username), msg.NodeId);
         } catch (const yexception& e) {
             LOG_E("[RemoveOldTmp] removing failed due to: " << e.what());
         }
+    }
+
+    void RemoveOwnDirs(const TFsPath& root, const TEvPrivate::TEvRemoveOldTmp& msg) {
+        const TString prefix = TStringBuilder() << SpillingDirPrefix << msg.NodeId << "-";
+        const TString suffix = TStringBuilder() << "-" << msg.Username;
+        const TString currentDirName = MakeSpillingNodeDirName(msg.NodeId, msg.Username, msg.SpillingSessionId);
+
+        RemoveMatchingChildren(root, [&](TStringBuf dirName) {
+            TStringBuf sessionId = dirName;
+            if (!sessionId.SkipPrefix(prefix) || !sessionId.ChopSuffix(suffix)) {
+                return false;
+            }
+
+            TGUID guid;
+            return GetGuid(sessionId, guid) && dirName != currentDirName;
+        });
+    }
+
+    void RemoveOwnOldFormatDirs(const TFsPath& dir, ui32 nodeId) {
+        const TString nodeIdString = ToString(nodeId);
+
+        RemoveMatchingChildren(dir, [&](TStringBuf dirName) {
+            TStringBuf rest = dirName;
+            return rest.SkipPrefix("node_") && rest.NextTok('_') == nodeIdString && !rest.empty();
+        });
     }
 
     template <typename TPredicate>

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.h
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.h
@@ -34,8 +34,8 @@ inline NActors::TActorId MakeDqLocalFileSpillingServiceID(ui32 nodeId) {
 
 TFsPath GetTmpSpillingRootForCurrentUser();
 
-inline TString MakeSpillingNodeDirName(ui32 nodeId, TStringBuf username) {
-    return TStringBuilder() << "spilling-tmp-" << nodeId << "-" << username;
+inline TString MakeSpillingNodeDirName(ui32 nodeId, TStringBuf username, TStringBuf sessionId) {
+    return TStringBuilder() << "spilling-tmp-" << nodeId << "-" << username << "-" << sessionId;
 }
 
 NActors::IActor* CreateDqLocalFileSpillingActor(TTxId txId, const TString& details, const NActors::TActorId& client, bool removeBlobsAfterRead, ESpillingType spillingType);

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.h
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.h
@@ -32,10 +32,12 @@ inline NActors::TActorId MakeDqLocalFileSpillingServiceID(ui32 nodeId) {
     return NActors::TActorId(nodeId, TStringBuf(name, 12));
 }
 
-TFsPath GetTmpSpillingRootForCurrentUser();
+TFsPath GetDefaultSpillingRoot();
+
+constexpr TStringBuf SpillingDirPrefix = "spilling-tmp-";
 
 inline TString MakeSpillingNodeDirName(ui32 nodeId, TStringBuf username, TStringBuf sessionId) {
-    return TStringBuilder() << "spilling-tmp-" << nodeId << "-" << username << "-" << sessionId;
+    return TStringBuilder() << SpillingDirPrefix << nodeId << "-" << username << "-" << sessionId;
 }
 
 NActors::IActor* CreateDqLocalFileSpillingActor(TTxId txId, const TString& details, const NActors::TActorId& client, bool removeBlobsAfterRead, ESpillingType spillingType);

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.h
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.h
@@ -37,7 +37,7 @@ TFsPath GetDefaultSpillingRoot();
 constexpr TStringBuf SpillingDirPrefix = "spilling-tmp-";
 
 inline TString MakeSpillingNodeDirName(ui32 nodeId, TStringBuf username, TStringBuf sessionId) {
-    return TStringBuilder() << SpillingDirPrefix << nodeId << "-" << username << "-" << sessionId;
+    return TStringBuilder() << SpillingDirPrefix << nodeId << "-" << sessionId << "-" << username;
 }
 
 NActors::IActor* CreateDqLocalFileSpillingActor(TTxId txId, const TString& details, const NActors::TActorId& client, bool removeBlobsAfterRead, ESpillingType spillingType);

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.h
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.h
@@ -9,6 +9,7 @@
 #include <util/generic/strbuf.h>
 #include <util/folder/path.h>
 #include <util/generic/guid.h>
+#include <util/string/builder.h>
 
 #include <limits>
 
@@ -32,6 +33,10 @@ inline NActors::TActorId MakeDqLocalFileSpillingServiceID(ui32 nodeId) {
 }
 
 TFsPath GetTmpSpillingRootForCurrentUser();
+
+inline TString MakeSpillingNodeDirName(ui32 nodeId, TStringBuf username) {
+    return TStringBuilder() << "spilling-tmp-" << nodeId << "-" << username;
+}
 
 NActors::IActor* CreateDqLocalFileSpillingActor(TTxId txId, const TString& details, const NActors::TActorId& client, bool removeBlobsAfterRead, ESpillingType spillingType);
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/library/services/services.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <ydb/library/testlib/helpers.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
 
 #include <util/system/fs.h>
@@ -30,7 +31,7 @@ public:
     }
 
     ~TTestActorRuntime() {
-        if (SpillingRoot_ && SpillingRoot_.Exists()) {
+        if (SpillingRoot_ && SpillingRoot_.Exists() && SpillingRoot_ != GetDefaultSpillingRoot()) {
             SpillingRoot_.ForceDelete();
         }
     }
@@ -123,6 +124,13 @@ TChunkedBuffer CreateRope(ui32 size, char symbol, ui32 chunkSize = 7) {
         size -= count;
     }
     return result;
+}
+
+TFsPath MakeDirWithContent(const TFsPath& path) {
+    path.MkDirs();
+    (path / "nested").MkDir();
+    TFileOutput((path / "nested" / "blob").GetPath()).Write("data");
+    return path;
 }
 
 void AssertEquals(const TBuffer& lhs, const TBuffer& rhs) {
@@ -701,6 +709,115 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
             auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester, TDuration::Seconds(1));
             UNIT_ASSERT_VALUES_EQUAL(resp->Get()->BlobId, 1);
+        }
+    }
+
+    // The service spills into <root>/spilling-tmp-<nodeId>-<user>-<sessionId>/, where <root> is the
+    // configured Root, or $TMP when Root is empty. Both roots are covered by UseDefaultRoot.
+    //
+    // Directories left by the previous version of the service are named node_<nodeId>_<sessionId> and
+    // live either directly in <root> (Root was configured) or in <root>/spilling-tmp-<user>/ (Root was
+    // empty, so the service spilled into $TMP/spilling-tmp-<user>/). Both places are cleaned up here.
+    //
+    // Before the service starts:
+    //
+    //   <root>/
+    //   ├── node_<thisNode>_<old-session>/                       delete: this node, old format
+    //   ├── node_<otherNode>_<old-session>/                      keep:   other node may still be running
+    //   ├── spilling-tmp-<thisNode>-<user>-<old-session>/        delete: this node, previous run
+    //   ├── spilling-tmp-<thisNode>-<other-user>-<old-session>/  keep:   same node id, another OS user
+    //   ├── spilling-tmp-<otherNode>-<user>-<old-session>/       keep:   other node may still be running
+    //   ├── unrelated-<old-session>/                             keep:   not a spilling directory
+    //   └── spilling-tmp-<user>/                                 keep:   shared root of the old format
+    //       ├── node_<thisNode>_<old-session>/                   delete: this node, old format
+    //       └── node_<otherNode>_<old-session>/                  keep:   other node may still be running
+    //
+    // After the service starts:
+    //
+    //   <root>/
+    //   ├── node_<otherNode>_<old-session>/
+    //   ├── spilling-tmp-<thisNode>-<user>-<current-session>/    created by the service for this run
+    //   ├── spilling-tmp-<thisNode>-<other-user>-<old-session>/
+    //   ├── spilling-tmp-<otherNode>-<user>-<old-session>/
+    //   ├── unrelated-<old-session>/
+    //   └── spilling-tmp-<user>/
+    //       └── node_<otherNode>_<old-session>/
+    Y_UNIT_TEST_TWIN(RemoveOldTmpDirectories, UseDefaultRoot) {
+        TTestActorRuntime runtime;
+        runtime.Initialize();
+
+        const ui32 thisNodeId = runtime.GetNodeId();
+        const ui32 otherNodeId = thisNodeId + 1;
+        const TString username = GetUsername();
+        const TString oldSessionId = CreateGuidAsString();
+
+        const TFsPath root = UseDefaultRoot
+            ? GetDefaultSpillingRoot()
+            : TFsPath::Cwd() / (runtime.GetSpillingPrefix() + "_cleanup");
+        if (!UseDefaultRoot) {
+            root.ForceDelete();
+        }
+        root.MkDir();
+
+        // $TMP is shared with the rest of the system, so the test removes what it created instead of
+        // deleting the whole root.
+        struct TCreatedPaths {
+            TVector<TFsPath> Paths;
+
+            TFsPath Add(const TFsPath& path) {
+                Track(path);
+                return MakeDirWithContent(path);
+            }
+
+            TFsPath Track(const TFsPath& path) {
+                Paths.push_back(path);
+                return path;
+            }
+
+            ~TCreatedPaths() {
+                for (const auto& path : Paths) {
+                    if (path.Exists()) {
+                        path.ForceDelete();
+                    }
+                }
+            }
+        } created;
+
+        const auto oldFormatDirName = [&](ui32 nodeId) {
+            return TStringBuilder() << "node_" << nodeId << "_" << oldSessionId;
+        };
+
+        const TFsPath oldFormatThisNode = created.Add(root / oldFormatDirName(thisNodeId));
+        const TFsPath oldFormatOtherNode = created.Add(root / oldFormatDirName(otherNodeId));
+        const TFsPath thisNodePreviousRun = created.Add(root / MakeSpillingNodeDirName(thisNodeId, username, oldSessionId));
+        const TFsPath otherUserSameNode = created.Add(root / MakeSpillingNodeDirName(thisNodeId, "other-user", oldSessionId));
+        const TFsPath otherNode = created.Add(root / MakeSpillingNodeDirName(otherNodeId, username, oldSessionId));
+        const TFsPath unrelated = created.Add(root / (TStringBuilder() << "unrelated-" << oldSessionId));
+
+        const TFsPath oldFormatRoot = root / (TStringBuilder() << SpillingDirPrefix << username);
+        const TFsPath oldFormatRootThisNode = created.Add(oldFormatRoot / oldFormatDirName(thisNodeId));
+        const TFsPath oldFormatRootOtherNode = created.Add(oldFormatRoot / oldFormatDirName(otherNodeId));
+
+        runtime.StartSpillingService(1000, 500, 100, 1000, root);
+        runtime.WaitBootstrap();
+
+        // Cleanup is asynchronous, so wait until the service actually spills something.
+        auto tester = runtime.AllocateEdgeActor();
+        auto spillingActor = runtime.StartSpillingActor(tester);
+        runtime.WaitBootstrap();
+        runtime.Send(new IEventHandle(spillingActor, tester, new TEvDqSpilling::TEvWrite(1, CreateRope(10, 'a'))));
+        auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester, TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(resp->Get()->BlobId, 1);
+
+        const TFsPath currentDir = created.Track(runtime.GetSpillingNodeDir());
+        UNIT_ASSERT_C(currentDir.IsDirectory(), currentDir);
+
+        for (const auto& removed : {oldFormatThisNode, thisNodePreviousRun, oldFormatRootThisNode}) {
+            UNIT_ASSERT_C(!removed.Exists(), TStringBuilder() << "must be removed: " << removed);
+        }
+
+        for (const auto& kept : {oldFormatOtherNode, otherUserSameNode, otherNode, unrelated, oldFormatRoot, oldFormatRootOtherNode}) {
+            UNIT_ASSERT_C(kept.IsDirectory(), TStringBuilder() << "must be kept: " << kept);
         }
     }
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -4,7 +4,6 @@
 #include <ydb/library/services/services.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
-#include <ydb/library/testlib/helpers.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
 
 #include <util/system/fs.h>
@@ -713,40 +712,44 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
     }
 
     // The service spills into <root>/spilling-tmp-<nodeId>-<sessionId>-<user>/, where <root> is the
-    // configured Root, or $TMP when Root is empty. Both roots are covered by UseDefaultRoot.
+    // configured Root, or $TMP when Root is empty.
     //
-    // Directories left by the previous version of the service are named node_<nodeId>_<sessionId> and
-    // live either directly in <root> (Root was configured) or in <root>/spilling-tmp-<user>/ (Root was
-    // empty, so the service spilled into $TMP/spilling-tmp-<user>/). Both places are cleaned up here.
+    // Directories left by the previous version of the service are named node_<nodeId>_<sessionId> and live
+    // either directly in <root>, or in $TMP/spilling-tmp-<user>/, which was the root of the old default
+    // layout. Both places are cleaned up, no matter where the service spills now.
     //
     // Before the service starts:
     //
     //   <root>/
     //   ├── node_<thisNode>_<old-session>/                       delete: this node, old format
+    //   ├── node_<thisNode>_backup/                              keep:   old format has a session id here
     //   ├── node_<otherNode>_<old-session>/                      keep:   other node may still be running
     //   ├── spilling-tmp-<thisNode>-<old-session>-<user>/        delete: this node, previous run
     //   ├── spilling-tmp-<thisNode>-<old-session>-<otherUser>/   keep:   same node id, another OS user
     //   ├── spilling-tmp-<thisNode>-<old-session>-<user>-other/  keep:   OS user named <user>-other
     //   ├── spilling-tmp-<thisNode>-<old-session>-other-<user>/  keep:   OS user named other-<user>
     //   ├── spilling-tmp-<otherNode>-<old-session>-<user>/       keep:   other node may still be running
-    //   ├── unrelated-<old-session>/                             keep:   not a spilling directory
-    //   └── spilling-tmp-<user>/                                 keep:   shared root of the old format
-    //       ├── node_<thisNode>_<old-session>/                   delete: this node, old format
-    //       └── node_<otherNode>_<old-session>/                  keep:   other node may still be running
+    //   └── unrelated-<old-session>/                             keep:   not a spilling directory
+    //
+    //   $TMP/spilling-tmp-<user>/                                keep:   root of the old default layout
+    //   ├── node_<thisNode>_<old-session>/                       delete: this node, old format
+    //   └── node_<otherNode>_<old-session>/                      keep:   other node may still be running
     //
     // After the service starts:
     //
     //   <root>/
+    //   ├── node_<thisNode>_backup/
     //   ├── node_<otherNode>_<old-session>/
     //   ├── spilling-tmp-<thisNode>-<current-session>-<user>/    created by the service for this run
     //   ├── spilling-tmp-<thisNode>-<old-session>-<otherUser>/
     //   ├── spilling-tmp-<thisNode>-<old-session>-<user>-other/
     //   ├── spilling-tmp-<thisNode>-<old-session>-other-<user>/
     //   ├── spilling-tmp-<otherNode>-<old-session>-<user>/
-    //   ├── unrelated-<old-session>/
-    //   └── spilling-tmp-<user>/
-    //       └── node_<otherNode>_<old-session>/
-    Y_UNIT_TEST_TWIN(RemoveOldTmpDirectories, UseDefaultRoot) {
+    //   └── unrelated-<old-session>/
+    //
+    //   $TMP/spilling-tmp-<user>/
+    //   └── node_<otherNode>_<old-session>/
+    Y_UNIT_TEST(RemoveOldTmpDirectories) {
         TTestActorRuntime runtime;
         runtime.Initialize();
 
@@ -755,16 +758,12 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         const TString username = GetUsername();
         const TString oldSessionId = CreateGuidAsString();
 
-        const TFsPath root = UseDefaultRoot
-            ? GetDefaultSpillingRoot()
-            : TFsPath::Cwd() / (runtime.GetSpillingPrefix() + "_cleanup");
-        if (!UseDefaultRoot) {
-            root.ForceDelete();
-        }
+        const TFsPath root = TFsPath::Cwd() / (runtime.GetSpillingPrefix() + "_cleanup");
+        root.ForceDelete();
         root.MkDir();
 
-        // $TMP is shared with the rest of the system, so the test removes what it created instead of
-        // deleting the whole root.
+        // The old default layout lives in $TMP, which is shared with the rest of the system, so the test
+        // removes what it created instead of deleting whole directories.
         struct TCreatedPaths {
             TVector<TFsPath> Paths;
 
@@ -792,6 +791,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         };
 
         const TFsPath oldFormatThisNode = created.Add(root / oldFormatDirName(thisNodeId));
+        const TFsPath oldFormatNoSession = created.Add(root / (TStringBuilder() << "node_" << thisNodeId << "_backup"));
         const TFsPath oldFormatOtherNode = created.Add(root / oldFormatDirName(otherNodeId));
         const TFsPath thisNodePreviousRun = created.Add(root / MakeSpillingNodeDirName(thisNodeId, username, oldSessionId));
         const TFsPath otherUserSameNode = created.Add(root / MakeSpillingNodeDirName(thisNodeId, "other-user", oldSessionId));
@@ -800,7 +800,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         const TFsPath otherNode = created.Add(root / MakeSpillingNodeDirName(otherNodeId, username, oldSessionId));
         const TFsPath unrelated = created.Add(root / (TStringBuilder() << "unrelated-" << oldSessionId));
 
-        const TFsPath oldFormatRoot = root / (TStringBuilder() << SpillingDirPrefix << username);
+        const TFsPath oldFormatRoot = created.Track(GetDefaultSpillingRoot() / (TStringBuilder() << SpillingDirPrefix << username));
         const TFsPath oldFormatRootThisNode = created.Add(oldFormatRoot / oldFormatDirName(thisNodeId));
         const TFsPath oldFormatRootOtherNode = created.Add(oldFormatRoot / oldFormatDirName(otherNodeId));
 
@@ -818,13 +818,13 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         const TFsPath currentDir = created.Track(runtime.GetSpillingNodeDir());
         UNIT_ASSERT_C(currentDir.IsDirectory(), currentDir);
 
-        for (const auto& removed : {oldFormatThisNode, thisNodePreviousRun, oldFormatRootThisNode}) {
-            UNIT_ASSERT_C(!removed.Exists(), TStringBuilder() << "must be removed: " << removed);
+        for (const auto& path : {oldFormatThisNode, thisNodePreviousRun, oldFormatRootThisNode}) {
+            UNIT_ASSERT_C(!path.Exists(), TStringBuilder() << "must be removed: " << path);
         }
 
-        for (const auto& kept : {oldFormatOtherNode, otherUserSameNode, userWithOurNameAtStart, userWithOurNameAtEnd,
-                                 otherNode, unrelated, oldFormatRoot, oldFormatRootOtherNode}) {
-            UNIT_ASSERT_C(kept.IsDirectory(), TStringBuilder() << "must be kept: " << kept);
+        for (const auto& path : {oldFormatNoSession, oldFormatOtherNode, otherUserSameNode, userWithOurNameAtStart,
+                                 userWithOurNameAtEnd, otherNode, unrelated, oldFormatRoot, oldFormatRootOtherNode}) {
+            UNIT_ASSERT_C(path.IsDirectory(), TStringBuilder() << "must be kept: " << path);
         }
     }
 

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -490,8 +490,8 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester);
             UNIT_ASSERT_VALUES_EQUAL(0, resp->Get()->BlobId);
         }
-        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername(), runtime.GetSpillingSessionId()));
-        (runtime.GetSpillingRoot() / nodePath / "1_test_0").ForceDelete();
+        const TFsPath blobFile = runtime.GetSpillingNodeDir() / "1_test_0";
+        blobFile.ForceDelete();
 
         {
             auto ev = new TEvDqSpilling::TEvRead(0, true);
@@ -499,7 +499,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
             auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvError>(tester);
             auto err = resp->Get()->Message;
-            auto expected = "can't open \"" + runtime.GetSpillingRoot().GetPath() + "/" + nodePath.GetPath() +"/1_test_0\" with mode RdOnly";
+            auto expected = "can't open \"" + blobFile.GetPath() + "\" with mode RdOnly";
             UNIT_ASSERT_C(err.Contains("No such file or directory"), err);
             UNIT_ASSERT_C(err.Contains(expected), err);
         }
@@ -547,8 +547,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
         runtime.WaitBootstrap();
 
-        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername(), runtime.GetSpillingSessionId()));
-        const TFsPath spillingDir = runtime.GetSpillingRoot() / nodePath;
+        const TFsPath spillingDir = runtime.GetSpillingNodeDir();
         const TFsPath firstFile = spillingDir / "1_test_0";
         const TFsPath secondFile = spillingDir / "1_test_1";
 
@@ -680,12 +679,11 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             UNIT_ASSERT_VALUES_EQUAL("Spilling service is not started", resp->Get()->Message);
         }
 
-        // Unblock the root: remove the file and create a real directory.
-        // The service does not create Root itself, only spilling-tmp-<nodeId>-<username>-<sessionId> inside it.
+        // Unblock the root: the service creates only its own directory inside an existing root.
         root.ForceDelete();
         root.MkDir();
 
-        const TFsPath nodeDir = root / MakeSpillingNodeDirName(runtime.GetNodeId(), GetUsername(), runtime.GetSpillingSessionId());
+        const TFsPath nodeDir = runtime.GetSpillingNodeDir();
 
         TDispatchOptions retryOptions;
         retryOptions.CustomFinalCondition = [&nodeDir]() { return nodeDir.IsDirectory(); };

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -712,7 +712,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         }
     }
 
-    // The service spills into <root>/spilling-tmp-<nodeId>-<user>-<sessionId>/, where <root> is the
+    // The service spills into <root>/spilling-tmp-<nodeId>-<sessionId>-<user>/, where <root> is the
     // configured Root, or $TMP when Root is empty. Both roots are covered by UseDefaultRoot.
     //
     // Directories left by the previous version of the service are named node_<nodeId>_<sessionId> and
@@ -724,9 +724,11 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
     //   <root>/
     //   ├── node_<thisNode>_<old-session>/                       delete: this node, old format
     //   ├── node_<otherNode>_<old-session>/                      keep:   other node may still be running
-    //   ├── spilling-tmp-<thisNode>-<user>-<old-session>/        delete: this node, previous run
-    //   ├── spilling-tmp-<thisNode>-<other-user>-<old-session>/  keep:   same node id, another OS user
-    //   ├── spilling-tmp-<otherNode>-<user>-<old-session>/       keep:   other node may still be running
+    //   ├── spilling-tmp-<thisNode>-<old-session>-<user>/        delete: this node, previous run
+    //   ├── spilling-tmp-<thisNode>-<old-session>-<otherUser>/   keep:   same node id, another OS user
+    //   ├── spilling-tmp-<thisNode>-<old-session>-<user>-other/  keep:   OS user named <user>-other
+    //   ├── spilling-tmp-<thisNode>-<old-session>-other-<user>/  keep:   OS user named other-<user>
+    //   ├── spilling-tmp-<otherNode>-<old-session>-<user>/       keep:   other node may still be running
     //   ├── unrelated-<old-session>/                             keep:   not a spilling directory
     //   └── spilling-tmp-<user>/                                 keep:   shared root of the old format
     //       ├── node_<thisNode>_<old-session>/                   delete: this node, old format
@@ -736,9 +738,11 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
     //
     //   <root>/
     //   ├── node_<otherNode>_<old-session>/
-    //   ├── spilling-tmp-<thisNode>-<user>-<current-session>/    created by the service for this run
-    //   ├── spilling-tmp-<thisNode>-<other-user>-<old-session>/
-    //   ├── spilling-tmp-<otherNode>-<user>-<old-session>/
+    //   ├── spilling-tmp-<thisNode>-<current-session>-<user>/    created by the service for this run
+    //   ├── spilling-tmp-<thisNode>-<old-session>-<otherUser>/
+    //   ├── spilling-tmp-<thisNode>-<old-session>-<user>-other/
+    //   ├── spilling-tmp-<thisNode>-<old-session>-other-<user>/
+    //   ├── spilling-tmp-<otherNode>-<old-session>-<user>/
     //   ├── unrelated-<old-session>/
     //   └── spilling-tmp-<user>/
     //       └── node_<otherNode>_<old-session>/
@@ -791,6 +795,8 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         const TFsPath oldFormatOtherNode = created.Add(root / oldFormatDirName(otherNodeId));
         const TFsPath thisNodePreviousRun = created.Add(root / MakeSpillingNodeDirName(thisNodeId, username, oldSessionId));
         const TFsPath otherUserSameNode = created.Add(root / MakeSpillingNodeDirName(thisNodeId, "other-user", oldSessionId));
+        const TFsPath userWithOurNameAtStart = created.Add(root / MakeSpillingNodeDirName(thisNodeId, username + "-other", oldSessionId));
+        const TFsPath userWithOurNameAtEnd = created.Add(root / MakeSpillingNodeDirName(thisNodeId, "other-" + username, oldSessionId));
         const TFsPath otherNode = created.Add(root / MakeSpillingNodeDirName(otherNodeId, username, oldSessionId));
         const TFsPath unrelated = created.Add(root / (TStringBuilder() << "unrelated-" << oldSessionId));
 
@@ -816,7 +822,8 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             UNIT_ASSERT_C(!removed.Exists(), TStringBuilder() << "must be removed: " << removed);
         }
 
-        for (const auto& kept : {oldFormatOtherNode, otherUserSameNode, otherNode, unrelated, oldFormatRoot, oldFormatRootOtherNode}) {
+        for (const auto& kept : {oldFormatOtherNode, otherUserSameNode, userWithOurNameAtStart, userWithOurNameAtEnd,
+                                 otherNode, unrelated, oldFormatRoot, oldFormatRootOtherNode}) {
             UNIT_ASSERT_C(kept.IsDirectory(), TStringBuilder() << "must be kept: " << kept);
         }
     }

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -57,6 +57,7 @@ public:
         ui64 maxFilePartSize = 100, ui32 ioThreadPoolQueueSize = 1000, const TFsPath& root = TFsPath::Cwd() / GetSpillingPrefix())
     {
         SpillingRoot_ = root;
+        SpillingRoot_.MkDir();
         SpillingSessionId_ = CreateGuidAsString();
 
         auto config = TFileSpillingServiceConfig{

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/library/actors/testlib/test_runtime.h>
 
 #include <util/system/fs.h>
+#include <util/system/user.h>
 #include <util/generic/string.h>
 #include <util/folder/path.h>
 #include <util/stream/file.h>
@@ -96,6 +97,10 @@ public:
 
     const TFsPath& GetSpillingRoot() const {
         return SpillingRoot_;
+    }
+
+    TFsPath GetSpillingNodeDir() const {
+        return SpillingRoot_ / MakeSpillingNodeDirName(GetNodeId(), GetUsername());
     }
 
 private:
@@ -313,7 +318,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         auto spillingActor = runtime.StartSpillingActor(tester);
 
         runtime.WaitBootstrap();
-        const TString filePrefix = TStringBuilder() << runtime.GetSpillingRoot().GetPath() << "/node_" << runtime.GetNodeId() << "_" << runtime.GetSpillingSessionId() << "/1_test_";
+        const TString filePrefix = TStringBuilder() << runtime.GetSpillingNodeDir().GetPath() << "/1_test_";
 
         for (ui32 i = 0; i < 5; ++i) {
             // Cerr << "---- store blob #" << i << Endl;
@@ -355,7 +360,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
         runtime.WaitBootstrap();
 
-        const TString filePrefix = TStringBuilder() << runtime.GetSpillingRoot().GetPath() << "/node_" << runtime.GetNodeId() << "_" << runtime.GetSpillingSessionId() << "/1_test_";
+        const TString filePrefix = TStringBuilder() << runtime.GetSpillingNodeDir().GetPath() << "/1_test_";
 
         for (ui32 i = 0; i < 5; ++i) {
             // Cerr << "---- store blob #" << i << Endl;
@@ -397,7 +402,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
         runtime.WaitBootstrap();
 
-        const TString filePrefix = TStringBuilder() << runtime.GetSpillingRoot().GetPath() << "/node_" << runtime.GetNodeId() << "_" << runtime.GetSpillingSessionId() << "/1_test_";
+        const TString filePrefix = TStringBuilder() << runtime.GetSpillingNodeDir().GetPath() << "/1_test_";
 
         constexpr const size_t numBlobs = 5;
         constexpr const size_t numFiles = MultiPart ? numBlobs : 1;
@@ -485,7 +490,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester);
             UNIT_ASSERT_VALUES_EQUAL(0, resp->Get()->BlobId);
         }
-        auto nodePath = TFsPath("node_" + std::to_string(spillingSvc.NodeId()) + "_" + runtime.GetSpillingSessionId());
+        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername()));
         (runtime.GetSpillingRoot() / nodePath / "1_test_0").ForceDelete();
 
         {
@@ -542,7 +547,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
         runtime.WaitBootstrap();
 
-        auto nodePath = TFsPath("node_" + std::to_string(spillingSvc.NodeId()) + "_" + runtime.GetSpillingSessionId());
+        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername()));
         const TFsPath spillingDir = runtime.GetSpillingRoot() / nodePath;
         const TFsPath firstFile = spillingDir / "1_test_0";
         const TFsPath secondFile = spillingDir / "1_test_1";
@@ -675,11 +680,15 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             UNIT_ASSERT_VALUES_EQUAL("Spilling service is not started", resp->Get()->Message);
         }
 
-        // Unblock the root and let the scheduled retry start the service.
+        // Unblock the root: remove the file and create a real directory.
+        // The service does not create Root itself, only spilling-tmp-<nodeId>-<username> inside it.
         root.ForceDelete();
+        root.MkDir();
+
+        const TFsPath nodeDir = root / MakeSpillingNodeDirName(runtime.GetNodeId(), GetUsername());
 
         TDispatchOptions retryOptions;
-        retryOptions.CustomFinalCondition = [&root]() { return root.IsDirectory(); };
+        retryOptions.CustomFinalCondition = [&nodeDir]() { return nodeDir.IsDirectory(); };
         UNIT_ASSERT(runtime.DispatchEvents(retryOptions, TDuration::Seconds(5)));
 
         {

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -100,7 +100,7 @@ public:
     }
 
     TFsPath GetSpillingNodeDir() const {
-        return SpillingRoot_ / MakeSpillingNodeDirName(GetNodeId(), GetUsername());
+        return SpillingRoot_ / MakeSpillingNodeDirName(GetNodeId(), GetUsername(), SpillingSessionId_);
     }
 
 private:
@@ -490,7 +490,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester);
             UNIT_ASSERT_VALUES_EQUAL(0, resp->Get()->BlobId);
         }
-        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername()));
+        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername(), runtime.GetSpillingSessionId()));
         (runtime.GetSpillingRoot() / nodePath / "1_test_0").ForceDelete();
 
         {
@@ -547,7 +547,7 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
 
         runtime.WaitBootstrap();
 
-        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername()));
+        auto nodePath = TFsPath(MakeSpillingNodeDirName(spillingSvc.NodeId(), GetUsername(), runtime.GetSpillingSessionId()));
         const TFsPath spillingDir = runtime.GetSpillingRoot() / nodePath;
         const TFsPath firstFile = spillingDir / "1_test_0";
         const TFsPath secondFile = spillingDir / "1_test_1";
@@ -681,11 +681,11 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         }
 
         // Unblock the root: remove the file and create a real directory.
-        // The service does not create Root itself, only spilling-tmp-<nodeId>-<username> inside it.
+        // The service does not create Root itself, only spilling-tmp-<nodeId>-<username>-<sessionId> inside it.
         root.ForceDelete();
         root.MkDir();
 
-        const TFsPath nodeDir = root / MakeSpillingNodeDirName(runtime.GetNodeId(), GetUsername());
+        const TFsPath nodeDir = root / MakeSpillingNodeDirName(runtime.GetNodeId(), GetUsername(), runtime.GetSpillingSessionId());
 
         TDispatchOptions retryOptions;
         retryOptions.CustomFinalCondition = [&nodeDir]() { return nodeDir.IsDirectory(); };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. YDB will not create spilling root anymore: the directory must exist before the nodes start.
2. Simplified spilling layout in case when spilling root is not set.

### Description for reviewers <!-- (optional) description for those who read this PR -->
Static and dynamic nodes may run under different users but share the same spilling root. If YDB creates that root itself, the first node creates it under its own user with `0700`, and other nodes may not have permissions to write there.

- If `Root` is set in the config, that directory must already exist and be writable by all node users. YDB will not create it.
- If `Root` is not set, YDB uses `$TMP` as the root and creates no intermediate directory there.

Also, unified the spilling subdirectories creation logic.

### was
spilling root is set: `/spilling/node_<node_id>_<session>`
spilling root is not set: `/tmp/spilling-tmp-<user>/node_<node_id>_<session>`

### now
spilling root is set: `/spilling/spilling-tmp-<node_id>-<session>-<user>`
spilling root is not set: `/tmp/spilling-tmp-<node_id>-<session>-<user>`

for example: `/tmp/spilling-tmp-1-1144b692-f1e5d361-f3960fe8-f607582e-kikimr`

so, the intermediate `spilling-tmp-<user>` directory is removed, and the node id and the OS username are now part of the directory name, so nodes of different users no longer collide.