### PR TITLE
sqs: skip test_dlq_mechanics_in_cloud on legacy YMQ (no topic migration)

### DIFF
--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -15,13 +15,9 @@ import pytest
 import ydb
 from hamcrest import assert_that, equal_to, not_none, has_item, has_items, is_not, contains_string
 from hamcrest import raises, greater_than
-from ydb.tests.library.sqs.test_base import (
-    IS_FIFO_PARAMS,
-    TABLES_FORMAT_PARAMS,
-    KikimrSqsTestBase,
-    get_test_with_sqs_tenant_installation,
-)
+from ydb.tests.library.sqs.test_base import IS_FIFO_PARAMS, TABLES_FORMAT_PARAMS
 from ydb.tests.library.sqs.cloud_test_base import YandexCloudSqsTestBase
+from ydb.tests.library.sqs.test_base import get_test_with_sqs_tenant_installation
 from ydb.tests.library.sqs.requests_client import REQUEST_TIMEOUT
 from ydb.tests.library.harness.util import LogLevels
 
@@ -393,7 +389,7 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(YandexCloudSq
 
     @pytest.mark.parametrize(**IS_FIFO_PARAMS)
     @pytest.mark.skipif(
-        not KikimrSqsTestBase._is_topic_migration_stage(),
+        not YandexCloudSqsTestBase._is_topic_migration_stage(),
         reason='Legacy YMQ DLQ readiness race; covered by migration compatibility/finished suites',
     )
     def test_dlq_mechanics_in_cloud(self, is_fifo):

--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -15,9 +15,13 @@ import pytest
 import ydb
 from hamcrest import assert_that, equal_to, not_none, has_item, has_items, is_not, contains_string
 from hamcrest import raises, greater_than
-from ydb.tests.library.sqs.test_base import IS_FIFO_PARAMS, TABLES_FORMAT_PARAMS
+from ydb.tests.library.sqs.test_base import (
+    IS_FIFO_PARAMS,
+    TABLES_FORMAT_PARAMS,
+    KikimrSqsTestBase,
+    get_test_with_sqs_tenant_installation,
+)
 from ydb.tests.library.sqs.cloud_test_base import YandexCloudSqsTestBase
-from ydb.tests.library.sqs.test_base import get_test_with_sqs_tenant_installation
 from ydb.tests.library.sqs.requests_client import REQUEST_TIMEOUT
 from ydb.tests.library.harness.util import LogLevels
 
@@ -388,6 +392,10 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(YandexCloudSq
         wait_check_messages_sent(cloud_q_name, 0)
 
     @pytest.mark.parametrize(**IS_FIFO_PARAMS)
+    @pytest.mark.skipif(
+        not KikimrSqsTestBase._is_topic_migration_stage(),
+        reason='Legacy YMQ DLQ readiness race; covered by migration compatibility/finished suites',
+    )
     def test_dlq_mechanics_in_cloud(self, is_fifo):
         tables_format = 1
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Skip `test_dlq_mechanics_in_cloud` when `YDB_SQS_MIGRATION_STAGE` is not `compatibility`/`finished`.

On legacy YMQ (no topic migration) the test flakes because redrive depends on async `DlqInfo_` resolution in the queue leader after `SetQueueAttributes`, while the test only waits a fixed sleep and checks `RedrivePolicy` via `GetQueueAttributes` (DB), which does not mean the leader is ready. Symptom: third receive still returns the message (`ApproximateReceiveCount=3`) with `maxReceiveCount=2`.

The same test remains covered by migration suites (`migration/compatibility/cloud`, `migration/finished/cloud`), where DLQ goes through topic/MLP.

Fixes https://github.com/ydb-platform/ydb/issues/49733