### PR TITLE
EXT-2349 add UT for ExpectedSlotSize reported as SlotSizeBytes to monitoring

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -1138,6 +1138,59 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         UNIT_ASSERT_LE(ui64(evCheckSpaceResult->TotalChunks) * formatChunkSize, expectedSlotSize);
     }
 
+    Y_UNIT_TEST(SlotSizeBytesUsesFormulaUnlessExpectedSlotSizeIsSet) {
+        TActorTestContext testCtx({
+            .DiskSize = 1_GB,
+            .ChunkSize = 1_MB,
+        });
+
+        const ui32 firstNodeId = testCtx.GetRuntime()->GetFirstNodeId();
+        testCtx.GetRuntime()->SetDispatchTimeout(10 * TDuration::MilliSeconds(testCtx.GetPDiskConfig()->StatisticsUpdateIntervalMs));
+        testCtx.GetRuntime()->RegisterService(NNodeWhiteboard::MakeNodeWhiteboardServiceId(firstNodeId), testCtx.Sender);
+
+        auto waitForPDiskStateUpdate = [&](ui32 expectedSlotCount, ui64 expectedSlotSize) {
+            for (ui32 i = 0; i < 10; ++i) {
+                const auto evPDiskStateUpdate = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate>();
+                const NKikimrWhiteboard::TPDiskStateInfo& pdiskInfo = evPDiskStateUpdate->Record;
+                if (pdiskInfo.GetExpectedSlotCount() == expectedSlotCount &&
+                        pdiskInfo.GetExpectedSlotSize() == expectedSlotSize) {
+                    return;
+                }
+            }
+            UNIT_ASSERT_C(false, "No PDisk state update with expected slot settings received");
+        };
+
+        auto getSlotSizeBytes = [&] {
+            return testCtx.SafeRunOnPDisk([](const NPDisk::TPDisk* pdisk) {
+                return pdisk->Mon.SlotSizeBytes->Val();
+            });
+        };
+
+        const ui32 expectedSlotCount = 4;
+
+        testCtx.TestResponse<NPDisk::TEvChangeExpectedSlotCountResult>(
+            new NPDisk::TEvChangeExpectedSlotCount(expectedSlotCount),
+            NKikimrProto::OK);
+        testCtx.Send(new TEvents::TEvWakeup());
+        waitForPDiskStateUpdate(expectedSlotCount, 0);
+
+        const ui64 formulaSlotSizeBytes = testCtx.SafeRunOnPDisk([&](const NPDisk::TPDisk* pdisk) {
+            return ui64(pdisk->Keeper.GetUserChunkPoolSize() / expectedSlotCount) * ui64(pdisk->Format.ChunkSize);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(getSlotSizeBytes(), formulaSlotSizeBytes);
+
+        const ui64 expectedSlotSize = 3ull * testCtx.GetPDiskConfig()->ChunkSize + 1;
+        UNIT_ASSERT_VALUES_UNEQUAL(expectedSlotSize, formulaSlotSizeBytes);
+
+        testCtx.TestResponse<NPDisk::TEvChangeExpectedSlotCountResult>(
+            new NPDisk::TEvChangeExpectedSlotCount(expectedSlotCount, expectedSlotSize),
+            NKikimrProto::OK);
+        testCtx.Send(new TEvents::TEvWakeup());
+        waitForPDiskStateUpdate(expectedSlotCount, expectedSlotSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(getSlotSizeBytes(), expectedSlotSize);
+    }
+
     Y_UNIT_TEST(ChangeExpectedSlotSettingsLive) {
         TActorTestContext testCtx({
             .DiskSize = 1_GB,


### PR DESCRIPTION
### Changelog entry
Unit tests for ExpectedSlotSize reporting

### Description for reviewers

ExpectedSlotSize support was implemented in #47509. This PR adds units tests.