### PR TITLE
Preserve DQ gateway issues

### DIFF
--- a/ydb/library/yql/providers/dq/provider/exec/yql_dq_exectransformer.cpp
+++ b/ydb/library/yql/providers/dq/provider/exec/yql_dq_exectransformer.cpp
@@ -1118,7 +1118,7 @@ private:
                     if (state->Settings->FallbackPolicy.Get().GetOrElse(EFallbackPolicy::Default) == EFallbackPolicy::Never || state->TypeCtx->ForceDq) {
                         auto issues = TIssues{TIssue(ctx.GetPosition(input->Pos()), "Gateway Error").SetCode(TIssuesIds::DQ_GATEWAY_NEED_FALLBACK_ERROR, TSeverityIds::S_WARNING)};
                         issues.AddIssues(res.Issues());
-                        ctx.AssociativeIssues.emplace(input.Get(), std::move(issues));
+                        ctx.IssueManager.RaiseIssues(issues);
                         return IGraphTransformer::TStatus(IGraphTransformer::TStatus::Error);
                     }
 


### PR DESCRIPTION
### Changelog entry

Preserve DQ gateway issues when DQ fallback is disabled.

### Description for reviewers

Preserve gateway issues by raising them through IssueManager in the DQ execution transformer.

Validation:

```
./ya make --build relwithdebinfo ydb/library/yql/providers/dq/provider/exec
```