### PR TITLE
Add VDisk emergency compaction strategy

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -61,6 +61,9 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , FreshCompMaxInFlightWrites(10, 1, 1000)
     , FreshCompMaxInFlightReads(10, 1, 1000)
     , HullCompFreeSpaceThresholdPerMille(2000, 0, 100'000)
+    , HullCompEmergencyMaxSsts(8, 0, 64)
+    , HullCompEmergencyChunkReserve(1, 0, 64)
+    , HullCompEmergencyEnableAtColor(15, 0, 60)
     , HullCompMaxInFlightWrites(10, 1, 1000)
     , HullCompMaxInFlightReads(20, 1, 1000)
     , HullCompFullCompPeriodSec(0, 0, 7 * 24 * 60 * 60)
@@ -472,6 +475,9 @@ void TNodeWarden::Bootstrap() {
         TControlBoard::RegisterSharedControl(HullCompThrottlerBytesRate, icb->VDiskControls.HullCompThrottlerBytesRate);
         TControlBoard::RegisterSharedControl(GarbageThresholdToRunFullCompactionPerMille, icb->VDiskControls.GarbageThresholdToRunFullCompactionPerMille);
         TControlBoard::RegisterSharedControl(HullCompFreeSpaceThresholdPerMille, icb->VDiskControls.HullCompFreeSpaceThresholdPerMille);
+        TControlBoard::RegisterSharedControl(HullCompEmergencyMaxSsts, icb->VDiskControls.HullCompEmergencyMaxSsts);
+        TControlBoard::RegisterSharedControl(HullCompEmergencyChunkReserve, icb->VDiskControls.HullCompEmergencyChunkReserve);
+        TControlBoard::RegisterSharedControl(HullCompEmergencyEnableAtColor, icb->VDiskControls.HullCompEmergencyEnableAtColor);
         TControlBoard::RegisterSharedControl(DefragThrottlerBytesRate, icb->VDiskControls.DefragThrottlerBytesRate);
 
         TControlBoard::RegisterSharedControl(ThrottlingDryRun, icb->VDiskControls.ThrottlingDryRun);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -255,6 +255,9 @@ namespace NKikimr::NStorage {
         TControlWrapper FreshCompMaxInFlightWrites;
         TControlWrapper FreshCompMaxInFlightReads;
         TControlWrapper HullCompFreeSpaceThresholdPerMille;
+        TControlWrapper HullCompEmergencyMaxSsts;
+        TControlWrapper HullCompEmergencyChunkReserve;
+        TControlWrapper HullCompEmergencyEnableAtColor;
         TControlWrapper HullCompMaxInFlightWrites;
         TControlWrapper HullCompMaxInFlightReads;
         TControlWrapper HullCompFullCompPeriodSec;

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -326,6 +326,9 @@ namespace NKikimr::NStorage {
             vdiskConfig->HullCompThrottlerBytesRate = HullCompThrottlerBytesRate;
             vdiskConfig->GarbageThresholdToRunFullCompactionPerMille = GarbageThresholdToRunFullCompactionPerMille;
             vdiskConfig->HullCompFreeSpaceThresholdPerMille = HullCompFreeSpaceThresholdPerMille;
+            vdiskConfig->HullCompEmergencyMaxSsts = HullCompEmergencyMaxSsts;
+            vdiskConfig->HullCompEmergencyChunkReserve = HullCompEmergencyChunkReserve;
+            vdiskConfig->HullCompEmergencyEnableAtColor = HullCompEmergencyEnableAtColor;
             vdiskConfig->MaxActiveCompactionsPerPDisk = MaxActiveCompactionsPerPDisk;
             vdiskConfig->DefragThrottlerBytesRate = DefragThrottlerBytesRate;
             vdiskConfig->EnableLocalSyncLogDataCutting = EnableLocalSyncLogDataCutting;

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -602,6 +602,9 @@ config:
                 ADD_ICB_CONTROL(VDiskControls.EnableChecksumWriteValidationOnVDisk, false, false, true, false);
                 ADD_ICB_CONTROL(VDiskControls.EnableChunkKeeper, true, false, true, Settings.EnableChunkKeeper);
                 ADD_ICB_CONTROL(VDiskControls.HullCompFreeSpaceThresholdPerMille, 2000, 0, 100'000, 2000);
+                ADD_ICB_CONTROL(VDiskControls.HullCompEmergencyMaxSsts, 8, 0, 64, 8);
+                ADD_ICB_CONTROL(VDiskControls.HullCompEmergencyChunkReserve, 1, 0, 64, 1);
+                ADD_ICB_CONTROL(VDiskControls.HullCompEmergencyEnableAtColor, 15, 0, 60, 15);
 #undef ADD_ICB_CONTROL
 
                 {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
@@ -39,6 +39,9 @@ namespace NKikimr {
         HullCompSortedPartsNum = 8u;
         HullCompLevelRateThreshold = 1.0;
         HullCompFreeSpaceThresholdPerMille = 2000; // default ratio is 2x
+        HullCompEmergencyMaxSsts = 8; // 0 disables Emergency
+        HullCompEmergencyChunkReserve = 1;
+        HullCompEmergencyEnableAtColor = 15; // LIGHT_YELLOW
         FreshCompMaxInFlightWrites = 10;
         FreshCompMaxInFlightReads = 10; // when moving huge blobs
         HullCompMaxInFlightWrites = 10;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -128,6 +128,9 @@ namespace NKikimr {
         ui32 HullCompSortedPartsNum;
         double HullCompLevelRateThreshold;
         TControlWrapper HullCompFreeSpaceThresholdPerMille;
+        TControlWrapper HullCompEmergencyMaxSsts;
+        TControlWrapper HullCompEmergencyChunkReserve;
+        TControlWrapper HullCompEmergencyEnableAtColor;
         TControlWrapper FreshCompMaxInFlightWrites;
         TControlWrapper FreshCompMaxInFlightReads;
         TControlWrapper HullCompMaxInFlightWrites;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
@@ -972,6 +972,7 @@ public:                                                                         
                 COUNTER_INIT(BlobsBalanceLevel, true);
                 COUNTER_INIT(BlobsBalanceFull, true);
                 COUNTER_INIT(BlobsFreeSpace, true);
+                COUNTER_INIT(BlobsEmergency, true);
                 COUNTER_INIT(BlobsSqueeze, true);
 
                 COUNTER_INIT(BlocksPromoteSsts, true);
@@ -990,6 +991,7 @@ public:                                                                         
             COUNTER_DEF(BlobsBalanceLevel);
             COUNTER_DEF(BlobsBalanceFull);
             COUNTER_DEF(BlobsFreeSpace);
+            COUNTER_DEF(BlobsEmergency);
             COUNTER_DEF(BlobsSqueeze);
 
             COUNTER_DEF(BlocksPromoteSsts);

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_balance.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_balance.h
@@ -646,6 +646,7 @@ namespace NKikimr {
                 , Task(task)
                 , RankThreshold(params.RankThreshold)
                 , FullCompactionAttrs(params.FullCompactionAttrs)
+                , FreeChunksBudget(params.FreeChunksBudget)
                 , Sublog({})
                 , BalanceLevel0(HullCtx, Sublog, params.Boundaries, LevelSnap.SliceSnap, Task->CompactSsts,
                         Task->IsFullCompaction)
@@ -677,6 +678,7 @@ namespace NKikimr {
             TTask *Task;
             const double RankThreshold;
             const std::optional<TFullCompactionAttrs> FullCompactionAttrs;
+            const ui32 FreeChunksBudget;
             TSublog<> Sublog;
             TBalanceLevel0 BalanceLevel0;
             TBalancePartiallySortedLevels BalancePartiallySortedLevels;
@@ -702,6 +704,27 @@ namespace NKikimr {
                 }
             };
 
+            bool AcceptIfFitsBudget() {
+                if (FreeChunksBudget == Max<ui32>()) {
+                    return true;
+                }
+                const ui32 estimated = TUtils<TKey, TMemRec>::EstimateCompactSstsOutputChunks(
+                    Task->CompactSsts, HullCtx->ChunkSize);
+                if (estimated <= FreeChunksBudget) {
+                    return true;
+                }
+                if (HullCtx->VCtx->ActorSystem) {
+                    YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP,
+                        "TStrategyBalance skipped compaction because estimated output exceeds free-chunk budget",
+                        {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix},
+                        {"estimatedOutputChunks", estimated},
+                        {"freeChunksBudget", FreeChunksBudget});
+                }
+                Task->CompactSsts.Clear();
+                Task->IsFullCompaction = false;
+                return false;
+            }
+
             EAction BalanceLevelsTree(TRanks &ranks) {
                 // calculate ranks
                 ranks.push_back(BalanceLevel0.CalculateRank());
@@ -726,27 +749,33 @@ namespace NKikimr {
                 if (maxRank < RankThreshold) {
                     if (FullCompactionAttrs) {
                         if (BalanceLevel0.FullCompact(FullCompactionAttrs->FullCompactionLsn)) {
-                            if (HullCtx->VCtx->ActorSystem) {
-                                YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP, "TStrategyBalance decided to full compact compact level 0",
-                                    {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix});
+                            if (AcceptIfFitsBudget()) {
+                                if (HullCtx->VCtx->ActorSystem) {
+                                    YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP, "TStrategyBalance decided to full compact compact level 0",
+                                        {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix});
+                                }
+                                return ActCompactSsts;
                             }
-                            return ActCompactSsts;
                         }
 
                         if (BalancePartiallySortedLevels.FullCompact(FullCompactionAttrs->FullCompactionLsn)) {
-                            if (HullCtx->VCtx->ActorSystem) {
-                                YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP, "TStrategyBalance decided to full compact compact sorted level",
-                                    {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix});
+                            if (AcceptIfFitsBudget()) {
+                                if (HullCtx->VCtx->ActorSystem) {
+                                    YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP, "TStrategyBalance decided to full compact compact sorted level",
+                                        {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix});
+                                }
+                                return ActCompactSsts;
                             }
-                            return ActCompactSsts;
                         }
 
                         if (BalanceLevelX.FullCompact(*FullCompactionAttrs)) {
-                            if (HullCtx->VCtx->ActorSystem) {
-                                YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP, "TStrategyBalance decided to full compact compact level x",
-                                    {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix});
+                            if (AcceptIfFitsBudget()) {
+                                if (HullCtx->VCtx->ActorSystem) {
+                                    YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP, "TStrategyBalance decided to full compact compact level x",
+                                        {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix});
+                                }
+                                return ActCompactSsts;
                             }
-                            return ActCompactSsts;
                         }
 
                         // mark that full compaction has been finished
@@ -766,6 +795,9 @@ namespace NKikimr {
                         case 0:     BalanceLevel0.Compact(); break;
                         case 1:     BalancePartiallySortedLevels.Compact(); break;
                         default:    BalanceLevelX.Compact(ranks.VirtualLevelToCompact);
+                    }
+                    if (!AcceptIfFitsBudget()) {
+                        return ActNothing;
                     }
                     return ActCompactSsts;
                 }

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_defs.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_defs.h
@@ -36,6 +36,7 @@ namespace NKikimr {
             Explicit,
             BalanceLevel,
             BalanceFull,
+            Emergency,
             FreeSpace,
             Squeeze,
         };
@@ -425,6 +426,11 @@ namespace NKikimr {
             TInstant SqueezeBefore;
             // Full compact LevelIndex before this lsn
             std::optional<TFullCompactionAttrs> FullCompactionAttrs;
+            // Max index chunks the compaction job may allocate before commit (peak extra space).
+            // Max<ui32>() means no limit (budget unknown / plenty of space).
+            ui32 FreeChunksBudget = Max<ui32>();
+            // When true, skip unconstrained Balance and prefer Emergency packing/merges.
+            bool EmergencyMode = false;
         };
 
     } // NHullComp

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_emergency.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_emergency.h
@@ -1,0 +1,311 @@
+#pragma once
+
+#include "defs.h"
+#include "hulldb_compstrat_utils.h"
+#include <util/generic/algorithm.h>
+
+namespace NKikimr {
+    namespace NHullComp {
+
+        ////////////////////////////////////////////////////////////////////////////
+        // NHullComp::TStrategyEmergency
+        // Pick a small SST set whose estimated output fits FreeChunksBudget and
+        // is expected to free index chunks (or a chunk of huge-blob garbage).
+        ////////////////////////////////////////////////////////////////////////////
+        template <class TKey, class TMemRec>
+        class TStrategyEmergency {
+        public:
+            using TTask = ::NKikimr::NHullComp::TTask<TKey, TMemRec>;
+            using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
+            using TLevelSegmentPtr = TIntrusivePtr<TLevelSegment>;
+            using TLevelIndexSnapshot = ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>;
+            using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
+            using TSortedLevel = typename TLevelSliceSnapshot::TSortedLevel;
+            using TSegments = typename TLevelSliceSnapshot::TSegments;
+            using TUtils = ::NKikimr::NHullComp::TUtils<TKey, TMemRec>;
+
+            TStrategyEmergency(
+                    TIntrusivePtr<THullCtx> hullCtx,
+                    const TSelectorParams &params,
+                    const TLevelIndexSnapshot &levelSnap,
+                    TTask *task)
+                : HullCtx(std::move(hullCtx))
+                , Params(params)
+                , LevelSnap(levelSnap)
+                , Task(task)
+                , MaxSsts(ui32(HullCtx->VCfg->HullCompEmergencyMaxSsts))
+                , ChunkSize(HullCtx->ChunkSize)
+            {}
+
+            EAction Select() {
+                TInstant startTime(TAppData::TimeProvider->Now());
+                EAction action = ActNothing;
+                if (MaxSsts > 0) {
+                    action = Choose();
+                }
+                if (action != ActNothing) {
+                    Task->SetupAction(action);
+                }
+
+                TInstant finishTime(TAppData::TimeProvider->Now());
+                if (HullCtx->VCtx->ActorSystem) {
+                    YDB_LOG_CTX_COMP(*HullCtx->VCtx->ActorSystem,
+                        action == ActNothing ? NLog::PRI_DEBUG : NLog::PRI_INFO,
+                        NKikimrServices::BS_HULLCOMP,
+                        VDISKP(HullCtx->VCtx->VDiskLogPrefix,
+                            "%s: Emergency: action# %s timeSpent# %s budget# %" PRIu32
+                            " maxSsts# %" PRIu32 " candidate# %s",
+                            PDiskSignatureForHullDbKey<TKey>().ToString().data(),
+                            ActionToStr(action),
+                            (finishTime - startTime).ToString().data(),
+                            Params.FreeChunksBudget,
+                            MaxSsts,
+                            Best.ToString().data()));
+                }
+                return action;
+            }
+
+        private:
+            struct TLess {
+                bool operator()(const TKey &key, const TLevelSegmentPtr &ptr) const {
+                    return key < ptr->FirstKey();
+                }
+                bool operator()(const TLevelSegmentPtr &ptr, const TKey &key) const {
+                    return ptr->FirstKey() < key;
+                }
+            };
+
+            struct TCandidate {
+                enum class EKind {
+                    None,
+                    Pack,
+                    Squeeze,
+                    CrossLevel,
+                };
+
+                EKind Kind = EKind::None;
+                ui32 TargetLevel = 0;
+                ui32 SrcLevel = 0;
+                ui32 InputChunks = 0;
+                ui32 OutputChunks = 0;
+                ui64 HugeGarbage = 0;
+                typename TSegments::const_iterator SrcFirst{};
+                typename TSegments::const_iterator SrcLast{};
+                typename TSegments::const_iterator NextFirst{};
+                typename TSegments::const_iterator NextLast{};
+
+                i64 NetIndexChunks() const {
+                    return i64(InputChunks) - i64(OutputChunks);
+                }
+
+                bool BetterThan(const TCandidate &o) const {
+                    if (NetIndexChunks() != o.NetIndexChunks()) {
+                        return NetIndexChunks() > o.NetIndexChunks();
+                    }
+                    if (HugeGarbage != o.HugeGarbage) {
+                        return HugeGarbage > o.HugeGarbage;
+                    }
+                    return OutputChunks < o.OutputChunks;
+                }
+
+                TString ToString() const {
+                    TStringStream str;
+                    str << "{Kind# ";
+                    switch (Kind) {
+                        case EKind::None: str << "None"; break;
+                        case EKind::Pack: str << "Pack"; break;
+                        case EKind::Squeeze: str << "Squeeze"; break;
+                        case EKind::CrossLevel: str << "CrossLevel"; break;
+                    }
+                    str << " SrcLevel# " << SrcLevel
+                        << " TargetLevel# " << TargetLevel
+                        << " InputChunks# " << InputChunks
+                        << " OutputChunks# " << OutputChunks
+                        << " HugeGarbage# " << HugeGarbage
+                        << "}";
+                    return str.Str();
+                }
+            };
+
+            TIntrusivePtr<THullCtx> HullCtx;
+            const TSelectorParams &Params;
+            const TLevelIndexSnapshot &LevelSnap;
+            TTask *Task;
+            const ui32 MaxSsts;
+            const ui32 ChunkSize;
+            TCandidate Best;
+
+            bool FitsBudget(ui32 outputChunks) const {
+                return outputChunks <= Params.FreeChunksBudget;
+            }
+
+            bool IsUseful(const TCandidate &c) const {
+                return c.NetIndexChunks() > 0 || c.HugeGarbage >= ChunkSize;
+            }
+
+            void Consider(TCandidate &&c) {
+                if (c.Kind == TCandidate::EKind::None) {
+                    return;
+                }
+                if (!FitsBudget(c.OutputChunks) || !IsUseful(c)) {
+                    return;
+                }
+                if (Best.Kind == TCandidate::EKind::None || c.BetterThan(Best)) {
+                    Best = std::move(c);
+                }
+            }
+
+            void AddRangeMetrics(
+                    typename TSegments::const_iterator first,
+                    typename TSegments::const_iterator last,
+                    ui32 &inputChunks,
+                    ui64 &keepBytes,
+                    ui64 &hugeGarbage) const
+            {
+                for (auto it = first; it != last; ++it) {
+                    inputChunks += TUtils::SstInputChunks(**it);
+                    keepBytes += TUtils::SstKeepBytes(**it);
+                    hugeGarbage += TUtils::SstHugeGarbageBytes(**it);
+                }
+            }
+
+            void ScanSameLevel(ui32 levelIdx) {
+                const TLevelSliceSnapshot &slice = LevelSnap.SliceSnap;
+                const TSortedLevel &sorted = slice.GetLevelXRef(levelIdx);
+                const TSegments &segs = sorted.Segs->Segments;
+                if (segs.size() < 1) {
+                    return;
+                }
+
+                const ui32 level = levelIdx + 1;
+                const ui32 n = segs.size();
+                for (ui32 i = 0; i < n; ++i) {
+                    ui32 inputChunks = 0;
+                    ui64 keepBytes = 0;
+                    ui64 hugeGarbage = 0;
+                    const ui32 maxW = Min(MaxSsts, n - i);
+                    for (ui32 w = 1; w <= maxW; ++w) {
+                        const auto sst = segs[i + w - 1];
+                        inputChunks += TUtils::SstInputChunks(*sst);
+                        keepBytes += TUtils::SstKeepBytes(*sst);
+                        hugeGarbage += TUtils::SstHugeGarbageBytes(*sst);
+
+                        TCandidate c;
+                        c.SrcLevel = level;
+                        c.TargetLevel = level;
+                        c.SrcFirst = segs.begin() + i;
+                        c.SrcLast = segs.begin() + i + w;
+                        c.InputChunks = inputChunks;
+                        c.OutputChunks = TUtils::EstimateOutputChunks(keepBytes, ChunkSize);
+                        c.HugeGarbage = hugeGarbage;
+                        c.Kind = (w == 1) ? TCandidate::EKind::Squeeze : TCandidate::EKind::Pack;
+                        Consider(std::move(c));
+                    }
+                }
+            }
+
+            std::pair<typename TSegments::const_iterator, typename TSegments::const_iterator>
+            FindOverlap(const TSegments &segs, const TKey &firstKey, const TKey &lastKey) const {
+                if (segs.empty()) {
+                    return {segs.end(), segs.end()};
+                }
+                auto firstIt = ::LowerBound(segs.begin(), segs.end(), firstKey, TLess());
+                if (firstIt != segs.begin()) {
+                    --firstIt;
+                    if ((*firstIt)->LastKey() < firstKey) {
+                        ++firstIt;
+                    }
+                }
+                auto endIt = ::UpperBound(segs.begin(), segs.end(), lastKey, TLess());
+                return {firstIt, endIt};
+            }
+
+            void ScanCrossLevel(ui32 srcLevelIdx) {
+                const TLevelSliceSnapshot &slice = LevelSnap.SliceSnap;
+                if (srcLevelIdx + 1 >= slice.GetLevelXNumber()) {
+                    return;
+                }
+                const TSegments &srcSegs = slice.GetLevelXRef(srcLevelIdx).Segs->Segments;
+                const TSegments &nextSegs = slice.GetLevelXRef(srcLevelIdx + 1).Segs->Segments;
+                if (srcSegs.empty() || nextSegs.empty()) {
+                    return;
+                }
+
+                const ui32 srcLevel = srcLevelIdx + 1;
+                for (auto srcIt = srcSegs.begin(); srcIt != srcSegs.end(); ++srcIt) {
+                    auto [nextFirst, nextLast] = FindOverlap(nextSegs,
+                        (*srcIt)->FirstKey(), (*srcIt)->LastKey());
+                    const ui32 overlap = static_cast<ui32>(nextLast - nextFirst);
+                    if (overlap == 0) {
+                        continue; // PromoteSsts handles non-intersecting SSTs
+                    }
+                    if (overlap + 1 > MaxSsts) {
+                        continue;
+                    }
+
+                    TCandidate c;
+                    c.Kind = TCandidate::EKind::CrossLevel;
+                    c.SrcLevel = srcLevel;
+                    c.TargetLevel = srcLevel + 1;
+                    c.SrcFirst = srcIt;
+                    c.SrcLast = srcIt + 1;
+                    c.NextFirst = nextFirst;
+                    c.NextLast = nextLast;
+                    ui64 keepBytes = 0;
+                    AddRangeMetrics(c.SrcFirst, c.SrcLast, c.InputChunks, keepBytes, c.HugeGarbage);
+                    AddRangeMetrics(c.NextFirst, c.NextLast, c.InputChunks, keepBytes, c.HugeGarbage);
+                    c.OutputChunks = TUtils::EstimateOutputChunks(keepBytes, ChunkSize);
+                    Consider(std::move(c));
+                }
+            }
+
+            void ApplyBest() {
+                auto &compactSsts = Task->CompactSsts;
+                if (Best.Kind == TCandidate::EKind::CrossLevel) {
+                    compactSsts.TargetLevel = Best.TargetLevel;
+                    compactSsts.PushSstFromLevelX(Best.SrcLevel, Best.SrcFirst, Best.SrcLast);
+                    compactSsts.LastCompactedKey = (*Best.SrcFirst)->LastKey();
+                    compactSsts.PushSstFromLevelX(Best.SrcLevel + 1, Best.NextFirst, Best.NextLast);
+                } else {
+                    TUtils::CompactContiguousSsts(
+                        LevelSnap.SliceSnap,
+                        Best.SrcLevel,
+                        Best.SrcFirst,
+                        Best.SrcLast,
+                        compactSsts);
+                }
+            }
+
+            EAction Choose() {
+                const TLevelSliceSnapshot &slice = LevelSnap.SliceSnap;
+                const ui32 nLevels = slice.GetLevelXNumber();
+                if (nLevels == 0) {
+                    return ActNothing;
+                }
+
+                // Prefer last populated level first (typical "all data on 17/18" case).
+                for (i32 i = static_cast<i32>(nLevels) - 1; i >= 0; --i) {
+                    ScanSameLevel(static_cast<ui32>(i));
+                }
+                for (i32 i = static_cast<i32>(nLevels) - 2; i >= 0; --i) {
+                    ScanCrossLevel(static_cast<ui32>(i));
+                }
+
+                if (Best.Kind == TCandidate::EKind::None) {
+                    return ActNothing;
+                }
+
+                if (HullCtx->VCtx->ActorSystem) {
+                    YDB_LOG_INFO_CTX_COMP(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP,
+                        "TStrategyEmergency decided to compact",
+                        {"VDiskLogPrefix", HullCtx->VCtx->VDiskLogPrefix},
+                        {"candidate", Best.ToString()},
+                        {"budget", Params.FreeChunksBudget});
+                }
+                ApplyBest();
+                return ActCompactSsts;
+            }
+        };
+
+    } // NHullComp
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
@@ -6,6 +6,7 @@
 #include "hulldb_compstrat_space.h"
 #include "hulldb_compstrat_squeeze.h"
 #include "hulldb_compstrat_explicit.h"
+#include "hulldb_compstrat_emergency.h"
 
 namespace NKikimr {
     namespace NHullComp {
@@ -26,6 +27,7 @@ namespace NKikimr {
             using TStrategyPromoteSsts = NHullComp::TStrategyPromoteSsts<TKeyLogoBlob, TMemRecLogoBlob>;
             using TStrategyStorageRatio = NHullComp::TStrategyStorageRatio<TKeyLogoBlob, TMemRecLogoBlob>;
             using TStrategySqueeze = NHullComp::TStrategySqueeze<TKeyLogoBlob, TMemRecLogoBlob>;
+            using TStrategyEmergency = NHullComp::TStrategyEmergency<TKeyLogoBlob, TMemRecLogoBlob>;
 
             // calculate storage ratio and gather space consumption statistics
             TIntrusivePtr<TBarriersSnapshot::TBarriersEssence> barriersEssence = BarriersSnap.CreateEssence(HullCtx);
@@ -53,12 +55,22 @@ namespace NKikimr {
                 return action;
             }
 
-            // try to find what to compact based on levels balance
-            action = TStrategyBalance(HullCtx, Params, LevelSnap, Task).Select();
+            // try to find what to compact based on levels balance (skipped in emergency mode;
+            // even then Balance refuses jobs whose estimated output exceeds the free-chunk budget)
+            if (!Params.EmergencyMode) {
+                action = TStrategyBalance(HullCtx, Params, LevelSnap, Task).Select();
+                if (action != ActNothing) {
+                    Task->SelectStrategy = Task->IsFullCompaction
+                        ? ESelectStrategy::BalanceFull
+                        : ESelectStrategy::BalanceLevel;
+                    return action;
+                }
+            }
+
+            // reclaim index chunks with a small, budgeted compaction
+            action = TStrategyEmergency(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                Task->SelectStrategy = Task->IsFullCompaction
-                    ? ESelectStrategy::BalanceFull
-                    : ESelectStrategy::BalanceLevel;
+                Task->SelectStrategy = ESelectStrategy::Emergency;
                 return action;
             }
 

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ut.cpp
@@ -1,8 +1,11 @@
 #include "hulldb_compstrat_selector.h"
+#include "hulldb_compstrat_emergency.h"
 #include "hulldb_compstrat_ratio.h"
 #include <util/stream/null.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/test/testhull_index.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_arena.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/generic/hullds_leveledssts.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #define STR     Cnull
@@ -16,8 +19,10 @@ namespace NKikimr {
         static constexpr ui32 HullCompSortedPartsNum = 8u;
         static constexpr bool Level0UseDreg = true;
         using TStrategy = ::NKikimr::NHullComp::TStrategy<TKeyLogoBlob, TMemRecLogoBlob>;
+        using TStrategyEmergency = ::NKikimr::NHullComp::TStrategyEmergency<TKeyLogoBlob, TMemRecLogoBlob>;
         using TTask = ::NKikimr::NHullComp::TTask<TKeyLogoBlob, TMemRecLogoBlob>;
-
+        using TUtils = ::NKikimr::NHullComp::TUtils<TKeyLogoBlob, TMemRecLogoBlob>;
+        using TLeveledSstsIterator = TLeveledSsts<TKeyLogoBlob, TMemRecLogoBlob>::TIterator;
 
         Y_UNIT_TEST(Test1) {
             STR << "Building LevelIndex\n";
@@ -49,6 +54,222 @@ namespace NKikimr {
             STR << "action = " << NHullComp::ActionToStr(action) << "\n";
         }
 
+        struct TSynthHull {
+            TTestContexts Ctx;
+            std::shared_ptr<TRopeArena> Arena;
+            TIntrusivePtr<THullDs> Ds;
+            NHullComp::TBoundariesConstPtr Boundaries;
+
+            TSynthHull(ui32 nSortedLevels, ui32 chunkSize = ChunkSize)
+                : Ctx(chunkSize)
+                , Arena(std::make_shared<TRopeArena>(&TRopeArenaBackend::Allocate))
+                , Ds(MakeIntrusive<THullDs>(Ctx.GetHullCtx()))
+                , Boundaries(new NHullComp::TBoundaries(chunkSize,
+                    HullCompLevel0MaxSstsAtOnce, HullCompSortedPartsNum, Level0UseDreg))
+            {
+                Ds->LogoBlobs = MakeIntrusive<TLogoBlobsDs>(Ctx.GetLevelIndexSettings(), Arena);
+                for (ui32 i = 0; i < nSortedLevels; ++i) {
+                    Ds->LogoBlobs->CurSlice->SortedLevels.push_back(
+                        TSortedLevel<TKeyLogoBlob, TMemRecLogoBlob>(TKeyLogoBlob()));
+                }
+                Ds->Blocks = MakeIntrusive<TBlocksDs>(Ctx.GetLevelIndexSettings(), Arena);
+                Ds->Barriers = MakeIntrusive<TBarriersDs>(Ctx.GetLevelIndexSettings(), Arena);
+                Ds->LogoBlobs->LoadCompleted();
+                Ds->Blocks->LoadCompleted();
+                Ds->Barriers->LoadCompleted();
+            }
+
+            TLogoBlobsSstPtr MakeSst(ui64 tabletId, ui32 firstStep, ui32 lastStep, ui32 chunkIdx,
+                    ui32 inplacedSize, NHullComp::TSstRatioPtr ratio)
+            {
+                auto sst = MakeIntrusive<TLogoBlobsSst>(Ctx.GetVCtx());
+                TTrackableVector<TLogoBlobsSst::TRec> index(TMemoryConsumer(Ctx.GetVCtx()->SstIndex));
+                for (ui32 step = firstStep; step <= lastStep; ++step) {
+                    TLogoBlobID id(tabletId, 1, step, 0, 1, 0, 1);
+                    TMemRecLogoBlob memRec;
+                    memRec.SetDiskBlob(TDiskPart(chunkIdx, 0, inplacedSize));
+                    index.emplace_back(TKeyLogoBlob(id), memRec);
+                }
+                sst->LoadLinearIndex(index);
+                sst->AllChunks.push_back(chunkIdx);
+                sst->Info.Chunks = 1;
+                sst->Info.Items = lastStep - firstStep + 1;
+                sst->Info.InplaceDataTotalSize = ui64(inplacedSize) * sst->Info.Items;
+                sst->Info.FirstLsn = 1;
+                sst->Info.LastLsn = 1;
+                if (ratio) {
+                    sst->StorageRatio.Set(ratio, TInstant::Zero());
+                }
+                return sst;
+            }
+
+            static NHullComp::TSstRatioPtr KeepRatio(ui64 keepBytes) {
+                auto ratio = MakeIntrusive<NHullComp::TSstRatio>();
+                ratio->IndexItemsTotal = 1;
+                ratio->IndexItemsKeep = 1;
+                ratio->InplacedDataTotal = keepBytes;
+                ratio->InplacedDataKeep = keepBytes;
+                return ratio;
+            }
+
+            void PutLevel(ui32 levelIdx, TLogoBlobsSstPtr sst) {
+                Ds->LogoBlobs->CurSlice->SortedLevels[levelIdx].Put(sst);
+            }
+
+            void PutL0(TLogoBlobsSstPtr sst) {
+                Ds->LogoBlobs->CurSlice->Level0.Put(sst);
+            }
+
+            ui32 LastLevelIdx() const {
+                return Ds->LogoBlobs->CurSlice->SortedLevels.size() - 1;
+            }
+
+            ui32 LastPhysicalLevel() const {
+                return LastLevelIdx() + 1;
+            }
+        };
+
+        ui32 CountSstsToDelete(const TTask &task) {
+            ui32 n = 0;
+            TLeveledSstsIterator it(&task.GetSstsToDelete());
+            it.SeekToFirst();
+            while (it.Valid()) {
+                ++n;
+                it.Next();
+            }
+            return n;
+        }
+
+        void AssertAction(NHullComp::EAction actual, NHullComp::EAction expected) {
+            UNIT_ASSERT_VALUES_EQUAL(TString(NHullComp::ActionToStr(actual)),
+                TString(NHullComp::ActionToStr(expected)));
+        }
+
+        void AssertStrategy(NHullComp::ESelectStrategy actual, NHullComp::ESelectStrategy expected) {
+            UNIT_ASSERT_VALUES_EQUAL(ui32(actual), ui32(expected));
+        }
+
+        Y_UNIT_TEST(EmergencyPacksTwoSparseSstsOnLastLevel) {
+            TSynthHull hull(17);
+            const ui64 keep = hull.Ctx.GetHullCtx()->ChunkSize / 3;
+            hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, 1, 1, 10, 100, hull.KeepRatio(keep)));
+            hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, 2, 2, 11, 100, hull.KeepRatio(keep)));
+
+            auto snap = hull.Ds->GetIndexSnapshot();
+            TTask task;
+            NHullComp::TSelectorParams params = {hull.Boundaries, 1.0, TInstant::Seconds(0), {}};
+            params.FreeChunksBudget = 1;
+            params.EmergencyMode = true;
+
+            TStrategyEmergency emergency(snap.HullCtx, params, snap.LogoBlobsSnap, &task);
+            AssertAction(emergency.Select(), NHullComp::ActCompactSsts);
+            UNIT_ASSERT_VALUES_EQUAL(task.CompactSsts.TargetLevel, hull.LastPhysicalLevel());
+            UNIT_ASSERT_VALUES_EQUAL(CountSstsToDelete(task), 2u);
+        }
+
+        Y_UNIT_TEST(EmergencyFullSelectPacksTwoSparseSsts) {
+            TSynthHull hull(17);
+            const ui64 keep = hull.Ctx.GetHullCtx()->ChunkSize / 3;
+            hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, 1, 1, 10, 100, hull.KeepRatio(keep)));
+            hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, 2, 2, 11, 100, hull.KeepRatio(keep)));
+
+            auto snap = hull.Ds->GetIndexSnapshot();
+            TTask task;
+            NHullComp::TSelectorParams params = {hull.Boundaries, 1.0, TInstant::Seconds(0), {}};
+            params.FreeChunksBudget = 1;
+            params.EmergencyMode = true;
+            TStrategy strategy(snap.HullCtx, params, std::move(snap.LogoBlobsSnap), std::move(snap.BarriersSnap),
+                    &task, true);
+            AssertAction(strategy.Select(), NHullComp::ActCompactSsts);
+            AssertStrategy(task.SelectStrategy, NHullComp::ESelectStrategy::Emergency);
+            UNIT_ASSERT_VALUES_EQUAL(task.CompactSsts.TargetLevel, hull.LastPhysicalLevel());
+            UNIT_ASSERT_VALUES_EQUAL(CountSstsToDelete(task), 2u);
+        }
+
+        Y_UNIT_TEST(EmergencyDoesNotPackTwoFullSstsUnderTinyBudget) {
+            TSynthHull hull(17);
+            const ui64 keep = hull.Ctx.GetHullCtx()->ChunkSize;
+            hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, 1, 1, 10, 100, hull.KeepRatio(keep)));
+            hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, 2, 2, 11, 100, hull.KeepRatio(keep)));
+
+            auto snap = hull.Ds->GetIndexSnapshot();
+            TTask task;
+            NHullComp::TSelectorParams params = {hull.Boundaries, 1.0, TInstant::Seconds(0), {}};
+            params.FreeChunksBudget = 1;
+            params.EmergencyMode = true;
+            TStrategyEmergency emergency(snap.HullCtx, params, snap.LogoBlobsSnap, &task);
+            AssertAction(emergency.Select(), NHullComp::ActNothing);
+        }
+
+        Y_UNIT_TEST(EmergencySkipsWideCrossLevelAndPacksLastLevel) {
+            TSynthHull hull(17);
+            const ui64 keep = hull.Ctx.GetHullCtx()->ChunkSize / 3;
+            // Wide SST on the previous level overlaps every SST on the last level.
+            hull.PutLevel(hull.LastLevelIdx() - 1, hull.MakeSst(1, 1, 100, 9, 100, hull.KeepRatio(keep)));
+            for (ui32 i = 0; i < 10; ++i) {
+                const ui32 step = i + 1;
+                hull.PutLevel(hull.LastLevelIdx(), hull.MakeSst(1, step, step, 20 + i, 100, hull.KeepRatio(keep)));
+            }
+
+            auto snap = hull.Ds->GetIndexSnapshot();
+            TTask task;
+            NHullComp::TSelectorParams params = {hull.Boundaries, 1.0, TInstant::Seconds(0), {}};
+            params.FreeChunksBudget = 2;
+            params.EmergencyMode = true;
+            TStrategyEmergency emergency(snap.HullCtx, params, snap.LogoBlobsSnap, &task);
+            AssertAction(emergency.Select(), NHullComp::ActCompactSsts);
+            UNIT_ASSERT_VALUES_EQUAL(task.CompactSsts.TargetLevel, hull.LastPhysicalLevel());
+            UNIT_ASSERT(CountSstsToDelete(task) >= 2);
+            UNIT_ASSERT(CountSstsToDelete(task) <= 8);
+        }
+
+        Y_UNIT_TEST(BalanceStillSelectedWhenSpaceIsPlenty) {
+            TSynthHull hull(17);
+            for (ui32 i = 0; i < 20; ++i) {
+                hull.PutL0(hull.MakeSst(1, i + 1, i + 1, 100 + i, 100, hull.KeepRatio(hull.Ctx.GetHullCtx()->ChunkSize)));
+            }
+
+            auto snap = hull.Ds->GetIndexSnapshot();
+            TTask task;
+            NHullComp::TSelectorParams params = {hull.Boundaries, 1.0, TInstant::Seconds(0), {}};
+            params.FreeChunksBudget = Max<ui32>();
+            params.EmergencyMode = false;
+            TStrategy strategy(snap.HullCtx, params, std::move(snap.LogoBlobsSnap), std::move(snap.BarriersSnap),
+                    &task, true);
+            AssertAction(strategy.Select(), NHullComp::ActCompactSsts);
+            AssertStrategy(task.SelectStrategy, NHullComp::ESelectStrategy::BalanceLevel);
+        }
+
+        Y_UNIT_TEST(DelSstWinsOverEmergencyForFullyDeadSst) {
+            TSynthHull hull(17);
+            auto deadRatio = hull.KeepRatio(0);
+            deadRatio->IndexItemsTotal = 1;
+            deadRatio->IndexItemsKeep = 0;
+            deadRatio->InplacedDataTotal = 100;
+            deadRatio->InplacedDataKeep = 0;
+            auto deadSst = hull.MakeSst(1, 1, 1, 10, 100, deadRatio);
+            // Stamp the ratio as freshly calculated so TStrategyStorageRatio keeps it.
+            deadSst->StorageRatio.Set(deadRatio, TAppData::TimeProvider->Now());
+            hull.PutLevel(hull.LastLevelIdx(), deadSst);
+
+            auto snap = hull.Ds->GetIndexSnapshot();
+            TTask task;
+            NHullComp::TSelectorParams params = {hull.Boundaries, 1.0, TInstant::Seconds(0), {}};
+            params.FreeChunksBudget = 1;
+            params.EmergencyMode = true;
+            TStrategy strategy(snap.HullCtx, params, std::move(snap.LogoBlobsSnap), std::move(snap.BarriersSnap),
+                    &task, true);
+            AssertAction(strategy.Select(), NHullComp::ActDeleteSsts);
+            AssertStrategy(task.SelectStrategy, NHullComp::ESelectStrategy::DelSst);
+        }
+
+        Y_UNIT_TEST(EstimateOutputChunksIsConservative) {
+            UNIT_ASSERT_VALUES_EQUAL(TUtils::EstimateOutputChunks(0, 4096), 0u);
+            UNIT_ASSERT_VALUES_EQUAL(TUtils::EstimateOutputChunks(1, 4096), 1u);
+            const ui32 usable = 4096 - sizeof(TIdxDiskPlaceHolder);
+            UNIT_ASSERT(TUtils::EstimateOutputChunks(usable, 4096) >= 1);
+            UNIT_ASSERT(TUtils::EstimateOutputChunks(usable * 2, 4096) >= 2);
+        }
     }
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_utils.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_utils.h
@@ -2,6 +2,7 @@
 
 #include "defs.h"
 #include "hulldb_compstrat_defs.h"
+#include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_glue.h>
 
 namespace NKikimr {
     namespace NHullComp {
@@ -21,6 +22,87 @@ namespace NKikimr {
             using TSstIterator = typename TLevelSliceSnapshot::TSstIterator;
             using TSortedLevelsIter = typename TLevelSliceSnapshot::TSortedLevelsIter;
             using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
+            using TSegments = TVector<TLevelSegmentPtr>;
+            using TLeveledSsts = ::NKikimr::TLeveledSsts<TKey, TMemRec>;
+            using TLeveledSstsIterator = typename TLeveledSsts::TIterator;
+
+            static ui32 SstInputChunks(const TLevelSegment &sst) {
+                if (!sst.AllChunks.empty()) {
+                    return sst.AllChunks.size();
+                }
+                return sst.Info.Chunks ? sst.Info.Chunks : 1;
+            }
+
+            static ui64 SstKeepBytes(const TLevelSegment &sst) {
+                if (TSstRatioPtr ratio = sst.StorageRatio.Get()) {
+                    return ratio->IndexBytesKeep + ratio->InplacedDataKeep;
+                }
+                return ui64(sst.Info.IdxTotalSize) + sst.Info.InplaceDataTotalSize;
+            }
+
+            static ui64 SstHugeGarbageBytes(const TLevelSegment &sst) {
+                if (TSstRatioPtr ratio = sst.StorageRatio.Get()) {
+                    return ratio->HugeDataTotal > ratio->HugeDataKeep
+                        ? ratio->HugeDataTotal - ratio->HugeDataKeep
+                        : 0;
+                }
+                return 0;
+            }
+
+            // Conservative estimate of output index chunks from live index+inplaced bytes.
+            static ui32 EstimateOutputChunks(ui64 keepBytes, ui32 chunkSize) {
+                if (keepBytes == 0 || chunkSize == 0) {
+                    return 0;
+                }
+                const ui32 suffix = sizeof(TIdxDiskPlaceHolder);
+                const ui32 usable = chunkSize > suffix ? chunkSize - suffix : chunkSize;
+                const ui64 withSlack = keepBytes + keepBytes / 10; // ~1.1x for alignment/outbound
+                return static_cast<ui32>((withSlack + usable - 1) / usable);
+            }
+
+            static ui32 EstimateCompactSstsOutputChunks(
+                    const typename TTask::TCompactSsts &compactSsts,
+                    ui32 chunkSize)
+            {
+                ui64 keepBytes = 0;
+                TLeveledSstsIterator it(&compactSsts.TablesToDelete);
+                it.SeekToFirst();
+                while (it.Valid()) {
+                    keepBytes += SstKeepBytes(*it.Get().SstPtr);
+                    it.Next();
+                }
+                return EstimateOutputChunks(keepBytes, chunkSize);
+            }
+
+            static void PreserveLastCompactedKey(
+                    const TLevelSliceSnapshot &sliceSnap,
+                    ui32 level,
+                    typename TTask::TCompactSsts &compactSsts)
+            {
+                TSortedLevelsIter sortedLevelsIt(&sliceSnap);
+                sortedLevelsIt.SeekToFirst();
+                while (sortedLevelsIt.Valid()) {
+                    auto r = sortedLevelsIt.Get();
+                    if (r.Level == level) {
+                        compactSsts.LastCompactedKey = r.SortedLevel.LastCompactedKey;
+                        break;
+                    }
+                    sortedLevelsIt.Next();
+                }
+            }
+
+            // Compact a contiguous run of SSTs on the same sorted level (packing / squeeze).
+            static void CompactContiguousSsts(
+                    const TLevelSliceSnapshot &sliceSnap,
+                    ui32 level,
+                    typename TSegments::const_iterator first,
+                    typename TSegments::const_iterator last,
+                    typename TTask::TCompactSsts &compactSsts)
+            {
+                compactSsts.TargetLevel = level;
+                compactSsts.PushSstFromLevelX(level, first, last);
+                PreserveLastCompactedKey(sliceSnap, level, compactSsts);
+            }
 
             // rewrite one SST (compact it). All references to huge blobs would be removed
             static void SqueezeOneSst(
@@ -34,16 +116,7 @@ namespace NKikimr {
 
                 // keep LastCompactedKey untouched (so find current value and set it)
                 // by default compactSsts.LastCompactedKey is set to TKey::First()
-                TSortedLevelsIter sortedLevelsIt(&sliceSnap);
-                sortedLevelsIt.SeekToFirst();
-                while (sortedLevelsIt.Valid()) {
-                    auto r = sortedLevelsIt.Get();
-                    if (r.Level == sstPtr.Level) {
-                        compactSsts.LastCompactedKey = r.SortedLevel.LastCompactedKey;
-                        break;
-                    }
-                    sortedLevelsIt.Next();
-                }
+                PreserveLastCompactedKey(sliceSnap, sstPtr.Level, compactSsts);
             }
         };
 

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/ya.make
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/ya.make
@@ -12,6 +12,7 @@ SRCS(
     hulldb_compstrat_defs.cpp
     hulldb_compstrat_defs.h
     hulldb_compstrat_delsst.h
+    hulldb_compstrat_emergency.h
     hulldb_compstrat_explicit.h
     hulldb_compstrat_promote.h
     hulldb_compstrat_ratio.h

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
@@ -8,6 +8,7 @@
 #include <ydb/core/blobstorage/vdisk/hullop/hullcompdelete/blobstorage_hullcompdelete.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/bulksst_add/hulldb_bulksst_add.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/bulksst_add/hulldb_fullsyncsst_add.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_outofspace.h>
 
 #include <type_traits>
 
@@ -262,6 +263,18 @@ namespace NKikimr {
             const double rateThreshold = Config->HullCompLevelRateThreshold;
             auto fullCompactionAttrs = FullCompactionState.GetFullCompactionAttrsForLevelCompactionSelector(RTCtx);
             NHullComp::TSelectorParams params = {Boundaries, rateThreshold, TInstant::Seconds(0), fullCompactionAttrs};
+            {
+                const auto& oos = HullDs->HullCtx->VCtx->GetOutOfSpaceState();
+                const ui32 totalChunks = oos.GetLocalTotalChunks();
+                const ui32 usedChunks = oos.GetLocalUsedChunks();
+                const ui32 reserve = ui32(Config->HullCompEmergencyChunkReserve);
+                if (totalChunks > 0) {
+                    const ui32 freeChunks = totalChunks > usedChunks ? totalChunks - usedChunks : 0;
+                    params.FreeChunksBudget = freeChunks > reserve ? freeChunks - reserve : 0;
+                }
+                params.EmergencyMode = oos.GetLocalColor() >= static_cast<ESpaceColor>(
+                    ui64(Config->HullCompEmergencyEnableAtColor));
+            }
             auto selector = std::make_unique<TSelectorActor>(HullDs->HullCtx, params, std::move(levelSnap),
                 std::move(barriersSnap), ctx.SelfID, std::move(CompactionTask), AllowGarbageCollection);
             auto aid = RunInBatchPool(ctx, selector.release());
@@ -355,6 +368,9 @@ namespace NKikimr {
                         break;
                     case NHullComp::ESelectStrategy::FreeSpace:
                         ++group.BlobsFreeSpace();
+                        break;
+                    case NHullComp::ESelectStrategy::Emergency:
+                        ++group.BlobsEmergency();
                         break;
                     case NHullComp::ESelectStrategy::Squeeze:
                         ++group.BlobsSqueeze();

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1824,6 +1824,21 @@ message TImmediateControlsConfig {
             MinValue: 0,
             MaxValue: 100000,
             DefaultValue: 2000 }];
+        optional uint64 HullCompEmergencyMaxSsts = 53 [(ControlOptions) = {
+            Description: "Maximum number of SSTables in one Emergency compaction job. Zero disables the Emergency compaction strategy.",
+            MinValue: 0,
+            MaxValue: 64,
+            DefaultValue: 8 }];
+        optional uint64 HullCompEmergencyChunkReserve = 54 [(ControlOptions) = {
+            Description: "Index chunks reserved for fresh/huge/synclog and subtracted from the Emergency free-chunk budget.",
+            MinValue: 0,
+            MaxValue: 64,
+            DefaultValue: 1 }];
+        optional uint64 HullCompEmergencyEnableAtColor = 55 [(ControlOptions) = {
+            Description: "Enable Emergency compaction mode when local PDisk space color is at least this value (0=GREEN, 10=CYAN, 15=LIGHT_YELLOW, 20=YELLOW, 30=LIGHT_ORANGE, 35=PRE_ORANGE, 40=ORANGE, 50=RED, 60=BLACK).",
+            MinValue: 0,
+            MaxValue: 60,
+            DefaultValue: 15 }];
 
         reserved 14;
         optional uint64 ThrottlingDryRun = 26 [(ControlOptions) = {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add VDisk emergency compaction strategy

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds new emergency VDisk compaction strategy that tries to minimize number of chunks used during each compaction step.
