### PR TITLE
Remove unused providers/dq peerdirs from pq libraries

### DIFF
--- a/ydb/library/yql/providers/pq/async_io/ya.make
+++ b/ydb/library/yql/providers/pq/async_io/ya.make
@@ -18,7 +18,6 @@ PEERDIR(
     ydb/library/actors/log_backend
     ydb/library/yql/dq/actors/compute
     ydb/library/yql/providers/common/token_accessor/client
-    ydb/library/yql/providers/dq/api/protos
     ydb/library/yql/providers/pq/common
     ydb/library/yql/providers/pq/gateway/abstract
     ydb/library/yql/providers/pq/gateway/clients/composite

--- a/ydb/library/yql/providers/pq/provider/ya.make
+++ b/ydb/library/yql/providers/pq/provider/ya.make
@@ -35,7 +35,7 @@ PEERDIR(
     ydb/library/yql/providers/common/pushdown
     ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes
-    ydb/library/yql/providers/dq/provider/exec
+    ydb/library/yql/providers/dq/mkql
     ydb/library/yql/providers/generic/provider
     ydb/library/yql/providers/pq/cm_client
     ydb/library/yql/providers/pq/common


### PR DESCRIPTION
## Summary
- Remove unused `providers/dq/` peerdirs from pq libraries where there are no direct includes from those libs
- Drop `dq/provider/exec` from `pq/provider` (no direct includes)
- Drop `dq/api/protos` from `pq/async_io` (no direct includes)
- Add explicit `dq/mkql` peerdir to `pq/provider` for the direct `parser.h` include in `yql_pq_mkql_compiler.cpp`

## Test plan
- [x] `./ya make ydb/library/yql/providers/pq/provider ydb/library/yql/providers/pq/async_io ydb/library/yql/providers/pq/task_meta`
- [x] `./ya make ydb/library/yql/providers/pq`