### PR TITLE
http_proxy ut: raise RunYqlDataQuery timeouts to fix ASAN flake

### DIFF
--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
@@ -458,21 +458,34 @@ TMaybe<NYdb::TResultSet> THttpProxyTestMock::RunYqlDataQuery(TString query) {
 
     TMaybe<NYdb::TResultSet> resultSet;
 
+    // Default GetSessionClientTimeout is 5s; under ASAN + UseRealThreads(false) CreateSession
+    // often exceeds that and flakes with "request deadline expired".
+    NYdb::NTable::TRetryOperationSettings retrySettings;
+    retrySettings.GetSessionClientTimeout(TDuration::Seconds(60));
+    retrySettings.MaxTimeout(TDuration::Seconds(120));
+
     auto operationResult = tableClient.RetryOperationSync([&](NYdb::NTable::TSession session) {
+        NYdb::NTable::TExecDataQuerySettings execSettings;
+        execSettings.ClientTimeout(TDuration::Seconds(60));
+        execSettings.OperationTimeout(TDuration::Seconds(60));
+
         NYdb::TParamsBuilder paramsBuilder;
         auto queryResult = session.ExecuteDataQuery(
                 query,
                 NYdb::NTable::TTxControl::BeginTx(NYdb::NTable::TTxSettings::SerializableRW()).CommitTx(),
-                paramsBuilder.Build()
+                paramsBuilder.Build(),
+                execSettings
             ).GetValueSync();
 
         if (queryResult.IsSuccess() && queryResult.GetResultSets().size() > 0) {
             resultSet = queryResult.GetResultSet(0);
         }
         return queryResult;
-    });
+    }, retrySettings);
 
-    Y_ABORT_UNLESS(operationResult.IsSuccess());
+    UNIT_ASSERT_C(operationResult.IsSuccess(),
+        "RunYqlDataQuery failed: " << operationResult.GetIssues().ToOneLineString()
+        << " for query: " << query);
     return resultSet;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

*Not for changelog. Test-only fix.*

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes flake [#48625](https://github.com/ydb-platform/ydb/issues/48625): `TestSqsTopicHttpProxy.TestCreateQueueWithEmptySecurityToken` aborts under release-asan during fixture init.

**Cause:** `RunYqlDataQuery()` uses `RetryOperationSync` with default `GetSessionClientTimeout` of 5s. Under ASAN + `UseRealThreads(false)`, CreateSession often exceeds that → KQP `request deadline expired` → `Y_ABORT_UNLESS` kills the process (rc -6). TIMEOUT is not retried by default SDK settings.

**Fix:**
- Raise `GetSessionClientTimeout` / query client & operation timeouts (60s) and overall `MaxTimeout` (120s)
- Replace `Y_ABORT_UNLESS` with `UNIT_ASSERT_C` so a failure fails the test instead of aborting the suite