### PR TITLE
Actors: remove common activation queue

### DIFF
--- a/ydb/core/driver_lib/run/config_helpers.cpp
+++ b/ydb/core/driver_lib/run/config_helpers.cpp
@@ -60,7 +60,6 @@ void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig
             NActors::TBasicExecutorPoolConfig basic;
             basic.PoolId = poolId;
             basic.PoolName = poolConfig.GetName();
-            basic.UseRingQueue = systemConfig.GetUseRingQueue();
             if (poolConfig.HasMaxAvgPingDeviation() && counters) {
                 auto poolGroup = counters->GetSubgroup("execpool", basic.PoolName);
                 auto &poolInfo = cpuManager.PingInfoByPool[poolId];
@@ -122,7 +121,6 @@ void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig
             io.Threads = poolConfig.GetThreads();
             io.Affinity = ParseAffinity(poolConfig.GetAffinity());
             cpuManager.IO.emplace_back(std::move(io));
-            io.UseRingQueue = systemConfig.HasUseRingQueue() && systemConfig.GetUseRingQueue();
             break;
         }
 

--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -32,7 +32,6 @@ namespace NActors {
         i16 SoftProcessingDurationTs = 0;
         EASProfile ActorSystemProfile = EASProfile::Default;
         bool HasSharedThread = false;
-        bool UseRingQueue = true;
         bool AllThreadsAreShared = false;
         ui16 MinLocalQueueSize = 0;
         ui16 MaxLocalQueueSize = 0;
@@ -57,7 +56,6 @@ namespace NActors {
         TString PoolName;
         ui32 Threads = 1;
         TCpuMask Affinity; // Executor thread affinity
-        bool UseRingQueue = false;
     };
 
     struct TSelfPingInfo {

--- a/ydb/library/actors/core/executor_pool_base.cpp
+++ b/ydb/library/actors/core/executor_pool_base.cpp
@@ -51,21 +51,15 @@ namespace NActors {
     }
 #endif
 
-    TExecutorPoolBase::TExecutorPoolBase(ui32 poolId, ui32 threads, TAffinity* affinity, bool useRingQueue)
+    TExecutorPoolBase::TExecutorPoolBase(ui32 poolId, ui32 threads, TAffinity* affinity)
         : TExecutorPoolBaseMailboxed(poolId)
         , PoolThreads(threads)
-        , UseRingQueueValue(useRingQueue)
         , ThreadsAffinity(affinity)
-    {
-        if (useRingQueue) {
-            Activations.emplace<TRingActivationQueueV4>(threads);
-        } else {
-            Activations.emplace<TUnorderedCacheActivationQueue>();
-        }
-    }
+        , Activations(threads)
+    {}
 
     TExecutorPoolBase::~TExecutorPoolBase() {
-        while (std::visit([](auto &x){return x.Pop(0);}, Activations))
+        while (Activations.Pop(0))
             ;
     }
 
@@ -130,11 +124,7 @@ namespace NActors {
     }
 
     void TExecutorPoolBase::ScheduleActivation(TMailbox* mailbox) {
-        if (UseRingQueue()) {
-            ScheduleActivationEx(mailbox, 0);
-        } else {
-            ScheduleActivationEx(mailbox, AtomicIncrement(ActivationsRevolvingCounter));
-        }
+        ScheduleActivationEx(mailbox, 0);
     }
 
     Y_FORCE_INLINE bool IsAllowedToCapture(IExecutorPool *self) {
@@ -155,11 +145,7 @@ namespace NActors {
         if (!mailbox) {
             return;
         }
-        if (UseRingQueueValue) {
-            ScheduleActivationEx(mailbox, 0);
-        } else {
-            ScheduleActivationEx(mailbox, AtomicIncrement(ActivationsRevolvingCounter));
-        }
+        ScheduleActivationEx(mailbox, 0);
     }
 
     TActorId TExecutorPoolBaseMailboxed::Register(IActor* actor, TMailboxType::EType, ui64 revolvingWriteCounter, const TActorId& parentId) {
@@ -289,7 +275,4 @@ namespace NActors {
         return MailboxTable;
     }
 
-    bool TExecutorPoolBase::UseRingQueue() const {
-        return UseRingQueueValue;
-    }
 }

--- a/ydb/library/actors/core/executor_pool_base.h
+++ b/ydb/library/actors/core/executor_pool_base.h
@@ -6,7 +6,6 @@
 #include "scheduler_queue.h"
 #include <ydb/library/actors/queues/activation_queue.h>
 #include <ydb/library/actors/util/affinity.h>
-#include <ydb/library/actors/util/unordered_cache.h>
 #include <ydb/library/actors/util/threadparkpad.h>
 
 //#define RING_ACTIVATION_QUEUE
@@ -50,23 +49,18 @@ namespace NActors {
 
     class TExecutorPoolBase: public TExecutorPoolBaseMailboxed {
     protected:
-        using TUnorderedCacheActivationQueue = TUnorderedCache<ui32, 512, 4>;
-
         const i16 PoolThreads;
-        const bool UseRingQueueValue;
         alignas(64) TIntrusivePtr<TAffinity> ThreadsAffinity;
         alignas(64) TAtomic Semaphore = 0;
-        alignas(64) std::variant<TUnorderedCacheActivationQueue, TRingActivationQueueV4> Activations;
-        TAtomic ActivationsRevolvingCounter = 0;
+        alignas(64) TRingActivationQueueV4 Activations;
         std::atomic_bool StopFlag = false;
     public:
-        TExecutorPoolBase(ui32 poolId, ui32 threads, TAffinity* affinity, bool useRingQueue);
+        TExecutorPoolBase(ui32 poolId, ui32 threads, TAffinity* affinity);
         ~TExecutorPoolBase();
         void ScheduleActivation(TMailbox* mailbox) override;
         void SpecificScheduleActivation(TMailbox* mailbox) override;
         TAffinity* Affinity() const override;
         ui32 GetThreads() const override;
-        bool UseRingQueue() const;
     };
 
     void DoActorInit(TActorSystem*, IActor*, const TActorId&, const TActorId&);

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -330,7 +330,7 @@ namespace NActors {
             TlsThreadContext->LocalQueueContext.WriteTurn = 0;
             TlsThreadContext->LocalQueueContext.LocalQueueSize = LocalQueueSize.load(std::memory_order_relaxed);
         }
-        EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue done; moving to common");
+        EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue done; moving to ring queue");
         return GetReadyActivationRingQueue(revolvingCounter);
     }
 

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -96,7 +96,7 @@ namespace NActors {
     }
 
     TBasicExecutorPool::TBasicExecutorPool(const TBasicExecutorPoolConfig& cfg, IHarmonizer *harmonizer, TExecutorPoolJail *jail)
-        : TExecutorPoolBase(cfg.PoolId, cfg.Threads, new TAffinity(cfg.Affinity), cfg.UseRingQueue)
+        : TExecutorPoolBase(cfg.PoolId, cfg.Threads, new TAffinity(cfg.Affinity))
         , DefaultSpinThresholdCycles(cfg.SpinThreshold * NHPTimer::GetCyclesPerSecond() * 0.000001) // convert microseconds to cycles
         , SpinThresholdCycles(DefaultSpinThresholdCycles)
         , SpinThresholdCyclesPerThread(new NThreading::TPadded<std::atomic<ui64>>[cfg.Threads])
@@ -254,61 +254,6 @@ namespace NActors {
         } while (true);
     }
 
-    TMailbox* TBasicExecutorPool::GetReadyActivationCommon(ui64 revolvingCounter) {
-        TWorkerId workerId = TlsThreadContext->WorkerId();
-        EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "");
-        NHPTimer::STime hpnow = GetCycleCountFast();
-        TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION, false> activityGuard(hpnow);
-
-        Y_DEBUG_ABORT_UNLESS(workerId < MaxFullThreadCount);
-
-        Threads[workerId].UnsetWork();
-        if (Harmonizer) {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "try to harmonize");
-            LWPROBE(TryToHarmonize, PoolId, PoolName);
-            Harmonizer->Harmonize(hpnow);
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "harmonize done");
-        }
-
-        TAtomic semaphoreRaw = AtomicGet(Semaphore);
-        TSemaphore semaphore = TSemaphore::GetSemaphore(semaphoreRaw);
-        while (!StopFlag.load(std::memory_order_acquire)) {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "semaphore.OldSemaphore == ", semaphore.OldSemaphore, " semaphore.CurrentSleepThreadCount == ", semaphore.CurrentSleepThreadCount);
-            if (!semaphore.OldSemaphore || workerId >= 0 && semaphore.CurrentSleepThreadCount < 0) {
-                EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "semaphore.OldSemaphore == 0 or workerId >= 0 && semaphore.CurrentSleepThreadCount < 0");
-                if (!TlsThreadContext->ExecutionContext.IsNeededToWaitNextActivation) {
-                    EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "wctx.ExecutionContext.IsNeededToWaitNextActivation == false");
-                    return nullptr;
-                }
-
-                bool needToWait = false;
-                bool needToBlock = false;
-                AskToGoToSleep(&needToWait, &needToBlock);
-                if (needToWait) {
-                    EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "go to sleep");
-                    if (Threads[workerId].Wait(SpinThresholdCycles, &StopFlag)) {
-                        EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "sleep interrupted");
-                        return nullptr;
-                    }
-                }
-            } else {
-                TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> activityGuard;
-                if (const ui32 activation = std::visit([&revolvingCounter](auto &x) {return x.Pop(revolvingCounter++);}, Activations)) {
-                    EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "activation found");
-                    Threads[workerId].SetWork();
-                    AtomicDecrement(Semaphore);
-                    return MailboxTable->Get(activation);
-                }
-            }
-
-            SpinLockPause();
-            semaphoreRaw = AtomicGet(Semaphore);
-            semaphore = TSemaphore::GetSemaphore(semaphoreRaw);
-        }
-
-        return nullptr;
-    }
-
     TMailbox* TBasicExecutorPool::GetReadyActivationRingQueue(ui64 revolvingCounter) {
         if (StopFlag.load(std::memory_order_acquire)) {
             return nullptr;
@@ -337,7 +282,7 @@ namespace NActors {
                     CheckToSleepWorkers.compare_exchange_weak(checkToSleepWorkers, checkToSleepWorkers - 1, std::memory_order_release, std::memory_order_relaxed);
                 } else { // otherwise we ready to get activation
                     TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> activityGuard;
-                    if (const ui32 activation = std::visit([&revolvingCounter](auto &x) {return x.Pop(++revolvingCounter);}, Activations)) {
+                    if (const ui32 activation = Activations.Pop(++revolvingCounter)) {
                         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "activation found");
                         Threads[workerId].SetWork();
                         AtomicDecrement(Semaphore);
@@ -386,22 +331,16 @@ namespace NActors {
             TlsThreadContext->LocalQueueContext.LocalQueueSize = LocalQueueSize.load(std::memory_order_relaxed);
         }
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue done; moving to common");
-        if (TlsThreadContext->UseRingQueue()) {
-            return GetReadyActivationRingQueue(revolvingCounter);
-        }
-        return GetReadyActivationCommon(revolvingCounter);
+        return GetReadyActivationRingQueue(revolvingCounter);
     }
 
     TMailbox* TBasicExecutorPool::GetReadyActivation(ui64 revolvingCounter) {
         if (MaxLocalQueueSize) {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue");
             return GetReadyActivationLocalQueue(revolvingCounter);
-        } else if (TlsThreadContext->UseRingQueue()) {
+        } else {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "ring queue");
             return GetReadyActivationRingQueue(revolvingCounter);
-        } else {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "");
-            return GetReadyActivationCommon(revolvingCounter);
         }
     }
 
@@ -419,10 +358,8 @@ namespace NActors {
         }
     }
 
-    void TBasicExecutorPool::ScheduleActivationExCommon(TMailbox* mailbox, ui64 revolvingCounter, std::optional<TAtomic> initSemaphore) {
-        std::visit([mailbox, revolvingCounter](auto &queue) {
-            queue.Push(mailbox->Hint, revolvingCounter);
-        }, Activations);
+    void TBasicExecutorPool::ScheduleActivationExRingQueue(TMailbox* mailbox, ui64 revolvingCounter, std::optional<TAtomic> initSemaphore) {
+        Activations.Push(mailbox->Hint, revolvingCounter);
         bool needToWakeUp = false;
         bool needToChangeOldSemaphore = true;
 
@@ -505,18 +442,18 @@ namespace NActors {
                         }
                     }
                 }
-                ScheduleActivationExCommon(mailbox, revolvingWriteCounter, x);
+                ScheduleActivationExRingQueue(mailbox, revolvingWriteCounter, x);
                 return;
             }
         }
-        ScheduleActivationExCommon(mailbox, revolvingWriteCounter, std::nullopt);
+        ScheduleActivationExRingQueue(mailbox, revolvingWriteCounter, std::nullopt);
     }
 
     void TBasicExecutorPool::ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingCounter) {
         if (MaxLocalQueueSize) {
             ScheduleActivationExLocalQueue(mailbox, revolvingCounter);
         } else {
-            ScheduleActivationExCommon(mailbox, revolvingCounter, std::nullopt);
+            ScheduleActivationExRingQueue(mailbox, revolvingCounter, std::nullopt);
         }
     }
 
@@ -854,7 +791,7 @@ namespace NActors {
                 return nullptr;
             } else {
                 TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> activityGuard;
-                if (const ui32 activation = std::visit([&revolvingCounter](auto &x) {return x.Pop(revolvingCounter++);}, Activations)) {
+                if (const ui32 activation = Activations.Pop(revolvingCounter++)) {
                     SharedPool->Threads[workerId].SetWork();
                     AtomicDecrement(Semaphore);
                     EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "activation == ", activation, " semaphore == ", semaphore.OldSemaphore);

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <ydb/library/actors/core/harmonizer/harmonizer.h>
 #include <ydb/library/actors/actor_type/indexes.h>
-#include <ydb/library/actors/util/unordered_cache.h>
 #include <ydb/library/actors/util/threadparkpad.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -234,7 +234,6 @@ namespace NActors {
 
         void Initialize() override;
         TMailbox* GetReadyActivation(ui64 revolvingReadCounter) override;
-        TMailbox* GetReadyActivationCommon(ui64 revolvingReadCounter);
         TMailbox* GetReadyActivationShared(ui64 revolvingReadCounter);
         TMailbox* GetReadyActivationRingQueue(ui64 revolvingReadCounter);
         TMailbox* GetReadyActivationLocalQueue(ui64 revolvingReadCounter);
@@ -244,7 +243,7 @@ namespace NActors {
         void Schedule(TDuration delta, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie, TWorkerId workerId) override;
 
         void ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingWriteCounter) override;
-        void ScheduleActivationExCommon(TMailbox* mailbox, ui64 revolvingWriteCounter, std::optional<TAtomic> semaphoreValue);
+        void ScheduleActivationExRingQueue(TMailbox* mailbox, ui64 revolvingWriteCounter, std::optional<TAtomic> semaphoreValue);
         void ScheduleActivationExLocalQueue(TMailbox* mailbox, ui64 revolvingWriteCounter);
 
         void SetLocalQueueSize(ui16 size);

--- a/ydb/library/actors/core/executor_pool_io.cpp
+++ b/ydb/library/actors/core/executor_pool_io.cpp
@@ -7,8 +7,8 @@
 #include <ydb/library/actors/util/datetime.h>
 
 namespace NActors {
-    TIOExecutorPool::TIOExecutorPool(ui32 poolId, ui32 threads, const TString& poolName, TAffinity* affinity, bool useRingQueue)
-        : TExecutorPoolBase(poolId, threads, affinity, useRingQueue)
+    TIOExecutorPool::TIOExecutorPool(ui32 poolId, ui32 threads, const TString& poolName, TAffinity* affinity)
+        : TExecutorPoolBase(poolId, threads, affinity)
         , Threads(new TExecutorThreadCtx[threads])
         , PoolName(poolName)
     {}
@@ -18,8 +18,7 @@ namespace NActors {
             cfg.PoolId,
             cfg.Threads,
             cfg.PoolName,
-            new TAffinity(cfg.Affinity),
-            cfg.UseRingQueue
+            new TAffinity(cfg.Affinity)
         )
     {
         Harmonizer = harmonizer;
@@ -59,7 +58,7 @@ namespace NActors {
         }
 
         while (!StopFlag.load(std::memory_order_acquire)) {
-            if (const ui32 activation = std::visit([&revolvingCounter](auto &queue){return queue.Pop(++revolvingCounter);}, Activations)) {
+            if (const ui32 activation = Activations.Pop(++revolvingCounter)) {
                 return MailboxTable->Get(activation);
             }
             SpinLockPause();
@@ -92,9 +91,7 @@ namespace NActors {
     }
 
     void TIOExecutorPool::ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingWriteCounter) {
-        std::visit([mailbox, revolvingWriteCounter](auto &queue) {
-            queue.Push(mailbox->Hint, revolvingWriteCounter);
-        }, Activations);
+        Activations.Push(mailbox->Hint, revolvingWriteCounter);
         const TAtomic semaphoreRaw = AtomicIncrement(Semaphore);
         if (semaphoreRaw <= 0) {
             for (;; ++revolvingWriteCounter) {

--- a/ydb/library/actors/core/executor_pool_io.h
+++ b/ydb/library/actors/core/executor_pool_io.h
@@ -26,7 +26,7 @@ namespace NActors {
         const TString PoolName;
         const ui32 ActorSystemIndex = NActors::TActorTypeOperator::GetActorSystemIndex();
     public:
-        TIOExecutorPool(ui32 poolId, ui32 threads, const TString& poolName = "", TAffinity* affinity = nullptr, bool useRingQueue = false);
+        TIOExecutorPool(ui32 poolId, ui32 threads, const TString& poolName = "", TAffinity* affinity = nullptr);
         explicit TIOExecutorPool(const TIOExecutorPoolConfig& cfg, IHarmonizer *harmonizer = nullptr);
         ~TIOExecutorPool();
 

--- a/ydb/library/actors/core/executor_pool_shared.h
+++ b/ydb/library/actors/core/executor_pool_shared.h
@@ -9,7 +9,6 @@
 #include "scheduler_queue.h"
 #include <memory>
 #include <ydb/library/actors/actor_type/indexes.h>
-#include <ydb/library/actors/util/unordered_cache.h>
 #include <ydb/library/actors/util/threadparkpad.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 

--- a/ydb/library/actors/core/thread_context.cpp
+++ b/ydb/library/actors/core/thread_context.cpp
@@ -1,23 +1,14 @@
 #include "thread_context.h"
 
 #include "executor_pool.h"
-#include "executor_pool_base.h"
 
 namespace NActors {
-
-    bool UseRingQueue(IExecutorPool* pool) {
-        if (auto* basePool = dynamic_cast<TExecutorPoolBase*>(pool)) {
-            return basePool->UseRingQueue();
-        }
-        return false;
-    }
 
     TWorkerContext::TWorkerContext(TWorkerId workerId, IExecutorPool* pool, IExecutorPool* sharedPool)
         : WorkerId(workerId)
         , Pool(pool)
         , OwnerPool(pool)
         , SharedPool(sharedPool)
-        , UseRingQueueValue(::NActors::UseRingQueue(pool))
     {
         AssignPool(pool);
     }
@@ -44,10 +35,6 @@ namespace NActors {
 
     bool TWorkerContext::IsShared() const {
         return SharedPool != nullptr;
-    }
-
-    bool TWorkerContext::UseRingQueue() const {
-        return UseRingQueueValue;
     }
 
     void TWorkerContext::AssignPool(IExecutorPool* pool, ui64 softDeadlineTs) {
@@ -89,10 +76,6 @@ namespace NActors {
 
     bool TThreadContext::IsShared() const {
         return WorkerContext.IsShared();
-    }
-
-    bool TThreadContext::UseRingQueue() const {
-        return WorkerContext.UseRingQueue();
     }
 
     ui64 TThreadContext::TimePerMailboxTs() const {

--- a/ydb/library/actors/core/thread_context.h
+++ b/ydb/library/actors/core/thread_context.h
@@ -50,7 +50,6 @@ namespace NActors {
         ui64 TimePerMailboxTs = 0;
         ui32 EventsPerMailbox = 0;
         ui64 SoftDeadlineTs = ui64(-1);
-        bool UseRingQueueValue = false;
 
         TWorkerContext(TWorkerId workerId, IExecutorPool* pool, IExecutorPool* sharedPool);
 
@@ -58,7 +57,6 @@ namespace NActors {
         TString PoolName() const;
         ui32 OwnerPoolId() const;
         bool IsShared() const;
-        bool UseRingQueue() const;
         void AssignPool(IExecutorPool* pool, ui64 softDeadlineTs = -1);
         void FreeMailbox(TMailbox* mailbox);
     };
@@ -126,7 +124,6 @@ namespace NActors {
         ui32 EventsPerMailbox() const;
         ui64 SoftDeadlineTs() const;
         void FreeMailbox(TMailbox* mailbox);
-        bool UseRingQueue() const;
         void AssignPool(IExecutorPool* pool, ui64 softDeadlineTs = Max<ui64>());
 
         bool CheckSendingType(ESendingType type) const;

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -223,7 +223,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1,
-            .UseRingQueue = false,
             .MinLocalQueueSize = 0,
             .MaxLocalQueueSize = 0
         }, nullptr);
@@ -244,21 +243,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
                 UNIT_ASSERT_EQUAL(activation, mailbox);
             }
         }
-    }
-
-    TString ToString(std::vector<TMailbox*> mailboxes) {
-        TStringStream ss;
-        ss << "[";
-        bool first = true;
-        for (auto mailbox : mailboxes) {
-            if (!first) {
-                ss << ", ";
-            }
-            ss << mailbox->Hint;
-            first = false;
-        }
-        ss << "]";
-        return ss.Str();
     }
 
     TString ToString(std::vector<ui64> counters) {
@@ -283,57 +267,9 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
         return ss.Str();
     }
 
-    Y_UNIT_TEST(ReorderingOfCommonQueue) {
-        std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
-            .Threads = 1,
-            .UseRingQueue = false,
-            .MinLocalQueueSize = 0,
-            .MaxLocalQueueSize = 0
-        }, nullptr);
-
-        PreparePool(pool.get());
-
-        TThreadEmulator emulator({pool.get()}, nullptr);
-
-        std::vector<TMailbox*> mailboxes;
-        for (ui32 i = 0; i < 4; ++i) {
-            mailboxes.push_back(pool->GetMailboxTable()->Allocate());
-        }
-
-        std::vector<ui64> readCounters {0, 1, 2, 3};
-        std::vector<ui64> writeCounters {0, 1, 2, 3};
-        std::vector<TMailbox*> activations {nullptr, nullptr, nullptr, nullptr};
-        TWorkerIdentity workerIdentity{pool.get(), 0};
-
-        while (std::next_permutation(readCounters.begin(), readCounters.end())) {
-            std::sort(writeCounters.begin(), writeCounters.end());
-            while (std::next_permutation(writeCounters.begin(), writeCounters.end())) {
-                for (ui64 idx = 0; idx < 4; ++idx) {
-                    emulator.ScheduleActivation(workerIdentity, pool.get(), mailboxes[idx], writeCounters[idx]);
-                    activations[writeCounters[idx]] = mailboxes[idx];
-                }
-                for (ui64 idx = 0; idx < 4; ++idx) {
-                    TMailbox* activation = emulator.GetReadyActivation(workerIdentity, readCounters[idx]);
-                    UNIT_ASSERT(activation);
-                    UNIT_ASSERT_VALUES_EQUAL_C(activation->Hint, activations[readCounters[idx]]->Hint,
-                        "idx: " << idx
-                        << ", readCounters: " << ToString(readCounters)
-                        << ", writeCounters: " << ToString(writeCounters)
-                        << ", activations: " << ToString(activations));
-                    UNIT_ASSERT_EQUAL_C(activation, activations[readCounters[idx]],
-                        "idx: " << idx
-                        << ", readCounters: " << ToString(readCounters)
-                        << ", writeCounters: " << ToString(writeCounters)
-                        << ", activations: " << ToString(activations));
-                }
-            }
-        }
-    }
-
     Y_UNIT_TEST(OrderingOfRingQueue) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1,
-            .UseRingQueue = true,
             .MinLocalQueueSize = 0,
             .MaxLocalQueueSize = 0
         }, nullptr);
@@ -376,7 +312,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
     Y_UNIT_TEST(CorrectnessOfLocalQueue) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1,
-            .UseRingQueue = false,
             .MinLocalQueueSize = 8,
             .MaxLocalQueueSize = 8
         }, nullptr);
@@ -427,7 +362,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
         std::unique_ptr<TBasicExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1,
             .HasSharedThread = true,
-            .UseRingQueue = false,
             .MinLocalQueueSize = 0,
             .MaxLocalQueueSize = 0,
         }, nullptr);
@@ -491,7 +425,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
                 .PoolName = "Pool" + ToString(i),
                 .Threads = 1,
                 .HasSharedThread = true,
-                .UseRingQueue = false,
                 .MinLocalQueueSize = 0,
                 .MaxLocalQueueSize = 0,
             }, nullptr));
@@ -613,7 +546,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
                 .PoolName = i < 2 ? "WorkerPool" + ToString(i) : "TaskPool" + ToString(i),
                 .Threads = 1,
                 .HasSharedThread = true,
-                .UseRingQueue = false,
                 .MinLocalQueueSize = 0,
                 .MaxLocalQueueSize = 0,
             }, nullptr));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Actor executor pools now use the ring activation queue exclusively.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Removes the legacy unordered-cache activation queue, its runtime selection plumbing, and the common-queue-specific test while preserving the protobuf configuration field for compatibility.