### PR TITLE
Add InterruptInheritance flag to secrets describe

### DIFF
--- a/ydb/public/lib/ydb_cli/common/describe.cpp
+++ b/ydb/public/lib/ydb_cli/common/describe.cpp
@@ -756,13 +756,13 @@ int TDescribeLogic::PrintPathResponse(const TString& path, const NScheme::TDescr
     case NScheme::ESchemeEntryType::SysView:
         return DescribeSystemView(path, format);
     case NScheme::ESchemeEntryType::Secret:
-        return DescribeSecret(path, format);
+        return DescribeSecret(path, options, format);
     default:
         return DescribeEntryDefault(entry, options);
     }
 }
 
-int TDescribeLogic::DescribeSecret(const TString& path, EDataFormat format) {
+int TDescribeLogic::DescribeSecret(const TString& path, const TDescribeOptions& options, EDataFormat format) {
     NSecret::TSecretClient secretClient(Driver);
 
     auto secretResult = secretClient.DescribeSecret(path).GetValueSync();
@@ -772,7 +772,7 @@ int TDescribeLogic::DescribeSecret(const TString& path, EDataFormat format) {
     }
 
     if (format == EDataFormat::Pretty || format == EDataFormat::Default) {
-        return PrintSecretResponsePretty(secretResult);
+        return PrintSecretResponsePretty(secretResult, options);
     }
     if (format == EDataFormat::Json) {
         Cerr << "Warning! Option --json is deprecated and will be removed soon. "
@@ -786,8 +786,13 @@ int TDescribeLogic::DescribeSecret(const TString& path, EDataFormat format) {
     return PrintProtoJsonBase64(msg, Out);
 }
 
-int TDescribeLogic::PrintSecretResponsePretty(const NSecret::TDescribeSecretResult& result) const {
+int TDescribeLogic::PrintSecretResponsePretty(const NSecret::TDescribeSecretResult& result, const TDescribeOptions& options) const {
     Out << "Version: " << result.GetVersion() << Endl;
+    if (options.ShowPermissions) {
+        const auto& entry = result.GetEntry();
+        Out << Endl;
+        PrintAllPermissions(entry.Owner, entry.Permissions, entry.EffectivePermissions, entry.InterruptInheritance, Out);
+    }
     return EXIT_SUCCESS;
 }
 

--- a/ydb/public/lib/ydb_cli/common/describe.h
+++ b/ydb/public/lib/ydb_cli/common/describe.h
@@ -60,8 +60,8 @@ private:
     int DescribeSystemView(const TString& path, EDataFormat format);
     int PrintSystemViewResponsePretty(const NYdb::NTable::TSystemViewDescription& result) const;
 
-    int DescribeSecret(const TString& path, EDataFormat format);
-    int PrintSecretResponsePretty(const NSecret::TDescribeSecretResult& result) const;
+    int DescribeSecret(const TString& path, const TDescribeOptions& options, EDataFormat format);
+    int PrintSecretResponsePretty(const NSecret::TDescribeSecretResult& result, const TDescribeOptions& options) const;
 
     int TryTopicConsumerDescribeOrFail(const TString& path, const NScheme::TDescribePathResult& result, const TDescribeOptions& options, EDataFormat format);
     std::pair<TString, TString> ParseTopicConsumer(const TString& path) const;

--- a/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
@@ -252,7 +252,6 @@ class TestSecretSchemeDescribe:
             expected_version=1,
         )
 
-
     @pytest.mark.parametrize(
         "inherit_permissions",
         [

--- a/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
@@ -62,10 +62,14 @@ def create_external_table(session, external_table, external_data_source):
     )
 
 
-def create_secret(session, secret_name, value):
+def create_secret(session, secret_name, value, inherit_permissions):
+    inherit_permissions_sql_value = "TRUE" if inherit_permissions else "FALSE"
     session.execute_scheme(
         f"""
-        CREATE SECRET `{secret_name}` WITH ( value = '{value}' );
+        CREATE SECRET `{secret_name}` WITH (
+            value = '{value}',
+            inherit_permissions = {inherit_permissions_sql_value}
+        );
         """
     )
 
@@ -202,7 +206,7 @@ class TestSecretSchemeDescribe:
 
         # check the initial state
         with session_pool.checkout() as session:
-            create_secret(session, secret_name, self.secret_value_created)
+            create_secret(session, secret_name, self.secret_value_created, inherit_permissions=False)
         self._assert_scheme_describe_secret_default(
             ydb_cluster,
             ydb_database,
@@ -228,7 +232,7 @@ class TestSecretSchemeDescribe:
 
         # check the initial state
         with session_pool.checkout() as session:
-            create_secret(session, secret_name, self.secret_value_created)
+            create_secret(session, secret_name, self.secret_value_created, inherit_permissions=False)
         self._assert_scheme_describe_secret_proto_json_base64(
             ydb_cluster,
             ydb_database,
@@ -247,6 +251,41 @@ class TestSecretSchemeDescribe:
             absent_substrings=[self.secret_value_created, self.secret_value_altered],
             expected_version=1,
         )
+
+
+    @pytest.mark.parametrize(
+        "inherit_permissions",
+        [
+            pytest.param(False, id="inherit_permissions_false"),
+            pytest.param(True, id="inherit_permissions_true"),
+        ],
+    )
+    def test_describe_secret_permissions(
+        self,
+        ydb_cluster,
+        ydb_database,
+        ydb_client_session,
+        inherit_permissions,
+    ):
+        secret_name = f"cli_scheme_describe_secret_permissions_{str(inherit_permissions).lower()}"
+        session_pool = ydb_client_session(ydb_database)
+        interrupted_line = "Is permission inheritance interrupted: true"
+
+        with session_pool.checkout() as session:
+            create_secret(session, secret_name, self.secret_value_created, inherit_permissions=inherit_permissions)
+
+        describe_permissions = execute_ydb_cli_command(
+            ydb_cluster.nodes[1],
+            ydb_database,
+            ["scheme", "describe", "--permissions", secret_name],
+        )
+
+        assert "<secret>" in describe_permissions
+        assert "Version: 0" in describe_permissions
+        if not inherit_permissions:
+            assert interrupted_line in describe_permissions
+        else:
+            assert interrupted_line not in describe_permissions
 
 
 class TestViewSchemeDescribe:


### PR DESCRIPTION
### Description for reviewers
Флаг ранее в https://github.com/ydb-platform/ydb/pull/49236 добавился в `ydb scheme permissions list`, но его не было в `ydb scheme describe --permissions`. Сейчас добавил.