### PR TITLE
report export failure when the multipart upload is gone

### DIFF
--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -638,7 +638,10 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
 
         const auto& error = result.GetError();
         if (error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD) {
-            return PassAway();
+            auto request = Aws::S3::Model::HeadObjectRequest()
+                .WithKey(Settings.GetDataKey(DataFormat, CompressionCodec));
+            this->Send(Client, new TEvExternalStorage::TEvHeadObjectRequest(request));
+            return this->Become(&TThis::StateCheckUploadedData);
         }
 
         if (CanRetry(error)) {
@@ -646,6 +649,32 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
                 ForceNewUpload = true;
             }
             UploadId.Clear(); // force getting info after restart
+            Retry();
+        } else {
+            NActors::NStructuredLog::TTextWriter writer;
+
+            TStringBuilder errorBuilder;
+            writer.Write(errorBuilder, LogPrefix());
+            errorBuilder << " error: " << error;
+
+            Error = errorBuilder;
+            PassAway();
+        }
+    }
+
+    void Handle(TEvExternalStorage::TEvHeadObjectResponse::TPtr& ev) {
+        const auto& result = ev->Get()->Result;
+
+        YDB_LOG_DEBUG("[Export]",
+            {"result", result});
+
+        if (result.IsSuccess()) {
+            return PassAway();
+        }
+
+        const auto& error = result.GetError();
+        if (CanRetry(error)) {
+            UploadId.Clear();
             Retry();
         } else {
             NActors::NStructuredLog::TTextWriter writer;
@@ -935,6 +964,16 @@ public:
             hFunc(TEvExternalStorage::TEvUploadPartResponse, Handle);
             hFunc(TEvExternalStorage::TEvCompleteMultipartUploadResponse, Handle);
             hFunc(TEvExternalStorage::TEvAbortMultipartUploadResponse, Handle);
+        default:
+            return StateBase(ev);
+        }
+    }
+
+    STATEFN(StateCheckUploadedData) {
+        YDB_LOG_CREATE_CONTEXT(LogPrefix(),
+            {"actorState", "StateCheckUploadedData"});
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvExternalStorage::TEvHeadObjectResponse, Handle);
         default:
             return StateBase(ev);
         }

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -2762,6 +2762,108 @@ partitioning_settings {
         UNIT_ASSERT_VALUES_EQUAL(*data, "1,\"valueA\"\n2,\"valueB\"\n");
     }
 
+    Y_UNIT_TEST(ShouldNotSucceedWhenMultipartUploadIsLost) {
+        Env(); // Init test env
+        ui64 txId = 100;
+
+        TestCreateTable(Runtime(), ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        Env().TestWaitNotification(Runtime(), txId);
+
+        UpdateRow(Runtime(), "Table", 1, "valueA");
+        UpdateRow(Runtime(), "Table", 2, "valueB");
+
+        THolder<IEventHandle> injectResult;
+        auto prevObserver = Runtime().SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvDataShard::EvProposeTransaction: {
+                    auto& record = ev->Get<TEvDataShard::TEvProposeTransaction>()->Record;
+                    if (record.GetTxKind() != NKikimrTxDataShard::ETransactionKind::TX_KIND_SCHEME) {
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    }
+
+                    NKikimrTxDataShard::TFlatSchemeTransaction schemeTx;
+                    UNIT_ASSERT(schemeTx.ParseFromString(record.GetTxBody()));
+
+                    // Force a multipart upload so that CompleteMultipartUpload is reached.
+                    if (schemeTx.HasBackup()) {
+                        schemeTx.MutableBackup()->MutableScanSettings()->SetRowsBatchSize(1);
+                        schemeTx.MutableBackup()->MutableS3Settings()->MutableLimits()->SetMinWriteBatchSize(1);
+                        record.SetTxBody(schemeTx.SerializeAsString());
+                    }
+
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+
+                case NWrappers::NExternalStorage::EvCompleteMultipartUploadRequest: {
+                    // S3 no longer knows about this multipart upload (session expired, aborted by
+                    // a lifecycle policy, or lost across a restart). Drop the request so it never
+                    // reaches the server: CompleteMultipartUpload is what assembles the object, so
+                    // nothing is materialised - exactly what happens in production.
+                    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+                        Aws::S3::S3Errors::NO_SUCH_UPLOAD,
+                        "NoSuchUpload",
+                        "The specified upload does not exist. The upload ID may be invalid,"
+                        " or the upload may have been aborted or completed.",
+                        false /* isRetryable */);
+                    // The 4-arg ctor leaves m_responseCode at REQUEST_NOT_MADE, which
+                    // NWrappers::ShouldRetry treats as retryable - set the real code explicitly.
+                    error.SetResponseCode(Aws::Http::HttpResponseCode::NOT_FOUND);
+
+                    auto response = MakeHolder<NWrappers::NExternalStorage::TEvCompleteMultipartUploadResponse>(
+                        std::nullopt,
+                        Aws::Utils::Outcome<Aws::S3::Model::CompleteMultipartUploadResult, Aws::S3::S3Error>(error)
+                    );
+                    // Reply to the uploader (the request's sender) on behalf of the storage wrapper.
+                    injectResult = MakeHolder<IEventHandle>(ev->Sender, ev->Recipient, response.Release(), 0, ev->Cookie);
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                default: {
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+            }
+        });
+
+        const auto exportId = ++txId;
+        TestExport(Runtime(), txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_path: "/MyRoot/Table"
+                destination_prefix: ""
+              }
+            }
+        )", S3Port()));
+
+        if (!injectResult) {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&injectResult](IEventHandle&) -> bool {
+                return bool(injectResult);
+            });
+            Runtime().DispatchEvents(opts);
+        }
+
+        Runtime().SetObserverFunc(prevObserver);
+        Runtime().Send(injectResult.Release(), 0, true);
+
+        Env().TestWaitNotification(Runtime(), exportId);
+
+        // The table's data object was never assembled by S3.
+        const auto& data = S3Mock().GetData();
+        UNIT_ASSERT_C(data.find("/data_00.csv") == data.end(),
+            "precondition: CompleteMultipartUpload failed, so /data_00.csv must not exist");
+
+        // Therefore the export must NOT report success. Reporting SUCCESS here means the backup
+        // is recorded as complete while the exported table is missing from the bucket.
+        TestGetExport(Runtime(), exportId, "/MyRoot", Ydb::StatusIds::CANCELLED);
+    }
+
     Y_UNIT_TEST(CorruptedDyNumber) {
         EnvOptions().DisableStatsBatching(true);
         Env(); // Init test env


### PR DESCRIPTION
## Problem

`CompleteMultipartUpload` is what assembles the object in the storage. When it came back with `NoSuchUpload` the handler returned early without recording anything:

```cpp
const auto& error = result.GetError();
if (error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD) {
    return PassAway();
}
```

`PassAway()` reports `TEvFinish(Error.Empty(), ...)` to the scan, so an unset `Error` means success. An export whose data object was never assembled finished with `SUCCESS` and no issues while the table was missing from the bucket — a backup silently recorded as good.

## What NoSuchUpload actually means

It does not say on its own whether anything was written. The upload can be gone for two opposite reasons:

- it expired, was aborted by a lifecycle policy, or was lost across a restart — nothing was assembled, and the export must fail
- a completion of ours already succeeded and its response never reached us — the object is there and the export did finish

Reporting success loses data in the first case. Reporting failure fails a completed export in the second, which is not hypothetical: the retry path re-issues `CompleteMultipartUpload` after a lost or retryable response, and the storage answers `NoSuchUpload` because our own earlier completion consumed the upload. `TExportToS3Tests::ShouldRetryAtFinalStage` already covers exactly that sequence.

## Fix

Ask the storage rather than guess. On `NoSuchUpload` the uploader heads the data key and decides on the answer:

```cpp
if (error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD) {
    auto request = Aws::S3::Model::HeadObjectRequest()
        .WithKey(Settings.GetDataKey(DataFormat, CompressionCodec));
    this->Send(Client, new TEvExternalStorage::TEvHeadObjectRequest(request));
    return this->Become(&TThis::StateCheckUploadedData);
}
```

The object being present means an earlier completion succeeded and the export is done. Its absence means the upload is gone and nothing was written, which is reported as an error and cancels the export:

```
TExport::TTxProgress: issues during backing up, cancelling
Issue: 'shard: ...:2, error: s3 error: 404 ...'
```

A head that fails for a retryable reason takes the usual retry path rather than being read as absence.

Restarting the upload is not an option here, unlike `InvalidPart` in #49946: `ForceNewUpload` reuses the persisted upload id, which is exactly the one the storage no longer knows about. Recovering rather than failing would additionally require dropping the persisted `TS3Upload` row so a fresh id is minted, which is a larger change than this correctness fix.

## Tests

`TExportToS3Tests::ShouldNotSucceedWhenMultipartUploadIsLost` drops the `CompleteMultipartUpload` **request** rather than injecting an error into its response. `TS3Mock` is an http server, so by the time the response event exists the object has already been assembled; dropping the request means nothing is written and the missing data is asserted rather than assumed:

```cpp
UNIT_ASSERT_C(data.find("/data_00.csv") == data.end(), ...);   // nothing was assembled
TestGetExport(Runtime(), exportId, "/MyRoot", Ydb::StatusIds::CANCELLED);
```

Without the fix the first assertion passes and the second fails with `Unexpected status: SUCCESS, issues:` — the export claiming success over missing data.

The pre-existing `ShouldRetryAtFinalStage` covers the opposite direction. It injects a retryable error into the **response**, so the mock has already assembled the object and erased the upload; the retry then meets `NoSuchUpload` over data that exists, and the export must still succeed. The two together pin both readings of the error.

## Relation to #49946

Independent, and both branch from the same base. #49946 handles `InvalidPart`, where the upload still exists but the recorded part etags are stale, and the export fails loudly. This one handles `NoSuchUpload`, where the upload is gone. The `NO_SUCH_UPLOAD` branch short-circuits before `RequiresNewUpload()` is consulted, so #49946 does not cover it — verified by running this test against that branch.
