### PR TITLE
[NBS-7486] Keep changed blocks in memory when ddisk is lagging.

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.cpp
@@ -1,5 +1,7 @@
 #include "block_range_field.h"
 
+#include <util/string/builder.h>
+
 namespace NYdb::NBS::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,6 +77,11 @@ void TBlockRangeField::Remove(TBlockRange64 range)
     }
 }
 
+void TBlockRangeField::Clear()
+{
+    Intervals.clear();
+}
+
 bool TBlockRangeField::Overlaps(TBlockRange64 other) const
 {
     if (Intervals.empty()) {
@@ -95,8 +102,24 @@ bool TBlockRangeField::Overlaps(TBlockRange64 other) const
 void TBlockRangeField::Enumerate(TEnumerateFunc func) const
 {
     for (const auto& range: Intervals) {
-        func(range);
+        if (func(range) == EEnumerateContinuation::Stop) {
+            break;
+        }
     }
+}
+
+bool TBlockRangeField::Empty() const
+{
+    return Intervals.empty();
+}
+
+TString TBlockRangeField::Print() const
+{
+    TStringBuilder result;
+    for (const auto& range: Intervals) {
+        result << range.Print();
+    }
+    return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h
@@ -13,14 +13,24 @@ namespace NYdb::NBS::NBlockStore {
 class TBlockRangeField
 {
 public:
-    using TEnumerateFunc = std::function<void(TBlockRange64 item)>;
+    enum class EEnumerateContinuation
+    {
+        Continue,
+        Stop,
+    };
+    using TEnumerateFunc =
+        std::function<EEnumerateContinuation(TBlockRange64 item)>;
 
     void Add(TBlockRange64 range);
     void Remove(TBlockRange64 range);
+    void Clear();
 
     [[nodiscard]] bool Overlaps(TBlockRange64 other) const;
 
     void Enumerate(TEnumerateFunc func) const;
+
+    [[nodiscard]] bool Empty() const;
+    [[nodiscard]] TString Print() const;
 
 private:
     struct TBlockRangeComparator

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field_ut.cpp
@@ -13,7 +13,12 @@ namespace {
 TVector<TBlockRange64> Collect(const TBlockRangeField& field)
 {
     TVector<TBlockRange64> result;
-    field.Enumerate([&](TBlockRange64 r) { result.push_back(r); });
+    field.Enumerate(
+        [&](TBlockRange64 r)
+        {
+            result.push_back(r);
+            return TBlockRangeField::EEnumerateContinuation::Continue;
+        });
     return result;
 }
 
@@ -315,6 +320,29 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
         UNIT_ASSERT_VALUES_EQUAL(3u, v.size());
         UNIT_ASSERT(v[0].Start < v[1].Start);
         UNIT_ASSERT(v[1].Start < v[2].Start);
+    }
+
+    Y_UNIT_TEST(EnumerateStopsAtCondition)
+    {
+        TBlockRangeField f;
+        f.Add(R(0, 5));
+        f.Add(R(10, 15));
+        f.Add(R(20, 25));
+
+        TVector<TBlockRange64> seen;
+        f.Enumerate(
+            [&](TBlockRange64 r)
+            {
+                seen.push_back(r);
+                return r.Start >= 10
+                           ? TBlockRangeField::EEnumerateContinuation::Stop
+                           : TBlockRangeField::EEnumerateContinuation::Continue;
+            });
+
+        // Visits first two ranges, then stops on the second.
+        UNIT_ASSERT_VALUES_EQUAL(2u, seen.size());
+        UNIT_ASSERT_VALUES_EQUAL(R(0, 5), seen[0]);
+        UNIT_ASSERT_VALUES_EQUAL(R(10, 15), seen[1]);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
@@ -23,6 +23,14 @@ namespace {
 constexpr auto MinBackoff = TDuration::MilliSeconds(100);
 constexpr auto MaxBackoff = TDuration::Seconds(10);
 
+TBlockRange64 TrimRange(TBlockRange64 range, size_t maxBlockCount)
+{
+    if (range.Size() > maxBlockCount) {
+        return TBlockRange64::WithLength(range.Start, maxBlockCount);
+    }
+    return range;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -101,15 +109,9 @@ TFuture<TDDiskDataCopier::EResult> TDDiskDataCopier::Start()
         }
     }
 
-    if (auto watermark = DirtyMap->GetFreshWatermark(Destination)) {
-        FreshWatermark = *watermark;
-        Complete = NewPromise<EResult>();
-        StartCopyRange();
-        return Complete.GetFuture();
-    }
-
-    State = EState::Stopped;
-    return MakeFuture(EResult::Ok);
+    Complete = NewPromise<EResult>();
+    StartCopyRange();
+    return Complete.GetFuture();
 }
 
 TFuture<TDDiskDataCopier::EResult> TDDiskDataCopier::Stop()
@@ -128,17 +130,38 @@ TFuture<TDDiskDataCopier::EResult> TDDiskDataCopier::Stop()
     }
 }
 
-NWilson::TSpan TDDiskDataCopier::CreateSpan() const
+std::optional<TBlockRange64> TDDiskDataCopier::GetFreshRange() const
+{
+    auto freshRange = DirtyMap->GetFreshRange(Destination);
+    if (!freshRange) {
+        return std::nullopt;
+    }
+
+    return TrimRange(*freshRange, CopyRangeSize / VolumeConfig->BlockSize);
+}
+
+NWilson::TSpan TDDiskDataCopier::CreateSpan(TBlockRange64 range) const
 {
     auto span = TraceService->CreateRootSpan("CopyRange");
     span.Attribute("DiskId", VolumeConfig->DiskId);
-    span.Attribute("From", static_cast<i64>(FreshWatermark));
-    span.Attribute("Length", static_cast<i64>(CopyRangeSize));
+    span.Attribute("From", static_cast<i64>(range.Start));
+    span.Attribute(
+        "Length",
+        static_cast<i64>(range.Size() * VolumeConfig->BlockSize));
     return span;
 }
 
 void TDDiskDataCopier::StartCopyRange()
 {
+    auto freshRange = GetFreshRange();
+
+    LOG_DEBUG(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s Will copy range: %s",
+        LogTitle.GetWithTime().c_str(),
+        freshRange ? freshRange->Print().c_str() : "<empty>");
+
     switch (State) {
         case EState::Stopped: {
             Y_ABORT_UNLESS(false);
@@ -150,24 +173,40 @@ void TDDiskDataCopier::StartCopyRange()
             return;
         }
         case EState::Running:
+            if (!freshRange) {
+                State = EState::Stopped;
+                Complete.SetValue(EResult::Ok);
+                return;
+            }
             break;
     }
 
-    Y_ABORT_UNLESS(
-        DirtyMap->GetFreshWatermark(Destination) &&
-        FreshWatermark == DirtyMap->GetFreshWatermark(Destination));
+    auto start = DirtyMap->GetRangeSyncStartTrigger(Destination, *freshRange);
+    start.Subscribe(
+        [weakSelf = weak_from_this(),
+         range = *freshRange](const TFuture<void>& f)
+        {
+            Y_UNUSED(f);
 
-    const ui64 futureWatermark = FreshWatermark + CopyRangeSize;
-    auto range = TBlockRange64::WithLength(
-        FreshWatermark / VolumeConfig->BlockSize,
-        CopyRangeSize / VolumeConfig->BlockSize);
+            if (auto self = weakSelf.lock()) {
+                self->CopyRange(range);
+            }
+        });
+}
+
+void TDDiskDataCopier::CopyRange(TBlockRange64 range)
+{
+    LOG_DEBUG(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s Copy range: %s",
+        LogTitle.GetWithTime().c_str(),
+        range.Print().c_str());
 
     auto copyRangeState = std::make_shared<TCopyRangeRequestState>(
         range,
         TRangeLock(DirtyMap, range, THostMask::MakeOne(Destination)),
-        CreateSpan());
-
-    DirtyMap->SetFlushWatermark(Destination, futureWatermark);
+        CreateSpan(range));
 
     auto readHint = DirtyMap->MakeReadHint(range);
     if (readHint.RangeHints.empty()) {
@@ -226,6 +265,14 @@ void TDDiskDataCopier::OnRangeRead(
 {
     copyRangeState->Span.Event("OnRangeRead");
 
+    LOG_DEBUG(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s %s Read: %s",
+        LogTitle.GetWithTime().c_str(),
+        copyRangeState->Range.Print().c_str(),
+        FormatError(response.Error).Quote().c_str());
+
     if (HasError(response.Error)) {
         LOG_ERROR(
             *ActorSystem,
@@ -266,6 +313,14 @@ void TDDiskDataCopier::OnRangeWritten(
 {
     copyRangeState->Span.Event("OnRangeWritten");
 
+    LOG_DEBUG(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s %s Write: %s",
+        LogTitle.GetWithTime().c_str(),
+        copyRangeState->Range.Print().c_str(),
+        FormatError(response.Error).Quote().c_str());
+
     if (HasError(response.Error)) {
         LOG_ERROR(
             *ActorSystem,
@@ -284,14 +339,8 @@ void TDDiskDataCopier::OnRangeWritten(
     }
 
     BackoffDelayProvider.Reset();
-    FreshWatermark = (copyRangeState->Range.End + 1) * VolumeConfig->BlockSize;
-    DirtyMap->SetReadWatermark(Destination, FreshWatermark);
-    Y_ABORT_UNLESS(VolumeConfig->VChunkSize > 0);
-    if (FreshWatermark < VolumeConfig->VChunkSize) {
-        StartCopyRange();
-    } else {
-        Complete.SetValue(EResult::Ok);
-    }
+    DirtyMap->RangeSynced(Destination, copyRangeState->Range);
+    StartCopyRange();
 }
 
 void TDDiskDataCopier::ScheduleStartCopyRange(TDuration delay)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
@@ -56,8 +56,10 @@ private:
     struct TCopyRangeRequestState;
     using TCopyRangeRequestStatePtr = std::shared_ptr<TCopyRangeRequestState>;
 
-    NWilson::TSpan CreateSpan() const;
+    std::optional<TBlockRange64> GetFreshRange() const;
+    NWilson::TSpan CreateSpan(TBlockRange64 range) const;
     void StartCopyRange();
+    void CopyRange(TBlockRange64 range);
     void OnRangeRead(
         TCopyRangeRequestStatePtr copyRangeState,
         const IReadRequestExecutor::TResponse& response);
@@ -76,7 +78,6 @@ private:
 
     TLogTitle LogTitle;
     EState State = EState::Stopped;
-    size_t FreshWatermark = 0;
     TBackoffDelayProvider BackoffDelayProvider;
     NThreading::TPromise<EResult> Complete;
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
@@ -22,6 +22,13 @@ THostMask MakePrimariesMask()
     return result;
 }
 
+void FinishFlushes(TBlocksDirtyMap& dirtyMap, const TFlushHints& hints)
+{
+    for (const auto& [route, flush]: hints.GetAllHints()) {
+        dirtyMap.FlushFinished(route, {MakeLsnVector(flush.Segments)}, {});
+    }
+}
+
 struct TFixture: public TBaseFixture
 {
     TDDiskDataCopierPtr Copier;
@@ -55,21 +62,21 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         Init();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
 
         // Mark DDisk#1 completely fresh.
-        DirtyMap->MarkFresh(FreshDDisk, 0);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,0,0};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,0};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
 
         // No ranges locked.
@@ -111,12 +118,12 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             if (i == 5) {
                 // Check state on 5th iteration
                 UNIT_ASSERT_VALUES_EQUAL(
-                    "H0*{Operational,32768,32768};"
-                    "H1*{Fresh,1536,1792};"   // Watermarks for reading
-                                              // and writing raised
-                    "H2*{Operational,32768,32768};"
-                    "H3*{Operational,32768,32768};"
-                    "H4+{Disabled,0,0};",
+                    "H0*{Operational,32768};"
+                    "H1*{Fresh+,1536};"   // Watermarks for reading
+                                          // and writing raised
+                    "H2*{Operational,32768};"
+                    "H3*{Operational,32768};"
+                    "H4+{Disabled,0};",
                     DirtyMap->DebugPrintDDiskState());
             }
         }
@@ -129,11 +136,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
 
         // All DDisk fully operational
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
     }
 
@@ -164,7 +171,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         };
 
         // Mark DDisk#1 completely fresh.
-        DirtyMap->MarkFresh(FreshDDisk, 0);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
 
         // Start data copy
         ExpectedRange = TBlockRange64::WithLength(0, BlocksPerCopy);
@@ -176,14 +183,16 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
 
         // Data copying should not be advanced.
         UNIT_ASSERT_VALUES_EQUAL(false, complete.IsReady());
-        UNIT_ASSERT_VALUES_EQUAL(0, *DirtyMap->GetFreshWatermark(FreshDDisk));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TBlockRange64::WithLength(0, 32768),
+            *DirtyMap->GetFreshRange(FreshDDisk));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,0,256};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,0};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
     }
 
@@ -210,7 +219,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         };
 
         // Mark DDisk#1 completely fresh.
-        DirtyMap->MarkFresh(FreshDDisk, 0);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
 
         // Start data copy
         ExpectedRange = TBlockRange64::WithLength(0, BlocksPerCopy);
@@ -225,14 +234,16 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             TDDiskDataCopier::EResult::Error,
             complete.GetValue());
 
-        UNIT_ASSERT_VALUES_EQUAL(0, *DirtyMap->GetFreshWatermark(FreshDDisk));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TBlockRange64::WithLength(0, 32768),
+            *DirtyMap->GetFreshRange(FreshDDisk));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,0,256};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,0};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
     }
 
@@ -282,7 +293,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         };
 
         // Mark DDisk#1 completely fresh.
-        DirtyMap->MarkFresh(FreshDDisk, 0);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
 
         // Start data copy
         ExpectedRange = TBlockRange64::WithLength(0, BlocksPerCopy);
@@ -295,13 +306,15 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
 
         // Data copying should not be advanced.
         UNIT_ASSERT_VALUES_EQUAL(false, complete.IsReady());
-        UNIT_ASSERT_VALUES_EQUAL(0, *DirtyMap->GetFreshWatermark(FreshDDisk));
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,0,256};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            TBlockRange64::WithLength(0, 32768),
+            *DirtyMap->GetFreshRange(FreshDDisk));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,0};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
     }
 
@@ -310,7 +323,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         Init();
 
         // Mark DDisk#1 completely fresh.
-        DirtyMap->MarkFresh(FreshDDisk, 0);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
 
         // Start data coping
         ExpectedRange = TBlockRange64::WithLength(0, BlocksPerCopy);
@@ -340,11 +353,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             complete.GetValue());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,256,256};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,256};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
 
         // Start data coping again
@@ -375,11 +388,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             complete.GetValue());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,512,512};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,512};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
     }
 
@@ -388,7 +401,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         Init();
 
         // Mark DDisk#1 partially fresh.
-        DirtyMap->MarkFresh(FreshDDisk, CopyRangeSize);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, CopyRangeSize);
 
         // Start data copy
         ExpectedRange = TBlockRange64::WithLength(256, BlocksPerCopy);
@@ -411,30 +424,40 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             complete.GetValue());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            CopyRangeSize * 2,
-            *DirtyMap->GetFreshWatermark(FreshDDisk));
+            TBlockRange64::MakeClosedInterval(512, 32767),
+            *DirtyMap->GetFreshRange(FreshDDisk));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Fresh,512,512};"   // Watermarks
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Fresh+,512};"   // Watermarks
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
     }
 
     Y_UNIT_TEST_F(ShouldCopyWithWrites, TFixture)
     {
+        const auto overlapped_0 = TBlockRange64::WithLength(
+            10,
+            10);   // overlapped with #0 sync range
+        const auto overlapped_1 = TBlockRange64::WithLength(
+            260,
+            10);   // overlapped with #1 sync range
+        const auto overlapped_01 = TBlockRange64::WithLength(
+            250,
+            10);   // overlapped with #0 + #1 sync range
+
         Init();
         RangeData = GenerateRandomString(CopyRangeSize * 3);
 
         // Mark DDisk#1 completely fresh.
-        DirtyMap->MarkFresh(FreshDDisk, 0);
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
 
         DirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
         DirtyMap->WriteFinished(
             123,
-            TBlockRange64::WithLength(10, 10),   // #0
+            overlapped_0,
             MakePrimariesMask(),
             MakePrimariesMask());
         DirtyMap->RegisterInflightWrite(
@@ -442,7 +465,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             TBlockRange64::WithLength(250, 10));
         DirtyMap->WriteFinished(
             124,
-            TBlockRange64::WithLength(250, 10),   // #0 + #1
+            overlapped_01,
             MakePrimariesMask(),
             MakePrimariesMask());
         DirtyMap->RegisterInflightWrite(
@@ -450,7 +473,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             TBlockRange64::WithLength(260, 10));
         DirtyMap->WriteFinished(
             125,
-            TBlockRange64::WithLength(260, 10),   // #1
+            overlapped_1,
             MakePrimariesMask(),
             MakePrimariesMask());
 
@@ -459,6 +482,9 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         auto complete = Copier->Start();
 
         // Coping range #0 in progress.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H1[0..255]ready;",
+            DirtyMap->DebugPrintInflightSync());
 
         // Flush hints should not contains writes overlapped with copied
         // range #0
@@ -466,6 +492,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         UNIT_ASSERT_VALUES_EQUAL(
             "H0->H0:125[260..269];"
             "H0->H3:125[260..269];"
+            "H1->H1:125[260..269];"
             "H2->H2:125[260..269];",
             flushHints.DebugPrint());
 
@@ -481,7 +508,18 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             TDBGWriteBlocksResponse{.Error = MakeError(S_OK)},
             false);
 
+        // Coping range #1 waiting for flushes completed.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H1[256..511]wait;",
+            DirtyMap->DebugPrintInflightSync());
+
+        // Complete flushes to start coping range #1.
+        FinishFlushes(*DirtyMap, flushHints);
+
         // Coping range #1 in progress.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H1[256..511]ready;",
+            DirtyMap->DebugPrintInflightSync());
 
         // Flush hints should not contains writes overlapped with range #1,
         // but contains #0
@@ -506,6 +544,9 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             false);
 
         //  Coping range #2 in progress.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H1[512..767]ready;",
+            DirtyMap->DebugPrintInflightSync());
 
         // Flush hints should contains writes overlapped with range #1
         flushHints = DirtyMap->MakeFlushHint(1);
@@ -524,6 +565,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         SetWriteResult(
             TDBGWriteBlocksResponse{.Error = MakeError(S_OK)},
             false);
+        UNIT_ASSERT_VALUES_EQUAL("", DirtyMap->DebugPrintInflightSync());
 
         // Data copying should be completed with error.
         UNIT_ASSERT_VALUES_EQUAL(true, complete.IsReady());
@@ -532,8 +574,8 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             complete.GetValue());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            CopyRangeSize * 3,
-            *DirtyMap->GetFreshWatermark(FreshDDisk));
+            TBlockRange64::MakeClosedInterval(768, 32767),
+            *DirtyMap->GetFreshRange(FreshDDisk));
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -1358,12 +1358,12 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             "Enabled{++++++}",
             configAfter);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};"
-            "H5+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};"
+            "H5+{Disabled,0};",
             dirtyMapDDiskAfter);
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -205,15 +205,57 @@ TString TEraseHints::DebugPrint() const
 void TDDiskState::Init(ui64 totalBlockCount, ui64 operationalBlockCount)
 {
     TotalBlockCount = totalBlockCount;
-    SetFlushWatermark(operationalBlockCount);
-    SetReadWatermark(operationalBlockCount);
+    OperationalBlockCount = operationalBlockCount;
+    UpdateState(true);
 }
 
 void TDDiskState::SwitchOffline()
 {
     State = EState::Disabled;
-    FlushableBlockCount = 0;
     OperationalBlockCount = 0;
+}
+
+bool TDDiskState::IsLagging() const
+{
+    return Lagging;
+}
+
+void TDDiskState::StartLagging()
+{
+    Lagging = true;
+}
+
+void TDDiskState::StopLagging()
+{
+    Lagging = false;
+}
+
+bool TDDiskState::IsTrackingEnabled() const
+{
+    return State != EState::Disabled && (Lagging || IsFresh());
+}
+
+void TDDiskState::OnRangeFlushed(TBlockRange64 range)
+{
+    if (!IsTrackingEnabled()) {
+        return;
+    }
+
+    if (Lagging) {
+        BehindField.Add(range);
+    } else {
+        BehindField.Remove(range);
+    }
+
+    if (IsFresh() && !Lagging) {
+        AheadField.Add(range);
+        if (OperationalBlockCount) {
+            AheadField.Remove(
+                TBlockRange64::WithLength(0, OperationalBlockCount));
+        }
+    }
+
+    UpdateState(false);
 }
 
 TDDiskState::EState TDDiskState::GetState() const
@@ -223,47 +265,104 @@ TDDiskState::EState TDDiskState::GetState() const
 
 bool TDDiskState::CanReadFromDDisk(TBlockRange64 range) const
 {
-    return State == EState::Operational || range.End < OperationalBlockCount;
+    if (State == EState::Disabled) {
+        return false;
+    }
+    if (State == EState::Operational) {
+        return true;
+    }
+
+    // if (AheadField.Contains(range))
+    //    return true;
+    if (BehindField.Overlaps(range)) {
+        return false;
+    }
+
+    return range.End < OperationalBlockCount;
 }
 
-bool TDDiskState::NeedFlushToDDisk(TBlockRange64 range) const
+std::optional<TBlockRange64> TDDiskState::GetFreshRange() const
 {
-    return State == EState::Operational || range.Start < FlushableBlockCount;
+    std::optional<TBlockRange64> result;
+
+    if (GetState() == TDDiskState::EState::Operational ||
+        GetState() == TDDiskState::EState::Disabled)
+    {
+        return result;
+    }
+
+    if (!BehindField.Empty()) {
+        BehindField.Enumerate(
+            [&](TBlockRange64 range)
+            {
+                result = range;
+                return TBlockRangeField::EEnumerateContinuation::Stop;
+            });
+        return result;
+    }
+
+    result = TBlockRange64::WithLength(
+        OperationalBlockCount,
+        TotalBlockCount - OperationalBlockCount);
+
+    return result;
 }
 
-void TDDiskState::SetReadWatermark(ui64 blockCount)
+void TDDiskState::RangeSynced(TBlockRange64 range)
 {
+    BehindField.Remove(range);
+    AheadField.Remove(range);
+
+    const ui64 newWatermark = range.End + 1;
+    if (OperationalBlockCount < newWatermark &&
+        !BehindField.Overlaps(TBlockRange64::WithLength(0, newWatermark)))
+    {
+        OperationalBlockCount = newWatermark;
+    }
+    UpdateState(false);
+}
+
+void TDDiskState::UpdateWatermarkDebugOnly(ui64 blockCount)
+{
+    Y_ABORT_UNLESS(blockCount <= TotalBlockCount);
+
     OperationalBlockCount = blockCount;
-    UpdateState();
-}
-
-void TDDiskState::SetFlushWatermark(ui64 blockCount)
-{
-    FlushableBlockCount = blockCount;
-    UpdateState();
-}
-
-ui64 TDDiskState::GetOperationalBlockCount() const
-{
-    return OperationalBlockCount;
+    UpdateState(false);
 }
 
 TString TDDiskState::DebugPrint() const
 {
-    return TStringBuilder()
-           << "{" << ToString(State) << "," << OperationalBlockCount << ","
-           << FlushableBlockCount << "}";
+    TStringBuilder result;
+    result << "{" << ToString(State);
+    if (State == EState::Fresh) {
+        result << (Lagging ? "-" : "+");
+    }
+    result << "," << OperationalBlockCount << "}";
+    return result;
 }
 
-void TDDiskState::UpdateState()
+TString TDDiskState::DebugPrintAhead() const
 {
-    Y_ABORT_UNLESS(OperationalBlockCount <= TotalBlockCount);
-    Y_ABORT_UNLESS(FlushableBlockCount <= TotalBlockCount);
+    return AheadField.Print();
+}
 
-    State = (OperationalBlockCount == TotalBlockCount &&
-             FlushableBlockCount == TotalBlockCount)
-                ? EState::Operational
-                : EState::Fresh;
+TString TDDiskState::DebugPrintBehind() const
+{
+    return BehindField.Print();
+}
+
+bool TDDiskState::IsFresh() const
+{
+    return OperationalBlockCount != TotalBlockCount || !BehindField.Empty();
+}
+
+void TDDiskState::UpdateState(bool force)
+{
+    if (!force && State == EState::Disabled) {
+        return;
+    }
+
+    State = IsFresh() ? EState::Fresh : EState::Operational;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -328,12 +427,16 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
             watermark ? *watermark / BlockSize : BlockCount);
     }
 
-    if (removed.Empty()) {
-        return;
-    }
-
-    for (auto indx: removed) {
-        DDiskStates[indx].SwitchOffline();
+    for (THostIndex h = 0; h < GetHostCount(); ++h) {
+        const bool isDDiskDisabled =
+            DisabledHosts.Get(h) && DesiredDDisks.Get(h);
+        if (removed.Get(h)) {
+            DDiskStates[h].SwitchOffline();
+        } else if (isDDiskDisabled) {
+            DDiskStates[h].StartLagging();
+        } else {
+            DDiskStates[h].StopLagging();
+        }
     }
 
     TVector<ui64> erased;
@@ -341,7 +444,7 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
         [&](TInflightMap::TFindItem& item)
         {
             TInflightInfo& inflightItem = item.Value;
-            inflightItem.RemoveHosts(removed);
+            inflightItem.UpdateHosts(added, removed, DisabledHosts);
             if (inflightItem.GetState() == TInflightInfo::EState::PBufferErased)
             {
                 erased.push_back(item.Key);
@@ -372,7 +475,13 @@ void TBlocksDirtyMap::RestorePBuffer(
         Inflight.AddRange(
             lsn,
             range,
-            TInflightInfo(this, lsn, range.Size() * BlockSize, host));
+            TInflightInfo(
+                this,
+                DesiredDDisks,
+                DisabledHosts,
+                lsn,
+                range.Size() * BlockSize,
+                host));
     }
 }
 
@@ -452,9 +561,11 @@ TFlushHints TBlocksDirtyMap::MakeFlushHint(size_t batchSize)
         return result;
     }
 
-    if (!DesiredDDisks.LogicalAnd(DisabledHosts).Empty()) {
-        // We can't make a flush while DDisk is unavailable. Will wait until it
-        // becomes available or is excluded.
+    if (DesiredDDisks.Exclude(DisabledHosts).Count() <
+        QuorumDirectBlockGroupHostCount)
+    {
+        // We can't make a flush while DDisk quorum is unavailable. Will wait
+        // until it becomes available.
         return result;
     }
 
@@ -472,13 +583,14 @@ TFlushHints TBlocksDirtyMap::MakeFlushHint(size_t batchSize)
             continue;
         }
 
-        for (THostIndex destination: DesiredDDisks) {
-            if (!DDiskStates[destination].NeedFlushToDDisk(item->Range)) {
-                continue;
-            }
+        if (InflightDDiskSyncMap.HasOverlaps(item->Range)) {
+            // Can't flush to DDisk during sync of overlapped range.
+            ReadyToFlush.insert(lsn);
+            continue;
+        }
 
-            const THostIndex source =
-                val.RequestFlush(destination, DisabledHosts);
+        for (THostIndex destination: DesiredDDisks.Exclude(DisabledHosts)) {
+            const THostIndex source = val.RequestFlush(destination);
             if (source != InvalidHostIndex) {
                 result.AddHint(source, destination, item->Key, item->Range);
             }
@@ -546,7 +658,12 @@ void TBlocksDirtyMap::RegisterInflightWrite(ui64 lsn, TBlockRange64 range)
     const bool inserted = Inflight.AddRange(
         lsn,
         range,
-        TInflightInfo(this, lsn, range.Size() * BlockSize));
+        TInflightInfo(
+            this,
+            DesiredDDisks,
+            DisabledHosts,
+            lsn,
+            range.Size() * BlockSize));
     Y_ABORT_UNLESS(inserted);
 }
 
@@ -575,18 +692,15 @@ void TBlocksDirtyMap::WriteFinished(
     }
 
     inflightItem.OnWritten(requested, confirmed);
-
-    if (!DisabledHosts.Empty()) {
-        const auto demotedHosts = DisabledHosts.Exclude(DesiredDDisks);
-        // It could happen that the host was turned off before we received a
-        // successful write response. In this case, remove all references to the
-        // turned-off host.
-        inflightItem.RemoveHosts(demotedHosts);
-        if (inflightItem.GetState() == TInflightInfo::EState::PBufferErased) {
-            const bool removed = Inflight.RemoveRange(lsn);
-            Y_ABORT_UNLESS(removed);
-        }
+    /*
+    const auto demotedHosts = DisabledHosts.Exclude(DesiredDDisks);
+    if (!demotedHosts.Empty()) {
+        inflightItem.UpdateHosts(
+            THostMask::MakeEmpty(),
+            demotedHosts,
+            DisabledHosts);
     }
+            */
 }
 
 void TBlocksDirtyMap::FlushFinished(
@@ -609,6 +723,7 @@ void TBlocksDirtyMap::FlushFinished(
         auto& inflight = item->Value;
 
         inflight.ConfirmFlush(route.DestinationHostIndex);
+        InflightFlushFinished(item->Range);
     }
 
     for (ui64 lsn: flushFailed) {
@@ -620,6 +735,7 @@ void TBlocksDirtyMap::FlushFinished(
         auto& inflight = item->Value;
 
         inflight.FlushFailed(route.DestinationHostIndex);
+        InflightFlushFinished(item->Range);
     }
 }
 
@@ -675,28 +791,81 @@ void TBlocksDirtyMap::UpdateBelatedEraseQueue(
     }
 }
 
-void TBlocksDirtyMap::MarkFresh(THostIndex host, ui64 bytesOffset)
+void TBlocksDirtyMap::UpdateWatermarkDebugOnly(
+    THostIndex host,
+    ui64 bytesOffset)
 {
-    DDiskStates[host].SetReadWatermark(bytesOffset / BlockSize);
-    DDiskStates[host].SetFlushWatermark(bytesOffset / BlockSize);
+    DDiskStates[host].UpdateWatermarkDebugOnly(bytesOffset / BlockSize);
 }
 
-std::optional<ui64> TBlocksDirtyMap::GetFreshWatermark(THostIndex host) const
+std::optional<TBlockRange64> TBlocksDirtyMap::GetFreshRange(
+    THostIndex host) const
 {
-    if (DDiskStates[host].GetState() == TDDiskState::EState::Operational) {
-        return std::nullopt;
+    return DDiskStates[host].GetFreshRange();
+}
+
+NThreading::TFuture<void> TBlocksDirtyMap::GetRangeSyncStartTrigger(
+    THostIndex host,
+    TBlockRange64 range)
+{
+    TInflightDDiskSync sync{
+        .DestinationHost = host,
+        .SyncStartTrigger = NThreading::NewPromise<void>()};
+
+    if (!HasInflightFlush(host, range)) {
+        sync.SyncStartTrigger.SetValue();
     }
-    return DDiskStates[host].GetOperationalBlockCount() * BlockSize;
+
+    auto result = sync.SyncStartTrigger.GetFuture();
+    InflightDDiskSyncMap.AddRange(
+        ++InflightDDiskSyncIdGenerator,
+        range,
+        std::move(sync));
+
+    return result;
 }
 
-void TBlocksDirtyMap::SetReadWatermark(THostIndex host, ui64 bytesOffset)
+void TBlocksDirtyMap::RangeSynced(THostIndex host, TBlockRange64 range)
 {
-    DDiskStates[host].SetReadWatermark(bytesOffset / BlockSize);
+    DDiskStates[host].RangeSynced(range);
+
+    ui64 syncId = 0;
+    InflightDDiskSyncMap.EnumerateOverlapping(
+        range,
+        [&](TInflightDDiskSyncMap::TFindItem& item)
+        {
+            if (item.Value.DestinationHost == host && item.Range == range) {
+                syncId = item.Key;
+                return TInflightDDiskSyncMap::EEnumerateContinuation::Stop;
+            }
+
+            return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
+        });
+    Y_ABORT_UNLESS(syncId != 0);
+    InflightDDiskSyncMap.RemoveRange(syncId);
 }
 
-void TBlocksDirtyMap::SetFlushWatermark(THostIndex host, ui64 bytesOffset)
+void TBlocksDirtyMap::ClearRangeSyncs(THostIndex host)
 {
-    DDiskStates[host].SetFlushWatermark(bytesOffset / BlockSize);
+    TVector<ui64> syncIds;
+    InflightDDiskSyncMap.Enumerate(
+        [&](TInflightDDiskSyncMap::TFindItem& item)
+        {
+            if (item.Value.DestinationHost == host) {
+                item.Value.SyncStartTrigger.TrySetValue();
+                syncIds.push_back(item.Key);
+            }
+
+            return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
+        });
+    for (ui64 syncId: syncIds) {
+        InflightDDiskSyncMap.RemoveRange(syncId);
+    }
+}
+
+size_t TBlocksDirtyMap::GetHostCount() const
+{
+    return DDiskStates.size();
 }
 
 size_t TBlocksDirtyMap::GetInflightCount() const
@@ -786,7 +955,7 @@ ILockableRanges::TLockRangeHandle TBlocksDirtyMap::LockDDiskRange(
 
             if (state == TInflightInfo::EState::PBufferFlushing) {
                 Y_ABORT_UNLESS(
-                    item.Value.GetRequestedFlushes().LogicalAnd(mask).Empty());
+                    item.Value.GetInflightFlushes().LogicalAnd(mask).Empty());
             }
             return TInflightMap::EEnumerateContinuation::Continue;
         });
@@ -819,6 +988,7 @@ void TBlocksDirtyMap::Register(ui64 lsn, EQueueType queueType)
             break;
         }
         case IReadyQueue::EQueueType::Erase: {
+            AddToAheadAndBehind(lsn);
             ReadyToErase.insert(lsn);
 
             ReadyToClone.erase(lsn);
@@ -981,6 +1151,47 @@ TString TBlocksDirtyMap::DebugPrintReadyToErase() const
     return result;
 }
 
+TString TBlocksDirtyMap::DebugPrintAhead() const
+{
+    TStringBuilder result;
+    for (THostIndex h = 0; h < GetHostCount(); ++h) {
+        auto ahead = DDiskStates[h].DebugPrintAhead();
+        if (ahead.empty()) {
+            continue;
+        }
+        result << "  " << PrintHostIndex(h) << ": " << ahead << "\n";
+    }
+    return result;
+}
+
+TString TBlocksDirtyMap::DebugPrintBehind() const
+{
+    TStringBuilder result;
+    for (THostIndex h = 0; h < GetHostCount(); ++h) {
+        auto behind = DDiskStates[h].DebugPrintBehind();
+        if (behind.empty()) {
+            continue;
+        }
+        result << "  " << PrintHostIndex(h) << ": " << behind << "\n";
+    }
+    return result;
+}
+
+TString TBlocksDirtyMap::DebugPrintInflightSync()
+{
+    TStringBuilder result;
+    InflightDDiskSyncMap.Enumerate(
+        [&](TInflightDDiskSyncMap::TFindItem& item)
+        {
+            result << PrintHostIndex(item.Value.DestinationHost) << item.Range
+                   << (item.Value.SyncStartTrigger.IsReady() ? "ready" : "wait")
+                   << ";";
+
+            return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
+        });
+    return result;
+}
+
 void TBlocksDirtyMap::ResizeHosts(size_t newHostCount)
 {
     Y_ABORT_UNLESS(newHostCount <= MaxHostCount);
@@ -1036,6 +1247,65 @@ TReadRangeHint TBlocksDirtyMap::MakeReadRangeHint(
         lsn == 0 ? TRangeLock(weak_from_this(), range, mask)
                  : TRangeLock(weak_from_this(), lsn));
 }
+
+void TBlocksDirtyMap::AddToAheadAndBehind(ui64 lsn)
+{
+    bool needNotify = AnyOf(
+        DDiskStates,
+        [](const TDDiskState& ddisk) { return ddisk.IsTrackingEnabled(); });
+
+    if (!needNotify) {
+        return;
+    }
+
+    auto inflight = Inflight.GetValue(lsn);
+    Y_ABORT_UNLESS(inflight);
+    const auto state = inflight->Value.GetState();
+    Y_ABORT_UNLESS(
+        state == TInflightInfo::EState::PBufferFlushed ||
+        state == TInflightInfo::EState::PBufferErasing);
+
+    for (auto& ddiskState: DDiskStates) {
+        ddiskState.OnRangeFlushed(inflight->Range);
+    }
+}
+
+bool TBlocksDirtyMap::HasInflightFlush(THostIndex host, TBlockRange64 range)
+{
+    bool hasOverlaps = false;
+    Inflight.EnumerateOverlapping(
+        range,
+        [&](TInflightMap::TFindItem& item)
+        {
+            const auto state = item.Value.GetState();
+
+            if (state == TInflightInfo::EState::PBufferFlushing &&
+                item.Value.GetInflightFlushes().Get(host))
+            {
+                hasOverlaps = true;
+                return TInflightMap::EEnumerateContinuation::Stop;
+            }
+            return TInflightMap::EEnumerateContinuation::Continue;
+        });
+    return hasOverlaps;
+}
+
+void TBlocksDirtyMap::InflightFlushFinished(TBlockRange64 range)
+{
+    InflightDDiskSyncMap.EnumerateOverlapping(
+        range,
+        [&](TInflightDDiskSyncMap::TFindItem& item)
+        {
+            auto& sync = item.Value;
+            if (!HasInflightFlush(sync.DestinationHost, item.Range)) {
+                sync.SyncStartTrigger.TrySetValue();
+            }
+
+            return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
+        });
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 bool TBlocksDirtyMap::TInfoEraseBelated::operator<(
     const TInfoEraseBelated& other) const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -3,6 +3,7 @@
 #include "inflight_info.h"
 #include "range_locker.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
@@ -150,9 +151,13 @@ public:
                     // cannot be used.
 
         Operational,   // The DDisk is fully functional and can be read from
-                       // anywhere.
+                       // anywhere. BehindField and AheadField are empty.
+
         Fresh,   // The ddisk is only partially filled, and you can only read
                  // from the blocks below the OperationalBlockCount.
+                 // The AheadField shows which ranges flushed over watermark and
+                 // can be read from. The BehindField shows which ranges
+                 // outdated and can't be read.
     };
 
     // Enables the use of DDisk. If the operational blocks count less then total
@@ -162,30 +167,50 @@ public:
     // Completely disables DDisk usage.
     void SwitchOffline();
 
+    [[nodiscard]] bool IsLagging() const;
+    // DDisk has stopped receiving writes. Now the written ranges are
+    // interpreted as "bad" and added to the BehindField.
+    void StartLagging();
+    // DDisk now receive all writes. The written ranges are interpreted as
+    // "good" and removed from the BehindField.
+    void StopLagging();
+    // Is it necessary to receive information about all written ranges. If true
+    // is returned, it means that all ranged that have been flushed must be
+    // passed to the OnRangeFlushed() method.
+    [[nodiscard]] bool IsTrackingEnabled() const;
+    // Updates the BehindField and the Ahead Field if required.
+    void OnRangeFlushed(TBlockRange64 range);
+
     [[nodiscard]] EState GetState() const;
     [[nodiscard]] bool CanReadFromDDisk(TBlockRange64 range) const;
-    [[nodiscard]] bool NeedFlushToDDisk(TBlockRange64 range) const;
 
-    void SetReadWatermark(ui64 blockCount);
-    void SetFlushWatermark(ui64 blockCount);
-    [[nodiscard]] ui64 GetOperationalBlockCount() const;
+    [[nodiscard]] std::optional<TBlockRange64> GetFreshRange() const;
+    void RangeSynced(TBlockRange64 range);
 
+    void UpdateWatermarkDebugOnly(ui64 blockCount);
     [[nodiscard]] TString DebugPrint() const;
+    [[nodiscard]] TString DebugPrintAhead() const;
+    [[nodiscard]] TString DebugPrintBehind() const;
 
 private:
-    void UpdateState();
+    [[nodiscard]] bool IsFresh() const;
+    void UpdateState(bool force);
 
     EState State = EState::Disabled;
 
     ui64 TotalBlockCount = 0;
 
     // If the block address below OperationalBlockCount, then it can be read
-    // from DDisk.
+    // from DDisk (except BehindField).
     ui64 OperationalBlockCount = 0;
 
-    // If the block address below FlushableBlockCount, then it should be written
-    // (flushed) to DDisk.
-    ui64 FlushableBlockCount = 0;
+    // Lagging means that flush operations are not performed and DDisk has
+    // outdated data in the ranges listed in the BehindField.
+    bool Lagging = false;
+    TBlockRangeField BehindField;
+    // When a user writes to a range above OperationalBlockCount, this range has
+    // up-to-date data and does not require sync.
+    TBlockRangeField AheadField;
 };
 
 struct TPBufferCounters
@@ -263,17 +288,22 @@ public:
 
     void UpdateBelatedEraseQueue(THostMask completedWrites, ui64 lsn);
 
-    // Sets a mark on the ddisk to which offset it contains data and can be read
-    // from it.
-    void MarkFresh(THostIndex host, ui64 bytesOffset);
-    // Returns the offset to which ddisk contains the data. nullopt means that
-    // the disk is completely full of data. And you can read it from anywhere.
-    [[nodiscard]] std::optional<ui64> GetFreshWatermark(THostIndex host) const;
     // Sets the mark up to which the disk can be read.
-    void SetReadWatermark(THostIndex host, ui64 bytesOffset);
-    // Sets the mark to which writes should be flushed to the ddisk.
-    void SetFlushWatermark(THostIndex host, ui64 bytesOffset);
+    void UpdateWatermarkDebugOnly(THostIndex host, ui64 bytesOffset);
+    // Returns the first "fresh" range to be synced with data from another
+    // replicas. Nullopt means that the disk is completely full of data. And you
+    // can read it from anywhere.
+    [[nodiscard]] std::optional<TBlockRange64> GetFreshRange(
+        THostIndex host) const;
+    // Returns TFuture, which will be triggered at the moment when all
+    // overlapping flush operations with this range are completed.
+    NThreading::TFuture<void> GetRangeSyncStartTrigger(
+        THostIndex host,
+        TBlockRange64 range);
+    void RangeSynced(THostIndex host, TBlockRange64 range);
+    void ClearRangeSyncs(THostIndex host);
 
+    [[nodiscard]] size_t GetHostCount() const;
     // Returns the number of in-flight write requests.
     [[nodiscard]] size_t GetInflightCount() const;
     [[nodiscard]] size_t GetFlushPendingCount() const;
@@ -317,6 +347,9 @@ public:
     [[nodiscard]] TString DebugPrintReadyToClone() const;
     [[nodiscard]] TString DebugPrintReadyToFlush() const;
     [[nodiscard]] TString DebugPrintReadyToErase() const;
+    [[nodiscard]] TString DebugPrintAhead() const;
+    [[nodiscard]] TString DebugPrintBehind() const;
+    [[nodiscard]] TString DebugPrintInflightSync();
 
 private:
     using TInflightMap = TBlockRangeMap<ui64, TInflightInfo>;
@@ -331,6 +364,14 @@ private:
         bool operator<(const TInfoEraseBelated& other) const;
     };
 
+    struct TInflightDDiskSync
+    {
+        THostIndex DestinationHost = InvalidHostIndex;
+        NThreading::TPromise<void> SyncStartTrigger;
+    };
+
+    using TInflightDDiskSyncMap = TBlockRangeMap<ui64, TInflightDDiskSync>;
+
     void ResizeHosts(size_t newHostCount);
 
     [[nodiscard]] THostMask FilterLocations(
@@ -343,6 +384,11 @@ private:
         ui64 lsn,
         TBlockRange64 range,
         ui64 offsetBlocks);
+
+    void AddToAheadAndBehind(ui64 lsn);
+
+    [[nodiscard]] bool HasInflightFlush(THostIndex host, TBlockRange64 range);
+    void InflightFlushFinished(TBlockRange64 range);
 
     const ui32 BlockSize;
     const ui64 BlockCount;
@@ -370,6 +416,11 @@ private:
     // In-flight reads and the locks they create.
     ILockableRanges::TLockRangeHandle InflightDDiskReadsGenerator = 0;
     TInflightDDiskReadsMap InflightDDiskReads;
+
+    // DDisk sync operations that are running or waiting for overlapped flushes
+    // to complete in order to start execution.
+    ui64 InflightDDiskSyncIdGenerator = 0;
+    TInflightDDiskSyncMap InflightDDiskSyncMap;
 
     // DDisks freshness state.
     TVector<TDDiskState> DDiskStates;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -65,11 +65,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // We should be able to get read hints (default DesiredDDisks =
@@ -106,12 +106,12 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             0u,
             dirtyMap->GetPBufferCounters(newIdx).CurrentBytesCount);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};"
-            "H5+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};"
+            "H5+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
     }
 
@@ -127,11 +127,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,30,30};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Fresh,40,40};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Fresh+,30};"
+            "H1*{Operational,32768};"
+            "H2*{Fresh+,40};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
     }
 
@@ -148,11 +148,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         vchunkConfig.SetWatermark(3, 40 * DefaultBlockSize);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,40,40};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,40};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
     }
 
@@ -168,141 +168,142 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1-{Disabled,0,0};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1-{Disabled,0};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,0};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Offline H0
         vchunkConfig.EvacuateHost(0);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0-{Disabled,0};"
+            "H1-{Disabled,0};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Can't switch H2 offline
         vchunkConfig.EvacuateHost(2);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3*{Fresh,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0-{Disabled,0};"
+            "H1-{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3*{Fresh+,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Offline H3
         vchunkConfig.EvacuateHost(3);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3-{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0-{Disabled,0};"
+            "H1-{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3-{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Offline H4
         vchunkConfig.EvacuateHost(4);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3-{Disabled,0,0};"
-            "H4-{Disabled,0,0};",
+            "H0-{Disabled,0};"
+            "H1-{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3-{Disabled,0};"
+            "H4-{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Enable H4
         vchunkConfig.EnableHost(4);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3-{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0-{Disabled,0};"
+            "H1-{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3-{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Enable H0
         vchunkConfig.EnableHost(0);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3-{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0*{Fresh+,0};"
+            "H1-{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3-{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Enable H1
         vchunkConfig.EnableHost(1);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,0,0};"
-            "H1+{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3-{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0*{Fresh+,0};"
+            "H1+{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3-{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Enable H2
         vchunkConfig.EnableHost(2);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,0,0};"
-            "H1+{Disabled,0,0};"
-            "H2*{Operational,32768,32768};"
-            "H3-{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0*{Fresh+,0};"
+            "H1+{Disabled,0};"
+            "H2*{Operational,32768};"
+            "H3-{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Enable H3
         vchunkConfig.EnableHost(3);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,0,0};"
-            "H1+{Disabled,0,0};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0*{Fresh+,0};"
+            "H1+{Disabled,0};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Can't switch H2 offline
         vchunkConfig.EvacuateHost(2);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,0,0};"
-            "H1+{Disabled,0,0};"
-            "H2-{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4*{Fresh,0,0};",
+            "H0*{Fresh+,0};"
+            "H1+{Disabled,0};"
+            "H2-{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4*{Fresh+,0};",
             dirtyMap->DebugPrintDDiskState());
     }
 
     Y_UNIT_TEST(ShouldNotReadFromFresh)
     {
         auto vchunkConfig = MakeTestVChunkConfig();
+
+        vchunkConfig.SetWatermark(THostIndex{0}, 30 * DefaultBlockSize);
+        vchunkConfig.SetWatermark(THostIndex{2}, 40 * DefaultBlockSize);
+
         auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->MarkFresh(THostIndex{0}, 30 * DefaultBlockSize);
-        dirtyMap->MarkFresh(THostIndex{2}, 40 * DefaultBlockSize);
-
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Fresh,30,30};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Fresh,40,40};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Fresh+,30};"
+            "H1*{Operational,32768};"
+            "H2*{Fresh+,40};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Read below fresh watermark
@@ -764,11 +765,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
         dirtyMap->UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,1024,1024};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,1024};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Written to 2 primary and 1 hand-off
@@ -841,6 +842,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
             "H1->H1:123[10..19];"
+            "H1->H4:123[10..19];"   // ???
             "H2->H2:123[10..19];"
             "H3->H3:123[10..19];",
             flushHint.DebugPrint());
@@ -882,11 +884,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1-{Disabled,0,0};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,1024,1024};"
-            "H4*{Fresh,1024,1024};",
+            "H0-{Disabled,0};"
+            "H1-{Disabled,0};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,1024};"
+            "H4*{Fresh+,1024};",
             dirtyMap->DebugPrintDDiskState());
 
         // Written to one primary and two hand-off
@@ -939,11 +941,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,1024,1024};"
-            "H4+{Disabled,0,0};",
+            "H0-{Disabled,0};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,1024};"
+            "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
         // Written to all 3 primary PBuffers (hosts 0,1,2). Host 0 is disabled,
@@ -987,88 +989,39 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
     }
 
-    Y_UNIT_TEST(ShouldNotFlushOverWriteWatermark)
+    Y_UNIT_TEST(ShouldFlushOverWriteWatermark)
     {
         auto vchunkConfig = MakeTestVChunkConfig();
-        // Enable 4 DDisks (hosts 0,1,2,3 primary)
+        // Disable DDisks H2
+        // Promote DDisks H3 (hosts 0,1,2,3 primary)
         // Available DDisks is enough for a quorum.
+        vchunkConfig.DisableHost(2);
         vchunkConfig.PromoteHost(3);
-        vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
+        vchunkConfig.SetWatermark(3, 100);
         auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->SetFlushWatermark(THostIndex{2}, 100 * DefaultBlockSize);
-
         const THostMask requested =
-            MakeHostMask(true, true, true, false, false);
+            MakeHostMask(true, true, false, true, false);
         const THostMask confirmed = requested;
 
-        // Range below write watermark. Should be flushed to 4 ddisks.
+        // Range below write watermark. Should be flushed to 3 enabled ddisks.
         dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
             123,
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
-        // Range cross write watermark. Should be flushed to 4 ddisks.
+        // Range cross write watermark. Should be flushed to 3 enabled ddisks.
         dirtyMap->RegisterInflightWrite(124, TBlockRange64::WithLength(95, 10));
         dirtyMap->WriteFinished(
             124,
             TBlockRange64::WithLength(95, 10),
             requested,
             confirmed);
-        // Range over write watermark. Should be flushed to 3 ddisks.
-        dirtyMap->RegisterInflightWrite(
-            125,
-            TBlockRange64::WithLength(100, 10));
-        dirtyMap->WriteFinished(
-            125,
-            TBlockRange64::WithLength(100, 10),
-            requested,
-            confirmed);
-
-        auto flushHint = dirtyMap->MakeFlushHint(3);
-        UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19],124[95..104],125[100..109];"
-            "H0->H3:123[10..19],124[95..104],125[100..109];"
-            "H1->H1:123[10..19],124[95..104],125[100..109];"
-            "H2->H2:123[10..19],124[95..104];",
-            flushHint.DebugPrint());
-    }
-
-    Y_UNIT_TEST(ShouldBlockFlushOverWriteWatermark)
-    {
-        const auto vchunkConfig = MakeTestVChunkConfig();
-        auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
-            vchunkConfig,
-            DefaultBlockSize,
-            DefaultVChunkSize / DefaultBlockSize);
-
-        // Only 3 DDisks available by default. For some requests, ddisk will not
-        // be sufficient for quorum.
-        dirtyMap->SetFlushWatermark(THostIndex{2}, 100 * DefaultBlockSize);
-
-        const THostMask requested =
-            MakeHostMask(true, true, true, false, false);
-        const THostMask confirmed = requested;
-
-        // Range below write watermark. Should be flushed.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
-        dirtyMap->WriteFinished(
-            123,
-            TBlockRange64::WithLength(10, 10),
-            requested,
-            confirmed);
-        // Range cross write watermark. Should be flushed.
-        dirtyMap->RegisterInflightWrite(124, TBlockRange64::WithLength(95, 10));
-        dirtyMap->WriteFinished(
-            124,
-            TBlockRange64::WithLength(95, 10),
-            requested,
-            confirmed);
-        // Range over write watermark. Should be flushed only to healthy DDisks.
+        // Range over write watermark. Should be flushed to 3 enabled ddisks.
         dirtyMap->RegisterInflightWrite(
             125,
             TBlockRange64::WithLength(100, 10));
@@ -1082,7 +1035,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(
             "H0->H0:123[10..19],124[95..104],125[100..109];"
             "H1->H1:123[10..19],124[95..104],125[100..109];"
-            "H2->H2:123[10..19],124[95..104];",
+            "H3->H3:123[10..19],124[95..104],125[100..109];",
             flushHint.DebugPrint());
     }
 
@@ -2013,10 +1966,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         vchunkConfig.EvacuateHost(1);
         dirtyMap->UpdateConfig(vchunkConfig);
 
-        // Host 1 bytes should be released by RemoveHosts.
-        UNIT_ASSERT_VALUES_EQUAL(
-            0,
-            dirtyMap->GetPBufferCounters(THostIndex{1}).CurrentBytesCount);
+        // Flush to promoted host requested.
+        flushHint = dirtyMap->MakeFlushHint(1);
+        UNIT_ASSERT_VALUES_EQUAL("H0->H3:123[10..19];", flushHint.DebugPrint());
+        dirtyMap->FlushFinished(
+            THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 3},
+            {123},
+            {});
 
         // Flush should have completed (FlushDesired became {0,2} which equals
         // FlushConfirmed), erase should now be possible.
@@ -2075,7 +2031,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Inflight item still present — host 1 erase pending.
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap->GetInflightCount());
 
-        // Evacuate host 1 — RemoveHosts completes the erase.
+        // Evacuate host 1
         vchunkConfig.EvacuateHost(1);
         dirtyMap->UpdateConfig(vchunkConfig);
 
@@ -2111,18 +2067,16 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         vchunkConfig.EvacuateHost(2);
         dirtyMap->UpdateConfig(vchunkConfig);
 
-        // Host 2 byte counter should be released.
-        UNIT_ASSERT_VALUES_EQUAL(
-            0,
-            dirtyMap->GetPBufferCounters(THostIndex{2}).CurrentBytesCount);
-
-        // Hosts 0 and 1 should be unchanged.
+        // Hosts counters should be unchanged.
         UNIT_ASSERT_VALUES_EQUAL(
             40960,
             dirtyMap->GetPBufferCounters(THostIndex{0}).CurrentBytesCount);
         UNIT_ASSERT_VALUES_EQUAL(
             40960,
             dirtyMap->GetPBufferCounters(THostIndex{1}).CurrentBytesCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            40960,
+            dirtyMap->GetPBufferCounters(THostIndex{2}).CurrentBytesCount);
 
         // Total bytes should remain as historical record.
         UNIT_ASSERT_VALUES_EQUAL(
@@ -2224,12 +2178,10 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // survives.
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap->GetInflightCount());
 
-        // References to the evacuated host 0 are dropped: its PBuffer byte
-        // counters are released ...
+        // Counters should not be changed
         UNIT_ASSERT_VALUES_EQUAL(
-            0,
+            40960,
             dirtyMap->GetPBufferCounters(THostIndex{0}).CurrentBytesCount);
-        // ... while the remaining hosts keep their data.
         UNIT_ASSERT_VALUES_EQUAL(
             40960,
             dirtyMap->GetPBufferCounters(THostIndex{1}).CurrentBytesCount);
@@ -2303,6 +2255,135 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // No flush is generated while a desired DDisk is still disabled.
         UNIT_ASSERT_EQUAL(true, dirtyMap->MakeFlushHint(1).Empty());
+    }
+
+    Y_UNIT_TEST(ShouldReturnFreshRangeForFreshDDisk)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+
+        // Make H0 partially fresh: only the first 30 blocks are up to date.
+        vchunkConfig.SetWatermark(THostIndex{0}, 30 * DefaultBlockSize);
+
+        auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        const ui64 totalBlocks = DefaultVChunkSize / DefaultBlockSize;
+
+        // A fully operational DDisk has no fresh range to sync.
+        UNIT_ASSERT_EQUAL(std::nullopt, dirtyMap->GetFreshRange(THostIndex{1}));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh+,30};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
+            dirtyMap->DebugPrintDDiskState());
+
+        // The fresh range starts right after the operational block count and
+        // spans up to the end of the vchunk.
+        auto freshRange = dirtyMap->GetFreshRange(THostIndex{0});
+        UNIT_ASSERT(freshRange.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TBlockRange64::MakeClosedInterval(30, totalBlocks - 1),
+            *freshRange);
+
+        // Operational DDisks still have no fresh range.
+        UNIT_ASSERT_EQUAL(std::nullopt, dirtyMap->GetFreshRange(THostIndex{1}));
+        UNIT_ASSERT_EQUAL(std::nullopt, dirtyMap->GetFreshRange(THostIndex{2}));
+    }
+
+    Y_UNIT_TEST(ShouldAdvanceFreshRangeAfterRangeSynced)
+    {
+        const ui64 totalBlocks = DefaultVChunkSize / DefaultBlockSize;
+
+        auto vchunkConfig = MakeTestVChunkConfig();
+
+        // Make H0 completely fresh (nothing synced yet).
+        vchunkConfig.SetWatermark(THostIndex{0}, 0);
+
+        auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TBlockRange64::MakeClosedInterval(0, totalBlocks - 1),
+            *dirtyMap->GetFreshRange(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh+,0};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
+            dirtyMap->DebugPrintDDiskState());
+
+        // Sync the first 256 blocks. The operational block count should advance
+        // to 256 and the fresh range should shrink accordingly.
+        auto freshRange = dirtyMap->GetFreshRange(THostIndex{0});
+        UNIT_ASSERT_VALUES_EQUAL(
+            TBlockRange64::MakeClosedInterval(0, totalBlocks - 1),
+            *freshRange);
+        auto syncRange = TBlockRange64::MakeClosedInterval(0, 255);
+        dirtyMap->GetRangeSyncStartTrigger(THostIndex{0}, syncRange);
+        dirtyMap->RangeSynced(THostIndex{0}, syncRange);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TBlockRange64::MakeClosedInterval(256, totalBlocks - 1),
+            *dirtyMap->GetFreshRange(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh+,256};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
+            dirtyMap->DebugPrintDDiskState());
+
+        // Sync the remaining blocks. The DDisk becomes fully operational and no
+        // longer reports a fresh range.
+        syncRange = TBlockRange64::MakeClosedInterval(256, totalBlocks - 1);
+        dirtyMap->GetRangeSyncStartTrigger(THostIndex{0}, syncRange);
+        dirtyMap->RangeSynced(THostIndex{0}, syncRange);
+
+        UNIT_ASSERT_EQUAL(std::nullopt, dirtyMap->GetFreshRange(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
+            dirtyMap->DebugPrintDDiskState());
+    }
+
+    Y_UNIT_TEST(ShouldTriggerRangeSyncStartWithoutInflightFlush)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+
+        // Make H0 completely fresh.
+        vchunkConfig.SetWatermark(THostIndex{0}, 0);
+
+        auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        const auto range = TBlockRange64::MakeClosedInterval(0, 255);
+
+        // With no overlapping inflight flush, the sync start trigger should be
+        // ready immediately.
+        auto trigger = dirtyMap->GetRangeSyncStartTrigger(THostIndex{0}, range);
+        UNIT_ASSERT_VALUES_EQUAL(true, trigger.HasValue());
+
+        // The sync should be registered as in-flight and ready to run.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0[0..255]ready;",
+            dirtyMap->DebugPrintInflightSync());
+
+        // Completing the sync removes it from the in-flight sync map.
+        dirtyMap->RangeSynced(THostIndex{0}, range);
+        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintInflightSync());
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -13,6 +13,8 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 TInflightInfo::TInflightInfo(
     IReadyQueue* readyQueues,
+    THostMask desiredDDisks,
+    THostMask disabled,
     ui64 lsn,
     size_t byteCount,
     THostIndex host)
@@ -21,6 +23,8 @@ TInflightInfo::TInflightInfo(
     , Lsn(lsn)
     , ByteCount(byteCount)
     , StartAt(TInstant::Now())
+    , DesiredDDisks(desiredDDisks)
+    , Disabled(disabled)
 {
     WriteRequested.Set(host);
     WriteConfirmed.Set(host);
@@ -30,6 +34,8 @@ TInflightInfo::TInflightInfo(
 
 TInflightInfo::TInflightInfo(
     IReadyQueue* readyQueue,
+    THostMask desiredDDisks,
+    THostMask disabled,
     ui64 lsn,
     size_t byteCount)
     : State(EState::PBufferPendingWrite)
@@ -37,6 +43,8 @@ TInflightInfo::TInflightInfo(
     , Lsn(lsn)
     , ByteCount(byteCount)
     , StartAt(TInstant::Now())
+    , DesiredDDisks(desiredDDisks)
+    , Disabled(disabled)
 {
     // Pending: no PBuffer holds the data yet, so nothing is registered in a
     // ready queue and no bytes are accounted. The write is not acknowledged, so
@@ -51,9 +59,10 @@ TInflightInfo::TInflightInfo(TInflightInfo&& other) noexcept
     , StartAt(other.StartAt)
     , PBuffersLockCount(other.PBuffersLockCount)
     , QuorumReadyPromise(std::move(other.QuorumReadyPromise))
+    , DesiredDDisks(other.DesiredDDisks)
+    , Disabled(other.Disabled)
     , WriteRequested(other.WriteRequested)
     , WriteConfirmed(other.WriteConfirmed)
-    , FlushDesired(other.FlushDesired)
     , FlushRequested(other.FlushRequested)
     , FlushConfirmed(other.FlushConfirmed)
     , EraseRequested(other.EraseRequested)
@@ -156,27 +165,30 @@ TReadSource TInflightInfo::ReadMask() const
     }
 }
 
-THostIndex TInflightInfo::RequestFlush(
-    THostIndex destination,
-    THostMask disabledHosts)
+THostIndex TInflightInfo::RequestFlush(THostIndex destination)
 {
     Y_ABORT_UNLESS(
         State == EState::PBufferWritten || State == EState::PBufferFlushing);
 
-    FlushDesired.Set(destination);
+    if (!DesiredDDisks.Exclude(Disabled).Get(destination)) {
+        // Requested flush to absent or disabled host.
+        return InvalidHostIndex;
+    }
 
     if (FlushRequested.Get(destination)) {
+        // Flush to destination already requested.
         return InvalidHostIndex;
     }
 
     if (WriteConfirmed.Get(destination)) {
+        // Flush from PBuffer to DDisk inside same node.
         SetState(EState::PBufferFlushing);
         FlushRequested.Set(destination);
         return destination;
     }
 
-    // Prefer enabled hosts.
-    for (auto source: WriteConfirmed.Exclude(disabledHosts)) {
+    for (auto source: WriteConfirmed.Exclude(Disabled)) {
+        // Cross-node flushing.
         SetState(EState::PBufferFlushing);
         FlushRequested.Set(destination);
         return source;
@@ -199,14 +211,7 @@ void TInflightInfo::ConfirmFlush(THostIndex host)
     Y_ABORT_UNLESS(!FlushConfirmed.Get(host));
 
     FlushConfirmed.Set(host);
-
-    if (FlushDesired == FlushConfirmed) {
-        SetState(EState::PBufferFlushed);
-    }
-
-    if (State == EState::PBufferFlushed && PBuffersLockCount == 0) {
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
-    }
+    MaybeAdvanceToFlushed();
 }
 
 void TInflightInfo::FlushFailed(THostIndex host)
@@ -219,7 +224,7 @@ void TInflightInfo::FlushFailed(THostIndex host)
     ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
 }
 
-THostMask TInflightInfo::GetRequestedFlushes() const
+THostMask TInflightInfo::GetInflightFlushes() const
 {
     return FlushRequested;
 }
@@ -232,10 +237,7 @@ void TInflightInfo::RequestErase(THostIndex host)
     Y_ABORT_UNLESS(WriteRequested.Get(host));
     Y_ABORT_UNLESS(!EraseRequested.Get(host));
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
-
-    // When the DDisk is not fully filled, the flush is made into the filled
-    // area. Thus, the number of completed flushes may be less than the quorum.
-    Y_ABORT_UNLESS(!FlushConfirmed.Empty());
+    Y_ABORT_UNLESS(FlushConfirmed.Count() >= QuorumDirectBlockGroupHostCount);
 
     SetState(EState::PBufferErasing);
     EraseRequested.Set(host);
@@ -248,20 +250,25 @@ bool TInflightInfo::ConfirmErase(THostIndex host)
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
 
     EraseConfirmed.Set(host);
-    if (EraseConfirmed == WriteRequested) {
-        SetState(EState::PBufferErased);
-    }
 
+    MaybeAdvanceToErased();
     return State == EState::PBufferErased;
 }
 
 void TInflightInfo::EraseFailed(THostIndex host)
 {
-    Y_ABORT_UNLESS(State == EState::PBufferErasing);
+    Y_ABORT_UNLESS(
+        State == EState::PBufferErasing || State == EState::PBufferErased);
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
 
+    if (State == EState::PBufferErased) {
+        // Belated error response after config has bee changed.
+        Y_ABORT_UNLESS(Disabled.Get(host));
+        return;
+    }
+
     EraseRequested.Reset(host);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+    MaybeQueryErase();
 }
 
 THostMask TInflightInfo::GetEraseNeeded() const
@@ -269,47 +276,53 @@ THostMask TInflightInfo::GetEraseNeeded() const
     return WriteRequested.Exclude(EraseRequested).Exclude(EraseConfirmed);
 }
 
-void TInflightInfo::RemoveHosts(THostMask removed)
+void TInflightInfo::UpdateHosts(
+    THostMask added,
+    THostMask removed,
+    THostMask disabled)
 {
-    const THostMask removedFromWrite = WriteRequested.LogicalAnd(removed);
-    if (removedFromWrite.Empty()) {
-        return;
-    }
+    // Removed hosts should be disabled to.
+    Y_ABORT_UNLESS(removed.Exclude(disabled).Empty());
 
-    // Release byte counters for removed hosts that had writes.
-    ApplyBytes(removedFromWrite, IReadyQueue::EPBufferCounter::Total, false);
+    switch (State) {
+        case EState::PBufferPendingWrite:
+        case EState::PBufferIncompleteWrite:
+        case EState::PBufferWritten: {
+            // Just update DesiredDDisks and Disabled.
+            DesiredDDisks = DesiredDDisks.Include(added).Exclude(removed);
+            Disabled = disabled;
+            break;
+        }
+        case EState::PBufferFlushing: {
+            // Just update DesiredDDisks and Disabled.
+            DesiredDDisks = DesiredDDisks.Include(added).Exclude(removed);
+            Disabled = disabled;
 
-    if (PBuffersLockCount > 0) {
-        ApplyBytes(
-            WriteConfirmed.LogicalAnd(removed),
-            IReadyQueue::EPBufferCounter::Locked,
-            false);
-    }
-
-    // Remove hosts from all tracking masks.
-    WriteRequested = WriteRequested.Exclude(removed);
-    WriteConfirmed = WriteConfirmed.Exclude(removed);
-    FlushDesired = FlushDesired.Exclude(removed);
-    FlushRequested = FlushRequested.Exclude(removed);
-    FlushConfirmed = FlushConfirmed.Exclude(removed);
-    EraseRequested = EraseRequested.Exclude(removed);
-    EraseConfirmed = EraseConfirmed.Exclude(removed);
-
-    // Check if flush became complete after removing hosts.
-    const bool flushDone =
-        !FlushConfirmed.Empty() && FlushDesired == FlushConfirmed;
-    if (State == EState::PBufferFlushing && flushDone) {
-        SetState(EState::PBufferFlushed);
-    }
-
-    // Register for erase if flush is done and PBuffers are not locked.
-    if (State == EState::PBufferFlushed && PBuffersLockCount == 0) {
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
-    }
-
-    // Check if erase became complete after removing hosts.
-    if (State == EState::PBufferErasing && EraseConfirmed == WriteRequested) {
-        SetState(EState::PBufferErased);
+            auto notRequestsFlushes =
+                DesiredDDisks.Exclude(Disabled).Exclude(FlushRequested);
+            if (!notRequestsFlushes.Empty()) {
+                // New desired added. Will flush to it.
+                ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+            }
+            MaybeAdvanceToFlushed();
+            break;
+        }
+        case EState::PBufferFlushed: {
+            // Already flushed to DDisk quorum, do not reconfigure
+            // DesiredDDisks.
+            Disabled = disabled;
+            break;
+        }
+        case EState::PBufferErasing: {
+            // Already flushed to DDisk quorum, do not reconfigure
+            // DesiredDDisks.
+            Disabled = disabled;
+            MaybeAdvanceToErased();
+            break;
+        }
+        case EState::PBufferErased: {
+            // Nothing to do.
+        } break;
     }
 }
 
@@ -322,6 +335,7 @@ void TInflightInfo::LockPBuffer()
     ++PBuffersLockCount;
 
     if (PBuffersLockCount == 1) {
+        // When lsn locked for reading, we should not erase it. (TODO)
         ReadyQueue->UnRegister(Lsn);
         ApplyBytes(WriteConfirmed, IReadyQueue::EPBufferCounter::Locked, true);
     }
@@ -352,9 +366,9 @@ TString TInflightInfo::DebugPrint(TInstant now) const
     TStringBuilder result;
     result << " " << FormatDuration(now - StartAt) << ", " << ToString(State)
            << ", size:" << ByteCount << ", locks:" << PBuffersLockCount
+           << ", dd:" << DesiredDDisks.Print() << ", d:" << Disabled.Print()
            << ", wr:" << WriteRequested.Print()
            << ", wc:" << WriteConfirmed.Print()
-           << ", fd:" << FlushDesired.Print()
            << ", fr:" << FlushRequested.Print()
            << ", fc:" << FlushConfirmed.Print()
            << ", er:" << EraseRequested.Print()
@@ -420,6 +434,41 @@ void TInflightInfo::SetState(EState newState)
     }
 
     State = newState;
+}
+
+void TInflightInfo::MaybeAdvanceToFlushed()
+{
+    Y_ABORT_UNLESS(State == EState::PBufferFlushing);
+
+    if (DesiredDDisks.Exclude(Disabled) == FlushConfirmed &&
+        FlushConfirmed.Count() >= QuorumDirectBlockGroupHostCount)
+    {
+        SetState(EState::PBufferFlushed);
+    }
+
+    if (State == EState::PBufferFlushed && PBuffersLockCount == 0) {
+        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+    }
+}
+
+void TInflightInfo::MaybeAdvanceToErased()
+{
+    Y_ABORT_UNLESS(
+        State == EState::PBufferFlushed || State == EState::PBufferErasing);
+
+    if (EraseConfirmed.Exclude(Disabled) == WriteRequested.Exclude(Disabled)) {
+        SetState(EState::PBufferErased);
+    }
+}
+
+void TInflightInfo::MaybeQueryErase()
+{
+    Y_ABORT_UNLESS(
+        State == EState::PBufferFlushed || State == EState::PBufferErasing);
+
+    if (!WriteRequested.Exclude(Disabled).Exclude(EraseRequested).Empty()) {
+        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -109,8 +109,11 @@ public:
         PBufferErased,
     };
 
+    // Restored from PBuffer on recovery.
     TInflightInfo(
         IReadyQueue* readyQueues,
+        THostMask desiredDDisks,
+        THostMask disabled,
         ui64 lsn,
         size_t byteCount,
         THostIndex host);
@@ -118,15 +121,21 @@ public:
     // Pending write: lsn is generated but data is not in any PBuffer yet.
     // ReadMask is empty (reads wait on the quorum future) and the write is not
     // flushable. Call OnWritten once a quorum of PBuffers confirms the write.
-    TInflightInfo(IReadyQueue* readyQueue, ui64 lsn, size_t byteCount);
+    TInflightInfo(
+        IReadyQueue* readyQueue,
+        THostMask desiredDDisks,
+        THostMask disabled,
+        ui64 lsn,
+        size_t byteCount);
 
     TInflightInfo(TInflightInfo&& other) noexcept;
 
     ~TInflightInfo();
 
-    // Detach from ReadyQueue.
+    // Detach from ReadyQueue. Called before parent DirtyMap destroyed.
     void Detach();
 
+    // Instance of PBuffer record found on host during recovery.
     void RestorePBuffer(THostIndex host);
 
     // Transitions a pending write (see the byteCount-only constructor) to the
@@ -145,12 +154,10 @@ public:
     // DDisk, specified in the parameter destination. If InvalidHostIndex is
     // returned, it means that the transfer of data to destination has already
     // been requested earlier.
-    [[nodiscard]] THostIndex RequestFlush(
-        THostIndex destination,
-        THostMask disabledHosts);
+    [[nodiscard]] THostIndex RequestFlush(THostIndex destination);
     void ConfirmFlush(THostIndex host);
     void FlushFailed(THostIndex host);
-    [[nodiscard]] THostMask GetRequestedFlushes() const;
+    [[nodiscard]] THostMask GetInflightFlushes() const;
 
     void RequestErase(THostIndex host);
     // Returns true when all erases confirmed.
@@ -160,8 +167,8 @@ public:
     // requested/confirmed.
     [[nodiscard]] THostMask GetEraseNeeded() const;
 
-    // Skip removed hosts flushing and erase. Update state.
-    void RemoveHosts(THostMask removed);
+    // Update state according to the changed configuration.
+    void UpdateHosts(THostMask added, THostMask removed, THostMask disabled);
 
     // Sets a lock that prohibits erasing the PBuffer.
     void LockPBuffer();
@@ -182,6 +189,10 @@ private:
 
     void SetState(EState newState);
 
+    void MaybeAdvanceToFlushed();
+    void MaybeAdvanceToErased();
+    void MaybeQueryErase();
+
     EState State;
 
     IReadyQueue* ReadyQueue = nullptr;
@@ -191,9 +202,10 @@ private:
     size_t PBuffersLockCount = 0;
     NThreading::TPromise<void> QuorumReadyPromise;
 
+    THostMask DesiredDDisks;
+    THostMask Disabled;
     THostMask WriteRequested;
     THostMask WriteConfirmed;
-    THostMask FlushDesired;
     THostMask FlushRequested;
     THostMask FlushConfirmed;
     THostMask EraseRequested;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -76,9 +76,43 @@ struct TTestReadyQueue: public IReadyQueue
     TMap<THostIndex, TMap<EPBufferCounter, size_t>> PBufferCounters;
 };
 
-THostMask MakePrimaryHosts()
+// The default set of DDisk hosts a write is expected to be flushed to. Three
+// hosts satisfy the quorum (QuorumDirectBlockGroupHostCount == 3).
+THostMask MakeDDisks(size_t hostCount = 3)
 {
-    return THostMask::MakeAll(3);
+    return THostMask::MakeAll(hostCount);
+}
+
+THostMask MakePrimaryHosts(size_t hostCount = 3)
+{
+    return THostMask::MakeAll(hostCount);
+}
+
+// Drives an inflight from PBufferWritten through a full flush of all
+// `hostCount` hosts, leaving it in PBufferFlushed.
+void FlushAll(TInflightInfo& inflightInfo)
+{
+    auto ddisks = MakeDDisks();
+    for (THostIndex host: ddisks) {
+        THostIndex result = inflightInfo.RequestFlush(host);
+        UNIT_ASSERT_VALUES_UNEQUAL(InvalidHostIndex, result);
+    }
+    for (THostIndex host: ddisks) {
+        inflightInfo.ConfirmFlush(host);
+    }
+}
+
+// Erases all `hostCount` hosts, moving a flushed inflight to PBufferErased.
+void EraseAll(TInflightInfo& inflightInfo)
+{
+    auto pbuffers = inflightInfo.GetEraseNeeded();
+
+    for (THostIndex host: pbuffers) {
+        inflightInfo.RequestErase(host);
+    }
+    for (THostIndex host: pbuffers) {
+        Y_UNUSED(inflightInfo.ConfirmErase(host));
+    }
 }
 
 }   // namespace
@@ -90,34 +124,57 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldHandleRestore)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096, THostIndex{0});
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096,
+            THostIndex{0});
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferIncompleteWrite,
+            inflightInfo.GetState());
 
+        // Restoring a second PBuffer does not yet reach the quorum (3 hosts).
         inflightInfo.RestorePBuffer(THostIndex{1});
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferIncompleteWrite,
+            inflightInfo.GetState());
 
+        // Third PBuffer reaches the quorum: switches to Written and the lsn
+        // moves from the clone queue to the flush queue.
         inflightInfo.RestorePBuffer(THostIndex{2});
         UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferWritten,
+            inflightInfo.GetState());
     }
 
     Y_UNIT_TEST(ShouldHandleConfirmedWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
 
         // Start flushes
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{0}));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{1},
-            inflightInfo.RequestFlush(THostIndex{1}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{1}));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{2},
-            inflightInfo.RequestFlush(THostIndex{2}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{2}));
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
@@ -147,15 +204,19 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldHandleLock)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
 
         // Start flushes
-        auto l = inflightInfo.RequestFlush(THostIndex{0}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{1}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{2}, THostMask());
-        Y_UNUSED(l);
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{1}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{2}));
 
         // Confirm two flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
@@ -192,29 +253,39 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldPutToReadyQueueOnFail)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Flush started
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{0}));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{1},
-            inflightInfo.RequestFlush(THostIndex{1}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{1}));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{2},
-            inflightInfo.RequestFlush(THostIndex{2}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{2}));
 
         // When a flush fails, the lsn must be queued for a flush again.
         readyQueue.ReadyToFlush.clear();
         inflightInfo.FlushFailed(THostIndex{0});
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
 
+        // The failed host is no longer inflight.
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            inflightInfo.GetInflightFlushes().Get(THostIndex{0}));
+
         // Restart flush to host 0
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
+            inflightInfo.RequestFlush(THostIndex{0}));
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
@@ -233,13 +304,56 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         readyQueue.ReadyToErase.clear();
         inflightInfo.EraseFailed(THostIndex{0});
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+
+        // Redo the failed erase so the destructor invariants hold.
+        inflightInfo.RequestErase(THostIndex{0});
+        Y_UNUSED(inflightInfo.ConfirmErase(THostIndex{0}));
+    }
+
+    Y_UNIT_TEST(ShouldNotRequestFlushToDisabledOrAbsentHost)
+    {
+        TTestReadyQueue readyQueue;
+        // DesiredDDisks = {0, 1, 2}, host 2 disabled.
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeMask({THostIndex{2}}),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        // Flush to a disabled host is refused.
+        UNIT_ASSERT_VALUES_EQUAL(
+            InvalidHostIndex,
+            inflightInfo.RequestFlush(THostIndex{2}));
+
+        // Flush to a host outside DesiredDDisks is refused.
+        UNIT_ASSERT_VALUES_EQUAL(
+            InvalidHostIndex,
+            inflightInfo.RequestFlush(THostIndex{5}));
+
+        // Flush to an enabled desired host succeeds.
+        UNIT_ASSERT_VALUES_EQUAL(
+            THostIndex{0},
+            inflightInfo.RequestFlush(THostIndex{0}));
+
+        // A second flush request to the same host is refused.
+        UNIT_ASSERT_VALUES_EQUAL(
+            InvalidHostIndex,
+            inflightInfo.RequestFlush(THostIndex{0}));
     }
 
     Y_UNIT_TEST(ShouldCountTotalBytesForRestore)
     {
         TTestReadyQueue readyQueue;
         {
-            TInflightInfo inflightInfo(&readyQueue, 123, 4096, THostIndex{0});
+            TInflightInfo inflightInfo(
+                &readyQueue,
+                MakeDDisks(),
+                THostMask::MakeEmpty(),
+                123,
+                4096,
+                THostIndex{0});
 
             inflightInfo.RestorePBuffer(THostIndex{1});
             inflightInfo.RestorePBuffer(THostIndex{2});
@@ -263,7 +377,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     {
         TTestReadyQueue readyQueue;
         {
-            TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+            TInflightInfo inflightInfo(
+                &readyQueue,
+                MakeDDisks(),
+                THostMask::MakeEmpty(),
+                123,
+                4096);
             inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
             UNIT_ASSERT_VALUES_EQUAL(
@@ -284,39 +403,26 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldTrackGetEraseNeeded)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Start and confirm flushes to all 3 hosts.
-        UNIT_ASSERT_VALUES_EQUAL(
-            0,
-            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            inflightInfo.RequestFlush(THostIndex{1}, THostMask()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            2,
-            inflightInfo.RequestFlush(THostIndex{2}, THostMask()));
-
-        inflightInfo.ConfirmFlush(THostIndex{0});
-        inflightInfo.ConfirmFlush(THostIndex{1});
-        inflightInfo.ConfirmFlush(THostIndex{2});
+        FlushAll(inflightInfo);
 
         // Before any erase, all written hosts need erasing.
         auto eraseNeeded = inflightInfo.GetEraseNeeded();
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{1}));
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{2}));
-        UNIT_ASSERT_VALUES_EQUAL(3, eraseNeeded.Count());
+        UNIT_ASSERT_VALUES_EQUAL("[H0,H1,H2]", eraseNeeded.Print());
 
         // After requesting erase for host 0, it should no longer be in
         // GetEraseNeeded (it's now in EraseRequested).
         inflightInfo.RequestErase(THostIndex{0});
         eraseNeeded = inflightInfo.GetEraseNeeded();
-        UNIT_ASSERT_VALUES_EQUAL(false, eraseNeeded.Get(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{1}));
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{2}));
-        UNIT_ASSERT_VALUES_EQUAL(2, eraseNeeded.Count());
+        UNIT_ASSERT_VALUES_EQUAL("[H1,H2]", eraseNeeded.Print());
 
         // After confirming erase for host 0, it's in EraseConfirmed and still
         // excluded from GetEraseNeeded.
@@ -324,10 +430,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             false,
             inflightInfo.ConfirmErase(THostIndex{0}));
         eraseNeeded = inflightInfo.GetEraseNeeded();
-        UNIT_ASSERT_VALUES_EQUAL(false, eraseNeeded.Get(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{1}));
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{2}));
-        UNIT_ASSERT_VALUES_EQUAL(2, eraseNeeded.Count());
+        UNIT_ASSERT_VALUES_EQUAL("[H1,H2]", eraseNeeded.Print());
 
         // After requesting and confirming all remaining hosts, nothing is left.
         inflightInfo.RequestErase(THostIndex{1});
@@ -339,48 +442,46 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             true,
             inflightInfo.ConfirmErase(THostIndex{2}));
         eraseNeeded = inflightInfo.GetEraseNeeded();
-        UNIT_ASSERT_VALUES_EQUAL(0, eraseNeeded.Count());
+        UNIT_ASSERT_VALUES_EQUAL("[]", eraseNeeded.Print());
     }
 
     Y_UNIT_TEST(ShouldReturnEraseNeededAfterEraseFailed)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
-        // Flush all hosts.
-        UNIT_ASSERT_VALUES_EQUAL(
-            0,
-            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            inflightInfo.RequestFlush(THostIndex{1}, THostMask()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            2,
-            inflightInfo.RequestFlush(THostIndex{2}, THostMask()));
-
-        inflightInfo.ConfirmFlush(THostIndex{0});
-        inflightInfo.ConfirmFlush(THostIndex{1});
-        inflightInfo.ConfirmFlush(THostIndex{2});
+        FlushAll(inflightInfo);
 
         // Request erase for host 0 and then fail it.
         inflightInfo.RequestErase(THostIndex{0});
         auto eraseNeeded = inflightInfo.GetEraseNeeded();
-        UNIT_ASSERT_VALUES_EQUAL(2, eraseNeeded.Count());
-        UNIT_ASSERT_VALUES_EQUAL(false, eraseNeeded.Get(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL("[H1,H2]", eraseNeeded.Print());
 
         // EraseFailed resets EraseRequested for host 0, so GetEraseNeeded
         // should include it again.
         inflightInfo.EraseFailed(THostIndex{0});
         eraseNeeded = inflightInfo.GetEraseNeeded();
-        UNIT_ASSERT_VALUES_EQUAL(3, eraseNeeded.Count());
-        UNIT_ASSERT_VALUES_EQUAL(true, eraseNeeded.Get(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL("[H0,H1,H2]", eraseNeeded.Print());
+
+        // Complete the erase so the destructor invariants hold.
+        EraseAll(inflightInfo);
     }
 
     Y_UNIT_TEST(ShouldReturnDDiskReadMaskForPendingWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
 
         // In PBufferPendingWrite state, ReadMask should return DDisk with all
         // hosts enabled (Lsn=0 means DDisk read).
@@ -404,27 +505,94 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(123, readSource.Lsn);
     }
 
+    Y_UNIT_TEST(ShouldReturnEmptyReadMaskForIncompleteWrite)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096,
+            THostIndex{0});
+
+        // Incomplete write is invisible to reads until the quorum is reached.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferIncompleteWrite,
+            inflightInfo.GetState());
+
+        auto readSource = inflightInfo.ReadMask();
+        UNIT_ASSERT_VALUES_EQUAL(true, readSource.Empty());
+        UNIT_ASSERT_VALUES_EQUAL(true, readSource.OnlyDDisk());
+
+        // Once the quorum is restored, reads go to the confirmed PBuffers.
+        inflightInfo.RestorePBuffer(THostIndex{1});
+        inflightInfo.RestorePBuffer(THostIndex{2});
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferWritten,
+            inflightInfo.GetState());
+
+        readSource = inflightInfo.ReadMask();
+        UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
+        UNIT_ASSERT_VALUES_EQUAL(false, readSource.OnlyDDisk());
+        UNIT_ASSERT_VALUES_EQUAL(123, readSource.Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldReadFromDDiskAfterFlushed)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        FlushAll(inflightInfo);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+
+        // Once flushed the data is read from DDisk (Lsn=0).
+        auto readSource = inflightInfo.ReadMask();
+        UNIT_ASSERT_VALUES_EQUAL(true, readSource.OnlyDDisk());
+        UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
+
+        // Drain erases so the destructor invariants hold.
+        EraseAll(inflightInfo);
+    }
+
     Y_UNIT_TEST(ShouldQuorumReadyFutureForPendingWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
 
         auto future = inflightInfo.GetQuorumReadyFuture();
         UNIT_ASSERT_VALUES_EQUAL(false, future.IsReady());
 
-        // OnWritten should not trigger the quorum future (it's for
-        // PBufferIncompleteWrite path).
+        // OnWritten transitions to Written directly and does not go through the
+        // quorum-ready promise (that path is only for PBufferIncompleteWrite).
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-
-        // The future should still not be ready because it's only triggered
-        // by RestorePBuffer reaching quorum.
         UNIT_ASSERT_VALUES_EQUAL(false, future.IsReady());
     }
 
     Y_UNIT_TEST(ShouldQuorumReadyFutureForIncompleteWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096, THostIndex{0});
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096,
+            THostIndex{0});
 
         auto future = inflightInfo.GetQuorumReadyFuture();
         UNIT_ASSERT_VALUES_EQUAL(false, future.IsReady());
@@ -441,7 +609,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     {
         TTestReadyQueue readyQueue;
         {
-            TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+            TInflightInfo inflightInfo(
+                &readyQueue,
+                MakeDDisks(),
+                THostMask::MakeEmpty(),
+                123,
+                4096);
 
             // Pending write should not account any bytes.
             UNIT_ASSERT_VALUES_EQUAL(
@@ -472,136 +645,21 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
     }
 
-    Y_UNIT_TEST(ShouldRemoveHostsNoOpWhenNoOverlap)
+    Y_UNIT_TEST(ShouldTrackLockedBytes)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
-        // Hosts 3 and 4 were never written to — RemoveHosts should be a no-op.
-        THostMask removed;
-        removed.Set(THostIndex{3});
-        removed.Set(THostIndex{4});
-        inflightInfo.RemoveHosts(removed);
-
-        // State stays PBufferWritten; bytes unchanged.
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferWritten,
-            inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{1}));
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{2}));
-    }
-
-    Y_UNIT_TEST(ShouldRemoveHostsReleaseBytesInWrittenState)
-    {
-        TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
-        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-
-        // All 3 hosts have 4096 bytes in Total.
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{1}));
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{2}));
-
-        // Remove host 2.
-        THostMask removed;
-        removed.Set(THostIndex{2});
-        inflightInfo.RemoveHosts(removed);
-
-        // State stays PBufferWritten; host 2 bytes released.
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferWritten,
-            inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{1}));
-        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
-    }
-
-    Y_UNIT_TEST(ShouldRemoveHostsCompleteFlush)
-    {
-        TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
-        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-
-        // Request flush for all 3 hosts.
-        auto l = inflightInfo.RequestFlush(THostIndex{0}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{1}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{2}, THostMask());
-        Y_UNUSED(l);
-
-        // Confirm flush for hosts 0 and 1 only.
-        inflightInfo.ConfirmFlush(THostIndex{0});
-        inflightInfo.ConfirmFlush(THostIndex{1});
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferFlushing,
-            inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
-
-        // Remove host 2 — flush should now be complete.
-        THostMask removed;
-        removed.Set(THostIndex{2});
-        inflightInfo.RemoveHosts(removed);
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferFlushed,
-            inflightInfo.GetState());
-        // Erase should be registered.
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
-        // Host 2 bytes released.
-        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
-    }
-
-    Y_UNIT_TEST(ShouldRemoveHostsCompleteErase)
-    {
-        TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
-        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-
-        // Flush all hosts.
-        auto l = inflightInfo.RequestFlush(THostIndex{0}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{1}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{2}, THostMask());
-        Y_UNUSED(l);
-        inflightInfo.ConfirmFlush(THostIndex{0});
-        inflightInfo.ConfirmFlush(THostIndex{1});
-        inflightInfo.ConfirmFlush(THostIndex{2});
-
-        // Start erasing hosts 0 and 1, confirm both.
-        inflightInfo.RequestErase(THostIndex{0});
-        inflightInfo.RequestErase(THostIndex{1});
-        inflightInfo.RequestErase(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(
-            false,
-            inflightInfo.ConfirmErase(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(
-            false,
-            inflightInfo.ConfirmErase(THostIndex{1}));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferErasing,
-            inflightInfo.GetState());
-
-        // Remove host 2 — erase should now be complete.
-        THostMask removed;
-        removed.Set(THostIndex{2});
-        inflightInfo.RemoveHosts(removed);
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferErased,
-            inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
-    }
-
-    Y_UNIT_TEST(ShouldRemoveHostsReleaseLockBytesWhenLocked)
-    {
-        TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
-        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-
-        // Lock PBuffer — this should track locked bytes.
+        // Locking accounts locked bytes on all confirmed hosts and unregisters
+        // the lsn from the flush queue.
         inflightInfo.LockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToFlush.contains(123));
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
             readyQueue.GetLockedBytes(THostIndex{0}));
@@ -612,92 +670,205 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             4096,
             readyQueue.GetLockedBytes(THostIndex{2}));
 
-        // Remove host 2 while locked.
-        THostMask removed;
-        removed.Set(THostIndex{2});
-        inflightInfo.RemoveHosts(removed);
-
-        // Both Total and Locked bytes for host 2 should be released.
-        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
-        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{2}));
-
-        // Hosts 0 and 1 should be unaffected.
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{0}));
+        // Nested lock does not double-count.
+        inflightInfo.LockPBuffer();
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
             readyQueue.GetLockedBytes(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{1}));
+
+        // First unlock keeps the lock (count still > 0).
+        inflightInfo.UnlockPBuffer();
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
-            readyQueue.GetLockedBytes(THostIndex{1}));
+            readyQueue.GetLockedBytes(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToFlush.contains(123));
 
-        // Unlock so destructor doesn't assert.
+        // Final unlock releases the locked bytes and re-registers the flush.
         inflightInfo.UnlockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{1}));
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{2}));
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
     }
 
-    Y_UNIT_TEST(ShouldRemoveHostsNotRegisterEraseWhenLocked)
+    Y_UNIT_TEST(ShouldRegisterEraseAfterUnlockInFlushedState)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
-        // Request and confirm flush for hosts 0 and 1.
-        auto l = inflightInfo.RequestFlush(THostIndex{0}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{1}, THostMask());
-        l = inflightInfo.RequestFlush(THostIndex{2}, THostMask());
-        Y_UNUSED(l);
-        inflightInfo.ConfirmFlush(THostIndex{0});
-        inflightInfo.ConfirmFlush(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferFlushing,
-            inflightInfo.GetState());
-
-        // Lock PBuffer before completing flush.
+        // Lock before flushing completes.
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{1}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{2}));
         inflightInfo.LockPBuffer();
 
-        // Remove host 2 — flush completes, but erase should NOT register
-        // because PBuffer is locked.
-        THostMask removed;
-        removed.Set(THostIndex{2});
-        inflightInfo.RemoveHosts(removed);
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
 
+        // Flush completed but erase must not be registered while locked.
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
         UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
 
-        // After unlock, erase should be registered.
+        // Unlocking in the flushed state registers the erase.
         inflightInfo.UnlockPBuffer();
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+
+        EraseAll(inflightInfo);
     }
 
-    Y_UNIT_TEST(ShouldRemoveHostsNotCompleteFlushWithEmptyConfirmed)
+    // UpdateHosts requires every removed host to also be disabled
+    // (removed is a subset of disabled). Removing an already-disabled host must
+    // not touch the byte counters and, for a written inflight, must not change
+    // the state.
+    Y_UNIT_TEST(ShouldUpdateHostsRemoveDisabledInWrittenState)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
-        // Request flush for host 0 only; do NOT confirm it.
-        // FlushDesired = {0}, FlushConfirmed = {}.
+        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{2}));
+
+        // Remove host 2. It must also be reported as disabled.
+        auto removed = THostMask::MakeMask({THostIndex{2}});
+        auto disabled = THostMask::MakeMask({THostIndex{2}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), removed, disabled);
+
+        // State stays PBufferWritten; per-host byte accounting is unchanged.
         UNIT_ASSERT_VALUES_EQUAL(
-            THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            TInflightInfo::EState::PBufferFlushing,
+            TInflightInfo::EState::PBufferWritten,
             inflightInfo.GetState());
+        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{1}));
+        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{2}));
+    }
 
-        // Remove host 0 — this empties FlushDesired while FlushConfirmed is
-        // still empty. The flush must NOT be considered complete.
-        THostMask removed;
-        removed.Set(THostIndex{0});
-        inflightInfo.RemoveHosts(removed);
+    // In the flushing state, disabling the not-yet-confirmed host drops it from
+    // the effective DDisk set. The remaining confirmed hosts already form a
+    // quorum, so the flush completes and the erase gets registered.
+    Y_UNIT_TEST(ShouldUpdateHostsCompleteFlushWhenDisablingPendingHost)
+    {
+        TTestReadyQueue readyQueue;
+        // 4 desired DDisks so that after disabling one, 3 remain (== quorum).
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(4),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
 
-        // State must stay PBufferFlushing and erase must NOT be registered.
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{1}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{2}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{3}));
+
+        // Confirm a quorum (hosts 0, 1, 2) but not host 3.
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushing,
             inflightInfo.GetState());
         UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+
+        // Disable + remove host 3. Now DesiredDDisks\Disabled == FlushConfirmed
+        // and the quorum holds, so the flush completes.
+        auto mask = THostMask::MakeMask({THostIndex{3}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), mask, mask);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+
+        // Erase all still-written hosts (host 3 excluded via Disabled).
+        inflightInfo.RequestErase(THostIndex{0});
+        inflightInfo.RequestErase(THostIndex{1});
+        inflightInfo.RequestErase(THostIndex{2});
+        Y_UNUSED(inflightInfo.ConfirmErase(THostIndex{0}));
+        Y_UNUSED(inflightInfo.ConfirmErase(THostIndex{1}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            inflightInfo.ConfirmErase(THostIndex{2}));
+    }
+
+    // In the erasing state, disabling the last non-erased host lets the erase
+    // complete because EraseConfirmed\Disabled == WriteRequested\Disabled.
+    Y_UNIT_TEST(ShouldUpdateHostsCompleteEraseWhenDisablingPendingHost)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        FlushAll(inflightInfo);
+
+        // Erase and confirm hosts 0 and 1 only.
+        inflightInfo.RequestErase(THostIndex{0});
+        inflightInfo.RequestErase(THostIndex{1});
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            inflightInfo.ConfirmErase(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            inflightInfo.ConfirmErase(THostIndex{1}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferErasing,
+            inflightInfo.GetState());
+
+        // Disable + remove host 2. Erase completes.
+        auto mask = THostMask::MakeMask({THostIndex{2}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), mask, mask);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferErased,
+            inflightInfo.GetState());
+    }
+
+    // Adding a new desired DDisk while flushing must re-register the lsn for
+    // flushing so the new host gets its copy.
+    Y_UNIT_TEST(ShouldUpdateHostsRegisterFlushWhenAddingDesired)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{1}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{2}));
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
+
+        // Flushed to the quorum, erase registered.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+
+        EraseAll(inflightInfo);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.cpp
@@ -45,6 +45,16 @@ THostMask THostMask::MakeFromRoute(const THostRoute& route)
     return result;
 }
 
+// static
+THostMask THostMask::MakeMask(std::initializer_list<THostIndex> hosts)
+{
+    THostMask mask;
+    for (auto host: hosts) {
+        mask.Set(host);
+    }
+    return mask;
+}
+
 void THostMask::Set(THostIndex host)
 {
     Y_ABORT_UNLESS(host < MaxHostCount);
@@ -55,6 +65,16 @@ void THostMask::Reset(THostIndex host)
 {
     Y_ABORT_UNLESS(host < MaxHostCount);
     Bits &= ~(ui32(1) << host);
+}
+
+void THostMask::Update(THostIndex host, bool value)
+{
+    Y_ABORT_UNLESS(host < MaxHostCount);
+    if (value) {
+        Set(host);
+    } else {
+        Reset(host);
+    }
 }
 
 bool THostMask::Get(THostIndex host) const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h
@@ -35,9 +35,11 @@ public:
     static THostMask MakeOne(THostIndex host);
     static THostMask MakeAll(size_t hostCount);
     static THostMask MakeFromRoute(const THostRoute& route);
+    static THostMask MakeMask(std::initializer_list<THostIndex> hosts);
 
     void Set(THostIndex host);
     void Reset(THostIndex host);
+    void Update(THostIndex host, bool value);
     [[nodiscard]] bool Get(THostIndex host) const;
 
     [[nodiscard]] bool Empty() const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask_ut.cpp
@@ -30,6 +30,36 @@ Y_UNIT_TEST_SUITE(THostMaskTest)
         UNIT_ASSERT_VALUES_EQUAL(2u, mask.Count());
     }
 
+    Y_UNIT_TEST(ShouldUpdate)
+    {
+        THostMask mask;
+
+        // Update with true sets the bit.
+        mask.Update(2, true);
+        UNIT_ASSERT(mask.Get(2));
+        UNIT_ASSERT_VALUES_EQUAL(1u, mask.Count());
+
+        // Update with true again is idempotent.
+        mask.Update(2, true);
+        UNIT_ASSERT(mask.Get(2));
+        UNIT_ASSERT_VALUES_EQUAL(1u, mask.Count());
+
+        // Update with false resets the bit.
+        mask.Update(2, false);
+        UNIT_ASSERT(!mask.Get(2));
+        UNIT_ASSERT(mask.Empty());
+
+        // Update with false on an already unset bit is a no-op.
+        mask.Update(5, false);
+        UNIT_ASSERT(!mask.Get(5));
+        UNIT_ASSERT(mask.Empty());
+
+        // Update the highest valid host index.
+        mask.Update(31, true);
+        UNIT_ASSERT(mask.Get(31));
+        UNIT_ASSERT_VALUES_EQUAL(1u, mask.Count());
+    }
+
     Y_UNIT_TEST(ShouldMakeAll)
     {
         UNIT_ASSERT(THostMask::MakeAll(0).Empty());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
@@ -193,6 +193,27 @@ void TVChunkConfig::PromoteHost(THostIndex hostIndex)
     }
 }
 
+TString TVChunkConfig::PromoteHostIfNeeded()
+{
+    TStringBuilder result;
+    auto enabledDDisks = GetEnabledDDisks();
+    if (enabledDDisks.Count() >= QuorumDirectBlockGroupHostCount) {
+        result << "Enabled DDisks already enough " << DebugPrint();
+        return result;
+    }
+    const THostIndex hostToPromote =
+        GetPrimaryCandidate(DDiskHosts, EnabledHosts);
+    if (hostToPromote == InvalidHostIndex) {
+        result << "Can't find primary candidate " << DebugPrint();
+        return result;
+    }
+
+    result << "Promote " << PrintHostIndex(hostToPromote) << " "
+           << DebugPrint();
+    PromoteHost(hostToPromote);
+    return result;
+}
+
 EHostRole TVChunkConfig::GetPBufferRole(THostIndex hostIndex) const
 {
     return PBufferHosts.GetRole(hostIndex);
@@ -246,6 +267,11 @@ THostMask TVChunkConfig::GetDDisks() const
         EHostRole::Primary);
 }
 
+THostMask TVChunkConfig::GetEnabledDDisks() const
+{
+    return Filter(DDiskHosts, EnabledHosts, EHostRole::Primary);
+}
+
 THostMask TVChunkConfig::GetFullDDisks() const
 {
     THostMask result;
@@ -259,7 +285,7 @@ THostMask TVChunkConfig::GetFullDDisks() const
 
 THostMask TVChunkConfig::GetDisabledHosts() const
 {
-    return EnabledHosts.LogicalNot();
+    return EnabledHosts.LogicalNot().LogicalAnd(THostMask::MakeAll(HostCount));
 }
 
 THostMask TVChunkConfig::GetHealthyDDisks() const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
@@ -48,6 +48,7 @@ public:
     TString DemoteHost(THostIndex hostIndex);
     // Adds ddisk to the host.
     void PromoteHost(THostIndex hostIndex);
+    TString PromoteHostIfNeeded();
 
     [[nodiscard]] EHostRole GetPBufferRole(THostIndex hostIndex) const;
     [[nodiscard]] EHostRole GetDDiskRole(THostIndex hostIndex) const;
@@ -64,6 +65,8 @@ public:
 
     // Get a list of all DDisks (enabled and disabled).
     [[nodiscard]] THostMask GetDDisks() const;
+    // Get a list of all enabled DDisks.
+    [[nodiscard]] THostMask GetEnabledDDisks() const;
     // Get a list of all DDisks with full data (enabled or not).
     [[nodiscard]] THostMask GetFullDDisks() const;
     // Get a list of all healthy DDisks (enabled and full filed).

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config_ut.cpp
@@ -119,6 +119,67 @@ Y_UNIT_TEST_SUITE(TVChunkConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(0, *cfg.GetWatermark(newIdx));
         UNIT_ASSERT(cfg.GetDDisks().Get(newIdx));
     }
+
+    Y_UNIT_TEST(ShouldReturnEnabledDDisks)
+    {
+        auto cfg = TVChunkConfig::MakeDefault(0, 5, 3);
+        // Primary DDisks are hosts 0, 1, 2 and all hosts are enabled.
+        UNIT_ASSERT_VALUES_EQUAL("[H0,H1,H2]", cfg.GetEnabledDDisks().Print());
+        UNIT_ASSERT_VALUES_EQUAL("[H0,H1,H2]", cfg.GetDDisks().Print());
+
+        // Disabling a primary DDisk host removes it from the enabled set but
+        // keeps it in the full DDisk set.
+        cfg.DisableHost(0);
+        UNIT_ASSERT_VALUES_EQUAL("[H1,H2]", cfg.GetEnabledDDisks().Print());
+        UNIT_ASSERT_VALUES_EQUAL("[H0,H1,H2]", cfg.GetDDisks().Print());
+
+        // Disabling a non-DDisk host does not change the enabled DDisk set.
+        cfg.DisableHost(4);
+        UNIT_ASSERT_VALUES_EQUAL("[H1,H2]", cfg.GetEnabledDDisks().Print());
+    }
+
+    Y_UNIT_TEST(ShouldNotPromoteWhenEnabledDDisksEnough)
+    {
+        auto cfg = TVChunkConfig::MakeDefault(0, 5, 3);
+        // Enabled DDisks == quorum (3), nothing to promote.
+        UNIT_ASSERT_VALUES_EQUAL(3u, cfg.GetEnabledDDisks().Count());
+
+        const auto before = cfg.GetDDisks();
+        const TString result = cfg.PromoteHostIfNeeded();
+
+        UNIT_ASSERT_STRING_CONTAINS(result, "Enabled DDisks already enough");
+        UNIT_ASSERT_VALUES_EQUAL(before.Print(), cfg.GetDDisks().Print());
+    }
+
+    Y_UNIT_TEST(ShouldPromoteWhenEnabledDDisksBelowQuorum)
+    {
+        auto cfg = TVChunkConfig::MakeDefault(0, 5, 3);
+        // Disable one primary DDisk host so only 2 enabled DDisks remain.
+        cfg.DisableHost(0);
+        UNIT_ASSERT_VALUES_EQUAL(2u, cfg.GetEnabledDDisks().Count());
+
+        const TString result = cfg.PromoteHostIfNeeded();
+
+        // Host 3 (first enabled non-DDisk host) is promoted to Primary.
+        UNIT_ASSERT_STRING_CONTAINS(result, "Promote");
+        UNIT_ASSERT(cfg.GetDDiskRole(3) == EHostRole::Primary);
+        UNIT_ASSERT(cfg.GetEnabledDDisks().Get(3));
+        UNIT_ASSERT_VALUES_EQUAL(3u, cfg.GetEnabledDDisks().Count());
+    }
+
+    Y_UNIT_TEST(ShouldNotPromoteWhenNoCandidate)
+    {
+        // All hosts are primary DDisks; there is no candidate to promote.
+        auto cfg = TVChunkConfig::MakeDefault(0, 3, 3);
+        cfg.DisableHost(0);
+        UNIT_ASSERT_VALUES_EQUAL(2u, cfg.GetEnabledDDisks().Count());
+
+        const auto before = cfg.GetDDisks();
+        const TString result = cfg.PromoteHostIfNeeded();
+
+        UNIT_ASSERT_STRING_CONTAINS(result, "Can't find primary candidate");
+        UNIT_ASSERT_VALUES_EQUAL(before.Print(), cfg.GetDDisks().Print());
+    }
 }
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -330,6 +330,9 @@ TString TVChunk::DebugPrintDirtyMap()
     sb << "CloneQueue: " << BlocksDirtyMap->DebugPrintReadyToClone() << "\n";
     sb << "FlushQueue: " << BlocksDirtyMap->DebugPrintReadyToFlush() << "\n";
     sb << "EraseQueue: " << BlocksDirtyMap->DebugPrintReadyToErase() << "\n";
+    sb << "Ahead:\n" << BlocksDirtyMap->DebugPrintAhead();
+    sb << "Behind:\n" << BlocksDirtyMap->DebugPrintBehind();
+    sb << "DDiskSyncs: " << BlocksDirtyMap->DebugPrintInflightSync() << "\n";
     return sb;
 }
 
@@ -974,74 +977,67 @@ void TVChunk::ApplyConfig(TVChunkConfig newConfig, const TString& message)
     VChunkConfig = std::move(newConfig);
     BlocksDirtyMap->UpdateConfig(VChunkConfig);
 
-    // Remove unnecessary copiers
     for (THostIndex hostIndex = 0; hostIndex < VChunkConfig.GetHostCount();
          ++hostIndex)
     {
-        const auto watermark = VChunkConfig.GetWatermark(hostIndex);
-        const bool needCopier = watermark != std::nullopt;
-        const auto* copier = Copiers.FindPtr(hostIndex);
-        if (needCopier || !copier) {
-            continue;
-        }
-
-        LOG_INFO(
-            *ActorSystem,
-            NKikimrServices::NBS_PARTITION,
-            "%s Copier %s stopping",
-            LogTitle.GetWithTime().c_str(),
-            PrintHostAndNode(hostIndex).c_str());
-
-        (*copier)->Stop().Subscribe(
-            [weakSelf = weak_from_this(), hostIndex]   //
-            (const TFuture<TDDiskDataCopier::EResult>& f)
-            {
-                if (auto self = weakSelf.lock()) {
-                    self->OnCopierStopped(hostIndex, f.GetValue());
-                }
-            });
-        Copiers.erase(hostIndex);
-    }
-
-    // Add new copiers
-    for (THostIndex hostIndex = 0; hostIndex < VChunkConfig.GetHostCount();
-         ++hostIndex)
-    {
-        const auto watermark = VChunkConfig.GetWatermark(hostIndex);
-        const bool needCopier = watermark != std::nullopt;
+        const bool needCopier =
+            BlocksDirtyMap->GetFreshRange(hostIndex) != std::nullopt &&
+            VChunkConfig.GetDisabledHosts().Get(hostIndex) == false;
         const auto* copier = Copiers.FindPtr(hostIndex);
 
-        if (!needCopier || copier) {
-            continue;
+        if (needCopier && !copier) {
+            // Add new copier
+
+            LOG_INFO(
+                *ActorSystem,
+                NKikimrServices::NBS_PARTITION,
+                "%s Copier %s started",
+                LogTitle.GetWithTime().c_str(),
+                PrintHostAndNode(hostIndex).c_str());
+
+            auto newCopier = Copiers[hostIndex] =
+                std::make_shared<TDDiskDataCopier>(
+                    ActorSystem,
+                    TraceService,
+                    PartitionDirectService,
+                    DiskDescription,
+                    VChunkConfig,
+                    DirectBlockGroup,
+                    BlocksDirtyMap,
+                    hostIndex);
+
+            newCopier->Start().Subscribe(
+                [weakSelf = weak_from_this(), hostIndex]   //
+                (const TFuture<TDDiskDataCopier::EResult>& f)
+                {
+                    if (auto self = weakSelf.lock()) {
+                        self->OnCopyComplete(hostIndex, f.GetValue());
+                    }
+                });
         }
+        if (!needCopier && copier) {
+            // Remove unnecessary copier
 
-        BlocksDirtyMap->SetReadWatermark(hostIndex, *watermark);
-        auto newCopier = Copiers[hostIndex] =
-            std::make_shared<TDDiskDataCopier>(
-                ActorSystem,
-                TraceService,
-                PartitionDirectService,
-                DiskDescription,
-                VChunkConfig,
-                DirectBlockGroup,
-                BlocksDirtyMap,
-                hostIndex);
+            LOG_INFO(
+                *ActorSystem,
+                NKikimrServices::NBS_PARTITION,
+                "%s Copier %s stopping",
+                LogTitle.GetWithTime().c_str(),
+                PrintHostAndNode(hostIndex).c_str());
 
-        LOG_INFO(
-            *ActorSystem,
-            NKikimrServices::NBS_PARTITION,
-            "%s Copier %s started",
-            LogTitle.GetWithTime().c_str(),
-            PrintHostAndNode(hostIndex).c_str());
+            (*copier)->Stop().Subscribe(
+                [weakSelf = weak_from_this(), hostIndex]   //
+                (const TFuture<TDDiskDataCopier::EResult>& f)
+                {
+                    if (auto self = weakSelf.lock()) {
+                        self->OnCopierStopped(hostIndex, f.GetValue());
+                    }
+                });
+            Copiers.erase(hostIndex);
 
-        newCopier->Start().Subscribe(
-            [weakSelf = weak_from_this(), hostIndex]   //
-            (const TFuture<TDDiskDataCopier::EResult>& f)
-            {
-                if (auto self = weakSelf.lock()) {
-                    self->OnCopyComplete(hostIndex, f.GetValue());
-                }
-            });
+            // Just in case, clear the locks of the deleted copier.
+            BlocksDirtyMap->ClearRangeSyncs(hostIndex);
+        }
     }
 }
 
@@ -1061,7 +1057,8 @@ TVChunkConfig TVChunk::PrepareNewConfig(
             break;
         }
         case EHostState::Offline: {
-            const TString message = newConfig.EvacuateHost(hostIndex);
+            newConfig.DisableHost(hostIndex);
+            const TString message = newConfig.PromoteHostIfNeeded();
             if (!message.empty()) {
                 LOG_WARN(
                     *ActorSystem,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -301,11 +301,11 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // DirtyMap config should stay the same too.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         // Reply UpdateConfig request.
@@ -324,11 +324,11 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // DirtyMap config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0-{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         // Call SetHostState(Online)
@@ -362,11 +362,11 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // DirtyMap config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         auto onStop = vchunk->Stop();
@@ -426,12 +426,12 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             "DDisk{Primary;Primary;Primary;None;None;None} Enabled{++++++}",
             AccessConfig(*vchunk).DebugPrint());
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};"
-            "H5+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};"
+            "H5+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         auto onStop = vchunk->Stop();
@@ -442,6 +442,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
     {
         Init();
 
+        bool isHostOffline = false;
         DirectBlockGroup->ReadBlocksFromDDiskHandler = [&]   //
             (ui32 vChunkIndex,
              THostIndex hostIndex,
@@ -455,8 +456,10 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             Y_UNUSED(guardedSglist);
             Y_UNUSED(traceId);
 
-            // Should not read from offline host.
-            UNIT_ASSERT_VALUES_UNEQUAL(0, hostIndex);
+            // Should not read from offline host when host disabled.
+            if (isHostOffline) {
+                UNIT_ASSERT_VALUES_UNEQUAL(0, hostIndex);
+            }
 
             auto promise = NewPromise<TDBGReadBlocksResponse>();
             auto future = promise.GetFuture();
@@ -513,6 +516,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
                     ready.SetValue();
                 });
             wait.GetValue(TDuration::Seconds(10));
+            isHostOffline = true;
         }
 
         // Config should stay the same since new config is not persisted yet.
@@ -525,11 +529,11 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // DirtyMap config should stay the same too.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0*{Operational,32768,32768};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3+{Disabled,0,0};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3+{Disabled,0};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         // Reply UpdateConfig request.
@@ -541,18 +545,18 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
             "[0/100] "
-            "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
-            "DDisk{None;Primary;Primary;Primary;None} "
+            "PBuffer{Primary;Primary;Primary;Primary;HandOff} "
+            "DDisk{Primary;Primary;Primary;Primary;None} "
             "Enabled{-+++[0]+}",
             AccessConfig(*vchunk).DebugPrint());
 
         // DirtyMap config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0-{Disabled,0,0};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,0,256};"
-            "H4+{Disabled,0,0};",
+            "H0-{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,0};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         // Call SetHostState(Online)
@@ -568,6 +572,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
                     ready.SetValue();
                 });
             wait.GetValue(TDuration::Seconds(10));
+            isHostOffline = false;
         }
 
         // Reply UpdateConfig request.
@@ -579,18 +584,18 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
             "[0/100] "
-            "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
-            "DDisk{None;Primary;Primary;Primary;None} "
+            "PBuffer{Primary;Primary;Primary;Primary;HandOff} "
+            "DDisk{Primary;Primary;Primary;Primary;None} "
             "Enabled{++++[0]+}",
             AccessConfig(*vchunk).DebugPrint());
 
         // DirtyMap config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0+{Disabled,0,0};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Fresh,0,256};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,0};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         // Execute copier reads and writes.
@@ -612,18 +617,18 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
             "[0/100] "
-            "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
-            "DDisk{None;Primary;Primary;Primary;None} "
+            "PBuffer{Primary;Primary;Primary;Primary;HandOff} "
+            "DDisk{Primary;Primary;Primary;Primary;None} "
             "Enabled{+++++}",
             AccessConfig(*vchunk).DebugPrint());
 
         // DirtyMap config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0+{Disabled,0,0};"
-            "H1*{Operational,32768,32768};"
-            "H2*{Operational,32768,32768};"
-            "H3*{Operational,32768,32768};"
-            "H4+{Disabled,0,0};",
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Operational,32768};"
+            "H4+{Disabled,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
         auto onStop = vchunk->Stop();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Keep changed blocks in memory when ddisk is lagging

### Description for reviewers <!-- (optional) description for those who read this PR -->

