### PR TITLE
Restart multipart upload on InvalidPart instead of failing the export

### DIFF
--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -642,7 +642,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
         }
 
         if (CanRetry(error)) {
-            if (error.GetExceptionName() == "FsCompleteMultipartUploadFailed") {
+            if (RequiresNewUpload(error)) {
                 ForceNewUpload = true;
             }
             UploadId.Clear(); // force getting info after restart
@@ -697,6 +697,13 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
 
     bool CanRetry(const Aws::S3::S3Error& error) const {
         return Attempt < Retries && NWrappers::ShouldRetry(error);
+    }
+
+    static bool RequiresNewUpload(const Aws::S3::S3Error& error) {
+        const auto& exceptionName = error.GetExceptionName();
+        return exceptionName == "FsCompleteMultipartUploadFailed"
+            || exceptionName == "InvalidPart"
+            || exceptionName == "InvalidPartOrder";
     }
 
     void Retry() {

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -2664,6 +2664,104 @@ partitioning_settings {
         TestGetExport(Runtime(), exportId, "/MyRoot");
     }
 
+    Y_UNIT_TEST(ShouldRestartUploadOnInvalidPart) {
+        Env(); // Init test env
+        ui64 txId = 100;
+
+        TestCreateTable(Runtime(), ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        Env().TestWaitNotification(Runtime(), txId);
+
+        UpdateRow(Runtime(), "Table", 1, "valueA");
+        UpdateRow(Runtime(), "Table", 2, "valueB");
+        Runtime().SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_DEBUG);
+
+        // Reject the first 'CompleteMultipartUpload' the way s3 does when the stored etags do not
+        // match the parts it holds. The request is dropped, so the upload is still there and its
+        // parts have to be uploaded anew. 'InvalidPart' is unknown to the aws sdk, so it arrives
+        // as UNKNOWN with the exception name set and without the retryable flag.
+        THolder<IEventHandle> injectResult;
+        auto prevObserver = Runtime().SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvDataShard::EvProposeTransaction: {
+                    auto& record = ev->Get<TEvDataShard::TEvProposeTransaction>()->Record;
+                    if (record.GetTxKind() != NKikimrTxDataShard::ETransactionKind::TX_KIND_SCHEME) {
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    }
+
+                    NKikimrTxDataShard::TFlatSchemeTransaction schemeTx;
+                    UNIT_ASSERT(schemeTx.ParseFromString(record.GetTxBody()));
+
+                    if (schemeTx.HasBackup()) {
+                        schemeTx.MutableBackup()->MutableScanSettings()->SetRowsBatchSize(1);
+                        schemeTx.MutableBackup()->MutableS3Settings()->MutableLimits()->SetMinWriteBatchSize(1);
+                        record.SetTxBody(schemeTx.SerializeAsString());
+                    }
+
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+
+                case NWrappers::NExternalStorage::EvCompleteMultipartUploadRequest: {
+                    if (injectResult) {
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    }
+
+                    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN, "InvalidPart",
+                        "Unable to parse ExceptionName: InvalidPart Message: One or more of the specified"
+                        " parts could not be found.", false);
+                    // Without the response code the error defaults to REQUEST_NOT_MADE, which is retryable
+                    error.SetResponseCode(Aws::Http::HttpResponseCode::BAD_REQUEST);
+
+                    auto response = MakeHolder<NWrappers::NExternalStorage::TEvCompleteMultipartUploadResponse>(
+                        std::nullopt,
+                        Aws::Utils::Outcome<Aws::S3::Model::CompleteMultipartUploadResult, Aws::S3::S3Error>(std::move(error))
+                    );
+                    injectResult = MakeHolder<IEventHandle>(ev->Sender, ev->Recipient, response.Release(), ev->Flags, ev->Cookie);
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                default: {
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+            }
+        });
+
+        const auto exportId = ++txId;
+        TestExport(Runtime(), exportId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              number_of_retries: 10
+              items {
+                source_path: "/MyRoot/Table"
+                destination_prefix: ""
+              }
+            }
+        )", S3Port()));
+
+        if (!injectResult) {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&injectResult](IEventHandle&) -> bool {
+                return bool(injectResult);
+            });
+            Runtime().DispatchEvents(opts);
+        }
+
+        Runtime().SetObserverFunc(prevObserver);
+        Runtime().Send(injectResult.Release(), 0, true);
+
+        Env().TestWaitNotification(Runtime(), exportId);
+        TestGetExport(Runtime(), exportId, "/MyRoot");
+
+        const auto* data = S3Mock().GetData().FindPtr("/data_00.csv");
+        UNIT_ASSERT(data);
+        UNIT_ASSERT_VALUES_EQUAL(*data, "1,\"valueA\"\n2,\"valueB\"\n");
+    }
+
     Y_UNIT_TEST(CorruptedDyNumber) {
         EnvOptions().DisableStatsBatching(true);
         Env(); // Init test env

--- a/ydb/core/wrappers/retry_policy.cpp
+++ b/ydb/core/wrappers/retry_policy.cpp
@@ -15,7 +15,9 @@ bool ShouldRetry(const Aws::S3::S3Error& error) {
 
     const auto& exceptionName = error.GetExceptionName();
     if (exceptionName == "TooManyRequests" ||
-        exceptionName == "OperationAborted") {
+        exceptionName == "OperationAborted" ||
+        exceptionName == "InvalidPart" ||
+        exceptionName == "InvalidPartOrder") {
         return true;
     }
 


### PR DESCRIPTION
## Problem

Export to S3 fails permanently, on every shard of a table, with:

```
s3 error: 400 Unable to parse ExceptionName: InvalidPart Message: One or more of the
specified parts could not be found. The part may not have been uploaded, or the
specified entity tag may not match the part's entity tag.
```

Observed after node restarts. The export never recovers, and retrying it does not help.

## Why it never recovers

`InvalidPart` means the ETags recorded in the shard's local DB (`S3UploadedParts`) no
longer describe what the storage holds for that upload id.

The aws sdk has no mapping for `InvalidPart` (it is absent from `S3Errors.h`/`S3Errors.cpp`),
so `AWSErrorMarshaller` builds it via the fallback at `AWSErrorMarshaller.cpp:188` —
`CoreErrors::UNKNOWN`, exception name `InvalidPart`, `isRetryable = false`. With a 400
response code, `NWrappers::ShouldRetry` returns false, so `CanRetry()` is false and
`Handle(TEvCompleteMultipartUploadResponse)` goes straight to the terminal branch.

The damaging part is that the bad state is **persisted**: the upload id and `Complete`
status live in the shard's local database, so every later attempt — and every tablet
restart — replays the identical doomed `CompleteMultipartUpload`. Hence "never recovers".

## Fix

Treat `InvalidPart`/`InvalidPartOrder` the way the filesystem backend's
`FsCompleteMultipartUploadFailed` is already treated: set `ForceNewUpload` and retry,
which resets the persisted upload back to `UploadParts`, clears the stored parts, and
re-uploads every part from number 1. The scan is reset to row 0 on retry, so the fresh
parts cover the whole shard slice and the object is assembled correctly; parts left over
above the new count are discarded by S3 at completion time.

`InvalidPart` and `InvalidPartOrder` join the exception names already listed in
`NWrappers::ShouldRetry`, so `CanRetry()` covers them and the existing retry budget bounds
the loop as it does for every other retryable error. The `ForceNewUpload` decision stays a
separate question inside that branch, since being retryable and needing a fresh upload are
not the same property — `FsCompleteMultipartUploadFailed` was already handled exactly this
way.

Widening `ShouldRetry` does not reach the other callers: `import_s3.cpp`,
`schemeshard_import_getters.cpp` and `schemeshard_export_uploaders.cpp` never complete a
multipart upload, so neither name can be produced there.

`NoSuchUpload` is intentionally left alone: recovering it would need a genuinely new
`CreateMultipartUpload`, and `TS3UploadsManager::Add` refuses to replace an existing row
(`Y_ENSURE(!Uploads.contains(txId))`), so that needs a larger change. See below.

## Test

`TExportToS3Tests::ShouldRestartUploadOnInvalidPart` rejects the first
`CompleteMultipartUpload` with a faithful `InvalidPart`. The **request** is dropped rather
than the response, so the mock does not complete the upload — matching real S3 rejecting
the call while the upload is still alive.

Verified test-first:

- **without** the fix: `FAIL` — export ends `CANCELLED` with the exact production message
- **with** the fix: `GOOD`, and the log shows the intended path —
  `Status: Complete Parts: [...]` → `Status: UploadParts Parts: []` → parts re-uploaded →
  `CompleteMultipartUploadResult`
- the test also asserts the final object content, so a silently corrupted object would fail it

Full suite: **119/119 GOOD** (`ydb/core/tx/schemeshard/ut_export`), including
`ShouldRetryAtFinalStage`, the `ShouldNotCorrupt*OnRetry` family, and all
`TSchemeShardExportToFsTests`.

Note for future test authors: the 4-arg `AWSError` constructor defaults the response code to
`REQUEST_NOT_MADE`, which `retry_policy.cpp` treats as retryable. An injected error without an
explicit `SetResponseCode` therefore does not reproduce this bug at all — an earlier version of
this test passed against unfixed code for that reason. Hence the explicit `BAD_REQUEST`.

## Affected versions

Long-standing latent bug, not a regression. The handler is identical in 26.2.1.11
(`8d6c5a3414d`) and 26.3.1.4 (`c319be96f3d`) — a two-dot diff of the file shows only an
unrelated `DataFormat` line — and `retry_policy.cpp` is byte-identical between them.

## Related defects found but NOT fixed here

1. **Stale part rows are never deleted.** `TS3UploadsManager::ChangeStatus` only ever
   `Update`s `S3UploadedParts` rows, and `Load()` rebuilds the vector up to the highest
   part number present. A part list that shrinks leaves a stale tail on disk that the next
   tablet restart resurrects — which either completes the object with a garbage tail or
   produces exactly this `InvalidPart`. Left out because I have no test that forces a
   shrinking part list, and it touches shard persistence.
2. **`NoSuchUpload` is reported as success.** `Handle(TEvCompleteMultipartUploadResponse)`
   returns `PassAway()` without setting `Error`, so `PassAway` sends
   `TEvFinish(Success = true)` and the shard reports the backup as done with no check that
   the object exists. Correct when a completion response was merely lost, but the same error
   is returned when the upload was aborted or reaped by a bucket lifecycle rule — in which
   case a green export leaves no object. Fixing it properly needs a `HeadObject`
   confirmation.
3. **Orphaned uploads leak.** Nothing aborts the previous multipart upload on this path,
   and S3 bills for orphaned parts.
