### PR TITLE
Align providers/dq peerdirs with actual includes

### DIFF
--- a/ydb/core/kqp/opt/cbo/solver/ya.make
+++ b/ydb/core/kqp/opt/cbo/solver/ya.make
@@ -8,7 +8,6 @@ PEERDIR(
     ydb/library/yql/dq/opt/core
     ydb/library/yql/dq/proto
     ydb/library/yql/dq/type_ann
-    ydb/library/yql/providers/dq/expr_nodes
     yql/essentials/ast
     yql/essentials/core
     yql/essentials/core/dq_integration

--- a/ydb/core/kqp/provider/ya.make
+++ b/ydb/core/kqp/provider/ya.make
@@ -43,7 +43,9 @@ PEERDIR(
     ydb/library/yql/dq/constraints
     ydb/library/yql/dq/expr_nodes
     ydb/library/yql/dq/opt
+    ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes
+    ydb/library/yql/providers/dq/provider
     ydb/public/lib/scheme_types
     ydb/public/sdk/cpp/src/client/topic
     ydb/services/metadata/optimization

--- a/ydb/core/kqp/query_compiler/ya.make
+++ b/ydb/core/kqp/query_compiler/ya.make
@@ -21,6 +21,7 @@ PEERDIR(
     yql/essentials/minikql
     yql/essentials/providers/common/mkql
     ydb/library/yql/providers/dq/common
+    ydb/library/yql/providers/dq/expr_nodes
     ydb/library/yql/providers/s3/expr_nodes
 )
 

--- a/ydb/library/yql/providers/generic/provider/ya.make
+++ b/ydb/library/yql/providers/generic/provider/ya.make
@@ -55,6 +55,7 @@ PEERDIR(
     yql/essentials/providers/common/transform
     ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes
+    ydb/library/yql/providers/dq/mkql
     ydb/library/yql/providers/generic/expr_nodes
     ydb/library/yql/providers/generic/proto
     yql/essentials/providers/common/proto

--- a/ydb/library/yql/providers/s3/provider/ya.make
+++ b/ydb/library/yql/providers/s3/provider/ya.make
@@ -45,6 +45,7 @@ PEERDIR(
     yql/essentials/providers/common/transform
     ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes
+    ydb/library/yql/providers/dq/mkql
     ydb/library/yql/providers/generic/provider
     yql/essentials/providers/result/expr_nodes
     ydb/library/yql/providers/s3/actors

--- a/ydb/library/yql/providers/solomon/provider/ya.make
+++ b/ydb/library/yql/providers/solomon/provider/ya.make
@@ -24,7 +24,9 @@ PEERDIR(
     ydb/library/yql/dq/expr_nodes
     ydb/library/yql/dq/opt
     ydb/library/yql/providers/common/token_accessor/client
+    ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes
+    ydb/library/yql/providers/dq/mkql
     ydb/library/yql/providers/solomon/actors
     ydb/library/yql/providers/solomon/common
     ydb/library/yql/providers/solomon/expr_nodes


### PR DESCRIPTION
## Summary
- Add missing explicit `providers/dq/` peerdirs where code directly includes headers from those libs:
  - `generic/provider`: `dq/mkql`
  - `s3/provider`: `dq/mkql`
  - `solomon/provider`: `dq/common`, `dq/mkql`
  - `kqp/provider`: `dq/common`, `dq/provider`
  - `kqp/query_compiler`: `dq/expr_nodes`
- Remove unused `dq/expr_nodes` peerdir from `kqp/opt/cbo/solver`

## Test plan
- [x] `./ya make ydb/library/yql/providers/generic/provider ydb/library/yql/providers/s3/provider ydb/library/yql/providers/solomon/provider ydb/core/kqp/opt/cbo/solver ydb/core/kqp/provider ydb/core/kqp/query_compiler`