### PR TITLE
Check query-params for HTTP-requests for strict database users (part 1)

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1032,9 +1032,6 @@ bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::unord
 }
 
 bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(const std::unordered_set<TNodeId>& nodeIds) {
-    if (!IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()))) {
-        return false;
-    }
     if (nodeIds.empty()) {
         return false;
     }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1035,19 +1035,31 @@ bool TViewerPipeClient::IsStrictDatabaseOnlyRequest() {
     return *StrictDatabaseOnlyRequest;
 }
 
+TString TViewerPipeClient::GetUserSID() const {
+    return NACLib::TUserToken(GetRequest().GetUserTokenObject()).GetUserSID();
+}
+
 bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds) {
     if (nodeIds.empty()) {
         return false;
     }
     // We can't validate the scope of the requested nodes without the database node list, and this
     // is an access check, so an unresolved database denies the request instead of letting it through.
+    const bool databaseNodesKnown = AreDatabaseNodesKnown();
     std::unordered_set<TNodeId> databaseNodes;
-    if (AreDatabaseNodesKnown()) {
+    if (databaseNodesKnown) {
         const auto nodes = GetDatabaseNodes();
         databaseNodes.insert(nodes.begin(), nodes.end());
     }
     for (const auto& nodeId : nodeIds) {
         if (!databaseNodes.count(nodeId)) {
+            YDB_LOG_INFO("Access denied: requested node is outside the database",
+                {"logPrefix", GetLogPrefix()},
+                {"user", GetUserSID()},
+                {"database", Database},
+                {"outOfDatabaseNode", nodeId},
+                {"databaseNodeCount", databaseNodes.size()},
+                {"databaseNodesKnown", databaseNodesKnown});
             ReplyAndPassAway(
                 GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
                 "Access denied");

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1023,6 +1023,34 @@ bool TViewerPipeClient::IsDatabaseRequest() const {
     return DatabaseBoardInfoResponse || ResourceBoardInfoResponse;
 }
 
+bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::vector<TNodeId>& nodeIds) {
+    return ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl({nodeIds.begin(), nodeIds.end()});
+}
+
+bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::unordered_set<TNodeId>& nodeIds) {
+    return ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(nodeIds);
+}
+
+bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(const std::unordered_set<TNodeId>& nodeIds) {
+    if (!IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()))) {
+        return false;
+    }
+    if (nodeIds.empty()) {
+        return false;
+    }
+    const auto databaseNodes = GetDatabaseNodes();
+    const auto nodesSet = std::unordered_set<TNodeId>(databaseNodes.begin(), databaseNodes.end());
+    for (const auto& nodeId : nodeIds) {
+        if (!nodesSet.count(nodeId)) {
+            ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
+                "Access denied");
+            return true;
+        }
+    }
+    return false;
+}
+
 void TViewerPipeClient::InitConfig(const TCgiParameters& params) {
     Followers = FromStringWithDefault(params.Get("followers"), Followers);
     Metrics = FromStringWithDefault(params.Get("metrics"), Metrics);

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1023,31 +1023,31 @@ bool TViewerPipeClient::IsDatabaseRequest() const {
     return DatabaseBoardInfoResponse || ResourceBoardInfoResponse;
 }
 
+bool TViewerPipeClient::AreDatabaseNodesKnown() const {
+    return (DatabaseBoardInfoResponse && DatabaseBoardInfoResponse->IsOk()) ||
+        (ResourceBoardInfoResponse && ResourceBoardInfoResponse->IsOk());
+}
+
 bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::vector<TNodeId>& nodeIds) {
-    return ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl({nodeIds.begin(), nodeIds.end()});
-}
-
-bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::unordered_set<TNodeId>& nodeIds) {
-    return ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(nodeIds);
-}
-
-bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(const std::unordered_set<TNodeId>& nodeIds) {
     if (nodeIds.empty()) {
         return false;
     }
-    if (!IsDatabaseRequest()) {
-        // GetDatabaseNodes() can return real database nodes only when IsDatabaseRequest() is true,
-        // otherwise it will return 0 – sentinel for the current node.
-        return false;
+    auto accessDenied = [this]() {
+        ReplyAndPassAway(
+            GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
+            "Access denied");
+        return true;
+    };
+    if (!AreDatabaseNodesKnown()) {
+        // We can't validate the scope of the requested nodes, and this is an access check,
+        // so we deny the request instead of silently letting it through.
+        return accessDenied();
     }
     const auto databaseNodes = GetDatabaseNodes();
     const auto nodesSet = std::unordered_set<TNodeId>(databaseNodes.begin(), databaseNodes.end());
     for (const auto& nodeId : nodeIds) {
         if (!nodesSet.count(nodeId)) {
-            ReplyAndPassAway(
-                GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
-                "Access denied");
-            return true;
+            return accessDenied();
         }
     }
     return false;

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1,5 +1,6 @@
 #include "json_pipe_req.h"
 #include "log.h"
+#include <ydb/core/base/auth.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
 #include <util/generic/overloaded.h>
@@ -1352,6 +1353,14 @@ bool TViewerPipeClient::NeedToRedirect(bool checkDatabaseAuth) {
         Send(HttpEvent->Sender, new NHttp::TEvHttpProxy::TEvSubscribeForCancel(), IEventHandle::FlagTrackDelivery);
     }
     auto request = GetRequest();
+    if (Params.Has("direct") && FromStringWithDefault<bool>(Params.Get("direct"), false) &&
+        IsStrictDatabaseOnlyToken(AppData(), TString(request.GetUserTokenObject()))
+    ) {
+        ReplyAndPassAway(
+            GETHTTPACCESSDENIED("text/plain", "Direct requests are not allowed for database-scoped access"),
+            "Access denied");
+        return true;
+    }
     CheckDatabase = checkDatabaseAuth;
     if (NeedRedirect && request) {
         NeedRedirect = false;

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1028,26 +1028,30 @@ bool TViewerPipeClient::AreDatabaseNodesKnown() const {
         (ResourceBoardInfoResponse && ResourceBoardInfoResponse->IsOk());
 }
 
-bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::vector<TNodeId>& nodeIds) {
+bool TViewerPipeClient::IsStrictDatabaseOnlyRequest() {
+    if (!StrictDatabaseOnlyRequest) {
+        StrictDatabaseOnlyRequest = IsStrictDatabaseOnlyToken(AppData(), GetRequest().GetUserTokenObject());
+    }
+    return *StrictDatabaseOnlyRequest;
+}
+
+bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds) {
     if (nodeIds.empty()) {
         return false;
     }
-    auto accessDenied = [this]() {
-        ReplyAndPassAway(
-            GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
-            "Access denied");
-        return true;
-    };
-    if (!AreDatabaseNodesKnown()) {
-        // We can't validate the scope of the requested nodes, and this is an access check,
-        // so we deny the request instead of silently letting it through.
-        return accessDenied();
+    // We can't validate the scope of the requested nodes without the database node list, and this
+    // is an access check, so an unresolved database denies the request instead of letting it through.
+    std::unordered_set<TNodeId> databaseNodes;
+    if (AreDatabaseNodesKnown()) {
+        const auto nodes = GetDatabaseNodes();
+        databaseNodes.insert(nodes.begin(), nodes.end());
     }
-    const auto databaseNodes = GetDatabaseNodes();
-    const auto nodesSet = std::unordered_set<TNodeId>(databaseNodes.begin(), databaseNodes.end());
     for (const auto& nodeId : nodeIds) {
-        if (!nodesSet.count(nodeId)) {
-            return accessDenied();
+        if (!databaseNodes.count(nodeId)) {
+            ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
+                "Access denied");
+            return true;
         }
     }
     return false;
@@ -1383,14 +1387,6 @@ bool TViewerPipeClient::NeedToRedirect(bool checkDatabaseAuth) {
         Send(HttpEvent->Sender, new NHttp::TEvHttpProxy::TEvSubscribeForCancel(), IEventHandle::FlagTrackDelivery);
     }
     auto request = GetRequest();
-    if (Params.Has("direct") && FromStringWithDefault<bool>(Params.Get("direct"), false) &&
-        IsStrictDatabaseOnlyToken(AppData(), TString(request.GetUserTokenObject()))
-    ) {
-        ReplyAndPassAway(
-            GETHTTPACCESSDENIED("text/plain", "Direct requests are not allowed for database-scoped access"),
-            "Access denied");
-        return true;
-    }
     CheckDatabase = checkDatabaseAuth;
     if (NeedRedirect && request) {
         NeedRedirect = false;

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1038,6 +1038,11 @@ bool TViewerPipeClient::ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(const std::u
     if (nodeIds.empty()) {
         return false;
     }
+    if (!IsDatabaseRequest()) {
+        // GetDatabaseNodes() can return real database nodes only when IsDatabaseRequest() is true,
+        // otherwise it will return 0 – sentinel for the current node.
+        return false;
+    }
     const auto databaseNodes = GetDatabaseNodes();
     const auto nodesSet = std::unordered_set<TNodeId>(databaseNodes.begin(), databaseNodes.end());
     for (const auto& nodeId : nodeIds) {

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "viewer.h"
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/statestorage.h>
 #include <ydb/core/base/tablet_pipe.h>
@@ -340,6 +341,10 @@ protected:
     std::vector<TNodeId> GetNodesFromBoardReply(const TEvStateStorage::TEvBoardInfo& ev);
     std::vector<TNodeId> GetDatabaseNodes();
     bool IsDatabaseRequest() const;
+
+    bool ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::vector<TNodeId>& nodeIds);
+    bool ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::unordered_set<TNodeId>& nodeIds);
+
     void InitConfig(const TCgiParameters& params);
     void InitConfig(const TRequestSettings& settings);
     void BuildParamsFromJson(TStringBuf data);
@@ -360,6 +365,8 @@ protected:
 
     void ClosePipes();
     i32 FailPipeConnect(TTabletId tabletId);
+
+    bool ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(const std::unordered_set<TNodeId>& nodeIds);
 
     bool IsLastRequest() const {
         return DataRequests == 1;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -354,6 +354,9 @@ protected:
     // to see the information about its own database only, never about the cluster.
     bool IsStrictDatabaseOnlyRequest();
 
+    // The SID of the user who sent the request, for logging of the denied requests.
+    TString GetUserSID() const;
+
     // Denies the request unless every given node belongs to the requested database. If the database
     // nodes are unknown, the request is denied too. Returns true if the response has been already sent.
     bool DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds);

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -18,6 +18,8 @@
 #include <ydb/library/wilson_ids/wilson.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
+#include <unordered_set>
+
 namespace NKikimr::NViewer {
 
 using namespace NKikimr;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -341,11 +341,16 @@ protected:
     TRequestResponse<TEvStateStorage::TEvBoardInfo> MakeRequestStateStorageEndpointsLookup(const TString& path, ui64 cookie = 0);
     std::vector<TNodeId> GetNodesFromBoardReply(TEvStateStorage::TEvBoardInfo::TPtr& ev);
     std::vector<TNodeId> GetNodesFromBoardReply(const TEvStateStorage::TEvBoardInfo& ev);
+
+    // Returns real database nodes only when the database (or the shared database for serverless)
+    // endpoints lookup has succeeded, otherwise it returns 0 - a sentinel for the current node.
     std::vector<TNodeId> GetDatabaseNodes();
     bool IsDatabaseRequest() const;
+    bool AreDatabaseNodesKnown() const;
 
+    // Denies the request if any of the given nodes doesn't belong to the requested database,
+    // or if the database nodes are unknown. Returns true if the response has been already sent.
     bool ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::vector<TNodeId>& nodeIds);
-    bool ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::unordered_set<TNodeId>& nodeIds);
 
     void InitConfig(const TCgiParameters& params);
     void InitConfig(const TRequestSettings& settings);
@@ -367,8 +372,6 @@ protected:
 
     void ClosePipes();
     i32 FailPipeConnect(TTabletId tabletId);
-
-    bool ReplyAndPassAwayIfNodesAreOutOfDatabaseImpl(const std::unordered_set<TNodeId>& nodeIds);
 
     bool IsLastRequest() const {
         return DataRequests == 1;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -18,6 +18,7 @@
 #include <ydb/library/wilson_ids/wilson.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
+#include <span>
 #include <unordered_set>
 
 namespace NKikimr::NViewer {
@@ -50,6 +51,7 @@ protected:
     i32 DataRequests = 0; // how many requests we wait to process data
     bool PassedAway = false;
     bool ReplySent = false;
+    std::optional<bool> StrictDatabaseOnlyRequest; // lazily calculated by IsStrictDatabaseOnlyRequest()
     bool UseCache = false;
     bool CheckDatabase = true;
     TDuration CachedDataMaxAge;
@@ -348,9 +350,13 @@ protected:
     bool IsDatabaseRequest() const;
     bool AreDatabaseNodesKnown() const;
 
-    // Denies the request if any of the given nodes doesn't belong to the requested database,
-    // or if the database nodes are unknown. Returns true if the response has been already sent.
-    bool ReplyAndPassAwayIfNodesAreOutOfDatabase(const std::vector<TNodeId>& nodeIds);
+    // True for a token whose highest access level is EAccessLevel::Database: such a user is allowed
+    // to see the information about its own database only, never about the cluster.
+    bool IsStrictDatabaseOnlyRequest();
+
+    // Denies the request unless every given node belongs to the requested database. If the database
+    // nodes are unknown, the request is denied too. Returns true if the response has been already sent.
+    bool DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds);
 
     void InitConfig(const TCgiParameters& params);
     void InitConfig(const TRequestSettings& settings);

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -96,6 +96,10 @@ public:
             if (TBase::RequestSettings.FilterNodeIds.empty() && TBase::IsStrictDatabaseOnlyRequest()) {
                 // If a database has no registered nodes, a strict database-only user gets
                 // 200 with an empty response, not the nodes of the whole cluster.
+                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Empty response: the database has no nodes to ask",
+                    {"logPrefix", TBase::GetLogPrefix()},
+                    {"user", TBase::GetUserSID()},
+                    {"database", TBase::Database});
                 return ReplyAndPassAway();
             }
         }

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -6,7 +6,6 @@
 #include "wb_group.h"
 #include "wb_merge.h"
 #include "wb_req.h"
-#include <ydb/core/base/auth.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/viewer/json/json.h>
 #include <ydb/core/viewer/yaml/yaml.h>
@@ -48,22 +47,8 @@ public:
                      (TNodeId)0,
                      TlsActivationContext->ActorSystem()->NodeId);
 
-        const bool strictDatabaseToken =
-            IsStrictDatabaseOnlyToken(AppData(), TString(TBase::GetRequest().GetUserTokenObject()));
-        // Strict database users must pass `database` query parameter before the handler runs;
-        // IsDatabaseRequest() check below means board resolve succeeded and GetDatabaseNodes() is meaningful.
-        if (strictDatabaseToken && TBase::IsDatabaseRequest() && !nodeIds.empty()) {
-            auto databaseNodes = TBase::GetDatabaseNodes();
-            auto nodesSet = std::unordered_set<TNodeId>(databaseNodes.begin(), databaseNodes.end());
-            for (TNodeId nodeId : nodeIds) {
-                if (!nodesSet.count(nodeId)) {
-                    return ReplyAndPassAway(
-                        TBase::GETHTTPACCESSDENIED(
-                            "text/plain",
-                            "Some requested nodes are outside the specified database"),
-                        "Access denied");
-                }
-            }
+        if (this->ReplyAndPassAwayIfNodesAreOutOfDatabase(nodeIds)) {
+            return;
         }
         if (!nodeIds.empty()) {
             if (TBase::RequestSettings.FilterNodeIds.empty()) {

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -27,6 +27,7 @@ public:
     using TBase::Event;
     using TBase::ReplyAndPassAway;
     TJsonSettings JsonSettings;
+    bool StrictDatabaseOnlyToken = false;
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::VIEWER_HANDLER;
@@ -36,22 +37,35 @@ public:
         : TBase(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (TBase::NeedToRedirect()) {
-            return;
-        }
+    std::vector<TNodeId> GetNodeIdsFromParams() const {
         std::vector<TNodeId> nodeIds;
         SplitIds(TBase::Params.Get("node_id"), ',', nodeIds);
         std::replace(nodeIds.begin(),
                      nodeIds.end(),
                      (TNodeId)0,
                      TlsActivationContext->ActorSystem()->NodeId);
+        return nodeIds;
+    }
 
-        const bool strictDatabaseToken =
-            IsStrictDatabaseOnlyToken(AppData(), TString(TBase::GetRequest().GetUserTokenObject()));
-        if (strictDatabaseToken && TBase::ReplyAndPassAwayIfNodesAreOutOfDatabase(nodeIds)) {
+    // Strict database-only tokens are allowed to request the nodes of their database only.
+    // Must be called after NeedToRedirect(), otherwise the database nodes are not resolved yet.
+    // Returns true if the response has been already sent.
+    bool ReplyAndPassAwayIfNodeIdsAreOutOfDatabase() {
+        StrictDatabaseOnlyToken = IsStrictDatabaseOnlyToken(AppData(), TString(TBase::GetRequest().GetUserTokenObject()));
+        if (!StrictDatabaseOnlyToken) {
+            return false;
+        }
+        return TBase::ReplyAndPassAwayIfNodesAreOutOfDatabase(GetNodeIdsFromParams());
+    }
+
+    void Bootstrap() override {
+        if (TBase::NeedToRedirect()) {
             return;
         }
+        if (ReplyAndPassAwayIfNodeIdsAreOutOfDatabase()) {
+            return;
+        }
+        std::vector<TNodeId> nodeIds = GetNodeIdsFromParams();
         if (!nodeIds.empty()) {
             if (TBase::RequestSettings.FilterNodeIds.empty()) {
                 TBase::RequestSettings.FilterNodeIds = nodeIds;
@@ -81,8 +95,8 @@ public:
                     return ReplyAndPassAway();
                 }
             }
-            if (strictDatabaseToken && TBase::RequestSettings.FilterNodeIds.empty()) {
-                // For strictDatabaseToken if a database has no registered nodes,
+            if (StrictDatabaseOnlyToken && TBase::RequestSettings.FilterNodeIds.empty()) {
+                // For StrictDatabaseOnlyToken if a database has no registered nodes,
                 // we report 200 with an empty response, not with a cluster nodes.
                 return ReplyAndPassAway();
             }

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -27,7 +27,6 @@ public:
     using TBase::Event;
     using TBase::ReplyAndPassAway;
     TJsonSettings JsonSettings;
-    bool StrictDatabaseOnlyToken = false;
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::VIEWER_HANDLER;
@@ -47,22 +46,21 @@ public:
         return nodeIds;
     }
 
-    // Strict database-only tokens are allowed to request the nodes of their database only.
+    // Strict database-only users are allowed to ask the nodes of their database only.
     // Must be called after NeedToRedirect(), otherwise the database nodes are not resolved yet.
     // Returns true if the response has been already sent.
-    bool ReplyAndPassAwayIfNodeIdsAreOutOfDatabase() {
-        StrictDatabaseOnlyToken = IsStrictDatabaseOnlyToken(AppData(), TString(TBase::GetRequest().GetUserTokenObject()));
-        if (!StrictDatabaseOnlyToken) {
+    bool DenyRequestIfNodeIdsAreOutOfDatabase() {
+        if (!TBase::IsStrictDatabaseOnlyRequest()) {
             return false;
         }
-        return TBase::ReplyAndPassAwayIfNodesAreOutOfDatabase(GetNodeIdsFromParams());
+        return TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams());
     }
 
     void Bootstrap() override {
         if (TBase::NeedToRedirect()) {
             return;
         }
-        if (ReplyAndPassAwayIfNodeIdsAreOutOfDatabase()) {
+        if (DenyRequestIfNodeIdsAreOutOfDatabase()) {
             return;
         }
         std::vector<TNodeId> nodeIds = GetNodeIdsFromParams();
@@ -95,9 +93,9 @@ public:
                     return ReplyAndPassAway();
                 }
             }
-            if (StrictDatabaseOnlyToken && TBase::RequestSettings.FilterNodeIds.empty()) {
-                // For StrictDatabaseOnlyToken if a database has no registered nodes,
-                // we report 200 with an empty response, not with a cluster nodes.
+            if (TBase::RequestSettings.FilterNodeIds.empty() && TBase::IsStrictDatabaseOnlyRequest()) {
+                // If a database has no registered nodes, a strict database-only user gets
+                // 200 with an empty response, not the nodes of the whole cluster.
                 return ReplyAndPassAway();
             }
         }

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -47,7 +47,9 @@ public:
                      (TNodeId)0,
                      TlsActivationContext->ActorSystem()->NodeId);
 
-        if (this->ReplyAndPassAwayIfNodesAreOutOfDatabase(nodeIds)) {
+        const bool strictDatabaseToken =
+            IsStrictDatabaseOnlyToken(AppData(), TString(TBase::GetRequest().GetUserTokenObject()));
+        if (strictDatabaseToken && TBase::ReplyAndPassAwayIfNodesAreOutOfDatabase(nodeIds)) {
             return;
         }
         if (!nodeIds.empty()) {
@@ -78,6 +80,11 @@ public:
                 if (TBase::RequestSettings.FilterNodeIds.empty()) {
                     return ReplyAndPassAway();
                 }
+            }
+            if (strictDatabaseToken && TBase::RequestSettings.FilterNodeIds.empty()) {
+                // For strictDatabaseToken if a database has no registered nodes,
+                // we report 200 with an empty response, not with a cluster nodes.
+                return ReplyAndPassAway();
             }
         }
         {

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -6,6 +6,7 @@
 #include "wb_group.h"
 #include "wb_merge.h"
 #include "wb_req.h"
+#include <ydb/core/base/auth.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/viewer/json/json.h>
 #include <ydb/core/viewer/yaml/yaml.h>
@@ -46,6 +47,24 @@ public:
                      nodeIds.end(),
                      (TNodeId)0,
                      TlsActivationContext->ActorSystem()->NodeId);
+
+        const bool strictDatabaseToken =
+            IsStrictDatabaseOnlyToken(AppData(), TString(TBase::GetRequest().GetUserTokenObject()));
+        // Strict database users must pass `database` query parameter before the handler runs;
+        // IsDatabaseRequest() check below means board resolve succeeded and GetDatabaseNodes() is meaningful.
+        if (strictDatabaseToken && TBase::IsDatabaseRequest() && !nodeIds.empty()) {
+            auto databaseNodes = TBase::GetDatabaseNodes();
+            auto nodesSet = std::unordered_set<TNodeId>(databaseNodes.begin(), databaseNodes.end());
+            for (TNodeId nodeId : nodeIds) {
+                if (!nodesSet.count(nodeId)) {
+                    return ReplyAndPassAway(
+                        TBase::GETHTTPACCESSDENIED(
+                            "text/plain",
+                            "Some requested nodes are outside the specified database"),
+                        "Access denied");
+                }
+            }
+        }
         if (!nodeIds.empty()) {
             if (TBase::RequestSettings.FilterNodeIds.empty()) {
                 TBase::RequestSettings.FilterNodeIds = nodeIds;

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -1334,6 +1334,20 @@
         ],
         "TotalGroups": 5
     },
+    "test.TestViewer.test_storage_groups_pdisk_fields_hidden_for_database_user": {
+        "database": [
+            {
+                "HasPDisk": false,
+                "PDiskId": null
+            }
+        ],
+        "root": [
+            {
+                "HasPDisk": true,
+                "PDiskId": "1-1"
+            }
+        ]
+    },
     "test.TestViewer.test_storage_stats": {
         "Paths": [
             {

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -812,10 +812,7 @@ class TestViewer(object):
             'database': cls.dedicated_db,
             'fields_required': 'VDisk,PDisk,NodeId,PDiskId',
         }
-        probe_visibility = pdisk_visibility(cls.get_viewer("/storage/groups", {
-            **params,
-            'with': 'all',
-        }))
+        probe_visibility = pdisk_visibility(cls.get_viewer("/storage/groups", params))
         pdisk_id = next((entry['PDiskId'] for entry in probe_visibility if entry['HasPDisk']), None)
         request_params = {
             **params,

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -797,6 +797,41 @@ class TestViewer(object):
         }))
 
     @classmethod
+    def test_storage_groups_pdisk_fields_hidden_for_database_user(cls):
+        def pdisk_visibility(data):
+            return [
+                {
+                    'HasPDisk': bool((vdisk.get('PDisk') or {}).get('PDiskId')),
+                    'PDiskId': (vdisk.get('PDisk') or {}).get('PDiskId'),
+                }
+                for group in data.get('StorageGroups') or []
+                for vdisk in group.get('VDisks') or []
+            ]
+
+        params = {
+            'database': cls.dedicated_db,
+            'fields_required': 'VDisk,PDisk,NodeId,PDiskId',
+        }
+        probe_visibility = pdisk_visibility(cls.get_viewer("/storage/groups", {
+            **params,
+            'with': 'all',
+        }))
+        pdisk_id = next((entry['PDiskId'] for entry in probe_visibility if entry['HasPDisk']), None)
+        request_params = {
+            **params,
+            'pdisk_id': str(pdisk_id).rsplit('-', 1)[-1] if pdisk_id else '',
+        }
+
+        return {
+            'database': pdisk_visibility(cls.get_viewer(
+                "/storage/groups",
+                request_params,
+                headers=cls.make_cookie_headers(cls.database_session_id),
+            )),
+            'root': pdisk_visibility(cls.get_viewer("/storage/groups", request_params)),
+        }
+
+    @classmethod
     def test_viewer_groups_group_by_pool_name(cls):
         return [
             cls.get_viewer_normalized("/viewer/groups", {

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -141,6 +141,12 @@ public:
         if (Params.Has("path_id") || Params.Has("schemeshard_id")) {
             if (!Viewer->CheckAccessMonitoring(GetRequest())) {
                 // it's dangerous because we don't check access to scoped ids here
+                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: `path_id`/`schemeshard_id` require the monitoring access level",
+                    {"logPrefix", GetLogPrefix()},
+                    {"user", GetUserSID()},
+                    {"database", Database},
+                    {"pathId", Params.Get("path_id")},
+                    {"schemeShardId", Params.Get("schemeshard_id")});
                 ReplyAndPassAway(GETHTTPACCESSDENIED("text/html", "<html><body><h1>403 Forbidden</h1></body></html>"), "Access denied");
                 return;
             }

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -3,6 +3,7 @@
 #include "json_pipe_req.h"
 #include "log.h"
 #include "viewer.h"
+#include <ydb/core/base/auth.h>
 #include <ydb/core/external_sources/external_source_factory.h>
 
 namespace NKikimr::NViewer {
@@ -137,9 +138,9 @@ public:
         if (NeedToRedirect()) {
             return;
         }
-        if (Params.Has("path_id")) {
+        if (Params.Has("path_id") || Params.Has("schemeshard_id")) {
             if (!Viewer->CheckAccessMonitoring(GetRequest())) {
-                // it's dangerous because we don't check access to specific path here
+                // it's dangerous because we don't check access to scoped ids here
                 ReplyAndPassAway(GETHTTPACCESSDENIED("text/html", "<html><body><h1>403 Forbidden</h1></body></html>"), "Access denied");
                 return;
             }

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -160,6 +160,7 @@ public:
     std::unordered_set<TNodeId> FilterNodeIds;
     std::unordered_set<ui32> FilterPDiskIds; // may be cleared while applying filters
     std::unordered_set<ui32> InitialFilterPDiskIds; // copy of initially sent FilterPDiskIds
+    bool StrictDatabaseOnlyToken = false;
 
     enum class EWith {
         Everything,
@@ -939,6 +940,7 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        StrictDatabaseOnlyToken = IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()));
         if (ReplyAndPassAwayIfNodesAreOutOfDatabase(FilterNodeIds)) {
             return;
         }
@@ -960,9 +962,7 @@ public:
         }
         // Database-only users normally don't fetch PDiskId (see CheckAccessViewer above).
         // If pdisk_id was passed, we need to request PDiskId from BSC to validate parameters scope.
-        if (IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject())) &&
-            !InitialFilterPDiskIds.empty()
-        ) {
+        if (StrictDatabaseOnlyToken && !InitialFilterPDiskIds.empty()) {
             FieldsRequired.set(+EGroupFields::PDiskId);
         }
         if (Database) {
@@ -1080,7 +1080,7 @@ public:
                 return true;
             }
         }
-        if (IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject())) && IsDatabaseRequest()) {
+        if (StrictDatabaseOnlyToken && IsDatabaseRequest()) {
             // We don't want to provide a possibility for strict database users to get groups outside the database.
             if (!FilterGroupIds.empty() && ReplyAndPassAwayIfGroupsAreOutOfDatabase()) {
                 return false;
@@ -1411,7 +1411,7 @@ public:
         if (!ApplyFilterAndCheckAccess()) {
             return false;
         }
-        if (IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject())) && IsDatabaseRequest()) {
+        if (StrictDatabaseOnlyToken && IsDatabaseRequest()) {
             // We don't want to provide a possibility for strict database users to get pdisks outside the database.
             if (!InitialFilterPDiskIds.empty() && ReplyAndPassAwayIfPDisksAreOutOfDatabase()) {
                 return false;

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -159,7 +159,7 @@ public:
     std::unordered_set<TGroupId> FilterGroupIds;
     std::unordered_set<TNodeId> FilterNodeIds;
     std::unordered_set<ui32> FilterPDiskIds; // may be cleared while applying filters
-    std::unordered_set<ui32> InitialFilterPDiskIds; // copy of initialyy sent FilterPDiskIds
+    std::unordered_set<ui32> InitialFilterPDiskIds; // copy of initially sent FilterPDiskIds
 
     enum class EWith {
         Everything,

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -152,33 +152,17 @@ public:
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvPDiskStateResponse>> PDiskStateResponse;
     ui64 PDiskStateRequestsInFlight = 0;
 
-    // A set of ids requested by a query param. The pending part is consumed (cleared) as soon as
-    // the corresponding filter has been applied to the group view, while the requested part stays
-    // intact - it's needed to validate that the request doesn't reach out of the database.
+    // Ids requested by a query param. ToApply is emptied as soon as the corresponding filter has
+    // been applied to the group view, while Requested keeps the original set - it's needed to
+    // validate that the request doesn't reach out of the database.
     template<typename TId>
     struct TIdsFilter {
         std::unordered_set<TId> Requested; // as they came from the query params
-        std::unordered_set<TId> Pending; // not applied to the group view yet
+        std::unordered_set<TId> ToApply; // not applied to the group view yet
 
         void Parse(const TString& value) {
-            SplitIds(value, ',', Pending);
-            Requested = Pending;
-        }
-
-        bool RequestedAnything() const {
-            return !Requested.empty();
-        }
-
-        bool IsPending() const {
-            return !Pending.empty();
-        }
-
-        bool IsPending(const TId& id) const {
-            return Pending.count(id) != 0;
-        }
-
-        void Applied() {
-            Pending.clear();
+            SplitIds(value, ',', ToApply);
+            Requested = ToApply;
         }
     };
 
@@ -872,15 +856,15 @@ public:
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
         }
-        if (FilterNodeIds.IsPending()) {
+        if (!FilterNodeIds.ToApply.empty()) {
             FieldsRequired.set(+EGroupFields::NodeId);
             NeedFilter = true;
         }
-        if (FilterPDiskIds.IsPending()) {
+        if (!FilterPDiskIds.ToApply.empty()) {
             FieldsRequired.set(+EGroupFields::PDiskId);
             NeedFilter = true;
         }
-        if (FilterGroupIds.IsPending()) {
+        if (!FilterGroupIds.ToApply.empty()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
         }
@@ -987,13 +971,13 @@ public:
         // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
         // These fields are not added to FieldsRequested, so they are not rendered in the response.
         if (IsStrictDatabaseOnlyRequest()) {
-            if (FilterGroupIds.RequestedAnything() || FilterNodeIds.RequestedAnything() || FilterPDiskIds.RequestedAnything()) {
+            if (!FilterGroupIds.Requested.empty() || !FilterNodeIds.Requested.empty() || !FilterPDiskIds.Requested.empty()) {
                 FieldsRequired.set(+EGroupFields::PoolName);
             }
-            if (FilterNodeIds.RequestedAnything()) {
+            if (!FilterNodeIds.Requested.empty()) {
                 FieldsRequired.set(+EGroupFields::NodeId);
             }
-            if (FilterPDiskIds.RequestedAnything()) {
+            if (!FilterPDiskIds.Requested.empty()) {
                 FieldsRequired.set(+EGroupFields::PDiskId);
             }
         }
@@ -1081,33 +1065,34 @@ public:
     // Strict database-only users must not be able to address storage objects outside their database.
     // Returns true if the response has been already sent.
     bool DenyRequestIfStorageIdsAreOutOfDatabase() {
-        if (!FilterGroupIds.RequestedAnything() && !FilterNodeIds.RequestedAnything() && !FilterPDiskIds.RequestedAnything()) {
+        if (FilterGroupIds.Requested.empty() && FilterNodeIds.Requested.empty() && FilterPDiskIds.Requested.empty()) {
             return false;
         }
         const TDatabaseStorageScope scope = GetDatabaseStorageScope();
-        auto outOfScope = [](const auto& requested, const auto& allowed) {
+        auto denyIfOutOfScope = [this](TStringBuf objects, const auto& requested, const auto& allowed) {
             for (const auto& id : requested) {
-                if (!allowed.count(id)) {
-                    return true;
+                if (allowed.count(id)) {
+                    continue;
                 }
+                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: requested storage id is outside the database",
+                    {"logPrefix", GetLogPrefix()},
+                    {"user", GetUserSID()},
+                    {"database", Database},
+                    {"objects", objects},
+                    {"outOfDatabaseId", id},
+                    {"requestedCount", requested.size()},
+                    {"databaseScopeCount", allowed.size()});
+                TBase::ReplyAndPassAway(
+                    GETHTTPACCESSDENIED("text/plain", TStringBuilder()
+                        << "Some requested " << objects << " are outside the specified database"),
+                    "Access denied");
+                return true;
             }
             return false;
         };
-        TStringBuf objects;
-        if (outOfScope(FilterGroupIds.Requested, scope.GroupIds)) {
-            objects = "storage groups";
-        } else if (outOfScope(FilterNodeIds.Requested, scope.NodeIds)) {
-            objects = "nodes";
-        } else if (outOfScope(FilterPDiskIds.Requested, scope.PDiskIds)) {
-            objects = "PDisk identifiers";
-        } else {
-            return false;
-        }
-        TBase::ReplyAndPassAway(
-            GETHTTPACCESSDENIED("text/plain", TStringBuilder()
-                << "Some requested " << objects << " are outside the specified database"),
-            "Access denied");
-        return true;
+        return denyIfOutOfScope("storage groups", FilterGroupIds.Requested, scope.GroupIds)
+            || denyIfOutOfScope("nodes", FilterNodeIds.Requested, scope.NodeIds)
+            || denyIfOutOfScope("PDisk identifiers", FilterPDiskIds.Requested, scope.PDiskIds);
     }
 
     void ApplyFilter() {
@@ -1129,16 +1114,16 @@ public:
             }
         }
         // group id pre-filter, affects TotalGroups count
-        if (FilterGroupIds.IsPending()) {
+        if (!FilterGroupIds.ToApply.empty()) {
             TGroupView groupView;
             for (TGroup* group : GroupView) {
-                if (FilterGroupIds.IsPending(group->GroupId)) {
+                if (FilterGroupIds.ToApply.count(group->GroupId)) {
                     groupView.push_back(group);
                 }
             }
             GroupView.swap(groupView);
             FoundGroups = TotalGroups = GroupView.size();
-            FilterGroupIds.Applied();
+            FilterGroupIds.ToApply.clear();
             GroupsByGroupId.clear();
         }
         // storage pool pre-filter, affects TotalGroups count
@@ -1159,12 +1144,12 @@ public:
             }
         }
         // node_id + pdisk_id pre-filter, affects TotalGroups count
-        if (FilterNodeIds.IsPending() && FilterPDiskIds.IsPending()) {
+        if (!FilterNodeIds.ToApply.empty() && !FilterPDiskIds.ToApply.empty()) {
             if (FieldsAvailable.test(+EGroupFields::NodeId) && FieldsAvailable.test(+EGroupFields::PDiskId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterNodeIds.IsPending(vdisk.VSlotId.NodeId) && FilterPDiskIds.IsPending(vdisk.VSlotId.PDiskId)) {
+                        if (FilterNodeIds.ToApply.count(vdisk.VSlotId.NodeId) && FilterPDiskIds.ToApply.count(vdisk.VSlotId.PDiskId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1172,20 +1157,20 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterNodeIds.Applied();
-                FilterPDiskIds.Applied();
+                FilterNodeIds.ToApply.clear();
+                FilterPDiskIds.ToApply.clear();
                 GroupsByGroupId.clear();
             } else {
                 return;
             }
         }
         // node_id pre-filter, affects TotalGroups count
-        if (FilterNodeIds.IsPending()) {
+        if (!FilterNodeIds.ToApply.empty()) {
             if (FieldsAvailable.test(+EGroupFields::NodeId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterNodeIds.IsPending(vdisk.VSlotId.NodeId)) {
+                        if (FilterNodeIds.ToApply.count(vdisk.VSlotId.NodeId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1193,19 +1178,19 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterNodeIds.Applied();
+                FilterNodeIds.ToApply.clear();
                 GroupsByGroupId.clear();
             } else {
                 return;
             }
         }
         // pdisk_id pre-filter, affects TotalGroups count
-        if (FilterPDiskIds.IsPending()) {
+        if (!FilterPDiskIds.ToApply.empty()) {
             if (FieldsAvailable.test(+EGroupFields::PDiskId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterPDiskIds.IsPending(vdisk.VSlotId.PDiskId)) {
+                        if (FilterPDiskIds.ToApply.count(vdisk.VSlotId.PDiskId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1213,7 +1198,7 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterPDiskIds.Applied();
+                FilterPDiskIds.ToApply.clear();
                 GroupsByGroupId.clear();
             } else {
                 return;
@@ -1278,7 +1263,7 @@ public:
                 FilterGroup.clear();
                 GroupsByGroupId.clear();
             }
-            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || FilterNodeIds.IsPending() || FilterPDiskIds.IsPending() || FilterGroupIds.IsPending() || !FilterGroup.empty();
+            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.ToApply.empty() || !FilterPDiskIds.ToApply.empty() || !FilterGroupIds.ToApply.empty() || !FilterGroup.empty();
             FoundGroups = GroupView.size();
         }
     }
@@ -1549,10 +1534,10 @@ public:
         if (!FilterStoragePools.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PoolName)) {
             return true;
         }
-        if (FilterNodeIds.IsPending() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
+        if (!FilterNodeIds.ToApply.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
             return true;
         }
-        if (FilterPDiskIds.IsPending() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
+        if (!FilterPDiskIds.ToApply.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
             return true;
         }
         if (With == EWith::MissingDisks && NeedToWaitForFieldBeforeHive(EGroupFields::MissingDisks)) {

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -154,12 +154,17 @@ public:
     ui64 PDiskStateRequestsInFlight = 0;
 
     TString Filter;
-    std::unordered_set<TString> DatabaseStoragePools;
+    std::unordered_set<TString> DatabaseStoragePools; // pre-filter, cleared once it has been applied
+    std::unordered_set<TString> DatabaseStoragePoolNames; // the same pools, kept for the scope validation
     std::unordered_set<TString> FilterStoragePools;
+    // Filter* sets may be cleared while applying filters, so the initially requested ids
+    // are kept separately - they are needed to validate the scope of the request.
     std::unordered_set<TGroupId> FilterGroupIds;
     std::unordered_set<TNodeId> FilterNodeIds;
-    std::unordered_set<ui32> FilterPDiskIds; // may be cleared while applying filters
-    std::unordered_set<ui32> InitialFilterPDiskIds; // copy of initially sent FilterPDiskIds
+    std::unordered_set<ui32> FilterPDiskIds;
+    std::unordered_set<TGroupId> InitialFilterGroupIds;
+    std::unordered_set<TNodeId> InitialFilterNodeIds;
+    std::unordered_set<ui32> InitialFilterPDiskIds;
     bool StrictDatabaseOnlyToken = false;
 
     enum class EWith {
@@ -840,7 +845,9 @@ public:
         SplitIds(Params.Get("node_id"), ',', FilterNodeIds);
         SplitIds(Params.Get("pdisk_id"), ',', FilterPDiskIds);
         SplitIds(Params.Get("group_id"), ',', FilterGroupIds);
+        InitialFilterNodeIds = FilterNodeIds;
         InitialFilterPDiskIds = FilterPDiskIds;
+        InitialFilterGroupIds = FilterGroupIds;
         if (!FilterStoragePools.empty()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
@@ -941,11 +948,6 @@ public:
             return;
         }
         StrictDatabaseOnlyToken = IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()));
-        if (StrictDatabaseOnlyToken) {
-            if (ReplyAndPassAwayIfNodesAreOutOfDatabase(FilterNodeIds)) {
-                return;
-            }
-        }
         if (!Viewer->CheckAccessViewer(TBase::GetRequest())) {
             // fields that are not available for database users
             FieldsRequired.reset(+EGroupFields::NodeId);
@@ -962,10 +964,19 @@ public:
                 }
             }
         }
-        // Database-only users normally don't fetch PDiskId (see CheckAccessViewer above).
-        // If pdisk_id was passed, we need to request PDiskId from BSC to validate parameters scope.
-        if (StrictDatabaseOnlyToken && !InitialFilterPDiskIds.empty()) {
-            FieldsRequired.set(+EGroupFields::PDiskId);
+        // Database-only users normally don't fetch NodeId/PDiskId (see CheckAccessViewer above),
+        // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
+        // These fields are not added to FieldsRequested, so they are not rendered in the response.
+        if (StrictDatabaseOnlyToken) {
+            if (!InitialFilterGroupIds.empty() || !InitialFilterNodeIds.empty() || !InitialFilterPDiskIds.empty()) {
+                FieldsRequired.set(+EGroupFields::PoolName);
+            }
+            if (!InitialFilterNodeIds.empty()) {
+                FieldsRequired.set(+EGroupFields::NodeId);
+            }
+            if (!InitialFilterPDiskIds.empty()) {
+                FieldsRequired.set(+EGroupFields::PDiskId);
+            }
         }
         if (Database) {
             if (!DatabaseNavigateResponse) {
@@ -1007,64 +1018,77 @@ public:
         }
     }
 
-    bool ReplyAndPassAwayIfGroupsAreOutOfDatabase() {
-        std::unordered_set<TGroupId> allowedGroupIds;
-        for (TGroup* group : GroupView) {
-            allowedGroupIds.insert(group->GroupId);
-        }
-        for (TGroupId groupId : FilterGroupIds) {
-            if (!allowedGroupIds.contains(groupId)) {
-                TBase::ReplyAndPassAway(
-                    GETHTTPACCESSDENIED("text/plain",
-                        "Some requested storage groups are outside the specified database"),
-                    "Access denied");
-                return true;
+    // Storage objects that belong to the requested database: its groups, the nodes and the pdisks
+    // holding the vdisks of those groups, plus the nodes of the database itself.
+    // It's built from the raw BS Controller data, so it doesn't depend on the user-provided filters
+    // and on the order in which the responses arrive. An id which is missing here is either out of
+    // the database, or we have no data to prove it belongs to the database - in both cases the
+    // request of a strict database-only user is denied.
+    struct TDatabaseStorageScope {
+        std::unordered_set<TGroupId> GroupIds;
+        std::unordered_set<TNodeId> NodeIds;
+        std::unordered_set<ui32> PDiskIds;
+    };
+
+    TDatabaseStorageScope GetDatabaseStorageScope() {
+        TDatabaseStorageScope scope;
+        if (AreDatabaseNodesKnown()) {
+            for (TNodeId nodeId : GetDatabaseNodes()) {
+                scope.NodeIds.insert(nodeId);
             }
         }
-        return false;
+        if (DatabaseStoragePoolNames.empty() || !FieldsAvailable.test(+EGroupFields::PoolName)) {
+            return scope; // we don't know which groups belong to the database
+        }
+        for (const TGroup& group : GroupData) {
+            if (DatabaseStoragePoolNames.count(group.PoolName)) {
+                scope.GroupIds.insert(group.GroupId);
+            }
+        }
+        // VSlotsByVSlotId is filled from the BS Controller vslots response and holds every vslot
+        // of the cluster, so - unlike TGroup::VDisks - it's not affected by the applied filters.
+        for (const auto& [vslotId, info] : VSlotsByVSlotId) {
+            if (info && scope.GroupIds.count(info->GetGroupId())) {
+                scope.NodeIds.insert(vslotId.NodeId);
+                scope.PDiskIds.insert(vslotId.PDiskId);
+            }
+        }
+        return scope;
     }
 
-    bool ReplyAndPassAwayIfPDisksAreOutOfDatabase() {
-        // Scope validation needs PDisk data from BS Controller; defer until it arrives.
-        if (!AreBSControllerRequestsDone() || !FieldsAvailable.test(+EGroupFields::PDiskId)) {
+    // Strict database-only users must not be able to address storage objects outside their database.
+    // Returns true if the response has been already sent.
+    bool ReplyAndPassAwayIfStorageIdsAreOutOfDatabase() {
+        if (InitialFilterGroupIds.empty() && InitialFilterNodeIds.empty() && InitialFilterPDiskIds.empty()) {
             return false;
         }
-
-        std::unordered_set<ui32> allowedPDiskIds;
-        for (TGroup* group : GroupView) {
-            for (const auto& vdisk : group->VDisks) {
-                allowedPDiskIds.insert(vdisk.VSlotId.PDiskId);
-            }
-        }
-        if (allowedPDiskIds.empty() && !VSlotsByVSlotId.empty()) {
-            std::unordered_set<TGroupId> allowedGroupIds;
-            for (TGroup* group : GroupView) {
-                allowedGroupIds.insert(group->GroupId);
-            }
-            for (const auto& [vslotId, info] : VSlotsByVSlotId) {
-                if (info && allowedGroupIds.count(info->GetGroupId())) {
-                    allowedPDiskIds.insert(vslotId.PDiskId);
+        const TDatabaseStorageScope scope = GetDatabaseStorageScope();
+        auto outOfScope = [](const auto& requested, const auto& allowed) {
+            for (const auto& id : requested) {
+                if (!allowed.count(id)) {
+                    return true;
                 }
             }
+            return false;
+        };
+        TStringBuf objects;
+        if (outOfScope(InitialFilterGroupIds, scope.GroupIds)) {
+            objects = "storage groups";
+        } else if (outOfScope(InitialFilterNodeIds, scope.NodeIds)) {
+            objects = "nodes";
+        } else if (outOfScope(InitialFilterPDiskIds, scope.PDiskIds)) {
+            objects = "PDisk identifiers";
+        } else {
+            return false;
         }
-        if (allowedPDiskIds.empty()) {
-            TBase::ReplyAndPassAway(
-                GETHTTPACCESSDENIED("text/plain", "Some requested PDisk identifiers are outside the specified database"),
-                "Access denied");
-            return true;
-        }
-        for (ui32 pdiskId : InitialFilterPDiskIds) {
-            if (!allowedPDiskIds.contains(pdiskId)) {
-                TBase::ReplyAndPassAway(
-                    GETHTTPACCESSDENIED("text/plain", "Some requested PDisk identifiers are outside the specified database"),
-                    "Access denied");
-                return true;
-            }
-        }
-        return false;
+        TBase::ReplyAndPassAway(
+            GETHTTPACCESSDENIED("text/plain", TStringBuilder()
+                << "Some requested " << objects << " are outside the specified database"),
+            "Access denied");
+        return true;
     }
 
-    bool ApplyFilterAndCheckAccess() {
+    void ApplyFilter() {
         // database pre-filter, affects TotalGroups count
         if (!DatabaseStoragePools.empty()) {
             if (FieldsAvailable.test(+EGroupFields::PoolName)) {
@@ -1079,13 +1103,7 @@ public:
                 FoundGroups = TotalGroups = GroupView.size();
                 GroupsByGroupId.clear();
             } else {
-                return true;
-            }
-        }
-        if (StrictDatabaseOnlyToken && IsDatabaseRequest()) {
-            // We don't want to provide a possibility for strict database users to get groups outside the database.
-            if (!FilterGroupIds.empty() && ReplyAndPassAwayIfGroupsAreOutOfDatabase()) {
-                return false;
+                return;
             }
         }
         // group id pre-filter, affects TotalGroups count
@@ -1115,7 +1133,7 @@ public:
                 FilterStoragePools.clear();
                 GroupsByGroupId.clear();
             } else {
-                return true;
+                return;
             }
         }
         // node_id + pdisk_id pre-filter, affects TotalGroups count
@@ -1136,7 +1154,7 @@ public:
                 FilterPDiskIds.clear();
                 GroupsByGroupId.clear();
             } else {
-                return true;
+                return;
             }
         }
         // node_id pre-filter, affects TotalGroups count
@@ -1156,7 +1174,7 @@ public:
                 FilterNodeIds.clear();
                 GroupsByGroupId.clear();
             } else {
-                return true;
+                return;
             }
         }
         // pdisk_id pre-filter, affects TotalGroups count
@@ -1176,7 +1194,7 @@ public:
                 FilterPDiskIds.clear();
                 GroupsByGroupId.clear();
             } else {
-                return true;
+                return;
             }
         }
         if (NeedFilter) {
@@ -1241,7 +1259,6 @@ public:
             NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.empty() || !FilterPDiskIds.empty() || !FilterGroupIds.empty() || !FilterGroup.empty();
             FoundGroups = GroupView.size();
         }
-        return true;
     }
 
     void GroupCollection() {
@@ -1409,20 +1426,11 @@ public:
         }
     }
 
-    bool ApplyEverything() {
-        if (!ApplyFilterAndCheckAccess()) {
-            return false;
-        }
-        if (StrictDatabaseOnlyToken && IsDatabaseRequest()) {
-            // We don't want to provide a possibility for strict database users to get pdisks outside the database.
-            if (!InitialFilterPDiskIds.empty() && ReplyAndPassAwayIfPDisksAreOutOfDatabase()) {
-                return false;
-            }
-        }
+    void ApplyEverything() {
+        ApplyFilter();
         ApplyGroup();
         ApplySort();
         ApplyLimit();
-        return true;
     }
 
     bool CollectedHiveData = false;
@@ -1789,6 +1797,7 @@ public:
                     for (const auto& storagePool : domainDescription->Description.GetStoragePools()) {
                         TString storagePoolName = storagePool.GetName();
                         DatabaseStoragePools.emplace(storagePoolName);
+                        DatabaseStoragePoolNames.emplace(storagePoolName);
                     }
                     NeedFilter = true;
                 }
@@ -2390,9 +2399,10 @@ public:
 
     void ReplyAndPassAway() override {
         AddEvent("ReplyAndPassAway");
-        if (!ApplyEverything()) {
+        if (StrictDatabaseOnlyToken && ReplyAndPassAwayIfStorageIdsAreOutOfDatabase()) {
             return;
         }
+        ApplyEverything();
         ApplyLimitForced(); // in case we had a problem and don't want to return too much data
         NKikimrViewer::TStorageGroupsInfo json;
         json.SetVersion(Viewer->GetCapabilityVersion("/storage/groups"));

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -2,6 +2,7 @@
 #include "json_pipe_req.h"
 #include "log.h"
 #include "viewer_helper.h"
+#include <ydb/core/base/auth.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
 
 namespace NKikimr::NViewer {
@@ -157,7 +158,8 @@ public:
     std::unordered_set<TString> FilterStoragePools;
     std::unordered_set<TGroupId> FilterGroupIds;
     std::unordered_set<TNodeId> FilterNodeIds;
-    std::unordered_set<ui32> FilterPDiskIds;
+    std::unordered_set<ui32> FilterPDiskIds; // may be cleared while applying filters
+    std::unordered_set<ui32> InitialFilterPDiskIds; // copy of initialyy sent FilterPDiskIds
 
     enum class EWith {
         Everything,
@@ -837,6 +839,7 @@ public:
         SplitIds(Params.Get("node_id"), ',', FilterNodeIds);
         SplitIds(Params.Get("pdisk_id"), ',', FilterPDiskIds);
         SplitIds(Params.Get("group_id"), ',', FilterGroupIds);
+        InitialFilterPDiskIds = FilterPDiskIds;
         if (!FilterStoragePools.empty()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
@@ -936,8 +939,12 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        if (ReplyAndPassAwayIfNodesAreOutOfDatabase(FilterNodeIds)) {
+            return;
+        }
         if (!Viewer->CheckAccessViewer(TBase::GetRequest())) {
-            FieldsRequired.reset(+EGroupFields::NodeId); // fields that are not available for database users
+            // fields that are not available for database users
+            FieldsRequired.reset(+EGroupFields::NodeId);
             FieldsRequired.reset(+EGroupFields::PDiskId);
             FieldsRequired.reset(+EGroupFields::PDisk);
             FieldsRequired.reset(+EGroupFields::PileName);
@@ -950,6 +957,13 @@ public:
                     FieldsRequired |= itDependentFields->second;
                 }
             }
+        }
+        // Database-only users normally don't fetch PDiskId (see CheckAccessViewer above).
+        // If pdisk_id was passed, we need to request PDiskId from BSC to validate parameters scope.
+        if (IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject())) &&
+            !InitialFilterPDiskIds.empty()
+        ) {
+            FieldsRequired.set(+EGroupFields::PDiskId);
         }
         if (Database) {
             if (!DatabaseNavigateResponse) {
@@ -991,7 +1005,64 @@ public:
         }
     }
 
-    void ApplyFilter() {
+    bool ReplyAndPassAwayIfGroupsAreOutOfDatabase() {
+        std::unordered_set<TGroupId> allowedGroupIds;
+        for (TGroup* group : GroupView) {
+            allowedGroupIds.insert(group->GroupId);
+        }
+        for (TGroupId groupId : FilterGroupIds) {
+            if (!allowedGroupIds.contains(groupId)) {
+                TBase::ReplyAndPassAway(
+                    GETHTTPACCESSDENIED("text/plain",
+                        "Some requested storage groups are outside the specified database"),
+                    "Access denied");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool ReplyAndPassAwayIfPDisksAreOutOfDatabase() {
+        // Scope validation needs PDisk data from BS Controller; defer until it arrives.
+        if (!AreBSControllerRequestsDone() || !FieldsAvailable.test(+EGroupFields::PDiskId)) {
+            return false;
+        }
+
+        std::unordered_set<ui32> allowedPDiskIds;
+        for (TGroup* group : GroupView) {
+            for (const auto& vdisk : group->VDisks) {
+                allowedPDiskIds.insert(vdisk.VSlotId.PDiskId);
+            }
+        }
+        if (allowedPDiskIds.empty() && !VSlotsByVSlotId.empty()) {
+            std::unordered_set<TGroupId> allowedGroupIds;
+            for (TGroup* group : GroupView) {
+                allowedGroupIds.insert(group->GroupId);
+            }
+            for (const auto& [vslotId, info] : VSlotsByVSlotId) {
+                if (info && allowedGroupIds.count(info->GetGroupId())) {
+                    allowedPDiskIds.insert(vslotId.PDiskId);
+                }
+            }
+        }
+        if (allowedPDiskIds.empty()) {
+            TBase::ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain", "Some requested PDisk identifiers are outside the specified database"),
+                "Access denied");
+            return true;
+        }
+        for (ui32 pdiskId : InitialFilterPDiskIds) {
+            if (!allowedPDiskIds.contains(pdiskId)) {
+                TBase::ReplyAndPassAway(
+                    GETHTTPACCESSDENIED("text/plain", "Some requested PDisk identifiers are outside the specified database"),
+                    "Access denied");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool ApplyFilterAndCheckAccess() {
         // database pre-filter, affects TotalGroups count
         if (!DatabaseStoragePools.empty()) {
             if (FieldsAvailable.test(+EGroupFields::PoolName)) {
@@ -1006,7 +1077,13 @@ public:
                 FoundGroups = TotalGroups = GroupView.size();
                 GroupsByGroupId.clear();
             } else {
-                return;
+                return true;
+            }
+        }
+        if (IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject())) && IsDatabaseRequest()) {
+            // We don't want to provide a possibility for strict database users to get groups outside the database.
+            if (!FilterGroupIds.empty() && ReplyAndPassAwayIfGroupsAreOutOfDatabase()) {
+                return false;
             }
         }
         // group id pre-filter, affects TotalGroups count
@@ -1036,7 +1113,7 @@ public:
                 FilterStoragePools.clear();
                 GroupsByGroupId.clear();
             } else {
-                return;
+                return true;
             }
         }
         // node_id + pdisk_id pre-filter, affects TotalGroups count
@@ -1057,7 +1134,7 @@ public:
                 FilterPDiskIds.clear();
                 GroupsByGroupId.clear();
             } else {
-                return;
+                return true;
             }
         }
         // node_id pre-filter, affects TotalGroups count
@@ -1077,7 +1154,7 @@ public:
                 FilterNodeIds.clear();
                 GroupsByGroupId.clear();
             } else {
-                return;
+                return true;
             }
         }
         // pdisk_id pre-filter, affects TotalGroups count
@@ -1097,7 +1174,7 @@ public:
                 FilterPDiskIds.clear();
                 GroupsByGroupId.clear();
             } else {
-                return;
+                return true;
             }
         }
         if (NeedFilter) {
@@ -1162,6 +1239,7 @@ public:
             NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.empty() || !FilterPDiskIds.empty() || !FilterGroupIds.empty() || !FilterGroup.empty();
             FoundGroups = GroupView.size();
         }
+        return true;
     }
 
     void GroupCollection() {
@@ -1329,11 +1407,20 @@ public:
         }
     }
 
-    void ApplyEverything() {
-        ApplyFilter();
+    bool ApplyEverything() {
+        if (!ApplyFilterAndCheckAccess()) {
+            return false;
+        }
+        if (IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject())) && IsDatabaseRequest()) {
+            // We don't want to provide a possibility for strict database users to get pdisks outside the database.
+            if (!InitialFilterPDiskIds.empty() && ReplyAndPassAwayIfPDisksAreOutOfDatabase()) {
+                return false;
+            }
+        }
         ApplyGroup();
         ApplySort();
         ApplyLimit();
+        return true;
     }
 
     bool CollectedHiveData = false;
@@ -2301,7 +2388,9 @@ public:
 
     void ReplyAndPassAway() override {
         AddEvent("ReplyAndPassAway");
-        ApplyEverything();
+        if (!ApplyEverything()) {
+            return;
+        }
         ApplyLimitForced(); // in case we had a problem and don't want to return too much data
         NKikimrViewer::TStorageGroupsInfo json;
         json.SetVersion(Viewer->GetCapabilityVersion("/storage/groups"));

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -2,7 +2,6 @@
 #include "json_pipe_req.h"
 #include "log.h"
 #include "viewer_helper.h"
-#include <ydb/core/base/auth.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
 
 namespace NKikimr::NViewer {
@@ -153,19 +152,43 @@ public:
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvPDiskStateResponse>> PDiskStateResponse;
     ui64 PDiskStateRequestsInFlight = 0;
 
+    // A set of ids requested by a query param. The pending part is consumed (cleared) as soon as
+    // the corresponding filter has been applied to the group view, while the requested part stays
+    // intact - it's needed to validate that the request doesn't reach out of the database.
+    template<typename TId>
+    struct TIdsFilter {
+        std::unordered_set<TId> Requested; // as they came from the query params
+        std::unordered_set<TId> Pending; // not applied to the group view yet
+
+        void Parse(const TString& value) {
+            SplitIds(value, ',', Pending);
+            Requested = Pending;
+        }
+
+        bool RequestedAnything() const {
+            return !Requested.empty();
+        }
+
+        bool IsPending() const {
+            return !Pending.empty();
+        }
+
+        bool IsPending(const TId& id) const {
+            return Pending.count(id) != 0;
+        }
+
+        void Applied() {
+            Pending.clear();
+        }
+    };
+
     TString Filter;
-    std::unordered_set<TString> DatabaseStoragePools; // pre-filter, cleared once it has been applied
-    std::unordered_set<TString> DatabaseStoragePoolNames; // the same pools, kept for the scope validation
+    std::unordered_set<TString> DatabaseStoragePools; // storage pools of the requested database
+    bool DatabaseStoragePoolsApplied = false; // the pre-filter by DatabaseStoragePools is already applied
     std::unordered_set<TString> FilterStoragePools;
-    // Filter* sets may be cleared while applying filters, so the initially requested ids
-    // are kept separately - they are needed to validate the scope of the request.
-    std::unordered_set<TGroupId> FilterGroupIds;
-    std::unordered_set<TNodeId> FilterNodeIds;
-    std::unordered_set<ui32> FilterPDiskIds;
-    std::unordered_set<TGroupId> InitialFilterGroupIds;
-    std::unordered_set<TNodeId> InitialFilterNodeIds;
-    std::unordered_set<ui32> InitialFilterPDiskIds;
-    bool StrictDatabaseOnlyToken = false;
+    TIdsFilter<TGroupId> FilterGroupIds;
+    TIdsFilter<TNodeId> FilterNodeIds;
+    TIdsFilter<ui32> FilterPDiskIds;
 
     enum class EWith {
         Everything,
@@ -842,25 +865,22 @@ public:
         if (!filterStoragePool.empty()) {
             FilterStoragePools.emplace(filterStoragePool);
         }
-        SplitIds(Params.Get("node_id"), ',', FilterNodeIds);
-        SplitIds(Params.Get("pdisk_id"), ',', FilterPDiskIds);
-        SplitIds(Params.Get("group_id"), ',', FilterGroupIds);
-        InitialFilterNodeIds = FilterNodeIds;
-        InitialFilterPDiskIds = FilterPDiskIds;
-        InitialFilterGroupIds = FilterGroupIds;
+        FilterNodeIds.Parse(Params.Get("node_id"));
+        FilterPDiskIds.Parse(Params.Get("pdisk_id"));
+        FilterGroupIds.Parse(Params.Get("group_id"));
         if (!FilterStoragePools.empty()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
         }
-        if (!FilterNodeIds.empty()) {
+        if (FilterNodeIds.IsPending()) {
             FieldsRequired.set(+EGroupFields::NodeId);
             NeedFilter = true;
         }
-        if (!FilterPDiskIds.empty()) {
+        if (FilterPDiskIds.IsPending()) {
             FieldsRequired.set(+EGroupFields::PDiskId);
             NeedFilter = true;
         }
-        if (!FilterGroupIds.empty()) {
+        if (FilterGroupIds.IsPending()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
         }
@@ -947,7 +967,6 @@ public:
         if (NeedToRedirect()) {
             return;
         }
-        StrictDatabaseOnlyToken = IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()));
         if (!Viewer->CheckAccessViewer(TBase::GetRequest())) {
             // fields that are not available for database users
             FieldsRequired.reset(+EGroupFields::NodeId);
@@ -967,14 +986,14 @@ public:
         // Database-only users normally don't fetch NodeId/PDiskId (see CheckAccessViewer above),
         // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
         // These fields are not added to FieldsRequested, so they are not rendered in the response.
-        if (StrictDatabaseOnlyToken) {
-            if (!InitialFilterGroupIds.empty() || !InitialFilterNodeIds.empty() || !InitialFilterPDiskIds.empty()) {
+        if (IsStrictDatabaseOnlyRequest()) {
+            if (FilterGroupIds.RequestedAnything() || FilterNodeIds.RequestedAnything() || FilterPDiskIds.RequestedAnything()) {
                 FieldsRequired.set(+EGroupFields::PoolName);
             }
-            if (!InitialFilterNodeIds.empty()) {
+            if (FilterNodeIds.RequestedAnything()) {
                 FieldsRequired.set(+EGroupFields::NodeId);
             }
-            if (!InitialFilterPDiskIds.empty()) {
+            if (FilterPDiskIds.RequestedAnything()) {
                 FieldsRequired.set(+EGroupFields::PDiskId);
             }
         }
@@ -1037,16 +1056,19 @@ public:
                 scope.NodeIds.insert(nodeId);
             }
         }
-        if (DatabaseStoragePoolNames.empty() || !FieldsAvailable.test(+EGroupFields::PoolName)) {
+        if (DatabaseStoragePools.empty() || !FieldsAvailable.test(+EGroupFields::PoolName)) {
             return scope; // we don't know which groups belong to the database
         }
         for (const TGroup& group : GroupData) {
-            if (DatabaseStoragePoolNames.count(group.PoolName)) {
+            if (DatabaseStoragePools.count(group.PoolName)) {
                 scope.GroupIds.insert(group.GroupId);
             }
         }
-        // VSlotsByVSlotId is filled from the BS Controller vslots response and holds every vslot
-        // of the cluster, so - unlike TGroup::VDisks - it's not affected by the applied filters.
+        // The disks of a group could also be taken from TGroup::VDisks, but GroupView (and hence
+        // the groups whose VDisks are filled in) shrinks every time a filter is applied, so by the
+        // time we get here the disks of a group filtered out by, say, "with=space" would be missing
+        // and its node would look foreign. VSlotsByVSlotId is a plain index over the BS Controller
+        // vslots response: it holds every vslot of the cluster and no filter ever touches it.
         for (const auto& [vslotId, info] : VSlotsByVSlotId) {
             if (info && scope.GroupIds.count(info->GetGroupId())) {
                 scope.NodeIds.insert(vslotId.NodeId);
@@ -1058,8 +1080,8 @@ public:
 
     // Strict database-only users must not be able to address storage objects outside their database.
     // Returns true if the response has been already sent.
-    bool ReplyAndPassAwayIfStorageIdsAreOutOfDatabase() {
-        if (InitialFilterGroupIds.empty() && InitialFilterNodeIds.empty() && InitialFilterPDiskIds.empty()) {
+    bool DenyRequestIfStorageIdsAreOutOfDatabase() {
+        if (!FilterGroupIds.RequestedAnything() && !FilterNodeIds.RequestedAnything() && !FilterPDiskIds.RequestedAnything()) {
             return false;
         }
         const TDatabaseStorageScope scope = GetDatabaseStorageScope();
@@ -1072,11 +1094,11 @@ public:
             return false;
         };
         TStringBuf objects;
-        if (outOfScope(InitialFilterGroupIds, scope.GroupIds)) {
+        if (outOfScope(FilterGroupIds.Requested, scope.GroupIds)) {
             objects = "storage groups";
-        } else if (outOfScope(InitialFilterNodeIds, scope.NodeIds)) {
+        } else if (outOfScope(FilterNodeIds.Requested, scope.NodeIds)) {
             objects = "nodes";
-        } else if (outOfScope(InitialFilterPDiskIds, scope.PDiskIds)) {
+        } else if (outOfScope(FilterPDiskIds.Requested, scope.PDiskIds)) {
             objects = "PDisk identifiers";
         } else {
             return false;
@@ -1090,7 +1112,7 @@ public:
 
     void ApplyFilter() {
         // database pre-filter, affects TotalGroups count
-        if (!DatabaseStoragePools.empty()) {
+        if (!DatabaseStoragePools.empty() && !DatabaseStoragePoolsApplied) {
             if (FieldsAvailable.test(+EGroupFields::PoolName)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
@@ -1099,7 +1121,7 @@ public:
                     }
                 }
                 GroupView.swap(groupView);
-                DatabaseStoragePools.clear();
+                DatabaseStoragePoolsApplied = true;
                 FoundGroups = TotalGroups = GroupView.size();
                 GroupsByGroupId.clear();
             } else {
@@ -1107,16 +1129,16 @@ public:
             }
         }
         // group id pre-filter, affects TotalGroups count
-        if (!FilterGroupIds.empty()) {
+        if (FilterGroupIds.IsPending()) {
             TGroupView groupView;
             for (TGroup* group : GroupView) {
-                if (FilterGroupIds.count(group->GroupId)) {
+                if (FilterGroupIds.IsPending(group->GroupId)) {
                     groupView.push_back(group);
                 }
             }
             GroupView.swap(groupView);
             FoundGroups = TotalGroups = GroupView.size();
-            FilterGroupIds.clear();
+            FilterGroupIds.Applied();
             GroupsByGroupId.clear();
         }
         // storage pool pre-filter, affects TotalGroups count
@@ -1137,12 +1159,12 @@ public:
             }
         }
         // node_id + pdisk_id pre-filter, affects TotalGroups count
-        if (!FilterNodeIds.empty() && !FilterPDiskIds.empty()) {
+        if (FilterNodeIds.IsPending() && FilterPDiskIds.IsPending()) {
             if (FieldsAvailable.test(+EGroupFields::NodeId) && FieldsAvailable.test(+EGroupFields::PDiskId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterNodeIds.count(vdisk.VSlotId.NodeId) && FilterPDiskIds.count(vdisk.VSlotId.PDiskId)) {
+                        if (FilterNodeIds.IsPending(vdisk.VSlotId.NodeId) && FilterPDiskIds.IsPending(vdisk.VSlotId.PDiskId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1150,20 +1172,20 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterNodeIds.clear();
-                FilterPDiskIds.clear();
+                FilterNodeIds.Applied();
+                FilterPDiskIds.Applied();
                 GroupsByGroupId.clear();
             } else {
                 return;
             }
         }
         // node_id pre-filter, affects TotalGroups count
-        if (!FilterNodeIds.empty()) {
+        if (FilterNodeIds.IsPending()) {
             if (FieldsAvailable.test(+EGroupFields::NodeId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterNodeIds.count(vdisk.VSlotId.NodeId)) {
+                        if (FilterNodeIds.IsPending(vdisk.VSlotId.NodeId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1171,19 +1193,19 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterNodeIds.clear();
+                FilterNodeIds.Applied();
                 GroupsByGroupId.clear();
             } else {
                 return;
             }
         }
         // pdisk_id pre-filter, affects TotalGroups count
-        if (!FilterPDiskIds.empty()) {
+        if (FilterPDiskIds.IsPending()) {
             if (FieldsAvailable.test(+EGroupFields::PDiskId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterPDiskIds.count(vdisk.VSlotId.PDiskId)) {
+                        if (FilterPDiskIds.IsPending(vdisk.VSlotId.PDiskId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1191,7 +1213,7 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterPDiskIds.clear();
+                FilterPDiskIds.Applied();
                 GroupsByGroupId.clear();
             } else {
                 return;
@@ -1256,7 +1278,7 @@ public:
                 FilterGroup.clear();
                 GroupsByGroupId.clear();
             }
-            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.empty() || !FilterPDiskIds.empty() || !FilterGroupIds.empty() || !FilterGroup.empty();
+            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || FilterNodeIds.IsPending() || FilterPDiskIds.IsPending() || FilterGroupIds.IsPending() || !FilterGroup.empty();
             FoundGroups = GroupView.size();
         }
     }
@@ -1527,10 +1549,10 @@ public:
         if (!FilterStoragePools.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PoolName)) {
             return true;
         }
-        if (!FilterNodeIds.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
+        if (FilterNodeIds.IsPending() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
             return true;
         }
-        if (!FilterPDiskIds.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
+        if (FilterPDiskIds.IsPending() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
             return true;
         }
         if (With == EWith::MissingDisks && NeedToWaitForFieldBeforeHive(EGroupFields::MissingDisks)) {
@@ -1797,7 +1819,6 @@ public:
                     for (const auto& storagePool : domainDescription->Description.GetStoragePools()) {
                         TString storagePoolName = storagePool.GetName();
                         DatabaseStoragePools.emplace(storagePoolName);
-                        DatabaseStoragePoolNames.emplace(storagePoolName);
                     }
                     NeedFilter = true;
                 }
@@ -2399,7 +2420,7 @@ public:
 
     void ReplyAndPassAway() override {
         AddEvent("ReplyAndPassAway");
-        if (StrictDatabaseOnlyToken && ReplyAndPassAwayIfStorageIdsAreOutOfDatabase()) {
+        if (IsStrictDatabaseOnlyRequest() && DenyRequestIfStorageIdsAreOutOfDatabase()) {
             return;
         }
         ApplyEverything();

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -941,8 +941,10 @@ public:
             return;
         }
         StrictDatabaseOnlyToken = IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()));
-        if (ReplyAndPassAwayIfNodesAreOutOfDatabase(FilterNodeIds)) {
-            return;
+        if (StrictDatabaseOnlyToken) {
+            if (ReplyAndPassAwayIfNodesAreOutOfDatabase(FilterNodeIds)) {
+                return;
+            }
         }
         if (!Viewer->CheckAccessViewer(TBase::GetRequest())) {
             // fields that are not available for database users

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -1372,6 +1372,12 @@ public:
             AddEvent("Type Filter Applied");
         }
         if (RestrictToDatabaseNodes && FieldsAvailable.test(+ENodeFields::NodeId)) {
+            if (RestrictedNodeIds.empty()) {
+                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Empty response: the database has no nodes to show",
+                    {"logPrefix", GetLogPrefix()},
+                    {"user", GetUserSID()},
+                    {"database", Database});
+            }
             TNodeView nodeView;
             for (TNode* node : NodeView) {
                 if (RestrictedNodeIds.count(node->GetNodeId()) > 0) {

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -129,6 +129,7 @@ class TJsonNodes : public TViewerPipeClient {
     std::vector<TString> FilterStoragePools;
     std::vector<std::pair<ui64, ui64>> FilterStoragePoolsIds;
     std::unordered_set<TNodeId> RestrictedNodeIds; // due to access rights
+    bool RestrictToDatabaseNodes = false; // the filter by RestrictedNodeIds is required, even if the set is empty
     std::unordered_set<TNodeId> FilterNodeIds;
     std::unordered_set<ui32> FilterGroupIds;
     std::optional<std::size_t> Offset;
@@ -1170,6 +1171,9 @@ public:
         if (IsDatabaseRequest() && !Viewer->CheckAccessViewer(TBase::GetRequest())) {
             auto nodes = GetDatabaseNodes();
             RestrictedNodeIds = std::unordered_set<TNodeId>(nodes.begin(), nodes.end());
+            // The filter must be applied even when the database has no nodes at all,
+            // otherwise a database user would get the nodes of the whole cluster.
+            RestrictToDatabaseNodes = true;
             NeedFilter = true;
         }
 
@@ -1367,7 +1371,7 @@ public:
             InvalidateNodes();
             AddEvent("Type Filter Applied");
         }
-        if (!RestrictedNodeIds.empty() && FieldsAvailable.test(+ENodeFields::NodeId)) {
+        if (RestrictToDatabaseNodes && FieldsAvailable.test(+ENodeFields::NodeId)) {
             TNodeView nodeView;
             for (TNode* node : NodeView) {
                 if (RestrictedNodeIds.count(node->GetNodeId()) > 0) {
@@ -1378,6 +1382,7 @@ public:
             FoundNodes = TotalNodes = NodeView.size();
             InvalidateNodes();
             RestrictedNodeIds.clear();
+            RestrictToDatabaseNodes = false;
             AddEvent("Restricted Filter Applied");
         }
 
@@ -1490,7 +1495,7 @@ public:
                 InvalidateNodes();
                 AddEvent("Group Filter Applied");
             }
-            NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0 || !FilterGroup.empty() || !RestrictedNodeIds.empty();
+            NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0 || !FilterGroup.empty() || RestrictToDatabaseNodes;
             FoundNodes = NodeView.size();
         }
     }

--- a/ydb/core/viewer/viewer_peers.h
+++ b/ydb/core/viewer/viewer_peers.h
@@ -392,6 +392,12 @@ class TJsonPeers : public TViewerPipeClient {
 
     void ApplyFilter() {
         if (RestrictToDatabaseNodes) {
+            if (RestrictedNodeIds.empty()) {
+                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Empty response: the database has no nodes to show",
+                    {"logPrefix", GetLogPrefix()},
+                    {"user", GetUserSID()},
+                    {"database", Database});
+            }
             TPeerView peerView;
             for (TPeer* peer : PeerView) {
                 if (RestrictedNodeIds.count(peer->GetPeerId()) > 0) {

--- a/ydb/core/viewer/viewer_peers.h
+++ b/ydb/core/viewer/viewer_peers.h
@@ -52,6 +52,7 @@ class TJsonPeers : public TViewerPipeClient {
     std::unordered_map<TNodeId, TRequestResponse<TEvViewer::TEvViewerResponse>> PeersViewerResponse;
 
     std::unordered_set<TNodeId> RestrictedNodeIds; // due to access rights
+    bool RestrictToDatabaseNodes = false; // the filter by RestrictedNodeIds is required, even if the set is empty
     TNodeId NodeId = 0;
     std::optional<std::size_t> Offset;
     std::optional<std::size_t> Limit;
@@ -351,6 +352,9 @@ class TJsonPeers : public TViewerPipeClient {
         if (IsDatabaseRequest() && !Viewer->CheckAccessViewer(TBase::GetRequest())) {
             auto nodes = GetDatabaseNodes();
             RestrictedNodeIds = std::unordered_set<TNodeId>(nodes.begin(), nodes.end());
+            // The filter must be applied even when the database has no nodes at all,
+            // otherwise a database user would get the peers of the whole cluster.
+            RestrictToDatabaseNodes = true;
             NeedFilter = true;
         }
         NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
@@ -387,7 +391,7 @@ class TJsonPeers : public TViewerPipeClient {
     }
 
     void ApplyFilter() {
-        if (!RestrictedNodeIds.empty()) {
+        if (RestrictToDatabaseNodes) {
             TPeerView peerView;
             for (TPeer* peer : PeerView) {
                 if (RestrictedNodeIds.count(peer->GetPeerId()) > 0) {
@@ -398,6 +402,7 @@ class TJsonPeers : public TViewerPipeClient {
             FoundPeers = TotalPeers = PeerView.size();
             InvalidatePeers();
             RestrictedNodeIds.clear();
+            RestrictToDatabaseNodes = false;
             AddEvent("Restricted Filter Applied");
         }
 

--- a/ydb/core/viewer/viewer_put_record.h
+++ b/ydb/core/viewer/viewer_put_record.h
@@ -55,9 +55,6 @@ public:
         }
     }
     void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
         if (!PostData.Has("path") || !PostData.Has("message")) {
             return ReplyAndPassAway(TBase::GetHTTPBADREQUEST("text/plain", "fields 'path' and 'message' are required and should not be empty"));
         }

--- a/ydb/core/viewer/viewer_put_record.h
+++ b/ydb/core/viewer/viewer_put_record.h
@@ -55,6 +55,9 @@ public:
         }
     }
     void Bootstrap() override {
+        if (NeedToRedirect()) {
+            return;
+        }
         if (!PostData.Has("path") || !PostData.Has("message")) {
             return ReplyAndPassAway(TBase::GetHTTPBADREQUEST("text/plain", "fields 'path' and 'message' are required and should not be empty"));
         }

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -89,9 +89,12 @@ public:
         if (NeedToRedirect()) {
             return;
         }
-        // The check is done here, before the describe request below, because in the "path" branch
-        // TBase::Bootstrap() (and its node_id scope check) is reached only after the describe response.
-        if (TBase::ReplyAndPassAwayIfNodeIdsAreOutOfDatabase()) {
+        // node_id is normally validated by TBase::Bootstrap(), but this handler calls it at the very
+        // end: with a "path" param it first asks SchemeShard and reaches TBase::Bootstrap() only from
+        // the describe response handler. Denying the request there would be both too late (SchemeShard
+        // has already been asked) and unsafe (the handler goes on building the whiteboard request
+        // that TBase::Bootstrap() never created). So the check is done up front, for both branches.
+        if (TBase::DenyRequestIfNodeIdsAreOutOfDatabase()) {
             return;
         }
         if (DatabaseNavigateResponse && DatabaseNavigateResponse->IsOk()) {

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -89,6 +89,11 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        // The check is done here, before the describe request below, because in the "path" branch
+        // TBase::Bootstrap() (and its node_id scope check) is reached only after the describe response.
+        if (TBase::ReplyAndPassAwayIfNodeIdsAreOutOfDatabase()) {
+            return;
+        }
         if (DatabaseNavigateResponse && DatabaseNavigateResponse->IsOk()) {
             TPathId domainRoot;
             if (AppData()) {
@@ -339,6 +344,11 @@ public:
         }
         if (!Tablets.empty()) {
             TBase::Bootstrap();
+            if (ReplySent) {
+                // TBase::Bootstrap() has already replied (e.g. the database has no nodes to ask),
+                // so the whiteboard request has not been built.
+                return;
+            }
             for (auto tablet : Tablets) {
                 Request->Record.AddFilterTabletId(tablet.first);
             }

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -7,6 +7,7 @@
 #include "viewer_tabletinfo.h"
 #include "wb_aggregate.h"
 #include "wb_merge.h"
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/memory_stats.h>
 
 namespace NKikimr::NViewer {
@@ -134,6 +135,12 @@ public:
         OffloadMerge = FromStringWithDefault<bool>(Params.Get("offload_merge"), OffloadMerge);
         MetadataCache = FromStringWithDefault<bool>(Params.Get("metadata_cache"), MetadataCache);
         ShowAllDatabases = FromStringWithDefault<bool>(Params.Get("show_all_databases"), ShowAllDatabases);
+        if (ShowAllDatabases && IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()))) {
+            ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain", "`show_all_databases` is not allowed for database-scoped access"),
+                "Access denied");
+            return;
+        }
 
         TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
         auto* domain = domains->GetDomain();

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -7,7 +7,6 @@
 #include "viewer_tabletinfo.h"
 #include "wb_aggregate.h"
 #include "wb_merge.h"
-#include <ydb/core/base/auth.h>
 #include <ydb/core/base/memory_stats.h>
 
 namespace NKikimr::NViewer {
@@ -135,7 +134,7 @@ public:
         OffloadMerge = FromStringWithDefault<bool>(Params.Get("offload_merge"), OffloadMerge);
         MetadataCache = FromStringWithDefault<bool>(Params.Get("metadata_cache"), MetadataCache);
         ShowAllDatabases = FromStringWithDefault<bool>(Params.Get("show_all_databases"), ShowAllDatabases);
-        if (ShowAllDatabases && IsStrictDatabaseOnlyToken(AppData(), TString(GetRequest().GetUserTokenObject()))) {
+        if (ShowAllDatabases && IsStrictDatabaseOnlyRequest()) {
             ReplyAndPassAway(
                 GETHTTPACCESSDENIED("text/plain", "`show_all_databases` is not allowed for database-scoped access"),
                 "Access denied");

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -135,6 +135,10 @@ public:
         MetadataCache = FromStringWithDefault<bool>(Params.Get("metadata_cache"), MetadataCache);
         ShowAllDatabases = FromStringWithDefault<bool>(Params.Get("show_all_databases"), ShowAllDatabases);
         if (ShowAllDatabases && IsStrictDatabaseOnlyRequest()) {
+            YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: `show_all_databases` is not allowed for database-scoped access",
+                {"logPrefix", GetLogPrefix()},
+                {"user", GetUserSID()},
+                {"database", Database});
             ReplyAndPassAway(
                 GETHTTPACCESSDENIED("text/plain", "`show_all_databases` is not allowed for database-scoped access"),
                 "Access denied");

--- a/ydb/tests/functional/secrets/test_secrets_monitoring.py
+++ b/ydb/tests/functional/secrets/test_secrets_monitoring.py
@@ -3,6 +3,7 @@
 import logging
 
 from ydb.tests.functional.secrets.lib.secrets_plugin import create_secrets, DATABASE, ROOT
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
 import requests
 
 logger = logging.getLogger(__name__)
@@ -12,15 +13,6 @@ CLUSTER_CONFIG = dict(
         # 'TX_PROXY': LogLevels.DEBUG,
     },
 )
-
-
-def get_tenant_schemeshard_id(ydb_cluster, root_path, database_path):
-    mon_url = f"http://{cluster_http_endpoint(ydb_cluster)}"
-    response = requests.get(f"{mon_url}/viewer/json/describe?database={root_path}&path={database_path}", timeout=10)
-    response.raise_for_status()
-    data = response.json()
-
-    return int(data["PathDescription"]["Self"]["SchemeshardId"])
 
 
 def cluster_http_endpoint(cluster):

--- a/ydb/tests/functional/secrets/ya.make
+++ b/ydb/tests/functional/secrets/ya.make
@@ -27,6 +27,7 @@ PEERDIR(
     contrib/python/boto3
     contrib/python/requests
     ydb/tests/functional/secrets/lib
+    ydb/tests/functional/security/lib
     ydb/tests/library
     ydb/tests/library/fixtures
     ydb/tests/library/flavours

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -140,10 +140,12 @@ def get_foreign_node_id_for_database(base_url, database, token='root@builtin'):
     return min(foreign_nodes)
 
 
-def get_storage_groups(base_url, database, token='root@builtin', timeout=30, **params):
+def get_storage_groups(base_url, database=None, token='root@builtin', timeout=30, **params):
+    if database is not None:
+        params = {'database': database, **params}
     response = requests.get(
         base_url + '/storage/groups',
-        params={'database': database, **params},
+        params=params,
         headers={'Authorization': token},
         verify=False,
         timeout=timeout,
@@ -152,58 +154,43 @@ def get_storage_groups(base_url, database, token='root@builtin', timeout=30, **p
     return response.json()
 
 
-def get_tenant_storage_group_id(base_url, database, token='root@builtin', timeout_seconds=60):
-    last_data = {}
+def get_storage_ids(base_url, database=None, token='root@builtin', timeout=60):
+    """Ids covered by the storage groups of the given database, or of the whole cluster
+    when database is None: the groups themselves and the nodes/pdisks holding their vdisks."""
+    data = get_storage_groups(
+        base_url,
+        database,
+        token,
+        fields_required='GroupId,VDisk,PDisk,NodeId,PDiskId',
+        timeout=timeout,
+    )
+    ids = {'group_ids': set(), 'node_ids': set(), 'pdisk_ids': set()}
+    for group in data.get('StorageGroups') or []:
+        ids['group_ids'].add(int(group['GroupId']))
+        for vdisk in group.get('VDisks') or []:
+            # PDiskId is reported as "<node_id>-<pdisk_id>"
+            pdisk_id_str = str((vdisk.get('PDisk') or {}).get('PDiskId') or '')
+            if '-' in pdisk_id_str:
+                node_id_str, _, local_pdisk_id_str = pdisk_id_str.partition('-')
+                ids['node_ids'].add(int(node_id_str))
+                ids['pdisk_ids'].add(int(local_pdisk_id_str))
+    return ids
+
+
+def wait_for_storage_ids(base_url, database, token='root@builtin', timeout_seconds=60):
+    """Same as get_storage_ids, but waits until the database gets its storage groups."""
+    last = {}
 
     def ready():
-        data = get_storage_groups(
-            base_url,
-            database,
-            token,
-            fields_required='GroupId,PoolName',
-        )
-        last_data['data'] = data
-        groups = data.get('StorageGroups') or []
-        return bool(groups)
+        last['ids'] = get_storage_ids(base_url, database, token)
+        return bool(last['ids']['node_ids'])
 
     if not wait_for(ready, timeout_seconds=timeout_seconds, step_seconds=1):
         raise AssertionError(
-            f'no storage groups for database={database} after {timeout_seconds}s; '
-            f'last={last_data.get("data")}'
+            f'no storage groups with disks for database={database} after {timeout_seconds}s; '
+            f'last={last.get("ids")}'
         )
-    return int(last_data['data']['StorageGroups'][0]['GroupId'])
-
-
-def get_tenant_storage_disk_location(base_url, database, token='root@builtin', timeout_seconds=60):
-    """Returns (node_id, pdisk_id) of a pdisk holding a vdisk of the database storage groups."""
-    last_data = {}
-
-    def ready():
-        data = get_storage_groups(
-            base_url,
-            database,
-            token,
-            fields_required='GroupId,VDisk,PDisk,NodeId,PDiskId',
-            timeout=60,
-        )
-        last_data['data'] = data
-        for group in data.get('StorageGroups') or []:
-            for vdisk in group.get('VDisks') or []:
-                pdisk = vdisk.get('PDisk') or {}
-                # PDiskId is reported as "<node_id>-<pdisk_id>"
-                pdisk_id_str = str(pdisk.get('PDiskId') or '')
-                if '-' in pdisk_id_str:
-                    node_id_str, _, local_pdisk_id_str = pdisk_id_str.partition('-')
-                    last_data['location'] = (int(node_id_str), int(local_pdisk_id_str))
-                    return True
-        return False
-
-    if not wait_for(ready, timeout_seconds=timeout_seconds, step_seconds=1):
-        raise AssertionError(
-            f'no pdisk id found for database={database} after {timeout_seconds}s; '
-            f'last={last_data.get("data")}'
-        )
-    return last_data['location']
+    return last['ids']
 
 
 def get_unknown_node_id(base_url, token='root@builtin'):

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -118,6 +118,28 @@ def get_tenant_path_id(cluster, root_path, database_path, use_tls=False):
     return int(describe_path_self(cluster, root_path, database_path, use_tls)['PathId'])
 
 
+def get_nodelist_ids(base_url, database=None, token='root@builtin'):
+    params = {}
+    if database is not None:
+        params['database'] = database
+    response = requests.get(
+        base_url + '/viewer/json/nodelist',
+        params=params,
+        headers={'Authorization': token},
+        verify=False,
+        timeout=5,
+    )
+    response.raise_for_status()
+    return [node['Id'] for node in response.json()]
+
+
+def get_foreign_node_id_for_database(base_url, database, token='root@builtin'):
+    database_nodes = set(get_nodelist_ids(base_url, database=database, token=token))
+    foreign_nodes = set(get_nodelist_ids(base_url, token=token)) - database_nodes
+    assert foreign_nodes, f'no foreign nodes found for database={database}'
+    return min(foreign_nodes)
+
+
 def wait_for_viewer_ready(
     base_url,
     database=DATABASE,

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -89,6 +89,35 @@ def mon_base_url(cluster, node_index=1):
     return f'https://{node.host}:{node.mon_port}'
 
 
+def describe_path_self(cluster, root_path, database_path, use_tls=False):
+    node = cluster.nodes[1]
+    if use_tls:
+        base_url = f'https://{node.host}:{node.mon_port}'
+        headers = {'Authorization': 'root@builtin'}
+        verify = False
+    else:
+        base_url = f'http://{node.host}:{node.mon_port}'
+        headers = {}
+        verify = True
+    response = requests.get(
+        base_url + '/viewer/json/describe',
+        params={'database': root_path, 'path': database_path},
+        headers=headers,
+        verify=verify,
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()['PathDescription']['Self']
+
+
+def get_tenant_schemeshard_id(cluster, root_path, database_path, use_tls=False):
+    return int(describe_path_self(cluster, root_path, database_path, use_tls)['SchemeshardId'])
+
+
+def get_tenant_path_id(cluster, root_path, database_path, use_tls=False):
+    return int(describe_path_self(cluster, root_path, database_path, use_tls)['PathId'])
+
+
 def wait_for_viewer_ready(
     base_url,
     database=DATABASE,

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -174,7 +174,8 @@ def get_tenant_storage_group_id(base_url, database, token='root@builtin', timeou
     return int(last_data['data']['StorageGroups'][0]['GroupId'])
 
 
-def get_tenant_storage_pdisk_id(base_url, database, token='root@builtin', timeout_seconds=60):
+def get_tenant_storage_disk_location(base_url, database, token='root@builtin', timeout_seconds=60):
+    """Returns (node_id, pdisk_id) of a pdisk holding a vdisk of the database storage groups."""
     last_data = {}
 
     def ready():
@@ -183,16 +184,17 @@ def get_tenant_storage_pdisk_id(base_url, database, token='root@builtin', timeou
             database,
             token,
             fields_required='GroupId,VDisk,PDisk,NodeId,PDiskId',
-            **{'with': 'all'},
             timeout=60,
         )
         last_data['data'] = data
         for group in data.get('StorageGroups') or []:
             for vdisk in group.get('VDisks') or []:
                 pdisk = vdisk.get('PDisk') or {}
+                # PDiskId is reported as "<node_id>-<pdisk_id>"
                 pdisk_id_str = str(pdisk.get('PDiskId') or '')
                 if '-' in pdisk_id_str:
-                    last_data['pdisk_id'] = int(pdisk_id_str.split('-', 1)[1])
+                    node_id_str, _, local_pdisk_id_str = pdisk_id_str.partition('-')
+                    last_data['location'] = (int(node_id_str), int(local_pdisk_id_str))
                     return True
         return False
 
@@ -201,7 +203,12 @@ def get_tenant_storage_pdisk_id(base_url, database, token='root@builtin', timeou
             f'no pdisk id found for database={database} after {timeout_seconds}s; '
             f'last={last_data.get("data")}'
         )
-    return last_data['pdisk_id']
+    return last_data['location']
+
+
+def get_unknown_node_id(base_url, token='root@builtin'):
+    """Returns a node id that does not exist in the cluster at all."""
+    return max(get_nodelist_ids(base_url, token=token)) + 100
 
 
 def wait_for_viewer_ready(

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -140,6 +140,70 @@ def get_foreign_node_id_for_database(base_url, database, token='root@builtin'):
     return min(foreign_nodes)
 
 
+def get_storage_groups(base_url, database, token='root@builtin', timeout=30, **params):
+    response = requests.get(
+        base_url + '/storage/groups',
+        params={'database': database, **params},
+        headers={'Authorization': token},
+        verify=False,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_tenant_storage_group_id(base_url, database, token='root@builtin', timeout_seconds=60):
+    last_data = {}
+
+    def ready():
+        data = get_storage_groups(
+            base_url,
+            database,
+            token,
+            fields_required='GroupId,PoolName',
+        )
+        last_data['data'] = data
+        groups = data.get('StorageGroups') or []
+        return bool(groups)
+
+    if not wait_for(ready, timeout_seconds=timeout_seconds, step_seconds=1):
+        raise AssertionError(
+            f'no storage groups for database={database} after {timeout_seconds}s; '
+            f'last={last_data.get("data")}'
+        )
+    return int(last_data['data']['StorageGroups'][0]['GroupId'])
+
+
+def get_tenant_storage_pdisk_id(base_url, database, token='root@builtin', timeout_seconds=60):
+    last_data = {}
+
+    def ready():
+        data = get_storage_groups(
+            base_url,
+            database,
+            token,
+            fields_required='GroupId,VDisk,PDisk,NodeId,PDiskId',
+            **{'with': 'all'},
+            timeout=60,
+        )
+        last_data['data'] = data
+        for group in data.get('StorageGroups') or []:
+            for vdisk in group.get('VDisks') or []:
+                pdisk = vdisk.get('PDisk') or {}
+                pdisk_id_str = str(pdisk.get('PDiskId') or '')
+                if '-' in pdisk_id_str:
+                    last_data['pdisk_id'] = int(pdisk_id_str.split('-', 1)[1])
+                    return True
+        return False
+
+    if not wait_for(ready, timeout_seconds=timeout_seconds, step_seconds=1):
+        raise AssertionError(
+            f'no pdisk id found for database={database} after {timeout_seconds}s; '
+            f'last={last_data.get("data")}'
+        )
+    return last_data['pdisk_id']
+
+
 def wait_for_viewer_ready(
     base_url,
     database=DATABASE,

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -89,33 +89,29 @@ def mon_base_url(cluster, node_index=1):
     return f'https://{node.host}:{node.mon_port}'
 
 
-def describe_path_self(cluster, root_path, database_path, use_tls=False):
+# use_tls only picks the scheme, and token only decides whether the request is authenticated:
+# a cluster without authentication rejects a request with an Authorization header with 400,
+# and a cluster with authentication rejects a request without it with 401.
+def describe_path_self(cluster, root_path, database_path, use_tls=False, token=None):
     node = cluster.nodes[1]
-    if use_tls:
-        base_url = f'https://{node.host}:{node.mon_port}'
-        headers = {'Authorization': 'root@builtin'}
-        verify = False
-    else:
-        base_url = f'http://{node.host}:{node.mon_port}'
-        headers = {}
-        verify = True
+    scheme = 'https' if use_tls else 'http'
     response = requests.get(
-        base_url + '/viewer/json/describe',
+        f'{scheme}://{node.host}:{node.mon_port}/viewer/json/describe',
         params={'database': root_path, 'path': database_path},
-        headers=headers,
-        verify=verify,
+        headers={'Authorization': token} if token is not None else {},
+        verify=False,
         timeout=5,
     )
     response.raise_for_status()
     return response.json()['PathDescription']['Self']
 
 
-def get_tenant_schemeshard_id(cluster, root_path, database_path, use_tls=False):
-    return int(describe_path_self(cluster, root_path, database_path, use_tls)['SchemeshardId'])
+def get_tenant_schemeshard_id(cluster, root_path, database_path, use_tls=False, token=None):
+    return int(describe_path_self(cluster, root_path, database_path, use_tls, token)['SchemeshardId'])
 
 
-def get_tenant_path_id(cluster, root_path, database_path, use_tls=False):
-    return int(describe_path_self(cluster, root_path, database_path, use_tls)['PathId'])
+def get_tenant_path_id(cluster, root_path, database_path, use_tls=False, token=None):
+    return int(describe_path_self(cluster, root_path, database_path, use_tls, token)['PathId'])
 
 
 def get_nodelist_ids(base_url, database=None, token='root@builtin'):

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -8,6 +8,7 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.functional.security.lib.cluster_config import create_ydb_configurator, generate_certificates
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import grant_describe_schema_provided
+from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 pytest_plugins = ['ydb.tests.library.fixtures', 'ydb.tests.library.flavours']
@@ -183,6 +184,29 @@ def ydb_cluster_with_extra_sids_controls(certificates):
     cluster.start()
     yield cluster
     cluster.stop()
+
+
+TENANT_DATABASE = '/Root/Tenant'
+
+
+@pytest.fixture(scope='module')
+def tenant_database(ydb_cluster_with_extra_sids_controls):
+    cluster = ydb_cluster_with_extra_sids_controls
+    cluster.create_database(
+        TENANT_DATABASE,
+        storage_pool_units_count={'hdd': 1},
+        token='root@builtin',
+    )
+    slots = cluster.register_and_start_slots(TENANT_DATABASE, count=1)
+    cluster.wait_tenant_up(TENANT_DATABASE, token='root@builtin')
+    tenant_node = slots[0]
+    run_viewer_query(
+        f'https://{tenant_node.host}:{tenant_node.mon_port}',
+        f"GRANT 'ydb.granular.describe_schema' ON `{TENANT_DATABASE}` "
+        f"TO `database@builtin`, `viewer@builtin`, `monitoring@builtin`, `root@builtin`;",
+        database=TENANT_DATABASE,
+    )
+    return TENANT_DATABASE
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -7,6 +7,8 @@ import requests
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.functional.security.lib.cluster_config import create_ydb_configurator, generate_certificates
 from ydb.tests.functional.security.lib.security_test_helpers import grant_describe_schema_provided
+from ydb.tests.functional.security.lib.security_test_helpers import get_foreign_node_id_for_database
+from ydb.tests.functional.security.lib.security_test_helpers import get_nodelist_ids
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
@@ -218,6 +220,18 @@ def tenant_describe_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
         'path_id': get_tenant_path_id(cluster, tenant_database, tenant_database, use_tls=True),
         'schemeshard_id': get_tenant_schemeshard_id(cluster, tenant_database, tenant_database, use_tls=True),
     }
+
+
+@pytest.fixture(scope='module')
+def tenant_nodelist_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_nodelist_ids(base_url, database=tenant_database)
+
+
+@pytest.fixture(scope='module')
+def foreign_node_id(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_foreign_node_id_for_database(base_url, tenant_database)
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -11,9 +11,9 @@ from ydb.tests.functional.security.lib.security_test_helpers import get_foreign_
 from ydb.tests.functional.security.lib.security_test_helpers import get_nodelist_ids
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
-from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_group_id
-from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_disk_location
+from ydb.tests.functional.security.lib.security_test_helpers import get_storage_ids
 from ydb.tests.functional.security.lib.security_test_helpers import get_unknown_node_id
+from ydb.tests.functional.security.lib.security_test_helpers import wait_for_storage_ids
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -237,16 +237,18 @@ def foreign_node_id(ydb_cluster_with_extra_sids_controls, tenant_database):
     return get_foreign_node_id_for_database(base_url, tenant_database)
 
 
+# Storage groups of the tenant database and the nodes/pdisks they live on.
 @pytest.fixture(scope='module')
-def tenant_storage_group_id(ydb_cluster_with_extra_sids_controls, tenant_database):
+def tenant_storage_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
     base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
-    return get_tenant_storage_group_id(base_url, tenant_database)
+    return wait_for_storage_ids(base_url, tenant_database)
 
 
+# The same for the whole cluster, so that a test can pick an id outside the tenant database.
 @pytest.fixture(scope='module')
-def tenant_storage_disk_location(ydb_cluster_with_extra_sids_controls, tenant_database):
+def cluster_storage_ids(ydb_cluster_with_extra_sids_controls, tenant_storage_ids):
     base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
-    return get_tenant_storage_disk_location(base_url, tenant_database)
+    return get_storage_ids(base_url)
 
 
 @pytest.fixture(scope='module')

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -220,8 +220,8 @@ def tenant_database(ydb_cluster_with_extra_sids_controls):
 def tenant_describe_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
     cluster = ydb_cluster_with_extra_sids_controls
     return {
-        'path_id': get_tenant_path_id(cluster, tenant_database, tenant_database, use_tls=True),
-        'schemeshard_id': get_tenant_schemeshard_id(cluster, tenant_database, tenant_database, use_tls=True),
+        'path_id': get_tenant_path_id(cluster, tenant_database, tenant_database, use_tls=True, token='root@builtin'),
+        'schemeshard_id': get_tenant_schemeshard_id(cluster, tenant_database, tenant_database, use_tls=True, token='root@builtin'),
     }
 
 

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -11,6 +11,8 @@ from ydb.tests.functional.security.lib.security_test_helpers import get_foreign_
 from ydb.tests.functional.security.lib.security_test_helpers import get_nodelist_ids
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_group_id
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_pdisk_id
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -232,6 +234,18 @@ def tenant_nodelist_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
 def foreign_node_id(ydb_cluster_with_extra_sids_controls, tenant_database):
     base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
     return get_foreign_node_id_for_database(base_url, tenant_database)
+
+
+@pytest.fixture(scope='module')
+def tenant_storage_group_id(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_tenant_storage_group_id(base_url, tenant_database)
+
+
+@pytest.fixture(scope='module')
+def tenant_storage_pdisk_id(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_tenant_storage_pdisk_id(base_url, tenant_database)
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -12,7 +12,8 @@ from ydb.tests.functional.security.lib.security_test_helpers import get_nodelist
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_group_id
-from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_pdisk_id
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_storage_disk_location
+from ydb.tests.functional.security.lib.security_test_helpers import get_unknown_node_id
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -243,9 +244,15 @@ def tenant_storage_group_id(ydb_cluster_with_extra_sids_controls, tenant_databas
 
 
 @pytest.fixture(scope='module')
-def tenant_storage_pdisk_id(ydb_cluster_with_extra_sids_controls, tenant_database):
+def tenant_storage_disk_location(ydb_cluster_with_extra_sids_controls, tenant_database):
     base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
-    return get_tenant_storage_pdisk_id(base_url, tenant_database)
+    return get_tenant_storage_disk_location(base_url, tenant_database)
+
+
+@pytest.fixture(scope='module')
+def unknown_node_id(ydb_cluster_with_extra_sids_controls):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_unknown_node_id(base_url)
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -6,8 +6,10 @@ import requests
 
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.functional.security.lib.cluster_config import create_ydb_configurator, generate_certificates
-from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import grant_describe_schema_provided
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
+from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -207,6 +209,15 @@ def tenant_database(ydb_cluster_with_extra_sids_controls):
         database=TENANT_DATABASE,
     )
     return TENANT_DATABASE
+
+
+@pytest.fixture(scope='module')
+def tenant_describe_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
+    cluster = ydb_cluster_with_extra_sids_controls
+    return {
+        'path_id': get_tenant_path_id(cluster, tenant_database, tenant_database, use_tls=True),
+        'schemeshard_id': get_tenant_schemeshard_id(cluster, tenant_database, tenant_database, use_tls=True),
+    }
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -374,60 +374,34 @@ def test_out_of_scope_path_nodes_gives_400(mon_base_url_with_extra_sids_control)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
 
 
-def test_viewer_direct_forbidden_for_strict_database_token(
-    mon_base_url_with_extra_sids_control,
-    tenant_database,
-):
-    # this list is not exhaustive and covers some of the endpoints that use direct param
-    for ep in [
-        '/viewer/sysinfo',
-        '/viewer/json/feature_flags',
-        '/viewer/nodelist',
-    ]:
-        forbidden_path = _build_endpoint_path(
-            ep,
-            with_database_cgi=True,
-            extra_params={'direct': 'true'},
-            database=tenant_database,
-        )
-        _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 403)
-
-        allowed_path = _build_endpoint_path(
-            ep,
-            with_database_cgi=True,
-            database=tenant_database,
-        )
-        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
-
-        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
-            _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, token, 200)
-
-
 def test_storage_groups_scope_params_forbidden_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,
     tenant_nodelist_ids,
+    tenant_storage_ids,
+    cluster_storage_ids,
     unknown_node_id,
-    tenant_storage_group_id,
-    tenant_storage_disk_location,
 ):
     assert tenant_nodelist_ids, 'tenant database must have at least one node'
-    tenant_node_id = tenant_nodelist_ids[0]
-    storage_node_id, storage_pdisk_id = tenant_storage_disk_location
-    foreign_group_id = tenant_storage_group_id + 0x10000000
     base = mon_base_url_with_extra_sids_control
 
     allowed_cases = (
-        {'group_id': str(tenant_storage_group_id)},
+        {'group_id': str(min(tenant_storage_ids['group_ids']))},
         # both the nodes of the database itself and the nodes holding its storage are in scope
-        {'node_id': str(tenant_node_id)},
-        {'node_id': str(storage_node_id)},
-        {'pdisk_id': str(storage_pdisk_id)},
+        {'node_id': str(tenant_nodelist_ids[0])},
+        {'node_id': str(min(tenant_storage_ids['node_ids']))},
+        {'pdisk_id': str(min(tenant_storage_ids['pdisk_ids']))},
     )
+
+    foreign_group_ids = cluster_storage_ids['group_ids'] - tenant_storage_ids['group_ids']
+    foreign_pdisk_ids = cluster_storage_ids['pdisk_ids'] - tenant_storage_ids['pdisk_ids']
+    assert foreign_group_ids, 'the cluster must have a storage group outside the tenant database'
     forbidden_cases = (
-        {'group_id': str(foreign_group_id)},
+        {'group_id': str(min(foreign_group_ids))},
         {'node_id': str(unknown_node_id)},
-        {'pdisk_id': '999999'},
+        # a pdisk which exists but holds nothing of the database may be absent in a small cluster,
+        # then an id of a pdisk that doesn't exist at all is checked instead
+        {'pdisk_id': str(min(foreign_pdisk_ids) if foreign_pdisk_ids else 999999)},
     )
 
     for extra_params in allowed_cases:

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -336,6 +336,44 @@ def test_viewer_describe_strict_database_token_forbidden_params(mon_base_url_wit
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
 
 
+# path_id/schemeshard_id require monitoring access; strict database and viewer tokens get 403.
+def test_viewer_describe_path_id_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_describe_ids,
+):
+    for ep in ['/viewer/describe', '/viewer/json/describe']:
+        # path_id alone is accepted for monitoring+ access level,
+        # as well as both params together: path_id and schemeshard_id
+        for extra_params in (
+            {'path_id': str(tenant_describe_ids['path_id'])},
+            {
+                'path_id': str(tenant_describe_ids['path_id']),
+                'schemeshard_id': str(tenant_describe_ids['schemeshard_id']),
+            },
+        ):
+            path = _build_endpoint_path(
+                ep,
+                with_database_cgi=True,
+                extra_params=extra_params,
+                database=tenant_database,
+            )
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 403)
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'viewer@builtin', 403)
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'monitoring@builtin', 200)
+
+        # schemeshard_id alone without path_id is rejected always
+        path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'schemeshard_id': str(tenant_describe_ids['schemeshard_id'])},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 403)
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
+
+
 # Path outside database scope gives endpoint validation error (400), not role-denied (403).
 def test_out_of_scope_path_nodes_gives_400(mon_base_url_with_extra_sids_control):
     for ep in ['/viewer/nodes', '/viewer/json/nodes']:

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -407,23 +407,26 @@ def test_storage_groups_scope_params_forbidden_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,
     tenant_nodelist_ids,
-    foreign_node_id,
+    unknown_node_id,
     tenant_storage_group_id,
-    tenant_storage_pdisk_id,
+    tenant_storage_disk_location,
 ):
     assert tenant_nodelist_ids, 'tenant database must have at least one node'
     tenant_node_id = tenant_nodelist_ids[0]
+    storage_node_id, storage_pdisk_id = tenant_storage_disk_location
     foreign_group_id = tenant_storage_group_id + 0x10000000
     base = mon_base_url_with_extra_sids_control
 
     allowed_cases = (
         {'group_id': str(tenant_storage_group_id)},
+        # both the nodes of the database itself and the nodes holding its storage are in scope
         {'node_id': str(tenant_node_id)},
-        {'pdisk_id': str(tenant_storage_pdisk_id)},
+        {'node_id': str(storage_node_id)},
+        {'pdisk_id': str(storage_pdisk_id)},
     )
     forbidden_cases = (
         {'group_id': str(foreign_group_id)},
-        {'node_id': str(foreign_node_id)},
+        {'node_id': str(unknown_node_id)},
         {'pdisk_id': '999999'},
     )
 
@@ -481,3 +484,33 @@ def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
         # Foreign node_id is filtered out by database scope which results with OK (200) empty response, not 4xx.
         for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
             _assert_status(mon_base_url_with_extra_sids_control, foreign_path, token, 200)
+
+
+# /viewer/tabletinfo with the "path" param asks SchemeShard first and builds the whiteboard request
+# only after the describe response, so the node_id scope check has its own code path there.
+def test_viewer_tabletinfo_path_with_node_id_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_nodelist_ids,
+    foreign_node_id,
+):
+    assert tenant_nodelist_ids, 'tenant database must have at least one node'
+    base = mon_base_url_with_extra_sids_control
+    for ep in ['/viewer/tabletinfo', '/viewer/json/tabletinfo']:
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': tenant_database, 'node_id': str(foreign_node_id)},
+            database=tenant_database,
+        )
+        _assert_status(base, forbidden_path, 'database@builtin', 403)
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(base, forbidden_path, token, 200)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': tenant_database, 'node_id': str(tenant_nodelist_ids[0])},
+            database=tenant_database,
+        )
+        _assert_status(base, allowed_path, 'database@builtin', 200)

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -286,16 +286,9 @@ def test_viewer_tenantinfo_show_all_databases_forbidden_for_strict_database_toke
             database=tenant_database,
         )
         _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 403)
-        # Scope-param validation must not block tokens above database level.
+        # Scope-param validation must not block users above database level.
         for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
-            headers = {'Authorization': token}
-            response = requests.get(
-                mon_base_url_with_extra_sids_control + forbidden_path,
-                headers=headers,
-                verify=False,
-                timeout=5,
-            )
-            assert response.status_code != 403, response.text
+            _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, token, 200)
 
         allowed_path = _build_endpoint_path(
             ep,
@@ -313,18 +306,26 @@ def test_viewer_tenantinfo_show_all_databases_forbidden_for_strict_database_toke
 
 
 # database@builtin is a strict database-only token and must be rejected when path is out of database scope.
-def test_viewer_describe_out_of_scope_path(mon_base_url_with_extra_sids_control):
+def test_viewer_describe_out_of_scope_path(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+):
     for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path': '/Other'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': '/Other'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 400)
 
-
-# Extra CGI params (e.g. merge) are forbidden for strict database tokens on describe.
-def test_viewer_describe_strict_database_token_extra_params(mon_base_url_with_extra_sids_control):
-    for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'merge': 'true'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': tenant_database},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'root@builtin', 200)
 
 
 # path_id/schemeshard_id params require monitoring+ level access; strict database and viewer tokens get 4xx.

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -390,6 +390,35 @@ def test_viewer_describe_schemeshard_id_forbidden(mon_base_url_with_extra_sids_c
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
 
 
+def test_viewer_direct_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+):
+    # this list is not exhaustive and covers some of the endpoints that use direct param
+    for ep in [
+        '/viewer/sysinfo',
+        '/viewer/json/feature_flags',
+        '/viewer/nodelist',
+    ]:
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'direct': 'true'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 403)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
+
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, token, 200)
+
+
 def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -336,7 +336,7 @@ def test_viewer_describe_strict_database_token_forbidden_params(mon_base_url_wit
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
 
 
-# path_id/schemeshard_id require monitoring access; strict database and viewer tokens get 403.
+# path_id/schemeshard_id params require monitoring+ level access; strict database and viewer tokens get 4xx.
 def test_viewer_describe_path_id_forbidden_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,
@@ -388,3 +388,38 @@ def test_viewer_describe_schemeshard_id_forbidden(mon_base_url_with_extra_sids_c
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
         # An administrator also gets 400, but from handler validation
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
+
+
+def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_nodelist_ids,
+    foreign_node_id,
+):
+    assert tenant_nodelist_ids, 'tenant database must have at least one node'
+    tenant_node_id = tenant_nodelist_ids[0]
+    endpoints = [
+        '/viewer/sysinfo',
+        '/viewer/tabletinfo',
+    ]
+    for ep in endpoints:
+        foreign_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'node_id': str(foreign_node_id)},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, foreign_path, 'database@builtin', 403)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'node_id': str(tenant_node_id)},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
+
+        # Scope-param validation must not block tokens above strict database level.
+        # Foreign node_id is filtered out by database scope which results with OK (200) empty response, not 4xx.
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(mon_base_url_with_extra_sids_control, foreign_path, token, 200)

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -419,6 +419,51 @@ def test_viewer_direct_forbidden_for_strict_database_token(
             _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, token, 200)
 
 
+def test_storage_groups_scope_params_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_nodelist_ids,
+    foreign_node_id,
+    tenant_storage_group_id,
+    tenant_storage_pdisk_id,
+):
+    assert tenant_nodelist_ids, 'tenant database must have at least one node'
+    tenant_node_id = tenant_nodelist_ids[0]
+    foreign_group_id = tenant_storage_group_id + 0x10000000
+    base = mon_base_url_with_extra_sids_control
+
+    allowed_cases = (
+        {'group_id': str(tenant_storage_group_id)},
+        {'node_id': str(tenant_node_id)},
+        {'pdisk_id': str(tenant_storage_pdisk_id)},
+    )
+    forbidden_cases = (
+        {'group_id': str(foreign_group_id)},
+        {'node_id': str(foreign_node_id)},
+        {'pdisk_id': '999999'},
+    )
+
+    for extra_params in allowed_cases:
+        path = _build_endpoint_path(
+            '/storage/groups',
+            with_database_cgi=True,
+            extra_params=extra_params,
+            database=tenant_database,
+        )
+        _assert_status(base, path, 'database@builtin', 200)
+
+    for extra_params in forbidden_cases:
+        path = _build_endpoint_path(
+            '/storage/groups',
+            with_database_cgi=True,
+            extra_params=extra_params,
+            database=tenant_database,
+        )
+        _assert_status(base, path, 'database@builtin', 403)
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(base, path, token, 200)
+
+
 def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -55,10 +55,10 @@ def _assert_viewer_query_post(base_url, token, status=200, database=DATABASE):
     assert response.status_code == status, response.text
 
 
-def _build_endpoint_path(endpoint, with_database_cgi, extra_params=None):
+def _build_endpoint_path(endpoint, with_database_cgi, extra_params=None, database=DATABASE):
     params = dict(extra_params or {})
     if with_database_cgi:
-        params = {'database': DATABASE, **params}
+        params = {'database': database, **params}
     if not params:
         return endpoint
     separator = '&' if '?' in endpoint else '?'
@@ -272,6 +272,44 @@ def test_topic_data_access_controls(mon_base_url_with_extra_sids_control, topic_
                 token = 'root@builtin'
                 _assert_status(mon_base_url_with_extra_sids_control, _build_topic_path(ep, with_database_cgi=True), token, 200)
                 _assert_status(mon_base_url_with_extra_sids_control, _build_topic_path(ep, with_database_cgi=False), token, 200)
+
+
+def test_viewer_tenantinfo_show_all_databases_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+):
+    for ep in ['/viewer/tenantinfo', '/viewer/json/tenantinfo']:
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'show_all_databases': 'true'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 403)
+        # Scope-param validation must not block tokens above database level.
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            headers = {'Authorization': token}
+            response = requests.get(
+                mon_base_url_with_extra_sids_control + forbidden_path,
+                headers=headers,
+                verify=False,
+                timeout=5,
+            )
+            assert response.status_code != 403, response.text
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
+        allowed_path_false = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'show_all_databases': 'false'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path_false, 'database@builtin', 200)
 
 
 # database@builtin is a strict database-only token and must be rejected when path is out of database scope.

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -319,21 +319,12 @@ def test_viewer_describe_out_of_scope_path(mon_base_url_with_extra_sids_control)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
 
 
-# Only CGI params that bypass regular path validation (e.g. path_id, schemeshard_id) are forbidden.
+# Extra CGI params (e.g. merge) are forbidden for strict database tokens on describe.
 def test_viewer_describe_strict_database_token_extra_params(mon_base_url_with_extra_sids_control):
     for ep in ['/viewer/describe', '/viewer/json/describe']:
         path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'merge': 'true'})
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
-
-
-# path_id CGI param bypasses regular path validation, so handler validation rejects it as a bad request.
-def test_viewer_describe_strict_database_token_forbidden_params(mon_base_url_with_extra_sids_control):
-    for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path_id': '1'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-        # path_id is rejected only for some access levels
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
 
 
 # path_id/schemeshard_id params require monitoring+ level access; strict database and viewer tokens get 4xx.
@@ -363,7 +354,7 @@ def test_viewer_describe_path_id_forbidden_for_strict_database_token(
             _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
             _assert_status(mon_base_url_with_extra_sids_control, path, 'monitoring@builtin', 200)
 
-        # schemeshard_id alone without path_id is rejected always
+        # schemeshard_id alone without path_id: handler gives 403 for strict database users and rejects other with 400
         path = _build_endpoint_path(
             ep,
             with_database_cgi=True,
@@ -371,6 +362,7 @@ def test_viewer_describe_path_id_forbidden_for_strict_database_token(
             database=tenant_database,
         )
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 403)
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'viewer@builtin', 403)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
 
 
@@ -379,15 +371,6 @@ def test_out_of_scope_path_nodes_gives_400(mon_base_url_with_extra_sids_control)
     for ep in ['/viewer/nodes', '/viewer/json/nodes']:
         path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path': '/Other'})
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-
-
-# schemeshard_id CGI param bypasses regular path validation, so handler validation rejects it as a bad request.
-def test_viewer_describe_schemeshard_id_forbidden(mon_base_url_with_extra_sids_control):
-    for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'schemeshard_id': '1'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-        # An administrator also gets 400, but from handler validation
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
 
 
 def test_viewer_direct_forbidden_for_strict_database_token(


### PR DESCRIPTION
### Description for reviewers 
Пять изменений, которые сделаны только для strict database пользователей, т.е. таких, которые есть только в списках `database_allwed_sids` и которым можно видеть только информацию уровня базы, но не уровня клатера.

1. В хендлере `/viewer/tenantinfo` отдаём 403, если включен параметр `show_all_databases` (+тест).
По логам UI, такой параметр для strict database пользователей никогда не передаётся.

2. В хендлере `/viewer/describe` дополнительно к query-параметру `path_id` запретил параметр `schemeshard_id` (+тест).
По логам UI, отдельно `schemeshard_id` без `path_id` не передаётся, а в запросах с `path_id` действительно отдаётся 403.

3. В хендлерах `/viewer/sysinfo` и `/viewer/tabletinfo` проверяем, что нода из node_id принадлежит базе (+тест).

4. Во всех хендлерах запрещён параметр `direct`, т.к. он позволяет выполнять запросы на той же ноде, куда пришёл запрос, а для strict database пользователей правильнее работать на нодах из их базы (+тест).
По логам UI, этот параметр не передают ни в каких хендлерах.

5. В хендлере `/storage/groups`  проверяем, что node_id , pdisk_id, group_id принадлежат базе (+тесты).