### PR TITLE
[NBS-7486] Better registration lsn in erase queue. Explicit notification of a completed flush.

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -235,24 +235,24 @@ bool TDDiskState::IsTrackingEnabled() const
     return State != EState::Disabled && (Lagging || IsFresh());
 }
 
-void TDDiskState::OnRangeFlushed(TBlockRange64 range)
+void TDDiskState::OnRangeFlushed(TBlockRange64 range, EFlushCompletion flush)
 {
     if (!IsTrackingEnabled()) {
         return;
     }
 
-    if (Lagging) {
+    // The replica is lagging and data has not been written. Adding the range to
+    // the behind map. Due to lagging switching races with notifications, it is
+    // possible to receive successful flush confirmation on a lagging replica.
+    // We will ignore such ranges for safety.
+    if (Lagging && flush == EFlushCompletion::Missed) {
         BehindField.Add(range);
-    } else {
-        BehindField.Remove(range);
     }
 
-    if (IsFresh() && !Lagging) {
-        AheadField.Add(range);
-        if (OperationalBlockCount) {
-            AheadField.Remove(
-                TBlockRange64::WithLength(0, OperationalBlockCount));
-        }
+    // The replica is not lagging and data has been written. Adding the range to
+    // the ahead map.
+    if (!Lagging && flush == EFlushCompletion::Completed) {
+        AddAhead(range);
     }
 
     UpdateState(false);
@@ -363,6 +363,17 @@ void TDDiskState::UpdateState(bool force)
     }
 
     State = IsFresh() ? EState::Fresh : EState::Operational;
+}
+
+void TDDiskState::AddAhead(TBlockRange64 range)
+{
+    Y_ABORT_UNLESS(!Lagging);
+
+    BehindField.Remove(range);
+    AheadField.Add(range);
+    if (OperationalBlockCount) {
+        AheadField.Remove(TBlockRange64::WithLength(0, OperationalBlockCount));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -988,7 +999,6 @@ void TBlocksDirtyMap::Register(ui64 lsn, EQueueType queueType)
             break;
         }
         case IReadyQueue::EQueueType::Erase: {
-            AddToAheadAndBehind(lsn);
             ReadyToErase.insert(lsn);
 
             ReadyToClone.erase(lsn);
@@ -998,11 +1008,27 @@ void TBlocksDirtyMap::Register(ui64 lsn, EQueueType queueType)
     }
 }
 
-void TBlocksDirtyMap::UnRegister(ui64 lsn)
+void TBlocksDirtyMap::UnRegister(ui64 lsn, EQueueType queueType)
 {
-    ReadyToErase.erase(lsn);
-    ReadyToClone.erase(lsn);
-    ReadyToFlush.erase(lsn);
+    switch (queueType) {
+        case IReadyQueue::EQueueType::Clone: {
+            ReadyToClone.erase(lsn);
+            break;
+        }
+        case IReadyQueue::EQueueType::Flush: {
+            ReadyToFlush.erase(lsn);
+            break;
+        }
+        case IReadyQueue::EQueueType::Erase: {
+            ReadyToErase.erase(lsn);
+            break;
+        }
+    }
+}
+
+void TBlocksDirtyMap::FlushCompleted(ui64 lsn, THostMask ddisks)
+{
+    AddToAheadAndBehind(lsn, ddisks);
 }
 
 void TBlocksDirtyMap::DataToPBufferAdded(
@@ -1248,8 +1274,10 @@ TReadRangeHint TBlocksDirtyMap::MakeReadRangeHint(
                  : TRangeLock(weak_from_this(), lsn));
 }
 
-void TBlocksDirtyMap::AddToAheadAndBehind(ui64 lsn)
+void TBlocksDirtyMap::AddToAheadAndBehind(ui64 lsn, THostMask ddisks)
 {
+    // Check that one of the ddisks is lagging or aheading, in this case it
+    // needs to be notified about the data flush to ddisk.
     bool needNotify = AnyOf(
         DDiskStates,
         [](const TDDiskState& ddisk) { return ddisk.IsTrackingEnabled(); });
@@ -1265,8 +1293,11 @@ void TBlocksDirtyMap::AddToAheadAndBehind(ui64 lsn)
         state == TInflightInfo::EState::PBufferFlushed ||
         state == TInflightInfo::EState::PBufferErasing);
 
-    for (auto& ddiskState: DDiskStates) {
-        ddiskState.OnRangeFlushed(inflight->Range);
+    for (THostIndex host = 0; host < GetHostCount(); ++host) {
+        DDiskStates[host].OnRangeFlushed(
+            inflight->Range,
+            ddisks.Get(host) ? TDDiskState::EFlushCompletion::Completed
+                             : TDDiskState::EFlushCompletion::Missed);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -160,6 +160,12 @@ public:
                  // outdated and can't be read.
     };
 
+    enum class EFlushCompletion
+    {
+        Completed,   // Data flushed to DDisk
+        Missed,      // Data not flushed to DDisk
+    };
+
     // Enables the use of DDisk. If the operational blocks count less then total
     // block count, then the DDisk is only partially filled (fresh).
     void Init(ui64 totalBlockCount, ui64 operationalBlockCount);
@@ -179,7 +185,7 @@ public:
     // passed to the OnRangeFlushed() method.
     [[nodiscard]] bool IsTrackingEnabled() const;
     // Updates the BehindField and the Ahead Field if required.
-    void OnRangeFlushed(TBlockRange64 range);
+    void OnRangeFlushed(TBlockRange64 range, EFlushCompletion flush);
 
     [[nodiscard]] EState GetState() const;
     [[nodiscard]] bool CanReadFromDDisk(TBlockRange64 range) const;
@@ -195,6 +201,7 @@ public:
 private:
     [[nodiscard]] bool IsFresh() const;
     void UpdateState(bool force);
+    void AddAhead(TBlockRange64 range);
 
     EState State = EState::Disabled;
 
@@ -326,7 +333,8 @@ public:
 
     // IReadyQueue implementation
     void Register(ui64 lsn, EQueueType queueType) override;
-    void UnRegister(ui64 lsn) override;
+    void UnRegister(ui64 lsn, EQueueType queueType) override;
+    void FlushCompleted(ui64 lsn, THostMask ddisks) override;
     void DataToPBufferAdded(
         THostIndex host,
         EPBufferCounter counter,
@@ -385,7 +393,7 @@ private:
         TBlockRange64 range,
         ui64 offsetBlocks);
 
-    void AddToAheadAndBehind(ui64 lsn);
+    void AddToAheadAndBehind(ui64 lsn, THostMask ddisks);
 
     [[nodiscard]] bool HasInflightFlush(THostIndex host, TBlockRange64 range);
     void InflightFlushFinished(TBlockRange64 range);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -811,6 +811,97 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         }
     }
 
+    // A range missed while the DDisk was lagging is recorded in the Behind
+    // field. Once the DDisk stops lagging and the same range is flushed
+    // successfully, AddAhead must move it out of Behind and into Ahead (the
+    // BehindField.Remove step): the range is now up-to-date, not outdated.
+    Y_UNIT_TEST(ShouldMoveRangeFromBehindToAheadOnLateFlush)
+    {
+        TDDiskState ddisk;
+        // Fresh DDisk (operational 5 < total 100) => tracking enabled.
+        ddisk.Init(/*totalBlockCount=*/100, /*operationalBlockCount=*/5);
+        UNIT_ASSERT_VALUES_EQUAL(true, ddisk.IsTrackingEnabled());
+
+        // While lagging, a missed flush marks the range as outdated (Behind).
+        ddisk.StartLagging();
+        ddisk.OnRangeFlushed(
+            TBlockRange64::WithLength(10, 10),
+            TDDiskState::EFlushCompletion::Missed);
+        UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintAhead());
+
+        // The DDisk catches up and the same range is flushed successfully.
+        // The range must leave Behind and appear in Ahead.
+        ddisk.StopLagging();
+        ddisk.OnRangeFlushed(
+            TBlockRange64::WithLength(10, 10),
+            TDDiskState::EFlushCompletion::Completed);
+        UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintAhead());
+    }
+
+    // A Fresh DDisk has range tracking enabled. When a write is flushed to it,
+    // FlushCompleted must propagate the completion down to the DDisk state so
+    // the flushed range is recorded in the DDisk's Ahead field (data that is
+    // already up-to-date above the operational watermark and needs no sync).
+    // Operational DDisks have tracking disabled, so they record nothing.
+    Y_UNIT_TEST(ShouldTrackAheadRangeOnFreshDDiskAfterFlush)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+        auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        // Promote hand-off H3 to primary and make it Fresh with a low
+        // watermark so tracking is enabled and writes above the watermark are
+        // recorded as "ahead".
+        vchunkConfig.PromoteHost(3);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 5);
+        dirtyMap->UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768};"
+            "H1*{Operational,32768};"
+            "H2*{Operational,32768};"
+            "H3*{Fresh+,5};"
+            "H4+{Disabled,0};",
+            dirtyMap->DebugPrintDDiskState());
+
+        // Nothing tracked before the flush.
+        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintAhead());
+        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintBehind());
+
+        // Write above the fresh watermark to all four DDisks.
+        const THostMask requested = MakeHostMask(true, true, true, true, false);
+        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->WriteFinished(
+            123,
+            TBlockRange64::WithLength(10, 10),
+            requested,
+            requested);
+
+        // Finish flushes to every DDisk.
+        auto flushHint = dirtyMap->MakeFlushHint(1);
+        UNIT_ASSERT_EQUAL(false, flushHint.Empty());
+        for (const auto& [route, hint]: flushHint.GetAllHints()) {
+            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
+        }
+
+        // FlushCompleted recorded the flushed range in the Fresh DDisk's Ahead
+        // field. Only the Fresh host H3 tracks; the Operational hosts do not.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "  H3: [10..19]\n",
+            dirtyMap->DebugPrintAhead());
+        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintBehind());
+
+        // Drain erases so the inflight map ends clean.
+        auto eraseHints = dirtyMap->MakeEraseHint(1);
+        for (const auto& [host, hint]: eraseHints.GetAllHints()) {
+            dirtyMap->EraseFinished(host, MakeLsnVector(hint.Segments), {});
+        }
+        UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
+    }
+
     Y_UNIT_TEST(ShouldWriteAndFlushAndEraseWithOneDisabled)
     {
         auto vchunkConfig = MakeTestVChunkConfig();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -74,6 +74,10 @@ TInflightInfo::TInflightInfo(TInflightInfo&& other) noexcept
 
 TInflightInfo::~TInflightInfo()
 {
+    if (!ReadyQueue) {
+        return;
+    }
+
     Y_ABORT_UNLESS(PBuffersLockCount == 0);
     Y_ABORT_UNLESS(WriteConfirmed.Exclude(WriteRequested).Empty());
 
@@ -238,6 +242,7 @@ void TInflightInfo::RequestErase(THostIndex host)
     Y_ABORT_UNLESS(!EraseRequested.Get(host));
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
     Y_ABORT_UNLESS(FlushConfirmed.Count() >= QuorumDirectBlockGroupHostCount);
+    Y_ABORT_UNLESS(PBuffersLockCount == 0);
 
     SetState(EState::PBufferErasing);
     EraseRequested.Set(host);
@@ -248,6 +253,7 @@ bool TInflightInfo::ConfirmErase(THostIndex host)
     Y_ABORT_UNLESS(State == EState::PBufferErasing);
     Y_ABORT_UNLESS(EraseRequested.Get(host));
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
+    Y_ABORT_UNLESS(PBuffersLockCount == 0);
 
     EraseConfirmed.Set(host);
 
@@ -260,9 +266,10 @@ void TInflightInfo::EraseFailed(THostIndex host)
     Y_ABORT_UNLESS(
         State == EState::PBufferErasing || State == EState::PBufferErased);
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
+    Y_ABORT_UNLESS(PBuffersLockCount == 0);
 
     if (State == EState::PBufferErased) {
-        // Belated error response after config has bee changed.
+        // Belated error response after config has been changed.
         Y_ABORT_UNLESS(Disabled.Get(host));
         return;
     }
@@ -281,7 +288,7 @@ void TInflightInfo::UpdateHosts(
     THostMask removed,
     THostMask disabled)
 {
-    // Removed hosts should be disabled to.
+    // Removed hosts should be disabled too.
     Y_ABORT_UNLESS(removed.Exclude(disabled).Empty());
 
     switch (State) {
@@ -335,8 +342,8 @@ void TInflightInfo::LockPBuffer()
     ++PBuffersLockCount;
 
     if (PBuffersLockCount == 1) {
-        // When lsn locked for reading, we should not erase it. (TODO)
-        ReadyQueue->UnRegister(Lsn);
+        // When lsn locked for reading, we should not erase it.
+        ReadyQueue->UnRegister(Lsn, IReadyQueue::EQueueType::Erase);
         ApplyBytes(WriteConfirmed, IReadyQueue::EPBufferCounter::Locked, true);
     }
 }
@@ -352,12 +359,7 @@ void TInflightInfo::UnlockPBuffer()
 
     if (PBuffersLockCount == 0) {
         ApplyBytes(WriteConfirmed, IReadyQueue::EPBufferCounter::Locked, false);
-
-        if (State == EState::PBufferWritten) {
-            ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
-        } else if (State == EState::PBufferFlushed) {
-            ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
-        }
+        MaybeQueryErase();
     }
 }
 
@@ -444,10 +446,7 @@ void TInflightInfo::MaybeAdvanceToFlushed()
         FlushConfirmed.Count() >= QuorumDirectBlockGroupHostCount)
     {
         SetState(EState::PBufferFlushed);
-    }
-
-    if (State == EState::PBufferFlushed && PBuffersLockCount == 0) {
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+        MaybeQueryErase();
     }
 }
 
@@ -463,11 +462,18 @@ void TInflightInfo::MaybeAdvanceToErased()
 
 void TInflightInfo::MaybeQueryErase()
 {
+    if (PBuffersLockCount != 0 || State == EState::PBufferWritten ||
+        State == EState::PBufferFlushing)
+    {
+        return;
+    }
+
     Y_ABORT_UNLESS(
         State == EState::PBufferFlushed || State == EState::PBufferErasing);
 
     if (!WriteRequested.Exclude(Disabled).Exclude(EraseRequested).Empty()) {
         ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+        ReadyQueue->FlushCompleted(Lsn, FlushConfirmed);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -37,8 +37,11 @@ struct IReadyQueue
     // the old one.
     virtual void Register(ui64 lsn, EQueueType queueType) = 0;
 
-    // Removes all registrations from Lsn.
-    virtual void UnRegister(ui64 lsn) = 0;
+    // Removes Lsn registration.
+    virtual void UnRegister(ui64 lsn, EQueueType queueType) = 0;
+
+    // Notifies of flushes completion to DDisks.
+    virtual void FlushCompleted(ui64 lsn, THostMask ddisks) = 0;
 
     // Notification about the change of byte counters in PBuffer
     virtual void DataToPBufferAdded(
@@ -83,7 +86,7 @@ public:
         // concurrent read sees the pre-write data on DDisk, as before).
         PBufferPendingWrite,
 
-        // During the recovery, a item without quorum was detected. It must be
+        // During the recovery, an item without quorum was detected. It must be
         // copied to other PBuffers.
         // Reading will be possible only after receiving a quorum.
         PBufferIncompleteWrite,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -37,11 +37,27 @@ struct TTestReadyQueue: public IReadyQueue
         }
     }
 
-    void UnRegister(ui64 lsn) override
+    void UnRegister(ui64 lsn, EQueueType queueType) override
     {
-        ReadyToErase.erase(lsn);
-        ReadyToClone.erase(lsn);
-        ReadyToFlush.erase(lsn);
+        switch (queueType) {
+            case IReadyQueue::EQueueType::Clone: {
+                ReadyToClone.erase(lsn);
+                break;
+            }
+            case IReadyQueue::EQueueType::Flush: {
+                ReadyToFlush.erase(lsn);
+                break;
+            }
+            case IReadyQueue::EQueueType::Erase: {
+                ReadyToErase.erase(lsn);
+                break;
+            }
+        }
+    }
+
+    void FlushCompleted(ui64 lsn, THostMask ddisks) override
+    {
+        FlushCompletions[lsn] = ddisks;
     }
 
     void DataToPBufferAdded(
@@ -65,6 +81,17 @@ struct TTestReadyQueue: public IReadyQueue
         return PBufferCounters[host][EPBufferCounter::Total];
     }
 
+    bool HasFlushCompleted(ui64 lsn)
+    {
+        return FlushCompletions.contains(lsn);
+    }
+
+    TString GetFlushCompletedMask(ui64 lsn)
+    {
+        auto it = FlushCompletions.find(lsn);
+        return it == FlushCompletions.end() ? "" : it->second.Print();
+    }
+
     size_t GetLockedBytes(THostIndex host)
     {
         return PBufferCounters[host][EPBufferCounter::Locked];
@@ -73,6 +100,7 @@ struct TTestReadyQueue: public IReadyQueue
     THashSet<ui64> ReadyToClone;
     THashSet<ui64> ReadyToFlush;
     THashSet<ui64> ReadyToErase;
+    THashMap<ui64, THostMask> FlushCompletions;
     TMap<THostIndex, TMap<EPBufferCounter, size_t>> PBufferCounters;
 };
 
@@ -655,11 +683,13 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             123,
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+        FlushAll(inflightInfo);
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
 
         // Locking accounts locked bytes on all confirmed hosts and unregisters
-        // the lsn from the flush queue.
+        // the lsn from the erase queue.
         inflightInfo.LockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
             readyQueue.GetLockedBytes(THostIndex{0}));
@@ -683,12 +713,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             readyQueue.GetLockedBytes(THostIndex{0}));
         UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToFlush.contains(123));
 
-        // Final unlock releases the locked bytes and re-registers the flush.
+        // Final unlock releases the locked bytes and re-registers the erase.
         inflightInfo.UnlockPBuffer();
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{0}));
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{1}));
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{2}));
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
     }
 
     Y_UNIT_TEST(ShouldRegisterEraseAfterUnlockInFlushedState)
@@ -867,6 +897,319 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
+
+        EraseAll(inflightInfo);
+    }
+
+    // Locking a still-written (not yet flushed) inflight must only remove it
+    // from the erase queue. Its flush registration has to survive so the buffer
+    // can still be flushed while a read holds the lock.
+    Y_UNIT_TEST(ShouldKeepFlushRegistrationWhenLockingWrittenState)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+
+        // Locking in the written state accounts locked bytes and keeps the lsn
+        // in the flush queue (only the erase queue is touched).
+        inflightInfo.LockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            4096,
+            readyQueue.GetLockedBytes(THostIndex{0}));
+
+        // Unlocking in the written state must not register an erase: erase is
+        // only registered once the buffer is flushed.
+        inflightInfo.UnlockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{0}));
+
+        // Finish flush + erase so the destructor invariants hold.
+        FlushAll(inflightInfo);
+        EraseAll(inflightInfo);
+    }
+
+    // Detach() drops the ready-queue back-reference. A detached inflight must
+    // destruct cleanly even while it is still locked: the destructor short
+    // circuits on the null ReadyQueue instead of asserting on the lock count.
+    Y_UNIT_TEST(ShouldDestructLockedInflightAfterDetach)
+    {
+        TTestReadyQueue readyQueue;
+        {
+            TInflightInfo inflightInfo(
+                &readyQueue,
+                MakeDDisks(),
+                THostMask::MakeEmpty(),
+                123,
+                4096);
+            inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+            FlushAll(inflightInfo);
+
+            // Hold a lock, then detach. The destructor must not abort on the
+            // outstanding lock because ReadyQueue is now null.
+            inflightInfo.LockPBuffer();
+            inflightInfo.Detach();
+        }
+
+        // Detach happens before the counters are released, so they stay put.
+        UNIT_ASSERT_VALUES_EQUAL(4096, readyQueue.GetTotalBytes(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            4096,
+            readyQueue.GetLockedBytes(THostIndex{0}));
+    }
+
+    // The move constructor transfers ownership of the ready-queue
+    // back-reference and resets the source. The moved-from object must destruct
+    // without touching the ready queue, so the accounted bytes are released
+    // only once.
+    Y_UNIT_TEST(ShouldReleaseBytesOnceAfterMove)
+    {
+        TTestReadyQueue readyQueue;
+        {
+            TInflightInfo source(
+                &readyQueue,
+                MakeDDisks(),
+                THostMask::MakeEmpty(),
+                123,
+                4096);
+            source.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+            UNIT_ASSERT_VALUES_EQUAL(
+                4096,
+                readyQueue.GetTotalBytes(THostIndex{0}));
+
+            // Move ownership. The destination keeps the accounting; the source
+            // is left inert and must not double-release on destruction.
+            TInflightInfo destination(std::move(source));
+            UNIT_ASSERT_VALUES_EQUAL(
+                4096,
+                readyQueue.GetTotalBytes(THostIndex{0}));
+
+            FlushAll(destination);
+            EraseAll(destination);
+        }
+
+        // Both objects are destroyed: the source released nothing, the
+        // destination released everything exactly once (no underflow).
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{0}));
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{1}));
+        UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
+    }
+
+    // Once a write is flushed to the DDisk quorum, the ready queue must be
+    // notified via FlushCompleted with the mask of DDisks that confirmed the
+    // flush (here all three hosts).
+    Y_UNIT_TEST(ShouldNotifyFlushCompletedWhenFlushed)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        // No notification before the flush completes.
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+
+        FlushAll(inflightInfo);
+
+        // After the flush reaches the quorum FlushCompleted fires with the full
+        // set of confirmed DDisks.
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[H0,H1,H2]",
+            readyQueue.GetFlushCompletedMask(123));
+
+        EraseAll(inflightInfo);
+    }
+
+    // When a host is disabled/removed before it confirms the flush, the
+    // remaining hosts still form a quorum. FlushCompleted must report only the
+    // hosts that actually confirmed (the disabled one is excluded), so the
+    // dirty map can mark that DDisk as having missed the range.
+    Y_UNIT_TEST(ShouldReportPartialDDiskMaskInFlushCompleted)
+    {
+        TTestReadyQueue readyQueue;
+        // 4 desired DDisks so that after disabling one, 3 remain (== quorum).
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(4),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
+
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{1}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{2}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{3}));
+
+        // Confirm a quorum (hosts 0, 1, 2) but not host 3.
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+
+        // Disable + remove host 3. The quorum holds, the flush completes and
+        // FlushCompleted reports only the confirmed hosts.
+        auto mask = THostMask::MakeMask({THostIndex{3}});
+        inflightInfo.UpdateHosts(THostMask::MakeEmpty(), mask, mask);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[H0,H1,H2]",
+            readyQueue.GetFlushCompletedMask(123));
+
+        // Erase all still-written hosts (host 3 excluded via Disabled).
+        inflightInfo.RequestErase(THostIndex{0});
+        inflightInfo.RequestErase(THostIndex{1});
+        inflightInfo.RequestErase(THostIndex{2});
+        Y_UNUSED(inflightInfo.ConfirmErase(THostIndex{0}));
+        Y_UNUSED(inflightInfo.ConfirmErase(THostIndex{1}));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            inflightInfo.ConfirmErase(THostIndex{2}));
+    }
+
+    // While a read lock is held FlushCompleted must be suppressed: the erase is
+    // not allowed to be registered, and no completion notification may fire
+    // until the buffer is unlocked.
+    Y_UNIT_TEST(ShouldNotNotifyFlushCompletedWhileLocked)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        // Lock before flushing completes.
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{1}));
+        Y_UNUSED(inflightInfo.RequestFlush(THostIndex{2}));
+        inflightInfo.LockPBuffer();
+
+        inflightInfo.ConfirmFlush(THostIndex{0});
+        inflightInfo.ConfirmFlush(THostIndex{1});
+        inflightInfo.ConfirmFlush(THostIndex{2});
+
+        // Flush completed but the lock suppresses the notification.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushed,
+            inflightInfo.GetState());
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+
+        // Unlocking in the flushed state finally fires FlushCompleted.
+        inflightInfo.UnlockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[H0,H1,H2]",
+            readyQueue.GetFlushCompletedMask(123));
+
+        EraseAll(inflightInfo);
+    }
+
+    // A write that is only in the PBufferWritten state (not flushed yet) must
+    // never trigger FlushCompleted, even across a lock/unlock cycle.
+    Y_UNIT_TEST(ShouldNotNotifyFlushCompletedInWrittenState)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        // Lock/unlock while still in the written state: no flush happened, so
+        // no completion notification may fire.
+        inflightInfo.LockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+        inflightInfo.UnlockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+
+        // Finish flush + erase so the destructor invariants hold.
+        FlushAll(inflightInfo);
+        EraseAll(inflightInfo);
+    }
+
+    // A failed erase drops the host back into the erase-needed set and re-runs
+    // the erase-query path, which must notify FlushCompleted again.
+    Y_UNIT_TEST(ShouldNotifyFlushCompletedAgainAfterEraseFailed)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        FlushAll(inflightInfo);
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+
+        // Request erase for host 0 and then fail it. Clearing the capture map
+        // lets us observe the re-notification.
+        inflightInfo.RequestErase(THostIndex{0});
+        readyQueue.FlushCompletions.clear();
+        inflightInfo.EraseFailed(THostIndex{0});
+
+        // EraseFailed re-runs the erase-query path and notifies again.
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[H0,H1,H2]",
+            readyQueue.GetFlushCompletedMask(123));
+
+        EraseAll(inflightInfo);
+    }
+
+    // UnRegister now targets a single queue. Locking a written inflight must
+    // remove it only from the erase queue while keeping the clone registration
+    // of a still-incomplete write intact.
+    Y_UNIT_TEST(ShouldTargetOnlyEraseQueueOnUnRegister)
+    {
+        TTestReadyQueue readyQueue;
+        // Recovery constructor: starts in the clone queue.
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096,
+            THostIndex{0});
+        inflightInfo.RestorePBuffer(THostIndex{1});
+        inflightInfo.RestorePBuffer(THostIndex{2});
+
+        // Quorum reached: moved from clone to flush queue.
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+
+        FlushAll(inflightInfo);
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+
+        // Locking unregisters only the erase queue, nothing else.
+        inflightInfo.LockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
+
+        inflightInfo.UnlockPBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
 
         EraseAll(inflightInfo);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. Better registration lsn in erase queue. 
2. Explicit notification of a completed flush.

### Description for reviewers <!-- (optional) description for those who read this PR -->

