### PR TITLE
Actors: remove local activation queues

### DIFF
--- a/ydb/core/driver_lib/run/config_helpers.cpp
+++ b/ydb/core/driver_lib/run/config_helpers.cpp
@@ -94,12 +94,6 @@ void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig
                 "HarmonizerNeedyCpuWindowSeconds must be in range [1, 32], got %" PRIu32,
                 harmonizerNeedyCpuWindowSeconds);
             basic.HarmonizerNeedyCpuWindowSeconds = static_cast<ui8>(harmonizerNeedyCpuWindowSeconds);
-            if (poolConfig.HasMinLocalQueueSize()) {
-                basic.MinLocalQueueSize = poolConfig.GetMinLocalQueueSize();
-            }
-            if (poolConfig.HasMaxLocalQueueSize()) {
-                basic.MaxLocalQueueSize = poolConfig.GetMaxLocalQueueSize();
-            }
             for (const auto& pool : poolConfig.GetAdjacentPools()) {
                 basic.AdjacentPools.push_back(pool);
             }

--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -33,9 +33,6 @@ namespace NActors {
         EASProfile ActorSystemProfile = EASProfile::Default;
         bool HasSharedThread = false;
         bool AllThreadsAreShared = false;
-        ui16 MinLocalQueueSize = 0;
-        ui16 MaxLocalQueueSize = 0;
-
         // tiny-ydb configs
         std::vector<i16> AdjacentPools;
         i16 ForcedForeignSlotCount = 0;

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -113,8 +113,6 @@ namespace NActors {
         , Harmonizer(harmonizer)
         , SoftProcessingDurationTs(cfg.SoftProcessingDurationTs)
         , HasOwnSharedThread(cfg.HasSharedThread)
-        , MaxLocalQueueSize(cfg.MaxLocalQueueSize)
-        , MinLocalQueueSize(cfg.MinLocalQueueSize)
         , SharedOnly(cfg.ForcedForeignSlotCount || cfg.AdjacentPools.size() || (!cfg.Threads && !cfg.MaxThreadCount))
         , Priority(cfg.Priority)
         , Jail(jail)
@@ -132,10 +130,6 @@ namespace NActors {
                 threads = 0;
             }
 
-            if (MaxLocalQueueSize) {
-                LocalQueues.Reset(new NThreading::TPadded<std::queue<ui32>>[threads]);
-                LocalQueueSize = MinLocalQueueSize;
-            }
             if constexpr (NFeatures::TSpinFeatureFlags::CalcPerThread) {
                 for (ui32 idx = 0; idx < threads; ++idx) {
                     SpinThresholdCyclesPerThread[idx].store(0);
@@ -161,10 +155,6 @@ namespace NActors {
                 threads = threads - 1;
             }
 
-            if (MaxLocalQueueSize) {
-                LocalQueues.Reset(new NThreading::TPadded<std::queue<ui32>>[threads]);
-                LocalQueueSize = MinLocalQueueSize;
-            }
             if constexpr (NFeatures::TSpinFeatureFlags::CalcPerThread) {
                 for (ui32 idx = 0; idx < threads; ++idx) {
                     SpinThresholdCyclesPerThread[idx].store(0);
@@ -317,31 +307,9 @@ namespace NActors {
         return nullptr;
     }
 
-    TMailbox* TBasicExecutorPool::GetReadyActivationLocalQueue(ui64 revolvingCounter) {
-        TWorkerId workerId = TlsThreadContext->WorkerId();
-        Y_DEBUG_ABORT_UNLESS(workerId < static_cast<i32>(MaxFullThreadCount));
-
-        if (workerId >= 0 && LocalQueues[workerId].size()) {
-            ui32 activation = LocalQueues[workerId].front();
-            LocalQueues[workerId].pop();
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue: activation found");
-            return MailboxTable->Get(activation);
-        } else {
-            TlsThreadContext->LocalQueueContext.WriteTurn = 0;
-            TlsThreadContext->LocalQueueContext.LocalQueueSize = LocalQueueSize.load(std::memory_order_relaxed);
-        }
-        EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue done; moving to ring queue");
-        return GetReadyActivationRingQueue(revolvingCounter);
-    }
-
     TMailbox* TBasicExecutorPool::GetReadyActivation(ui64 revolvingCounter) {
-        if (MaxLocalQueueSize) {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue");
-            return GetReadyActivationLocalQueue(revolvingCounter);
-        } else {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "ring queue");
-            return GetReadyActivationRingQueue(revolvingCounter);
-        }
+        EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "ring queue");
+        return GetReadyActivationRingQueue(revolvingCounter);
     }
 
     inline void TBasicExecutorPool::WakeUpLoop(i16 currentThreadCount) {
@@ -414,47 +382,8 @@ namespace NActors {
         }
     }
 
-    void TBasicExecutorPool::ScheduleActivationExLocalQueue(TMailbox* mailbox, ui64 revolvingWriteCounter) {
-        if (TlsThreadContext && TlsThreadContext->Pool() == this) {
-            TWorkerId workerId = TlsThreadContext->WorkerId();
-            if (++TlsThreadContext->LocalQueueContext.WriteTurn < TlsThreadContext->LocalQueueContext.LocalQueueSize) {
-                LocalQueues[workerId].push(mailbox->Hint);
-                return;
-            }
-            if (ActorSystemProfile != EASProfile::Default) {
-                TAtomic x = AtomicGet(Semaphore);
-                TSemaphore semaphore = TSemaphore::GetSemaphore(x);
-                if constexpr (NFeatures::TLocalQueuesFeatureFlags::UseIfAllOtherThreadsAreSleeping) {
-                    if (semaphore.CurrentSleepThreadCount == semaphore.CurrentThreadCount - 1 && semaphore.OldSemaphore == 0) {
-                        if (LocalQueues[workerId].empty()) {
-                            LocalQueues[workerId].push(mailbox->Hint);
-                            return;
-                        }
-                    }
-                }
-
-                if constexpr (NFeatures::TLocalQueuesFeatureFlags::UseOnMicroburst) {
-                    if (semaphore.OldSemaphore >= semaphore.CurrentThreadCount) {
-                        if (LocalQueues[workerId].empty() && TlsThreadContext->LocalQueueContext.WriteTurn < 1) {
-                            TlsThreadContext->LocalQueueContext.WriteTurn++;
-                            LocalQueues[workerId].push(mailbox->Hint);
-                            return;
-                        }
-                    }
-                }
-                ScheduleActivationExRingQueue(mailbox, revolvingWriteCounter, x);
-                return;
-            }
-        }
-        ScheduleActivationExRingQueue(mailbox, revolvingWriteCounter, std::nullopt);
-    }
-
     void TBasicExecutorPool::ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingCounter) {
-        if (MaxLocalQueueSize) {
-            ScheduleActivationExLocalQueue(mailbox, revolvingCounter);
-        } else {
-            ScheduleActivationExRingQueue(mailbox, revolvingCounter, std::nullopt);
-        }
+        ScheduleActivationExRingQueue(mailbox, revolvingCounter, std::nullopt);
     }
 
     void TBasicExecutorPool::GetCurrentStats(TExecutorPoolStats& poolStats, TVector<TExecutorThreadStats>& statsCopy) const {
@@ -695,11 +624,6 @@ namespace NActors {
         return Priority;
     }
 
-    void TBasicExecutorPool::SetLocalQueueSize(ui16 size) {
-        size = std::min(size, MaxLocalQueueSize);
-        LocalQueueSize.store(size, std::memory_order_relaxed);
-    }
-
     void TBasicExecutorPool::Initialize() {
         TlsThreadContext->WaitingStats = &WaitingStats[TlsThreadContext->WorkerId()];
     }
@@ -817,18 +741,6 @@ namespace NActors {
 
     ui32 TBasicExecutorPool::EventsPerMailbox() const {
         return EventsPerMailboxValue;
-    }
-
-    ui16 TBasicExecutorPool::GetLocalQueueSize() const {
-        return LocalQueueSize.load(std::memory_order_relaxed);
-    }
-
-    ui16 TBasicExecutorPool::GetMaxLocalQueueSize() const {
-        return MaxLocalQueueSize;
-    }
-
-    ui16 TBasicExecutorPool::GetMinLocalQueueSize() const {
-        return MinLocalQueueSize;
     }
 
 }

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -18,8 +18,6 @@
 
 #include <util/system/mutex.h>
 
-#include <queue>
-
 namespace NActors {
 
     class TExecutorPoolJail;
@@ -140,10 +138,8 @@ namespace NActors {
 
         TArrayHolder<NThreading::TPadded<TExecutorThreadCtx>> Threads;
         static_assert(sizeof(std::decay_t<decltype(Threads[0])>) == PLATFORM_CACHE_LINE);
-        TArrayHolder<NThreading::TPadded<std::queue<ui32>>> LocalQueues;
         TArrayHolder<TWaitingStats<ui64>> WaitingStats;
         TArrayHolder<TWaitingStats<double>> MovingWaitingStats;
-        std::atomic<ui16> LocalQueueSize;
 
         TArrayHolder<NSchedulerQueue::TReader> ScheduleReaders;
         TArrayHolder<NSchedulerQueue::TWriter> ScheduleWriters;
@@ -174,8 +170,6 @@ namespace NActors {
         IHarmonizer *Harmonizer = nullptr;
         ui64 SoftProcessingDurationTs = 0;
         bool HasOwnSharedThread = false;
-        ui16 MaxLocalQueueSize = 0;
-        ui16 MinLocalQueueSize = 0;
         bool SharedOnly = false;
 
         const i16 Priority = 0;
@@ -235,7 +229,6 @@ namespace NActors {
         TMailbox* GetReadyActivation(ui64 revolvingReadCounter) override;
         TMailbox* GetReadyActivationShared(ui64 revolvingReadCounter);
         TMailbox* GetReadyActivationRingQueue(ui64 revolvingReadCounter);
-        TMailbox* GetReadyActivationLocalQueue(ui64 revolvingReadCounter);
 
         void Schedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie, TWorkerId workerId) override;
         void Schedule(TMonotonic deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie, TWorkerId workerId) override;
@@ -243,12 +236,6 @@ namespace NActors {
 
         void ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingWriteCounter) override;
         void ScheduleActivationExRingQueue(TMailbox* mailbox, ui64 revolvingWriteCounter, std::optional<TAtomic> semaphoreValue);
-        void ScheduleActivationExLocalQueue(TMailbox* mailbox, ui64 revolvingWriteCounter);
-
-        void SetLocalQueueSize(ui16 size);
-        ui16 GetLocalQueueSize() const;
-        ui16 GetMaxLocalQueueSize() const;
-        ui16 GetMinLocalQueueSize() const;
         void Prepare(TActorSystem* actorSystem, NSchedulerQueue::TReader** scheduleReaders, ui32* scheduleSz) override;
         void Start() override;
         void PrepareStop() override;

--- a/ydb/library/actors/core/executor_pool_basic_feature_flags.h
+++ b/ydb/library/actors/core/executor_pool_basic_feature_flags.h
@@ -9,20 +9,12 @@ namespace NActors::NFeatures {
 
     enum class EActorSystemOptimizationType {
         Common,
-        LocalQueues,
     };
 
     struct TCommonFeatureFlags {
         static constexpr EActorSystemOptimizationType OptimizationType = EActorSystemOptimizationType::Common;
 
         static constexpr bool ProbeSpinCycles = false;
-    };
-
-    struct TLocalQueuesFeatureFlags {
-        static constexpr EActorSystemOptimizationType OptimizationType = EActorSystemOptimizationType::LocalQueues;
-
-        static constexpr bool UseIfAllOtherThreadsAreSleeping = false;
-        static constexpr bool UseOnMicroburst = false;
     };
 
     struct TSpinFeatureFlags {

--- a/ydb/library/actors/core/harmonizer/harmonizer.cpp
+++ b/ydb/library/actors/core/harmonizer/harmonizer.cpp
@@ -194,7 +194,6 @@ void THarmonizer::ProcessNeedyState() {
             continue;
         }
         float fullThreadCount = pool.GetFullThreadCount();
-        float threadCount = pool.GetFullThreadCount() + SharedInfo.CpuConsumption[needyPoolIdx].CpuQuota;
 
         float foreignElapsed = CpuConsumption.PoolForeignConsumption[needyPoolIdx].Elapsed;
         float extraForeignElapsed = std::max(0.0f, foreignElapsed - std::max(0, SharedInfo.ForeignThreadsAllowed[needyPoolIdx] - 1));
@@ -207,15 +206,6 @@ void THarmonizer::ProcessNeedyState() {
             SetForeignThreadSlotsForCurrentFullThreadCount(needyPoolIdx);
             ProcessingBudget -= 1.0;
             LWPROBE_WITH_DEBUG(HarmonizeOperation, needyPoolIdx, pool.Pool->GetName(), "increase by needs", fullThreadCount + 1, pool.DefaultFullThreadCount, pool.MaxFullThreadCount);
-        }
-        if (pool.MaxLocalQueueSize) {
-            bool needToExpandLocalQueue = ProcessingBudget < 1.0 || threadCount >= pool.MaxFullThreadCount;
-            needToExpandLocalQueue &= (bool)pool.BasicPool;
-            needToExpandLocalQueue &= (pool.MaxFullThreadCount > 1);
-            needToExpandLocalQueue &= (pool.LocalQueueSize < pool.MaxLocalQueueSize);
-            if (needToExpandLocalQueue) {
-                pool.BasicPool->SetLocalQueueSize(++pool.LocalQueueSize);
-            }
         }
     }
 }
@@ -299,10 +289,6 @@ void THarmonizer::ProcessHoggishState() {
             pool.SetFullThreadCount(fullThreadCount - 1);
             SetForeignThreadSlotsForCurrentFullThreadCount(hoggishPoolIdx);
             LWPROBE_WITH_DEBUG(HarmonizeOperation, hoggishPoolIdx, pool.Pool->GetName(), "decrease by hoggish", fullThreadCount - 1, pool.DefaultFullThreadCount, pool.MaxFullThreadCount);
-        }
-        if (pool.BasicPool && pool.LocalQueueSize > pool.MinLocalQueueSize) {
-            pool.LocalQueueSize = std::min<ui16>(pool.MinLocalQueueSize, pool.LocalQueueSize / 2);
-            pool.BasicPool->SetLocalQueueSize(pool.LocalQueueSize);
         }
         HARMONIZER_DEBUG_PRINT("poolIdx", hoggishPoolIdx, "threadCount", fullThreadCount, "pool.MinFullThreadCount", pool.MinFullThreadCount, "freeCpu", freeCpu);
     }
@@ -491,9 +477,6 @@ void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ign
     if (poolInfo.BasicPool) {
         poolInfo.WaitingStats.reset(new TWaitingStats<ui64>());
         poolInfo.MovingWaitingStats.reset(new TWaitingStats<double>());
-        poolInfo.MinLocalQueueSize = poolInfo.BasicPool->GetMinLocalQueueSize();
-        poolInfo.MaxLocalQueueSize = poolInfo.BasicPool->GetMaxLocalQueueSize();
-        poolInfo.LocalQueueSize = poolInfo.MinLocalQueueSize;
         poolInfo.IsSharedOnly = poolInfo.BasicPool->IsSharedOnly();
     }
     PriorityOrder.clear();

--- a/ydb/library/actors/core/harmonizer/pool.h
+++ b/ydb/library/actors/core/harmonizer/pool.h
@@ -39,10 +39,6 @@ struct TPoolInfo {
     float MinThreadCount = 0;
     float MaxThreadCount = 0;
 
-    ui16 LocalQueueSize;
-    ui16 MaxLocalQueueSize = 0;
-    ui16 MinLocalQueueSize = 0;
-
     i16 Priority = 0;
     ui8 NeedyCpuWindowSeconds = 1;
     NMonitoring::TDynamicCounters::TCounterPtr AvgPingCounter;

--- a/ydb/library/actors/core/thread_context.h
+++ b/ydb/library/actors/core/thread_context.h
@@ -28,11 +28,6 @@ namespace NActors {
         ESendingType SendingType = ESendingType::Common;
     };
 
-    struct TLocalQueueContext {
-        ui32 WriteTurn = 0;
-        ui16 LocalQueueSize = 0;
-    };
-
     struct TThreadActivityContext {
         std::atomic<i64> StartOfProcessingEventTS = GetCycleCountFast();
         std::atomic<i64> ActivationStartTS = 0;
@@ -84,7 +79,6 @@ namespace NActors {
 
     struct TThreadContext {
         TWorkerContext WorkerContext;
-        TLocalQueueContext LocalQueueContext;
         TThreadActivityContext ActivityContext;
         TExecutionContext ExecutionContext;
         TMailboxContext MailboxContext;

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -222,9 +222,7 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
-            .Threads = 1,
-            .MinLocalQueueSize = 0,
-            .MaxLocalQueueSize = 0
+            .Threads = 1
         }, nullptr);
         PreparePool(pool.get());
 
@@ -269,9 +267,7 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
     Y_UNIT_TEST(OrderingOfRingQueue) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
-            .Threads = 1,
-            .MinLocalQueueSize = 0,
-            .MaxLocalQueueSize = 0
+            .Threads = 1
         }, nullptr);
 
         PreparePool(pool.get());
@@ -309,44 +305,6 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
         }
     }
 
-    Y_UNIT_TEST(CorrectnessOfLocalQueue) {
-        std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
-            .Threads = 1,
-            .MinLocalQueueSize = 8,
-            .MaxLocalQueueSize = 8
-        }, nullptr);
-
-        PreparePool(pool.get());
-
-        TThreadEmulator emulator({pool.get()}, nullptr);
-        TOverriddenThreadContext turnOffWaiting{
-            .IsNeededToWaitNextActivation = false
-        };
-
-        TMailbox* mailbox = pool->GetMailboxTable()->Allocate();
-        TWorkerIdentity workerIdentity{pool.get(), 0};
-
-        UNIT_ASSERT(!emulator.GetReadyActivation(workerIdentity, 0, turnOffWaiting));
-        for (ui64 i = 0; i < 8; ++i) {
-            emulator.ScheduleActivation(workerIdentity, pool.get(), mailbox, i);
-        }
-
-        TMailbox* outerMailbox = pool->GetMailboxTable()->Allocate();
-        emulator.ScheduleActivation(workerIdentity, pool.get(), outerMailbox, 8);
-
-        for (ui64 i = 0; i < 8; ++i) {
-            TMailbox* activation = emulator.GetReadyActivation(workerIdentity, i);
-            UNIT_ASSERT(activation);
-            UNIT_ASSERT_EQUAL(activation, mailbox);
-        }
-
-        {
-            TMailbox* activation = emulator.GetReadyActivation(workerIdentity, 8);
-            UNIT_ASSERT(activation);
-            UNIT_ASSERT_EQUAL(activation, outerMailbox);
-        }
-    }
-
     Y_UNIT_TEST(SharedPoolWith1Thread1Pool) {
         std::unique_ptr<TSharedExecutorPool> sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
             .Threads = 1
@@ -361,9 +319,7 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
         std::unique_ptr<TBasicExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1,
-            .HasSharedThread = true,
-            .MinLocalQueueSize = 0,
-            .MaxLocalQueueSize = 0,
+            .HasSharedThread = true
         }, nullptr);
 
         TieBasicPoolsAndSharedPool({pool.get()}, sharedPool.get());
@@ -424,9 +380,7 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
                 .PoolId = i,
                 .PoolName = "Pool" + ToString(i),
                 .Threads = 1,
-                .HasSharedThread = true,
-                .MinLocalQueueSize = 0,
-                .MaxLocalQueueSize = 0,
+                .HasSharedThread = true
             }, nullptr));
         }
 
@@ -545,9 +499,7 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
                 .PoolId = i,
                 .PoolName = i < 2 ? "WorkerPool" + ToString(i) : "TaskPool" + ToString(i),
                 .Threads = 1,
-                .HasSharedThread = true,
-                .MinLocalQueueSize = 0,
-                .MaxLocalQueueSize = 0,
+                .HasSharedThread = true
             }, nullptr));
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Actor executor pools now use the shared ring activation queue without per-thread local queues.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Removes local queue storage and scheduling paths, their harmonizer tuning, in-process configuration plumbing, and the local-queue-specific test. The protobuf fields remain for configuration compatibility.