### PR TITLE
[NBS] Reintroduce DDisk-issued connection tokens

### DIFF
--- a/ydb/core/blobstorage/ddisk/ddisk.h
+++ b/ydb/core/blobstorage/ddisk/ddisk.h
@@ -21,6 +21,82 @@ namespace NKikimr::NDDisk {
 
     static_assert(MinSectorSize == IntegrityUnitSize);
 
+    struct TConnectionToken {
+        ui64 Low = 0;
+        ui64 High = 0;
+
+        TConnectionToken() = default;
+
+        TConnectionToken(ui64 low, ui64 high)
+            : Low(low)
+            , High(high)
+        {}
+
+        static TConnectionToken Make(
+                ui32 connectionIndex,
+                ui8 sequenceNo,
+                ui32 tabletIdSuffix,
+                ui16 nodeId,
+                ui16 pdiskId,
+                ui16 vslotId,
+                ui8 random
+        ) {
+            return {
+                connectionIndex | static_cast<ui64>(tabletIdSuffix) << 32,
+                sequenceNo |
+                    static_cast<ui64>(random) << 8 |
+                    static_cast<ui64>(nodeId) << 16 |
+                    static_cast<ui64>(pdiskId) << 32 |
+                    static_cast<ui64>(vslotId) << 48,
+            };
+        }
+
+        explicit TConnectionToken(const NKikimrBlobStorage::NDDisk::TConnectionToken& pb)
+            : Low(pb.GetLow())
+            , High(pb.GetHigh())
+        {}
+
+        [[nodiscard]] ui32 GetConnectionIndex() const {
+            return static_cast<ui32>(Low);
+        }
+
+        [[nodiscard]] ui8 GetSequenceNo() const {
+            return static_cast<ui8>(High);
+        }
+
+        [[nodiscard]] ui32 GetTabletIdSuffix() const {
+            return static_cast<ui32>(Low >> 32);
+        }
+
+        [[nodiscard]] ui16 GetNodeId() const {
+            return static_cast<ui16>(High >> 16);
+        }
+
+        [[nodiscard]] ui16 GetPDiskId() const {
+            return static_cast<ui16>(High >> 32);
+        }
+
+        [[nodiscard]] ui16 GetVSlotId() const {
+            return static_cast<ui16>(High >> 48);
+        }
+
+        [[nodiscard]] ui8 GetRandom() const {
+            return static_cast<ui8>(High >> 8);
+        }
+
+        explicit operator bool() const {
+            return Low || High;
+        }
+
+        bool operator==(const TConnectionToken&) const = default;
+
+        void Serialize(NKikimrBlobStorage::NDDisk::TConnectionToken* pb) const
+        {
+            pb->SetLow(Low);
+            pb->SetHigh(High);
+        }
+    };
+
     struct TEv {
         enum {
             EvConnect = EventSpaceBegin(TKikimrEvents::ES_DDISK),
@@ -55,13 +131,17 @@ namespace NKikimr::NDDisk {
     };
 
     struct TQueryCredentials {
+        using TRequestCredentials = NKikimrBlobStorage::NDDisk::TRequestCredentials;
         using ERequestKind = NKikimrBlobStorage::NDDisk::TQueryCredentials::ERequestKind;
 
-        ui64 TabletId;
-        ui32 Generation;
+        ui64 TabletId = 0;
+        ui32 Generation = 0;
+        ui32 DirectBlockGroupIndex = 0;
         std::optional<ui64> DDiskInstanceGuid;
         ui64 DDiskSessionSeqNo = 0;
         ERequestKind RequestKind = NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_DDISK;
+        std::optional<TConnectionToken> ConnectionToken;
+        bool ServerContext = false;
 
         TQueryCredentials() = default;
 
@@ -70,45 +150,49 @@ namespace NKikimr::NDDisk {
                 ui32 generation,
                 ui64 ddiskSessionSeqNo,
                 std::optional<ui64> ddiskInstanceGuid,
-                ERequestKind requestKind)
+                ERequestKind requestKind,
+                ui32 directBlockGroupIndex)
             : TabletId(tabletId)
             , Generation(generation)
+            , DirectBlockGroupIndex(directBlockGroupIndex)
             , DDiskInstanceGuid(ddiskInstanceGuid)
             , DDiskSessionSeqNo(ddiskSessionSeqNo)
             , RequestKind(requestKind)
         {}
 
-        // Tablet-originated request sent to a DDisk actor.
-        // Validation requires a registered tablet connection with matching generation and DDiskSessionSeqNo,
-        // matching DDiskInstanceGuid when it is set, and matching sender IC session.
+        // Connection metadata for a DDisk actor. Ordinary requests serialize
+        // only the token returned by TEvConnectResult.
         static TQueryCredentials ToDDisk(
                 ui64 tabletId,
                 ui32 generation,
                 ui64 ddiskSessionSeqNo,
-                std::optional<ui64> ddiskInstanceGuid) {
+                std::optional<ui64> ddiskInstanceGuid,
+                ui32 directBlockGroupIndex
+        ) {
             return TQueryCredentials(
                 tabletId,
                 generation,
                 ddiskSessionSeqNo,
                 ddiskInstanceGuid,
-                NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_DDISK);
+                NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_DDISK,
+                directBlockGroupIndex);
         }
 
-        // Tablet-originated request sent to a PersistentBuffer actor.
-        // Validation still requires a registered tablet connection, matching generation,
-        // matching DDiskInstanceGuid when it is set, and matching sender node. Interconnect session
-        // and DDiskSessionSeqNo are skipped because persistent buffers are not bound to a particular
-        // DDisk session.
+        // Connection metadata for a PersistentBuffer actor. Ordinary requests
+        // serialize only the token returned by TEvConnectResult.
         static TQueryCredentials ToPersistentBuffer(
                 ui64 tabletId,
                 ui32 generation,
-                std::optional<ui64> ddiskInstanceGuid) {
+                std::optional<ui64> ddiskInstanceGuid,
+                ui32 directBlockGroupIndex
+        ) {
             return TQueryCredentials(
                 tabletId,
                 generation,
                 0,
                 ddiskInstanceGuid,
-                NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_PERSISTENT_BUFFER);
+                NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_PERSISTENT_BUFFER,
+                directBlockGroupIndex);
         }
 
         // Internal DDisk/PersistentBuffer forwarding.
@@ -118,42 +202,80 @@ namespace NKikimr::NDDisk {
         static TQueryCredentials ForInternal(
                 ui64 tabletId,
                 ui32 generation,
-                std::optional<ui64> ddiskInstanceGuid) {
+                std::optional<ui64> ddiskInstanceGuid,
+                ui32 directBlockGroupIndex
+        ) {
             return TQueryCredentials(
                 tabletId,
                 generation,
                 0,
                 ddiskInstanceGuid,
-                NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_INTERNAL);
+                NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_INTERNAL,
+                directBlockGroupIndex);
         }
+
+        static TQueryCredentials ToDDisk(const TConnectionToken& connectionToken) {
+            TQueryCredentials creds;
+            creds.ConnectionToken.emplace(connectionToken);
+            return creds;
+        }
+
+        static TQueryCredentials ToDDisk(const NKikimrBlobStorage::NDDisk::TConnectionToken& connectionToken) {
+            return ToDDisk(TConnectionToken(connectionToken));
+        }
+
+        static TQueryCredentials ToPersistentBuffer(const TConnectionToken& connectionToken) {
+            return ToDDisk(connectionToken);
+        }
+
+        static TQueryCredentials ToPersistentBuffer(const NKikimrBlobStorage::NDDisk::TConnectionToken& connectionToken) {
+            return ToDDisk(connectionToken);
+        }
+
 
         TQueryCredentials(const NKikimrBlobStorage::NDDisk::TQueryCredentials& pb)
             : TabletId(pb.GetTabletId())
             , Generation(pb.GetGeneration())
+            , DirectBlockGroupIndex(pb.GetDirectBlockGroupIndex())
             , DDiskInstanceGuid(pb.HasDDiskInstanceGuid() ? std::make_optional(pb.GetDDiskInstanceGuid()) : std::nullopt)
             , DDiskSessionSeqNo(pb.GetDDiskSessionSeqNo())
             , RequestKind(pb.GetRequestKind())
         {}
 
+        TQueryCredentials(const TRequestCredentials& pb)
+        {
+            if (pb.HasInternal()) {
+                ServerContext = true;
+                const auto& internal = pb.GetInternal();
+                TabletId = internal.GetTabletId();
+                Generation = internal.GetGeneration();
+                DirectBlockGroupIndex = internal.GetDirectBlockGroupIndex();
+                DDiskInstanceGuid = internal.HasDDiskInstanceGuid()
+                    ? std::make_optional(internal.GetDDiskInstanceGuid())
+                    : std::nullopt;
+                DDiskSessionSeqNo = internal.GetDDiskSessionSeqNo();
+                RequestKind = internal.GetRequestKind();
+            } else if (pb.HasConnectionToken()) {
+                ConnectionToken.emplace(pb.GetConnectionToken());
+            }
+        }
+
         bool IsInternal() const {
             return RequestKind == NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_INTERNAL;
+        }
+
+        bool HasServerContext() const {
+            return ServerContext;
         }
 
         bool RequiresDDiskSessionSeqNoCheck() const {
             return RequestKind == NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_DDISK;
         }
 
-        bool RequiresSenderCheck() const {
-            return !IsInternal();
-        }
-
-        bool RequiresInterconnectSessionCheck() const {
-            return RequestKind == NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_DDISK;
-        }
-
         void Serialize(NKikimrBlobStorage::NDDisk::TQueryCredentials *pb) const {
             pb->SetTabletId(TabletId);
             pb->SetGeneration(Generation);
+            pb->SetDirectBlockGroupIndex(DirectBlockGroupIndex);
             if (DDiskInstanceGuid) {
                 pb->SetDDiskInstanceGuid(*DDiskInstanceGuid);
             }
@@ -163,6 +285,22 @@ namespace NKikimr::NDDisk {
             if (RequestKind != NKikimrBlobStorage::NDDisk::TQueryCredentials::REQUEST_KIND_TO_DDISK) {
                 pb->SetRequestKind(RequestKind);
             }
+        }
+
+        void SerializeForRequest(TRequestCredentials* pb) const
+        {
+            pb->Clear();
+            if (ConnectionToken) {
+                ConnectionToken->Serialize(pb->MutableConnectionToken());
+            } else if (IsInternal()) {
+                Serialize(pb->MutableInternal());
+            }
+        }
+
+        void SerializeResolvedForRequest(TRequestCredentials* pb) const
+        {
+            pb->Clear();
+            Serialize(pb->MutableInternal());
         }
     };
 
@@ -380,13 +518,17 @@ struct TPersistentBufferFormat {
 
         TEvConnectResult(NKikimrBlobStorage::NDDisk::TReplyStatus::E status,
                 const std::optional<TString>& errorReason = std::nullopt,
-                std::optional<ui64> ddiskInstanceGuid = std::nullopt) {
+                std::optional<ui64> ddiskInstanceGuid = std::nullopt,
+                std::optional<TConnectionToken> connectionToken = std::nullopt) {
             Record.SetStatus(status);
             if (errorReason) {
                 Record.SetErrorReason(*errorReason);
             }
             if (ddiskInstanceGuid) {
                 Record.SetDDiskInstanceGuid(*ddiskInstanceGuid);
+            }
+            if (connectionToken) {
+                connectionToken->Serialize(Record.MutableConnectionToken());
             }
         }
     };
@@ -413,7 +555,7 @@ struct TPersistentBufferFormat {
         TEvWrite() = default;
 
         TEvWrite(const TQueryCredentials& creds, const TBlockSelector& selector, const TWriteInstruction& instruction) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             selector.Serialize(Record.MutableSelector());
             instruction.Serialize(Record.MutableInstruction());
         }
@@ -458,7 +600,7 @@ struct TPersistentBufferFormat {
         TEvRead() = default;
 
         TEvRead(const TQueryCredentials& creds, const TBlockSelector& selector, const TReadInstruction& instruction) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             selector.Serialize(Record.MutableSelector());
             instruction.Serialize(Record.MutableInstruction());
         }
@@ -487,7 +629,7 @@ struct TPersistentBufferFormat {
 
         TEvWritePersistentBuffer(const TQueryCredentials& creds, const TBlockSelector& selector, ui64 lsn,
                 const TWriteInstruction& instruction) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             selector.Serialize(Record.MutableSelector());
             Record.SetLsn(lsn);
             instruction.Serialize(Record.MutableInstruction());
@@ -546,7 +688,7 @@ struct TPersistentBufferFormat {
         TEvReadThenWritePersistentBuffers(const TQueryCredentials& creds, ui64 lsn, ui32 generation,
                 const std::vector<std::tuple<ui32, ui32, ui32>>& persistentBufferIds,
                 ui32 replyTimeoutMicroseconds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             Record.SetLsn(lsn);
             Record.SetGeneration(generation);
             Record.SetReplyTimeoutMicroseconds(replyTimeoutMicroseconds);
@@ -567,7 +709,7 @@ struct TPersistentBufferFormat {
         TEvWritePersistentBuffers(const TQueryCredentials& creds, const TBlockSelector& selector, ui64 lsn,
                 const TWriteInstruction& instruction, const std::vector<std::tuple<ui32, ui32, ui32>>& persistentBufferIds,
                 ui32 replyTimeoutMicroseconds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             selector.Serialize(Record.MutableSelector());
             Record.SetLsn(lsn);
             Record.SetReplyTimeoutMicroseconds(replyTimeoutMicroseconds);
@@ -583,7 +725,7 @@ struct TPersistentBufferFormat {
         TEvWritePersistentBuffers(const TQueryCredentials& creds, const TBlockSelector& selector, ui64 lsn,
                 const TWriteInstruction& instruction, const std::vector<NKikimrBlobStorage::NDDisk::TDDiskId>& persistentBufferIds,
                 ui32 replyTimeoutMicroseconds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             selector.Serialize(Record.MutableSelector());
             Record.SetLsn(lsn);
             Record.SetReplyTimeoutMicroseconds(replyTimeoutMicroseconds);
@@ -623,7 +765,7 @@ struct TPersistentBufferFormat {
 
         TEvReadPersistentBuffer(const TQueryCredentials& creds, const TBlockSelector& selector,
                 ui64 lsn, ui32 generation, const TReadInstruction& instruction) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             selector.Serialize(Record.MutableSelector());
             Record.SetLsn(lsn);
             Record.SetGeneration(generation);
@@ -663,7 +805,7 @@ struct TPersistentBufferFormat {
         TEvErasePersistentBuffer() = default;
 
         TEvErasePersistentBuffer(const TQueryCredentials& creds, ui64 lsn) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             Record.SetLsn(lsn);
         }
     };
@@ -674,11 +816,11 @@ struct TPersistentBufferFormat {
         TEvBatchErasePersistentBuffer() = default;
 
         TEvBatchErasePersistentBuffer(const TQueryCredentials& creds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
         }
 
         TEvBatchErasePersistentBuffer(const TQueryCredentials& creds, const std::vector<std::tuple<ui64, ui32>>& erases) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
             for (auto& [lsn, generation] : erases) {
                 auto* erase = Record.AddErases();
                 erase->SetLsn(lsn);
@@ -764,7 +906,7 @@ struct TPersistentBufferFormat {
         TEvListPersistentBuffer() = default;
 
         TEvListPersistentBuffer(const TQueryCredentials& creds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
         }
     };
 
@@ -789,7 +931,7 @@ struct TPersistentBufferFormat {
         TEvSync() = default;
 
         explicit TEvSync(const TQueryCredentials& creds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
         }
 
         static void SetSource(TSource *source, const TDDiskId& ddiskId, ui64 ddiskInstanceGuid) {
@@ -882,7 +1024,7 @@ struct TPersistentBufferFormat {
         TEvDeleteTabletChunks() = default;
 
         TEvDeleteTabletChunks(const TQueryCredentials& creds) {
-            creds.Serialize(Record.MutableCredentials());
+            creds.SerializeForRequest(Record.MutableCredentials());
         }
     };
 

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -15,6 +15,50 @@
 
 namespace NKikimr::NDDisk {
 
+    template<typename TEventPtr>
+    void TDDiskActor::HandlePersistentBufferWriteRequest(TEventPtr& ev) {
+        Y_ABORT_UNLESS(IsPersistentBufferActor);
+        auto& record = ev->Get()->Record;
+        TQueryCredentials requestCreds(record.GetCredentials());
+        TQueryCredentials creds;
+        EConnectionResolution resolution = ResolveConnection(requestCreds, &creds);
+
+        if (resolution != EConnectionResolution::Resolved) {
+            YDB_LOG_DEBUG("TDDiskActor::HandlePersistentBufferWriteRequest token validation failed",
+                {"reason", DescribeConnectionFailure(requestCreds, resolution)},
+                {"DDiskId", DDiskId},
+                {"evType", ev->GetTypeRewrite()},
+                {"sender", ev->Sender},
+                {"cookie", ev->Cookie},
+                {"ICSession", ev->InterconnectSession});
+
+            auto result = std::make_unique<TEvWritePersistentBuffersResult>();
+            const TStringBuf errorReason = ConnectionErrorReason(resolution);
+
+            for (const auto& id : record.GetPersistentBufferIds()) {
+                auto* item = result->Record.AddResult();
+                item->MutablePersistentBufferId()->CopyFrom(id);
+                item->MutableResult()->SetStatus(NKikimrBlobStorage::NDDisk::TReplyStatus::SESSION_MISMATCH);
+                item->MutableResult()->SetErrorReason(errorReason.data(), errorReason.size());
+            }
+
+            SendReply(*ev, std::move(result));
+            return;
+        }
+
+        creds.SerializeResolvedForRequest(record.MutableCredentials());
+        Y_ABORT_UNLESS(WritePersistentBuffersActor);
+        TActivationContext::Send(ev->Forward(WritePersistentBuffersActor));
+    }
+
+    void TDDiskActor::Handle(TEvReadThenWritePersistentBuffers::TPtr ev) {
+        HandlePersistentBufferWriteRequest(ev);
+    }
+
+    void TDDiskActor::Handle(TEvWritePersistentBuffers::TPtr ev) {
+        HandlePersistentBufferWriteRequest(ev);
+    }
+
 namespace {
     const TVector<double> WriteBatchSizeBounds = {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 24, 32, 40, 48, 64, 128
@@ -352,12 +396,8 @@ namespace {
             hFunc(TEvents::TEvWakeup, HandleWakeup);
             cFunc(TEvents::TSystem::Poison, PassAway)
 
-            case TEvReadThenWritePersistentBuffers::EventType:
-            case TEvWritePersistentBuffers::EventType: {
-                Y_ABORT_UNLESS(WritePersistentBuffersActor);
-                TActivationContext::Forward(ev, WritePersistentBuffersActor);
-                break;
-            }
+            hFunc(TEvReadThenWritePersistentBuffers, Handle)
+            hFunc(TEvWritePersistentBuffers, Handle)
         )
     }
 

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -28,6 +28,7 @@
 
 #include <ydb/core/util/spsc_circular_queue.h>
 
+#include <array>
 #include <atomic>
 #include <queue>
 
@@ -575,20 +576,58 @@ namespace NKikimr::NDDisk {
         // Connection management
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        struct TConnectionInfo {
-            ui64 TabletId;
-            ui32 Generation;
-            ui64 DDiskSessionSeqNo;
-            ui32 NodeId;
-            TActorId InterconnectSessionId;
+        enum class EConnectionTokenInvalidationReason : ui8 {
+            Reconnect,
+            Disconnect,
         };
-        THashMap<ui64, TConnectionInfo> Connections;
+
+        struct TPreviousConnectionTokenInfo {
+            TConnectionToken Token;
+            ui64 TabletId = 0;
+            ui32 Generation = 0;
+            ui32 DirectBlockGroupIndex = 0;
+            ui64 DDiskSessionSeqNo = 0;
+            EConnectionTokenInvalidationReason InvalidationReason = EConnectionTokenInvalidationReason::Reconnect;
+            bool Valid = false;
+        };
+
+        struct TConnectionInfo {
+            ui64 TabletId = 0;
+            ui32 Generation = 0;
+            ui32 DirectBlockGroupIndex = 0;
+            ui64 DDiskSessionSeqNo = 0;
+            ui32 NodeId = 0;
+            TActorId InterconnectSessionId;
+            TConnectionToken Token;
+            ui8 TokenSequenceNo = 0;
+            std::array<TPreviousConnectionTokenInfo, 2> PreviousTokens;
+            ui32 NextPreviousTokenIndex = 0;
+            bool Active = false;
+        };
+
+        using TConnectionKey = std::pair<ui64, ui32>;
+        TVector<TConnectionInfo> Connections;
+        THashMap<TConnectionKey, ui32> ConnectionIndexBySession;
+        TVector<ui32> FreeConnectionIndices;
 
         void Handle(TEvConnect::TPtr ev);
         void Handle(TEvDisconnect::TPtr ev);
 
-        // validate query credentials against registered connections
-        bool ValidateConnection(const IEventHandle& ev, const TQueryCredentials& creds) const;
+        TConnectionToken IssueConnectionToken(ui32 connectionIndex, TConnectionInfo& connection);
+
+        void RememberConnectionToken(TConnectionInfo& connection, EConnectionTokenInvalidationReason reason);
+
+        enum class EConnectionResolution : ui8 {
+            Resolved,
+            StaleToken,
+            InvalidToken,
+        };
+
+        // validate query credentials and restore token-backed connection data
+        EConnectionResolution ResolveConnection(const TQueryCredentials& requestCreds, TQueryCredentials* resolvedCreds) const;
+        static TStringBuf ConnectionErrorReason(EConnectionResolution resolution);
+        static TStringBuf ConnectionInvalidationReason(EConnectionTokenInvalidationReason reason);
+        TString DescribeConnectionFailure(const TQueryCredentials& requestCreds, EConnectionResolution resolution) const;
 
         // a general way to send reply to any incoming message
         void SendReply(const IEventHandle& queryEv, std::unique_ptr<IEventBase> replyEv) const;
@@ -596,7 +635,7 @@ namespace NKikimr::NDDisk {
         // common function to validate any incoming event's credentials
         template<typename TEvent, typename TCountersPtr>
         bool CheckQuery(TEventHandle<TEvent>& ev, TCountersPtr counters) const {
-            const auto& record = ev.Get()->Record;
+            auto& record = ev.Get()->Record;
             using TEventType = std::decay_t<TEvent>;
 
             auto registerError = [&] {
@@ -616,27 +655,24 @@ namespace NKikimr::NDDisk {
                     {"ICSession", ev.InterconnectSession});
             };
 
-            const TQueryCredentials creds(record.GetCredentials());
-            if (!ValidateConnection(ev, creds)) {
-                TStringBuilder mismatchReason;
-                mismatchReason << "session mismatch"
-                    << " tabletId# " << creds.TabletId
-                    << " generation# " << creds.Generation;
-                const auto connIt = Connections.find(creds.TabletId);
-                if (connIt != Connections.end()) {
-                    mismatchReason
-                        << " storedGeneration# " << connIt->second.Generation
-                        << " storedNodeId# "     << connIt->second.NodeId
-                        << " storedICSession# "  << connIt->second.InterconnectSessionId;
-                } else {
-                    mismatchReason << " (no stored session for tabletId)";
-                }
-                logError(mismatchReason);
-                SendReply(ev, std::make_unique<typename TEvent::TResult>(
-                    NKikimrBlobStorage::NDDisk::TReplyStatus::SESSION_MISMATCH));
+            const TQueryCredentials requestCreds(record.GetCredentials());
+            TQueryCredentials creds;
+            const EConnectionResolution resolution = ResolveConnection(requestCreds, &creds);
+
+            if (resolution != EConnectionResolution::Resolved) {
+                logError(DescribeConnectionFailure(requestCreds, resolution));
+                auto result = std::make_unique<typename TEvent::TResult>(
+                    NKikimrBlobStorage::NDDisk::TReplyStatus::SESSION_MISMATCH
+                );
+                const TStringBuf errorReason = ConnectionErrorReason(resolution);
+                result->Record.SetErrorReason(errorReason.data(), errorReason.size());
+
+                SendReply(ev, std::move(result));
                 registerError();
                 return false;
             }
+
+            creds.SerializeResolvedForRequest(record.MutableCredentials());
 
             using TRecord = std::decay_t<decltype(record)>;
 
@@ -912,6 +948,10 @@ namespace NKikimr::NDDisk {
         void Handle(TEvPrivate::TEvDeallocatePersistentBufferChunkResult::TPtr ev);
         void Handle(TEvGetPersistentBufferInfo::TPtr ev);
 
+        template<typename TEventPtr>
+        void HandlePersistentBufferWriteRequest(TEventPtr& ev);
+
+        void Handle(TEvReadThenWritePersistentBuffers::TPtr ev);
         void Handle(TEvWritePersistentBuffers::TPtr ev);
 
         void Handle(TEvPrivate::TEvReadPersistentBufferPart::TPtr ev);

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_connect.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_connect.cpp
@@ -6,6 +6,40 @@
 
 namespace NKikimr::NDDisk {
 
+    TConnectionToken TDDiskActor::IssueConnectionToken(ui32 connectionIndex, TConnectionInfo& connection) {
+        if (++connection.TokenSequenceNo == 0) {
+            ++connection.TokenSequenceNo;
+        }
+
+        return TConnectionToken::Make(
+            connectionIndex,
+            connection.TokenSequenceNo,
+            static_cast<ui32>(connection.TabletId),
+            static_cast<ui16>(BaseInfo.PDiskActorID.NodeId()),
+            static_cast<ui16>(BaseInfo.PDiskId),
+            static_cast<ui16>(BaseInfo.VDiskSlotId),
+            static_cast<ui8>(RandomNumber<ui32>())
+        );
+    }
+
+    void TDDiskActor::RememberConnectionToken(TConnectionInfo& connection, EConnectionTokenInvalidationReason reason) {
+        if (!connection.Token) {
+            return;
+        }
+
+        ui8 nextIdx = connection.NextPreviousTokenIndex;
+        auto& prevTokens = connection.PreviousTokens;
+        TPreviousConnectionTokenInfo& previous = prevTokens[nextIdx];
+        previous.Token = connection.Token;
+        previous.TabletId = connection.TabletId;
+        previous.DirectBlockGroupIndex = connection.DirectBlockGroupIndex;
+        previous.Generation = connection.Generation;
+        previous.DDiskSessionSeqNo = connection.DDiskSessionSeqNo;
+        previous.InvalidationReason = reason;
+        previous.Valid = true;
+        connection.NextPreviousTokenIndex = (nextIdx + 1) % prevTokens.size();
+    }
+
     void TDDiskActor::Handle(TEvConnect::TPtr ev) {
         const auto& record = ev->Get()->Record;
         YDB_LOG_DEBUG("TDDiskActor::Handle(TEvConnect)",
@@ -14,13 +48,43 @@ namespace NKikimr::NDDisk {
             {"record", record});
 
         const TQueryCredentials creds(record.GetCredentials());
-        const auto [it, inserted] = Connections.try_emplace(creds.TabletId);
-        TConnectionInfo& connection = it->second;
 
-        if (!inserted) {
-            const bool obsoleteSession =
+        using TCreds = NKikimrBlobStorage::NDDisk::TQueryCredentials;
+        auto expectedRequestKind = IsPersistentBufferActor
+            ? TCreds::REQUEST_KIND_TO_PERSISTENT_BUFFER
+            : TCreds::REQUEST_KIND_TO_DDISK;
+        if (creds.RequestKind != expectedRequestKind) {
+            SendReply(*ev, std::make_unique<TEvConnectResult>(
+                NKikimrBlobStorage::NDDisk::TReplyStatus::INCORRECT_REQUEST,
+                TString("connection kind does not match recipient")));
+            return;
+        }
+
+        TConnectionKey connectionKey{
+            creds.TabletId,
+            creds.DirectBlockGroupIndex
+        };
+        auto [it, inserted] = ConnectionIndexBySession.try_emplace(connectionKey);
+
+        if (inserted) {
+            if (!FreeConnectionIndices.empty()) {
+                it->second = FreeConnectionIndices.back();
+                FreeConnectionIndices.pop_back();
+            } else {
+                Y_ABORT_UNLESS(Connections.size() < Max<ui32>());
+                it->second = Connections.size();
+                Connections.emplace_back();
+            }
+        }
+
+        ui32 connectionIndex = it->second;
+        TConnectionInfo& connection = Connections[connectionIndex];
+        bool sameSession = false;
+
+        if (!inserted && connection.Active) {
+            bool obsoleteSession =
                 creds.Generation < connection.Generation ||
-                (creds.RequiresDDiskSessionSeqNoCheck() &&
+                (!IsPersistentBufferActor &&
                  creds.Generation == connection.Generation &&
                  creds.DDiskSessionSeqNo < connection.DDiskSessionSeqNo);
             if (obsoleteSession) {
@@ -28,21 +92,34 @@ namespace NKikimr::NDDisk {
                 SendReply(*ev, std::make_unique<TEvConnectResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::BLOCKED));
                 return;
             }
+            sameSession =
+                creds.Generation == connection.Generation &&
+                (IsPersistentBufferActor || creds.DDiskSessionSeqNo == connection.DDiskSessionSeqNo);
+        }
+
+        if (!sameSession && connection.Active) {
+            RememberConnectionToken( connection, EConnectionTokenInvalidationReason::Reconnect);
         }
 
         connection.TabletId = creds.TabletId;
+        connection.DirectBlockGroupIndex = creds.DirectBlockGroupIndex;
         connection.Generation = creds.Generation;
         connection.DDiskSessionSeqNo = creds.DDiskSessionSeqNo;
         connection.NodeId = ev->Sender.NodeId();
         connection.InterconnectSessionId = ev->InterconnectSession;
+        connection.Active = true;
+        if (!sameSession) {
+            connection.Token = IssueConnectionToken(connectionIndex, connection);
+        }
 
         YDB_LOG_DEBUG("TDDiskActor::Handle(TEvConnect) sending OK",
             {"marker", "BSDD11"},
             {"DDiskId", DDiskId},
             {"recipient", ev->Sender},
             {"ICSession", ev->InterconnectSession});
-        SendReply(*ev, std::make_unique<TEvConnectResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
-                DDiskInstanceGuid));
+        auto result = std::make_unique<TEvConnectResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
+                DDiskInstanceGuid, connection.Token);
+        SendReply(*ev, std::move(result));
 
         if (ev->InterconnectSession) {
             // subscribe to session to check for disconnections (if not yet)
@@ -55,23 +132,183 @@ namespace NKikimr::NDDisk {
         }
 
         const auto& record = ev->Get()->Record;
-        const TQueryCredentials creds(record.GetCredentials());
-        Connections.erase(creds.TabletId);
+        TQueryCredentials creds(record.GetCredentials());
+        TConnectionKey connectionKey{
+            creds.TabletId,
+            creds.DirectBlockGroupIndex
+        };
+        auto &connectionDict = ConnectionIndexBySession;
+
+        if (auto it = connectionDict.find(connectionKey); it != connectionDict.end()) {
+            TConnectionInfo& connection = Connections[it->second];
+            RememberConnectionToken( connection, EConnectionTokenInvalidationReason::Disconnect);
+            connection.Active = false;
+            connection.Token = {};
+            FreeConnectionIndices.push_back(it->second);
+            connectionDict.erase(it);
+        }
         SendReply(*ev, std::make_unique<TEvDisconnectResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK));
     }
 
-    bool TDDiskActor::ValidateConnection(const IEventHandle& ev, const TQueryCredentials& creds) const {
-        const auto it = Connections.find(creds.TabletId);
-        if (it == Connections.end()) {
-            return creds.IsInternal();
+    TDDiskActor::EConnectionResolution TDDiskActor::ResolveConnection(const TQueryCredentials& requestCreds, TQueryCredentials* resolvedCreds) const {
+        if (requestCreds.ConnectionToken) {
+            ui32 index = requestCreds.ConnectionToken->GetConnectionIndex();
+            if (index >= Connections.size()) {
+                return EConnectionResolution::InvalidToken;
+            }
+
+            const TConnectionInfo* connection = &Connections[index];
+            if (!connection->Active || connection->Token != *requestCreds.ConnectionToken) {
+                for (const auto& previous : connection->PreviousTokens) {
+                    if (previous.Valid && previous.Token == *requestCreds.ConnectionToken) {
+                        return EConnectionResolution::StaleToken;
+                    }
+                }
+
+                return EConnectionResolution::InvalidToken;
+            }
+
+            using TCreds = NKikimrBlobStorage::NDDisk::TQueryCredentials;
+            auto requestKind = IsPersistentBufferActor
+                ? TCreds::REQUEST_KIND_TO_PERSISTENT_BUFFER
+                : TCreds::REQUEST_KIND_TO_DDISK;
+
+            *resolvedCreds = TQueryCredentials(
+                connection->TabletId,
+                connection->Generation,
+                connection->DDiskSessionSeqNo,
+                DDiskInstanceGuid,
+                requestKind,
+                connection->DirectBlockGroupIndex
+            );
+            resolvedCreds->ConnectionToken = requestCreds.ConnectionToken;
+            return EConnectionResolution::Resolved;
         }
-        const TConnectionInfo& connection = it->second;
-        return connection.TabletId == creds.TabletId &&
-            connection.Generation == creds.Generation &&
-            (!creds.RequiresDDiskSessionSeqNoCheck() || connection.DDiskSessionSeqNo == creds.DDiskSessionSeqNo) &&
-            (!creds.DDiskInstanceGuid || creds.DDiskInstanceGuid == DDiskInstanceGuid) &&
-            (!creds.RequiresSenderCheck() || connection.NodeId == ev.Sender.NodeId()) &&
-            (!creds.RequiresInterconnectSessionCheck() || connection.InterconnectSessionId == ev.InterconnectSession);
+
+        if (requestCreds.HasServerContext()) {
+            TConnectionKey connectionKey{
+                requestCreds.TabletId,
+                requestCreds.DirectBlockGroupIndex
+            };
+            auto it = ConnectionIndexBySession.find(connectionKey);
+
+            if (requestCreds.IsInternal()) {
+                // Cross-DDisk fanout may target an actor without a client
+                // connection. If the slot exists, preserve the old generation
+                // and instance checks.
+                if (it != ConnectionIndexBySession.end()) {
+                    const TConnectionInfo& connection = Connections[it->second];
+                    bool isValid = connection.Active &&
+                        connection.Generation == requestCreds.Generation &&
+                        (!requestCreds.DDiskInstanceGuid || requestCreds.DDiskInstanceGuid == DDiskInstanceGuid);
+
+                    if (!isValid) {
+                        return EConnectionResolution::InvalidToken;
+                    }
+                }
+            } else {
+                // A token-resolved request may re-enter the production
+                // executor. Accept its server context only for the exact slot
+                // from which it was restored.
+
+                using TCreds = NKikimrBlobStorage::NDDisk::TQueryCredentials;
+                auto expectedRequestKind = IsPersistentBufferActor
+                    ? TCreds::REQUEST_KIND_TO_PERSISTENT_BUFFER
+                    : TCreds::REQUEST_KIND_TO_DDISK;
+
+                if (requestCreds.RequestKind != expectedRequestKind || it == ConnectionIndexBySession.end()) {
+                    return EConnectionResolution::InvalidToken;
+                }
+
+                const TConnectionInfo& connection = Connections[it->second];
+                bool isValid = connection.Active &&
+                    connection.Generation == requestCreds.Generation &&
+                    connection.DDiskSessionSeqNo == requestCreds.DDiskSessionSeqNo &&
+                    (!requestCreds.DDiskInstanceGuid || requestCreds.DDiskInstanceGuid == DDiskInstanceGuid);
+
+                if (!isValid) {
+                    return EConnectionResolution::InvalidToken;
+                }
+            }
+
+            *resolvedCreds = requestCreds;
+            return EConnectionResolution::Resolved;
+        }
+
+        return EConnectionResolution::InvalidToken;
+    }
+
+    TStringBuf TDDiskActor::ConnectionErrorReason(EConnectionResolution resolution) {
+        switch (resolution) {
+            case EConnectionResolution::Resolved:
+                return {};
+            case EConnectionResolution::StaleToken:
+                return "stale connection token";
+            case EConnectionResolution::InvalidToken:
+                return "invalid connection token";
+        }
+        Y_UNREACHABLE();
+    }
+
+    TStringBuf TDDiskActor::ConnectionInvalidationReason(EConnectionTokenInvalidationReason reason) {
+        switch (reason) {
+            case EConnectionTokenInvalidationReason::Reconnect:
+                return "reconnect";
+            case EConnectionTokenInvalidationReason::Disconnect:
+                return "disconnect";
+        }
+        Y_UNREACHABLE();
+    }
+
+    TString TDDiskActor::DescribeConnectionFailure(const TQueryCredentials& requestCreds, EConnectionResolution resolution) const {
+        TStringBuilder reason;
+        reason << ConnectionErrorReason(resolution);
+
+        if (!requestCreds.ConnectionToken) {
+            return reason;
+        }
+
+        const TConnectionToken& token = *requestCreds.ConnectionToken;
+        const ui32 index = token.GetConnectionIndex();
+        reason
+            << " claimedConnectionIndex# " << index
+            << " claimedSequenceNo# " << static_cast<ui32>(token.GetSequenceNo())
+            << " claimedTabletIdSuffix# " << token.GetTabletIdSuffix()
+            << " claimedNodeId# " << token.GetNodeId()
+            << " claimedPDiskId# " << token.GetPDiskId()
+            << " claimedVSlotId# " << token.GetVSlotId();
+        if (index >= Connections.size()) {
+            reason << " slot# out-of-range";
+            return reason;
+        }
+
+        const TConnectionInfo& connection = Connections[index];
+        reason
+            << " slotActive# " << connection.Active
+            << " slotTabletId# " << connection.TabletId
+            << " slotDirectBlockGroupIndex# " << connection.DirectBlockGroupIndex
+            << " slotGeneration# " << connection.Generation
+            << " slotDDiskSessionSeqNo# " << connection.DDiskSessionSeqNo
+            << " slotTokenSequenceNo# " << static_cast<ui32>(connection.TokenSequenceNo)
+            << " slotNodeId# " << connection.NodeId
+            << " slotICSession# " << connection.InterconnectSessionId;
+
+        if (resolution == EConnectionResolution::StaleToken) {
+            for (const TPreviousConnectionTokenInfo& previous : connection.PreviousTokens) {
+                if (previous.Valid && previous.Token == token) {
+                    reason
+                        << " previousTabletId# " << previous.TabletId
+                        << " previousDirectBlockGroupIndex# " << previous.DirectBlockGroupIndex
+                        << " previousGeneration# " << previous.Generation
+                        << " previousDDiskSessionSeqNo# " << previous.DDiskSessionSeqNo
+                        << " invalidatedBy# " << ConnectionInvalidationReason(previous.InvalidationReason);
+
+                    break;
+                }
+            }
+        }
+
+        return reason;
     }
 
     void TDDiskActor::SendReply(const IEventHandle& queryEv, std::unique_ptr<IEventBase> replyEv) const {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_mon.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_mon.cpp
@@ -215,7 +215,11 @@ void TDDiskActor::Handle(NMon::TEvHttpInfo::TPtr ev) {
         }
 
         // --- Section 5: Active connections ------------------------------------------
-        str << "<h3>Active connections (" << Connections.size() << ")</h3>";
+        size_t activeConnectionCount = 0;
+        for (const auto& connection : Connections) {
+            activeConnectionCount += connection.Active;
+        }
+        str << "<h3>Active connections (" << activeConnectionCount << ")</h3>";
         TABLE_CLASS("table") {
             TABLEHEAD() {
                 TABLER() {
@@ -226,8 +230,10 @@ void TDDiskActor::Handle(NMon::TEvHttpInfo::TPtr ev) {
                 }
             }
             TABLEBODY() {
-                for (const auto& [tabletId, info] : Connections) {
-                    Y_UNUSED(tabletId);
+                for (const auto& info : Connections) {
+                    if (!info.Active) {
+                        continue;
+                    }
                     TABLER() {
                         TABLED() { str << info.TabletId; }
                         TABLED() { str << info.Generation; }

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_persistent_buffer.cpp
@@ -1324,11 +1324,12 @@ namespace NKikimr::NDDisk {
 
     void TDDiskActor::Handle(TEvReadPersistentBuffer::TPtr ev) {
         const auto& record = ev->Get()->Record;
-        const TQueryCredentials creds(record.GetCredentials());
+        TQueryCredentials creds(record.GetCredentials());
         if ((!creds.IsInternal() || record.HasSelector()) &&
             !CheckQuery(*ev, &Counters.Interface.ReadPersistentBuffer)) {
             return;
         }
+        creds = TQueryCredentials(record.GetCredentials());
 
         if (!PersistentBufferReady) {
             if (PendingPersistentBufferEvents.size() >= PersistentBufferFormat.MaxPendingEventsQueueSize) {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_sync.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_sync.cpp
@@ -75,7 +75,8 @@ namespace NKikimr::NDDisk {
             sourceInfo->Creds = TQueryCredentials::ForInternal(
                 creds.TabletId,
                 creds.Generation,
-                std::make_optional(source.GetDDiskInstanceGuid()));
+                std::make_optional(source.GetDDiskInstanceGuid()),
+                creds.DirectBlockGroupIndex);
             return true;
         };
 

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_batch_write_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_batch_write_ut.cpp
@@ -345,13 +345,15 @@ TString MakeData(char ch, ui32 size) {
 }
 
 NDDisk::TQueryCredentials Connect(TTestContext& ctx, const TActorId& serviceId, ui64 tabletId, ui32 generation) {
-    NDDisk::TQueryCredentials creds;
-    creds.TabletId = tabletId;
-    creds.Generation = generation;
+    const bool isPersistentBuffer = serviceId.IsService() && serviceId.ServiceId().StartsWith("NPB_");
+    NDDisk::TQueryCredentials creds = isPersistentBuffer
+        ? NDDisk::TQueryCredentials::ToPersistentBuffer(tabletId, generation, std::nullopt, 0)
+        : NDDisk::TQueryCredentials::ToDDisk(tabletId, generation, 0, std::nullopt, 0);
 
     auto connectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, serviceId, new NDDisk::TEvConnect(creds));
     AssertStatus(connectResult, TReplyStatus::OK);
     creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
+    creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
     return creds;
 }

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_checksum_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_checksum_ut.cpp
@@ -333,13 +333,15 @@ TRope MakeAlignedRope(const TString& data) {
 }
 
 NDDisk::TQueryCredentials Connect(TTestContext& ctx, const TActorId& serviceId, ui64 tabletId, ui32 generation) {
-    NDDisk::TQueryCredentials creds;
-    creds.TabletId = tabletId;
-    creds.Generation = generation;
+    const bool isPersistentBuffer = serviceId.IsService() && serviceId.ServiceId().StartsWith("NPB_");
+    NDDisk::TQueryCredentials creds = isPersistentBuffer
+        ? NDDisk::TQueryCredentials::ToPersistentBuffer(tabletId, generation, std::nullopt, 0)
+        : NDDisk::TQueryCredentials::ToDDisk(tabletId, generation, 0, std::nullopt, 0);
 
     auto connectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, serviceId, new NDDisk::TEvConnect(creds));
     AssertStatus(connectResult, TReplyStatus::OK);
     creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
+    creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
     return creds;
 }

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_common_ut.h
@@ -346,6 +346,7 @@ NDDisk::TQueryCredentials Connect(TTestContext& ctx, ui64 tabletId, ui32 generat
     auto connectResult = ctx.SendAndGrab<NDDisk::TEvConnectResult>(new NDDisk::TEvConnect(creds));
     AssertStatus<NDDisk::TEvConnectResult>(connectResult, TReplyStatus::OK);
     creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
+    creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
     return creds;
 }
@@ -358,6 +359,7 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
     auto connectResult = ctx.SendToAndGrab<NDDisk::TEvConnectResult>(diskIdx, new NDDisk::TEvConnect(creds));
     AssertStatus<NDDisk::TEvConnectResult>(connectResult, TReplyStatus::OK);
     creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
+    creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
     return creds;
 }
@@ -938,6 +940,35 @@ NDDisk::TQueryCredentials ConnectTo(TTestContext& ctx, ui32 diskIdx, ui64 tablet
         AssertStatus<NDDisk::TEvReadResult>(rr, TReplyStatus::OK);
         UNIT_ASSERT_VALUES_EQUAL(rr->Get()->GetPayload(0).ConvertToString(), data);
     }
+}
+
+[[maybe_unused]] void TestConnectionTokenAcrossRestart() {
+    TTestContext ctx;
+    NDDisk::TQueryCredentials creds = Connect(ctx, 702, 1);
+    const ui64 oldDDiskInstanceGuid = *creds.DDiskInstanceGuid;
+    const NDDisk::TConnectionToken oldToken = *creds.ConnectionToken;
+
+    ctx.RestartDDisk(0);
+
+    auto staleRead = ctx.SendAndGrab<NDDisk::TEvReadResult>(new NDDisk::TEvRead(creds, {0, 0, MinBlockSize}, {true}));
+    AssertStatus<NDDisk::TEvReadResult>(staleRead, TReplyStatus::SESSION_MISMATCH);
+
+    auto connectResult = ctx.SendAndGrab<NDDisk::TEvConnectResult>(new NDDisk::TEvConnect(creds));
+    AssertStatus<NDDisk::TEvConnectResult>(connectResult, TReplyStatus::OK);
+
+    creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
+    creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
+    UNIT_ASSERT_VALUES_UNEQUAL(*creds.DDiskInstanceGuid, oldDDiskInstanceGuid);
+    UNIT_ASSERT(*creds.ConnectionToken != oldToken);
+
+    auto currentRead = ctx.SendAndGrab<NDDisk::TEvReadResult>(new NDDisk::TEvRead(creds, {0, 0, MinBlockSize}, {true}));
+    AssertStatus<NDDisk::TEvReadResult>(currentRead, TReplyStatus::OK);
+
+    NDDisk::TQueryCredentials staleCreds = creds;
+    staleCreds.ConnectionToken = oldToken;
+    staleRead = ctx.SendAndGrab<NDDisk::TEvReadResult>(
+        new NDDisk::TEvRead(staleCreds, {0, 0, MinBlockSize}, {true}));
+    AssertStatus<NDDisk::TEvReadResult>(staleRead, TReplyStatus::SESSION_MISMATCH);
 }
 
 [[maybe_unused]] void TestRestartAfterCutLog(NDDisk::TDDiskConfig ddiskConfig) {

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_pdisk_ut.cpp
@@ -99,6 +99,10 @@ Y_UNIT_TEST_SUITE(TDDiskActorPDiskTest) {
         TestEmptyRestart({.ForcePDiskFallback = true});
     }
 
+    Y_UNIT_TEST(ConnectionTokenAcrossRestart) {
+        TestConnectionTokenAcrossRestart();
+    }
+
     Y_UNIT_TEST(RestartAfterCutLog_Uring) {
         TestRestartAfterCutLog({});
     }

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -230,14 +230,22 @@ NDDisk::TEvSync::TDDiskId MakeSyncSourceId(ui32 pdiskId, ui32 slotId) {
     return std::make_tuple(NodeId, pdiskId, slotId);
 }
 
-NDDisk::TQueryCredentials Connect(TTestContext& ctx, const TActorId& serviceId, ui64 tabletId, ui32 generation) {
-    NDDisk::TQueryCredentials creds;
-    creds.TabletId = tabletId;
-    creds.Generation = generation;
+NDDisk::TQueryCredentials Connect(
+        TTestContext& ctx,
+        const TActorId& serviceId,
+        ui64 tabletId,
+        ui32 generation,
+        ui32 directBlockGroupIndex = 0
+) {
+    const bool isPersistentBuffer = serviceId.IsService() && serviceId.ServiceId().StartsWith("NPB_");
+    NDDisk::TQueryCredentials creds = isPersistentBuffer
+        ? NDDisk::TQueryCredentials::ToPersistentBuffer(tabletId, generation, std::nullopt, directBlockGroupIndex)
+        : NDDisk::TQueryCredentials::ToDDisk(tabletId, generation, 0, std::nullopt, directBlockGroupIndex);
 
     auto connectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, serviceId, new NDDisk::TEvConnect(creds));
     AssertStatus(connectResult, TReplyStatus::OK);
     creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
+    creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
     return creds;
 }
@@ -370,15 +378,10 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             ctx, disk.ServiceId, new NDDisk::TEvConnect(creds));
         AssertStatus(connectResult, TReplyStatus::OK);
         creds.DDiskInstanceGuid = connectResult->Get()->Record.GetDDiskInstanceGuid();
-
-        NDDisk::TQueryCredentials badGuid = creds;
-        badGuid.DDiskInstanceGuid = *badGuid.DDiskInstanceGuid + 1;
-        auto wrongGuidRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
-            ctx, disk.ServiceId, new NDDisk::TEvRead(badGuid, {0, 0, BlockSize}, {true}));
-        AssertStatus(wrongGuidRead, TReplyStatus::SESSION_MISMATCH);
+        creds.ConnectionToken.emplace(connectResult->Get()->Record.GetConnectionToken());
 
         auto disconnect = std::make_unique<NDDisk::TEvDisconnect>();
-        creds.Serialize(disconnect->Record.MutableCredentials());
+        creds.SerializeForRequest(disconnect->Record.MutableCredentials());
         auto disconnectResult = SendToDDiskAndWait<NDDisk::TEvDisconnectResult>(ctx, disk.ServiceId,
             disconnect.release());
         AssertStatus(disconnectResult, TReplyStatus::OK);
@@ -386,6 +389,336 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         auto readAfterDisconnect = SendToDDiskAndWait<NDDisk::TEvReadResult>(
             ctx, disk.ServiceId, new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true}));
         AssertStatus(readAfterDisconnect, TReplyStatus::SESSION_MISMATCH);
+    }
+
+    Y_UNIT_TEST(ConnectionTokenBitLayout) {
+        // Verify the exact 128-bit connection token layout:
+        // 1. Pack distinct values into every field.
+        // 2. Check the resulting Low and High words.
+        // 3. Decode every field and compare it with the original value.
+        NDDisk::TConnectionToken token = NDDisk::TConnectionToken::Make(
+            0x1122'3344,
+            0x55,
+            0x6677'8899,
+            0xaabb,
+            0xccdd,
+            0xeeff,
+            0x12
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(0x6677'8899'1122'3344, token.Low);
+        UNIT_ASSERT_VALUES_EQUAL(0xeeff'ccdd'aabb'1255, token.High);
+        UNIT_ASSERT_VALUES_EQUAL(0x1122'3344, token.GetConnectionIndex());
+        UNIT_ASSERT_VALUES_EQUAL(0x55, token.GetSequenceNo());
+        UNIT_ASSERT_VALUES_EQUAL(0x6677'8899, token.GetTabletIdSuffix());
+        UNIT_ASSERT_VALUES_EQUAL(0xaabb, token.GetNodeId());
+        UNIT_ASSERT_VALUES_EQUAL(0xccdd, token.GetPDiskId());
+        UNIT_ASSERT_VALUES_EQUAL(0xeeff, token.GetVSlotId());
+        UNIT_ASSERT_VALUES_EQUAL(0x12, token.GetRandom());
+    }
+
+    Y_UNIT_TEST(ConnectionTokenValidation) {
+        // Verify token validation and bounded stale-token history:
+        // 1. Connect and check the issued token's slot and identity fields.
+        // 2. Corrupt the token and reject it as invalid.
+        // 3. Repeat the same connect idempotently, then reconnect in the same
+        //    slot with a larger session sequence and rotate the token.
+        // 4. Rotate twice more and check that the two recent tokens are stale
+        //    while the oldest token has fallen out of bounded history.
+        // 5. Use the current token successfully and verify the external request
+        //    contains no server-side context.
+        // 6. Disconnect, reuse the freed slot, and keep the disconnected token
+        //    classified as stale.
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(2, 4);
+
+        constexpr ui64 TabletId = 0x1234'5678'9abc'def0;
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, TabletId, 1);
+        UNIT_ASSERT(creds.ConnectionToken);
+
+        const NDDisk::TConnectionToken firstToken = *creds.ConnectionToken;
+        UNIT_ASSERT_VALUES_EQUAL(0, firstToken.GetConnectionIndex());
+        UNIT_ASSERT_VALUES_EQUAL(1, firstToken.GetSequenceNo());
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<ui32>(TabletId), firstToken.GetTabletIdSuffix());
+        UNIT_ASSERT_VALUES_EQUAL(NodeId, firstToken.GetNodeId());
+        UNIT_ASSERT_VALUES_EQUAL(disk.PDiskId, firstToken.GetPDiskId());
+        UNIT_ASSERT_VALUES_EQUAL(disk.SlotId, firstToken.GetVSlotId());
+
+        NDDisk::TQueryCredentials corrupted = creds;
+        corrupted.ConnectionToken->High ^= 1ull << 32;
+        auto corruptedTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(corrupted, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(corruptedTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("invalid connection token", corruptedTokenRead->Get()->Record.GetErrorReason());
+
+        auto reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(creds)
+        );
+        AssertStatus(reconnectResult, TReplyStatus::OK);
+
+        NDDisk::TQueryCredentials reconnected = creds;
+        reconnected.ConnectionToken.emplace(reconnectResult->Get()->Record.GetConnectionToken());
+        UNIT_ASSERT(firstToken == *reconnected.ConnectionToken);
+
+        reconnected.DDiskSessionSeqNo++;
+        reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(reconnected)
+        );
+        AssertStatus(reconnectResult, TReplyStatus::OK);
+        reconnected.ConnectionToken.emplace(reconnectResult->Get()->Record.GetConnectionToken());
+        UNIT_ASSERT_VALUES_EQUAL(firstToken.GetConnectionIndex(), reconnected.ConnectionToken->GetConnectionIndex());
+        UNIT_ASSERT_VALUES_EQUAL(firstToken.GetSequenceNo() + 1, reconnected.ConnectionToken->GetSequenceNo());
+        UNIT_ASSERT(firstToken != *reconnected.ConnectionToken);
+        const NDDisk::TConnectionToken secondToken = *reconnected.ConnectionToken;
+
+        auto obsoleteTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(obsoleteTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("stale connection token", obsoleteTokenRead->Get()->Record.GetErrorReason());
+
+        reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(reconnected)
+        );
+        AssertStatus(reconnectResult, TReplyStatus::OK);
+        auto expectedToken = NDDisk::TConnectionToken(reconnectResult->Get()->Record.GetConnectionToken());
+        UNIT_ASSERT(*reconnected.ConnectionToken == expectedToken);
+
+        reconnected.DDiskSessionSeqNo++;
+        reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(reconnected)
+        );
+        AssertStatus(reconnectResult, TReplyStatus::OK);
+
+        reconnected.ConnectionToken.emplace(reconnectResult->Get()->Record.GetConnectionToken());
+        obsoleteTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(obsoleteTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("stale connection token", obsoleteTokenRead->Get()->Record.GetErrorReason());
+
+        reconnected.DDiskSessionSeqNo++;
+        reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(reconnected)
+        );
+        AssertStatus(reconnectResult, TReplyStatus::OK);
+
+        reconnected.ConnectionToken.emplace(reconnectResult->Get()->Record.GetConnectionToken());
+        obsoleteTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(obsoleteTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("invalid connection token", obsoleteTokenRead->Get()->Record.GetErrorReason());
+
+        NDDisk::TQueryCredentials secondTokenCreds = creds;
+        secondTokenCreds.ConnectionToken = secondToken;
+        auto secondTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(secondTokenCreds, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(secondTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("stale connection token", secondTokenRead->Get()->Record.GetErrorReason());
+
+        auto currentTokenRequest = std::make_unique<NDDisk::TEvRead>(
+            reconnected,
+            NDDisk::TBlockSelector{0, 0, BlockSize},
+            NDDisk::TReadInstruction{true}
+        );
+        const auto& requestCredentials = currentTokenRequest->Record.GetCredentials();
+        UNIT_ASSERT(requestCredentials.HasConnectionToken());
+        UNIT_ASSERT(!requestCredentials.HasInternal());
+
+        auto currentTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            currentTokenRequest.release()
+        );
+        AssertStatus(currentTokenRead, TReplyStatus::OK);
+
+        auto disconnect = std::make_unique<NDDisk::TEvDisconnect>();
+        reconnected.SerializeForRequest(disconnect->Record.MutableCredentials());
+        auto disconnectResult = SendToDDiskAndWait<NDDisk::TEvDisconnectResult>(
+            ctx,
+            disk.ServiceId,
+            disconnect.release()
+        );
+        AssertStatus(disconnectResult, TReplyStatus::OK);
+
+        NDDisk::TQueryCredentials reused = Connect(ctx, disk.ServiceId, TabletId + 1, 1);
+        UNIT_ASSERT_VALUES_EQUAL(firstToken.GetConnectionIndex(), reused.ConnectionToken->GetConnectionIndex());
+        UNIT_ASSERT_VALUES_EQUAL(reconnected.ConnectionToken->GetSequenceNo() + 1, reused.ConnectionToken->GetSequenceNo());
+
+        auto invalidatedTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(reconnected, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(invalidatedTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("stale connection token", invalidatedTokenRead->Get()->Record.GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ConnectionTokenSequenceWraps) {
+        // Verify that the 8-bit token sequence wraps without breaking a slot:
+        // 1. Establish a connection and remember its vector index.
+        // 2. Reconnect in the same slot until the token sequence reaches 255.
+        // 3. Reconnect once more and check that zero is skipped and sequence 1
+        //    is issued for the same vector index.
+        // 4. Use the new token successfully and reject the preceding token as
+        //    stale.
+        TTestContext ctx;
+        TDiskHandle disk = ctx.CreateDDisk(2, 6);
+
+        NDDisk::TQueryCredentials creds = Connect(ctx, disk.ServiceId, 0x1234'5678'9abc'def0, 1);
+        ui32 connectionIndex = creds.ConnectionToken->GetConnectionIndex();
+        std::optional<NDDisk::TConnectionToken> tokenBeforeWrap;
+
+        for (ui32 i = 0; i < 255; ++i) {
+            if (i == 254) {
+                tokenBeforeWrap = creds.ConnectionToken;
+                UNIT_ASSERT_VALUES_EQUAL(Max<ui8>(), tokenBeforeWrap->GetSequenceNo());
+            }
+
+            ++creds.DDiskSessionSeqNo;
+            auto reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+                ctx,
+                disk.ServiceId,
+                new NDDisk::TEvConnect(creds)
+            );
+            AssertStatus(reconnectResult, TReplyStatus::OK);
+
+            const NDDisk::TConnectionToken nextToken(reconnectResult->Get()->Record.GetConnectionToken());
+            UNIT_ASSERT_VALUES_EQUAL(connectionIndex, nextToken.GetConnectionIndex());
+            UNIT_ASSERT(*creds.ConnectionToken != nextToken);
+            creds.ConnectionToken = nextToken;
+        }
+
+        UNIT_ASSERT(tokenBeforeWrap);
+        UNIT_ASSERT_VALUES_EQUAL(1, creds.ConnectionToken->GetSequenceNo());
+
+        auto currentTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(creds, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(currentTokenRead, TReplyStatus::OK);
+
+        NDDisk::TQueryCredentials staleCreds = creds;
+        staleCreds.ConnectionToken = tokenBeforeWrap;
+        auto staleTokenRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(staleCreds, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(staleTokenRead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "stale connection token",
+            staleTokenRead->Get()->Record.GetErrorReason()
+        );
+    }
+
+    Y_UNIT_TEST(ConnectionTokenSeparatesDirectBlockGroups) {
+        // Verify independent connection slots for two DBGs of one tablet:
+        // 1. Connect two DBGs and check that their slots and tokens differ.
+        // 2. Repeat DBG B's connect idempotently.
+        // 3. Reconnect DBG A in its original slot, invalidate only A's old
+        //    token, and keep DBG B usable.
+        // 4. Disconnect DBG A, reuse its freed slot for DBG C, and verify DBG B
+        //    is still usable.
+        TTestContext ctx;
+        const TDiskHandle disk = ctx.CreateDDisk(2, 5);
+
+        constexpr ui64 TabletId = 0x1234'5678'9abc'def0;
+        NDDisk::TQueryCredentials groupA = Connect(ctx, disk.ServiceId, TabletId, 1, 10);
+        NDDisk::TQueryCredentials groupB = Connect(ctx, disk.ServiceId, TabletId, 1, 11);
+
+        UNIT_ASSERT(groupA.ConnectionToken);
+        UNIT_ASSERT(groupB.ConnectionToken);
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            groupA.ConnectionToken->GetConnectionIndex(),
+            groupB.ConnectionToken->GetConnectionIndex()
+        );
+        UNIT_ASSERT(*groupA.ConnectionToken != *groupB.ConnectionToken);
+
+        auto duplicateConnect = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(groupB)
+        );
+        AssertStatus(duplicateConnect, TReplyStatus::OK);
+        auto expectedToken = NDDisk::TConnectionToken(duplicateConnect->Get()->Record.GetConnectionToken());
+        UNIT_ASSERT(*groupB.ConnectionToken == expectedToken);
+
+        NDDisk::TQueryCredentials reconnectedA = groupA;
+        ++reconnectedA.DDiskSessionSeqNo;
+        auto reconnectResult = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvConnect(reconnectedA)
+        );
+        AssertStatus(reconnectResult, TReplyStatus::OK);
+        reconnectedA.ConnectionToken.emplace(reconnectResult->Get()->Record.GetConnectionToken());
+        UNIT_ASSERT_VALUES_EQUAL(
+            groupA.ConnectionToken->GetConnectionIndex(),
+            reconnectedA.ConnectionToken->GetConnectionIndex()
+        );
+        UNIT_ASSERT(*groupA.ConnectionToken != *reconnectedA.ConnectionToken);
+
+        auto staleGroupARead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(groupA, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(staleGroupARead, TReplyStatus::SESSION_MISMATCH);
+        UNIT_ASSERT_VALUES_EQUAL("stale connection token", staleGroupARead->Get()->Record.GetErrorReason());
+
+        auto groupBRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(groupB, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(groupBRead, TReplyStatus::OK);
+
+        auto disconnectA = std::make_unique<NDDisk::TEvDisconnect>();
+        reconnectedA.SerializeForRequest(disconnectA->Record.MutableCredentials());
+        auto disconnectResult = SendToDDiskAndWait<NDDisk::TEvDisconnectResult>(
+            ctx,
+            disk.ServiceId,
+            disconnectA.release()
+        );
+        AssertStatus(disconnectResult, TReplyStatus::OK);
+
+        NDDisk::TQueryCredentials groupC = Connect(ctx, disk.ServiceId, TabletId, 1, 12);
+        UNIT_ASSERT_VALUES_EQUAL(
+            reconnectedA.ConnectionToken->GetConnectionIndex(),
+            groupC.ConnectionToken->GetConnectionIndex()
+        );
+
+        groupBRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(groupB, {0, 0, BlockSize}, {true})
+        );
+        AssertStatus(groupBRead, TReplyStatus::OK);
     }
 
     Y_UNIT_TEST(ConnectGenerationRules) {
@@ -399,6 +732,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             ctx, disk.ServiceId, new NDDisk::TEvConnect(gen2));
         AssertStatus(gen2Connect, TReplyStatus::OK);
         gen2.DDiskInstanceGuid = gen2Connect->Get()->Record.GetDDiskInstanceGuid();
+        gen2.ConnectionToken.emplace(gen2Connect->Get()->Record.GetConnectionToken());
         NDDisk::TQueryCredentials gen1 = gen2;
         gen1.Generation = 1;
         auto obsoleteConnect = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
@@ -411,6 +745,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             ctx, disk.ServiceId, new NDDisk::TEvConnect(gen3));
         AssertStatus(gen3Connect, TReplyStatus::OK);
         gen3.DDiskInstanceGuid = gen3Connect->Get()->Record.GetDDiskInstanceGuid();
+        gen3.ConnectionToken.emplace(gen3Connect->Get()->Record.GetConnectionToken());
 
         auto queryWithLatestGeneration = SendToDDiskAndWait<NDDisk::TEvReadResult>(
             ctx, disk.ServiceId, new NDDisk::TEvRead(gen3, {0, 0, BlockSize}, {true}));
@@ -422,14 +757,18 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
     }
 
     Y_UNIT_TEST(ConnectSessionSeqNoRules) {
+        // Scenario: reject an older session, rotate the token for a newer one,
+        // accept matching internal context, then reject stale generation and
+        // instance identity from internal forwarding.
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(2, 2);
 
-        NDDisk::TQueryCredentials seq1 = NDDisk::TQueryCredentials::ToDDisk(12, 4, 1, std::nullopt);
+        NDDisk::TQueryCredentials seq1 = NDDisk::TQueryCredentials::ToDDisk(12, 4, 1, std::nullopt, 0);
         auto seq1Connect = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
             ctx, disk.ServiceId, new NDDisk::TEvConnect(seq1));
         AssertStatus(seq1Connect, TReplyStatus::OK);
         seq1.DDiskInstanceGuid = seq1Connect->Get()->Record.GetDDiskInstanceGuid();
+        seq1.ConnectionToken.emplace(seq1Connect->Get()->Record.GetConnectionToken());
 
         NDDisk::TQueryCredentials obsoleteSeq = seq1;
         obsoleteSeq.DDiskSessionSeqNo = 0;
@@ -443,6 +782,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             ctx, disk.ServiceId, new NDDisk::TEvConnect(seq2));
         AssertStatus(seq2Connect, TReplyStatus::OK);
         seq2.DDiskInstanceGuid = seq2Connect->Get()->Record.GetDDiskInstanceGuid();
+        seq2.ConnectionToken.emplace(seq2Connect->Get()->Record.GetConnectionToken());
 
         auto oldSessionRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
             ctx, disk.ServiceId, new NDDisk::TEvRead(seq1, {0, 0, BlockSize}, {true}));
@@ -456,26 +796,77 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
             ctx,
             disk.ServiceId,
             new NDDisk::TEvRead(
-                NDDisk::TQueryCredentials::ForInternal(12, 4, std::nullopt),
+                NDDisk::TQueryCredentials::ForInternal(12, 4, std::nullopt, 0),
                 {0, 0, BlockSize},
                 {true}));
         AssertStatus(internalRead, TReplyStatus::OK);
+
+        auto staleInternalRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(
+                NDDisk::TQueryCredentials::ForInternal(12, 3, std::nullopt, 0),
+                {0, 0, BlockSize},
+                {true}
+            )
+        );
+        AssertStatus(staleInternalRead, TReplyStatus::SESSION_MISMATCH);
+
+        auto wrongInstanceRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(
+                NDDisk::TQueryCredentials::ForInternal(12, 4, *seq2.DDiskInstanceGuid + 1, 0),
+                {0, 0, BlockSize},
+                {true}
+            )
+        );
+        AssertStatus(wrongInstanceRead, TReplyStatus::SESSION_MISMATCH);
     }
 
-    Y_UNIT_TEST(PersistentBufferCredentialsSkipSessionSeqNo) {
+    Y_UNIT_TEST(PersistentBufferConnectIsHandledByPersistentBufferActor) {
+        // Scenario: connect directly to the PB actor, use its token for a PB
+        // request, reject that token at DDisk, then disconnect from PB.
         TTestContext ctx;
         const TDiskHandle disk = ctx.CreateDDisk(2, 3);
 
-        NDDisk::TQueryCredentials creds = NDDisk::TQueryCredentials::ToPersistentBuffer(12, 4, std::nullopt);
+        NDDisk::TQueryCredentials creds = NDDisk::TQueryCredentials::ToPersistentBuffer(12, 4, std::nullopt, 0);
+
+        auto wrongDDiskConnect = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, disk.ServiceId, new NDDisk::TEvConnect(creds));
+        AssertStatus(wrongDDiskConnect, TReplyStatus::INCORRECT_REQUEST);
+
+        auto ddiskCreds = NDDisk::TQueryCredentials::ToDDisk(12, 4, 1, std::nullopt, 0);
+        auto wrongPBConnect = SendToDDiskAndWait<NDDisk::TEvConnectResult>(ctx, disk.PBServiceId, new NDDisk::TEvConnect(ddiskCreds));
+        AssertStatus(wrongPBConnect, TReplyStatus::INCORRECT_REQUEST);
+
         auto connect = SendToDDiskAndWait<NDDisk::TEvConnectResult>(
             ctx, disk.PBServiceId, new NDDisk::TEvConnect(creds));
         AssertStatus(connect, TReplyStatus::OK);
         creds.DDiskInstanceGuid = connect->Get()->Record.GetDDiskInstanceGuid();
+        creds.ConnectionToken.emplace(connect->Get()->Record.GetConnectionToken());
+
+        auto list = SendToDDiskAndWait<NDDisk::TEvListPersistentBufferResult>(
+            ctx,
+            disk.PBServiceId,
+            new NDDisk::TEvListPersistentBuffer(creds)
+        );
+        AssertStatus(list, TReplyStatus::OK);
+
+        auto ddiskRead = SendToDDiskAndWait<NDDisk::TEvReadResult>(
+            ctx,
+            disk.ServiceId,
+            new NDDisk::TEvRead(
+                creds,
+                {0, 0, BlockSize},
+                {true}
+            )
+        );
+        AssertStatus(ddiskRead, TReplyStatus::SESSION_MISMATCH);
 
         NDDisk::TQueryCredentials mismatchedSeq = creds;
         mismatchedSeq.DDiskSessionSeqNo = 42;
         auto disconnect = std::make_unique<NDDisk::TEvDisconnect>();
-        mismatchedSeq.Serialize(disconnect->Record.MutableCredentials());
+        mismatchedSeq.SerializeForRequest(disconnect->Record.MutableCredentials());
         auto disconnectResult = SendToDDiskAndWait<NDDisk::TEvDisconnectResult>(
             ctx, disk.PBServiceId, disconnect.release());
         AssertStatus(disconnectResult, TReplyStatus::OK);
@@ -1377,7 +1768,10 @@ Y_UNIT_TEST_SUITE(TDDiskActorTest) {
         {
             auto* readEv = reinterpret_cast<TEventHandle<NDDisk::TEvRead>*>(readReq.get());
             const auto& readRecord = readEv->Get()->Record;
-            UNIT_ASSERT_VALUES_EQUAL(readRecord.GetCredentials().GetTabletId(), 50);
+            UNIT_ASSERT_VALUES_EQUAL(
+                readRecord.GetCredentials().GetInternal().GetTabletId(),
+                50
+            );
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetVChunkIndex(), 7);
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetOffsetInBytes(), 0u);
             UNIT_ASSERT_VALUES_EQUAL(readRecord.GetSelector().GetSize(), BlockSize);

--- a/ydb/core/blobstorage/ddisk/ut/ddisk_sync_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_sync_ut.cpp
@@ -32,7 +32,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorSync) {
         NDDisk::TQueryCredentials creds = Connect(ctx, 30, 1);
 
         auto syncEv = std::make_unique<NDDisk::TEvSync>();
-        creds.Serialize(syncEv->Record.MutableCredentials());
+        creds.SerializeForRequest(syncEv->Record.MutableCredentials());
 
         auto result = ctx.SendAndGrab<NDDisk::TEvSyncResult>(syncEv.release());
         AssertStatus<NDDisk::TEvSyncResult>(
@@ -75,7 +75,7 @@ Y_UNIT_TEST_SUITE(TDDiskActorSync) {
         NDDisk::TQueryCredentials creds = Connect(ctx, 30, 1);
 
         auto syncEv = std::make_unique<NDDisk::TEvSync>();
-        creds.Serialize(syncEv->Record.MutableCredentials());
+        creds.SerializeForRequest(syncEv->Record.MutableCredentials());
         auto *segment = syncEv->Record.AddSources()->AddSegments();
         NDDisk::TBlockSelector(0, 0, MinBlockSize).Serialize(
             segment->MutableSelector());

--- a/ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.cpp
@@ -141,7 +141,8 @@ namespace NKikimr::NDDisk {
         NDDisk::TQueryCredentials creds = NDDisk::TQueryCredentials::ForInternal(
             inflight.TabletId,
             inflight.TabletGeneration,
-            std::nullopt);
+            std::nullopt,
+            inflight.DirectBlockGroupIndex);
         const NDDisk::TBlockSelector selector{record.GetVChunkIndex(), record.GetOffsetInBytes(), record.GetSizeInBytes()};
 
         auto msg = std::make_unique<TEvWritePersistentBuffers>(creds, selector, inflight.Lsn, NDDisk::TWriteInstruction(0),
@@ -161,11 +162,12 @@ namespace NKikimr::NDDisk {
     void TWritePersistentBuffersRequestActor::Handle(TEvReadThenWritePersistentBuffers::TPtr ev) {
         auto cookie = NextCookie++;
         const auto& record = ev->Get()->Record;
-        auto recordCreds = record.GetCredentials();
+        TQueryCredentials recordCreds(record.GetCredentials());
         TQueryCredentials creds = TQueryCredentials::ForInternal(
-            recordCreds.GetTabletId(),
-            recordCreds.GetGeneration(),
-            std::nullopt);
+            recordCreds.TabletId,
+            recordCreds.Generation,
+            std::nullopt,
+            recordCreds.DirectBlockGroupIndex);
         auto requestGeneration = record.GetGeneration();
         auto lsn = record.GetLsn();
         auto timeout = record.GetReplyTimeoutMicroseconds();
@@ -175,6 +177,7 @@ namespace NKikimr::NDDisk {
             .Cookie = ev->Cookie,
             .TabletId = creds.TabletId,
             .TabletGeneration = creds.Generation,
+            .DirectBlockGroupIndex = creds.DirectBlockGroupIndex,
             .RequestGeneration = requestGeneration,
             .Lsn = lsn,
             .Timeout = timeout,
@@ -185,7 +188,7 @@ namespace NKikimr::NDDisk {
         }
 
         auto msg = std::make_unique<TEvReadPersistentBuffer>();
-        creds.Serialize(msg->Record.MutableCredentials());
+        creds.SerializeForRequest(msg->Record.MutableCredentials());
         msg->Record.SetLsn(lsn);
         msg->Record.SetGeneration(requestGeneration);
         NDDisk::TReadInstruction(true).Serialize(msg->Record.MutableInstruction());
@@ -207,11 +210,12 @@ namespace NKikimr::NDDisk {
 
         Y_ABORT_UNLESS(inserted);
         const auto& record = ev->Get()->Record;
-        auto recordCreds = record.GetCredentials();
+        TQueryCredentials recordCreds(record.GetCredentials());
         TQueryCredentials creds = TQueryCredentials::ForInternal(
-            recordCreds.GetTabletId(),
-            recordCreds.GetGeneration(),
-            std::nullopt);
+            recordCreds.TabletId,
+            recordCreds.Generation,
+            std::nullopt,
+            recordCreds.DirectBlockGroupIndex);
         const TBlockSelector selector(record.GetSelector());
         const ui64 lsn = record.GetLsn();
         const TWriteInstruction instr(record.GetInstruction());

--- a/ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.h
+++ b/ydb/core/blobstorage/ddisk/write_persistent_buffers_request_actor.h
@@ -15,6 +15,7 @@ namespace NKikimr::NDDisk {
             ui64 Cookie;
             ui64 TabletId;
             ui32 TabletGeneration;
+            ui32 DirectBlockGroupIndex;
             ui32 RequestGeneration;
             ui64 Lsn;
             ui32 Timeout;

--- a/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ddisk.cpp
@@ -156,17 +156,18 @@ Y_UNIT_TEST_SUITE(DDisk) {
                 auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvConnectResult>(Edge, false);
                 UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
                 Creds.DDiskInstanceGuid = res->Get()->Record.GetDDiskInstanceGuid();
+                Creds.ConnectionToken.emplace(res->Get()->Record.GetConnectionToken());
             }
 
             PBCreds.clear();
             PBCreds.resize(10);
             for (ui32 i : xrange(10)) {
-                PBCreds[i].TabletId = i + 1;
-                PBCreds[i].Generation = 1;
+                PBCreds[i] = NDDisk::TQueryCredentials::ToPersistentBuffer(i + 1, 1, std::nullopt, 0);
                 Env.Runtime->Send(new IEventHandle(PBServiceId, Edge, new NDDisk::TEvConnect(PBCreds[i])), Edge.NodeId());
                 auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvConnectResult>(Edge, false);
                 UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
                 PBCreds[i].DDiskInstanceGuid = res->Get()->Record.GetDDiskInstanceGuid();
+                PBCreds[i].ConnectionToken.emplace(res->Get()->Record.GetConnectionToken());
             }
         }
 
@@ -357,6 +358,7 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvConnectResult>(Edge, false);
             UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
             PBCreds[tabletIdx].DDiskInstanceGuid = res->Get()->Record.GetDDiskInstanceGuid();
+            PBCreds[tabletIdx].ConnectionToken.emplace(res->Get()->Record.GetConnectionToken());
         }
 
         // Write a persistent buffer record with an explicit generation (does NOT update PersistentBuffers map).
@@ -591,12 +593,14 @@ Y_UNIT_TEST_SUITE(DDisk) {
             auto res = Env.WaitForEdgeActorEvent<NDDisk::TEvConnectResult>(Edge, false);
             UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
             Creds.DDiskInstanceGuid = res->Get()->Record.GetDDiskInstanceGuid();
+            Creds.ConnectionToken.emplace(res->Get()->Record.GetConnectionToken());
 
             for (auto& cred : PBCreds) {
                 Env.Runtime->Send(new IEventHandle(PBServiceId, Edge, new NDDisk::TEvConnect(cred)), Edge.NodeId());
                 res = Env.WaitForEdgeActorEvent<NDDisk::TEvConnectResult>(Edge, false);
                 UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
                 cred.DDiskInstanceGuid = res->Get()->Record.GetDDiskInstanceGuid();
+                cred.ConnectionToken.emplace(res->Get()->Record.GetConnectionToken());
             }
         }
     };

--- a/ydb/core/load_test/ddisk_load.cpp
+++ b/ydb/core/load_test/ddisk_load.cpp
@@ -381,6 +381,7 @@ public:
 
         Connected = true;
         Credentials.DDiskInstanceGuid = msg.GetDDiskInstanceGuid();
+        Credentials.ConnectionToken.emplace(msg.GetConnectionToken());
 
         PrepareDataAndStart(ctx);
     }
@@ -505,7 +506,7 @@ public:
             if (Connected && !DisconnectSent) {
                 DisconnectSent = true;
                 auto ev = std::make_unique<NDDisk::TEvDisconnect>();
-                Credentials.Serialize(ev->Record.MutableCredentials());
+                Credentials.SerializeForRequest(ev->Record.MutableCredentials());
                 SendRequest(ctx, std::move(ev));
             } else {
                 FinishAndDie(ctx);

--- a/ydb/core/load_test/nbs_dbg_like_load_tablet.cpp
+++ b/ydb/core/load_test/nbs_dbg_like_load_tablet.cpp
@@ -276,6 +276,8 @@ struct TPerDbgState {
     std::array<TActorId, kHostsPerDbgMax> PBActor;
     std::array<ui64, kHostsPerDbgMax> DDGuid = {};
     std::array<ui64, kHostsPerDbgMax> PBGuid = {};
+    std::array<std::optional<NDDisk::TConnectionToken>, kHostsPerDbgMax> DDToken;
+    std::array<std::optional<NDDisk::TConnectionToken>, kHostsPerDbgMax> PBToken;
     std::bitset<kHostsPerDbgMax> DDConnected;
     std::bitset<kHostsPerDbgMax> PBConnected;
 
@@ -592,6 +594,7 @@ private:
     // Per-DBG connection state for this worker's own peers.
     struct TPeerConnState {
         ui64 Guid = 0;
+        std::optional<NDDisk::TConnectionToken> Token;
         bool Connected = false;
         bool ConnectInFlight = false;
     };
@@ -1801,9 +1804,9 @@ void TNbsDbgLikeActor::ConnectPeer(ui32 k, bool isPb) {
         ? MakeBlobStoragePersistentBufferId(id.GetNodeId(), id.GetPDiskId(), id.GetDDiskSlotId())
         : MakeBlobStorageDDiskId(id.GetNodeId(), id.GetPDiskId(), id.GetDDiskSlotId());
     auto creds = isPb
-        ? NDDisk::TQueryCredentials::ToPersistentBuffer(AllocConfig.GetTabletId(), Generation(), std::nullopt)
+        ? NDDisk::TQueryCredentials::ToPersistentBuffer(AllocConfig.GetTabletId(), Generation(), std::nullopt, MyDbgIndex)
         : NDDisk::TQueryCredentials::ToDDisk(
-            AllocConfig.GetTabletId(), Generation(), kInitialDDiskSessionSeqNo, std::nullopt);
+            AllocConfig.GetTabletId(), Generation(), kInitialDDiskSessionSeqNo, std::nullopt, MyDbgIndex);
     st.ConnectInFlight = true;
     Send(target, new NDDisk::TEvConnect(creds), 0, PackPeerCookie(k, isPb));
 }
@@ -1824,6 +1827,7 @@ void TNbsDbgLikeActor::HandlePeerConnect(NDDisk::TEvConnectResult::TPtr& ev) {
     if (rec.GetStatus() == NKikimrBlobStorage::NDDisk::TReplyStatus::OK) {
         st.Connected = true;
         st.Guid = rec.GetDDiskInstanceGuid();
+        st.Token.emplace(rec.GetConnectionToken());
         if (RootCnt.ConnectOk) {
             RootCnt.ConnectOk->Inc();
         }
@@ -1842,6 +1846,7 @@ void TNbsDbgLikeActor::HandlePeerConnect(NDDisk::TEvConnectResult::TPtr& ev) {
     } else {
         st.Connected = false;
         st.Guid = 0;
+        st.Token.reset();
         if (RootCnt.ConnectErr) {
             RootCnt.ConnectErr->Inc();
         }
@@ -1869,6 +1874,7 @@ void TNbsDbgLikeActor::HandlePeerDisconnect(NDDisk::TEvDisconnectResult::TPtr& e
     st.Connected = false;
     st.ConnectInFlight = false;
     st.Guid = 0;
+    st.Token.reset();
     if (RootCnt.DisconnectOk) {
         RootCnt.DisconnectOk->Inc();
     }
@@ -1882,32 +1888,32 @@ void TNbsDbgLikeActor::HandlePeerDisconnect(NDDisk::TEvDisconnectResult::TPtr& e
 
 void TNbsDbgLikeActor::DisconnectAllPeers() {
     const ui32 hostsPerDbg = HostsPerDbg();
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
     for (ui32 k = 0; k < hostsPerDbg; ++k) {
         if (PB[k].Connected) {
-            auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(
-                bscTabletId, generation, PB[k].Guid);
+            Y_ABORT_UNLESS(PB[k].Token);
+            auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(*PB[k].Token);
             auto ev = std::make_unique<NDDisk::TEvDisconnect>();
-            creds.Serialize(ev->Record.MutableCredentials());
+            creds.SerializeForRequest(ev->Record.MutableCredentials());
             const auto& id = DbgInfo.PBIds[k];
             Send(MakeBlobStoragePersistentBufferId(id.GetNodeId(), id.GetPDiskId(),
                     id.GetDDiskSlotId()),
                 ev.release());
             PB[k].Connected = false;
             PB[k].Guid = 0;
+            PB[k].Token.reset();
         }
         if (DD[k].Connected) {
-            auto creds = NDDisk::TQueryCredentials::ToDDisk(
-                bscTabletId, generation, kInitialDDiskSessionSeqNo, DD[k].Guid);
+            Y_ABORT_UNLESS(DD[k].Token);
+            auto creds = NDDisk::TQueryCredentials::ToDDisk(*DD[k].Token);
             auto ev = std::make_unique<NDDisk::TEvDisconnect>();
-            creds.Serialize(ev->Record.MutableCredentials());
+            creds.SerializeForRequest(ev->Record.MutableCredentials());
             const auto& id = DbgInfo.DDiskIds[k];
             Send(MakeBlobStorageDDiskId(id.GetNodeId(), id.GetPDiskId(),
                     id.GetDDiskSlotId()),
                 ev.release());
             DD[k].Connected = false;
             DD[k].Guid = 0;
+            DD[k].Token.reset();
         }
     }
 }
@@ -1946,10 +1952,12 @@ void TNbsDbgLikeActor::PopulateDbgState() {
         dst.PbIndexById.emplace(pb, k);
         if (DD[k].Connected) {
             dst.DDGuid[k] = DD[k].Guid;
+            dst.DDToken[k] = DD[k].Token;
             dst.DDConnected.set(k);
         }
         if (PB[k].Connected) {
             dst.PBGuid[k] = PB[k].Guid;
+            dst.PBToken[k] = PB[k].Token;
             dst.PBConnected.set(k);
         }
     }
@@ -2260,10 +2268,8 @@ void TNbsDbgLikeActor::HandleNbsWrite(TEvLoad::TEvNbsWrite::TPtr& ev, const TAct
     ++LsnsTotalAll;
     dbg.InflightLsnAtSlot[vChunkIndex][offset / IoSizeBytes] = lsn;
 
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
-    auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(
-        bscTabletId, generation, dbg.PBGuid[coord]);
+    Y_ABORT_UNLESS(dbg.PBToken[coord]);
+    auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(*dbg.PBToken[coord]);
     NDDisk::TBlockSelector selector(vChunkIndex, offset, IoSizeBytes);
     std::vector<NKikimrBlobStorage::NDDisk::TDDiskId> pbIds;
     if (TabletConfig.GetDisableReplication()) {
@@ -2322,14 +2328,12 @@ bool TNbsDbgLikeActor::SendPbRead(TPerDbgState& dbg, ui32 dbgIndex, ui64 lsn,
         return false;
     }
     const ui32 k = PickRandomSetBit(info.WriteConfirmed, Rng.GenRand());
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
-    auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(
-        bscTabletId, generation, dbg.PBGuid[k]);
+    Y_ABORT_UNLESS(dbg.PBToken[k]);
+    auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(*dbg.PBToken[k]);
     NDDisk::TBlockSelector selector(info.VChunkIndex,
         static_cast<ui32>(info.OffsetInVChunk), info.Size);
     auto ev = std::make_unique<NDDisk::TEvReadPersistentBuffer>(
-        creds, selector, lsn, generation, NDDisk::TReadInstruction(true));
+        creds, selector, lsn, Generation_, NDDisk::TReadInstruction(true));
     const ui64 cookie = NextBatchCookie++;
     TReadInflight ri;
     ri.DbgIndex = dbgIndex;
@@ -2357,10 +2361,8 @@ bool TNbsDbgLikeActor::SendDDiskRead(TPerDbgState& dbg, ui32 dbgIndex,
 {
     const TPeerBitset& effectiveMask = flushMask.any() ? flushMask : kAllPrimaryHostsMask;
     const ui32 k = PickRandomSetBit(effectiveMask, Rng.GenRand());
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
-    auto creds = NDDisk::TQueryCredentials::ToDDisk(
-        bscTabletId, generation, kInitialDDiskSessionSeqNo, dbg.DDGuid[k]);
+    Y_ABORT_UNLESS(dbg.DDToken[k]);
+    auto creds = NDDisk::TQueryCredentials::ToDDisk(*dbg.DDToken[k]);
     NDDisk::TBlockSelector selector(vChunkIndex, static_cast<ui32>(offset), size);
     auto ev = std::make_unique<NDDisk::TEvRead>(
         creds, selector, NDDisk::TReadInstruction(true));
@@ -2718,14 +2720,12 @@ void TNbsDbgLikeActor::DoFlush(TPerDbgState& dbg) {
         dbg.PendingFlush.pop_front();
     }
 
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
     for (ui32 k = 0; k < kPrimaryHostsPerDbg; ++k) {
         if (pending[k].empty()) {
             continue;
         }
-        auto creds = NDDisk::TQueryCredentials::ToDDisk(
-            bscTabletId, generation, kInitialDDiskSessionSeqNo, dbg.DDGuid[k]);
+        Y_ABORT_UNLESS(dbg.DDToken[k]);
+        auto creds = NDDisk::TQueryCredentials::ToDDisk(*dbg.DDToken[k]);
         std::tuple<ui32, ui32, ui32> srcId{
             dbg.PBIdsPb[k].GetNodeId(),
             dbg.PBIdsPb[k].GetPDiskId(),
@@ -2737,7 +2737,7 @@ void TNbsDbgLikeActor::DoFlush(TPerDbgState& dbg) {
         batchInfo.Lsns.reserve(pending[k].size());
         batchInfo.SentAt = MonotonicNow();
         for (auto& [lsn, sel] : pending[k]) {
-            ev->AddSegmentFromPB(srcId, dbg.PBGuid[k], sel, lsn, generation);
+            ev->AddSegmentFromPB(srcId, dbg.PBGuid[k], sel, lsn, Generation_);
             batchInfo.Lsns.push_back(lsn);
         }
         const ui64 cookie = NextBatchCookie++;
@@ -2976,14 +2976,12 @@ void TNbsDbgLikeActor::DoErase(TPerDbgState& dbg) {
         dbg.PendingErase.pop_front();
     }
 
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
     for (ui32 k = 0; k < hostsPerDbg; ++k) {
         if (pending[k].empty()) {
             continue;
         }
-        auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(
-            bscTabletId, generation, dbg.PBGuid[k]);
+        Y_ABORT_UNLESS(dbg.PBToken[k]);
+        auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(*dbg.PBToken[k]);
         auto ev = std::make_unique<NDDisk::TEvBatchErasePersistentBuffer>(creds);
         TEraseBatch batchInfo;
         batchInfo.DbgIndex = dbg.DbgIndex;
@@ -2991,7 +2989,7 @@ void TNbsDbgLikeActor::DoErase(TPerDbgState& dbg) {
         batchInfo.Lsns.reserve(pending[k].size());
         batchInfo.SentAt = MonotonicNow();
         for (ui64 lsn : pending[k]) {
-            ev->AddErase(lsn, generation);
+            ev->AddErase(lsn, Generation_);
             batchInfo.Lsns.push_back(lsn);
         }
         const ui64 cookie = NextBatchCookie++;
@@ -3186,21 +3184,19 @@ void TNbsDbgLikeActor::BestEffortEraseAll(TPerDbgState& dbg) {
             pending[k].push_back(lsn);
         }
     }
-    const ui64 bscTabletId = AllocConfig.GetTabletId();
-    const ui32 generation = Generation();
     for (ui32 k = 0; k < hostsPerDbg; ++k) {
         if (pending[k].empty()) {
             continue;
         }
-        auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(
-            bscTabletId, generation, dbg.PBGuid[k]);
+        Y_ABORT_UNLESS(dbg.PBToken[k]);
+        auto creds = NDDisk::TQueryCredentials::ToPersistentBuffer(*dbg.PBToken[k]);
         auto ev = std::make_unique<NDDisk::TEvBatchErasePersistentBuffer>(creds);
         TEraseBatch batchInfo;
         batchInfo.DbgIndex = dbg.DbgIndex;
         batchInfo.Sink = static_cast<ui8>(k);
         batchInfo.Lsns = pending[k];
         batchInfo.SentAt = MonotonicNow();
-        for (ui64 lsn : pending[k]) ev->AddErase(lsn, generation);
+        for (ui64 lsn : pending[k]) ev->AddErase(lsn, Generation_);
         const ui64 cookie = NextBatchCookie++;
         EraseInflight.emplace(cookie, std::move(batchInfo));
         Send(dbg.PBActor[k], ev.release(), 0, cookie);

--- a/ydb/core/load_test/persistent_buffer_write.cpp
+++ b/ydb/core/load_test/persistent_buffer_write.cpp
@@ -72,7 +72,7 @@ class TPersistentBufferWriterLoadTestActor : public TActorBootstrapped<TPersiste
     ui32 DDiskNodeId = 0;
     ui32 DDiskPDiskId = 0;
     ui32 DDiskSlotId = 0;
-    TActorId DDiskServiceId;
+    TActorId PersistentBufferServiceId;
     NDDisk::TQueryCredentials Credentials;
     bool Finished = false;
     bool Connected = false;
@@ -154,9 +154,9 @@ public:
         DDiskNodeId = ddiskId.GetNodeId();
         DDiskPDiskId = ddiskId.GetPDiskId();
         DDiskSlotId = ddiskId.GetDDiskSlotId();
-        DDiskServiceId = MakeBlobStoragePersistentBufferId(DDiskNodeId, DDiskPDiskId, DDiskSlotId);
+        PersistentBufferServiceId = MakeBlobStoragePersistentBufferId(DDiskNodeId, DDiskPDiskId, DDiskSlotId);
 
-        Credentials = NDDisk::TQueryCredentials::ToPersistentBuffer(Tag ? Tag : 1, 1, std::nullopt);
+        Credentials = NDDisk::TQueryCredentials::ToPersistentBuffer(Tag ? Tag : 1, 1, std::nullopt, 0);
 
         FillRatio = cmd.GetFillRatio();
         Y_ABORT_UNLESS(FillRatio <= 100, "FillRatio percentage should be less than or equal to 100");
@@ -201,7 +201,7 @@ public:
         Become(&TPersistentBufferWriterLoadTestActor::StateFunc);
         ctx.Schedule(TDuration::MilliSeconds(MonitoringUpdateCycleMs), new TEvUpdateMonitoring);
         AppData(ctx)->Dcb->RegisterLocalControl(MaxInFlight, Sprintf("PersistentBufferWriteLoadActor_MaxInFlight_%4" PRIu64, Tag).c_str());
-        SendRequest(ctx, std::make_unique<NDDisk::TEvConnect>(Credentials));
+        ctx.Send(PersistentBufferServiceId, new NDDisk::TEvConnect(Credentials));
     }
 
     void Handle(NDDisk::TEvConnectResult::TPtr& ev, const TActorContext& ctx) {
@@ -216,6 +216,7 @@ public:
 
         Connected = true;
         Credentials.DDiskInstanceGuid = msg.GetDDiskInstanceGuid();
+        Credentials.ConnectionToken.emplace(msg.GetConnectionToken());
 
         PrepareDataAndStart(ctx);
     }
@@ -283,8 +284,8 @@ public:
         } else if (!DisconnectSent) {
             DisconnectSent = true;
             auto ev = std::make_unique<NDDisk::TEvDisconnect>();
-            Credentials.Serialize(ev->Record.MutableCredentials());
-            SendRequest(ctx, std::move(ev));
+            Credentials.SerializeForRequest(ev->Record.MutableCredentials());
+            ctx.Send(PersistentBufferServiceId, ev.release());
         }
     }
 
@@ -352,8 +353,9 @@ public:
                 auto creds = NDDisk::TQueryCredentials::ForInternal(
                     Credentials.TabletId,
                     Credentials.Generation,
-                    Credentials.DDiskInstanceGuid);
-                creds.Serialize(msg->Record.MutableCredentials());
+                    Credentials.DDiskInstanceGuid,
+                    Credentials.DirectBlockGroupIndex);
+                creds.SerializeForRequest(msg->Record.MutableCredentials());
                 msg->Record.SetLsn(it.first);
                 msg->Record.SetGeneration(Credentials.Generation);
                 SendRequest(ctx, std::move(msg), requestIdx);
@@ -545,7 +547,7 @@ public:
 
     template<typename TRequest>
     void SendRequest(const TActorContext& ctx, std::unique_ptr<TRequest>&& request, ui64 cookie = 0) {
-        ctx.Send(DDiskServiceId, request.release(), 0, cookie);
+        ctx.Send(PersistentBufferServiceId, request.release(), 0, cookie);
     }
 
     void Handle(NMon::TEvHttpInfo::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -1456,7 +1456,8 @@ void TDirectBlockGroup::AddDDiskAndPBufferConnection(
                 TabletId,
                 TabletGeneration,
                 InitialDDiskSessionSeqNo,
-                std::nullopt)}});
+                std::nullopt,
+                static_cast<ui32>(DirectBlockGroupIndex))}});
 
     PBufferConnections.push_back(TDDiskConnection{
         .HostConnection = NTransport::THostConnection{
@@ -1465,7 +1466,8 @@ void TDirectBlockGroup::AddDDiskAndPBufferConnection(
             .Credentials = NDDisk::TQueryCredentials::ToPersistentBuffer(
                 TabletId,
                 TabletGeneration,
-                std::nullopt)}});
+                std::nullopt,
+                static_cast<ui32>(DirectBlockGroupIndex))}});
 
     NKikimrBlobStorage::NDDisk::TDDiskId id;
     pbufferId.Serialize(&id);
@@ -1591,8 +1593,6 @@ void TDirectBlockGroup::OnConnectResponse(
 
     if (!HasError(error)) {
         Counters.OnConnectOk(ToDBGConnectionType(connectionType));
-        connection.HostConnection.Credentials.DDiskInstanceGuid =
-            result.GetDDiskInstanceGuid();
         if (connectionType == EConnectionType::DDisk) {
             if (seqNo <= connection.ConfirmedSessionSeqNo) {
                 LOG_WARN(
@@ -1606,6 +1606,24 @@ void TDirectBlockGroup::OnConnectResponse(
                     connection.ConfirmedSessionSeqNo);
                 return;
             }
+        }
+
+        connection.HostConnection.Credentials.DDiskInstanceGuid =
+            result.GetDDiskInstanceGuid();
+        if (result.HasConnectionToken()) {
+            auto creds = connectionType == EConnectionType::DDisk
+                             ? NDDisk::TQueryCredentials::ToDDisk(
+                                   result.GetConnectionToken())
+                             : NDDisk::TQueryCredentials::ToPersistentBuffer(
+                                   result.GetConnectionToken());
+            connection.HostConnection.Credentials.ConnectionToken =
+                creds.ConnectionToken;
+        } else {
+            connection.HostConnection.Credentials.ConnectionToken =
+                std::nullopt;
+        }
+
+        if (connectionType == EConnectionType::DDisk) {
             connection.SessionState = EDDiskSessionState::Locked;
             connection.ConfirmedSessionSeqNo = seqNo;
             Oracle.OnDDiskConnected(hostIndex, TInstant::Now());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -1397,6 +1397,7 @@ Y_UNIT_TEST_SUITE(TDDiskSessionSeqNoTest)
 
     Y_UNIT_TEST_F(ShouldSeqNoOnInitialConnects, TDBGFixture)
     {
+        constexpr ui64 DirectBlockGroupIndex = 42;
         auto executor = MakeExecutor();
         auto transport = std::make_unique<TStorageTransportMock>();
         auto* transportPtr = transport.get();
@@ -1404,7 +1405,10 @@ Y_UNIT_TEST_SUITE(TDDiskSessionSeqNoTest)
         const auto& ddisks = transportPtr->GetDDiskIds();
         const auto& pbuffers = transportPtr->GetPBufferIds();
 
-        auto dbg = MakeDirectBlockGroup(executor, std::move(transport));
+        auto dbg = MakeDirectBlockGroup(
+            executor,
+            std::move(transport),
+            DirectBlockGroupIndex);
         auto initialReady = RunAndGetInitialReady(dbg);
 
         WaitReady(initialReady);
@@ -1416,6 +1420,9 @@ Y_UNIT_TEST_SUITE(TDDiskSessionSeqNoTest)
                 ddiskId);
             UNIT_ASSERT_VALUES_EQUAL(1, credentials.size());
             UNIT_ASSERT_VALUES_EQUAL(1, credentials[0].DDiskSessionSeqNo);
+            UNIT_ASSERT_VALUES_EQUAL(
+                DirectBlockGroupIndex,
+                credentials[0].DirectBlockGroupIndex);
         }
 
         // PBuffers
@@ -1425,7 +1432,41 @@ Y_UNIT_TEST_SUITE(TDDiskSessionSeqNoTest)
                 pbufferId);
             UNIT_ASSERT_VALUES_EQUAL(1, credentials.size());
             UNIT_ASSERT_VALUES_EQUAL(0, credentials[0].DDiskSessionSeqNo);
+            UNIT_ASSERT_VALUES_EQUAL(
+                DirectBlockGroupIndex,
+                credentials[0].DirectBlockGroupIndex);
         }
+    }
+
+    Y_UNIT_TEST_F(ShouldStoreConnectionTokenFromConnectResult, TDBGFixture)
+    {
+        auto executor = MakeExecutor();
+        auto transport = std::make_unique<TStorageTransportMock>();
+        const auto& ddisks = transport->GetDDiskIds();
+        auto pendingConnect =
+            transport->SetPendingConnect(EConnectionType::DDisk, ddisks[0]);
+
+        auto dbg = MakeDirectBlockGroup(executor, std::move(transport));
+        RunAndGetInitialReady(dbg);
+        DrainExecutor(executor);
+
+        const NDDisk::TConnectionToken expectedToken{
+            0x0123'4567'89ab'cdef,
+            0xfedc'ba98'7654'3210};
+        auto result = TStorageTransportMock::MakeConnectResult();
+        expectedToken.Serialize(result.MutableConnectionToken());
+        pendingConnect.SetValue(std::move(result));
+        DrainExecutor(executor);
+
+        const auto actualToken = GetConnectionToken(
+            executor,
+            dbg,
+            EConnectionType::DDisk,
+            0,
+            WaitTimeout);
+        UNIT_ASSERT(actualToken);
+        UNIT_ASSERT_VALUES_EQUAL(expectedToken.Low, actualToken->Low);
+        UNIT_ASSERT_VALUES_EQUAL(expectedToken.High, actualToken->High);
     }
 
     // After the first Connect every DDisk has seq_no=1 and credentials carry
@@ -1479,7 +1520,7 @@ Y_UNIT_TEST_SUITE(TDDiskSessionSeqNoTest)
     }
 
     // A stale connect response (seq_no <= ConfirmedSessionSeqNo) is ignored and
-    // does not roll back the confirmed seq_no.
+    // does not roll back the confirmed seq_no or connection token.
     Y_UNIT_TEST_F(ShouldIgnoreStaleConnectResponse, TDBGFixture)
     {
         auto executor = MakeExecutor();
@@ -1505,19 +1546,44 @@ Y_UNIT_TEST_SUITE(TDDiskSessionSeqNoTest)
             ddisks[0].NodeId);
         DrainExecutor(executor);
 
+        const NDDisk::TConnectionToken firstToken{1, 11};
+        const NDDisk::TConnectionToken secondToken{2, 22};
+
         // Resolve the new (seq_no=2) connect first.
-        secondConnect.SetValue(TStorageTransportMock::MakeConnectResult());
+        auto secondResult = TStorageTransportMock::MakeConnectResult();
+        secondToken.Serialize(secondResult.MutableConnectionToken());
+        secondConnect.SetValue(std::move(secondResult));
         DrainExecutor(executor);
 
         auto afterNew = GetDDiskSessionSeqNo(executor, dbg, 0, WaitTimeout);
         UNIT_ASSERT_VALUES_EQUAL(2, afterNew);
+        auto tokenAfterNew = GetConnectionToken(
+            executor,
+            dbg,
+            EConnectionType::DDisk,
+            0,
+            WaitTimeout);
+        UNIT_ASSERT(tokenAfterNew);
+        UNIT_ASSERT_VALUES_EQUAL(secondToken.Low, tokenAfterNew->Low);
+        UNIT_ASSERT_VALUES_EQUAL(secondToken.High, tokenAfterNew->High);
 
         // resolve the stale connect. It must be ignored.
-        firstConnect.SetValue(TStorageTransportMock::MakeConnectResult());
+        auto firstResult = TStorageTransportMock::MakeConnectResult();
+        firstToken.Serialize(firstResult.MutableConnectionToken());
+        firstConnect.SetValue(std::move(firstResult));
         DrainExecutor(executor);
 
         auto afterStale = GetDDiskSessionSeqNo(executor, dbg, 0, WaitTimeout);
         UNIT_ASSERT_VALUES_EQUAL(2, afterStale);
+        auto tokenAfterStale = GetConnectionToken(
+            executor,
+            dbg,
+            EConnectionType::DDisk,
+            0,
+            WaitTimeout);
+        UNIT_ASSERT(tokenAfterStale);
+        UNIT_ASSERT_VALUES_EQUAL(secondToken.Low, tokenAfterStale->Low);
+        UNIT_ASSERT_VALUES_EQUAL(secondToken.High, tokenAfterStale->High);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -118,6 +118,29 @@ ui64 TDBGFixture::GetDDiskSessionSeqNo(
         .GetValue(waitTimeout);
 }
 
+std::optional<NKikimr::NDDisk::TConnectionToken>
+TDBGFixture::GetConnectionToken(
+    const TExecutorPtr& executor,
+    const std::shared_ptr<TDirectBlockGroup>& dbg,
+    NTransport::THostConnection::EConnectionType connectionType,
+    size_t index,
+    TDuration waitTimeout)
+{
+    return RunOnExecutor(
+               executor,
+               [dbg, connectionType, index]
+               {
+                   const auto& connections =
+                       connectionType == NTransport::THostConnection::
+                                             EConnectionType::DDisk
+                           ? dbg->DDiskConnections
+                           : dbg->PBufferConnections;
+                   return connections[index]
+                       .HostConnection.Credentials.ConnectionToken;
+               })
+        .GetValue(waitTimeout);
+}
+
 TExecutorPtr TDBGFixture::MakeExecutor()
 {
     auto executor = TExecutor::Create("DBG_TEST");
@@ -131,14 +154,15 @@ TDBGFixture::MakeDirectBlockGroup(
     const TExecutorPtr& executor,
     std::unique_ptr<NStorage::NTransport::IStorageTransport> transport,
     const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
-    const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds) const
+    const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
+    size_t directBlockGroupIndex) const
 {
     return std::make_shared<TDirectBlockGroup>(
         Runtime->GetActorSystem(0),
         std::make_shared<TStorageConfig>(NProto::TStorageServiceConfig()),
         executor,
         DiskDescription,
-        0,
+        directBlockGroupIndex,
         ddisksIds,
         pbufferIds,
         std::move(transport),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
@@ -72,18 +72,27 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
         const std::shared_ptr<TDirectBlockGroup>& dbg,
         size_t index,
         TDuration waitTimeout);
+    [[nodiscard]] static std::optional<NKikimr::NDDisk::TConnectionToken>
+    GetConnectionToken(
+        const TExecutorPtr& executor,
+        const std::shared_ptr<TDirectBlockGroup>& dbg,
+        NTransport::THostConnection::EConnectionType connectionType,
+        size_t index,
+        TDuration waitTimeout);
 
     [[nodiscard]] std::shared_ptr<TDirectBlockGroup> MakeDirectBlockGroup(
         const TExecutorPtr& executor,
         std::unique_ptr<NTransport::IStorageTransport> transport,
         const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
-        const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds) const;
+        const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
+        size_t directBlockGroupIndex = 0) const;
 
     template <typename TTransport>
         requires std::derived_from<TTransport, NTransport::IStorageTransport>
     [[nodiscard]] std::shared_ptr<TDirectBlockGroup> MakeDirectBlockGroup(
         const TExecutorPtr& executor,
-        std::unique_ptr<TTransport> transport) const
+        std::unique_ptr<TTransport> transport,
+        size_t directBlockGroupIndex = 0) const
     {
         auto ddisks = transport->GetDDiskIds();
         auto pbuffers = transport->GetPBufferIds();
@@ -92,7 +101,8 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
             executor,
             std::move(transport),
             ddisks,
-            pbuffers);
+            pbuffers,
+            directBlockGroupIndex);
     }
 
     // Interleaves the simulated runtime and the coroutine executor: dispatches

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
@@ -37,7 +37,8 @@ THostConnection MakeDDiskConnection(
             /*tabletId=*/100,
             /*generation=*/1,
             /*sessionSeqNo=*/1,
-            guid)};
+            guid,
+            /*directBlockGroupIndex=*/0)};
 }
 
 THostConnection MakePBufferConnection(
@@ -50,7 +51,8 @@ THostConnection MakePBufferConnection(
         .Credentials = NDDisk::TQueryCredentials::ToPersistentBuffer(
             /*tabletId=*/100,
             /*generation=*/1,
-            guid)};
+            guid,
+            /*directBlockGroupIndex=*/0)};
 }
 
 TGuardedSgList MakeSgList(TString& buffer)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/ic_storage_transport_test_adapter.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/ic_storage_transport_test_adapter.cpp
@@ -108,6 +108,13 @@ void TICStorageTransportTestAdapter::RegisterStub(
                 ddiskId.NodeId,
                 ddiskId.PDiskId,
                 ddiskId.DDiskSlotId);
+            Runtime->RegisterService(
+                MakeBlobStorageDDiskId(
+                    ddiskId.NodeId,
+                    ddiskId.PDiskId,
+                    ddiskId.DDiskSlotId),
+                actorId,
+                0);
             break;
     }
 

--- a/ydb/core/protos/blobstorage_ddisk.proto
+++ b/ydb/core/protos/blobstorage_ddisk.proto
@@ -82,8 +82,23 @@ message TDDiskId {
     uint32 DDiskSlotId = 3;
 }
 
-// DDisk query credentials define who asks for an operation: tablet identifier, tablet generation and session sequence
-// number (to prevent races with obsolete instances), and DDiskInstanceGuid to identify cases when DDisk data was lost.
+// Opaque connection handle issued by DDisk:
+// - Low[0..31]   — connection-vector index
+// - Low[32..63]  — low 32 bits of TabletId
+// - High[0..7]   — sequence number of this vector slot
+// - High[8..15]  — random restart sanity check
+// - High[16..31] — low 16 bits of NodeId
+// - High[32..47] — low 16 bits of PDiskId
+// - High[48..63] — low 16 bits of VSlotId
+// Callers must return both parts unchanged.
+message TConnectionToken {
+    fixed64 Low = 1;
+    fixed64 High = 2;
+}
+
+// DDisk query credentials define who asks for an operation: tablet identifier, direct block group index, tablet
+// generation and session sequence number (to prevent races with obsolete instances), and DDiskInstanceGuid to identify
+// cases when DDisk data was lost.
 
 message TQueryCredentials {
     enum ERequestKind {
@@ -97,6 +112,17 @@ message TQueryCredentials {
     optional fixed64 DDiskInstanceGuid = 3;
     ERequestKind RequestKind = 4;
     uint64 DDiskSessionSeqNo = 5;
+    uint32 DirectBlockGroupIndex = 6;
+}
+
+message TRequestCredentials {
+    oneof Credentials {
+        TConnectionToken ConnectionToken = 1;
+
+        // DDisk-to-DDisk/PBuffer forwarding carries server-side context instead
+        // of a client connection token.
+        TQueryCredentials Internal = 2;
+    }
 }
 
 // DDisk block selector defines the range of blocks we are operating at; it includes through-numbered vChunk index and
@@ -146,13 +172,14 @@ message TEvConnectResult {
     TReplyStatus.E Status = 1;
     optional string ErrorReason = 2;
     fixed64 DDiskInstanceGuid = 3; // instance guid gets changed every time DDisk loses its data
+    TConnectionToken ConnectionToken = 4;
 }
 
 // DDisk disconnect query is issued when tablet is going to be stopped gracefully and don't need DDisk to keep any
 // context about that tablet anymore.
 
 message TEvDisconnect {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
 }
 
 message TEvDisconnectResult {
@@ -161,7 +188,7 @@ message TEvDisconnectResult {
 }
 
 message TEvWrite {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     TBlockSelector Selector = 2;
     TWriteInstruction Instruction = 3;
 
@@ -178,7 +205,7 @@ message TEvWriteResult {
 }
 
 message TEvRead {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     TBlockSelector Selector = 2;
     TReadInstruction Instruction = 3;
 }
@@ -193,7 +220,7 @@ message TEvReadResult {
 }
 
 message TEvDeleteTabletChunks {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
 }
 
 message TEvDeleteTabletChunksResult {
@@ -203,7 +230,7 @@ message TEvDeleteTabletChunksResult {
 }
 
 message TEvWritePersistentBuffer {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     TBlockSelector Selector = 2;
     uint64 Lsn = 3;
     TWriteInstruction Instruction = 4;
@@ -223,7 +250,7 @@ message TEvWritePersistentBufferResult {
 }
 
 message TEvReadThenWritePersistentBuffers {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     uint64 Lsn = 2;
     uint32 Generation = 3;
     repeated TDDiskId PersistentBufferIds = 4;
@@ -231,7 +258,7 @@ message TEvReadThenWritePersistentBuffers {
 }
 
 message TEvWritePersistentBuffers {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     TBlockSelector Selector = 2;
     uint64 Lsn = 3;
     TWriteInstruction Instruction = 4;
@@ -256,7 +283,7 @@ message TEvWritePersistentBuffersResult {
 }
 
 message TEvReadPersistentBuffer {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     TBlockSelector Selector = 2;
     uint64 Lsn = 3;
     TReadInstruction Instruction = 4;
@@ -306,7 +333,7 @@ message TEvSync {
         repeated TSegment Segments = 3;
     }
 
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     repeated TSource Sources = 2;
 }
 
@@ -318,7 +345,7 @@ message TEvSyncResult {
 }
 
 message TEvErasePersistentBuffer {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     reserved 2;
     uint64 Lsn = 3; // Erase all lsns for tablet less than or equal to
     reserved 4;
@@ -332,7 +359,7 @@ message TEvBatchErasePersistentBuffer {
         uint32 Generation = 3;
     }
 
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
     repeated TEraseInfo Erases = 2;
 }
 
@@ -344,7 +371,7 @@ message TEvErasePersistentBufferResult {
 }
 
 message TEvListPersistentBuffer {
-    TQueryCredentials Credentials = 1;
+    TRequestCredentials Credentials = 1;
 }
 
 message TEvListPersistentBufferResult {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added DDisk-issued connection tokens for authenticating direct block group and persistent buffer requests.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Reapplies #48291 after the rollback in #49876, on top of the current main branch.