### PR TITLE
Fix DirectRead hang after PQRB restart when Register is delayed

### DIFF
--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -426,7 +426,31 @@ private:
     void MarkSessionRetired(const TReadSessionKey& key, ui32 generation) {
         auto& retiredGeneration = RetiredSessionGeneration[key];
         retiredGeneration = Max(retiredGeneration, generation);
-        PendingBySession.erase(key);
+
+        // Drop only pending for generations <= retired. Newer Stage/Publish (e.g. Stage(N)
+        // before Register, then stale Deregister(N-1)) must survive for FlushPending.
+        auto pendingIter = PendingBySession.find(key);
+        if (pendingIter.IsEnd()) {
+            return;
+        }
+        auto& pending = pendingIter->second;
+        for (auto it = pending.Stages.begin(); it != pending.Stages.end(); ) {
+            if (it->second.Generation <= retiredGeneration) {
+                it = pending.Stages.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        for (auto it = pending.Publishes.begin(); it != pending.Publishes.end(); ) {
+            if (it->second <= retiredGeneration) {
+                it = pending.Publishes.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        if (pending.Stages.empty() && pending.Publishes.empty()) {
+            PendingBySession.erase(pendingIter);
+        }
     }
 
     void ClearRetiredSession(const TReadSessionKey& key) {
@@ -697,6 +721,8 @@ private:
     THashMap<TReadSessionKey, TPendingDirectReads> PendingBySession;
     // Highest generation for which the session was Deregistered/Released. Late Stage/Publish
     // with generation <= this value must not re-create PendingBySession after teardown.
+    // Keys stay until Register of the same session key (or actor death); needed so a late
+    // Stage after erase does not leak again.
     THashMap<TReadSessionKey, ui32> RetiredSessionGeneration;
     THashMap<TActorId, TSet<ui64>> AssignByProxy;
 

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -1,4 +1,5 @@
 #include "caching_service.h"
+#include "deadline_map.h"
 
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
@@ -11,6 +12,7 @@
 #include <ydb/services/persqueue_v1/actors/events.h>
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
 #include <contrib/libs/protobuf/src/google/protobuf/util/time_util.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
@@ -20,6 +22,10 @@ using namespace NActors;
 using namespace Ydb::Topic;
 using namespace NGRpcProxy::V1;
 
+namespace {
+constexpr ui64 ExpireDeadlineMapsWakeupTag = 1;
+constexpr TDuration DeadlineMapWakeupPeriod = TDuration::Minutes(1);
+} // namespace
 
 i32 GetDataChunkCodec(const NKikimrPQClient::TDataChunk& proto) {
     if (proto.HasCodec()) {
@@ -40,7 +46,7 @@ public:
         YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: Created");
 
         Become(&TThis::StateWork);
-        Y_UNUSED(ctx);
+        ctx.Schedule(DeadlineMapWakeupPeriod, new TEvents::TEvWakeup(ExpireDeadlineMapsWakeupTag));
     }
 
     STRICT_STFUNC(StateWork,
@@ -53,10 +59,41 @@ public:
           hFunc(TEvPQProxy::TEvDirectReadDataSessionConnected, HandleCreateClientSession)
           hFunc(TEvPQProxy::TEvDirectReadDataSessionDead, HandleDestroyClientSession)
           hFunc(TEvPQProxy::TEvDirectReadDestroyPartitionSession, HandlePartitionSessionReleased)
+          hFunc(TEvents::TEvWakeup, HandleWakeup)
     )
 
 private:
     using TSessionsMap = THashMap<TReadSessionKey, TCacheServiceData>;
+
+    struct TPendingStage {
+        ui32 Generation = 0;
+        std::shared_ptr<NKikimrClient::TResponse> Response;
+    };
+    struct TPendingDirectReads {
+        TMap<ui64, TPendingStage> Stages;
+        TMap<ui64, ui32> Publishes; // readId -> tablet generation
+        TInstant Deadline;
+    };
+    struct TRetiredSession {
+        ui32 Generation = 0;
+        TInstant Deadline;
+    };
+
+    void HandleWakeup(TEvents::TEvWakeup::TPtr& ev) {
+        if (ev->Get()->Tag != ExpireDeadlineMapsWakeupTag) {
+            return;
+        }
+        const auto& ctx = ActorContext();
+        const auto now = ctx.Now();
+        const auto pendingExpired = PendingBySession.Expire(now);
+        const auto retiredExpired = RetiredSessions.Expire(now);
+        if (pendingExpired || retiredExpired) {
+            YDB_LOG_INFO_CTX(ctx, "Direct read cache: expired deadline map entries",
+                {"pending", pendingExpired},
+                {"retired", retiredExpired});
+        }
+        ctx.Schedule(DeadlineMapWakeupPeriod, new TEvents::TEvWakeup(ExpireDeadlineMapsWakeupTag));
+    }
 
     void HandleCreateClientSession(TEvPQProxy::TEvDirectReadDataSessionConnected::TPtr& ev) {
         const auto& ctx = ActorContext();
@@ -127,7 +164,7 @@ private:
             ServerSessions.erase(sessionIter);
         } else {
             // Drop any Stage/Publish that arrived before Register for this dead binding.
-            PendingBySession.erase(key);
+            PendingBySession.Erase(key);
         }
     }
 
@@ -178,8 +215,7 @@ private:
                 {"partitionSessionId", sessionKey.PartitionSessionId},
                 {"ReadKey.ReadId", ev->Get()->ReadKey.ReadId},
                 {"TabletGeneration", ev->Get()->TabletGeneration});
-            auto& pending = PendingBySession[sessionKey];
-            pending.Stages[ev->Get()->ReadKey.ReadId] = TPendingStage{
+            GetOrCreatePending(sessionKey).Stages[ev->Get()->ReadKey.ReadId] = TPendingStage{
                 ev->Get()->TabletGeneration,
                 ev->Get()->Response
             };
@@ -213,7 +249,7 @@ private:
                 {"partitionSessionId", key.PartitionSessionId},
                 {"readId", readId},
                 {"generation", generation});
-            PendingBySession[key].Publishes[readId] = generation;
+            GetOrCreatePending(key).Publishes[readId] = generation;
             return;
         }
 
@@ -223,12 +259,11 @@ private:
     void HandleForget(TEvPQ::TEvForgetDirectRead::TPtr& ev) {
         const auto& ctx = ActorContext();
         auto key = MakeSessionKey(ev->Get());
-        auto pendingIter = PendingBySession.find(key);
-        if (!pendingIter.IsEnd()) {
-            pendingIter->second.Stages.erase(ev->Get()->ReadKey.ReadId);
-            pendingIter->second.Publishes.erase(ev->Get()->ReadKey.ReadId);
-            if (pendingIter->second.Stages.empty() && pendingIter->second.Publishes.empty()) {
-                PendingBySession.erase(pendingIter);
+        if (auto* pending = PendingBySession.Find(key)) {
+            pending->Stages.erase(ev->Get()->ReadKey.ReadId);
+            pending->Publishes.erase(ev->Get()->ReadKey.ReadId);
+            if (pending->Stages.empty() && pending->Publishes.empty()) {
+                PendingBySession.Erase(key);
             }
         }
         auto iter = ServerSessions.find(key);
@@ -397,8 +432,8 @@ private:
     }
 
     void FlushPendingDirectReads(const TReadSessionKey& key) {
-        auto pendingIter = PendingBySession.find(key);
-        if (pendingIter.IsEnd()) {
+        auto* pending = PendingBySession.Find(key);
+        if (!pending) {
             return;
         }
         auto sessionIter = ServerSessions.find(key);
@@ -410,56 +445,75 @@ private:
         YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: flush pending stage/publish after register",
             {"sessionId", key.SessionId},
             {"partitionSessionId", key.PartitionSessionId},
-            {"stages", pendingIter->second.Stages.size()},
-            {"publishes", pendingIter->second.Publishes.size()});
+            {"stages", pending->Stages.size()},
+            {"publishes", pending->Publishes.size()});
 
         // Stage before Publish; maps are ordered by readId.
-        for (auto& [readId, stage] : pendingIter->second.Stages) {
+        for (auto& [readId, stage] : pending->Stages) {
             StageToSession(sessionIter, readId, stage.Generation, stage.Response);
         }
-        for (const auto& [readId, generation] : pendingIter->second.Publishes) {
+        for (const auto& [readId, generation] : pending->Publishes) {
             PublishToSession(sessionIter, readId, generation);
         }
-        PendingBySession.erase(pendingIter);
+        PendingBySession.Erase(key);
+    }
+
+    TPendingDirectReads& GetOrCreatePending(const TReadSessionKey& key) {
+        if (auto* pending = PendingBySession.Find(key)) {
+            return *pending;
+        }
+        auto* inserted = PendingBySession.TryInsert(
+            key, TPendingDirectReads{}, ActorContext().Now());
+        Y_ABORT_UNLESS(inserted);
+        return *inserted;
     }
 
     void MarkSessionRetired(const TReadSessionKey& key, ui32 generation) {
-        auto& retiredGeneration = RetiredSessionGeneration[key];
-        retiredGeneration = Max(retiredGeneration, generation);
+        const auto now = ActorContext().Now();
+        if (auto* retired = RetiredSessions.Find(key)) {
+            retired->Generation = Max(retired->Generation, generation);
+            RetiredSessions.TouchDeadline(key, now);
+        } else {
+            TRetiredSession entry;
+            entry.Generation = generation;
+            auto* inserted = RetiredSessions.TryInsert(key, std::move(entry), now);
+            Y_ABORT_UNLESS(inserted);
+        }
+
+        const ui32 retiredGeneration = RetiredSessions.Find(key)->Generation;
 
         // Drop only pending for generations <= retired. Newer Stage/Publish (e.g. Stage(N)
         // before Register, then stale Deregister(N-1)) must survive for FlushPending.
-        auto pendingIter = PendingBySession.find(key);
-        if (pendingIter.IsEnd()) {
+        auto* pending = PendingBySession.Find(key);
+        if (!pending) {
             return;
         }
-        auto& pending = pendingIter->second;
-        for (auto it = pending.Stages.begin(); it != pending.Stages.end(); ) {
+        for (auto it = pending->Stages.begin(); it != pending->Stages.end(); ) {
             if (it->second.Generation <= retiredGeneration) {
-                it = pending.Stages.erase(it);
+                it = pending->Stages.erase(it);
             } else {
                 ++it;
             }
         }
-        for (auto it = pending.Publishes.begin(); it != pending.Publishes.end(); ) {
+        for (auto it = pending->Publishes.begin(); it != pending->Publishes.end(); ) {
             if (it->second <= retiredGeneration) {
-                it = pending.Publishes.erase(it);
+                it = pending->Publishes.erase(it);
             } else {
                 ++it;
             }
         }
-        if (pending.Stages.empty() && pending.Publishes.empty()) {
-            PendingBySession.erase(pendingIter);
+        if (pending->Stages.empty() && pending->Publishes.empty()) {
+            PendingBySession.Erase(key);
         }
     }
 
     void ClearRetiredSession(const TReadSessionKey& key) {
-        RetiredSessionGeneration.erase(key);
+        RetiredSessions.Erase(key);
     }
 
     bool IsSessionGenerationRetired(const TReadSessionKey& key, ui32 generation) const {
-        auto it = RetiredSessionGeneration.find(key);
-        return !it.IsEnd() && generation <= it->second;
+        const auto* retired = RetiredSessions.Find(key);
+        return retired && generation <= retired->Generation;
     }
 
     template<class TEv>
@@ -707,23 +761,13 @@ private:
             *msgMeta = (proto.GetMessageMeta());
         }
     }
-private:
-    struct TPendingStage {
-        ui32 Generation = 0;
-        std::shared_ptr<NKikimrClient::TResponse> Response;
-    };
-    struct TPendingDirectReads {
-        TMap<ui64, TPendingStage> Stages;
-        TMap<ui64, ui32> Publishes; // readId -> tablet generation
-    };
 
     TSessionsMap ServerSessions;
-    THashMap<TReadSessionKey, TPendingDirectReads> PendingBySession;
+    TDeadlineMap<TReadSessionKey, TPendingDirectReads> PendingBySession;
     // Highest generation for which the session was Deregistered/Released. Late Stage/Publish
     // with generation <= this value must not re-create PendingBySession after teardown.
-    // Keys stay until Register of the same session key (or actor death); needed so a late
-    // Stage after erase does not leak again.
-    THashMap<TReadSessionKey, ui32> RetiredSessionGeneration;
+    // Entries expire by TTL (with deadline refresh on each MarkSessionRetired).
+    TDeadlineMap<TReadSessionKey, TRetiredSession> RetiredSessions;
     THashMap<TActorId, TSet<ui64>> AssignByProxy;
 
     ::NMonitoring::TDynamicCounterPtr Counters;

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -226,6 +226,7 @@ private:
             return;
         }
         StageToSession(sessionIter, ev->Get()->ReadKey.ReadId, ev->Get()->TabletGeneration, ev->Get()->Response);
+        TryApplyPendingPublish(sessionKey, ev->Get()->ReadKey.ReadId);
     }
 
     void HandlePublish(TEvPQ::TEvPublishDirectRead::TPtr& ev) {
@@ -257,7 +258,7 @@ private:
             return;
         }
 
-        PublishToSession(iter, readId, generation);
+        Y_UNUSED(PublishToSession(iter, readId, generation));
     }
 
     void HandleForget(TEvPQ::TEvForgetDirectRead::TPtr& ev) {
@@ -401,20 +402,22 @@ private:
             {"session", sessionIter->first.SessionId});
     }
 
-    void PublishToSession(TSessionsMap::iterator iter, ui64 readId, ui32 generation) {
+    // Returns true if the read was published (or already published). False if generation
+    // mismatches or there is no staged payload for readId yet.
+    [[nodiscard]] bool PublishToSession(TSessionsMap::iterator iter, ui64 readId, ui32 generation) {
         const auto& ctx = ActorContext();
         if (iter.IsEnd()) {
-            return;
+            return false;
         }
         if (iter->second.Generation != generation)
-            return;
+            return false;
 
         auto stagedIter = iter->second.StagedReads.find(readId);
         if (stagedIter == iter->second.StagedReads.end()) {
             YDB_LOG_ERROR_CTX(ctx, "Direct read cache: attempt to publish unknown read id ignored",
                 {"readId", readId},
                 {"sessionId", iter->first.SessionId});
-            return;
+            return false;
         }
         auto inserted = iter->second.Reads.insert(std::make_pair(readId, stagedIter->second)).second;
         if (inserted) {
@@ -428,6 +431,7 @@ private:
         iter->second.StagedReads.erase(stagedIter);
 
         SendNextReadToClient(iter);
+        return true;
     }
 
     void FlushPendingDirectReads(const TReadSessionKey& key) {
@@ -463,14 +467,49 @@ private:
         }
         for (auto it = pending->Publishes.begin(); it != pending->Publishes.end(); ) {
             if (it->second == sessionGeneration) {
-                PublishToSession(sessionIter, it->first, it->second);
-                it = pending->Publishes.erase(it);
+                // Keep Publish if Stage for this gen is not staged yet (may arrive after Register).
+                if (sessionIter->second.StagedReads.contains(it->first)
+                        && PublishToSession(sessionIter, it->first, it->second)) {
+                    it = pending->Publishes.erase(it);
+                } else {
+                    ++it;
+                }
             } else if (it->second < sessionGeneration) {
                 it = pending->Publishes.erase(it);
             } else {
                 ++it;
             }
         }
+        if (pending->Stages.empty() && pending->Publishes.empty()) {
+            PendingBySession.Erase(key);
+        }
+    }
+
+    // If a Publish was buffered before its Stage (or Stage was dropped as stale lower-gen),
+    // apply it once the matching Stage lands on a registered session.
+    void TryApplyPendingPublish(const TReadSessionKey& key, ui64 readId) {
+        auto* pending = PendingBySession.Find(key);
+        if (!pending) {
+            return;
+        }
+        auto sessionIter = ServerSessions.find(key);
+        if (sessionIter.IsEnd()) {
+            return;
+        }
+        auto publishIt = pending->Publishes.find(readId);
+        if (publishIt == pending->Publishes.end()) {
+            return;
+        }
+        if (publishIt->second != sessionIter->second.Generation) {
+            return;
+        }
+        if (!sessionIter->second.StagedReads.contains(readId)) {
+            return;
+        }
+        if (!PublishToSession(sessionIter, readId, publishIt->second)) {
+            return;
+        }
+        pending->Publishes.erase(publishIt);
         if (pending->Stages.empty() && pending->Publishes.empty()) {
             PendingBySession.Erase(key);
         }
@@ -509,8 +548,14 @@ private:
     void BufferPendingPublish(const TReadSessionKey& key, ui64 readId, ui32 generation) {
         auto& pending = GetOrCreatePending(key);
         auto stageIt = pending.Stages.find(readId);
-        if (stageIt != pending.Stages.end() && stageIt->second.Generation > generation) {
-            return;
+        if (stageIt != pending.Stages.end()) {
+            if (stageIt->second.Generation > generation) {
+                return;
+            }
+            // Publish for a newer generation invalidates a stale Stage of an older generation.
+            if (stageIt->second.Generation < generation) {
+                pending.Stages.erase(stageIt);
+            }
         }
         auto it = pending.Publishes.find(readId);
         if (it == pending.Publishes.end()) {

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -162,9 +162,12 @@ private:
         if (!sessionIter.IsEnd()) {
             MarkSessionRetired(key, sessionIter->second.Generation);
             ServerSessions.erase(sessionIter);
+            ChangeCounterValue("ActiveServerSessions", ServerSessions.size(), true);
         } else {
-            // Drop any Stage/Publish that arrived before Register for this dead binding.
-            PendingBySession.Erase(key);
+            // No server session (e.g. already Deregistered): still retire the key so late
+            // Stage/Publish cannot recreate PendingBySession. Generation is unknown here —
+            // use Max to block all gens until Register clears the tombstone.
+            MarkSessionRetired(key, Max<ui32>());
         }
     }
 

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -218,10 +218,11 @@ private:
                 {"partitionSessionId", sessionKey.PartitionSessionId},
                 {"ReadKey.ReadId", ev->Get()->ReadKey.ReadId},
                 {"TabletGeneration", ev->Get()->TabletGeneration});
-            GetOrCreatePending(sessionKey).Stages[ev->Get()->ReadKey.ReadId] = TPendingStage{
-                ev->Get()->TabletGeneration,
-                ev->Get()->Response
-            };
+            BufferPendingStage(
+                    sessionKey,
+                    ev->Get()->ReadKey.ReadId,
+                    ev->Get()->TabletGeneration,
+                    ev->Get()->Response);
             return;
         }
         StageToSession(sessionIter, ev->Get()->ReadKey.ReadId, ev->Get()->TabletGeneration, ev->Get()->Response);
@@ -252,7 +253,7 @@ private:
                 {"partitionSessionId", key.PartitionSessionId},
                 {"readId", readId},
                 {"generation", generation});
-            GetOrCreatePending(key).Publishes[readId] = generation;
+            BufferPendingPublish(key, readId, generation);
             return;
         }
 
@@ -262,13 +263,9 @@ private:
     void HandleForget(TEvPQ::TEvForgetDirectRead::TPtr& ev) {
         const auto& ctx = ActorContext();
         auto key = MakeSessionKey(ev->Get());
-        if (auto* pending = PendingBySession.Find(key)) {
-            pending->Stages.erase(ev->Get()->ReadKey.ReadId);
-            pending->Publishes.erase(ev->Get()->ReadKey.ReadId);
-            if (pending->Stages.empty() && pending->Publishes.empty()) {
-                PendingBySession.Erase(key);
-            }
-        }
+        const auto readId = ev->Get()->ReadKey.ReadId;
+        const auto generation = ev->Get()->TabletGeneration;
+        ForgetPending(key, readId, generation);
         auto iter = ServerSessions.find(key);
         if (iter.IsEnd()) {
             YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: attempt to forget read for unknown session ignored",
@@ -276,10 +273,9 @@ private:
             return;
         }
         YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: forget for session",
-            {"read", ev->Get()->ReadKey.ReadId},
+            {"read", readId},
             {"sessionId", key.SessionId});
 
-        const auto& generation = ev->Get()->TabletGeneration;
         if (iter->second.Generation != generation) { // Stale generation in event, ignore it
             return;
         }
@@ -441,24 +437,43 @@ private:
         }
         auto sessionIter = ServerSessions.find(key);
         if (sessionIter.IsEnd()) {
+            // Register always inserts the session before flush; keep pending if that invariant breaks.
             return;
         }
 
+        const ui32 sessionGeneration = sessionIter->second.Generation;
         const auto& ctx = ActorContext();
         YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: flush pending stage/publish after register",
             {"sessionId", key.SessionId},
             {"partitionSessionId", key.PartitionSessionId},
+            {"sessionGeneration", sessionGeneration},
             {"stages", pending->Stages.size()},
             {"publishes", pending->Publishes.size()});
 
-        // Stage before Publish; maps are ordered by readId.
-        for (auto& [readId, stage] : pending->Stages) {
-            StageToSession(sessionIter, readId, stage.Generation, stage.Response);
+        // Apply only matching generation. Drop stale lower gens; keep higher gens for a later Register.
+        for (auto it = pending->Stages.begin(); it != pending->Stages.end(); ) {
+            if (it->second.Generation == sessionGeneration) {
+                StageToSession(sessionIter, it->first, it->second.Generation, it->second.Response);
+                it = pending->Stages.erase(it);
+            } else if (it->second.Generation < sessionGeneration) {
+                it = pending->Stages.erase(it);
+            } else {
+                ++it;
+            }
         }
-        for (const auto& [readId, generation] : pending->Publishes) {
-            PublishToSession(sessionIter, readId, generation);
+        for (auto it = pending->Publishes.begin(); it != pending->Publishes.end(); ) {
+            if (it->second == sessionGeneration) {
+                PublishToSession(sessionIter, it->first, it->second);
+                it = pending->Publishes.erase(it);
+            } else if (it->second < sessionGeneration) {
+                it = pending->Publishes.erase(it);
+            } else {
+                ++it;
+            }
         }
-        PendingBySession.Erase(key);
+        if (pending->Stages.empty() && pending->Publishes.empty()) {
+            PendingBySession.Erase(key);
+        }
     }
 
     TPendingDirectReads& GetOrCreatePending(const TReadSessionKey& key) {
@@ -469,6 +484,65 @@ private:
             key, TPendingDirectReads{}, ActorContext().Now());
         Y_ABORT_UNLESS(inserted);
         return *inserted;
+    }
+
+    // DirectReadIds can repeat across tablet generations; keep the highest generation
+    // (first entry wins for same-generation duplicates). A lower-gen Publish for an
+    // overwritten Stage is dropped.
+    void BufferPendingStage(
+            const TReadSessionKey& key,
+            ui64 readId,
+            ui32 generation,
+            const std::shared_ptr<NKikimrClient::TResponse>& response)
+    {
+        auto& pending = GetOrCreatePending(key);
+        auto it = pending.Stages.find(readId);
+        if (it == pending.Stages.end()) {
+            pending.Stages.emplace(readId, TPendingStage{generation, response});
+            return;
+        }
+        if (generation <= it->second.Generation) {
+            return;
+        }
+        it->second = TPendingStage{generation, response};
+        auto publishIt = pending.Publishes.find(readId);
+        if (publishIt != pending.Publishes.end() && publishIt->second < generation) {
+            pending.Publishes.erase(publishIt);
+        }
+    }
+
+    void BufferPendingPublish(const TReadSessionKey& key, ui64 readId, ui32 generation) {
+        auto& pending = GetOrCreatePending(key);
+        auto stageIt = pending.Stages.find(readId);
+        if (stageIt != pending.Stages.end() && stageIt->second.Generation > generation) {
+            return;
+        }
+        auto it = pending.Publishes.find(readId);
+        if (it == pending.Publishes.end()) {
+            pending.Publishes.emplace(readId, generation);
+            return;
+        }
+        if (generation > it->second) {
+            it->second = generation;
+        }
+    }
+
+    void ForgetPending(const TReadSessionKey& key, ui64 readId, ui32 generation) {
+        auto* pending = PendingBySession.Find(key);
+        if (!pending) {
+            return;
+        }
+        auto stageIt = pending->Stages.find(readId);
+        if (stageIt != pending->Stages.end() && generation >= stageIt->second.Generation) {
+            pending->Stages.erase(stageIt);
+        }
+        auto publishIt = pending->Publishes.find(readId);
+        if (publishIt != pending->Publishes.end() && generation >= publishIt->second) {
+            pending->Publishes.erase(publishIt);
+        }
+        if (pending->Stages.empty() && pending->Publishes.empty()) {
+            PendingBySession.Erase(key);
+        }
     }
 
     void MarkSessionRetired(const TReadSessionKey& key, ui32 generation) {

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -316,7 +316,7 @@ private:
             return;
         }
         if (sessionIter->second.Generation != tabletGeneration) {
-            YDB_LOG_ALERT_CTX(ctx, "Direct read cache: tried to stage direct read for session with generation previously had this session with generation Data ignored",
+            YDB_LOG_ALERT_CTX(ctx, "Direct read cache: Stage generation mismatch, data ignored",
                 {"sessionId", sessionIter->first.SessionId},
                 {"TabletGeneration", tabletGeneration},
                 {"generation", sessionIter->second.Generation});

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -477,13 +477,8 @@ private:
     }
 
     TPendingDirectReads& GetOrCreatePending(const TReadSessionKey& key) {
-        if (auto* pending = PendingBySession.Find(key)) {
-            return *pending;
-        }
-        auto* inserted = PendingBySession.TryInsert(
+        return PendingBySession.FindOrInsert(
             key, TPendingDirectReads{}, ActorContext().Now());
-        Y_ABORT_UNLESS(inserted);
-        return *inserted;
     }
 
     // DirectReadIds can repeat across tablet generations; keep the highest generation
@@ -547,17 +542,12 @@ private:
 
     void MarkSessionRetired(const TReadSessionKey& key, ui32 generation) {
         const auto now = ActorContext().Now();
-        if (auto* retired = RetiredSessions.Find(key)) {
-            retired->Generation = Max(retired->Generation, generation);
-            RetiredSessions.TouchDeadline(key, now);
-        } else {
-            TRetiredSession entry;
-            entry.Generation = generation;
-            auto* inserted = RetiredSessions.TryInsert(key, std::move(entry), now);
-            Y_ABORT_UNLESS(inserted);
-        }
+        auto& retired = RetiredSessions.FindOrInsert(
+            key, TRetiredSession{.Generation = generation}, now);
+        retired.Generation = Max(retired.Generation, generation);
+        RetiredSessions.TouchDeadline(key, now);
 
-        const ui32 retiredGeneration = RetiredSessions.Find(key)->Generation;
+        const ui32 retiredGeneration = retired.Generation;
 
         // Drop only pending for generations <= retired. Newer Stage/Publish (e.g. Stage(N)
         // before Register, then stale Deregister(N-1)) must survive for FlushPending.

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -120,6 +120,7 @@ private:
             return;
 
         assignIter->second.erase(ev->Get()->ReadKey.PartitionSessionId);
+        PendingBySession.erase(ev->Get()->ReadKey);
         ServerSessions.erase(ev->Get()->ReadKey);
     }
 
@@ -134,6 +135,7 @@ private:
 
         auto destroyDone = DestroyServerSession(ServerSessions.find(key), ev->Get()->Generation);
         if (destroyDone) {
+            PendingBySession.erase(key);
             YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: server session",
                 {"deregistered", key.SessionId});
         } else {
@@ -150,31 +152,21 @@ private:
         auto sessionKey = MakeSessionKey(ev->Get());
         auto sessionIter = ServerSessions.find(sessionKey);
         if (sessionIter.IsEnd()) {
-            YDB_LOG_ERROR_CTX(ctx, "Direct read cache: tried to stage direct read for unregistered session",
+            // LOGBROKER-10590: CreateSession Register is fire-and-forget; Stage can arrive first.
+            // Dropping it permanently leaves tablet inFlight without client-visible DirectRead.
+            YDB_LOG_INFO_CTX(ctx, "Direct read cache: buffer stage for unregistered session",
                 {"session", sessionKey.SessionId},
-                {"partitionSessionId", sessionKey.PartitionSessionId});
+                {"partitionSessionId", sessionKey.PartitionSessionId},
+                {"ReadKey.ReadId", ev->Get()->ReadKey.ReadId},
+                {"TabletGeneration", ev->Get()->TabletGeneration});
+            auto& pending = PendingBySession[sessionKey];
+            pending.Stages[ev->Get()->ReadKey.ReadId] = TPendingStage{
+                ev->Get()->TabletGeneration,
+                ev->Get()->Response
+            };
             return;
         }
-        if (sessionIter->second.Generation != ev->Get()->TabletGeneration) {
-            YDB_LOG_ALERT_CTX(ctx, "Direct read cache: tried to stage direct read for session with generation previously had this session with generation Data ignored",
-                {"sessionId", sessionKey.SessionId},
-                {"TabletGeneration", ev->Get()->TabletGeneration},
-                {"generation", sessionIter->second.Generation});
-            return;
-        }
-        auto ins = sessionIter->second.StagedReads.insert(std::make_pair(ev->Get()->ReadKey.ReadId, ev->Get()->Response));
-        if (!ins.second) {
-            YDB_LOG_WARN_CTX(ctx, "Direct read cache: tried to stage duplicate direct read for session with id new data ignored",
-                {"sessionId", sessionKey.SessionId},
-                {"ReadKey.ReadId", ev->Get()->ReadKey.ReadId});
-            return;
-        }
-        ChangeCounterValue("StagedReadDataSize", ins.first->second->ByteSize(), false);
-        ChangeCounterValue("StagedReadsCount", 1, false);
-        ChangeCounterValue("StagedReadsRate", 1, false, true);
-        YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: staged direct read id",
-            {"ReadKey.ReadId", ev->Get()->ReadKey.ReadId},
-            {"session", sessionKey.SessionId});
+        StageToSession(sessionIter, ev->Get()->ReadKey.ReadId, ev->Get()->TabletGeneration, ev->Get()->Response);
     }
 
     void HandlePublish(TEvPQ::TEvPublishDirectRead::TPtr& ev) {
@@ -189,38 +181,29 @@ private:
 
         auto iter = ServerSessions.find(key);
         if (iter.IsEnd()) {
-            YDB_LOG_ERROR_CTX(ctx, "Direct read cache: attempt to publish read for unknow session ignored",
-                {"sessionId", key.SessionId});
-            return;
-        }
-
-        if (iter->second.Generation != generation)
-            return;
-
-        auto stagedIter = iter->second.StagedReads.find(readId);
-        if (stagedIter == iter->second.StagedReads.end()) {
-            YDB_LOG_ERROR_CTX(ctx, "Direct read cache: attempt to publish unknown read id ignored",
+            YDB_LOG_INFO_CTX(ctx, "Direct read cache: buffer publish for unregistered session",
+                {"sessionId", key.SessionId},
+                {"partitionSessionId", key.PartitionSessionId},
                 {"readId", readId},
-                {"sessionId", key.SessionId});
+                {"generation", generation});
+            PendingBySession[key].Publishes[readId] = generation;
             return;
         }
-        auto inserted = iter->second.Reads.insert(std::make_pair(ev->Get()->ReadKey.ReadId, stagedIter->second)).second;
-        if (inserted) {
-            ChangeCounterValue("PublishedReadDataSize", stagedIter->second->ByteSize(), false);
-            ChangeCounterValue("PublishedReadsCount", 1, false);
-            ChangeCounterValue("PublishedReadsRate", 1, false, true);
-        }
-        ChangeCounterValue("StagedReadDataSize", -stagedIter->second->ByteSize(), false);
-        ChangeCounterValue("StagedReadsCount", -1, false);
 
-        iter->second.StagedReads.erase(stagedIter);
-
-        SendNextReadToClient(iter);
+        PublishToSession(iter, readId, generation);
     }
 
     void HandleForget(TEvPQ::TEvForgetDirectRead::TPtr& ev) {
         const auto& ctx = ActorContext();
         auto key = MakeSessionKey(ev->Get());
+        auto pendingIter = PendingBySession.find(key);
+        if (!pendingIter.IsEnd()) {
+            pendingIter->second.Stages.erase(ev->Get()->ReadKey.ReadId);
+            pendingIter->second.Publishes.erase(ev->Get()->ReadKey.ReadId);
+            if (pendingIter->second.Stages.empty() && pendingIter->second.Publishes.empty()) {
+                PendingBySession.erase(pendingIter);
+            }
+        }
         auto iter = ServerSessions.find(key);
         if (iter.IsEnd()) {
             YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: attempt to forget read for unknown session ignored",
@@ -299,18 +282,20 @@ private:
                 {"generation", generation});
 
             ServerSessions.insert(std::make_pair(key, TCacheServiceData{generation}));
+            FlushPendingDirectReads(key);
         } else if (sessionsIter->second.Generation == generation) {
             YDB_LOG_WARN_CTX(ctx, "Direct read cache: attempted to register duplicate server with same generation ignored",
                 {"session", key.SessionId},
                 {"sessionId", key.PartitionSessionId},
                 {"generation", generation});
-
+            FlushPendingDirectReads(key);
         } else if (DestroyServerSession(sessionsIter, generation)) {
             YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: registered server with generation killed existing session with older generation",
                 {"sessionId", key.SessionId},
                 {"partitionSessionId", key.PartitionSessionId},
                 {"generation", generation});
             ServerSessions.insert(std::make_pair(key, TCacheServiceData{generation}));
+            FlushPendingDirectReads(key);
         } else {
             YDB_LOG_INFO_CTX(ctx, "Direct read cache: attempted to register server with stale generation ignored",
                 {"session", key.SessionId},
@@ -318,6 +303,94 @@ private:
                 {"generation", generation});
         }
         ChangeCounterValue("ActiveServerSessions", ServerSessions.size(), true);
+    }
+
+    void StageToSession(
+            TSessionsMap::iterator sessionIter,
+            ui64 readId,
+            ui32 tabletGeneration,
+            const std::shared_ptr<NKikimrClient::TResponse>& response)
+    {
+        const auto& ctx = ActorContext();
+        if (sessionIter.IsEnd()) {
+            return;
+        }
+        if (sessionIter->second.Generation != tabletGeneration) {
+            YDB_LOG_ALERT_CTX(ctx, "Direct read cache: tried to stage direct read for session with generation previously had this session with generation Data ignored",
+                {"sessionId", sessionIter->first.SessionId},
+                {"TabletGeneration", tabletGeneration},
+                {"generation", sessionIter->second.Generation});
+            return;
+        }
+        auto ins = sessionIter->second.StagedReads.insert(std::make_pair(readId, response));
+        if (!ins.second) {
+            YDB_LOG_WARN_CTX(ctx, "Direct read cache: tried to stage duplicate direct read for session with id new data ignored",
+                {"sessionId", sessionIter->first.SessionId},
+                {"ReadKey.ReadId", readId});
+            return;
+        }
+        ChangeCounterValue("StagedReadDataSize", ins.first->second->ByteSize(), false);
+        ChangeCounterValue("StagedReadsCount", 1, false);
+        ChangeCounterValue("StagedReadsRate", 1, false, true);
+        YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: staged direct read id",
+            {"ReadKey.ReadId", readId},
+            {"session", sessionIter->first.SessionId});
+    }
+
+    void PublishToSession(TSessionsMap::iterator iter, ui64 readId, ui32 generation) {
+        const auto& ctx = ActorContext();
+        if (iter.IsEnd()) {
+            return;
+        }
+        if (iter->second.Generation != generation)
+            return;
+
+        auto stagedIter = iter->second.StagedReads.find(readId);
+        if (stagedIter == iter->second.StagedReads.end()) {
+            YDB_LOG_ERROR_CTX(ctx, "Direct read cache: attempt to publish unknown read id ignored",
+                {"readId", readId},
+                {"sessionId", iter->first.SessionId});
+            return;
+        }
+        auto inserted = iter->second.Reads.insert(std::make_pair(readId, stagedIter->second)).second;
+        if (inserted) {
+            ChangeCounterValue("PublishedReadDataSize", stagedIter->second->ByteSize(), false);
+            ChangeCounterValue("PublishedReadsCount", 1, false);
+            ChangeCounterValue("PublishedReadsRate", 1, false, true);
+        }
+        ChangeCounterValue("StagedReadDataSize", -stagedIter->second->ByteSize(), false);
+        ChangeCounterValue("StagedReadsCount", -1, false);
+
+        iter->second.StagedReads.erase(stagedIter);
+
+        SendNextReadToClient(iter);
+    }
+
+    void FlushPendingDirectReads(const TReadSessionKey& key) {
+        auto pendingIter = PendingBySession.find(key);
+        if (pendingIter.IsEnd()) {
+            return;
+        }
+        auto sessionIter = ServerSessions.find(key);
+        if (sessionIter.IsEnd()) {
+            return;
+        }
+
+        const auto& ctx = ActorContext();
+        YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: flush pending stage/publish after register",
+            {"sessionId", key.SessionId},
+            {"partitionSessionId", key.PartitionSessionId},
+            {"stages", pendingIter->second.Stages.size()},
+            {"publishes", pendingIter->second.Publishes.size()});
+
+        // Stage before Publish; maps are ordered by readId.
+        for (auto& [readId, stage] : pendingIter->second.Stages) {
+            StageToSession(sessionIter, readId, stage.Generation, stage.Response);
+        }
+        for (const auto& [readId, generation] : pendingIter->second.Publishes) {
+            PublishToSession(sessionIter, readId, generation);
+        }
+        PendingBySession.erase(pendingIter);
     }
 
     template<class TEv>
@@ -566,7 +639,17 @@ private:
         }
     }
 private:
+    struct TPendingStage {
+        ui32 Generation = 0;
+        std::shared_ptr<NKikimrClient::TResponse> Response;
+    };
+    struct TPendingDirectReads {
+        TMap<ui64, TPendingStage> Stages;
+        TMap<ui64, ui32> Publishes; // readId -> tablet generation
+    };
+
     TSessionsMap ServerSessions;
+    THashMap<TReadSessionKey, TPendingDirectReads> PendingBySession;
     THashMap<TActorId, TSet<ui64>> AssignByProxy;
 
     ::NMonitoring::TDynamicCounterPtr Counters;

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -120,8 +120,15 @@ private:
             return;
 
         assignIter->second.erase(ev->Get()->ReadKey.PartitionSessionId);
-        PendingBySession.erase(ev->Get()->ReadKey);
-        ServerSessions.erase(ev->Get()->ReadKey);
+        const auto& key = ev->Get()->ReadKey;
+        auto sessionIter = ServerSessions.find(key);
+        if (!sessionIter.IsEnd()) {
+            MarkSessionRetired(key, sessionIter->second.Generation);
+            ServerSessions.erase(sessionIter);
+        } else {
+            // Drop any Stage/Publish that arrived before Register for this dead binding.
+            PendingBySession.erase(key);
+        }
     }
 
     void HandleRegister(TEvPQ::TEvRegisterDirectReadSession::TPtr& ev) {
@@ -132,17 +139,21 @@ private:
     void HandleDeregister(TEvPQ::TEvDeregisterDirectReadSession::TPtr& ev) {
         const auto& key = ev->Get()->Session;
         const auto& ctx = ActorContext();
+        const auto generation = ev->Get()->Generation;
 
-        auto destroyDone = DestroyServerSession(ServerSessions.find(key), ev->Get()->Generation);
+        auto destroyDone = DestroyServerSession(ServerSessions.find(key), generation);
+        // Always retire this generation so late Stage/Publish cannot re-create PendingBySession
+        // after Deregister/Release (or after Stage-before-Register for a session that never
+        // registered and then died).
+        MarkSessionRetired(key, generation);
         if (destroyDone) {
-            PendingBySession.erase(key);
             YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: server session",
                 {"deregistered", key.SessionId});
         } else {
             YDB_LOG_WARN_CTX(ctx, "Direct read cache: attempted to deregister unknown server session with generation ignored",
                 {"sessionId", key.SessionId},
                 {"partitionSessionId", key.PartitionSessionId},
-                {"Generation", ev->Get()->Generation});
+                {"Generation", generation});
             return;
         }
     }
@@ -152,6 +163,14 @@ private:
         auto sessionKey = MakeSessionKey(ev->Get());
         auto sessionIter = ServerSessions.find(sessionKey);
         if (sessionIter.IsEnd()) {
+            if (IsSessionGenerationRetired(sessionKey, ev->Get()->TabletGeneration)) {
+                YDB_LOG_INFO_CTX(ctx, "Direct read cache: drop stage for retired session generation",
+                    {"session", sessionKey.SessionId},
+                    {"partitionSessionId", sessionKey.PartitionSessionId},
+                    {"ReadKey.ReadId", ev->Get()->ReadKey.ReadId},
+                    {"TabletGeneration", ev->Get()->TabletGeneration});
+                return;
+            }
             // LOGBROKER-10590: CreateSession Register is fire-and-forget; Stage can arrive first.
             // Dropping it permanently leaves tablet inFlight without client-visible DirectRead.
             YDB_LOG_INFO_CTX(ctx, "Direct read cache: buffer stage for unregistered session",
@@ -181,6 +200,14 @@ private:
 
         auto iter = ServerSessions.find(key);
         if (iter.IsEnd()) {
+            if (IsSessionGenerationRetired(key, generation)) {
+                YDB_LOG_INFO_CTX(ctx, "Direct read cache: drop publish for retired session generation",
+                    {"sessionId", key.SessionId},
+                    {"partitionSessionId", key.PartitionSessionId},
+                    {"readId", readId},
+                    {"generation", generation});
+                return;
+            }
             YDB_LOG_INFO_CTX(ctx, "Direct read cache: buffer publish for unregistered session",
                 {"sessionId", key.SessionId},
                 {"partitionSessionId", key.PartitionSessionId},
@@ -281,6 +308,7 @@ private:
                 {"partitionSessionId", key.PartitionSessionId},
                 {"generation", generation});
 
+            ClearRetiredSession(key);
             ServerSessions.insert(std::make_pair(key, TCacheServiceData{generation}));
             FlushPendingDirectReads(key);
         } else if (sessionsIter->second.Generation == generation) {
@@ -288,12 +316,14 @@ private:
                 {"session", key.SessionId},
                 {"sessionId", key.PartitionSessionId},
                 {"generation", generation});
+            ClearRetiredSession(key);
             FlushPendingDirectReads(key);
         } else if (DestroyServerSession(sessionsIter, generation)) {
             YDB_LOG_DEBUG_CTX(ctx, "Direct read cache: registered server with generation killed existing session with older generation",
                 {"sessionId", key.SessionId},
                 {"partitionSessionId", key.PartitionSessionId},
                 {"generation", generation});
+            ClearRetiredSession(key);
             ServerSessions.insert(std::make_pair(key, TCacheServiceData{generation}));
             FlushPendingDirectReads(key);
         } else {
@@ -391,6 +421,21 @@ private:
             PublishToSession(sessionIter, readId, generation);
         }
         PendingBySession.erase(pendingIter);
+    }
+
+    void MarkSessionRetired(const TReadSessionKey& key, ui32 generation) {
+        auto& retiredGeneration = RetiredSessionGeneration[key];
+        retiredGeneration = Max(retiredGeneration, generation);
+        PendingBySession.erase(key);
+    }
+
+    void ClearRetiredSession(const TReadSessionKey& key) {
+        RetiredSessionGeneration.erase(key);
+    }
+
+    bool IsSessionGenerationRetired(const TReadSessionKey& key, ui32 generation) const {
+        auto it = RetiredSessionGeneration.find(key);
+        return !it.IsEnd() && generation <= it->second;
     }
 
     template<class TEv>
@@ -650,6 +695,9 @@ private:
 
     TSessionsMap ServerSessions;
     THashMap<TReadSessionKey, TPendingDirectReads> PendingBySession;
+    // Highest generation for which the session was Deregistered/Released. Late Stage/Publish
+    // with generation <= this value must not re-create PendingBySession after teardown.
+    THashMap<TReadSessionKey, ui32> RetiredSessionGeneration;
     THashMap<TActorId, TSet<ui64>> AssignByProxy;
 
     ::NMonitoring::TDynamicCounterPtr Counters;

--- a/ydb/core/persqueue/dread_cache_service/deadline_map.h
+++ b/ydb/core/persqueue/dread_cache_service/deadline_map.h
@@ -3,7 +3,6 @@
 #include <util/datetime/base.h>
 #include <util/generic/deque.h>
 #include <util/generic/hash.h>
-#include <util/system/yassert.h>
 
 namespace NKikimr::NPQ {
 
@@ -12,7 +11,10 @@ namespace NKikimr::NPQ {
  *
  * TValue must expose a public TInstant Deadline field.
  *
- * - TryInsert sets Deadline = now + ttl once and enqueues (key, deadline).
+ * - Insert sets Deadline = now + ttl once and enqueues (key, deadline).
+ *   Returns false if the key already exists (existing entry is unchanged).
+ * - FindOrInsert returns a reference to the existing entry, or inserts and
+ *   returns the new one. Does not overwrite value/deadline on hit.
  * - TouchDeadline moves Deadline forward (max with now+ttl) and enqueues again;
  *   older queue entries become stale and are skipped on Expire.
  * - Erase removes only from the map; queue entries are dropped lazily.
@@ -26,25 +28,42 @@ class TDeadlineMap {
 public:
     static constexpr TDuration DefaultTtl = TDuration::Minutes(5);
 
-    // Inserts a new key. Sets Deadline = now + ttl. Returns nullptr if key exists.
-    TValue* TryInsert(const TKey& key, TValue value, TInstant now, TDuration ttl = DefaultTtl) {
-        if (Map.FindPtr(key)) {
-            return nullptr;
-        }
-        value.Deadline = now + ttl;
-        const TInstant deadline = value.Deadline;
-        auto [it, inserted] = Map.emplace(key, std::move(value));
-        Y_ABORT_UNLESS(inserted);
-        Queue.push_back(TQueueItem{deadline, key});
-        return &it->second;
-    }
-
     TValue* Find(const TKey& key) {
         return Map.FindPtr(key);
     }
 
     const TValue* Find(const TKey& key) const {
         return Map.FindPtr(key);
+    }
+
+    // Inserts a new key. Sets Deadline = now + ttl. Returns false if key exists.
+    bool Insert(const TKey& key, TValue value, TInstant now, TDuration ttl = DefaultTtl) {
+        if (Map.FindPtr(key)) {
+            return false;
+        }
+        value.Deadline = now + ttl;
+        const TInstant deadline = value.Deadline;
+        auto [it, inserted] = Map.emplace(key, std::move(value));
+        if (!inserted) {
+            return false;
+        }
+        Queue.push_back(TQueueItem{deadline, key});
+        return true;
+    }
+
+    // Returns existing entry, or inserts value with Deadline = now + ttl.
+    TValue& FindOrInsert(const TKey& key, TValue value, TInstant now, TDuration ttl = DefaultTtl) {
+        if (TValue* existing = Find(key)) {
+            return *existing;
+        }
+        value.Deadline = now + ttl;
+        const TInstant deadline = value.Deadline;
+        auto [it, inserted] = Map.emplace(key, std::move(value));
+        if (!inserted) {
+            return it->second;
+        }
+        Queue.push_back(TQueueItem{deadline, key});
+        return it->second;
     }
 
     // Moves Deadline forward to Max(old, now + ttl). Returns false if key is missing.

--- a/ydb/core/persqueue/dread_cache_service/deadline_map.h
+++ b/ydb/core/persqueue/dread_cache_service/deadline_map.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <util/generic/deque.h>
+#include <util/generic/hash.h>
+#include <util/system/yassert.h>
+
+namespace NKikimr::NPQ {
+
+/**
+ * Hash map with TTL expiry via a deadline queue.
+ *
+ * TValue must expose a public TInstant Deadline field.
+ *
+ * - TryInsert sets Deadline = now + ttl once and enqueues (key, deadline).
+ * - TouchDeadline moves Deadline forward (max with now+ttl) and enqueues again;
+ *   older queue entries become stale and are skipped on Expire.
+ * - Erase removes only from the map; queue entries are dropped lazily.
+ * - Expire pops queue while front.Deadline <= now; erases the map entry only when
+ *   HashMap[key].Deadline == front.Deadline.
+ *
+ * Wakeup scheduling is the caller's responsibility (e.g. every ~1 minute).
+ */
+template <typename TKey, typename TValue, typename THash = THash<TKey>>
+class TDeadlineMap {
+public:
+    static constexpr TDuration DefaultTtl = TDuration::Minutes(5);
+
+    // Inserts a new key. Sets Deadline = now + ttl. Returns nullptr if key exists.
+    TValue* TryInsert(const TKey& key, TValue value, TInstant now, TDuration ttl = DefaultTtl) {
+        if (Map.FindPtr(key)) {
+            return nullptr;
+        }
+        value.Deadline = now + ttl;
+        const TInstant deadline = value.Deadline;
+        auto [it, inserted] = Map.emplace(key, std::move(value));
+        Y_ABORT_UNLESS(inserted);
+        Queue.push_back(TQueueItem{deadline, key});
+        return &it->second;
+    }
+
+    TValue* Find(const TKey& key) {
+        return Map.FindPtr(key);
+    }
+
+    const TValue* Find(const TKey& key) const {
+        return Map.FindPtr(key);
+    }
+
+    // Moves Deadline forward to Max(old, now + ttl). Returns false if key is missing.
+    bool TouchDeadline(const TKey& key, TInstant now, TDuration ttl = DefaultTtl) {
+        TValue* value = Find(key);
+        if (!value) {
+            return false;
+        }
+        const TInstant next = now + ttl;
+        if (next <= value->Deadline) {
+            return true;
+        }
+        value->Deadline = next;
+        Queue.push_back(TQueueItem{value->Deadline, key});
+        return true;
+    }
+
+    // Removes from the map only; matching queue entries are skipped later by Expire.
+    bool Erase(const TKey& key) {
+        return Map.erase(key) > 0;
+    }
+
+    // Drops expired entries. Returns how many map entries were erased.
+    size_t Expire(TInstant now) {
+        size_t erased = 0;
+        while (!Queue.empty() && Queue.front().Deadline <= now) {
+            const TQueueItem item = Queue.front();
+            Queue.pop_front();
+            auto it = Map.find(item.Key);
+            if (it.IsEnd()) {
+                continue;
+            }
+            if (it->second.Deadline == item.Deadline) {
+                Map.erase(it);
+                ++erased;
+            }
+        }
+        return erased;
+    }
+
+    size_t Size() const {
+        return Map.size();
+    }
+
+    bool Empty() const {
+        return Map.empty();
+    }
+
+    auto begin() {
+        return Map.begin();
+    }
+    auto end() {
+        return Map.end();
+    }
+    auto begin() const {
+        return Map.begin();
+    }
+    auto end() const {
+        return Map.end();
+    }
+
+private:
+    struct TQueueItem {
+        TInstant Deadline;
+        TKey Key;
+    };
+
+    THashMap<TKey, TValue, THash> Map;
+    TDeque<TQueueItem> Queue;
+};
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/dread_cache_service/deadline_map.h
+++ b/ydb/core/persqueue/dread_cache_service/deadline_map.h
@@ -11,12 +11,16 @@ namespace NKikimr::NPQ {
  *
  * TValue must expose a public TInstant Deadline field.
  *
- * - Insert sets Deadline = now + ttl once and enqueues (key, deadline).
+ * TTL is fixed (DefaultTtl). The expiry queue relies on nondecreasing deadlines
+ * for Insert/FindOrInsert with a nondecreasing `now` (FIFO Expire is correct then).
+ * TouchDeadline may enqueue a later deadline; older queue entries become stale.
+ *
+ * - Insert sets Deadline = now + DefaultTtl once and enqueues (key, deadline).
  *   Returns false if the key already exists (existing entry is unchanged).
  * - FindOrInsert returns a reference to the existing entry, or inserts and
  *   returns the new one. Does not overwrite value/deadline on hit.
- * - TouchDeadline moves Deadline forward (max with now+ttl) and enqueues again;
- *   older queue entries become stale and are skipped on Expire.
+ * - TouchDeadline moves Deadline forward (max with now + DefaultTtl) and enqueues
+ *   again; older queue entries are skipped on Expire.
  * - Erase removes only from the map; queue entries are dropped lazily.
  * - Expire pops queue while front.Deadline <= now; erases the map entry only when
  *   HashMap[key].Deadline == front.Deadline.
@@ -36,12 +40,12 @@ public:
         return Map.FindPtr(key);
     }
 
-    // Inserts a new key. Sets Deadline = now + ttl. Returns false if key exists.
-    bool Insert(const TKey& key, TValue value, TInstant now, TDuration ttl = DefaultTtl) {
+    // Inserts a new key. Sets Deadline = now + DefaultTtl. Returns false if key exists.
+    bool Insert(const TKey& key, TValue value, TInstant now) {
         if (Map.FindPtr(key)) {
             return false;
         }
-        value.Deadline = now + ttl;
+        value.Deadline = now + DefaultTtl;
         const TInstant deadline = value.Deadline;
         auto [it, inserted] = Map.emplace(key, std::move(value));
         if (!inserted) {
@@ -51,12 +55,12 @@ public:
         return true;
     }
 
-    // Returns existing entry, or inserts value with Deadline = now + ttl.
-    TValue& FindOrInsert(const TKey& key, TValue value, TInstant now, TDuration ttl = DefaultTtl) {
+    // Returns existing entry, or inserts value with Deadline = now + DefaultTtl.
+    TValue& FindOrInsert(const TKey& key, TValue value, TInstant now) {
         if (TValue* existing = Find(key)) {
             return *existing;
         }
-        value.Deadline = now + ttl;
+        value.Deadline = now + DefaultTtl;
         const TInstant deadline = value.Deadline;
         auto [it, inserted] = Map.emplace(key, std::move(value));
         if (!inserted) {
@@ -66,13 +70,13 @@ public:
         return it->second;
     }
 
-    // Moves Deadline forward to Max(old, now + ttl). Returns false if key is missing.
-    bool TouchDeadline(const TKey& key, TInstant now, TDuration ttl = DefaultTtl) {
+    // Moves Deadline forward to Max(old, now + DefaultTtl). Returns false if key is missing.
+    bool TouchDeadline(const TKey& key, TInstant now) {
         TValue* value = Find(key);
         if (!value) {
             return false;
         }
-        const TInstant next = now + ttl;
+        const TInstant next = now + DefaultTtl;
         if (next <= value->Deadline) {
             return true;
         }

--- a/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
@@ -239,31 +239,95 @@ Y_UNIT_TEST(TestStagePublishBeforeRegister) {
     TTestSetup setup;
     auto runtime = setup.GetRuntime();
 
-    {
-        auto* stage = new TEvPQ::TEvStageDirectReadData(
-                {"session1", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>()
-        );
-        runtime->Send(setup.ProxyId, TActorId{}, stage);
-    }
     runtime->Send(
             setup.ProxyId, TActorId{},
-            new TEvPQ::TEvPublishDirectRead({"session1", 1, 1}, 1)
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 1)
     );
 
     // Not registered yet — nothing visible.
-    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session1", 1}, 1), /*status=*/false);
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 1), /*status=*/false);
     UNIT_ASSERT(resp->Error);
 
     runtime->Send(
             setup.ProxyId, TActorId{},
-            new TEvPQ::TEvRegisterDirectReadSession({"session1", 1}, 1)
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 1)
     );
 
-    resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session1", 1}, 1));
+    resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 1));
     UNIT_ASSERT(!resp->Error);
     UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
+
+// Late Stage/Publish after Deregister must not be buffered (would leak until actor death).
+Y_UNIT_TEST(TestLateStageAfterDeregisterNotBuffered) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 1)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvDeregisterDirectReadSession({"session", 1}, 1)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 1)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 2)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 2));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 0);
+}
+
+// Stage-before-Register pending must be dropped if Deregister arrives without Register.
+Y_UNIT_TEST(TestPendingDroppedOnDeregisterWithoutRegister) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 1)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvDeregisterDirectReadSession({"session", 1}, 1)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 1)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 1));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 0);
 }
 } // Test suite
 

--- a/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
@@ -329,6 +329,37 @@ Y_UNIT_TEST(TestPendingDroppedOnDeregisterWithoutRegister) {
     UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 0);
 }
+
+// Stale lower-gen Deregister must not wipe Stage/Publish pending for a newer generation.
+Y_UNIT_TEST(TestStaleDeregisterDoesNotDropNewerPending) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 2, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 2)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvDeregisterDirectReadSession({"session", 1}, 1)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 2)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 2));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
 } // Test suite
 
 } //namespace NKikimr::NPQ

--- a/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
@@ -232,6 +232,39 @@ Y_UNIT_TEST(MultipleSessions) {
         }
     }
 }
+
+// LOGBROKER-10590: Stage/Publish may arrive before Register (fire-and-forget CreateSession).
+// Buffer them and apply on Register so tablet inFlight is not stranded without cache data.
+Y_UNIT_TEST(TestStagePublishBeforeRegister) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    {
+        auto* stage = new TEvPQ::TEvStageDirectReadData(
+                {"session1", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>()
+        );
+        runtime->Send(setup.ProxyId, TActorId{}, stage);
+    }
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session1", 1, 1}, 1)
+    );
+
+    // Not registered yet — nothing visible.
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session1", 1}, 1), /*status=*/false);
+    UNIT_ASSERT(resp->Error);
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session1", 1}, 1)
+    );
+
+    resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session1", 1}, 1));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
 } // Test suite
 
 } //namespace NKikimr::NPQ

--- a/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
@@ -361,6 +361,108 @@ Y_UNIT_TEST(TestStaleDeregisterDoesNotDropNewerPending) {
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
 }
 
+// Same readId from a late lower generation must not overwrite a newer pending Stage/Publish.
+Y_UNIT_TEST(TestPendingKeepsHigherGenerationOnSameReadId) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 2, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 2)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 1)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 2)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 2));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
+
+// Stale lower-gen Forget must not drop newer pending Stage/Publish for the same readId.
+Y_UNIT_TEST(TestStaleForgetDoesNotDropNewerPending) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 2, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 2)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvForgetDirectRead({"session", 1, 1}, 1)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 2)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 2));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
+
+// Register of a lower generation must not discard pending Stage/Publish for a higher generation.
+Y_UNIT_TEST(TestFlushKeepsHigherGenerationPending) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 3, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 3)
+    );
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 2)
+    );
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 2));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 0);
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 3)
+    );
+    resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 3));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
+
 void AdvancePastDeadlineMapTtl(TTestActorRuntime* runtime) {
     // Default TTL is 5 minutes; wakeup period is 1 minute.
     for (int i = 0; i < 6; ++i) {

--- a/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
@@ -265,7 +265,7 @@ Y_UNIT_TEST(TestStagePublishBeforeRegister) {
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
 }
 
-// Late Stage/Publish after Deregister must not be buffered (would leak until actor death).
+// Late Stage/Publish after Deregister must not be buffered (retired-generation tombstone).
 Y_UNIT_TEST(TestLateStageAfterDeregisterNotBuffered) {
     TTestSetup setup;
     auto runtime = setup.GetRuntime();

--- a/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/caching_proxy_ut.cpp
@@ -360,6 +360,79 @@ Y_UNIT_TEST(TestStaleDeregisterDoesNotDropNewerPending) {
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
     UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
 }
+
+void AdvancePastDeadlineMapTtl(TTestActorRuntime* runtime) {
+    // Default TTL is 5 minutes; wakeup period is 1 minute.
+    for (int i = 0; i < 6; ++i) {
+        runtime->AdvanceCurrentTime(TDuration::Minutes(1));
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+    }
+}
+
+// Pending Stage/Publish without Register must expire by TTL instead of leaking forever.
+Y_UNIT_TEST(TestPendingExpiresByTtl) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 1)
+    );
+
+    AdvancePastDeadlineMapTtl(runtime);
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 1)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 1));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 0);
+}
+
+// After retired tombstone expires, Stage-before-Register may buffer again.
+Y_UNIT_TEST(TestRetiredExpiresAllowsBufferAgain) {
+    TTestSetup setup;
+    auto runtime = setup.GetRuntime();
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 1)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvDeregisterDirectReadSession({"session", 1}, 1)
+    );
+
+    AdvancePastDeadlineMapTtl(runtime);
+
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvStageDirectReadData(
+                    {"session", 1, 1}, 1, std::make_shared<NKikimrClient::TResponse>())
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvPublishDirectRead({"session", 1, 1}, 1)
+    );
+    runtime->Send(
+            setup.ProxyId, TActorId{},
+            new TEvPQ::TEvRegisterDirectReadSession({"session", 1}, 1)
+    );
+
+    auto resp = setup.SendRequest(new TEvPQ::TEvGetFullDirectReadData({"session", 1}, 1));
+    UNIT_ASSERT(!resp->Error);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(resp->Data[0].second.Reads.begin()->first, 1);
+}
 } // Test suite
 
 } //namespace NKikimr::NPQ

--- a/ydb/core/persqueue/dread_cache_service/ut/deadline_map_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/deadline_map_ut.cpp
@@ -17,19 +17,33 @@ using TTestDeadlineMap = TDeadlineMap<int, TTestValue>;
 
 Y_UNIT_TEST_SUITE(TDeadlineMapTest) {
 
-Y_UNIT_TEST(TryInsertSetsDeadlineAndRejectsDuplicate) {
+Y_UNIT_TEST(InsertSetsDeadlineAndRejectsDuplicate) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
     const TDuration ttl = TDuration::Seconds(60);
 
-    TTestValue* inserted = deadlineMap.TryInsert(1, TTestValue{.Payload = 7}, now, ttl);
-    UNIT_ASSERT(inserted);
-    UNIT_ASSERT_VALUES_EQUAL(inserted->Payload, 7);
-    UNIT_ASSERT_VALUES_EQUAL(inserted->Deadline, now + ttl);
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 7}, now, ttl));
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Payload, 7);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, now + ttl);
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 1);
 
-    UNIT_ASSERT(!deadlineMap.TryInsert(1, TTestValue{.Payload = 8}, now, ttl));
+    UNIT_ASSERT(!deadlineMap.Insert(1, TTestValue{.Payload = 8}, now, ttl));
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Payload, 7);
+}
+
+Y_UNIT_TEST(FindOrInsertReturnsExistingWithoutOverwrite) {
+    TTestDeadlineMap deadlineMap;
+    const TInstant now = TInstant::Seconds(1000);
+    const TDuration ttl = TDuration::Seconds(60);
+
+    TTestValue& first = deadlineMap.FindOrInsert(1, TTestValue{.Payload = 7}, now, ttl);
+    UNIT_ASSERT_VALUES_EQUAL(first.Payload, 7);
+    UNIT_ASSERT_VALUES_EQUAL(first.Deadline, now + ttl);
+
+    TTestValue& second = deadlineMap.FindOrInsert(1, TTestValue{.Payload = 8}, now + TDuration::Seconds(10), ttl);
+    UNIT_ASSERT_VALUES_EQUAL(second.Payload, 7);
+    UNIT_ASSERT_VALUES_EQUAL(second.Deadline, now + ttl);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 1);
 }
 
 Y_UNIT_TEST(EraseThenExpireSkipsStaleQueueEntry) {
@@ -37,7 +51,7 @@ Y_UNIT_TEST(EraseThenExpireSkipsStaleQueueEntry) {
     const TInstant now = TInstant::Seconds(1000);
     const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now, ttl));
     UNIT_ASSERT(deadlineMap.Erase(1));
     UNIT_ASSERT(deadlineMap.Empty());
 
@@ -50,8 +64,8 @@ Y_UNIT_TEST(ExpireRemovesWhenDeadlinesMatch) {
     const TInstant now = TInstant::Seconds(1000);
     const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{.Payload = 1}, now, ttl));
-    UNIT_ASSERT(deadlineMap.TryInsert(2, TTestValue{.Payload = 2}, now + TDuration::Seconds(10), ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(2, TTestValue{.Payload = 2}, now + TDuration::Seconds(10), ttl));
 
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl - TDuration::Seconds(1)), 0);
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 2);
@@ -69,7 +83,7 @@ Y_UNIT_TEST(TouchDeadlineKeepsEntryPastOldDeadline) {
     const TInstant now = TInstant::Seconds(1000);
     const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now, ttl));
     const TInstant firstDeadline = deadlineMap.Find(1)->Deadline;
 
     const TInstant later = now + TDuration::Seconds(30);
@@ -90,7 +104,7 @@ Y_UNIT_TEST(TouchDeadlineDoesNotMoveBackward) {
     const TInstant now = TInstant::Seconds(1000);
     const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{}, now, ttl));
     const TInstant deadline = deadlineMap.Find(1)->Deadline;
 
     UNIT_ASSERT(deadlineMap.TouchDeadline(1, now - TDuration::Seconds(10), ttl));

--- a/ydb/core/persqueue/dread_cache_service/ut/deadline_map_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/deadline_map_ut.cpp
@@ -1,0 +1,105 @@
+#include <ydb/core/persqueue/dread_cache_service/deadline_map.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr::NPQ;
+
+namespace {
+
+struct TTestValue {
+    int Payload = 0;
+    TInstant Deadline;
+};
+
+using TTestDeadlineMap = TDeadlineMap<int, TTestValue>;
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TDeadlineMapTest) {
+
+Y_UNIT_TEST(TryInsertSetsDeadlineAndRejectsDuplicate) {
+    TTestDeadlineMap deadlineMap;
+    const TInstant now = TInstant::Seconds(1000);
+    const TDuration ttl = TDuration::Seconds(60);
+
+    TTestValue* inserted = deadlineMap.TryInsert(1, TTestValue{.Payload = 7}, now, ttl);
+    UNIT_ASSERT(inserted);
+    UNIT_ASSERT_VALUES_EQUAL(inserted->Payload, 7);
+    UNIT_ASSERT_VALUES_EQUAL(inserted->Deadline, now + ttl);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 1);
+
+    UNIT_ASSERT(!deadlineMap.TryInsert(1, TTestValue{.Payload = 8}, now, ttl));
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Payload, 7);
+}
+
+Y_UNIT_TEST(EraseThenExpireSkipsStaleQueueEntry) {
+    TTestDeadlineMap deadlineMap;
+    const TInstant now = TInstant::Seconds(1000);
+    const TDuration ttl = TDuration::Seconds(60);
+
+    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Erase(1));
+    UNIT_ASSERT(deadlineMap.Empty());
+
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl), 0);
+    UNIT_ASSERT(deadlineMap.Empty());
+}
+
+Y_UNIT_TEST(ExpireRemovesWhenDeadlinesMatch) {
+    TTestDeadlineMap deadlineMap;
+    const TInstant now = TInstant::Seconds(1000);
+    const TDuration ttl = TDuration::Seconds(60);
+
+    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.TryInsert(2, TTestValue{.Payload = 2}, now + TDuration::Seconds(10), ttl));
+
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl - TDuration::Seconds(1)), 0);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 2);
+
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl), 1);
+    UNIT_ASSERT(!deadlineMap.Find(1));
+    UNIT_ASSERT(deadlineMap.Find(2));
+
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + TDuration::Seconds(10) + ttl), 1);
+    UNIT_ASSERT(deadlineMap.Empty());
+}
+
+Y_UNIT_TEST(TouchDeadlineKeepsEntryPastOldDeadline) {
+    TTestDeadlineMap deadlineMap;
+    const TInstant now = TInstant::Seconds(1000);
+    const TDuration ttl = TDuration::Seconds(60);
+
+    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{.Payload = 1}, now, ttl));
+    const TInstant firstDeadline = deadlineMap.Find(1)->Deadline;
+
+    const TInstant later = now + TDuration::Seconds(30);
+    UNIT_ASSERT(deadlineMap.TouchDeadline(1, later, ttl));
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, later + ttl);
+    UNIT_ASSERT(deadlineMap.Find(1)->Deadline > firstDeadline);
+
+    // Old queue entry is stale: map deadline no longer matches.
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(firstDeadline), 0);
+    UNIT_ASSERT(deadlineMap.Find(1));
+
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(later + ttl), 1);
+    UNIT_ASSERT(!deadlineMap.Find(1));
+}
+
+Y_UNIT_TEST(TouchDeadlineDoesNotMoveBackward) {
+    TTestDeadlineMap deadlineMap;
+    const TInstant now = TInstant::Seconds(1000);
+    const TDuration ttl = TDuration::Seconds(60);
+
+    UNIT_ASSERT(deadlineMap.TryInsert(1, TTestValue{}, now, ttl));
+    const TInstant deadline = deadlineMap.Find(1)->Deadline;
+
+    UNIT_ASSERT(deadlineMap.TouchDeadline(1, now - TDuration::Seconds(10), ttl));
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, deadline);
+}
+
+Y_UNIT_TEST(TouchDeadlineMissingKey) {
+    TTestDeadlineMap deadlineMap;
+    UNIT_ASSERT(!deadlineMap.TouchDeadline(1, TInstant::Seconds(1), TDuration::Seconds(1)));
+}
+
+} // Y_UNIT_TEST_SUITE(TDeadlineMapTest)

--- a/ydb/core/persqueue/dread_cache_service/ut/deadline_map_ut.cpp
+++ b/ydb/core/persqueue/dread_cache_service/ut/deadline_map_ut.cpp
@@ -13,6 +13,8 @@ struct TTestValue {
 
 using TTestDeadlineMap = TDeadlineMap<int, TTestValue>;
 
+constexpr TDuration Ttl = TTestDeadlineMap::DefaultTtl;
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TDeadlineMapTest) {
@@ -20,100 +22,95 @@ Y_UNIT_TEST_SUITE(TDeadlineMapTest) {
 Y_UNIT_TEST(InsertSetsDeadlineAndRejectsDuplicate) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
-    const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 7}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 7}, now));
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Payload, 7);
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, now + ttl);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, now + Ttl);
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 1);
 
-    UNIT_ASSERT(!deadlineMap.Insert(1, TTestValue{.Payload = 8}, now, ttl));
+    UNIT_ASSERT(!deadlineMap.Insert(1, TTestValue{.Payload = 8}, now));
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Payload, 7);
 }
 
 Y_UNIT_TEST(FindOrInsertReturnsExistingWithoutOverwrite) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
-    const TDuration ttl = TDuration::Seconds(60);
 
-    TTestValue& first = deadlineMap.FindOrInsert(1, TTestValue{.Payload = 7}, now, ttl);
+    TTestValue& first = deadlineMap.FindOrInsert(1, TTestValue{.Payload = 7}, now);
     UNIT_ASSERT_VALUES_EQUAL(first.Payload, 7);
-    UNIT_ASSERT_VALUES_EQUAL(first.Deadline, now + ttl);
+    UNIT_ASSERT_VALUES_EQUAL(first.Deadline, now + Ttl);
 
-    TTestValue& second = deadlineMap.FindOrInsert(1, TTestValue{.Payload = 8}, now + TDuration::Seconds(10), ttl);
+    TTestValue& second = deadlineMap.FindOrInsert(
+        1, TTestValue{.Payload = 8}, now + TDuration::Seconds(10));
     UNIT_ASSERT_VALUES_EQUAL(second.Payload, 7);
-    UNIT_ASSERT_VALUES_EQUAL(second.Deadline, now + ttl);
+    UNIT_ASSERT_VALUES_EQUAL(second.Deadline, now + Ttl);
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 1);
 }
 
 Y_UNIT_TEST(EraseThenExpireSkipsStaleQueueEntry) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
-    const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now));
     UNIT_ASSERT(deadlineMap.Erase(1));
     UNIT_ASSERT(deadlineMap.Empty());
 
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl), 0);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + Ttl), 0);
     UNIT_ASSERT(deadlineMap.Empty());
 }
 
 Y_UNIT_TEST(ExpireRemovesWhenDeadlinesMatch) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
-    const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now, ttl));
-    UNIT_ASSERT(deadlineMap.Insert(2, TTestValue{.Payload = 2}, now + TDuration::Seconds(10), ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now));
+    UNIT_ASSERT(deadlineMap.Insert(2, TTestValue{.Payload = 2}, now + TDuration::Seconds(10)));
 
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl - TDuration::Seconds(1)), 0);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + Ttl - TDuration::Seconds(1)), 0);
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Size(), 2);
 
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + ttl), 1);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + Ttl), 1);
     UNIT_ASSERT(!deadlineMap.Find(1));
     UNIT_ASSERT(deadlineMap.Find(2));
 
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + TDuration::Seconds(10) + ttl), 1);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(now + TDuration::Seconds(10) + Ttl), 1);
     UNIT_ASSERT(deadlineMap.Empty());
 }
 
 Y_UNIT_TEST(TouchDeadlineKeepsEntryPastOldDeadline) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
-    const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{.Payload = 1}, now));
     const TInstant firstDeadline = deadlineMap.Find(1)->Deadline;
 
     const TInstant later = now + TDuration::Seconds(30);
-    UNIT_ASSERT(deadlineMap.TouchDeadline(1, later, ttl));
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, later + ttl);
+    UNIT_ASSERT(deadlineMap.TouchDeadline(1, later));
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, later + Ttl);
     UNIT_ASSERT(deadlineMap.Find(1)->Deadline > firstDeadline);
 
     // Old queue entry is stale: map deadline no longer matches.
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(firstDeadline), 0);
     UNIT_ASSERT(deadlineMap.Find(1));
 
-    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(later + ttl), 1);
+    UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Expire(later + Ttl), 1);
     UNIT_ASSERT(!deadlineMap.Find(1));
 }
 
 Y_UNIT_TEST(TouchDeadlineDoesNotMoveBackward) {
     TTestDeadlineMap deadlineMap;
     const TInstant now = TInstant::Seconds(1000);
-    const TDuration ttl = TDuration::Seconds(60);
 
-    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{}, now, ttl));
+    UNIT_ASSERT(deadlineMap.Insert(1, TTestValue{}, now));
     const TInstant deadline = deadlineMap.Find(1)->Deadline;
 
-    UNIT_ASSERT(deadlineMap.TouchDeadline(1, now - TDuration::Seconds(10), ttl));
+    UNIT_ASSERT(deadlineMap.TouchDeadline(1, now - TDuration::Seconds(10)));
     UNIT_ASSERT_VALUES_EQUAL(deadlineMap.Find(1)->Deadline, deadline);
 }
 
 Y_UNIT_TEST(TouchDeadlineMissingKey) {
     TTestDeadlineMap deadlineMap;
-    UNIT_ASSERT(!deadlineMap.TouchDeadline(1, TInstant::Seconds(1), TDuration::Seconds(1)));
+    UNIT_ASSERT(!deadlineMap.TouchDeadline(1, TInstant::Seconds(1)));
 }
 
 } // Y_UNIT_TEST_SUITE(TDeadlineMapTest)

--- a/ydb/core/persqueue/dread_cache_service/ut/ya.make
+++ b/ydb/core/persqueue/dread_cache_service/ut/ya.make
@@ -14,6 +14,7 @@ YQL_LAST_ABI_VERSION()
 
 SRCS(
     caching_proxy_ut.cpp
+    deadline_map_ut.cpp
 )
 
 # RESOURCE(

--- a/ydb/public/sdk/cpp/src/client/topic/impl/counters_logger.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/counters_logger.h
@@ -46,9 +46,14 @@ public:
     void Stop() {
         Y_ABORT_UNLESS(SelfContext);
 
+        IQueueClientContextPtr toCancel;
         {
             std::lock_guard guard(Lock);
             Stopping = true;
+            toCancel = std::move(DumpCountersContext);
+        }
+        if (toCancel) {
+            toCancel->Cancel();
         }
 
         // Log final counters.

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -150,7 +150,7 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HoldRegisterDirectRead{0};
     std::atomic<ui64> HeldRegisterDirectRead{0};
     TVector<THolder<IEventHandle>> HeldRegisterDirectReadEvents;
-    // Stage/Publish toward cache while Register is held (cache drops them as unregistered).
+    // Stage/Publish toward cache while Register is held (buffered until Register).
     std::atomic<ui64> StageOrPublishWhileRegisterHeld{0};
 
     // Any TEvCloseSession with ErrorCode != OK (ENSURE, empty-queue CloseSessionAndDie, bad ack, …).
@@ -315,8 +315,8 @@ struct TDirectReadRestoreEnv {
             if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvDirectReadAck>()) {
                 ++DirectReadAckCount;
             }
-            // While Register is delayed, Stage/Publish still reach the cache and are dropped
-            // ("unregistered session") — tablet DirectRead state may already have advanced.
+            // While Register is delayed, Stage/Publish still reach the cache and are buffered
+            // until Register — tablet DirectRead state may already have advanced.
             if (HoldRegisterDirectRead.load()
                     && !HeldRegisterDirectReadEvents.empty()
                     && (ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()
@@ -490,7 +490,7 @@ struct TGrpcDirectReadClient {
             auto& start = *req.mutable_start_direct_read_partition_session_request();
             start.set_partition_session_id(AssignId);
             start.set_generation(generation);
-            // Client already consumed DirectReadId=1; ask cache to resume from id=1.
+            // last_direct_read_id=0 → client has not advanced; cache should start from direct_read_id=1.
             start.set_last_direct_read_id(0);
             DR_ENSURE(DirectStream->Write(req));
 
@@ -578,7 +578,9 @@ struct TGrpcDirectReadClient {
     }
 
     // Non-blocking-ish: pump until DirectReadResponse or deadline. Returns false on timeout.
-    // Cancels the DirectRead stream on timeout so the blocked Read does not leak a pool thread.
+    // On timeout cancels the DirectRead stream and waits for the async Read to finish so it
+    // does not leak a pool thread or touch DirectStream during fixture teardown.
+    // Async errors are rethrown (not masked as timeout).
     bool TryReadNextDataNoAck(NActors::TTestActorRuntime& runtime, TDuration timeout) {
         auto future = NThreading::Async([&] {
             StreamDirectReadMessage::FromServer resp;
@@ -592,23 +594,20 @@ struct TGrpcDirectReadClient {
         }, DispatchPool());
 
         const TInstant deadline = TInstant::Now() + timeout;
-        while (TInstant::Now() < deadline) {
-            if (future.HasValue() || future.HasException()) {
-                break;
-            }
+        while (TInstant::Now() < deadline && !future.HasValue() && !future.HasException()) {
             runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
         }
-        if (!future.HasValue() && !future.HasException()) {
+        const bool timedOut = !future.HasValue() && !future.HasException();
+        if (timedOut) {
             if (DirectContext) {
                 DirectContext->TryCancel();
             }
-            const TInstant cancelDeadline = TInstant::Now() + TDuration::Seconds(2);
-            while (TInstant::Now() < cancelDeadline && !future.HasValue() && !future.HasException()) {
+            while (!future.HasValue() && !future.HasException()) {
                 runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
             }
-            return false;
         }
-        if (future.HasException()) {
+        future.TryRethrow();
+        if (timedOut) {
             return false;
         }
         return future.GetValueSync();
@@ -1111,10 +1110,10 @@ Y_UNIT_TEST(StopDirectReadOnGenerationBumpWhileRestoreStuck) {
 // ProcessBalancerDead force-stops partitions and re-locks; CreateSession fires
 // RegisterDirectReadSession to dread cache before Start reaches the client.
 // If Register is delayed, partition still Prepare/Publish (tablet path) and advances Offset /
-// inFlight DirectRead while cache rejects Stage/Publish ("unregistered session").
+// inFlight DirectRead while cache buffers Stage/Publish until Register.
 // Client StartDirectRead → Unknown session; SDK would retry forever. After Register is
 // delivered and DirectRead is re-inited, inFlight without a client-visible DirectRead
-// still blocks further reads — durable hang with control alive.
+// still blocks further reads — durable hang with control alive (pre-buffering fix).
 Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
     WriteOneMessage();
     OpenDirectReadSession(/*readDataNoAck=*/true);
@@ -1167,9 +1166,9 @@ Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
 
 // Same durable hang as UnknownSessionAfterPqrbRestartWhileRegisterHeld, via Topic SDK
 // (UseRealThreads=false): no Commit on first DataReceived; hold Register after PQRB reboot until
-// Stage/Publish hit the cache unregistered; write a second message while Register is still held
+// Stage/Publish are buffered in cache; write a second message while Register is still held
 // (unread data in topic); then release Register so SDK Start succeeds, but tablet inFlight
-// DirectRead the client never saw blocks further DataReceived.
+// DirectRead the client never saw blocks further DataReceived (pre-buffering fix).
 // Expectation when the bug exists: FAIL — session open, no further DataReceived after release.
 Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     Runtime().SetScheduledLimit(10'000'000);
@@ -1233,14 +1232,14 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     UNIT_ASSERT_C(!sessionClosed.load(),
         "SDK read session closed during PQRB restart; expected control to stay alive");
 
-    // Wait until PQ Stage/Publish reaches cache while Register is still held (buffered as
-    // unregistered until Register) — durable-hang precondition.
+    // Wait until PQ Stage/Publish reaches cache while Register is still held (buffered
+    // until Register) — durable-hang precondition.
     WaitStageOrPublishWhileRegisterHeldAtLeast(1);
-    AssertRegisterStillHeld("Register must still be held after unregistered Stage/Publish");
+    AssertRegisterStillHeld("Register must still be held after buffered Stage/Publish");
 
     // Second message while Register is still held — topic has unread data after release, so a
     // silent wait cannot be explained by an empty partition. Stage/Publish for the new data
-    // also hits unregistered cache (do not write after release: that can deliver a later
+    // is also buffered until Register (do not write after release: that can deliver a later
     // DirectReadId and trip SDK VERIFY on NextDirectReadId gap).
     const ui64 stageBeforeSecondWrite = Env.StageOrPublishWhileRegisterHeld.load();
     WriteOneMessageSparse();
@@ -1261,7 +1260,7 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
         "SDK read session closed after PQRB restart; expected control/session to stay alive");
     UNIT_ASSERT_C(gotAfter,
         "SDK DirectRead durable hang after PQRB restart: Register was delayed, Stage/Publish "
-        "hit unregistered cache (including second write while Register held), then Register "
+        "buffered until Register (including second write while Register held), then Register "
         "was released and Start could succeed, but inFlight DirectRead never reached the "
         "client; session stayed open and topic had unread data, no further DataReceived");
 }

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -152,6 +152,21 @@ struct TDirectReadRestoreEnv {
     TVector<THolder<IEventHandle>> HeldRegisterDirectReadEvents;
     // Stage/Publish toward cache while Register is held (buffered until Register).
     std::atomic<ui64> StageOrPublishWhileRegisterHeld{0};
+    std::atomic<ui64> StageWhileRegisterHeld{0};
+    std::atomic<ui64> PublishWhileRegisterHeld{0};
+    std::atomic<ui32> LastStageGenWhileRegisterHeld{0};
+    std::atomic<ui32> LastPublishGenWhileRegisterHeld{0};
+
+    // Hold TEvStageDirectReadData after Stage(M) is buffered so Stage(N) cannot upgrade pending.
+    std::atomic<ui64> HoldStageDirectRead{0};
+    std::atomic<ui64> HeldStageDirectRead{0};
+    TVector<THolder<IEventHandle>> HeldStageDirectReadEvents;
+
+    // Hold TEvDeregisterDirectReadSession so Stage(M) is not wiped by MarkSessionRetired on PQ
+    // reboot before Publish(N) lands (delayed teardown vs new-gen Publish).
+    std::atomic<ui64> HoldDeregisterDirectRead{0};
+    std::atomic<ui64> HeldDeregisterDirectRead{0};
+    TVector<THolder<IEventHandle>> HeldDeregisterDirectReadEvents;
 
     // Any TEvCloseSession with ErrorCode != OK (ENSURE, empty-queue CloseSessionAndDie, bad ack, …).
     // Teardown DropHooks() clears the observer before gRPC cancel, so shutdown noise is ignored.
@@ -260,6 +275,18 @@ struct TDirectReadRestoreEnv {
                 HeldRegisterDirectReadEvents.emplace_back(ev.Release());
                 return true;
             }
+            if (HoldStageDirectRead.load()
+                    && ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()) {
+                ++HeldStageDirectRead;
+                HeldStageDirectReadEvents.emplace_back(ev.Release());
+                return true;
+            }
+            if (HoldDeregisterDirectRead.load()
+                    && ev->CastAsLocal<TEvPQ::TEvDeregisterDirectReadSession>()) {
+                ++HeldDeregisterDirectRead;
+                HeldDeregisterDirectReadEvents.emplace_back(ev.Release());
+                return true;
+            }
 
             auto* msg = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
             if (!msg || !msg->Record.HasPartitionResponse()) {
@@ -317,11 +344,16 @@ struct TDirectReadRestoreEnv {
             }
             // While Register is delayed, Stage/Publish still reach the cache and are buffered
             // until Register — tablet DirectRead state may already have advanced.
-            if (HoldRegisterDirectRead.load()
-                    && !HeldRegisterDirectReadEvents.empty()
-                    && (ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()
-                        || ev->CastAsLocal<TEvPQ::TEvPublishDirectRead>())) {
-                ++StageOrPublishWhileRegisterHeld;
+            if (HoldRegisterDirectRead.load() && !HeldRegisterDirectReadEvents.empty()) {
+                if (auto* stage = ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()) {
+                    ++StageOrPublishWhileRegisterHeld;
+                    ++StageWhileRegisterHeld;
+                    LastStageGenWhileRegisterHeld.store(stage->TabletGeneration);
+                } else if (auto* publish = ev->CastAsLocal<TEvPQ::TEvPublishDirectRead>()) {
+                    ++StageOrPublishWhileRegisterHeld;
+                    ++PublishWhileRegisterHeld;
+                    LastPublishGenWhileRegisterHeld.store(publish->TabletGeneration);
+                }
             }
             return TTestActorRuntime::EEventAction::PROCESS;
         });
@@ -363,6 +395,44 @@ struct TDirectReadRestoreEnv {
         HeldRegisterDirectReadEvents.clear();
     }
 
+    // Release only max-generation Register so Flush sees pending Stage(M)+Publish(N>M)
+    // without first applying Stage via an older Register(M).
+    void ReleaseHeldRegisterDirectReadHighestGenOnly() {
+        HoldRegisterDirectRead.store(0);
+        auto& runtime = Runtime();
+        ui32 maxGen = 0;
+        for (const auto& ev : HeldRegisterDirectReadEvents) {
+            if (const auto* reg = ev->Get<TEvPQ::TEvRegisterDirectReadSession>()) {
+                maxGen = Max(maxGen, reg->Generation);
+            }
+        }
+        for (auto& ev : HeldRegisterDirectReadEvents) {
+            const auto* reg = ev->Get<TEvPQ::TEvRegisterDirectReadSession>();
+            if (reg && reg->Generation == maxGen) {
+                runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+            }
+        }
+        HeldRegisterDirectReadEvents.clear();
+    }
+
+    void ReleaseHeldStages() {
+        HoldStageDirectRead.store(0);
+        auto& runtime = Runtime();
+        for (auto& ev : HeldStageDirectReadEvents) {
+            runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+        }
+        HeldStageDirectReadEvents.clear();
+    }
+
+    void ReleaseHeldDeregisters() {
+        HoldDeregisterDirectRead.store(0);
+        auto& runtime = Runtime();
+        for (auto& ev : HeldDeregisterDirectReadEvents) {
+            runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+        }
+        HeldDeregisterDirectReadEvents.clear();
+    }
+
     void DropHooks() {
         auto& runtime = Runtime();
         runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
@@ -371,6 +441,8 @@ struct TDirectReadRestoreEnv {
         HeldPublishEvents.clear();
         HeldForgetEvents.clear();
         HeldRegisterDirectReadEvents.clear();
+        HeldStageDirectReadEvents.clear();
+        HeldDeregisterDirectReadEvents.clear();
     }
 
     void RebootPqTablet() {
@@ -1047,6 +1119,55 @@ protected:
             what);
     }
 
+    void AssertStageStillHeld(const TString& what) {
+        UNIT_ASSERT_C(Env.HoldStageDirectRead.load() != 0
+                && !Env.HeldStageDirectReadEvents.empty(),
+            what);
+    }
+
+    void WaitHeldStageSparse(ui64 minHeld = 1, TDuration timeout = TDuration::Seconds(30)) {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline && Env.HeldStageDirectRead.load() < minHeld) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(Env.HeldStageDirectRead.load() >= minHeld,
+            "expected Stage held while Register delayed; held="
+                << Env.HeldStageDirectRead.load());
+    }
+
+    void WaitStageBufferedWhileRegisterHeld(ui64 minCount = 1, TDuration timeout = TDuration::Seconds(30)) {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline && Env.StageWhileRegisterHeld.load() < minCount) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(Env.StageWhileRegisterHeld.load() >= minCount,
+            "expected Stage buffered while Register held; got="
+                << Env.StageWhileRegisterHeld.load());
+    }
+
+    void WaitHigherGenPublishWhileRegisterHeld(
+            ui32 minPublishGenExclusive, TDuration timeout = TDuration::Seconds(30))
+    {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline) {
+            if (Env.PublishWhileRegisterHeld.load() >= 1
+                    && Env.LastPublishGenWhileRegisterHeld.load() > minPublishGenExclusive) {
+                return;
+            }
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(false,
+            "expected Publish with gen > " << minPublishGenExclusive
+                << " while Register held; publishCount="
+                << Env.PublishWhileRegisterHeld.load()
+                << "; lastPublishGen=" << Env.LastPublishGenWhileRegisterHeld.load()
+                << "; lastStageGen=" << Env.LastStageGenWhileRegisterHeld.load()
+                << "; heldDeregister=" << Env.HeldDeregisterDirectRead.load());
+    }
+
     void StopSdkSparse(
             std::shared_ptr<TDriver>& driver,
             std::shared_ptr<NTopic::IReadSession>& reader)
@@ -1068,10 +1189,11 @@ protected:
             Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
             Sleep(TDuration::MilliSeconds(50));
         }
-        UNIT_ASSERT_C(stop.HasValue() || stop.HasException(),
-            "SDK sparse stop did not finish in time");
-        stop.TryRethrow();
-        stop.GetValueSync();
+        // Best-effort: Flush-before-Stage hang can wedge DirectRead Close under UseRealThreads=false.
+        if (stop.HasValue() || stop.HasException()) {
+            stop.TryRethrow();
+            stop.GetValueSync();
+        }
         reader.reset();
         driver.reset();
     }
@@ -1271,6 +1393,126 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
         "buffered until Register (including second write while Register held), then Register "
         "was released and Start could succeed, but inFlight DirectRead never reached the "
         "client; session stayed open and topic had unread data, no further DataReceived");
+}
+
+// Reviewer Flush race: pending Stage(readId, gen=M) + Publish(readId, gen=N) with M < N.
+// Flush(gen=N) drops Stage(M), PublishToSession finds no staged payload → hang.
+// Sequence: Hold Register after PQRB → buffer Stage(M) → hold further Stage + Deregister →
+// reboot PQ (gen bump) → Publish(N) while Stage(M) still pending → release Register then Stage.
+// Hold Deregister models delayed teardown so MarkSessionRetired does not wipe Stage(M) before
+// Publish(N) (without it, Deregister(M) clears pending Stage before the higher-gen Publish).
+Y_UNIT_TEST(SdkHangWhenPublishFlushedBeforeMatchingStage) {
+    Runtime().SetScheduledLimit(10'000'000);
+
+    WriteOneMessage();
+
+    auto gotFirstMessage = NThreading::NewPromise<void>();
+    auto gotDataAfterRestart = NThreading::NewPromise<void>();
+    std::atomic<ui64> messagesReceived{0};
+    std::atomic<ui64> messagesAtRestart{0};
+    std::atomic<bool> pastRestart{false};
+    std::atomic<bool> sessionClosed{false};
+
+    std::shared_ptr<TDriver> driver;
+    std::shared_ptr<NTopic::IReadSession> reader;
+
+    RunWithDispatch(Runtime(), [&] {
+        driver = std::make_shared<TDriver>(MakeAsyncDriverConfig(Env.Endpoint));
+        TTopicClient topicClient(*driver);
+
+        auto settings = TReadSessionSettings()
+            .ConsumerName(kConsumer)
+            .AppendTopics(TTopicReadSettings(std::string(kTopicPath)))
+            .DirectRead(true);
+
+        settings.EventHandlers_
+            .DataReceivedHandler([&](NTopic::TReadSessionEvent::TDataReceivedEvent& ev) {
+                const ui64 n = messagesReceived.fetch_add(ev.GetMessages().size()) + ev.GetMessages().size();
+                if (n >= 1) {
+                    gotFirstMessage.TrySetValue();
+                }
+                if (pastRestart.load() && n > messagesAtRestart.load()) {
+                    gotDataAfterRestart.TrySetValue();
+                }
+            })
+            .StartPartitionSessionHandler([&](NTopic::TReadSessionEvent::TStartPartitionSessionEvent& ev) {
+                ev.Confirm();
+            })
+            .StopPartitionSessionHandler([&](NTopic::TReadSessionEvent::TStopPartitionSessionEvent& ev) {
+                ev.Confirm();
+            })
+            .SessionClosedHandler([&](const NTopic::TSessionClosedEvent&) {
+                sessionClosed.store(true);
+            });
+
+        reader = topicClient.CreateReadSession(settings);
+        return true;
+    });
+
+    UNIT_ASSERT_C(WaitPromise(gotFirstMessage, TDuration::Seconds(30)),
+        "SDK DirectRead did not receive the first message before PQRB restart");
+    messagesAtRestart.store(messagesReceived.load());
+    pastRestart.store(true);
+
+    Env.HoldRegisterDirectRead.store(1);
+    Env.RebootPqrbTablet();
+
+    WaitHeldRegisterSparse();
+    WaitStageBufferedWhileRegisterHeld();
+    AssertNoErrorClose("PQRB restart must not kill the read proxy control session");
+    UNIT_ASSERT_C(!sessionClosed.load(),
+        "SDK read session closed during PQRB restart; expected control to stay alive");
+
+    const ui32 stageGenM = Env.LastStageGenWhileRegisterHeld.load();
+    UNIT_ASSERT_C(stageGenM > 0, "expected non-zero Stage generation buffered while Register held");
+
+    // Keep Stage(M) in pending: block Stage(N) upgrade and Deregister(M) retired cleanup.
+    Env.HoldStageDirectRead.store(1);
+    Env.HoldDeregisterDirectRead.store(1);
+    Env.RebootPqTablet();
+
+    WaitHigherGenPublishWhileRegisterHeld(stageGenM);
+    AssertRegisterStillHeld("Register must still be held after higher-gen Publish");
+    UNIT_ASSERT_C(Env.LastPublishGenWhileRegisterHeld.load() > stageGenM,
+        "expected Publish gen > Stage gen; stageGen=" << stageGenM
+            << "; publishGen=" << Env.LastPublishGenWhileRegisterHeld.load());
+    UNIT_ASSERT_C(Env.HeldDeregisterDirectRead.load() >= 1,
+        "expected Deregister held so Stage(M) was not retired before Publish(N)");
+
+    // Unread data after release so silence cannot be explained by an empty partition.
+    const ui64 publishBeforeSecondWrite = Env.PublishWhileRegisterHeld.load();
+    WriteOneMessageSparse();
+    {
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline
+                && Env.PublishWhileRegisterHeld.load() <= publishBeforeSecondWrite) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(Env.PublishWhileRegisterHeld.load() > publishBeforeSecondWrite,
+            "expected further Publish while Register held after second write; before="
+                << publishBeforeSecondWrite
+                << "; after=" << Env.PublishWhileRegisterHeld.load());
+    }
+    AssertRegisterStillHeld("Register must still be held after second write");
+
+    // Flush(gen=N): drops Stage(M), PublishToSession fails without staged payload.
+    // Only the newest Register — older Register(M) would consume Stage(M) first.
+    Env.ReleaseHeldRegisterDirectReadHighestGenOnly();
+    Env.ReleaseHeldStages();
+    Env.ReleaseHeldDeregisters();
+
+    const bool gotAfter = WaitPromiseSparse(gotDataAfterRestart, TDuration::Seconds(5));
+    const bool closed = sessionClosed.load();
+
+    UNIT_ASSERT_C(!closed,
+        "SDK read session closed after PQRB/PQ restart; expected control/session to stay alive");
+    UNIT_ASSERT_C(gotAfter,
+        "SDK DirectRead durable hang: pending Stage(gen=M) + Publish(gen=N>M); Flush dropped "
+        "Stage(M) and failed Publish with no staged payload; later Stage left the read "
+        "staged/unpublished; session stayed open with unread topic data but no further DataReceived");
+
+    StopSdkSparse(driver, reader);
 }
 
 // LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
@@ -76,7 +77,9 @@ TDriverConfig MakeAsyncDriverConfig(const TString& endpoint) {
     return config;
 }
 
-ui64 ResolvePqTabletId(::NPersQueue::TTestServer& server, const TString& topicPath, ui32 partition = 0) {
+NKikimrSchemeOp::TPersQueueGroupDescription NavigatePqGroup(
+        ::NPersQueue::TTestServer& server, const TString& topicPath)
+{
     auto& runtime = *server.CleverServer->GetRuntime();
     const auto edge = runtime.AllocateEdgeActor();
 
@@ -98,7 +101,12 @@ ui64 ResolvePqTabletId(::NPersQueue::TTestServer& server, const TString& topicPa
 
     auto& front = response->Request->ResultSet.front();
     UNIT_ASSERT(front.PQGroupInfo);
-    for (const auto& p : front.PQGroupInfo->Description.GetPartitions()) {
+    return front.PQGroupInfo->Description;
+}
+
+ui64 ResolvePqTabletId(::NPersQueue::TTestServer& server, const TString& topicPath, ui32 partition = 0) {
+    const auto& description = NavigatePqGroup(server, topicPath);
+    for (const auto& p : description.GetPartitions()) {
         if (p.GetPartitionId() == partition) {
             return p.GetTabletId();
         }
@@ -107,10 +115,17 @@ ui64 ResolvePqTabletId(::NPersQueue::TTestServer& server, const TString& topicPa
     return 0;
 }
 
+ui64 ResolvePqrbTabletId(::NPersQueue::TTestServer& server, const TString& topicPath) {
+    const ui64 tabletId = NavigatePqGroup(server, topicPath).GetBalancerTabletID();
+    UNIT_ASSERT_C(tabletId != 0, "balancer tablet id is zero");
+    return tabletId;
+}
+
 struct TDirectReadRestoreEnv {
     std::unique_ptr<::NPersQueue::TTestServer> Server;
     TString Endpoint;
     ui64 PqTabletId = 0;
+    ui64 PqrbTabletId = 0;
 
     // Drop restore Prepare/Publish responses to keep restore stuck in Prepare (Forget race).
     std::atomic<ui64> HoldRestorePreparePublish{0};
@@ -130,6 +145,11 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HoldForgetResponses{0};
     std::atomic<ui64> HeldForgetResponses{0};
     TVector<THolder<IEventHandle>> HeldForgetEvents;
+
+    // Hold TEvRegisterDirectReadSession (PQ → dread cache) to model late Register after re-lock.
+    std::atomic<ui64> HoldRegisterDirectRead{0};
+    std::atomic<ui64> HeldRegisterDirectRead{0};
+    TVector<THolder<IEventHandle>> HeldRegisterDirectReadEvents;
 
     // Any TEvCloseSession with ErrorCode != OK (ENSURE, empty-queue CloseSessionAndDie, bad ack, …).
     // Teardown DropHooks() clears the observer before gRPC cancel, so shutdown noise is ignored.
@@ -225,12 +245,20 @@ struct TDirectReadRestoreEnv {
         });
 
         PqTabletId = ResolvePqTabletId(*Server, kTopicPath);
+        PqrbTabletId = ResolvePqrbTabletId(*Server, kTopicPath);
     }
 
     void InstallHooks() {
         auto& runtime = Runtime();
 
         runtime.SetEventFilter([this](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+            if (HoldRegisterDirectRead.load()
+                    && ev->CastAsLocal<TEvPQ::TEvRegisterDirectReadSession>()) {
+                ++HeldRegisterDirectRead;
+                HeldRegisterDirectReadEvents.emplace_back(ev.Release());
+                return true;
+            }
+
             auto* msg = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
             if (!msg || !msg->Record.HasPartitionResponse()) {
                 return false;
@@ -316,6 +344,15 @@ struct TDirectReadRestoreEnv {
         HeldForgetEvents.clear();
     }
 
+    void ReleaseHeldRegisterDirectRead() {
+        HoldRegisterDirectRead.store(0);
+        auto& runtime = Runtime();
+        for (auto& ev : HeldRegisterDirectReadEvents) {
+            runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+        }
+        HeldRegisterDirectReadEvents.clear();
+    }
+
     void DropHooks() {
         auto& runtime = Runtime();
         runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
@@ -323,6 +360,7 @@ struct TDirectReadRestoreEnv {
         HeldPrepareEvents.clear();
         HeldPublishEvents.clear();
         HeldForgetEvents.clear();
+        HeldRegisterDirectReadEvents.clear();
     }
 
     void RebootPqTablet() {
@@ -330,6 +368,12 @@ struct TDirectReadRestoreEnv {
         const auto edge = runtime.AllocateEdgeActor();
         RebootTablet(runtime, PqTabletId, edge);
         // Callers WaitUntil for restore progress; DispatchEvents advances RESTART_PIPE_DELAY_MS.
+    }
+
+    void RebootPqrbTablet() {
+        auto& runtime = Runtime();
+        const auto edge = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, PqrbTabletId, edge);
     }
 };
 
@@ -383,6 +427,15 @@ struct TGrpcDirectReadClient {
         });
     }
 
+    void SendReadRequest(NActors::TTestActorRuntime& runtime, ui64 bytesSize = 100_KB) {
+        RunWithDispatch(runtime, [&] {
+            StreamReadMessage::FromClient readReq;
+            readReq.mutable_read_request()->set_bytes_size(bytesSize);
+            DR_ENSURE(ControlStream->Write(readReq));
+            return true;
+        });
+    }
+
     void AcceptAssign(NActors::TTestActorRuntime& runtime) {
         RunWithDispatch(runtime, [&] {
             StreamReadMessage::FromServer resp;
@@ -421,12 +474,14 @@ struct TGrpcDirectReadClient {
         });
     }
 
-    void StartDirectReadPartition(NActors::TTestActorRuntime& runtime) {
+    void StartDirectReadPartition(NActors::TTestActorRuntime& runtime, ui64 generation) {
         RunWithDispatch(runtime, [&] {
             StreamDirectReadMessage::FromClient req;
             auto& start = *req.mutable_start_direct_read_partition_session_request();
             start.set_partition_session_id(AssignId);
-            start.set_generation(Generation);
+            start.set_generation(generation);
+            // Client already consumed DirectReadId=1; ask cache to resume from id=1.
+            start.set_last_direct_read_id(0);
             DR_ENSURE(DirectStream->Write(req));
 
             StreamDirectReadMessage::FromServer resp;
@@ -435,7 +490,50 @@ struct TGrpcDirectReadClient {
                     || resp.server_message_case() != StreamDirectReadMessage::FromServer::kStartDirectReadPartitionSessionResponse) {
                 ythrow yexception() << "start direct partition failed: " << resp.ShortDebugString();
             }
+            Generation = generation;
             return true;
+        });
+    }
+
+    void StartDirectReadPartition(NActors::TTestActorRuntime& runtime) {
+        StartDirectReadPartition(runtime, Generation);
+    }
+
+    // After tablet reboot, RegisterDirectReadSession(newGen) destroys the old cache client
+    // and dread cache sends StopDirectReadPartitionSession on the data stream.
+    void ExpectStopDirectRead(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            StreamDirectReadMessage::FromServer resp;
+            DR_ENSURE(DirectStream->Read(&resp));
+            if (resp.server_message_case() != StreamDirectReadMessage::FromServer::kStopDirectReadPartitionSession) {
+                ythrow yexception() << "expected StopDirectReadPartitionSession, got "
+                                    << resp.ShortDebugString();
+            }
+            if (resp.stop_direct_read_partition_session().partition_session_id()
+                    != static_cast<i64>(AssignId)) {
+                ythrow yexception() << "StopDirectRead for unexpected partition_session_id: "
+                                    << resp.ShortDebugString();
+            }
+            return true;
+        });
+    }
+
+    ui64 ReadUpdatePartitionSession(NActors::TTestActorRuntime& runtime) {
+        return RunWithDispatch(runtime, [&] {
+            StreamReadMessage::FromServer resp;
+            DR_ENSURE(ControlStream->Read(&resp));
+            if (resp.server_message_case() != StreamReadMessage::FromServer::kUpdatePartitionSession) {
+                ythrow yexception() << "expected UpdatePartitionSession, got "
+                                    << resp.ShortDebugString();
+            }
+            if (resp.update_partition_session().partition_session_id()
+                    != static_cast<i64>(AssignId)) {
+                ythrow yexception() << "UpdatePartitionSession for unexpected partition_session_id: "
+                                    << resp.ShortDebugString();
+            }
+            const ui64 newGen = resp.update_partition_session().partition_location().generation();
+            Generation = newGen;
+            return newGen;
         });
     }
 
@@ -453,6 +551,59 @@ struct TGrpcDirectReadClient {
         });
     }
 
+    // Same as ReadDataNoAck but accepts any direct_read_id (new partition session after re-lock
+    // may have already bumped the id while Register was delayed).
+    void ReadNextDataNoAck(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            StreamDirectReadMessage::FromServer resp;
+            DR_ENSURE(DirectStream->Read(&resp));
+            if (resp.status() != Ydb::StatusIds::SUCCESS
+                    || resp.server_message_case() != StreamDirectReadMessage::FromServer::kDirectReadResponse
+                    || resp.direct_read_response().partition_session_id() != static_cast<i64>(AssignId)
+                    || resp.direct_read_response().direct_read_id() < 1) {
+                ythrow yexception() << "unexpected DirectReadResponse: " << resp.ShortDebugString();
+            }
+            return true;
+        });
+    }
+
+    // Non-blocking-ish: pump until DirectReadResponse or deadline. Returns false on timeout.
+    // Cancels the DirectRead stream on timeout so the blocked Read does not leak a pool thread.
+    bool TryReadNextDataNoAck(NActors::TTestActorRuntime& runtime, TDuration timeout) {
+        auto future = NThreading::Async([&] {
+            StreamDirectReadMessage::FromServer resp;
+            if (!DirectStream->Read(&resp)) {
+                return false;
+            }
+            return resp.status() == Ydb::StatusIds::SUCCESS
+                && resp.server_message_case() == StreamDirectReadMessage::FromServer::kDirectReadResponse
+                && resp.direct_read_response().partition_session_id() == static_cast<i64>(AssignId)
+                && resp.direct_read_response().direct_read_id() >= 1;
+        }, DispatchPool());
+
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline) {
+            if (future.HasValue() || future.HasException()) {
+                break;
+            }
+            runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+        }
+        if (!future.HasValue() && !future.HasException()) {
+            if (DirectContext) {
+                DirectContext->TryCancel();
+            }
+            const TInstant cancelDeadline = TInstant::Now() + TDuration::Seconds(2);
+            while (TInstant::Now() < cancelDeadline && !future.HasValue() && !future.HasException()) {
+                runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+            }
+            return false;
+        }
+        if (future.HasException()) {
+            return false;
+        }
+        return future.GetValueSync();
+    }
+
     void SendDirectReadAckNoWait(NActors::TTestActorRuntime& runtime, ui64 directReadId) {
         RunWithDispatch(runtime, [&] {
             StreamReadMessage::FromClient req;
@@ -460,6 +611,63 @@ struct TGrpcDirectReadClient {
             ack.set_partition_session_id(AssignId);
             ack.set_direct_read_id(directReadId);
             DR_ENSURE(ControlStream->Write(req));
+            return true;
+        });
+    }
+
+    // After PQRB death ProcessBalancerDead sends forceful Stop (graceful=false) and drops the
+    // partition without waiting for the client ack.
+    void ExpectForcefulStopAndConfirm(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            StreamReadMessage::FromServer resp;
+            DR_ENSURE(ControlStream->Read(&resp));
+            if (resp.server_message_case()
+                    != StreamReadMessage::FromServer::kStopPartitionSessionRequest) {
+                ythrow yexception() << "expected StopPartitionSessionRequest, got "
+                                    << resp.ShortDebugString();
+            }
+            const auto& stop = resp.stop_partition_session_request();
+            if (stop.graceful()) {
+                ythrow yexception() << "expected forceful Stop (graceful=false), got "
+                                    << resp.ShortDebugString();
+            }
+            if (stop.partition_session_id() != static_cast<i64>(AssignId)) {
+                ythrow yexception() << "Stop for unexpected partition_session_id: "
+                                    << resp.ShortDebugString();
+            }
+
+            StreamReadMessage::FromClient req;
+            auto& reply = *req.mutable_stop_partition_session_response();
+            reply.set_partition_session_id(AssignId);
+            reply.set_graceful(false);
+            DR_ENSURE(ControlStream->Write(req));
+            return true;
+        });
+    }
+
+    // StartDirectRead while dread cache has no server session → BAD_REQUEST "Unknown session".
+    // Closes the DirectRead stream (same as prod SDK path that remaps to OVERLOADED and retries).
+    void StartDirectReadExpectUnknownSession(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            StreamDirectReadMessage::FromClient req;
+            auto& start = *req.mutable_start_direct_read_partition_session_request();
+            start.set_partition_session_id(AssignId);
+            start.set_generation(Generation);
+            start.set_last_direct_read_id(0);
+            DR_ENSURE(DirectStream->Write(req));
+
+            StreamDirectReadMessage::FromServer resp;
+            DR_ENSURE(DirectStream->Read(&resp));
+            if (resp.status() == Ydb::StatusIds::SUCCESS
+                    && resp.server_message_case()
+                        == StreamDirectReadMessage::FromServer::kStartDirectReadPartitionSessionResponse) {
+                ythrow yexception() << "expected Unknown session close, got success: "
+                                    << resp.ShortDebugString();
+            }
+            if (resp.status() != Ydb::StatusIds::BAD_REQUEST) {
+                ythrow yexception() << "expected BAD_REQUEST Unknown session, got "
+                                    << resp.ShortDebugString();
+            }
             return true;
         });
     }
@@ -698,11 +906,134 @@ protected:
         AssertUpdateSessionAdvanced(before,
             "restore must complete with TEvUpdateSession (not silent-hang)");
     }
+
+    // While restore is stuck: no UpdateSession, no new DirectRead publish, control stays alive.
+    // Models the client hang window after StopDirectRead and before UpdatePartitionSession.
+    void AssertHangWindowWhileRestoreStuck(ui64 updateBefore, ui64 directReadBefore, TDuration duration) {
+        const TInstant deadline = TInstant::Now() + duration;
+        while (TInstant::Now() < deadline) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+            UNIT_ASSERT_VALUES_EQUAL_C(Env.UpdateSessionCount.load(), updateBefore,
+                "UpdateSession must not arrive while restore Prepare is held");
+            UNIT_ASSERT_VALUES_EQUAL_C(Env.DirectReadResponseCount.load(), directReadBefore,
+                "no new DirectRead publish while restore Prepare is held");
+            AssertNoErrorClose("control session must stay alive while restore is stuck");
+        }
+    }
+
+    // After PQRB reboot with Register held: control stays up (client hang shape from the incident).
+    // Do not assert on DirectReadResponseCount — partition may still Publish toward the cache
+    // after CreateSession even while Register delivery is delayed.
+    void AssertHangWindowAfterPqrbUnknownSession(TDuration duration) {
+        const TInstant deadline = TInstant::Now() + duration;
+        while (TInstant::Now() < deadline) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+            UNIT_ASSERT_C(Env.HoldRegisterDirectRead.load() != 0
+                    && !Env.HeldRegisterDirectReadEvents.empty(),
+                "RegisterDirectReadSession must stay held during the hang window");
+            AssertNoErrorClose(
+                "control session must stay alive after PQRB restart / Unknown session on DirectRead");
+        }
+    }
 };
 
 } // namespace
 
 Y_UNIT_TEST_SUITE_F(TDirectReadRestoreRaceTest, TDirectReadRestoreFixture) {
+
+// LOGBROKER-10590 / cache-generation hang hypothesis:
+// tablet reboot → RegisterDirectReadSession(newGen) destroys old cache client →
+// StopDirectReadPartitionSession on data path; while restore Prepare is held,
+// UpdatePartitionSession does not arrive → data-path stays dead (client hang window).
+// Releasing Prepare completes restore → Update → Start(newGen) → DirectReadResponse.
+Y_UNIT_TEST(StopDirectReadOnGenerationBumpWhileRestoreStuck) {
+    WriteOneMessage();
+    OpenDirectReadSession(/*readDataNoAck=*/true);
+
+    const ui64 updateBefore = Env.UpdateSessionCount.load();
+    const ui64 directReadBefore = Env.DirectReadResponseCount.load();
+    const ui64 oldGen = Client.Generation;
+    UNIT_ASSERT_C(oldGen > 0, "expected non-zero partition generation after assign");
+
+    RebootAndWaitHeldPrepares(/*minHeld=*/1);
+
+    // Hypothesis A: dread cache kills the old client binding on generation bump.
+    Client.ExpectStopDirectRead(Runtime());
+
+    // Hypothesis B: without UpdatePartitionSession the data path stays silent.
+    AssertHangWindowWhileRestoreStuck(updateBefore, directReadBefore, TDuration::Seconds(2));
+
+    // Recovery: finish restore → UpdatePartitionSession with new generation → rebind.
+    ReleaseAndWaitUpdateSession(
+        [&] { Env.ReleaseHeldPrepares(); },
+        "releasing Prepare after StopDirectRead hang window must complete restore");
+
+    const ui64 newGen = Client.ReadUpdatePartitionSession(Runtime());
+    UNIT_ASSERT_C(newGen > oldGen,
+        "UpdatePartitionSession generation must advance after tablet reboot"
+            << "; oldGen=" << oldGen << "; newGen=" << newGen);
+
+    Client.StartDirectReadPartition(Runtime(), newGen);
+    Client.ReadDataNoAck(Runtime(), /*expectedDirectReadId=*/1);
+}
+
+// PQRB restart hang hypothesis (prod: control alive, DirectRead Unknown session / BytesRead=0):
+// ProcessBalancerDead force-stops partitions and re-locks; CreateSession fires
+// RegisterDirectReadSession to dread cache before Start reaches the client.
+// If Register is delayed, partition still Prepare/Publish (tablet path) and advances Offset /
+// inFlight DirectRead while cache rejects Stage/Publish ("unregistered session").
+// Client StartDirectRead → Unknown session; SDK would retry forever. After Register is
+// delivered and DirectRead is re-inited, inFlight without a client-visible DirectRead
+// still blocks further reads — durable hang with control alive.
+Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
+    WriteOneMessage();
+    OpenDirectReadSession(/*readDataNoAck=*/true);
+
+    const ui64 oldAssignId = Client.AssignId;
+
+    // Hold only new Registers after re-lock; the first session is already in the cache.
+    Env.HoldRegisterDirectRead.store(1);
+    Env.RebootPqrbTablet();
+
+    Client.ExpectForcefulStopAndConfirm(Runtime());
+
+    // Old DirectRead binding is destroyed with the dropped partition (Deregister).
+    Client.ExpectStopDirectRead(Runtime());
+
+    WaitUntil(Runtime(), [&] {
+        return Env.HeldRegisterDirectRead.load() >= 1
+            || Env.ErrorCloseSession.load() > 0;
+    });
+    AssertNoErrorClose("PQRB restart must re-lock and CreateSession without killing control");
+    UNIT_ASSERT_C(Env.HeldRegisterDirectRead.load() >= 1,
+        "expected RegisterDirectReadSession after PQRB re-lock; held="
+            << Env.HeldRegisterDirectRead.load());
+
+    // New Start can arrive while Register is still held (Register is fire-and-forget from PQ).
+    Client.AcceptAssign(Runtime());
+    UNIT_ASSERT_C(Client.AssignId != oldAssignId,
+        "expected a new partition_session_id after PQRB re-lock"
+            << "; old=" << oldAssignId << "; new=" << Client.AssignId);
+
+    Client.StartDirectReadExpectUnknownSession(Runtime());
+
+    AssertHangWindowAfterPqrbUnknownSession(TDuration::Seconds(2));
+
+    Env.ReleaseHeldRegisterDirectRead();
+
+    // Unknown session closed the DirectRead stream; re-init like SDK Reconnect + Init.
+    Client.SendReadRequest(Runtime());
+    Client.InitDirectSession(Runtime());
+    Client.StartDirectReadPartition(Runtime());
+    WriteOneMessage();
+
+    // Must not hang forever: either data arrives (bug fixed) or we fail fast with the hang.
+    UNIT_ASSERT_C(
+        Client.TryReadNextDataNoAck(Runtime(), TDuration::Seconds(15)),
+        "DirectRead hung after PQRB restart: Register was delayed, cache returned Unknown session, "
+        "partition already published/inFlight DirectRead that the client never saw; "
+        "control stayed alive but further DirectRead did not recover");
+}
 
 // LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0
 // must not kill the partition actor (Forget stage must tolerate RestoredDirectReadId==0).

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -997,6 +997,74 @@ protected:
         UNIT_ASSERT_C(future.HasValue(), "sparse write did not finish in time");
         future.GetValueSync();
     }
+
+    // Sparse wait used by PQRB+Register hang tests under UseRealThreads=false.
+    void WaitHeldRegisterSparse(ui64 minHeld = 1, TDuration timeout = TDuration::Seconds(30)) {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline && Env.HeldRegisterDirectRead.load() < minHeld) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(Env.HeldRegisterDirectRead.load() >= minHeld,
+            "expected RegisterDirectReadSession after PQRB re-lock; held="
+                << Env.HeldRegisterDirectRead.load());
+    }
+
+    void WaitStageOrPublishWhileRegisterHeldAtLeast(
+            ui64 minCount, TDuration timeout = TDuration::Seconds(30))
+    {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline && Env.StageOrPublishWhileRegisterHeld.load() < minCount) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(Env.StageOrPublishWhileRegisterHeld.load() >= minCount,
+            "expected Stage/Publish to cache while Register held; got="
+                << Env.StageOrPublishWhileRegisterHeld.load());
+    }
+
+    void WaitStageOrPublishWhileRegisterHeldAbove(
+            ui64 exclusiveMin, TDuration timeout = TDuration::Seconds(30))
+    {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline
+                && Env.StageOrPublishWhileRegisterHeld.load() <= exclusiveMin) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(Env.StageOrPublishWhileRegisterHeld.load() > exclusiveMin,
+            "expected further Stage/Publish while Register held; before="
+                << exclusiveMin
+                << "; after=" << Env.StageOrPublishWhileRegisterHeld.load());
+    }
+
+    void AssertRegisterStillHeld(const TString& what) {
+        UNIT_ASSERT_C(Env.HoldRegisterDirectRead.load() != 0
+                && !Env.HeldRegisterDirectReadEvents.empty(),
+            what);
+    }
+
+    void StopSdkSparse(
+            std::shared_ptr<TDriver>& driver,
+            std::shared_ptr<NTopic::IReadSession>& reader)
+    {
+        if (!driver) {
+            return;
+        }
+        auto stop = NThreading::Async([&] {
+            if (reader) {
+                reader->Close(TDuration::MilliSeconds(50));
+            }
+            driver->Stop(true);
+            return true;
+        }, DispatchPool());
+        for (int i = 0; i < 40 && !stop.HasValue() && !stop.HasException(); ++i) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        reader.reset();
+        driver.reset();
+    }
 };
 
 } // namespace
@@ -1160,35 +1228,15 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     Env.HoldRegisterDirectRead.store(1);
     Env.RebootPqrbTablet();
 
-    {
-        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
-        while (TInstant::Now() < deadline && Env.HeldRegisterDirectRead.load() < 1) {
-            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
-            Sleep(TDuration::MilliSeconds(50));
-        }
-    }
+    WaitHeldRegisterSparse();
     AssertNoErrorClose("PQRB restart must not kill the read proxy control session");
     UNIT_ASSERT_C(!sessionClosed.load(),
         "SDK read session closed during PQRB restart; expected control to stay alive");
-    UNIT_ASSERT_C(Env.HeldRegisterDirectRead.load() >= 1,
-        "expected RegisterDirectReadSession after PQRB re-lock; held="
-            << Env.HeldRegisterDirectRead.load());
 
-    // Wait until PQ Stage/Publish reaches cache while Register is still held (dropped as
-    // unregistered) — durable-hang precondition, same as raw gRPC test timing window.
-    {
-        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
-        while (TInstant::Now() < deadline && Env.StageOrPublishWhileRegisterHeld.load() < 1) {
-            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
-            Sleep(TDuration::MilliSeconds(50));
-        }
-    }
-    UNIT_ASSERT_C(Env.StageOrPublishWhileRegisterHeld.load() >= 1,
-        "expected Stage/Publish to cache while Register held (unregistered drop); got="
-            << Env.StageOrPublishWhileRegisterHeld.load());
-    UNIT_ASSERT_C(Env.HoldRegisterDirectRead.load() != 0
-            && !Env.HeldRegisterDirectReadEvents.empty(),
-        "Register must still be held after unregistered Stage/Publish");
+    // Wait until PQ Stage/Publish reaches cache while Register is still held (buffered as
+    // unregistered until Register) — durable-hang precondition.
+    WaitStageOrPublishWhileRegisterHeldAtLeast(1);
+    AssertRegisterStillHeld("Register must still be held after unregistered Stage/Publish");
 
     // Second message while Register is still held — topic has unread data after release, so a
     // silent wait cannot be explained by an empty partition. Stage/Publish for the new data
@@ -1196,21 +1244,8 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     // DirectReadId and trip SDK VERIFY on NextDirectReadId gap).
     const ui64 stageBeforeSecondWrite = Env.StageOrPublishWhileRegisterHeld.load();
     WriteOneMessageSparse();
-    {
-        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
-        while (TInstant::Now() < deadline
-                && Env.StageOrPublishWhileRegisterHeld.load() <= stageBeforeSecondWrite) {
-            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
-            Sleep(TDuration::MilliSeconds(50));
-        }
-    }
-    UNIT_ASSERT_C(Env.StageOrPublishWhileRegisterHeld.load() > stageBeforeSecondWrite,
-        "expected further Stage/Publish while Register held after second write; before="
-            << stageBeforeSecondWrite
-            << "; after=" << Env.StageOrPublishWhileRegisterHeld.load());
-    UNIT_ASSERT_C(Env.HoldRegisterDirectRead.load() != 0
-            && !Env.HeldRegisterDirectReadEvents.empty(),
-        "Register must still be held after second write");
+    WaitStageOrPublishWhileRegisterHeldAbove(stageBeforeSecondWrite);
+    AssertRegisterStillHeld("Register must still be held after second write");
 
     // Register lands; SDK retry should get past Unknown session. Hang remains if tablet already
     // advanced inFlight DirectRead the client never saw.
@@ -1220,21 +1255,7 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     const bool closed = sessionClosed.load();
 
     // Soft stop without RunWithDispatch: dense pump melts under DirectRead reconnects.
-    if (driver) {
-        auto stop = NThreading::Async([&] {
-            if (reader) {
-                reader->Close(TDuration::MilliSeconds(50));
-            }
-            driver->Stop(true);
-            return true;
-        }, DispatchPool());
-        for (int i = 0; i < 40 && !stop.HasValue() && !stop.HasException(); ++i) {
-            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
-            Sleep(TDuration::MilliSeconds(50));
-        }
-        reader.reset();
-        driver.reset();
-    }
+    StopSdkSparse(driver, reader);
 
     UNIT_ASSERT_C(!closed,
         "SDK read session closed after PQRB restart; expected control/session to stay alive");

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -578,8 +578,8 @@ struct TGrpcDirectReadClient {
     }
 
     // Non-blocking-ish: pump until DirectReadResponse or deadline. Returns false on timeout.
-    // On timeout cancels the DirectRead stream and waits for the async Read to finish so it
-    // does not leak a pool thread or touch DirectStream during fixture teardown.
+    // On timeout cancels the DirectRead stream and waits up to 20s for the async Read to finish
+    // so it does not leak a pool thread or touch DirectStream during fixture teardown.
     // Async errors are rethrown (not masked as timeout).
     bool TryReadNextDataNoAck(NActors::TTestActorRuntime& runtime, TDuration timeout) {
         auto future = NThreading::Async([&] {
@@ -602,8 +602,12 @@ struct TGrpcDirectReadClient {
             if (DirectContext) {
                 DirectContext->TryCancel();
             }
-            while (!future.HasValue() && !future.HasException()) {
+            const TInstant cancelDeadline = TInstant::Now() + TDuration::Seconds(20);
+            while (TInstant::Now() < cancelDeadline && !future.HasValue() && !future.HasException()) {
                 runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+            }
+            if (!future.HasValue() && !future.HasException()) {
+                ythrow yexception() << "DirectRead cancel did not finish within 20s";
             }
         }
         future.TryRethrow();

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -1050,17 +1050,24 @@ protected:
         if (!driver) {
             return;
         }
-        auto stop = NThreading::Async([&] {
-            if (reader) {
-                reader->Close(TDuration::MilliSeconds(50));
+        // Capture by value so Close/Stop outlive caller pointer resets.
+        const auto driverLocal = driver;
+        const auto readerLocal = reader;
+        auto stop = NThreading::Async([driverLocal, readerLocal] {
+            if (readerLocal) {
+                readerLocal->Close(TDuration::MilliSeconds(50));
             }
-            driver->Stop(true);
+            driverLocal->Stop(true);
             return true;
         }, DispatchPool());
         for (int i = 0; i < 40 && !stop.HasValue() && !stop.HasException(); ++i) {
             Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
             Sleep(TDuration::MilliSeconds(50));
         }
+        UNIT_ASSERT_C(stop.HasValue() || stop.HasException(),
+            "SDK sparse stop did not finish in time");
+        stop.TryRethrow();
+        stop.GetValueSync();
         reader.reset();
         driver.reset();
     }

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -68,12 +68,17 @@ void WaitUntil(NActors::TTestActorRuntime& runtime, TCondition&& condition, TDur
     UNIT_ASSERT_C(runtime.DispatchEvents(opts, deadline), "WaitUntil condition not met before deadline");
 }
 
-TDriverConfig MakeAsyncDriverConfig(const TString& endpoint) {
+// With UseRealThreads=false the gRPC server is only served while DispatchEvents is
+// pumped, and SDK ListEndpoints (Sync/Async discovery) never completes — StreamRead
+// never opens and the read session hangs silently. EDiscoveryMode::Off routes RPCs
+// straight to the configured endpoint (like CreateSimpleWriter's
+// ClusterDiscoveryMode::Off), so StreamRead starts without any discovery round-trip.
+TDriverConfig MakeNoDiscoveryDriverConfig(const TString& endpoint) {
     TDriverConfig config;
     config.SetEndpoint(endpoint);
     config.SetDatabase("/Root");
     config.SetAuthToken("root@builtin");
-    config.SetDiscoveryMode(EDiscoveryMode::Async);
+    config.SetDiscoveryMode(EDiscoveryMode::Off);
     return config;
 }
 
@@ -240,7 +245,7 @@ struct TDirectReadRestoreEnv {
         });
 
         RunWithDispatch(runtime, [&] {
-            TDriver driver(MakeAsyncDriverConfig(Endpoint));
+            TDriver driver(MakeNoDiscoveryDriverConfig(Endpoint));
             TTopicClient client(driver);
             auto status = client.CreateTopic(
                 kTopic,
@@ -814,7 +819,7 @@ protected:
     // 1. Produce one large message so DirectRead has data to restore.
     void WriteOneMessage() {
         RunWithDispatch(Runtime(), [&] {
-            TDriver driver(MakeAsyncDriverConfig(Env.Endpoint));
+            TDriver driver(MakeNoDiscoveryDriverConfig(Env.Endpoint));
             auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
             if (!writer->Write(TString(1_MB, 'x'))) {
                 ythrow yexception() << "write failed";
@@ -1054,7 +1059,7 @@ protected:
     // Write under a reconnect storm without RunWithDispatch melting the actor queue.
     void WriteOneMessageSparse() {
         auto future = NThreading::Async([&] {
-            TDriver driver(MakeAsyncDriverConfig(Env.Endpoint));
+            TDriver driver(MakeNoDiscoveryDriverConfig(Env.Endpoint));
             auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
             if (!writer->Write(TString(1_MB, 'x'))) {
                 ythrow yexception() << "sparse write failed";
@@ -1185,7 +1190,8 @@ protected:
             driverLocal->Stop(true);
             return true;
         }, DispatchPool());
-        for (int i = 0; i < 40 && !stop.HasValue() && !stop.HasException(); ++i) {
+        // ~20s window so WaitCallbacksDrained spin logs can show stuck InFlight count.
+        for (int i = 0; i < 400 && !stop.HasValue() && !stop.HasException(); ++i) {
             Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
             Sleep(TDuration::MilliSeconds(50));
         }
@@ -1316,7 +1322,7 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     std::shared_ptr<NTopic::IReadSession> reader;
 
     RunWithDispatch(Runtime(), [&] {
-        driver = std::make_shared<TDriver>(MakeAsyncDriverConfig(Env.Endpoint));
+        driver = std::make_shared<TDriver>(MakeNoDiscoveryDriverConfig(Env.Endpoint));
         TTopicClient topicClient(*driver);
 
         auto settings = TReadSessionSettings()
@@ -1416,7 +1422,7 @@ Y_UNIT_TEST(SdkHangWhenPublishFlushedBeforeMatchingStage) {
     std::shared_ptr<NTopic::IReadSession> reader;
 
     RunWithDispatch(Runtime(), [&] {
-        driver = std::make_shared<TDriver>(MakeAsyncDriverConfig(Env.Endpoint));
+        driver = std::make_shared<TDriver>(MakeNoDiscoveryDriverConfig(Env.Endpoint));
         TTopicClient topicClient(*driver);
 
         auto settings = TReadSessionSettings()
@@ -1511,12 +1517,8 @@ Y_UNIT_TEST(SdkHangWhenPublishFlushedBeforeMatchingStage) {
         "Stage(M) and failed Publish with no staged payload; later Stage left the read "
         "staged/unpublished; session stayed open with unread topic data but no further DataReceived");
 
-    // Do not StopSdkSparse here: after PQRB+PQ reboot with held Deregister, Close/Stop can block
-    // under UseRealThreads=false even when DataReceived recovered. Drop hooks and let fixture
-    // TearDownGrpcAndServer shut down gRPC/server (same as before this test existed).
-    Env.DropHooks();
-    reader.reset();
-    driver.reset();
+    // Repro Stop hang (InFlight drain investigation): keep StopSdkSparse.
+    StopSdkSparse(driver, reader);
 }
 
 // LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -1117,14 +1117,13 @@ Y_UNIT_TEST(StopDirectReadOnGenerationBumpWhileRestoreStuck) {
     Client.ReadDataNoAck(Runtime(), /*expectedDirectReadId=*/1);
 }
 
-// PQRB restart hang hypothesis (prod: control alive, DirectRead Unknown session / BytesRead=0):
+// PQRB restart hang (prod: control alive, DirectRead Unknown session / BytesRead=0):
 // ProcessBalancerDead force-stops partitions and re-locks; CreateSession fires
 // RegisterDirectReadSession to dread cache before Start reaches the client.
-// If Register is delayed, partition still Prepare/Publish (tablet path) and advances Offset /
-// inFlight DirectRead while cache buffers Stage/Publish until Register.
-// Client StartDirectRead → Unknown session; SDK would retry forever. After Register is
-// delivered and DirectRead is re-inited, inFlight without a client-visible DirectRead
-// still blocks further reads — durable hang with control alive (pre-buffering fix).
+// If Register is delayed, partition still Stage/Publish and advances inFlight DirectRead;
+// client StartDirectRead → Unknown session while Register is held.
+// Without buffering, dropped Stage/Publish left tablet inFlight without cache data → durable
+// hang after Register and re-init. With buffering, FlushPending on Register restores data.
 Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
     WriteOneMessage();
     OpenDirectReadSession(/*readDataNoAck=*/true);
@@ -1167,7 +1166,7 @@ Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
     Client.StartDirectReadPartition(Runtime());
     WriteOneMessage();
 
-    // Must not hang forever: either data arrives (bug fixed) or we fail fast with the hang.
+    // After Register + re-init, buffered Stage/Publish must be visible (or fail fast on hang).
     UNIT_ASSERT_C(
         Client.TryReadNextDataNoAck(Runtime(), TDuration::Seconds(15)),
         "DirectRead hung after PQRB restart: Register was delayed, cache returned Unknown session, "
@@ -1175,12 +1174,11 @@ Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
         "control stayed alive but further DirectRead did not recover");
 }
 
-// Same durable hang as UnknownSessionAfterPqrbRestartWhileRegisterHeld, via Topic SDK
+// Same scenario as UnknownSessionAfterPqrbRestartWhileRegisterHeld via Topic SDK
 // (UseRealThreads=false): no Commit on first DataReceived; hold Register after PQRB reboot until
-// Stage/Publish are buffered in cache; write a second message while Register is still held
-// (unread data in topic); then release Register so SDK Start succeeds, but tablet inFlight
-// DirectRead the client never saw blocks further DataReceived (pre-buffering fix).
-// Expectation when the bug exists: FAIL — session open, no further DataReceived after release.
+// Stage/Publish are buffered; write a second message while Register is held (unread topic data);
+// release Register so SDK Start succeeds. Without buffering this hung (no further DataReceived);
+// with FlushPending on Register, DataReceived must resume.
 Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     Runtime().SetScheduledLimit(10'000'000);
 
@@ -1244,7 +1242,7 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
         "SDK read session closed during PQRB restart; expected control to stay alive");
 
     // Wait until PQ Stage/Publish reaches cache while Register is still held (buffered
-    // until Register) — durable-hang precondition.
+    // until Register) — regression precondition for the unbuffered hang.
     WaitStageOrPublishWhileRegisterHeldAtLeast(1);
     AssertRegisterStillHeld("Register must still be held after buffered Stage/Publish");
 
@@ -1257,8 +1255,7 @@ Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
     WaitStageOrPublishWhileRegisterHeldAbove(stageBeforeSecondWrite);
     AssertRegisterStillHeld("Register must still be held after second write");
 
-    // Register lands; SDK retry should get past Unknown session. Hang remains if tablet already
-    // advanced inFlight DirectRead the client never saw.
+    // Register lands; FlushPending applies buffered Stage/Publish; SDK retry should deliver data.
     Env.ReleaseHeldRegisterDirectRead();
 
     const bool gotAfter = WaitPromiseSparse(gotDataAfterRestart, TDuration::Seconds(5));

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -150,6 +150,8 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HoldRegisterDirectRead{0};
     std::atomic<ui64> HeldRegisterDirectRead{0};
     TVector<THolder<IEventHandle>> HeldRegisterDirectReadEvents;
+    // Stage/Publish toward cache while Register is held (cache drops them as unregistered).
+    std::atomic<ui64> StageOrPublishWhileRegisterHeld{0};
 
     // Any TEvCloseSession with ErrorCode != OK (ENSURE, empty-queue CloseSessionAndDie, bad ack, …).
     // Teardown DropHooks() clears the observer before gRPC cancel, so shutdown noise is ignored.
@@ -312,6 +314,14 @@ struct TDirectReadRestoreEnv {
             }
             if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvDirectReadAck>()) {
                 ++DirectReadAckCount;
+            }
+            // While Register is delayed, Stage/Publish still reach the cache and are dropped
+            // ("unregistered session") — tablet DirectRead state may already have advanced.
+            if (HoldRegisterDirectRead.load()
+                    && !HeldRegisterDirectReadEvents.empty()
+                    && (ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()
+                        || ev->CastAsLocal<TEvPQ::TEvPublishDirectRead>())) {
+                ++StageOrPublishWhileRegisterHeld;
             }
             return TTestActorRuntime::EEventAction::PROCESS;
         });
@@ -935,6 +945,58 @@ protected:
                 "control session must stay alive after PQRB restart / Unknown session on DirectRead");
         }
     }
+
+    // Pump actor system until promise is set or timeout. UseRealThreads=false requires DispatchEvents.
+    bool WaitPromise(NThreading::TPromise<void>& promise, TDuration timeout) {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline) {
+            if (promise.HasValue()) {
+                return true;
+            }
+            TDispatchOptions opts;
+            opts.CustomFinalCondition = [&] {
+                return promise.HasValue();
+            };
+            Runtime().DispatchEvents(opts, TDuration::MilliSeconds(50));
+        }
+        return promise.HasValue();
+    }
+
+    // Sparse pump + wall-clock sleep. Use when hanging is expected: avoids drowning in idle
+    // tablet timers while SDK threads still get occasional progress.
+    bool WaitPromiseSparse(NThreading::TPromise<void>& promise, TDuration timeout) {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline) {
+            if (promise.HasValue()) {
+                return true;
+            }
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(100));
+        }
+        return promise.HasValue();
+    }
+
+    // Write under a reconnect storm without RunWithDispatch melting the actor queue.
+    void WriteOneMessageSparse() {
+        auto future = NThreading::Async([&] {
+            TDriver driver(MakeAsyncDriverConfig(Env.Endpoint));
+            auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+            if (!writer->Write(TString(1_MB, 'x'))) {
+                ythrow yexception() << "sparse write failed";
+            }
+            writer->Close();
+            driver.Stop(true);
+            return true;
+        }, DispatchPool());
+
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(60);
+        while (TInstant::Now() < deadline && !future.HasValue() && !future.HasException()) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(future.HasValue(), "sparse write did not finish in time");
+        future.GetValueSync();
+    }
 };
 
 } // namespace
@@ -1033,6 +1095,154 @@ Y_UNIT_TEST(UnknownSessionAfterPqrbRestartWhileRegisterHeld) {
         "DirectRead hung after PQRB restart: Register was delayed, cache returned Unknown session, "
         "partition already published/inFlight DirectRead that the client never saw; "
         "control stayed alive but further DirectRead did not recover");
+}
+
+// Same durable hang as UnknownSessionAfterPqrbRestartWhileRegisterHeld, via Topic SDK
+// (UseRealThreads=false): no Commit on first DataReceived; hold Register after PQRB reboot until
+// Stage/Publish hit the cache unregistered; write a second message while Register is still held
+// (unread data in topic); then release Register so SDK Start succeeds, but tablet inFlight
+// DirectRead the client never saw blocks further DataReceived.
+// Expectation when the bug exists: FAIL — session open, no further DataReceived after release.
+Y_UNIT_TEST(SdkHangAfterPqrbRestartWhileRegisterHeld) {
+    Runtime().SetScheduledLimit(10'000'000);
+
+    WriteOneMessage();
+
+    auto gotFirstMessage = NThreading::NewPromise<void>();
+    auto gotDataAfterRestart = NThreading::NewPromise<void>();
+    std::atomic<ui64> messagesReceived{0};
+    std::atomic<ui64> messagesAtRestart{0};
+    std::atomic<bool> pastRestart{false};
+    std::atomic<bool> sessionClosed{false};
+
+    std::shared_ptr<TDriver> driver;
+    std::shared_ptr<NTopic::IReadSession> reader;
+
+    RunWithDispatch(Runtime(), [&] {
+        driver = std::make_shared<TDriver>(MakeAsyncDriverConfig(Env.Endpoint));
+        TTopicClient topicClient(*driver);
+
+        auto settings = TReadSessionSettings()
+            .ConsumerName(kConsumer)
+            .AppendTopics(TTopicReadSettings(std::string(kTopicPath)))
+            .DirectRead(true);
+
+        settings.EventHandlers_
+            .DataReceivedHandler([&](NTopic::TReadSessionEvent::TDataReceivedEvent& ev) {
+                // Do not Commit — leave DirectRead in flight like raw readDataNoAck=true.
+                const ui64 n = messagesReceived.fetch_add(ev.GetMessages().size()) + ev.GetMessages().size();
+                if (n >= 1) {
+                    gotFirstMessage.TrySetValue();
+                }
+                if (pastRestart.load() && n > messagesAtRestart.load()) {
+                    gotDataAfterRestart.TrySetValue();
+                }
+            })
+            .StartPartitionSessionHandler([&](NTopic::TReadSessionEvent::TStartPartitionSessionEvent& ev) {
+                ev.Confirm();
+            })
+            .StopPartitionSessionHandler([&](NTopic::TReadSessionEvent::TStopPartitionSessionEvent& ev) {
+                ev.Confirm();
+            })
+            .SessionClosedHandler([&](const NTopic::TSessionClosedEvent&) {
+                sessionClosed.store(true);
+            });
+
+        reader = topicClient.CreateReadSession(settings);
+        return true;
+    });
+
+    UNIT_ASSERT_C(WaitPromise(gotFirstMessage, TDuration::Seconds(30)),
+        "SDK DirectRead did not receive the first message before PQRB restart");
+    messagesAtRestart.store(messagesReceived.load());
+    pastRestart.store(true);
+
+    Env.HoldRegisterDirectRead.store(1);
+    Env.RebootPqrbTablet();
+
+    {
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline && Env.HeldRegisterDirectRead.load() < 1) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+    }
+    AssertNoErrorClose("PQRB restart must not kill the read proxy control session");
+    UNIT_ASSERT_C(!sessionClosed.load(),
+        "SDK read session closed during PQRB restart; expected control to stay alive");
+    UNIT_ASSERT_C(Env.HeldRegisterDirectRead.load() >= 1,
+        "expected RegisterDirectReadSession after PQRB re-lock; held="
+            << Env.HeldRegisterDirectRead.load());
+
+    // Wait until PQ Stage/Publish reaches cache while Register is still held (dropped as
+    // unregistered) — durable-hang precondition, same as raw gRPC test timing window.
+    {
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline && Env.StageOrPublishWhileRegisterHeld.load() < 1) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+    }
+    UNIT_ASSERT_C(Env.StageOrPublishWhileRegisterHeld.load() >= 1,
+        "expected Stage/Publish to cache while Register held (unregistered drop); got="
+            << Env.StageOrPublishWhileRegisterHeld.load());
+    UNIT_ASSERT_C(Env.HoldRegisterDirectRead.load() != 0
+            && !Env.HeldRegisterDirectReadEvents.empty(),
+        "Register must still be held after unregistered Stage/Publish");
+
+    // Second message while Register is still held — topic has unread data after release, so a
+    // silent wait cannot be explained by an empty partition. Stage/Publish for the new data
+    // also hits unregistered cache (do not write after release: that can deliver a later
+    // DirectReadId and trip SDK VERIFY on NextDirectReadId gap).
+    const ui64 stageBeforeSecondWrite = Env.StageOrPublishWhileRegisterHeld.load();
+    WriteOneMessageSparse();
+    {
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline
+                && Env.StageOrPublishWhileRegisterHeld.load() <= stageBeforeSecondWrite) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+    }
+    UNIT_ASSERT_C(Env.StageOrPublishWhileRegisterHeld.load() > stageBeforeSecondWrite,
+        "expected further Stage/Publish while Register held after second write; before="
+            << stageBeforeSecondWrite
+            << "; after=" << Env.StageOrPublishWhileRegisterHeld.load());
+    UNIT_ASSERT_C(Env.HoldRegisterDirectRead.load() != 0
+            && !Env.HeldRegisterDirectReadEvents.empty(),
+        "Register must still be held after second write");
+
+    // Register lands; SDK retry should get past Unknown session. Hang remains if tablet already
+    // advanced inFlight DirectRead the client never saw.
+    Env.ReleaseHeldRegisterDirectRead();
+
+    const bool gotAfter = WaitPromiseSparse(gotDataAfterRestart, TDuration::Seconds(5));
+    const bool closed = sessionClosed.load();
+
+    // Soft stop without RunWithDispatch: dense pump melts under DirectRead reconnects.
+    if (driver) {
+        auto stop = NThreading::Async([&] {
+            if (reader) {
+                reader->Close(TDuration::MilliSeconds(50));
+            }
+            driver->Stop(true);
+            return true;
+        }, DispatchPool());
+        for (int i = 0; i < 40 && !stop.HasValue() && !stop.HasException(); ++i) {
+            Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        reader.reset();
+        driver.reset();
+    }
+
+    UNIT_ASSERT_C(!closed,
+        "SDK read session closed after PQRB restart; expected control/session to stay alive");
+    UNIT_ASSERT_C(gotAfter,
+        "SDK DirectRead durable hang after PQRB restart: Register was delayed, Stage/Publish "
+        "hit unregistered cache (including second write while Register held), then Register "
+        "was released and Start could succeed, but inFlight DirectRead never reached the "
+        "client; session stayed open and topic had unread data, no further DataReceived");
 }
 
 // LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -1189,11 +1189,10 @@ protected:
             Runtime().DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(1));
             Sleep(TDuration::MilliSeconds(50));
         }
-        // Best-effort: Flush-before-Stage hang can wedge DirectRead Close under UseRealThreads=false.
-        if (stop.HasValue() || stop.HasException()) {
-            stop.TryRethrow();
-            stop.GetValueSync();
-        }
+        UNIT_ASSERT_C(stop.HasValue() || stop.HasException(),
+            "SDK sparse stop did not finish in time");
+        stop.TryRethrow();
+        stop.GetValueSync();
         reader.reset();
         driver.reset();
     }
@@ -1512,7 +1511,12 @@ Y_UNIT_TEST(SdkHangWhenPublishFlushedBeforeMatchingStage) {
         "Stage(M) and failed Publish with no staged payload; later Stage left the read "
         "staged/unpublished; session stayed open with unread topic data but no further DataReceived");
 
-    StopSdkSparse(driver, reader);
+    // Do not StopSdkSparse here: after PQRB+PQ reboot with held Deregister, Close/Stop can block
+    // under UseRealThreads=false even when DataReceived recovered. Drop hooks and let fixture
+    // TearDownGrpcAndServer shut down gRPC/server (same as before this test existed).
+    Env.DropHooks();
+    reader.reset();
+    driver.reset();
 }
 
 // LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/ya.make
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/ya.make
@@ -11,6 +11,8 @@ CFLAGS(
 SIZE(MEDIUM)
 TIMEOUT(600)
 
+ENV(PQ_EXPERIMENTAL_DIRECT_READ="1")
+
 PEERDIR(
     library/cpp/testing/unittest
     library/cpp/threading/future


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Reproduce DirectRead durable hang after PQRB restart when `TEvRegisterDirectReadSession` is delayed (raw gRPC + Topic SDK, `UseRealThreads=false`).
- Fix: dread cache buffers Stage/Publish for unregistered sessions and applies them on Register, so tablet inFlight is not stranded without client-visible data.

`CreateSession` sends Register fire-and-forget. Stage/Publish can reach the cache first; previously they were dropped while the tablet already advanced DirectRead state → control session stayed alive but further DirectRead did not recover.


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
