### PR TITLE
Rewrite DescribeTopic actor

### DIFF
--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -5,7 +5,6 @@
 #include <ydb/core/persqueue/events/events.h>
 #include <ydb/core/util/backoff.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <util/string/join.h>
 
@@ -27,11 +26,11 @@ void AddWindowsStat(Ydb::Topic::MultipleWindowsStat* stat, ui64 perMin, ui64 per
     stat->set_per_day(stat->per_day() + perDay);
 }
 
-class TDescribeOperationActor: public NActors::TActorBootstrapped<TDescribeOperationActor>
-    , protected TPipeCacheClient
-    , public TConstantLogPrefix
+class TDescribeOperationActor: public TBaseActor<TDescribeOperationActor>
+                             , protected TPipeCacheClient
+                             , public TConstantLogPrefix
 {
-    static constexpr NKikimrServices::EServiceKikimr Service = NKikimrServices::EServiceKikimr::PQ_SCHEMA;
+private:
     static constexpr TDuration RequestTimeout = TDuration::Seconds(30);
     static constexpr size_t StatsMaxRetries = 15;
     static constexpr TDuration StatsRetryInitialDelay = TDuration::MilliSeconds(25);
@@ -45,7 +44,8 @@ public:
         const NActors::TActorId& parent,
         TDescribeOperationSettings&& settings,
         std::unique_ptr<IDescribeStrategy> strategy)
-        : TPipeCacheClient(this)
+        : TBaseActor<TDescribeOperationActor>(NKikimrServices::EServiceKikimr::PQ_SCHEMA)
+        , TPipeCacheClient(this)
         , Parent(parent)
         , Settings(std::move(settings))
         , Strategy(std::move(strategy))
@@ -79,6 +79,15 @@ public:
         return TStringBuilder() << "[" << (Strategy ? Strategy->GetName() : "DescribeOperation") << "]";
     }
 
+    bool OnUnhandledException(const std::exception& exc) override {
+        DoLogUnhandledException(Service, NPQ_LOG_PREFIX, exc);
+        ReplyWithError(
+            Ydb::StatusIds::INTERNAL_ERROR,
+            TStringBuilder() << "Unhandled exception: " << exc.what(),
+            Ydb::PersQueue::ErrorCode::ERROR);
+        return true;
+    }
+
 private:
     void PassAway() override {
         LOG_D("PassAway");
@@ -87,7 +96,7 @@ private:
             DescriberActorId = {};
         }
         TPipeCacheClient::Close();
-        TActorBootstrapped::PassAway();
+        TBaseActor::PassAway();
     }
 
     void HandlePoison() {
@@ -308,24 +317,22 @@ private:
                 partResult.GetAvgWriteSpeedPerHour(),
                 partResult.GetAvgWriteSpeedPerDay());
 
-            if (partResult.HasLagsInfo()) {
-                const auto& lagInfo = partResult.GetLagsInfo();
-                auto consStats = partRes.mutable_partition_consumer_stats();
+            const auto& lagInfo = partResult.GetLagsInfo();
+            auto consStats = partRes.mutable_partition_consumer_stats();
 
-                consStats->set_last_read_offset(lagInfo.GetReadPosition().GetOffset());
-                consStats->set_committed_offset(lagInfo.GetWritePosition().GetOffset());
+            consStats->set_last_read_offset(lagInfo.GetReadPosition().GetOffset());
+            consStats->set_committed_offset(lagInfo.GetWritePosition().GetOffset());
 
-                SetProtoTime(consStats->mutable_last_read_time(), lagInfo.GetLastReadTimestampMs());
-                SetProtoTime(consStats->mutable_max_read_time_lag(), lagInfo.GetReadLagMs());
-                SetProtoTime(consStats->mutable_max_write_time_lag(), lagInfo.GetWriteLagMs());
-                SetProtoTime(consStats->mutable_max_committed_time_lag(), lagInfo.GetCommitedLagMs());
+            SetProtoTime(consStats->mutable_last_read_time(), lagInfo.GetLastReadTimestampMs());
+            SetProtoTime(consStats->mutable_max_read_time_lag(), lagInfo.GetReadLagMs());
+            SetProtoTime(consStats->mutable_max_write_time_lag(), lagInfo.GetWriteLagMs());
+            SetProtoTime(consStats->mutable_max_committed_time_lag(), lagInfo.GetCommitedLagMs());
 
-                AddWindowsStat(
-                    consStats->mutable_bytes_read(),
-                    partResult.GetAvgReadSpeedPerMin(),
-                    partResult.GetAvgReadSpeedPerHour(),
-                    partResult.GetAvgReadSpeedPerDay());
-            }
+            AddWindowsStat(
+                consStats->mutable_bytes_read(),
+                partResult.GetAvgReadSpeedPerMin(),
+                partResult.GetAvgReadSpeedPerHour(),
+                partResult.GetAvgReadSpeedPerDay());
 
             if (const auto consumerCount = partResult.ConsumerResultSize(); consumerCount > 0) {
                 partitionInfo.Consumers.reserve(consumerCount);

--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -291,7 +291,8 @@ private:
         }
 
         for (const auto& partResult : record.GetPartResult()) {
-            Ydb::Topic::DescribeConsumerResult::PartitionInfo& partRes = Partitions[partResult.GetPartition()].Stats;
+            auto& partitionInfo = Partitions[partResult.GetPartition()];
+            Ydb::Topic::DescribeConsumerResult::PartitionInfo& partRes = partitionInfo.Stats;
             Ydb::Topic::PartitionStats* partStats = partRes.mutable_partition_stats();
 
             partStats->set_store_size_bytes(partResult.GetPartitionSize());
@@ -307,23 +308,40 @@ private:
                 partResult.GetAvgWriteSpeedPerHour(),
                 partResult.GetAvgWriteSpeedPerDay());
 
-            const auto& lagInfo = partResult.GetLagsInfo();
+            if (partResult.HasLagsInfo()) {
+                const auto& lagInfo = partResult.GetLagsInfo();
+                auto consStats = partRes.mutable_partition_consumer_stats();
 
-            auto consStats = partRes.mutable_partition_consumer_stats();
+                consStats->set_last_read_offset(lagInfo.GetReadPosition().GetOffset());
+                consStats->set_committed_offset(lagInfo.GetWritePosition().GetOffset());
 
-            consStats->set_last_read_offset(lagInfo.GetReadPosition().GetOffset());
-            consStats->set_committed_offset(lagInfo.GetWritePosition().GetOffset());
+                SetProtoTime(consStats->mutable_last_read_time(), lagInfo.GetLastReadTimestampMs());
+                SetProtoTime(consStats->mutable_max_read_time_lag(), lagInfo.GetReadLagMs());
+                SetProtoTime(consStats->mutable_max_write_time_lag(), lagInfo.GetWriteLagMs());
+                SetProtoTime(consStats->mutable_max_committed_time_lag(), lagInfo.GetCommitedLagMs());
 
-            SetProtoTime(consStats->mutable_last_read_time(), lagInfo.GetLastReadTimestampMs());
-            SetProtoTime(consStats->mutable_max_read_time_lag(), lagInfo.GetReadLagMs());
-            SetProtoTime(consStats->mutable_max_write_time_lag(), lagInfo.GetWriteLagMs());
-            SetProtoTime(consStats->mutable_max_committed_time_lag(), lagInfo.GetCommitedLagMs());
+                AddWindowsStat(
+                    consStats->mutable_bytes_read(),
+                    partResult.GetAvgReadSpeedPerMin(),
+                    partResult.GetAvgReadSpeedPerHour(),
+                    partResult.GetAvgReadSpeedPerDay());
+            }
 
-            AddWindowsStat(
-                consStats->mutable_bytes_read(),
-                partResult.GetAvgReadSpeedPerMin(),
-                partResult.GetAvgReadSpeedPerHour(),
-                partResult.GetAvgReadSpeedPerDay());
+            if (const auto consumerCount = partResult.ConsumerResultSize(); consumerCount > 0) {
+                partitionInfo.Consumers.reserve(consumerCount);
+                for (const auto& cons : partResult.GetConsumerResult()) {
+                    auto& consumerStats = partitionInfo.Consumers[cons.GetConsumer()];
+                    SetProtoTime(consumerStats.mutable_min_partitions_last_read_time(), cons.GetLastReadTimestampMs());
+                    SetProtoTime(consumerStats.mutable_max_read_time_lag(), cons.GetReadLagMs());
+                    SetProtoTime(consumerStats.mutable_max_write_time_lag(), cons.GetWriteLagMs());
+                    SetProtoTime(consumerStats.mutable_max_committed_time_lag(), cons.GetCommitedLagMs());
+                    AddWindowsStat(
+                        consumerStats.mutable_bytes_read(),
+                        cons.GetAvgReadSpeedPerMin(),
+                        cons.GetAvgReadSpeedPerHour(),
+                        cons.GetAvgReadSpeedPerDay());
+                }
+            }
         }
 
         StatsRetryPending.erase(tabletId);

--- a/ydb/core/persqueue/public/schema/describe_operation.h
+++ b/ydb/core/persqueue/public/schema/describe_operation.h
@@ -28,6 +28,7 @@ struct TPartitionDescribeInfo {
     Ydb::Topic::PartitionLocation Location;
     Ydb::Topic::DescribeConsumerResult::PartitionInfo Stats;
     NKikimrPQ::TReadSessionsInfoResponse::TPartitionInfo ReadSession;
+    absl::flat_hash_map<TString, Ydb::Topic::Consumer::ConsumerStats> Consumers;
 };
 
 struct TEvDescribeOperationResponse

--- a/ydb/core/ydb_convert/topic_description.cpp
+++ b/ydb/core/ydb_convert/topic_description.cpp
@@ -16,7 +16,7 @@ namespace NKikimr {
 bool FillConsumer(Ydb::Topic::Consumer& out, const NKikimrPQ::TPQTabletConfig& config, const NKikimrPQ::TPQTabletConfig_TConsumer& in,
     Ydb::StatusIds_StatusCode& status, TString& error, bool checkServiceType)
 {
-    const NKikimrPQ::TPQConfig pqConfig = AppData()->PQConfig;
+    const auto& pqConfig = AppData()->PQConfig;
     auto consumerName = NPersQueue::ConvertOldConsumerName(in.GetName(), pqConfig);
     out.set_name(consumerName);
 
@@ -95,7 +95,7 @@ bool FillTopicDescription(Ydb::Topic::DescribeTopicResult& out, const NKikimrSch
     const NKikimrSchemeOp::TDirEntry& inDirEntry, const TMaybe<TString>& cdcName,
     Ydb::StatusIds_StatusCode& status, TString& error) {
 
-    const NKikimrPQ::TPQConfig pqConfig = AppData()->PQConfig;
+    const auto& pqConfig = AppData()->PQConfig;
 
     Ydb::Scheme::Entry *selfEntry = out.mutable_self();
     ConvertDirectoryEntry(inDirEntry, selfEntry, true);

--- a/ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h
+++ b/ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h
@@ -21,8 +21,6 @@ inline Ydb::PersQueue::ErrorCode::ErrorCode AsIssueCode(Ydb::StatusIds::StatusCo
             return Ydb::PersQueue::ErrorCode::BAD_REQUEST;
     }
 }
-    
-    
 
 template<class TDerived, class TRequest>
 class TGrpcProxyActor : public NGRpcService::TRpcOperationRequestActor<TDerived, TRequest> {
@@ -39,7 +37,10 @@ public:
         NGRpcService::TRpcOperationRequestActor<TDerived, TRequest>::Bootstrap(ctx);
 
         if (this->Request_->GetSerializedToken().empty()) {
-            if (AppData(ctx)->EnforceUserTokenRequirement || AppData(ctx)->PQConfig.GetRequireCredentialsInNewProtocol()) {
+            const bool internalRequest = !!dynamic_cast<NGRpcService::IInternalRequestCtx*>(this->Request_.get());
+            if (!internalRequest &&
+                (AppData(ctx)->EnforceUserTokenRequirement || AppData(ctx)->PQConfig.GetRequireCredentialsInNewProtocol()))
+            {
                 return ReplyWithError(Ydb::StatusIds::UNAUTHORIZED,
                                       "Unauthenticated access is forbidden, please provide credentials");
             }
@@ -49,7 +50,6 @@ public:
     }
 
 protected:
-
     TIntrusiveConstPtr<NACLib::TUserToken> GetUserToken() const {
         return this->Request_->GetSerializedToken().empty() ? nullptr : new NACLib::TUserToken(this->Request_->GetSerializedToken());
     }

--- a/ydb/services/persqueue_v1/actors/schema/topic/actors.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/actors.h
@@ -12,6 +12,7 @@ NActors::IActor* CreateAlterTopicActor(NGRpcService::IRequestOpCtx* request);
 NActors::IActor* CreateCreateTopicActor(NGRpcService::IRequestOpCtx* request);
 NActors::IActor* CreateDescribeConsumerActor(NGRpcService::IRequestOpCtx* request);
 NActors::IActor* CreateDescribePartitionActor(NGRpcService::IRequestOpCtx* request);
+NActors::IActor* CreateDescribeTopicActor(NGRpcService::IRequestOpCtx* request);
 NActors::IActor* CreateDropTopicActor(NGRpcService::IRequestOpCtx* request);
 NActors::IActor* CreatePartitionsLocationActor(const TActorId& requester, const TGetPartitionsLocationRequest& request);
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/alter_topic.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/alter_topic.cpp
@@ -12,11 +12,6 @@ class TAlterTopicActor: public TGrpcProxyActor<TAlterTopicActor, NGRpcService::T
     using TRpcOpBase = NGRpcService::TRpcOperationRequestActor<TAlterTopicActor, NGRpcService::TEvAlterTopicRequest>;
 
 public:
-    TAlterTopicActor(NGRpcService::TEvAlterTopicRequest* request)
-        : TGrpcProxyActor<TAlterTopicActor, NGRpcService::TEvAlterTopicRequest>(request)
-    {
-    }
-
     TAlterTopicActor(NGRpcService::IRequestOpCtx* request)
         : TGrpcProxyActor<TAlterTopicActor, NGRpcService::TEvAlterTopicRequest>(request)
     {

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_consumer.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_consumer.cpp
@@ -106,12 +106,12 @@ private:
         Ydb::StatusIds::StatusCode status;
         TString error;
         FillConsumer(
-                *result.mutable_consumer(),
-                ev->Get()->TopicInfo.Info->Description.GetPQTabletConfig(),
-                *consumer,
-                status,
-                error,
-                false);
+            *result.mutable_consumer(),
+            ev->Get()->TopicInfo.Info->Description.GetPQTabletConfig(),
+            *consumer,
+            status,
+            error,
+            false);
 
         result.mutable_self()->CopyFrom(ev->Get()->SelfEntry);
         result.mutable_self()->set_name(TStringBuilder() << result.self().name() << "/" << consumerName);

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_consumer.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_consumer.cpp
@@ -101,20 +101,17 @@ private:
         const auto* consumer = NPQ::GetConsumer(
             ev->Get()->TopicInfo.Info->Description.GetPQTabletConfig(),
             consumerName);
-        AFL_ENSURE(consumer);
+        AFL_ENSURE(consumer)("consumer", consumerName);
 
         Ydb::StatusIds::StatusCode status;
         TString error;
-        if (!FillConsumer(
+        FillConsumer(
                 *result.mutable_consumer(),
                 ev->Get()->TopicInfo.Info->Description.GetPQTabletConfig(),
                 *consumer,
                 status,
                 error,
-                false))
-        {
-            return ReplyWithError(status, error);
-        }
+                false);
 
         result.mutable_self()->CopyFrom(ev->Get()->SelfEntry);
         result.mutable_self()->set_name(TStringBuilder() << result.self().name() << "/" << consumerName);

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_helpers.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_helpers.h
@@ -18,4 +18,10 @@ void UpdateProtoTime(T& proto, const T& time, bool storeMin) {
     }
 }
 
+inline void AddWindowsStat(Ydb::Topic::MultipleWindowsStat* stat, ui64 perMin, ui64 perHour, ui64 perDay) {
+    stat->set_per_minute(stat->per_minute() + perMin);
+    stat->set_per_hour(stat->per_hour() + perHour);
+    stat->set_per_day(stat->per_day() + perDay);
+}
+
 } // namespace NKikimr::NGRpcProxy::V1::NTopic

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_partition.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_partition.cpp
@@ -91,25 +91,24 @@ private:
         auto* p = FindIfPtr(ev->Get()->TopicInfo.Info->Description.GetPartitions(), [partitionId](const auto& part) {
             return part.GetPartitionId() == partitionId;
         });
+        AFL_ENSURE(p)("partitionId", partitionId);
 
-        if (p) {
-            auto& partition = *result.mutable_partition();
-            partition.set_partition_id(p->GetPartitionId());
-            partition.set_active(p->GetStatus() == ::NKikimrPQ::ETopicPartitionStatus::Active);
+        auto& partition = *result.mutable_partition();
+        partition.set_partition_id(p->GetPartitionId());
+        partition.set_active(p->GetStatus() == ::NKikimrPQ::ETopicPartitionStatus::Active);
 
-            auto it = ev->Get()->Partitions.find(p->GetPartitionId());
-            if (it != ev->Get()->Partitions.end()) {
-                auto& partitionInfo = it->second;
+        auto it = ev->Get()->Partitions.find(p->GetPartitionId());
+        if (it != ev->Get()->Partitions.end()) {
+            auto& partitionInfo = it->second;
 
-                if (includeLocation) {
-                    *partition.mutable_partition_location() = partitionInfo.Location;
-                }
+            if (includeLocation) {
+                *partition.mutable_partition_location() = partitionInfo.Location;
+            }
 
-                if (includeStats) {
-                    auto* partitionStats = partition.mutable_partition_stats();
-                    *partitionStats = partitionInfo.Stats.partition_stats();
-                    partitionStats->set_partition_node_id(partitionInfo.Location.node_id());
-                }
+            if (includeStats) {
+                auto* partitionStats = partition.mutable_partition_stats();
+                *partitionStats = partitionInfo.Stats.partition_stats();
+                partitionStats->set_partition_node_id(partitionInfo.Location.node_id());
             }
         }
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_topic.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_topic.cpp
@@ -1,0 +1,192 @@
+#include "describe_helpers.h"
+
+#include <ydb/core/grpc_services/rpc_calls_topic.h>
+#include <ydb/core/persqueue/public/schema/describe_operation.h>
+#include <ydb/core/ydb_convert/topic_description.h>
+#include <ydb/library/persqueue/topic_parser/topic_parser.h>
+#include <ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h>
+
+#include <absl/container/flat_hash_map.h>
+#include <util/generic/maybe.h>
+
+namespace NKikimr::NGRpcProxy::V1::NTopic {
+
+namespace {
+
+using namespace NPQ::NSchema;
+
+class TDescribeTopicStrategy: public IDescribeStrategy {
+public:
+    TString GetName() const override {
+        return "DescribeTopic";
+    }
+
+    TDescribeSchemaResult ValidateSchema(const NPQ::NDescriber::TTopicInfo&) override {
+        return {};
+    }
+
+    bool NeedProcessPartition(
+        const NKikimrSchemeOp::TPersQueueGroupDescription::TPartition&) const override
+    {
+        return true;
+    }
+
+    std::unique_ptr<TEvPersQueue::TEvGetReadSessionsInfo> CreateReadSessionsInfoRequest() const override {
+        return nullptr;
+    }
+
+    std::unique_ptr<TEvPersQueue::TEvStatus> CreateStatusRequest() const override {
+        return std::make_unique<TEvPersQueue::TEvStatus>("", true);
+    }
+};
+
+class TDescribeTopicGrpc: public TGrpcProxyActor<TDescribeTopicGrpc, NGRpcService::TEvDescribeTopicRequest> {
+    using TRpcOpBase = NGRpcService::TRpcOperationRequestActor<TDescribeTopicGrpc, NGRpcService::TEvDescribeTopicRequest>;
+
+public:
+    TDescribeTopicGrpc(NGRpcService::IRequestOpCtx* request)
+        : TGrpcProxyActor(request)
+    {
+    }
+
+    void DoAction() {
+        Become(&TDescribeTopicGrpc::StateWork);
+
+        LogicActorId = RegisterWithSameMailbox(CreateDescribeOperationActor(
+            SelfId(),
+            {
+                .Path = GetProtoRequest()->path(),
+                .Database = GetDatabase(),
+                .UserToken = GetUserToken(),
+                .AccessRights = NACLib::EAccessRights::DescribeSchema,
+                .IncludeStats = GetProtoRequest()->include_stats(),
+                .IncludeLocation = GetProtoRequest()->include_location(),
+            },
+            std::make_unique<TDescribeTopicStrategy>()));
+    }
+
+private:
+    void Handle(TEvDescribeOperationResponse::TPtr& ev) {
+        LogicActorId = {};
+        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+            return ReplyWithError(ev->Get()->Status, ev->Get()->ErrorMessage, ev->Get()->IssueCode);
+        }
+
+        const auto includeLocation = GetProtoRequest()->include_location();
+        const auto includeStats = GetProtoRequest()->include_stats();
+
+        Ydb::Topic::DescribeTopicResult result;
+        Ydb::StatusIds::StatusCode status;
+        TString error;
+        if (!FillTopicDescription(
+                result,
+                ev->Get()->TopicInfo.Info->Description,
+                ev->Get()->TopicInfo.Self->Info,
+                Nothing(),
+                status,
+                error))
+        {
+            return ReplyWithError(status, error);
+        }
+        result.mutable_self()->Swap(&ev->Get()->SelfEntry);
+
+        absl::flat_hash_map<TString, Ydb::Topic::Consumer*> consumersInfo;
+        if (includeStats) {
+            const auto& pqConfig = AppData()->PQConfig;
+            consumersInfo.reserve(result.consumers_size());
+            for (auto& consumer : *result.mutable_consumers()) {
+                consumersInfo.emplace(
+                    NPersQueue::ConvertNewConsumerName(consumer.name(), pqConfig),
+                    &consumer);
+            }
+        }
+
+        Ydb::Topic::DescribeTopicResult::TopicStats* topicStats = nullptr;
+        for (auto& partition : *result.mutable_partitions()) {
+            auto it = ev->Get()->Partitions.find(partition.partition_id());
+            if (it == ev->Get()->Partitions.end()) {
+                continue;
+            }
+
+            auto& partitionInfo = it->second;
+
+            if (includeStats) {
+                auto* partitionStats = partition.mutable_partition_stats();
+                partitionStats->Swap(partitionInfo.Stats.mutable_partition_stats());
+                partitionStats->set_partition_node_id(partitionInfo.Location.node_id());
+
+                if (!topicStats) {
+                    topicStats = result.mutable_topic_stats();
+                    topicStats->set_store_size_bytes(partitionStats->store_size_bytes());
+                    topicStats->mutable_min_last_write_time()->CopyFrom(partitionStats->last_write_time());
+                    topicStats->mutable_max_write_time_lag()->CopyFrom(partitionStats->max_write_time_lag());
+                } else {
+                    topicStats->set_store_size_bytes(topicStats->store_size_bytes() + partitionStats->store_size_bytes());
+                    UpdateProtoTime(*topicStats->mutable_min_last_write_time(), partitionStats->last_write_time(), true);
+                    UpdateProtoTime(*topicStats->mutable_max_write_time_lag(), partitionStats->max_write_time_lag(), false);
+                }
+                AddWindowsStat(
+                    topicStats->mutable_bytes_written(),
+                    partitionStats->bytes_written().per_minute(),
+                    partitionStats->bytes_written().per_hour(),
+                    partitionStats->bytes_written().per_day());
+
+                for (auto& [consumerName, consumerPartitionStats] : partitionInfo.Consumers) {
+                    auto consumerIt = consumersInfo.find(consumerName);
+                    if (consumerIt == consumersInfo.end()) {
+                        continue;
+                    }
+
+                    auto* consumerProto = consumerIt->second;
+                    if (!consumerProto->has_consumer_stats()) {
+                        consumerProto->mutable_consumer_stats()->Swap(&consumerPartitionStats);
+                    } else {
+                        auto* stats = consumerProto->mutable_consumer_stats();
+                        UpdateProtoTime(*stats->mutable_min_partitions_last_read_time(), consumerPartitionStats.min_partitions_last_read_time(), true);
+                        UpdateProtoTime(*stats->mutable_max_read_time_lag(), consumerPartitionStats.max_read_time_lag(), false);
+                        UpdateProtoTime(*stats->mutable_max_write_time_lag(), consumerPartitionStats.max_write_time_lag(), false);
+                        UpdateProtoTime(*stats->mutable_max_committed_time_lag(), consumerPartitionStats.max_committed_time_lag(), false);
+                        AddWindowsStat(
+                            stats->mutable_bytes_read(),
+                            consumerPartitionStats.bytes_read().per_minute(),
+                            consumerPartitionStats.bytes_read().per_hour(),
+                            consumerPartitionStats.bytes_read().per_day());
+                    }
+                }
+            }
+
+            if (includeLocation) {
+                partition.mutable_partition_location()->Swap(&partitionInfo.Location);
+            }
+        }
+
+        ReplyWithResult(Ydb::StatusIds::SUCCESS, result);
+    }
+
+    void PassAway() override {
+        if (LogicActorId) {
+            Send(LogicActorId, new NActors::TEvents::TEvPoison());
+            LogicActorId = {};
+        }
+        TRpcOpBase::PassAway();
+    }
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvDescribeOperationResponse, Handle);
+            default:
+                TRpcOpBase::StateFuncBase(ev);
+        }
+    }
+
+private:
+    NActors::TActorId LogicActorId;
+};
+
+} // namespace
+
+NActors::IActor* CreateDescribeTopicActor(NGRpcService::IRequestOpCtx* request) {
+    return new TDescribeTopicGrpc(request);
+}
+
+} // namespace NKikimr::NGRpcProxy::V1::NTopic

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_topic.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_topic.cpp
@@ -6,8 +6,9 @@
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 #include <ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h>
 
-#include <absl/container/flat_hash_map.h>
 #include <util/generic/maybe.h>
+
+#include <absl/container/flat_hash_map.h>
 
 namespace NKikimr::NGRpcProxy::V1::NTopic {
 
@@ -26,8 +27,7 @@ public:
     }
 
     bool NeedProcessPartition(
-        const NKikimrSchemeOp::TPersQueueGroupDescription::TPartition&) const override
-    {
+        const NKikimrSchemeOp::TPersQueueGroupDescription::TPartition&) const override {
         return true;
     }
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/drop_topic.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/drop_topic.cpp
@@ -12,11 +12,6 @@ class TDropTopicActor: public TGrpcProxyActor<TDropTopicActor, NGRpcService::TEv
     using TRpcOpBase = NGRpcService::TRpcOperationRequestActor<TDropTopicActor, NGRpcService::TEvDropTopicRequest>;
 
 public:
-    TDropTopicActor(NGRpcService::TEvDropTopicRequest* request)
-        : TGrpcProxyActor<TDropTopicActor, NGRpcService::TEvDropTopicRequest>(request)
-    {
-    }
-
     TDropTopicActor(NGRpcService::IRequestOpCtx* request)
         : TGrpcProxyActor<TDropTopicActor, NGRpcService::TEvDropTopicRequest>(request)
     {

--- a/ydb/services/persqueue_v1/actors/schema/topic/partitions_location.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/partitions_location.cpp
@@ -118,10 +118,6 @@ private:
 
         Response->Partitions.reserve(ev->Get()->Partitions.size());
         for (const auto& [partitionId, info] : ev->Get()->Partitions) {
-            if (!PartitionIds.empty() && !PartitionIds.contains(partitionId)) {
-                continue;
-            }
-
             TEvPQProxy::TPartitionLocationInfo partLocation;
             partLocation.PartitionId = partitionId;
             partLocation.Generation = info.Location.generation();

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -72,6 +72,15 @@ std::unique_ptr<TSimulatedServer> CreateSimulatedServer() {
 }
 
 template <typename TRequest, typename TResponse>
+class TInternalRequestCtx
+    : public TRequestCtx<TRequest, TResponse>
+    , public NGRpcService::IInternalRequestCtx
+{
+public:
+    using TRequestCtx<TRequest, TResponse>::TRequestCtx;
+};
+
+template <typename TRequest, typename TResponse>
 std::shared_ptr<TResultHolder<TResponse>> DoActorRequest(
     NActors::TTestActorRuntime& runtime,
     const TRequest& request,
@@ -793,6 +802,25 @@ Y_UNIT_TEST(DescribeTopicUnauthenticatedRejectedWhenRequired) {
     auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
         runtime, request, CreateDescribeTopicActor, path);
     AssertStatus(result, Ydb::StatusIds::UNAUTHORIZED, "Unauthenticated access is forbidden");
+}
+
+Y_UNIT_TEST(DescribeTopicInternalRequestAllowedWithoutToken) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_describe_topic_internal";
+    CreateTopic(runtime, path);
+    runtime.GetAppData().PQConfig.SetRequireCredentialsInNewProtocol(true);
+
+    Ydb::Topic::DescribeTopicRequest request;
+    request.set_path(path);
+    auto result = std::make_shared<TResultHolder<Ydb::Topic::DescribeTopicResponse>>();
+    auto edgeActor = runtime.AllocateEdgeActor();
+    auto* ctx = new TInternalRequestCtx<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+        request, path, "/Root", result, edgeActor);
+    runtime.Register(CreateDescribeTopicActor(ctx));
+    runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edgeActor, TDuration::Seconds(30));
+    UNIT_ASSERT_C(result->ResultStatus, "The operation is still in progress");
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
 }
 
 Y_UNIT_TEST(PartitionsLocationSmokeAndErrors) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -537,6 +537,60 @@ Y_UNIT_TEST(DescribeConsumerRetriesOnLocationDeliveryProblem) {
     AssertStatus(result, Ydb::StatusIds::SUCCESS);
     const auto& describeResult = GetResult<Ydb::Topic::DescribeConsumerResult>(result);
     UNIT_ASSERT(describeResult.partitions(0).has_partition_location());
+
+    {
+        const TString path2 = "/Root/topic_describe_consumer_false_status";
+        CreateTopic(runtime, path2);
+        size_t injected = 0;
+        auto injectObserver = InjectFalseLocationStatusOnce(runtime, injected);
+
+        Ydb::Topic::DescribeConsumerRequest request2;
+        request2.set_path(path2);
+        request2.set_consumer("user");
+        request2.set_include_location(true);
+        auto result2 = DoActorRequest<Ydb::Topic::DescribeConsumerRequest, Ydb::Topic::DescribeConsumerResponse>(
+            runtime, request2, CreateDescribeConsumerActor, path2);
+        UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+        AssertStatus(result2, Ydb::StatusIds::SUCCESS);
+        const auto& describeResult2 = GetResult<Ydb::Topic::DescribeConsumerResult>(result2);
+        UNIT_ASSERT(describeResult2.partitions(0).has_partition_location());
+    }
+}
+
+Y_UNIT_TEST(DescribeConsumerTimesOutWhenLocationStuck) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_consumer_timeout";
+    CreateTopic(runtime, path);
+
+    auto dropObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+        [](TEvPipeCache::TEvForward::TPtr& ev) {
+            if (ev && ev->Get()->Ev &&
+                ev->Get()->Ev->Type() == TEvPersQueue::TEvGetPartitionsLocation::EventType)
+            {
+                ev.Reset();
+            }
+        });
+
+    Ydb::Topic::DescribeConsumerRequest request;
+    request.set_path(path);
+    request.set_consumer("user");
+    request.set_include_location(true);
+
+    auto result = std::make_shared<TResultHolder<Ydb::Topic::DescribeConsumerResponse>>();
+    auto edgeActor = runtime.AllocateEdgeActor();
+    auto* ctx = new TRequestCtx<Ydb::Topic::DescribeConsumerRequest, Ydb::Topic::DescribeConsumerResponse>(
+        request, path, "/Root", result, edgeActor);
+
+    TEnableScheduleForRootGuard schedule(runtime);
+    schedule.SetRoot(runtime.Register(CreateDescribeConsumerActor(ctx)));
+
+    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
+    runtime.AdvanceCurrentTime(TDuration::Seconds(31));
+
+    runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edgeActor, TDuration::Seconds(5));
+    UNIT_ASSERT_C(result->ResultStatus, "The operation is still in progress");
+    AssertStatus(result, Ydb::StatusIds::TIMEOUT, "Describe request timed out");
 }
 
 Y_UNIT_TEST(DescribeConsumerUnauthenticatedRejectedWhenRequired) {
@@ -551,6 +605,193 @@ Y_UNIT_TEST(DescribeConsumerUnauthenticatedRejectedWhenRequired) {
     request.set_consumer("user");
     auto result = DoActorRequest<Ydb::Topic::DescribeConsumerRequest, Ydb::Topic::DescribeConsumerResponse>(
         runtime, request, CreateDescribeConsumerActor, path);
+    AssertStatus(result, Ydb::StatusIds::UNAUTHORIZED, "Unauthenticated access is forbidden");
+}
+
+Y_UNIT_TEST(DescribeTopicSmokeAndMissing) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_describe_topic_smoke";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::DescribeTopicRequest request;
+        request.set_path(path);
+        auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+            runtime, request, CreateDescribeTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        const auto& describeResult = GetResult<Ydb::Topic::DescribeTopicResult>(result);
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.partitions_size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.partitions(0).partition_id(), 0u);
+        UNIT_ASSERT(describeResult.partitions(0).active());
+        UNIT_ASSERT(!describeResult.partitions(0).has_partition_location());
+        UNIT_ASSERT(!describeResult.partitions(0).has_partition_stats());
+        UNIT_ASSERT(!describeResult.has_topic_stats());
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.consumers_size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.consumers(0).name(), "user");
+        UNIT_ASSERT(!describeResult.consumers(0).has_consumer_stats());
+    }
+
+    {
+        Ydb::Topic::DescribeTopicRequest request;
+        request.set_path("/Root/not_a_topic");
+        auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+            runtime, request, CreateDescribeTopicActor, request.path());
+        AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR);
+    }
+}
+
+Y_UNIT_TEST(DescribeTopicWithLocationAndStats) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_describe_topic_loc_stats";
+    CreateTopic(runtime, path, /*partitions=*/2);
+
+    {
+        Ydb::Topic::DescribeTopicRequest request;
+        request.set_path(path);
+        request.set_include_location(true);
+        auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+            runtime, request, CreateDescribeTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        const auto& describeResult = GetResult<Ydb::Topic::DescribeTopicResult>(result);
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.partitions_size(), 2u);
+        UNIT_ASSERT(!describeResult.has_topic_stats());
+        for (const auto& p : describeResult.partitions()) {
+            UNIT_ASSERT(p.has_partition_location());
+            UNIT_ASSERT_GT(p.partition_location().node_id(), 0);
+            UNIT_ASSERT_GT(p.partition_location().generation(), 0);
+            UNIT_ASSERT(!p.has_partition_stats());
+        }
+    }
+
+    {
+        Ydb::Topic::DescribeTopicRequest request;
+        request.set_path(path);
+        request.set_include_stats(true);
+        auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+            runtime, request, CreateDescribeTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        const auto& describeResult = GetResult<Ydb::Topic::DescribeTopicResult>(result);
+        UNIT_ASSERT(describeResult.has_topic_stats());
+        for (const auto& p : describeResult.partitions()) {
+            UNIT_ASSERT(p.has_partition_stats());
+            UNIT_ASSERT_GT(p.partition_stats().partition_node_id(), 0);
+            UNIT_ASSERT(!p.has_partition_location());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.consumers_size(), 1u);
+        UNIT_ASSERT(describeResult.consumers(0).has_consumer_stats());
+        ui64 storeSum = 0;
+        for (const auto& p : describeResult.partitions()) {
+            storeSum += p.partition_stats().store_size_bytes();
+        }
+        UNIT_ASSERT_VALUES_EQUAL(describeResult.topic_stats().store_size_bytes(), storeSum);
+    }
+
+    {
+        Ydb::Topic::DescribeTopicRequest request;
+        request.set_path(path);
+        request.set_include_location(true);
+        request.set_include_stats(true);
+        auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+            runtime, request, CreateDescribeTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        const auto& describeResult = GetResult<Ydb::Topic::DescribeTopicResult>(result);
+        UNIT_ASSERT(describeResult.has_topic_stats());
+        for (const auto& p : describeResult.partitions()) {
+            UNIT_ASSERT(p.has_partition_location());
+            UNIT_ASSERT(p.has_partition_stats());
+            UNIT_ASSERT_VALUES_EQUAL(
+                p.partition_stats().partition_node_id(),
+                p.partition_location().node_id());
+        }
+    }
+}
+
+Y_UNIT_TEST(DescribeTopicRetriesOnLocationDeliveryProblem) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_topic_retry";
+    CreateTopic(runtime, path);
+
+    size_t broken = 0;
+    auto breakObserver = BreakFirstLocationForward(runtime, broken);
+
+    Ydb::Topic::DescribeTopicRequest request;
+    request.set_path(path);
+    request.set_include_location(true);
+    auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+        runtime, request, CreateDescribeTopicActor, path);
+
+    UNIT_ASSERT_VALUES_EQUAL(broken, 1u);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    const auto& describeResult = GetResult<Ydb::Topic::DescribeTopicResult>(result);
+    UNIT_ASSERT(describeResult.partitions(0).has_partition_location());
+
+    {
+        const TString path2 = "/Root/topic_describe_topic_false_status";
+        CreateTopic(runtime, path2);
+        size_t injected = 0;
+        auto injectObserver = InjectFalseLocationStatusOnce(runtime, injected);
+
+        Ydb::Topic::DescribeTopicRequest request2;
+        request2.set_path(path2);
+        request2.set_include_location(true);
+        auto result2 = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+            runtime, request2, CreateDescribeTopicActor, path2);
+        UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+        AssertStatus(result2, Ydb::StatusIds::SUCCESS);
+        const auto& describeResult2 = GetResult<Ydb::Topic::DescribeTopicResult>(result2);
+        UNIT_ASSERT(describeResult2.partitions(0).has_partition_location());
+    }
+}
+
+Y_UNIT_TEST(DescribeTopicTimesOutWhenLocationStuck) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_topic_timeout";
+    CreateTopic(runtime, path);
+
+    auto dropObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+        [](TEvPipeCache::TEvForward::TPtr& ev) {
+            if (ev && ev->Get()->Ev &&
+                ev->Get()->Ev->Type() == TEvPersQueue::TEvGetPartitionsLocation::EventType)
+            {
+                ev.Reset();
+            }
+        });
+
+    Ydb::Topic::DescribeTopicRequest request;
+    request.set_path(path);
+    request.set_include_location(true);
+
+    auto result = std::make_shared<TResultHolder<Ydb::Topic::DescribeTopicResponse>>();
+    auto edgeActor = runtime.AllocateEdgeActor();
+    auto* ctx = new TRequestCtx<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+        request, path, "/Root", result, edgeActor);
+
+    TEnableScheduleForRootGuard schedule(runtime);
+    schedule.SetRoot(runtime.Register(CreateDescribeTopicActor(ctx)));
+
+    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
+    runtime.AdvanceCurrentTime(TDuration::Seconds(31));
+
+    runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edgeActor, TDuration::Seconds(5));
+    UNIT_ASSERT_C(result->ResultStatus, "The operation is still in progress");
+    AssertStatus(result, Ydb::StatusIds::TIMEOUT, "Describe request timed out");
+}
+
+Y_UNIT_TEST(DescribeTopicUnauthenticatedRejectedWhenRequired) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_describe_topic_auth";
+    CreateTopic(runtime, path);
+    runtime.GetAppData().PQConfig.SetRequireCredentialsInNewProtocol(true);
+
+    Ydb::Topic::DescribeTopicRequest request;
+    request.set_path(path);
+    auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+        runtime, request, CreateDescribeTopicActor, path);
     AssertStatus(result, Ydb::StatusIds::UNAUTHORIZED, "Unauthenticated access is forbidden");
 }
 
@@ -653,6 +894,54 @@ Y_UNIT_TEST(PartitionsLocationUnauthenticatedRejectedWhenRequired) {
     auto ev = DoPartitionsLocationRequest(runtime, {path, "/Root", "", {}});
     UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
     UNIT_ASSERT(ev->Issues.ToString().Contains("Unauthenticated access is forbidden"));
+}
+
+Y_UNIT_TEST(DropTopicSuccessAndMissing) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_drop";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::DropTopicRequest request;
+        request.set_path(path);
+        auto result = DoActorRequest<Ydb::Topic::DropTopicRequest, Ydb::Topic::DropTopicResponse>(
+            runtime, request, CreateDropTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::DropTopicRequest request;
+        request.set_path(path);
+        auto result = DoActorRequest<Ydb::Topic::DropTopicRequest, Ydb::Topic::DropTopicResponse>(
+            runtime, request, CreateDropTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR);
+    }
+}
+
+Y_UNIT_TEST(AlterTopicSuccessAndMissing) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.mutable_set_retention_period()->set_seconds(3600);
+        auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path("/Root/missing_topic");
+        request.mutable_set_retention_period()->set_seconds(3600);
+        auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, request.path());
+        AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR);
+    }
 }
 
 Y_UNIT_TEST(UnauthenticatedRejectedWhenRequired) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/ya.make
+++ b/ydb/services/persqueue_v1/actors/schema/topic/ya.make
@@ -11,6 +11,7 @@ SRCS(
     create_topic.cpp
     describe_consumer.cpp
     describe_partition.cpp
+    describe_topic.cpp
     drop_topic.cpp
     partitions_location.cpp
 )

--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -5,7 +5,6 @@
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/persqueue/public/constants.h>
-#include <ydb/core/ydb_convert/topic_description.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
 #include <ydb/public/sdk/cpp/src/library/persqueue/obfuscate/obfuscate.h>
 
@@ -276,24 +275,6 @@ void TPQDescribeTopicActor::Bootstrap(const NActors::TActorContext& ctx)
     Become(&TPQDescribeTopicActor::StateWork);
 }
 
-TDescribeTopicActor::TDescribeTopicActor(NKikimr::NGRpcService::TEvDescribeTopicRequest* request)
-    : TBase(request, request->GetProtoRequest()->path())
-    , TDescribeTopicActorImpl(TDescribeTopicActorSettings::DescribeTopic(
-            request->GetProtoRequest()->include_stats(),
-            request->GetProtoRequest()->include_location()))
-{
-    YDB_LOG_DEBUG("TDescribeTopicActor for request",
-        {"request", request->GetProtoRequest()->DebugString()});
-}
-
-TDescribeTopicActor::TDescribeTopicActor(NKikimr::NGRpcService::IRequestOpCtx * ctx)
-    : TBase(ctx, dynamic_cast<const Ydb::Topic::DescribeTopicRequest*>(ctx->GetRequest())->path())
-    , TDescribeTopicActorImpl(TDescribeTopicActorSettings::DescribeTopic(
-            dynamic_cast<const Ydb::Topic::DescribeTopicRequest*>(ctx->GetRequest())->include_stats(),
-            dynamic_cast<const Ydb::Topic::DescribeTopicRequest*>(ctx->GetRequest())->include_location()))
-{
-}
-
 TDescribeTopicActorImpl::TDescribeTopicActorImpl(const TDescribeTopicActorSettings& settings)
     : Settings(settings)
 {
@@ -340,12 +321,6 @@ TDuration TDescribeTopicActorImpl::RemainingRequestTimeout() const {
     return *RequestStartTime + RequestTimeout - now;
 }
 
-void TDescribeTopicActor::StateWork(TAutoPtr<IEventHandle>& ev) {
-    if (!TDescribeTopicActorImpl::StateWork(ev, this->ActorContext())) {
-        TBase::StateWork(ev);
-    }
-}
-
 void TDescribeTopicActorImpl::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx) {
     if (ev->Get()->Status != NKikimrProto::OK) {
         RestartTablet(ev->Get()->TabletId, ctx, ev->Sender);
@@ -359,14 +334,6 @@ void TDescribeTopicActorImpl::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev
 
 void TDescribeTopicActorImpl::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx) {
     RestartTablet(ev->Get()->TabletId, ctx, ev->Sender);
-}
-
-void TDescribeTopicActor::RaiseError(const TString& error, const Ydb::PersQueue::ErrorCode::ErrorCode errorCode, const Ydb::StatusIds::StatusCode status, const TActorContext& ctx) {
-    if (TBase::IsDead) {
-        return;
-    }
-    this->Request_->RaiseIssue(FillIssue(error, errorCode));
-    TBase::Reply(status, ctx);
 }
 
 void TDescribeTopicActorImpl::RestartTablet(ui64 tabletId, const TActorContext& ctx, TActorId pipe, const TDuration& delay) {
@@ -647,194 +614,6 @@ void TDescribeTopicActorImpl::CheckCloseBalancerPipe(const TActorContext& ctx) {
     BalancerTabletId = 0;
 }
 
-
-template<class T>
-void SetProtoTime(T* proto, const ui64 ms) {
-    proto->set_seconds(ms / 1000);
-    proto->set_nanos((ms % 1000) * 1'000'000);
-}
-
-template<class T>
-void UpdateProtoTime(T* proto, const ui64 ms, bool storeMin) {
-    ui64 storedMs = proto->seconds() * 1000 + proto->nanos() / 1'000'000;
-    if ((ms < storedMs) == storeMin) {
-        SetProtoTime(proto, ms);
-    }
-}
-
-void SetPartitionLocation(const NKikimrPQ::TPartitionLocation& location, Ydb::Topic::PartitionLocation* result) {
-    result->set_node_id(location.GetNodeId());
-    result->set_generation(location.GetGeneration());
-}
-
-
-void TDescribeTopicActor::ApplyResponse(TTabletInfo& tabletInfo, NKikimr::TEvPersQueue::TEvReadSessionsInfoResponse::TPtr& ev, const TActorContext& ctx) {
-    Y_UNUSED(ctx);
-    Y_UNUSED(tabletInfo);
-    Y_UNUSED(ev);
-    AFL_ENSURE(false)("reason", "TDescribeTopicActor: unexpected TEvReadSessionsInfoResponse");
-}
-
-
-void AddWindowsStat(Ydb::Topic::MultipleWindowsStat *stat, ui64 perMin, ui64 perHour, ui64 perDay) {
-    stat->set_per_minute(stat->per_minute() + perMin);
-    stat->set_per_hour(stat->per_hour() + perHour);
-    stat->set_per_day(stat->per_day() + perDay);
-}
-
-void FillPartitionStats(const NKikimrPQ::TStatusResponse::TPartResult& partResult, Ydb::Topic::PartitionStats* partStats, ui64 nodeId) {
-    partStats->set_store_size_bytes(partResult.GetPartitionSize());
-    partStats->mutable_partition_offsets()->set_start(partResult.GetStartOffset());
-    partStats->mutable_partition_offsets()->set_end(partResult.GetEndOffset());
-
-    SetProtoTime(partStats->mutable_last_write_time(), partResult.GetLastWriteTimestampMs());
-    SetProtoTime(partStats->mutable_max_write_time_lag(), partResult.GetWriteLagMs());
-
-    AddWindowsStat(partStats->mutable_bytes_written(), partResult.GetAvgWriteSpeedPerMin(), partResult.GetAvgWriteSpeedPerHour(), partResult.GetAvgWriteSpeedPerDay());
-
-    partStats->set_partition_node_id(nodeId);
-}
-
-void TDescribeTopicActor::ApplyResponse(TTabletInfo& tabletInfo, NKikimr::TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorContext& ctx) {
-    Y_UNUSED(ctx);
-
-    auto& record = ev->Get()->Record;
-
-    std::map<ui32, NKikimrPQ::TStatusResponse::TPartResult> res;
-
-    auto topicStats = Result.mutable_topic_stats();
-
-    if (record.PartResultSize() > 0) { // init with first value
-
-        SetProtoTime(topicStats->mutable_min_last_write_time(), record.GetPartResult(0).GetLastWriteTimestampMs());
-        SetProtoTime(topicStats->mutable_max_write_time_lag(), record.GetPartResult(0).GetWriteLagMs());
-    }
-
-    std::map<TString, Ydb::Topic::Consumer*> consumersInfo;
-    for (auto& consumer : *Result.mutable_consumers()) {
-        consumersInfo[NPersQueue::ConvertNewConsumerName(consumer.name(), ctx)] = &consumer;
-    }
-
-    for (auto& partResult : record.GetPartResult()) {
-        res[partResult.GetPartition()] = partResult;
-
-        topicStats->set_store_size_bytes(topicStats->store_size_bytes() + partResult.GetPartitionSize());
-
-        UpdateProtoTime(topicStats->mutable_min_last_write_time(), partResult.GetLastWriteTimestampMs(), true);
-        UpdateProtoTime(topicStats->mutable_max_write_time_lag(), partResult.GetWriteLagMs(), false);
-
-        AddWindowsStat(topicStats->mutable_bytes_written(), partResult.GetAvgWriteSpeedPerMin(), partResult.GetAvgWriteSpeedPerHour(), partResult.GetAvgWriteSpeedPerDay());
-
-
-        for (auto& cons : partResult.GetConsumerResult()) {
-            auto it = consumersInfo.find(cons.GetConsumer());
-            if (it == consumersInfo.end()) continue;
-
-            if (!it->second->has_consumer_stats()) {
-                auto* stats = it->second->mutable_consumer_stats();
-
-                SetProtoTime(stats->mutable_min_partitions_last_read_time(), cons.GetLastReadTimestampMs());
-                SetProtoTime(stats->mutable_max_read_time_lag(), cons.GetReadLagMs());
-                SetProtoTime(stats->mutable_max_write_time_lag(), cons.GetWriteLagMs());
-                SetProtoTime(stats->mutable_max_committed_time_lag(), cons.GetCommitedLagMs());
-            } else {
-                auto* stats = it->second->mutable_consumer_stats();
-
-                UpdateProtoTime(stats->mutable_min_partitions_last_read_time(), cons.GetLastReadTimestampMs(), true);
-                UpdateProtoTime(stats->mutable_max_read_time_lag(), cons.GetReadLagMs(), false);
-                UpdateProtoTime(stats->mutable_max_write_time_lag(), cons.GetWriteLagMs(), false);
-                UpdateProtoTime(stats->mutable_max_committed_time_lag(), cons.GetCommitedLagMs(), false);
-            }
-
-            AddWindowsStat(it->second->mutable_consumer_stats()->mutable_bytes_read(), cons.GetAvgReadSpeedPerMin(), cons.GetAvgReadSpeedPerHour(), cons.GetAvgReadSpeedPerDay());
-        }
-    }
-
-    for (auto& partRes : *(Result.mutable_partitions())) {
-        auto it = res.find(partRes.partition_id());
-        if (it == res.end())
-            continue;
-        FillPartitionStats(it->second, partRes.mutable_partition_stats(), tabletInfo.NodeId);
-    }
-}
-
-bool TDescribeTopicActor::ApplyResponse(
-        TEvPersQueue::TEvGetPartitionsLocationResponse::TPtr& ev, const TActorContext&
-) {
-    const auto& record = ev->Get()->Record;
-    AFL_ENSURE(Settings.RequireLocation);
-
-    for (auto i = 0u; i < std::min<ui64>(record.LocationsSize(), TotalPartitions); ++i) {
-        const auto& location = record.GetLocations(i);
-        auto* locationResult = Result.mutable_partitions(i)->mutable_partition_location();
-        SetPartitionLocation(location, locationResult);
-    }
-    return true;
-}
-
-void TDescribeTopicActor::PassAway() {
-    TDescribeTopicActorImpl::PassAway(ActorContext());
-    TBase::PassAway();
-}
-
-
-void TDescribeTopicActor::Reply(const TActorContext& ctx) {
-    if (TBase::IsDead) {
-        return;
-    }
-    return ReplyWithResult(Ydb::StatusIds::SUCCESS, Result, ctx);
-}
-
-void TDescribeTopicActor::HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-    AFL_ENSURE(ev->Get()->Request.Get()->ResultSet.size() == 1); // describe for only one topic
-    if (ReplyIfNotTopic(ev)) {
-        return;
-    }
-
-    const auto& response = ev->Get()->Request.Get()->ResultSet.front();
-
-    const TString path = JoinSeq("/", response.Path);
-
-    if (response.PQGroupInfo) {
-        const auto& pqDescr = response.PQGroupInfo->Description;
-        Ydb::StatusIds::StatusCode status;
-        TString error;
-        if (!FillTopicDescription(Result, pqDescr, response.Self->Info, GetCdcStreamName(), status, error)) {
-            return RaiseError(error, Ydb::PersQueue::ErrorCode::ERROR, status, ActorContext());
-        }
-
-        const auto &config = pqDescr.GetPQTabletConfig();
-        auto consumerName = NPersQueue::ConvertNewConsumerName(Settings.Consumer, ActorContext());
-        bool found = false;
-        for (const auto& consumer : config.GetConsumers()) {
-            if (consumerName == consumer.GetName()) {
-                found = true;
-                break;
-            }
-        }
-
-        if (GetProtoRequest()->include_stats() || GetProtoRequest()->include_location()) {
-            if (Settings.Consumer && !found) {
-                Request_->RaiseIssue(FillIssue(
-                        TStringBuilder() << "no consumer '" << Settings.Consumer << "' in topic",
-                        Ydb::PersQueue::ErrorCode::BAD_REQUEST
-                ));
-                return RespondWithCode(Ydb::StatusIds::SCHEME_ERROR);
-            }
-
-            ProcessTablets(pqDescr, ActorContext());
-            return;
-        }
-    } else {
-        Ydb::Scheme::Entry *selfEntry = Result.mutable_self();
-        ConvertDirectoryEntry(response.Self->Info, selfEntry, true);
-        if (const auto& name = GetCdcStreamName()) {
-            selfEntry->set_name(*name);
-        }
-    }
-    return ReplyWithResult(Ydb::StatusIds::SUCCESS, Result, ActorContext());
-}
-
 bool TDescribeTopicActorImpl::ProcessTablets(
         const NKikimrSchemeOp::TPersQueueGroupDescription& pqDescr, const TActorContext& ctx
 ) {
@@ -877,16 +656,6 @@ bool TDescribeTopicActorImpl::ProcessTablets(
     TimeoutTimerActorId = CreateLongTimer(ctx, RequestTimeout,
         new IEventHandle(ctx.SelfID, ctx.SelfID, new TEvents::TEvWakeup()));
     return true;
-}
-
-void TDescribeTopicActor::Bootstrap(const NActors::TActorContext& ctx)
-{
-    TBase::Bootstrap(ctx);
-
-    SendDescribeProposeRequest(ctx);
-    Become(&TDescribeTopicActor::StateWork);
-    YDB_LOG_DEBUG_CTX(ctx, "Describe topic actor for path",
-        {"path", GetProtoRequest()->path()});
 }
 
 } // namespace NKikimr::NGRpcProxy::V1

--- a/ydb/services/persqueue_v1/actors/schema_actors.h
+++ b/ydb/services/persqueue_v1/actors/schema_actors.h
@@ -154,34 +154,4 @@ protected:
     TDescribeTopicActorSettings Settings;
 };
 
-class TDescribeTopicActor : public TPQGrpcSchemaBase<TDescribeTopicActor, NKikimr::NGRpcService::TEvDescribeTopicRequest>
-                          , public TCdcStreamCompatible
-                          , public TDescribeTopicActorImpl
-{
-using TBase = TPQGrpcSchemaBase<TDescribeTopicActor, NKikimr::NGRpcService::TEvDescribeTopicRequest>;
-using TTabletInfo = TDescribeTopicActorImpl::TTabletInfo;
-
-public:
-     TDescribeTopicActor(NKikimr::NGRpcService::TEvDescribeTopicRequest* request);
-     TDescribeTopicActor(NKikimr::NGRpcService::IRequestOpCtx * ctx);
-
-    ~TDescribeTopicActor() = default;
-
-    void Bootstrap(const NActors::TActorContext& ctx);
-    void RaiseError(const TString& error, const Ydb::PersQueue::ErrorCode::ErrorCode errorCode, const Ydb::StatusIds::StatusCode status, const TActorContext& ctx) override;
-
-    void StateWork(TAutoPtr<IEventHandle>& ev);
-
-    void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) override;
-    void ApplyResponse(TTabletInfo& tabletInfo, NKikimr::TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorContext& ctx) override;
-    void ApplyResponse(TTabletInfo& tabletInfo, NKikimr::TEvPersQueue::TEvReadSessionsInfoResponse::TPtr& ev, const TActorContext& ctx) override;
-    bool ApplyResponse(TEvPersQueue::TEvGetPartitionsLocationResponse::TPtr& ev, const TActorContext& ctx) override;
-    virtual void Reply(const TActorContext& ctx) override;
-
-    void PassAway() override;
-
-private:
-    Ydb::Topic::DescribeTopicResult Result;
-};
-
 } // namespace NKikimr::NGRpcProxy::V1

--- a/ydb/services/persqueue_v1/grpc_pq_schema.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_schema.cpp
@@ -54,9 +54,8 @@ void DoAlterTopicRequest(std::unique_ptr<IRequestOpCtx> ctx, const IFacilityProv
 }
 
 void DoDescribeTopicRequest(std::unique_ptr<IRequestOpCtx> ctx, const NKikimr::NGRpcService::IFacilityProvider& f) {
-    auto p = dynamic_cast<TEvDescribeTopicRequest*>(ctx.release());
-
-    EnsureReq(p);
+    auto* p = ctx.release();
+    Y_VERIFY_DEBUG(dynamic_cast<const Ydb::Topic::DescribeTopicRequest*>(p->GetRequest()));
 
     YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "New Describe topic request");
     f.RegisterActor(NKikimr::NGRpcProxy::V1::NTopic::CreateDescribeTopicActor(p));

--- a/ydb/services/persqueue_v1/grpc_pq_schema.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_schema.cpp
@@ -54,11 +54,12 @@ void DoAlterTopicRequest(std::unique_ptr<IRequestOpCtx> ctx, const IFacilityProv
 }
 
 void DoDescribeTopicRequest(std::unique_ptr<IRequestOpCtx> ctx, const NKikimr::NGRpcService::IFacilityProvider& f) {
-    auto* p = ctx.release();
-    Y_VERIFY_DEBUG(dynamic_cast<const Ydb::Topic::DescribeTopicRequest*>(p->GetRequest()));
+    auto p = dynamic_cast<TEvDescribeTopicRequest*>(ctx.release());
+
+    EnsureReq(p);
 
     YDB_LOG_DEBUG_CTX(TActivationContext::AsActorContext(), "New Describe topic request");
-    f.RegisterActor(new NGRpcProxy::V1::TDescribeTopicActor(p));
+    f.RegisterActor(NKikimr::NGRpcProxy::V1::NTopic::CreateDescribeTopicActor(p));
 }
 
 void DoDescribeConsumerRequest(std::unique_ptr<IRequestOpCtx> ctx, const NKikimr::NGRpcService::IFacilityProvider& f) {
@@ -145,17 +146,10 @@ void DoPQRemoveReadRuleRequest(std::unique_ptr<IRequestOpCtx> ctx, const IFacili
     f.RegisterActor(NGRpcProxy::V1::NPQv1::CreateRemoveConsumerActor(p));
 }
 
-#ifdef DECLARE_RPC
-#error DECLARE_RPC macro already defined
-#endif
-
-#define DECLARE_RPC(name) template<> IActor* TEv##name##Request::CreateRpcActor(NKikimr::NGRpcService::IRequestOpCtx* msg) { \
-    return new NKikimr::NGRpcProxy::V1::T##name##Actor(msg);\
-    }
-
-DECLARE_RPC(DescribeTopic);
-
-#undef DECLARE_RPC
+template<>
+IActor* TEvDescribeTopicRequest::CreateRpcActor(NKikimr::NGRpcService::IRequestOpCtx* msg) {
+    return NGRpcProxy::V1::NTopic::CreateDescribeTopicActor(msg);
+}
 
 template<>
 IActor* TEvDescribeConsumerRequest::CreateRpcActor(NKikimr::NGRpcService::IRequestOpCtx* msg) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Moved Topic API DescribeTopic onto the shared `TDescribeOperationActor` used by DescribePartition and DescribeConsumer.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Рефакторинг: gRPC DescribeTopic переведён на общий `CreateDescribeOperationActor`, по аналогии с DescribePartition / DescribeConsumer.

#### Было
- `TDescribeTopicActor` в `schema_actors.h` / `schema_actors.cpp`
- Инстанцирование в `DoDescribeTopicRequest` и `TEvDescribeTopicRequest::CreateRpcActor`

#### Стало
- `ydb/services/persqueue_v1/actors/schema/topic/describe_topic.cpp`
  - `TDescribeTopicStrategy` (`TEvStatus("", /*all consumers*/ true)`)
  - `TDescribeTopicGrpc` → `CreateDescribeOperationActor`
  - схема через `FillTopicDescription`, stats/location из `TEvDescribeOperationResponse`
- `grpc_pq_schema.cpp` вызывает `CreateDescribeTopicActor`
- Kafka не трогался: `TDescribeTopicActorImpl` и `TDescribeTopicActorSettings` остаются в `schema_actors.*`

#### describe_operation
- `TPartitionDescribeInfo::Consumers` — per-consumer stats для агрегации `topic_stats` / `consumer_stats`
- `partition_consumer_stats` заполняется только при `HasLagsInfo()` (нужно DescribeConsumer, не DescribeTopic)

#### Tests
- `schema_ops_ut`: DescribeTopic smoke/missing, location/stats, retry (delivery problem + false status), timeout, auth
- дополнительно: timeout/retry DescribeConsumer, DropTopic / AlterTopic smoke