### PR TITLE
keep persisted import items in sync with the item list

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1682,7 +1682,7 @@ public:
 
     static void PersistCreateImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistNewImportItem(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemIdx);
-    static void PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
+    static void PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemsSizeBefore);
     void PersistRemoveImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistImportState(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistImportSettings(NIceDb::TNiceDb& db, const TImportInfo& importInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -274,7 +274,11 @@ void TSchemeShard::PersistNewImportItem(NIceDb::TNiceDb& db, const TImportInfo& 
     );
 }
 
-void TSchemeShard::PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo) {
+void TSchemeShard::PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemsSizeBefore) {
+    for (ui32 itemIdx = importInfo.Items.size(); itemIdx < itemsSizeBefore; ++itemIdx) {
+        db.Table<Schema::ImportItems>().Key(importInfo.Id, itemIdx).Delete();
+    }
+
     // There can be new items, so do at least the same as for creation
     for (ui32 itemIdx : xrange(importInfo.Items.size())) {
         const auto& item = importInfo.Items.at(itemIdx);

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -1451,6 +1451,7 @@ private:
             }
         }
 
+        const ui32 itemsSizeBefore = importInfo->Items.size();
         const TImportInfo::TFillItemsFromSchemaMappingResult fillResult = importInfo->FillItemsFromSchemaMapping(Self);
         if (!fillResult.Success) {
             return CancelAndPersist(db, importInfo, -1, fillResult.ErrorMessage, "invalid items in schema mapping");
@@ -1458,7 +1459,7 @@ private:
 
         importInfo->State = EState::Waiting;
         PersistImportState(db, *importInfo);
-        PersistSchemaMappingImportFields(db, *importInfo);
+        PersistSchemaMappingImportFields(db, *importInfo, itemsSizeBefore);
         Resume(txc, ctx);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -3478,7 +3478,9 @@ TImportInfo::TFillItemsFromSchemaMappingResult TImportInfo::FillItemsFromSchemaM
         result.AddError("no items to import");
     }
 
-    Items.swap(items);
+    if (result.Success) {
+        Items.swap(items);
+    }
 
     return result;
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1525,6 +1525,34 @@ namespace NSchemeShardUT_Private {
         return TestCancelImport(runtime, TTestTxConfig::SchemeShard, txId, dbName, importId, expectedStatus);
     }
 
+    TEvImport::TEvForgetImportRequest* ForgetImportRequest(ui64 txId, const TString& dbName, ui64 importId) {
+        return new TEvImport::TEvForgetImportRequest(txId, dbName, importId);
+    }
+
+    void AsyncForgetImport(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 txId, const TString& dbName, ui64 importId) {
+        AsyncSend(runtime, schemeshardId, ForgetImportRequest(txId, dbName, importId));
+    }
+
+    void AsyncForgetImport(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 importId) {
+        AsyncForgetImport(runtime, TTestTxConfig::SchemeShard, txId, dbName, importId);
+    }
+
+    NKikimrImport::TEvForgetImportResponse TestForgetImport(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 txId, const TString& dbName, ui64 importId,
+            Ydb::StatusIds::StatusCode expectedStatus) {
+        AsyncForgetImport(runtime, schemeshardId, txId, dbName, importId);
+
+        TAutoPtr<IEventHandle> handle;
+        auto ev = runtime.GrabEdgeEvent<TEvImport::TEvForgetImportResponse>(handle);
+        UNIT_ASSERT_EQUAL(ev->Record.GetResponse().GetStatus(), expectedStatus);
+
+        return ev->Record;
+    }
+
+    NKikimrImport::TEvForgetImportResponse TestForgetImport(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 importId,
+            Ydb::StatusIds::StatusCode expectedStatus) {
+        return TestForgetImport(runtime, TTestTxConfig::SchemeShard, txId, dbName, importId, expectedStatus);
+    }
+
     NKikimrBackup::TEvGetIncrementalBackupResponse TestGetIncrementalBackup(TTestActorRuntime& runtime, ui64 id, const TString& dbName,
             Ydb::StatusIds::StatusCode expectedStatus) {
         ForwardToTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor(), new TEvBackup::TEvGetIncrementalBackupRequest(dbName, id));

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -550,6 +550,13 @@ namespace NSchemeShardUT_Private {
             Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
     NKikimrImport::TEvCancelImportResponse TestCancelImport(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 importId,
             Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    TEvImport::TEvForgetImportRequest* ForgetImportRequest(ui64 txId, const TString& dbName, ui64 importId);
+    void AsyncForgetImport(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 txId, const TString& dbName, ui64 importId);
+    void AsyncForgetImport(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 importId);
+    NKikimrImport::TEvForgetImportResponse TestForgetImport(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 txId, const TString& dbName, ui64 importId,
+            Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    NKikimrImport::TEvForgetImportResponse TestForgetImport(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 importId,
+            Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
 
     ////////// backup
     NKikimrBackup::TEvGetIncrementalBackupResponse TestGetIncrementalBackup(TTestActorRuntime& runtime, ui64 id, const TString& dbName,

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -4017,8 +4017,9 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         TestGetImport(runtime, importId, "/MyRoot", Ydb::StatusIds::CANCELLED);
 
         if (forgetBeforeReboot) {
-            // PersistRemoveImport deletes ImportItems for [0, Items.size()) but drops the Imports
-            // row unconditionally, so rows past the shrunk count outlive their parent.
+            // Without the fix, PersistRemoveImport deleted ImportItems for [0, Items.size()) but
+            // dropped the Imports row unconditionally, so rows past the shrunk count outlived
+            // their parent.
             TestForgetImport(runtime, ++txId, "/MyRoot", importId);
         }
 
@@ -4036,6 +4037,98 @@ Y_UNIT_TEST_SUITE(TImportTests) {
     // Boots into "Import not found": forgetting the import leaves the surplus rows orphaned.
     Y_UNIT_TEST(ShouldNotOrphanItemsWhenForgettingFailedImport) {
         ImportWithMissingItemImpl(true);
+    }
+
+    // Same corruption, reached without any error at all. exclude_regexps is matched against the
+    // destination path when the items are created and against the source object path when the
+    // schema mapping is applied, so an item can be persisted and then contribute nothing. Its
+    // prefix is still found, so no error is recorded and FillItemsFromSchemaMapping succeeds with
+    // a shorter list; the ImportItems row written for it by PersistCreateImport survives.
+    void ImportWithExcludedItemImpl(bool forgetBeforeReboot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        runtime.GetAppData().FeatureFlags.SetEnableExportFiltering(true);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "String" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table2"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "String" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TestExport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              source_path: "/MyRoot"
+              destination_prefix: "BackupPrefix"
+              items {
+                source_path: "/MyRoot/Table1"
+              }
+              items {
+                source_path: "/MyRoot/Table2"
+              }
+            }
+        )", port));
+        env.TestWaitNotification(runtime, txId);
+        TestGetExport(runtime, txId, "/MyRoot");
+
+        // "Table2" does not match the destination "/MyRoot/Restored2", so the second item is
+        // created and persisted, but it does match the source object path in the backup listing,
+        // so the schema mapping drops it.
+        const ui64 importId = ++txId;
+        TestImport(runtime, importId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              source_prefix: "BackupPrefix"
+              exclude_regexps: "Table2"
+              items {
+                source_path: "Table1"
+                destination_path: "/MyRoot/Restored1"
+              }
+              items {
+                source_path: "Table2"
+                destination_path: "/MyRoot/Restored2"
+              }
+            }
+        )", port));
+        env.TestWaitNotification(runtime, importId);
+
+        if (forgetBeforeReboot) {
+            TestForgetImport(runtime, ++txId, "/MyRoot", importId);
+        }
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Getting here at all means SchemeShard came back up.
+        TestLs(runtime, "/MyRoot/Table1", false, NLs::PathExist);
+    }
+
+    // Boots into "Invalid item's index" even though the import itself reported no error.
+    Y_UNIT_TEST(ShouldNotCorruptItemsWhenSchemaMappingExcludesItem) {
+        ImportWithExcludedItemImpl(false);
+    }
+
+    // Boots into "Import not found": the surplus row outlives the parent it was never counted in.
+    Y_UNIT_TEST(ShouldNotOrphanItemsWhenForgettingExcludedItemImport) {
+        ImportWithExcludedItemImpl(true);
     }
 
     Y_UNIT_TEST_FLAG(ImportStandaloneColumnTableWithLocalMinMaxIndexes, EnableDataShardDirectPartImport) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -3956,6 +3956,88 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         assertBloomIndexes("/MyRoot/OlapBloomImported");
     }
 
+    // Runs an import that names one item present in the backup and one that is not, so that
+    // FillItemsFromSchemaMapping fails. It swaps the shortened list into Items regardless of the
+    // error and the cancellation persists that shorter count, while every ImportItems row written
+    // by PersistCreateImport is still there. Rebooting SchemeShard afterwards makes TTxInit read
+    // those rows back.
+    void ImportWithMissingItemImpl(bool forgetBeforeReboot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        // Needed to reach EState::DownloadExportMetadata, which is what fetches the schema
+        // mapping and thus runs FillItemsFromSchemaMapping.
+        runtime.GetAppData().FeatureFlags.SetEnableExportFiltering(true);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "String" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TestExport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              source_path: "/MyRoot"
+              destination_prefix: "BackupPrefix"
+              items {
+                source_path: "/MyRoot/Table"
+              }
+            }
+        )", port));
+        env.TestWaitNotification(runtime, txId);
+        TestGetExport(runtime, txId, "/MyRoot");
+
+        const ui64 importId = ++txId;
+        TestImport(runtime, importId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              source_prefix: "BackupPrefix"
+              items {
+                source_path: "Table"
+                destination_path: "/MyRoot/Restored"
+              }
+              items {
+                source_path: "NoSuchTable"
+                destination_path: "/MyRoot/Restored2"
+              }
+            }
+        )", port));
+        env.TestWaitNotification(runtime, importId);
+        TestGetImport(runtime, importId, "/MyRoot", Ydb::StatusIds::CANCELLED);
+
+        if (forgetBeforeReboot) {
+            // PersistRemoveImport deletes ImportItems for [0, Items.size()) but drops the Imports
+            // row unconditionally, so rows past the shrunk count outlive their parent.
+            TestForgetImport(runtime, ++txId, "/MyRoot", importId);
+        }
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Getting here at all means SchemeShard came back up.
+        TestLs(runtime, "/MyRoot/Table", false, NLs::PathExist);
+    }
+
+    // Boots into "Invalid item's index": the recorded count no longer covers the persisted rows.
+    Y_UNIT_TEST(ShouldNotCorruptItemsWhenSchemaMappingFails) {
+        ImportWithMissingItemImpl(false);
+    }
+
+    // Boots into "Import not found": forgetting the import leaves the surplus rows orphaned.
+    Y_UNIT_TEST(ShouldNotOrphanItemsWhenForgettingFailedImport) {
+        ImportWithMissingItemImpl(true);
+    }
+
     Y_UNIT_TEST_FLAG(ImportStandaloneColumnTableWithLocalMinMaxIndexes, EnableDataShardDirectPartImport) {
         TPortManager portManager;
         const ui16 port = portManager.GetPort();


### PR DESCRIPTION
## Problem

A schemeshard could not start, in a loop, after a restart:

```
VERIFY failed: Import not found: importId# 1137357911471465
  contrib/ydb/core/tx/schemeshard/schemeshard__init.cpp:5232
  ReadEverything(): requirement Self->Imports.contains(importId) failed
```

`TTxInit::ReadEverything` requires every `ImportItems` row to belong to a known import, and to have an index below the item count recorded for that import. A row that satisfies neither makes the tablet abort during boot — and it cannot be cleaned up, because cleaning it up needs a running schemeshard.

## Cause

`TImportInfo::FillItemsFromSchemaMapping` rebuilds the item list from the schema mapping and swaps it into `Items`. When the rebuilt list is shorter than the one persisted by `PersistCreateImport`, the recorded count stops covering the rows on disk: `PersistSchemaMappingImportFields` rewrites the surviving rows but never removes the rest.

From there, two ways to an unbootable tablet:

- restart directly → the surplus row's index is past the recorded count → `Invalid item's index`
- forget the import first → `PersistRemoveImport` deletes rows for the in-memory count but drops the `Imports` row unconditionally, orphaning the rest → `Import not found`

The list shrinks on two different paths.

**On failure**, the swap ran even when the mapping reported errors, so an unresolvable item shortened the list and the subsequent cancellation persisted the shorter count.

**On success**, no error is involved at all. `exclude_regexps` is matched against the destination path when items are created, and against the source object path when the mapping is applied. An item whose prefix is found in the mapping but whose every object is excluded contributes nothing, `notAllItemsFound` is never set, and the mapping succeeds with a shorter list.

The restart does not create the inconsistency; it is just when the state is read back. A cluster can carry it silently for a long time and only fail on the next start, e.g. during an upgrade.

## Fix

Swap only on success, so a failed expansion leaves the persisted state alone:

```cpp
if (result.Success) {
    Items.swap(items);
}
```

That covers the failing path only. On the succeeding path the list shrinks legitimately, so the persisted rows are kept in sync with it instead.

`PersistSchemaMappingImportFields` takes the size the list had before the mapping and deletes the rows past the new one:

```cpp
for (ui32 itemIdx = importInfo.Items.size(); itemIdx < itemsSizeBefore; ++itemIdx) {
    db.Table<Schema::ImportItems>().Key(importInfo.Id, itemIdx).Delete();
}
```

Both values are already in memory, so nothing is read back and the rows and the count that describes them are written in the same transaction. With the surplus rows gone the recorded count covers exactly the rows on disk again, so `PersistRemoveImport` deleting `[0, Items.size())` reaches all of them and leaves no orphan behind its unconditional drop of the parent row — which is what produced `Import not found`.

The checks in `TTxInit` are deliberately left alone. They guard an invariant, and skipping the rows would let genuine corruption load unnoticed — failing loudly is preferable to starting with silently incomplete state.

No stored format changes, so a database written by this code is still readable by the previous one.

## Tests

Both boot failures are reproduced on both paths, then the schemeshard is restarted:

- `TImportTests::ShouldNotCorruptItemsWhenSchemaMappingFails` — unresolvable item, restart directly
- `TImportTests::ShouldNotOrphanItemsWhenForgettingFailedImport` — unresolvable item, forget, then restart
- `TImportTests::ShouldNotCorruptItemsWhenSchemaMappingExcludesItem` — excluded item, mapping succeeds, restart directly
- `TImportTests::ShouldNotOrphanItemsWhenForgettingExcludedItemImport` — excluded item, forget, then restart

Each aborts inside `TTxInit::ReadEverything` without the fix, with `Invalid item's index` and `Import not found` respectively — the latter being the reported failure verbatim. The two excluded-item cases still abort with the swap guarded on success, which is what the counter addresses.

Reaching the schema mapping path needs a common `source_prefix` plus `EnableExportFiltering`; per-item prefixes never enter `EState::DownloadExportMetadata`.

`TestForgetImport` did not exist in `ut_helpers` and is added here, mirroring `TestForgetExport`.

## Note

This change is preventative only: clusters already holding such rows stay unbootable, and there is currently no in-product way to repair them.

