### PR TITLE
actors: add optional waker to basic executor pool

### DIFF
--- a/ydb/core/driver_lib/run/config_helpers.cpp
+++ b/ydb/core/driver_lib/run/config_helpers.cpp
@@ -54,6 +54,9 @@ void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig
     Y_ABORT_UNLESS(!poolConfig.HasHarmonizerNeedyCpuWindowSeconds()
         || poolConfig.GetType() == NKikimrConfig::TActorSystemConfig::TExecutor::BASIC,
         "HarmonizerNeedyCpuWindowSeconds is supported only for BASIC executors");
+    Y_ABORT_UNLESS(!poolConfig.HasEnableWaker()
+        || poolConfig.GetType() == NKikimrConfig::TActorSystemConfig::TExecutor::BASIC,
+        "EnableWaker is supported only for BASIC executors");
 
     switch (poolConfig.GetType()) {
         case NKikimrConfig::TActorSystemConfig::TExecutor::BASIC: {
@@ -73,6 +76,7 @@ void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig
             basic.Affinity = ParseAffinity(poolConfig.GetAffinity());
             basic.RealtimePriority = poolConfig.GetRealtimePriority();
             basic.HasSharedThread = poolConfig.GetHasSharedThread();
+            basic.EnableWaker = poolConfig.GetEnableWaker();
             if (poolConfig.HasTimePerMailboxMicroSecs()) {
                 basic.TimePerMailbox = TDuration::MicroSeconds(poolConfig.GetTimePerMailboxMicroSecs());
             } else if (systemConfig.HasTimePerMailboxMicroSecs()) {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -93,6 +93,7 @@ message TActorSystemConfig {
         optional int32 Priority = 16;
         optional int32 MaxAvgPingDeviation = 17;
         optional uint32 HarmonizerNeedyCpuWindowSeconds = 26 [default = 1]; // Supported for BASIC executors, range is [1, 32]
+        optional bool EnableWaker = 27 [default = false]; // Experimental, non-shared BASIC executors only
 
         optional bool HasSharedThread = 18;
         optional bool AllThreadsAreShared = 24;

--- a/ydb/library/actors/core/actor_benchmark_helper.h
+++ b/ydb/library/actors/core/actor_benchmark_helper.h
@@ -447,8 +447,10 @@ struct TActorBenchmark {
         ui64 MaxPairSentEvents;
     };
 
-    static auto BenchContentedThreads(ui32 threads, ui32 actorsPairsCount, EPoolType poolType, ESendingType sendingType, TDuration testDuration = TDuration::Zero(), ui32 inFlight = 1) {
+    static auto BenchContentedThreads(ui32 threads, ui32 actorsPairsCount, EPoolType poolType, ESendingType sendingType,
+            TDuration testDuration = TDuration::Zero(), ui32 inFlight = 1, bool enableWaker = false) {
         THolder<TActorSystemSetup> setup = InitActorSystemSetup(poolType, 1, threads, false);
+        setup->CpuManager.Basic.back().EnableWaker = enableWaker;
         TActorSystem actorSystem(setup);
         actorSystem.Start();
 

--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -33,6 +33,7 @@ namespace NActors {
         EASProfile ActorSystemProfile = EASProfile::Default;
         bool HasSharedThread = false;
         bool AllThreadsAreShared = false;
+        bool EnableWaker = false;
         // tiny-ydb configs
         std::vector<i16> AdjacentPools;
         i16 ForcedForeignSlotCount = 0;

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -11,9 +11,11 @@
 #include "debug.h"
 #include "thread_context.h"
 #include <atomic>
+#include <algorithm>
 #include <memory>
 #include <ydb/library/actors/util/affinity.h>
 #include <ydb/library/actors/util/datetime.h>
+#include <ydb/library/actors/util/thread.h>
 
 #ifdef _linux_
 #include <pthread.h>
@@ -31,6 +33,35 @@
 
 
 namespace NActors {
+
+    class TBasicExecutorPool::TWaker : public ISimpleThread {
+    public:
+        explicit TWaker(TBasicExecutorPool* pool)
+            : Pool(pool)
+            , ThreadName(pool->PoolName ? pool->PoolName + "_waker" : "BasicPoolWaker")
+        {
+            SleepingStack.reserve(Pool->MaxFullThreadCount);
+            ActiveWorkers.reserve(Pool->MaxFullThreadCount);
+            ActiveMask.resize(Pool->MaxFullThreadCount, true);
+            for (i16 workerId = 0; workerId < Pool->MaxFullThreadCount; ++workerId) {
+                ActiveWorkers.push_back(workerId);
+            }
+        }
+
+        void* ThreadProc() override {
+            ::SetCurrentThreadName(ThreadName);
+            Pool->WakerLoop();
+            return nullptr;
+        }
+
+    private:
+        friend class TBasicExecutorPool;
+        TBasicExecutorPool* const Pool;
+        const TString ThreadName;
+        TVector<i16> SleepingStack;
+        TVector<i16> ActiveWorkers;
+        TVector<bool> ActiveMask;
+    };
 
     namespace {
 #ifdef ACTOR_SANITIZER
@@ -107,6 +138,7 @@ namespace NActors {
         , EventsPerMailboxValue(cfg.EventsPerMailbox)
         , RealtimePriority(cfg.RealtimePriority)
         , ThreadCount(cfg.Threads)
+        , SuggestedThreadCount(cfg.Threads)
         , MinFullThreadCount(cfg.MinThreadCount)
         , MaxFullThreadCount(cfg.MaxThreadCount)
         , DefaultFullThreadCount(cfg.DefaultThreadCount)
@@ -116,6 +148,7 @@ namespace NActors {
         , SharedOnly(cfg.ForcedForeignSlotCount || cfg.AdjacentPools.size() || (!cfg.Threads && !cfg.MaxThreadCount))
         , Priority(cfg.Priority)
         , Jail(jail)
+        , EnableWaker(cfg.EnableWaker)
         , ActorSystemProfile(cfg.ActorSystemProfile)
     {
         Y_UNUSED(Jail, SoftProcessingDurationTs);
@@ -181,6 +214,7 @@ namespace NActors {
         }
 
         ThreadCount = static_cast<i16>(MaxFullThreadCount);
+        SuggestedThreadCount = ThreadCount;
         auto semaphore = TSemaphore();
         semaphore.CurrentThreadCount = ThreadCount;
         Semaphore = semaphore.ConvertToI64();
@@ -194,6 +228,11 @@ namespace NActors {
         }
 
         Threads.Reset(new NThreading::TPadded<TExecutorThreadCtx>[MaxFullThreadCount]);
+        if (EnableWaker) {
+            Y_ABORT_UNLESS(!HasOwnSharedThread && !SharedOnly,
+                "EnableWaker is supported only for non-shared Basic executor pools");
+            Waker = std::make_unique<TWaker>(this);
+        }
         if constexpr (DebugMode) {
             Sanitizer.reset(new TBasicExecutorPoolSanitizer(this));
         }
@@ -256,13 +295,13 @@ namespace NActors {
 
         Y_DEBUG_ABORT_UNLESS(workerId < MaxFullThreadCount);
 
-        Threads[workerId].UnsetWork();
         if (Harmonizer) {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "try to harmonize");
             LWPROBE(TryToHarmonize, PoolId, PoolName);
             Harmonizer->Harmonize(hpnow);
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "harmonize done");
         }
+        Threads[workerId].UnsetWork();
 
         while (!StopFlag.load(std::memory_order_acquire)) {
             {
@@ -307,9 +346,212 @@ namespace NActors {
         return nullptr;
     }
 
+    TMailbox* TBasicExecutorPool::GetReadyActivationWaker(ui64 revolvingCounter) {
+        if (StopFlag.load(std::memory_order_acquire)) {
+            return nullptr;
+        }
+
+        const TWorkerId workerId = TlsThreadContext->WorkerId();
+        Y_DEBUG_ABORT_UNLESS(workerId < MaxFullThreadCount);
+        NHPTimer::STime hpnow = GetCycleCountFast();
+        TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION, false> activityGuard(hpnow);
+        if (Harmonizer) {
+            LWPROBE(TryToHarmonize, PoolId, PoolName);
+            Harmonizer->Harmonize(hpnow);
+        }
+        Threads[workerId].UnsetWork();
+
+        while (!StopFlag.load(std::memory_order_acquire)) {
+            ui64 checkToSleepWorkers = CheckToSleepWorkers.load(std::memory_order_acquire);
+            bool needToBlock = false;
+            while (checkToSleepWorkers) {
+                if (CheckToSleepWorkers.compare_exchange_weak(checkToSleepWorkers, checkToSleepWorkers - 1,
+                        std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    needToBlock = true;
+                    break;
+                }
+            }
+            if (needToBlock) {
+                Y_ABORT_UNLESS(Threads[workerId].StartWakerBlocking());
+                RequestWaker();
+                if (Threads[workerId].WaitForWaker(0, &StopFlag, &ActivationCredits)) {
+                    return nullptr;
+                }
+                continue;
+            }
+
+            {
+                TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> queueActivityGuard;
+                if (const ui32 activation = Activations.Pop(++revolvingCounter)) {
+                    Threads[workerId].SetWork();
+                    const i64 previousCredits = ActivationCredits.fetch_sub(1, std::memory_order_acq_rel);
+                    Y_DEBUG_ABORT_UNLESS(previousCredits > 0);
+                    return MailboxTable->Get(activation);
+                }
+            }
+
+            if (ActivationCredits.load(std::memory_order_acquire) > 0) {
+                SpinLockPause();
+                continue;
+            }
+
+            if (!TlsThreadContext->ExecutionContext.IsNeededToWaitNextActivation) {
+                return nullptr;
+            }
+
+            if (Threads[workerId].StartWakerWait()) {
+                RequestWaker();
+                if (Threads[workerId].WaitForWaker(SpinThresholdCycles.load(std::memory_order_relaxed), &StopFlag, &ActivationCredits)) {
+                    return nullptr;
+                }
+            }
+        }
+        return nullptr;
+    }
+
     TMailbox* TBasicExecutorPool::GetReadyActivation(ui64 revolvingCounter) {
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "ring queue");
+        if (EnableWaker) {
+            return GetReadyActivationWaker(revolvingCounter);
+        }
         return GetReadyActivationRingQueue(revolvingCounter);
+    }
+
+    void TBasicExecutorPool::RequestWaker() {
+        if (!WakerPending.exchange(true, std::memory_order_acq_rel)) {
+            WakerPad.Unpark();
+        }
+    }
+
+    void TBasicExecutorPool::WakerLoop() {
+        const auto removeActiveWorker = [&](i16 workerId) {
+            Waker->ActiveMask[workerId] = false;
+            auto it = std::find(Waker->ActiveWorkers.begin(), Waker->ActiveWorkers.end(), workerId);
+            Y_ABORT_UNLESS(it != Waker->ActiveWorkers.end());
+            *it = Waker->ActiveWorkers.back();
+            Waker->ActiveWorkers.pop_back();
+        };
+        while (!StopFlag.load(std::memory_order_acquire)) {
+            if (WakerPad.Park()) {
+                break;
+            }
+            WakerPending.store(false, std::memory_order_release);
+
+            const i16 threadCount = AtomicLoad(&SuggestedThreadCount);
+            CheckToSleepWorkers.store(0, std::memory_order_release);
+
+            for (size_t idx = 0; idx < Waker->ActiveWorkers.size();) {
+                const i16 workerId = Waker->ActiveWorkers[idx];
+                EThreadState expected = EThreadState::Blocking;
+                if (Threads[workerId].GetState<EThreadState>() != EThreadState::Blocking) {
+                    ++idx;
+                    continue;
+                }
+                if (Waker->ActiveWorkers.size() > static_cast<size_t>(threadCount)) {
+                    if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
+                        Waker->SleepingStack.push_back(workerId);
+                        removeActiveWorker(workerId);
+                        continue;
+                    }
+                } else {
+                    if (Threads[workerId].ReplaceState(expected, EThreadState::None)) {
+                        Threads[workerId].WaitingPad.Unpark();
+                    }
+                }
+                ++idx;
+            }
+
+            for (size_t idx = 0; idx < Waker->ActiveWorkers.size()
+                    && Waker->ActiveWorkers.size() > static_cast<size_t>(threadCount);) {
+                const i16 workerId = Waker->ActiveWorkers[idx];
+                const EThreadState state = Threads[workerId].GetState<EThreadState>();
+                if (state == EThreadState::Sleep) {
+                    SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
+                    removeActiveWorker(workerId);
+                    continue;
+                }
+                if (state == EThreadState::Spin) {
+                    EThreadState expected = EThreadState::Spin;
+                    if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
+                        Waker->SleepingStack.push_back(workerId);
+                        removeActiveWorker(workerId);
+                        continue;
+                    }
+                }
+                ++idx;
+            }
+
+            while (Waker->ActiveWorkers.size() < static_cast<size_t>(threadCount)) {
+                auto it = std::find_if(Waker->SleepingStack.rbegin(), Waker->SleepingStack.rend(), [&](i16 workerId) {
+                    return !Waker->ActiveMask[workerId];
+                });
+                if (it == Waker->SleepingStack.rend()) {
+                    break;
+                }
+                const i16 workerId = *it;
+                Waker->ActiveMask[workerId] = true;
+                Waker->ActiveWorkers.push_back(workerId);
+                SleepingCount.fetch_add(1, std::memory_order_release);
+            }
+
+            const i16 activeThreadCount = static_cast<i16>(Waker->ActiveWorkers.size());
+            if (activeThreadCount > threadCount) {
+                CheckToSleepWorkers.store(activeThreadCount - threadCount, std::memory_order_release);
+            }
+            AtomicSet(ThreadCount, activeThreadCount);
+
+            const auto countSearchingWorkers = [&] {
+                i16 count = 0;
+                for (i16 workerId : Waker->ActiveWorkers) {
+                    if (Threads[workerId].GetState<EThreadState>() == EThreadState::None) {
+                        ++count;
+                    }
+                }
+                return count;
+            };
+
+            i64 budget = Max<i64>(ActivationCredits.load(std::memory_order_acquire) - countSearchingWorkers(), 0);
+            i16 newlySleeping = 0;
+
+            for (i16 workerId : Waker->ActiveWorkers) {
+                EThreadState expected = EThreadState::Spin;
+                if (budget > 0) {
+                    if (Threads[workerId].ReplaceState(expected, EThreadState::None)) {
+                        --budget;
+                    }
+                } else if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
+                    Waker->SleepingStack.push_back(workerId);
+                    ++newlySleeping;
+                }
+            }
+
+            if (newlySleeping) {
+                SleepingCount.fetch_add(newlySleeping, std::memory_order_release);
+            }
+
+            // This reload closes the race where a producer publishes a credit
+            // before the waker publishes the corresponding sleeping worker.
+            budget = Max<i64>(ActivationCredits.load(std::memory_order_acquire) - countSearchingWorkers(), 0);
+            while (budget > 0) {
+                bool wokeWorker = false;
+                for (size_t idx = Waker->SleepingStack.size(); idx > 0; --idx) {
+                    const i16 workerId = Waker->SleepingStack[idx - 1];
+                    if (!Waker->ActiveMask[workerId]) {
+                        continue;
+                    }
+                    Waker->SleepingStack.erase(Waker->SleepingStack.begin() + idx - 1);
+                    if (Threads[workerId].WakeFromWaker()) {
+                        SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
+                        --budget;
+                        wokeWorker = true;
+                    }
+                    break;
+                }
+                if (!wokeWorker) {
+                    break;
+                }
+            }
+        }
     }
 
     inline void TBasicExecutorPool::WakeUpLoop(i16 currentThreadCount) {
@@ -383,7 +625,19 @@ namespace NActors {
     }
 
     void TBasicExecutorPool::ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingCounter) {
+        if (EnableWaker) {
+            ScheduleActivationExWaker(mailbox, revolvingCounter);
+            return;
+        }
         ScheduleActivationExRingQueue(mailbox, revolvingCounter, std::nullopt);
+    }
+
+    void TBasicExecutorPool::ScheduleActivationExWaker(TMailbox* mailbox, ui64 revolvingCounter) {
+        ActivationCredits.fetch_add(1, std::memory_order_acq_rel);
+        Activations.Push(mailbox->Hint, revolvingCounter);
+        if (SleepingCount.load(std::memory_order_acquire) > 0) {
+            RequestWaker();
+        }
     }
 
     void TBasicExecutorPool::GetCurrentStats(TExecutorPoolStats& poolStats, TVector<TExecutorThreadStats>& statsCopy) const {
@@ -470,6 +724,10 @@ namespace NActors {
         ThreadUtilization = 0;
         AtomicAdd(MaxUtilizationCounter, -(i64)GetCycleCountFast());
 
+        if (EnableWaker) {
+            Waker->Start();
+        }
+
         for (i16 i = 0; i != MaxFullThreadCount; ++i) {
             Threads[i].Thread->Start();
         }
@@ -483,6 +741,9 @@ namespace NActors {
     void TBasicExecutorPool::PrepareStop() {
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::ExecutorPool, "stop flag set");
         StopFlag.store(true, std::memory_order_release);
+        if (EnableWaker) {
+            WakerPad.Interrupt();
+        }
         for (i16 i = 0; i != MaxFullThreadCount; ++i) {
             Threads[i].Thread->StopFlag.store(true, std::memory_order_release);
             Threads[i].Interrupt();
@@ -495,6 +756,9 @@ namespace NActors {
 
     void TBasicExecutorPool::Shutdown() {
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::ExecutorPool, "shutdown");
+        if (EnableWaker) {
+            Waker->Join();
+        }
         for (i16 i = 0; i != MaxFullThreadCount; ++i) {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::ExecutorPool, "join ", i);
             Threads[i].Thread->Join();
@@ -560,6 +824,14 @@ namespace NActors {
     void TBasicExecutorPool::SetFullThreadCount(i16 threads) {
         threads = Max<i16>(MinFullThreadCount, Min(MaxFullThreadCount, threads));
         with_lock (ChangeThreadsLock) {
+            if (EnableWaker) {
+                if (AtomicLoad(&SuggestedThreadCount) != threads) {
+                    AtomicSet(SuggestedThreadCount, threads);
+                    RequestWaker();
+                }
+                LWPROBE(ThreadCount, PoolId, PoolName, threads, MinThreadCount, MaxThreadCount, DefaultThreadCount);
+                return;
+            }
             i16 prevCount = GetFullThreadCount();
             AtomicSet(ThreadCount, threads);
             TSemaphore semaphore = TSemaphore::GetSemaphore(AtomicGet(Semaphore));

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -509,7 +509,8 @@ namespace NActors {
                 return count;
             };
 
-            i64 budget = Max<i64>(ActivationCredits.load(std::memory_order_acquire) - countSearchingWorkers(), 0);
+            const i64 previousActivationCredits = ActivationCredits.load(std::memory_order_acquire);
+            i64 budget = Max<i64>(previousActivationCredits - countSearchingWorkers(), 0);
             i16 newlySleeping = 0;
 
             for (i16 workerId : Waker->ActiveWorkers) {
@@ -528,9 +529,6 @@ namespace NActors {
                 SleepingCount.fetch_add(newlySleeping, std::memory_order_release);
             }
 
-            // This reload closes the race where a producer publishes a credit
-            // before the waker publishes the corresponding sleeping worker.
-            budget = Max<i64>(ActivationCredits.load(std::memory_order_acquire) - countSearchingWorkers(), 0);
             while (budget > 0) {
                 bool wokeWorker = false;
                 for (size_t idx = Waker->SleepingStack.size(); idx > 0; --idx) {
@@ -549,6 +547,12 @@ namespace NActors {
                 if (!wokeWorker) {
                     break;
                 }
+            }
+
+            // A producer may publish a credit before the corresponding
+            // sleeping worker becomes visible through SleepingCount.
+            if (ActivationCredits.load(std::memory_order_acquire) > previousActivationCredits) {
+                RequestWaker();
             }
         }
     }

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -354,7 +354,7 @@ namespace NActors {
                     continue;
                 }
                 if (state == EThreadState::Spin || state == EThreadState::Sleep || state == EThreadState::Blocking) {
-                    if (Threads[workerId].WaitForWaker(&StopFlag, &ActivationCredits)) {
+                    if (Threads[workerId].WaitForWaker(StopFlag, ActivationCredits, CheckToSleepWorkers)) {
                         return true;
                     }
                     continue;
@@ -365,69 +365,53 @@ namespace NActors {
         };
 
         while (!StopFlag.load(std::memory_order_acquire)) {
-            if (settleWakerState()) {
-                return nullptr;
-            }
-
-            ui64 reductions = CheckToSleepWorkers.load(std::memory_order_acquire);
-            bool claimedReduction = false;
-            while (true) {
-                if (reductions & WakerRequestBit) {
-                    if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions & WakerReductionMask,
-                            std::memory_order_acq_rel, std::memory_order_acquire)) {
-                        bool changed = Threads[workerId].TrySetNeedToBeWaker(EThreadState::None);
-                        Y_DEBUG_ABORT_UNLESS(changed);
-                        settleWakerState();
+            if (TlsThreadContext->ExecutionContext.IsNeededToWaitNextActivation) {
+                ui64 reductions = CheckToSleepWorkers.load(std::memory_order_acquire);
+                bool restartWorkerIteration = false;
+                while (true) {
+                    if (reductions & WakerRequestBit) {
+                        if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions & WakerReductionMask,
+                                std::memory_order_acq_rel, std::memory_order_acquire)) {
+                            EThreadState expected = EThreadState::None;
+                            bool changed = Threads[workerId].TrySetNeedToBeWaker(&expected);
+                            Y_DEBUG_ABORT_UNLESS(changed);
+                            settleWakerState();
+                            restartWorkerIteration = true;
+                            break;
+                        }
+                        continue;
+                    }
+                    if (reductions == 0) {
                         break;
                     }
-                    continue;
-                }
-                if (reductions == 0) {
+                    if (!CheckToSleepWorkers.compare_exchange_weak(reductions, reductions - 1,
+                            std::memory_order_acq_rel, std::memory_order_acquire)) {
+                        continue;
+                    }
+
+                    EThreadState expected = EThreadState::None;
+                    Y_ABORT_UNLESS(Threads[workerId].ReplaceState(expected, EThreadState::Blocking));
+                    if (!WakerPending.exchange(true, std::memory_order_acq_rel)) {
+                        Threads[workerId].TrySetNeedToBeWaker();
+                    }
+                    if (settleWakerState()) {
+                        return nullptr;
+                    }
+                    restartWorkerIteration = true;
                     break;
                 }
-                if (!CheckToSleepWorkers.compare_exchange_weak(reductions, reductions - 1,
-                        std::memory_order_acq_rel, std::memory_order_acquire)) {
+
+                if (restartWorkerIteration) {
                     continue;
                 }
-
-                EThreadState expected = EThreadState::None;
-                Y_ABORT_UNLESS(Threads[workerId].ReplaceState(expected, EThreadState::Blocking));
-                reductions = CheckToSleepWorkers.load(std::memory_order_acquire);
-                while (reductions & WakerRequestBit) {
-                    if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions & WakerReductionMask,
-                            std::memory_order_acq_rel, std::memory_order_acquire)) {
-                        Threads[workerId].TrySetNeedToBeWaker(EThreadState::Blocking);
-                        break;
-                    }
-                }
-                if (Threads[workerId].GetState<EThreadState>() == EThreadState::Blocking &&
-                        !WakerPending.exchange(true, std::memory_order_acq_rel)) {
-                    Threads[workerId].TrySetNeedToBeWaker(EThreadState::Blocking);
-                }
-                if (settleWakerState()) {
-                    return nullptr;
-                }
-                break;
-            }
-
-            if (IsNeedToBeWaker(Threads[workerId].GetState<EThreadState>())) {
-                RunWaker(workerId);
-                if (settleWakerState()) {
-                    return nullptr;
-                }
-            }
-
-            if (claimedReduction) {
-
-                continue;
             }
 
             {
                 TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> queueActivityGuard;
                 if (const ui32 activation = Activations.Pop(++revolvingCounter)) {
-                    Threads[workerId].SetWork();
                     const i64 previousCredits = ActivationCredits.fetch_sub(1, std::memory_order_acq_rel);
                     Y_DEBUG_ABORT_UNLESS(previousCredits > 0);
+                    Threads[workerId].SetWork();
                     return MailboxTable->Get(activation);
                 }
             }
@@ -446,7 +430,7 @@ namespace NActors {
                 continue;
             }
             if (!WakerPending.exchange(true, std::memory_order_acq_rel)) {
-                Threads[workerId].TrySetNeedToBeWaker(EThreadState::Spin);
+                Threads[workerId].TrySetNeedToBeWaker();
             }
             if (settleWakerState()) {
                 return nullptr;
@@ -474,18 +458,21 @@ namespace NActors {
         }
 
         for (i16 workerId = 0; workerId < MaxFullThreadCount; ++workerId) {
-            const EThreadState state = Threads[workerId].GetState<EThreadState>();
-            if (IsNeedToBeWaker(state) || state == EThreadState::Waker) {
-                return true;
-            }
-            if (state != EThreadState::Spin && state != EThreadState::Blocking && state != EThreadState::Sleep) {
-                continue;
-            }
-            if (Threads[workerId].TrySetNeedToBeWaker(state)) {
-                if (state == EThreadState::Blocking || state == EThreadState::Sleep) {
-                    Threads[workerId].WaitingPad.Unpark();
+            EThreadState state = Threads[workerId].GetState<EThreadState>();
+            while (true) {
+                if (IsNeedToBeWaker(state) || state == EThreadState::Waker) {
+                    return true;
                 }
-                return true;
+                if (state != EThreadState::Spin && state != EThreadState::Blocking && state != EThreadState::Sleep) {
+                    break;
+                }
+                const EThreadState requestedState = state;
+                if (Threads[workerId].TrySetNeedToBeWaker(&state)) {
+                    if (requestedState == EThreadState::Blocking || requestedState == EThreadState::Sleep) {
+                        Threads[workerId].WaitingPad.Unpark();
+                    }
+                    return true;
+                }
             }
         }
         return false;
@@ -496,12 +483,43 @@ namespace NActors {
             return;
         }
 
-        if (TryRequestWaker(!persistent)) {
-            return;
+        if (!persistent) {
+            if (TryRequestWaker(true)) {
+                return;
+            }
+
+            while (true) {
+                if (SleepingCount.load(std::memory_order_acquire) == 0) {
+                    const ui64 reductions = CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
+                    if (reductions & WakerRequestBit || SleepingCount.load(std::memory_order_acquire) == 0) {
+                        return;
+                    }
+                }
+                if (TryRequestWaker(true)) {
+                    return;
+                }
+            }
         }
 
-        CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
-        TryRequestWaker(false);
+        bool requestBitSet = false;
+        if (AtomicLoad(&SuggestedThreadCount) <= AtomicLoad(&ThreadCount) &&
+                SleepingCount.load(std::memory_order_acquire) == 0) {
+            const ui64 reductions = CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
+            if (reductions & WakerRequestBit) {
+                return;
+            }
+            requestBitSet = true;
+            if (SleepingCount.load(std::memory_order_acquire) == 0) {
+                return;
+            }
+        }
+
+        if (TryRequestWaker(false)) {
+            return;
+        }
+        if (!requestBitSet) {
+            CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
+        }
     }
 
     void TBasicExecutorPool::RunWaker(TWorkerId workerId) {
@@ -518,16 +536,16 @@ namespace NActors {
                             std::memory_order_acq_rel, std::memory_order_acquire)) {
                         continue;
                     }
-                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker(&resumeState));
+                    Y_ABORT_UNLESS(Threads[workerId].TryBecomeWaker(&resumeState));
                     hasResumeState = true;
                     continue;
                 }
                 if (owner == workerId) {
-                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker(&resumeState));
+                    Y_ABORT_UNLESS(Threads[workerId].TryBecomeWaker(&resumeState));
                     hasResumeState = true;
                     continue;
                 }
-                Threads[workerId].RestoreWakerResumeState();
+                Threads[workerId].CancelWakerRequest();
                 return;
             }
 
@@ -548,8 +566,8 @@ namespace NActors {
             Y_ABORT_UNLESS(Threads[workerId].ReplaceState(expectedState, finalState));
 
             if (WakerPending.load(std::memory_order_acquire)) {
-                Y_ABORT_UNLESS(Threads[workerId].TrySetNeedToBeWaker(finalState));
-                Y_ABORT_UNLESS(Threads[workerId].BecomeWaker(&resumeState));
+                Y_ABORT_UNLESS(Threads[workerId].TrySetNeedToBeWaker(&finalState));
+                Y_ABORT_UNLESS(Threads[workerId].TryBecomeWaker(&resumeState));
                 continue;
             }
 
@@ -563,7 +581,7 @@ namespace NActors {
                     continue;
                 }
                 if (currentState != EThreadState::Work &&
-                        Threads[workerId].TrySetNeedToBeWaker(currentState)) {
+                        Threads[workerId].TrySetNeedToBeWaker(&currentState)) {
                     continue;
                 }
             }

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -499,21 +499,22 @@ namespace NActors {
             }
             AtomicSet(ThreadCount, activeThreadCount);
 
-            const auto countSearchingWorkers = [&] {
-                i16 count = 0;
-                for (i16 workerId : Waker->ActiveWorkers) {
-                    if (Threads[workerId].GetState<EThreadState>() == EThreadState::None) {
-                        ++count;
-                    }
-                }
-                return count;
-            };
-
             const i64 previousActivationCredits = ActivationCredits.load(std::memory_order_acquire);
-            i64 budget = Max<i64>(previousActivationCredits - countSearchingWorkers(), 0);
+            i64 budget = previousActivationCredits;
             i16 newlySleeping = 0;
 
             for (i16 workerId : Waker->ActiveWorkers) {
+                const EThreadState state = Threads[workerId].GetState<EThreadState>();
+                if (state == EThreadState::None) {
+                    if (budget > 0) {
+                        --budget;
+                    }
+                    continue;
+                }
+                if (state != EThreadState::Spin) {
+                    continue;
+                }
+
                 EThreadState expected = EThreadState::Spin;
                 if (budget > 0) {
                     if (Threads[workerId].ReplaceState(expected, EThreadState::None)) {

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -377,7 +377,6 @@ namespace NActors {
                 if (Threads[workerId].WaitForWaker(0, &StopFlag, &ActivationCredits)) {
                     return nullptr;
                 }
-                continue;
             }
 
             {

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <ydb/library/actors/util/affinity.h>
 #include <ydb/library/actors/util/datetime.h>
-#include <ydb/library/actors/util/thread.h>
 
 #ifdef _linux_
 #include <pthread.h>
@@ -34,30 +33,20 @@
 
 namespace NActors {
 
-    class TBasicExecutorPool::TWaker : public ISimpleThread {
+    class TBasicExecutorPool::TWaker {
     public:
         explicit TWaker(TBasicExecutorPool* pool)
-            : Pool(pool)
-            , ThreadName(pool->PoolName ? pool->PoolName + "_waker" : "BasicPoolWaker")
         {
-            SleepingStack.reserve(Pool->MaxFullThreadCount);
-            ActiveWorkers.reserve(Pool->MaxFullThreadCount);
-            ActiveMask.resize(Pool->MaxFullThreadCount, true);
-            for (i16 workerId = 0; workerId < Pool->MaxFullThreadCount; ++workerId) {
+            SleepingStack.reserve(pool->MaxFullThreadCount);
+            ActiveWorkers.reserve(pool->MaxFullThreadCount);
+            ActiveMask.resize(pool->MaxFullThreadCount, true);
+            for (i16 workerId = 0; workerId < pool->MaxFullThreadCount; ++workerId) {
                 ActiveWorkers.push_back(workerId);
             }
         }
 
-        void* ThreadProc() override {
-            ::SetCurrentThreadName(ThreadName);
-            Pool->WakerLoop();
-            return nullptr;
-        }
-
     private:
         friend class TBasicExecutorPool;
-        TBasicExecutorPool* const Pool;
-        const TString ThreadName;
         TVector<i16> SleepingStack;
         TVector<i16> ActiveWorkers;
         TVector<bool> ActiveMask;
@@ -361,20 +350,59 @@ namespace NActors {
         }
         Threads[workerId].UnsetWork();
 
+        const auto settleWakerState = [&] {
+            while (!StopFlag.load(std::memory_order_acquire)) {
+                const EThreadState state = Threads[workerId].GetState<EThreadState>();
+                if (state == EThreadState::NeedToBeWaker || state == EThreadState::Waker) {
+                    RunWaker(workerId);
+                    continue;
+                }
+                if (state == EThreadState::Spin || state == EThreadState::Sleep || state == EThreadState::Blocking) {
+                    const ui64 spinThreshold = state == EThreadState::Spin
+                        ? SpinThresholdCycles.load(std::memory_order_relaxed)
+                        : 0;
+                    if (Threads[workerId].WaitForWaker(spinThreshold, &StopFlag, &ActivationCredits)) {
+                        return true;
+                    }
+                    continue;
+                }
+                return false;
+            }
+            return true;
+        };
+
         while (!StopFlag.load(std::memory_order_acquire)) {
-            ui64 checkToSleepWorkers = CheckToSleepWorkers.load(std::memory_order_acquire);
-            bool needToBlock = false;
-            while (checkToSleepWorkers) {
-                if (CheckToSleepWorkers.compare_exchange_weak(checkToSleepWorkers, checkToSleepWorkers - 1,
+            if (settleWakerState()) {
+                return nullptr;
+            }
+
+            ui64 reductions = CheckToSleepWorkers.load(std::memory_order_acquire);
+            EThreadState wakerResumeState = EThreadState::None;
+            bool startWaker = false;
+            while (true) {
+                if (reductions & WakerRequestBit) {
+                    if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions & WakerReductionMask,
+                            std::memory_order_acq_rel, std::memory_order_acquire)) {
+                        startWaker = true;
+                        break;
+                    }
+                    continue;
+                }
+                if (reductions == 0) {
+                    break;
+                }
+                if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions - 1,
                         std::memory_order_acq_rel, std::memory_order_acquire)) {
-                    needToBlock = true;
+                    wakerResumeState = EThreadState::Blocking;
+                    startWaker = true;
                     break;
                 }
             }
-            if (needToBlock) {
-                Y_ABORT_UNLESS(Threads[workerId].StartWakerBlocking());
-                RequestWaker();
-                if (Threads[workerId].WaitForWaker(0, &StopFlag, &ActivationCredits)) {
+            if (startWaker) {
+                Y_ABORT_UNLESS(Threads[workerId].StartWaker(EThreadState::None, wakerResumeState));
+                WakerPending.store(true, std::memory_order_release);
+                RunWaker(workerId);
+                if (settleWakerState()) {
                     return nullptr;
                 }
             }
@@ -398,9 +426,10 @@ namespace NActors {
                 return nullptr;
             }
 
-            if (Threads[workerId].StartWakerWait()) {
-                RequestWaker();
-                if (Threads[workerId].WaitForWaker(SpinThresholdCycles.load(std::memory_order_relaxed), &StopFlag, &ActivationCredits)) {
+            if (Threads[workerId].StartWaker(EThreadState::None, EThreadState::Spin)) {
+                WakerPending.store(true, std::memory_order_release);
+                RunWaker(workerId);
+                if (settleWakerState()) {
                     return nullptr;
                 }
             }
@@ -416,13 +445,116 @@ namespace NActors {
         return GetReadyActivationRingQueue(revolvingCounter);
     }
 
-    void TBasicExecutorPool::RequestWaker() {
-        if (!WakerPending.exchange(true, std::memory_order_acq_rel)) {
-            WakerPad.Unpark();
+    bool TBasicExecutorPool::TryRequestWaker(bool requireSleepingWorkers) {
+        const i16 owner = WakerWorkerId.load(std::memory_order_acquire);
+        if (owner != InvalidWakerWorkerId) {
+            return Threads[owner].RequestAnotherWakerPass();
+        }
+
+        if (requireSleepingWorkers && SleepingCount.load(std::memory_order_acquire) == 0) {
+            return false;
+        }
+
+        for (i16 workerId = 0; workerId < MaxFullThreadCount; ++workerId) {
+            const EThreadState state = Threads[workerId].GetState<EThreadState>();
+            if (state != EThreadState::Spin && state != EThreadState::Blocking && state != EThreadState::Sleep) {
+                continue;
+            }
+            if (Threads[workerId].StartWaker(state, state)) {
+                if (state == EThreadState::Blocking || state == EThreadState::Sleep) {
+                    Threads[workerId].WaitingPad.Unpark();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void TBasicExecutorPool::RequestWaker(bool persistent) {
+        if (!persistent && WakerPending.exchange(true, std::memory_order_acq_rel)) {
+            return;
+        }
+        WakerPending.store(true, std::memory_order_release);
+
+        if (TryRequestWaker(!persistent)) {
+            return;
+        }
+
+        if (persistent) {
+            CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
+            TryRequestWaker(false);
+        } else {
+            // The owner may have released WakerWorkerId after the first load.
+            // Retry once so the request can select the state it publishes on
+            // completion instead of being lost in that gap.
+            if (SleepingCount.load(std::memory_order_acquire) > 0 && TryRequestWaker(true)) {
+                return;
+            }
+            // The last sleeper may have been elected or completed a waker
+            // pass while it was being searched for. Either transition has
+            // already observed the activation credit.
+            WakerPending.store(false, std::memory_order_release);
         }
     }
 
-    void TBasicExecutorPool::WakerLoop() {
+    void TBasicExecutorPool::RunWaker(TWorkerId workerId) {
+        while (!StopFlag.load(std::memory_order_acquire)) {
+            const EThreadState state = Threads[workerId].GetState<EThreadState>();
+            if (state == EThreadState::NeedToBeWaker) {
+                const i16 owner = WakerWorkerId.load(std::memory_order_acquire);
+                if (owner == InvalidWakerWorkerId) {
+                    i16 expected = InvalidWakerWorkerId;
+                    if (!WakerWorkerId.compare_exchange_weak(expected, workerId,
+                            std::memory_order_acq_rel, std::memory_order_acquire)) {
+                        continue;
+                    }
+                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker());
+                    continue;
+                }
+                if (owner == workerId) {
+                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker());
+                    continue;
+                }
+                if (Threads[owner].RequestAnotherWakerPass()) {
+                    Y_ABORT_UNLESS(Threads[workerId].RestoreWakerResumeState());
+                    return;
+                }
+                continue;
+            }
+
+            if (state != EThreadState::Waker) {
+                return;
+            }
+
+            Y_ABORT_UNLESS(WakerWorkerId.load(std::memory_order_acquire) == workerId);
+            WakerLoop(workerId);
+
+            if (Threads[workerId].GetState<EThreadState>() == EThreadState::NeedToBeWaker) {
+                Y_ABORT_UNLESS(Threads[workerId].BecomeWaker());
+                continue;
+            }
+
+            i16 expectedOwner = workerId;
+            Y_ABORT_UNLESS(WakerWorkerId.compare_exchange_strong(expectedOwner, InvalidWakerWorkerId,
+                std::memory_order_acq_rel, std::memory_order_acquire));
+
+            if (CheckToSleepWorkers.fetch_and(WakerReductionMask, std::memory_order_acq_rel) & WakerRequestBit) {
+                Threads[workerId].RequestAnotherWakerPass();
+            }
+            if (Threads[workerId].GetState<EThreadState>() == EThreadState::NeedToBeWaker) {
+                continue;
+            }
+
+            const EThreadState finalState = Threads[workerId].GetWakerResumeState();
+            EThreadState expectedState = EThreadState::Waker;
+            if (Threads[workerId].ReplaceState(expectedState, finalState)) {
+                return;
+            }
+            Y_ABORT_UNLESS(expectedState == EThreadState::NeedToBeWaker);
+        }
+    }
+
+    void TBasicExecutorPool::WakerLoop(TWorkerId wakerWorkerId) {
         const auto removeActiveWorker = [&](i16 workerId) {
             Waker->ActiveMask[workerId] = false;
             auto it = std::find(Waker->ActiveWorkers.begin(), Waker->ActiveWorkers.end(), workerId);
@@ -430,29 +562,41 @@ namespace NActors {
             *it = Waker->ActiveWorkers.back();
             Waker->ActiveWorkers.pop_back();
         };
-        while (!StopFlag.load(std::memory_order_acquire)) {
-            if (WakerPad.Park()) {
-                break;
-            }
-            WakerPending.store(false, std::memory_order_release);
+        WakerPending.store(false, std::memory_order_release);
+        CheckToSleepWorkers.exchange(0, std::memory_order_acq_rel);
+        EThreadState wakerState = Threads[wakerWorkerId].GetWakerResumeState();
 
-            const i16 threadCount = AtomicLoad(&SuggestedThreadCount);
-            CheckToSleepWorkers.store(0, std::memory_order_release);
+        const i16 threadCount = AtomicLoad(&SuggestedThreadCount);
 
             for (size_t idx = 0; idx < Waker->ActiveWorkers.size();) {
                 const i16 workerId = Waker->ActiveWorkers[idx];
-                EThreadState expected = EThreadState::Blocking;
-                if (Threads[workerId].GetState<EThreadState>() != EThreadState::Blocking) {
+                const EThreadState state = workerId == wakerWorkerId
+                    ? wakerState
+                    : Threads[workerId].GetState<EThreadState>();
+                if (state != EThreadState::Blocking) {
                     ++idx;
                     continue;
                 }
                 if (Waker->ActiveWorkers.size() > static_cast<size_t>(threadCount)) {
+                    if (workerId == wakerWorkerId) {
+                        wakerState = EThreadState::Sleep;
+                        Waker->SleepingStack.push_back(workerId);
+                        removeActiveWorker(workerId);
+                        continue;
+                    }
+                    EThreadState expected = EThreadState::Blocking;
                     if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
                         Waker->SleepingStack.push_back(workerId);
                         removeActiveWorker(workerId);
                         continue;
                     }
                 } else {
+                    if (workerId == wakerWorkerId) {
+                        wakerState = EThreadState::None;
+                        ++idx;
+                        continue;
+                    }
+                    EThreadState expected = EThreadState::Blocking;
                     if (Threads[workerId].ReplaceState(expected, EThreadState::None)) {
                         Threads[workerId].WaitingPad.Unpark();
                     }
@@ -463,13 +607,21 @@ namespace NActors {
             for (size_t idx = 0; idx < Waker->ActiveWorkers.size()
                     && Waker->ActiveWorkers.size() > static_cast<size_t>(threadCount);) {
                 const i16 workerId = Waker->ActiveWorkers[idx];
-                const EThreadState state = Threads[workerId].GetState<EThreadState>();
+                const EThreadState state = workerId == wakerWorkerId
+                    ? wakerState
+                    : Threads[workerId].GetState<EThreadState>();
                 if (state == EThreadState::Sleep) {
                     SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
                     removeActiveWorker(workerId);
                     continue;
                 }
                 if (state == EThreadState::Spin) {
+                    if (workerId == wakerWorkerId) {
+                        wakerState = EThreadState::Sleep;
+                        Waker->SleepingStack.push_back(workerId);
+                        removeActiveWorker(workerId);
+                        continue;
+                    }
                     EThreadState expected = EThreadState::Spin;
                     if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
                         Waker->SleepingStack.push_back(workerId);
@@ -494,9 +646,12 @@ namespace NActors {
             }
 
             const i16 activeThreadCount = static_cast<i16>(Waker->ActiveWorkers.size());
-            if (activeThreadCount > threadCount) {
-                CheckToSleepWorkers.store(activeThreadCount - threadCount, std::memory_order_release);
-            }
+            const ui64 reductions = activeThreadCount > threadCount ? activeThreadCount - threadCount : 0;
+            ui64 currentReductions = CheckToSleepWorkers.load(std::memory_order_acquire);
+            while (!CheckToSleepWorkers.compare_exchange_weak(currentReductions,
+                (currentReductions & WakerRequestBit) | reductions,
+                std::memory_order_acq_rel, std::memory_order_acquire))
+            {}
             AtomicSet(ThreadCount, activeThreadCount);
 
             const i64 previousActivationCredits = ActivationCredits.load(std::memory_order_acquire);
@@ -504,7 +659,9 @@ namespace NActors {
             i16 newlySleeping = 0;
 
             for (i16 workerId : Waker->ActiveWorkers) {
-                const EThreadState state = Threads[workerId].GetState<EThreadState>();
+                const EThreadState state = workerId == wakerWorkerId
+                    ? wakerState
+                    : Threads[workerId].GetState<EThreadState>();
                 if (state == EThreadState::None) {
                     if (budget > 0) {
                         --budget;
@@ -512,6 +669,18 @@ namespace NActors {
                     continue;
                 }
                 if (state != EThreadState::Spin) {
+                    continue;
+                }
+
+                if (workerId == wakerWorkerId) {
+                    if (budget > 0) {
+                        wakerState = EThreadState::None;
+                        --budget;
+                    } else {
+                        wakerState = EThreadState::Sleep;
+                        Waker->SleepingStack.push_back(workerId);
+                        ++newlySleeping;
+                    }
                     continue;
                 }
 
@@ -534,11 +703,11 @@ namespace NActors {
                 bool wokeWorker = false;
                 for (size_t idx = Waker->SleepingStack.size(); idx > 0; --idx) {
                     const i16 workerId = Waker->SleepingStack[idx - 1];
-                    if (!Waker->ActiveMask[workerId]) {
+                    if (workerId == wakerWorkerId || !Waker->ActiveMask[workerId]) {
                         continue;
                     }
-                    Waker->SleepingStack.erase(Waker->SleepingStack.begin() + idx - 1);
                     if (Threads[workerId].WakeFromWaker()) {
+                        Waker->SleepingStack.erase(Waker->SleepingStack.begin() + idx - 1);
                         SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
                         --budget;
                         wokeWorker = true;
@@ -550,12 +719,21 @@ namespace NActors {
                 }
             }
 
+            if (budget > 0 && Waker->ActiveMask[wakerWorkerId] && wakerState == EThreadState::Sleep) {
+                auto it = std::find(Waker->SleepingStack.begin(), Waker->SleepingStack.end(), wakerWorkerId);
+                Y_ABORT_UNLESS(it != Waker->SleepingStack.end());
+                Waker->SleepingStack.erase(it);
+                SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
+                wakerState = EThreadState::None;
+                --budget;
+            }
+
             // A producer may publish a credit before the corresponding
             // sleeping worker becomes visible through SleepingCount.
             if (ActivationCredits.load(std::memory_order_acquire) > previousActivationCredits) {
-                RequestWaker();
+                RequestWaker(false);
             }
-        }
+        Threads[wakerWorkerId].SetWakerResumeState(wakerState);
     }
 
     inline void TBasicExecutorPool::WakeUpLoop(i16 currentThreadCount) {
@@ -640,7 +818,7 @@ namespace NActors {
         ActivationCredits.fetch_add(1, std::memory_order_acq_rel);
         Activations.Push(mailbox->Hint, revolvingCounter);
         if (SleepingCount.load(std::memory_order_acquire) > 0) {
-            RequestWaker();
+            RequestWaker(false);
         }
     }
 
@@ -728,10 +906,6 @@ namespace NActors {
         ThreadUtilization = 0;
         AtomicAdd(MaxUtilizationCounter, -(i64)GetCycleCountFast());
 
-        if (EnableWaker) {
-            Waker->Start();
-        }
-
         for (i16 i = 0; i != MaxFullThreadCount; ++i) {
             Threads[i].Thread->Start();
         }
@@ -745,9 +919,6 @@ namespace NActors {
     void TBasicExecutorPool::PrepareStop() {
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::ExecutorPool, "stop flag set");
         StopFlag.store(true, std::memory_order_release);
-        if (EnableWaker) {
-            WakerPad.Interrupt();
-        }
         for (i16 i = 0; i != MaxFullThreadCount; ++i) {
             Threads[i].Thread->StopFlag.store(true, std::memory_order_release);
             Threads[i].Interrupt();
@@ -760,9 +931,6 @@ namespace NActors {
 
     void TBasicExecutorPool::Shutdown() {
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::ExecutorPool, "shutdown");
-        if (EnableWaker) {
-            Waker->Join();
-        }
         for (i16 i = 0; i != MaxFullThreadCount; ++i) {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::ExecutorPool, "join ", i);
             Threads[i].Thread->Join();
@@ -831,7 +999,7 @@ namespace NActors {
             if (EnableWaker) {
                 if (AtomicLoad(&SuggestedThreadCount) != threads) {
                     AtomicSet(SuggestedThreadCount, threads);
-                    RequestWaker();
+                    RequestWaker(true);
                 }
                 LWPROBE(ThreadCount, PoolId, PoolName, threads, MinThreadCount, MaxThreadCount, DefaultThreadCount);
                 return;

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -354,7 +354,9 @@ namespace NActors {
                     continue;
                 }
                 if (state == EThreadState::Spin || state == EThreadState::Sleep || state == EThreadState::Blocking) {
-                    if (Threads[workerId].WaitForWaker(StopFlag, ActivationCredits, CheckToSleepWorkers)) {
+                    const bool stopped = Threads[workerId].WaitForWaker(
+                        StopFlag, ActivationCredits, CheckToSleepWorkers, WakerRequestBit);
+                    if (stopped) {
                         return true;
                     }
                     continue;
@@ -479,7 +481,8 @@ namespace NActors {
     }
 
     void TBasicExecutorPool::RequestWaker(bool persistent) {
-        if (WakerPending.exchange(true, std::memory_order_acq_rel)) {
+        const bool wasPending = WakerPending.exchange(true, std::memory_order_acq_rel);
+        if (wasPending) {
             return;
         }
 
@@ -596,6 +599,8 @@ namespace NActors {
             switch (state) {
                 case EThreadState::NeedToBeWaker:
                     return EThreadState::None;
+                case EThreadState::NeedToBeWakerFromSpin:
+                    return EThreadState::Spin;
                 case EThreadState::NeedToBeWakerFromSleep:
                     return EThreadState::Sleep;
                 case EThreadState::NeedToBeWakerFromBlocking:
@@ -670,12 +675,19 @@ namespace NActors {
             }
 
             if (logicalState == EThreadState::Spin) {
-                const EThreadState targetState = budget > 0 ? EThreadState::None : EThreadState::Sleep;
+                const bool consumeReduction = remainingReductions > 0;
+                const EThreadState targetState = consumeReduction || budget == 0
+                    ? EThreadState::Sleep
+                    : EThreadState::None;
                 if (isWaker) {
                     wakerState = targetState;
                     if (targetState == EThreadState::Sleep) {
                         Waker->SleepingStack.push_back(workerId);
-                        ++previousSleepingCount;
+                        if (consumeReduction) {
+                            --remainingReductions;
+                        } else {
+                            ++previousSleepingCount;
+                        }
                     }
                     continue;
                 }
@@ -685,7 +697,11 @@ namespace NActors {
                         --budget;
                     } else {
                         Waker->SleepingStack.push_back(workerId);
-                        ++previousSleepingCount;
+                        if (consumeReduction) {
+                            --remainingReductions;
+                        } else {
+                            ++previousSleepingCount;
+                        }
                     }
                 }
                 continue;

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -11,7 +11,6 @@
 #include "debug.h"
 #include "thread_context.h"
 #include <atomic>
-#include <algorithm>
 #include <memory>
 #include <ydb/library/actors/util/affinity.h>
 #include <ydb/library/actors/util/datetime.h>
@@ -38,18 +37,14 @@ namespace NActors {
         explicit TWaker(TBasicExecutorPool* pool)
         {
             SleepingStack.reserve(pool->MaxFullThreadCount);
-            ActiveWorkers.reserve(pool->MaxFullThreadCount);
-            ActiveMask.resize(pool->MaxFullThreadCount, true);
-            for (i16 workerId = 0; workerId < pool->MaxFullThreadCount; ++workerId) {
-                ActiveWorkers.push_back(workerId);
-            }
         }
 
     private:
         friend class TBasicExecutorPool;
         TVector<i16> SleepingStack;
-        TVector<i16> ActiveWorkers;
-        TVector<bool> ActiveMask;
+        ui64 PreviousReductions = 0;
+        ui64 TakenTokensToSleep = 0;
+        ui64 TakenTokensToWakeup = 0;
     };
 
     namespace {
@@ -353,15 +348,13 @@ namespace NActors {
         const auto settleWakerState = [&] {
             while (!StopFlag.load(std::memory_order_acquire)) {
                 const EThreadState state = Threads[workerId].GetState<EThreadState>();
-                if (state == EThreadState::NeedToBeWaker || state == EThreadState::Waker) {
+                Y_DEBUG_ABORT_UNLESS(state != EThreadState::Waker);
+                if (IsNeedToBeWaker(state)) {
                     RunWaker(workerId);
                     continue;
                 }
                 if (state == EThreadState::Spin || state == EThreadState::Sleep || state == EThreadState::Blocking) {
-                    const ui64 spinThreshold = state == EThreadState::Spin
-                        ? SpinThresholdCycles.load(std::memory_order_relaxed)
-                        : 0;
-                    if (Threads[workerId].WaitForWaker(spinThreshold, &StopFlag, &ActivationCredits)) {
+                    if (Threads[workerId].WaitForWaker(&StopFlag, &ActivationCredits)) {
                         return true;
                     }
                     continue;
@@ -377,13 +370,14 @@ namespace NActors {
             }
 
             ui64 reductions = CheckToSleepWorkers.load(std::memory_order_acquire);
-            EThreadState wakerResumeState = EThreadState::None;
-            bool startWaker = false;
+            bool claimedReduction = false;
             while (true) {
                 if (reductions & WakerRequestBit) {
                     if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions & WakerReductionMask,
                             std::memory_order_acq_rel, std::memory_order_acquire)) {
-                        startWaker = true;
+                        bool changed = Threads[workerId].TrySetNeedToBeWaker(EThreadState::None);
+                        Y_DEBUG_ABORT_UNLESS(changed);
+                        settleWakerState();
                         break;
                     }
                     continue;
@@ -391,20 +385,41 @@ namespace NActors {
                 if (reductions == 0) {
                     break;
                 }
-                if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions - 1,
+                if (!CheckToSleepWorkers.compare_exchange_weak(reductions, reductions - 1,
                         std::memory_order_acq_rel, std::memory_order_acquire)) {
-                    wakerResumeState = EThreadState::Blocking;
-                    startWaker = true;
-                    break;
+                    continue;
                 }
+
+                EThreadState expected = EThreadState::None;
+                Y_ABORT_UNLESS(Threads[workerId].ReplaceState(expected, EThreadState::Blocking));
+                reductions = CheckToSleepWorkers.load(std::memory_order_acquire);
+                while (reductions & WakerRequestBit) {
+                    if (CheckToSleepWorkers.compare_exchange_weak(reductions, reductions & WakerReductionMask,
+                            std::memory_order_acq_rel, std::memory_order_acquire)) {
+                        Threads[workerId].TrySetNeedToBeWaker(EThreadState::Blocking);
+                        break;
+                    }
+                }
+                if (Threads[workerId].GetState<EThreadState>() == EThreadState::Blocking &&
+                        !WakerPending.exchange(true, std::memory_order_acq_rel)) {
+                    Threads[workerId].TrySetNeedToBeWaker(EThreadState::Blocking);
+                }
+                if (settleWakerState()) {
+                    return nullptr;
+                }
+                break;
             }
-            if (startWaker) {
-                Y_ABORT_UNLESS(Threads[workerId].StartWaker(EThreadState::None, wakerResumeState));
-                WakerPending.store(true, std::memory_order_release);
+
+            if (IsNeedToBeWaker(Threads[workerId].GetState<EThreadState>())) {
                 RunWaker(workerId);
                 if (settleWakerState()) {
                     return nullptr;
                 }
+            }
+
+            if (claimedReduction) {
+
+                continue;
             }
 
             {
@@ -426,12 +441,15 @@ namespace NActors {
                 return nullptr;
             }
 
-            if (Threads[workerId].StartWaker(EThreadState::None, EThreadState::Spin)) {
-                WakerPending.store(true, std::memory_order_release);
-                RunWaker(workerId);
-                if (settleWakerState()) {
-                    return nullptr;
-                }
+            EThreadState expected = EThreadState::None;
+            if (!Threads[workerId].ReplaceState(expected, EThreadState::Spin)) {
+                continue;
+            }
+            if (!WakerPending.exchange(true, std::memory_order_acq_rel)) {
+                Threads[workerId].TrySetNeedToBeWaker(EThreadState::Spin);
+            }
+            if (settleWakerState()) {
+                return nullptr;
             }
         }
         return nullptr;
@@ -448,7 +466,7 @@ namespace NActors {
     bool TBasicExecutorPool::TryRequestWaker(bool requireSleepingWorkers) {
         const i16 owner = WakerWorkerId.load(std::memory_order_acquire);
         if (owner != InvalidWakerWorkerId) {
-            return Threads[owner].RequestAnotherWakerPass();
+            return true;
         }
 
         if (requireSleepingWorkers && SleepingCount.load(std::memory_order_acquire) == 0) {
@@ -457,10 +475,13 @@ namespace NActors {
 
         for (i16 workerId = 0; workerId < MaxFullThreadCount; ++workerId) {
             const EThreadState state = Threads[workerId].GetState<EThreadState>();
+            if (IsNeedToBeWaker(state) || state == EThreadState::Waker) {
+                return true;
+            }
             if (state != EThreadState::Spin && state != EThreadState::Blocking && state != EThreadState::Sleep) {
                 continue;
             }
-            if (Threads[workerId].StartWaker(state, state)) {
+            if (Threads[workerId].TrySetNeedToBeWaker(state)) {
                 if (state == EThreadState::Blocking || state == EThreadState::Sleep) {
                     Threads[workerId].WaitingPad.Unpark();
                 }
@@ -471,36 +492,25 @@ namespace NActors {
     }
 
     void TBasicExecutorPool::RequestWaker(bool persistent) {
-        if (!persistent && WakerPending.exchange(true, std::memory_order_acq_rel)) {
+        if (WakerPending.exchange(true, std::memory_order_acq_rel)) {
             return;
         }
-        WakerPending.store(true, std::memory_order_release);
 
         if (TryRequestWaker(!persistent)) {
             return;
         }
 
-        if (persistent) {
-            CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
-            TryRequestWaker(false);
-        } else {
-            // The owner may have released WakerWorkerId after the first load.
-            // Retry once so the request can select the state it publishes on
-            // completion instead of being lost in that gap.
-            if (SleepingCount.load(std::memory_order_acquire) > 0 && TryRequestWaker(true)) {
-                return;
-            }
-            // The last sleeper may have been elected or completed a waker
-            // pass while it was being searched for. Either transition has
-            // already observed the activation credit.
-            WakerPending.store(false, std::memory_order_release);
-        }
+        CheckToSleepWorkers.fetch_or(WakerRequestBit, std::memory_order_acq_rel);
+        TryRequestWaker(false);
     }
 
     void TBasicExecutorPool::RunWaker(TWorkerId workerId) {
+        EThreadState resumeState = EThreadState::None;
+        bool hasResumeState = false;
+
         while (!StopFlag.load(std::memory_order_acquire)) {
             const EThreadState state = Threads[workerId].GetState<EThreadState>();
-            if (state == EThreadState::NeedToBeWaker) {
+            if (IsNeedToBeWaker(state)) {
                 const i16 owner = WakerWorkerId.load(std::memory_order_acquire);
                 if (owner == InvalidWakerWorkerId) {
                     i16 expected = InvalidWakerWorkerId;
@@ -508,29 +518,38 @@ namespace NActors {
                             std::memory_order_acq_rel, std::memory_order_acquire)) {
                         continue;
                     }
-                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker());
+                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker(&resumeState));
+                    hasResumeState = true;
                     continue;
                 }
                 if (owner == workerId) {
-                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker());
+                    Y_ABORT_UNLESS(Threads[workerId].BecomeWaker(&resumeState));
+                    hasResumeState = true;
                     continue;
                 }
-                if (Threads[owner].RequestAnotherWakerPass()) {
-                    Y_ABORT_UNLESS(Threads[workerId].RestoreWakerResumeState());
-                    return;
-                }
-                continue;
+                Threads[workerId].RestoreWakerResumeState();
+                return;
             }
 
             if (state != EThreadState::Waker) {
                 return;
             }
 
+            Y_ABORT_UNLESS(hasResumeState);
             Y_ABORT_UNLESS(WakerWorkerId.load(std::memory_order_acquire) == workerId);
-            WakerLoop(workerId);
+            WakerLoop(workerId, &resumeState);
 
-            if (Threads[workerId].GetState<EThreadState>() == EThreadState::NeedToBeWaker) {
-                Y_ABORT_UNLESS(Threads[workerId].BecomeWaker());
+            if (WakerPending.load(std::memory_order_acquire)) {
+                continue;
+            }
+
+            EThreadState finalState = resumeState;
+            EThreadState expectedState = EThreadState::Waker;
+            Y_ABORT_UNLESS(Threads[workerId].ReplaceState(expectedState, finalState));
+
+            if (WakerPending.load(std::memory_order_acquire)) {
+                Y_ABORT_UNLESS(Threads[workerId].TrySetNeedToBeWaker(finalState));
+                Y_ABORT_UNLESS(Threads[workerId].BecomeWaker(&resumeState));
                 continue;
             }
 
@@ -538,202 +557,224 @@ namespace NActors {
             Y_ABORT_UNLESS(WakerWorkerId.compare_exchange_strong(expectedOwner, InvalidWakerWorkerId,
                 std::memory_order_acq_rel, std::memory_order_acquire));
 
-            if (CheckToSleepWorkers.fetch_and(WakerReductionMask, std::memory_order_acq_rel) & WakerRequestBit) {
-                Threads[workerId].RequestAnotherWakerPass();
+            if (WakerPending.load(std::memory_order_acquire)) {
+                EThreadState currentState = Threads[workerId].GetState<EThreadState>();
+                if (IsNeedToBeWaker(currentState) || currentState == EThreadState::Waker) {
+                    continue;
+                }
+                if (currentState != EThreadState::Work &&
+                        Threads[workerId].TrySetNeedToBeWaker(currentState)) {
+                    continue;
+                }
             }
-            if (Threads[workerId].GetState<EThreadState>() == EThreadState::NeedToBeWaker) {
-                continue;
-            }
-
-            const EThreadState finalState = Threads[workerId].GetWakerResumeState();
-            EThreadState expectedState = EThreadState::Waker;
-            if (Threads[workerId].ReplaceState(expectedState, finalState)) {
-                return;
-            }
-            Y_ABORT_UNLESS(expectedState == EThreadState::NeedToBeWaker);
+            return;
         }
     }
 
-    void TBasicExecutorPool::WakerLoop(TWorkerId wakerWorkerId) {
-        const auto removeActiveWorker = [&](i16 workerId) {
-            Waker->ActiveMask[workerId] = false;
-            auto it = std::find(Waker->ActiveWorkers.begin(), Waker->ActiveWorkers.end(), workerId);
-            Y_ABORT_UNLESS(it != Waker->ActiveWorkers.end());
-            *it = Waker->ActiveWorkers.back();
-            Waker->ActiveWorkers.pop_back();
+    void TBasicExecutorPool::WakerLoop(TWorkerId wakerWorkerId, EThreadState* resumeState) {
+        Y_ABORT_UNLESS(resumeState);
+        EThreadState wakerState = *resumeState;
+        const auto getLogicalState = [](EThreadState state) {
+            switch (state) {
+                case EThreadState::NeedToBeWaker:
+                    return EThreadState::None;
+                case EThreadState::NeedToBeWakerFromSleep:
+                    return EThreadState::Sleep;
+                case EThreadState::NeedToBeWakerFromBlocking:
+                    return EThreadState::Blocking;
+                default:
+                    return state;
+            }
         };
+
+        i16 previousSleepingCount = SleepingCount.exchange(0, std::memory_order_acq_rel);
         WakerPending.store(false, std::memory_order_release);
-        CheckToSleepWorkers.exchange(0, std::memory_order_acq_rel);
-        EThreadState wakerState = Threads[wakerWorkerId].GetWakerResumeState();
+        ui64 remainingReductions = CheckToSleepWorkers.exchange(0, std::memory_order_acq_rel) & WakerReductionMask;
+        Y_ABORT_UNLESS(Waker->PreviousReductions >= remainingReductions);
+        const ui64 claimedReductions = Waker->PreviousReductions - remainingReductions;
+        Y_ABORT_UNLESS(Waker->TakenTokensToSleep + Waker->TakenTokensToWakeup + claimedReductions
+            <= static_cast<ui64>(MaxFullThreadCount));
+        Waker->TakenTokensToSleep += claimedReductions;
+        Waker->PreviousReductions = 0;
 
-        const i16 threadCount = AtomicLoad(&SuggestedThreadCount);
+        const i16 desiredThreadCount = AtomicLoad(&SuggestedThreadCount);
+        const i16 previousThreadCount = AtomicLoad(&ThreadCount);
+        if (desiredThreadCount < previousThreadCount) {
+            ui64 delta = previousThreadCount - desiredThreadCount;
+            ui64 converted = Min(Waker->TakenTokensToWakeup, delta);
+            Waker->TakenTokensToWakeup -= converted;
+            Waker->TakenTokensToSleep += converted;
+            delta -= converted;
 
-            for (size_t idx = 0; idx < Waker->ActiveWorkers.size();) {
-                const i16 workerId = Waker->ActiveWorkers[idx];
-                const EThreadState state = workerId == wakerWorkerId
-                    ? wakerState
-                    : Threads[workerId].GetState<EThreadState>();
-                if (state != EThreadState::Blocking) {
-                    ++idx;
-                    continue;
-                }
-                if (Waker->ActiveWorkers.size() > static_cast<size_t>(threadCount)) {
-                    if (workerId == wakerWorkerId) {
-                        wakerState = EThreadState::Sleep;
-                        Waker->SleepingStack.push_back(workerId);
-                        removeActiveWorker(workerId);
-                        continue;
-                    }
-                    EThreadState expected = EThreadState::Blocking;
-                    if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
-                        Waker->SleepingStack.push_back(workerId);
-                        removeActiveWorker(workerId);
-                        continue;
-                    }
-                } else {
-                    if (workerId == wakerWorkerId) {
-                        wakerState = EThreadState::None;
-                        ++idx;
-                        continue;
-                    }
-                    EThreadState expected = EThreadState::Blocking;
-                    if (Threads[workerId].ReplaceState(expected, EThreadState::None)) {
-                        Threads[workerId].WaitingPad.Unpark();
-                    }
-                }
-                ++idx;
+            converted = Min(static_cast<ui64>(previousSleepingCount), delta);
+            previousSleepingCount -= static_cast<i16>(converted);
+            delta -= converted;
+
+            Y_ABORT_UNLESS(remainingReductions + delta <= static_cast<ui64>(MaxFullThreadCount));
+            remainingReductions += delta;
+        } else if (desiredThreadCount > previousThreadCount) {
+            ui64 delta = desiredThreadCount - previousThreadCount;
+            ui64 converted = Min(Waker->TakenTokensToSleep, delta);
+            Waker->TakenTokensToSleep -= converted;
+            Waker->TakenTokensToWakeup += converted;
+            delta -= converted;
+
+            converted = Min(remainingReductions, delta);
+            remainingReductions -= converted;
+            delta -= converted;
+
+            Y_ABORT_UNLESS(static_cast<ui64>(previousSleepingCount) + delta <= Waker->SleepingStack.size());
+            previousSleepingCount += static_cast<i16>(delta);
+        }
+        AtomicSet(ThreadCount, desiredThreadCount);
+
+        const i64 previousActivationCredits = ActivationCredits.load(std::memory_order_acquire);
+        i64 budget = previousActivationCredits;
+        for (i16 workerId = 0; workerId < MaxFullThreadCount; ++workerId) {
+            const bool isWaker = workerId == wakerWorkerId;
+            EThreadState state = wakerState;
+            EThreadState logicalState = wakerState;
+            if (!isWaker) {
+                state = Threads[workerId].GetState<EThreadState>();
+                logicalState = getLogicalState(state);
             }
 
-            for (size_t idx = 0; idx < Waker->ActiveWorkers.size()
-                    && Waker->ActiveWorkers.size() > static_cast<size_t>(threadCount);) {
-                const i16 workerId = Waker->ActiveWorkers[idx];
-                const EThreadState state = workerId == wakerWorkerId
-                    ? wakerState
-                    : Threads[workerId].GetState<EThreadState>();
-                if (state == EThreadState::Sleep) {
-                    SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
-                    removeActiveWorker(workerId);
+            if (logicalState == EThreadState::None) {
+                if (isWaker) {
+                    wakerState = EThreadState::None;
                     continue;
                 }
-                if (state == EThreadState::Spin) {
-                    if (workerId == wakerWorkerId) {
-                        wakerState = EThreadState::Sleep;
-                        Waker->SleepingStack.push_back(workerId);
-                        removeActiveWorker(workerId);
-                        continue;
-                    }
-                    EThreadState expected = EThreadState::Spin;
-                    if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
-                        Waker->SleepingStack.push_back(workerId);
-                        removeActiveWorker(workerId);
-                        continue;
-                    }
+                EThreadState expected = state;
+                if (Threads[workerId].ReplaceState(expected, EThreadState::None) && budget > 0) {
+                    --budget;
                 }
-                ++idx;
+                continue;
             }
 
-            while (Waker->ActiveWorkers.size() < static_cast<size_t>(threadCount)) {
-                auto it = std::find_if(Waker->SleepingStack.rbegin(), Waker->SleepingStack.rend(), [&](i16 workerId) {
-                    return !Waker->ActiveMask[workerId];
-                });
-                if (it == Waker->SleepingStack.rend()) {
-                    break;
-                }
-                const i16 workerId = *it;
-                Waker->ActiveMask[workerId] = true;
-                Waker->ActiveWorkers.push_back(workerId);
-                SleepingCount.fetch_add(1, std::memory_order_release);
-            }
-
-            const i16 activeThreadCount = static_cast<i16>(Waker->ActiveWorkers.size());
-            const ui64 reductions = activeThreadCount > threadCount ? activeThreadCount - threadCount : 0;
-            ui64 currentReductions = CheckToSleepWorkers.load(std::memory_order_acquire);
-            while (!CheckToSleepWorkers.compare_exchange_weak(currentReductions,
-                (currentReductions & WakerRequestBit) | reductions,
-                std::memory_order_acq_rel, std::memory_order_acquire))
-            {}
-            AtomicSet(ThreadCount, activeThreadCount);
-
-            const i64 previousActivationCredits = ActivationCredits.load(std::memory_order_acquire);
-            i64 budget = previousActivationCredits;
-            i16 newlySleeping = 0;
-
-            for (i16 workerId : Waker->ActiveWorkers) {
-                const EThreadState state = workerId == wakerWorkerId
-                    ? wakerState
-                    : Threads[workerId].GetState<EThreadState>();
-                if (state == EThreadState::None) {
-                    if (budget > 0) {
-                        --budget;
+            if (logicalState == EThreadState::Spin) {
+                const EThreadState targetState = budget > 0 ? EThreadState::None : EThreadState::Sleep;
+                if (isWaker) {
+                    wakerState = targetState;
+                    if (targetState == EThreadState::Sleep) {
+                        Waker->SleepingStack.push_back(workerId);
+                        ++previousSleepingCount;
                     }
                     continue;
                 }
-                if (state != EThreadState::Spin) {
-                    continue;
-                }
-
-                if (workerId == wakerWorkerId) {
-                    if (budget > 0) {
-                        wakerState = EThreadState::None;
+                EThreadState expected = state;
+                if (Threads[workerId].ReplaceState(expected, targetState)) {
+                    if (targetState == EThreadState::None) {
                         --budget;
                     } else {
-                        wakerState = EThreadState::Sleep;
                         Waker->SleepingStack.push_back(workerId);
-                        ++newlySleeping;
+                        ++previousSleepingCount;
                     }
-                    continue;
                 }
+                continue;
+            }
 
-                EThreadState expected = EThreadState::Spin;
+            if (logicalState != EThreadState::Blocking) {
+                continue;
+            }
+
+            EThreadState targetState;
+            bool useWakeupToken = false;
+            bool useSleepToken = false;
+            bool countAsSleeping = false;
+            if (Waker->TakenTokensToWakeup > 0) {
+                useWakeupToken = true;
                 if (budget > 0) {
-                    if (Threads[workerId].ReplaceState(expected, EThreadState::None)) {
-                        --budget;
-                    }
-                } else if (Threads[workerId].ReplaceState(expected, EThreadState::Sleep)) {
-                    Waker->SleepingStack.push_back(workerId);
-                    ++newlySleeping;
+                    targetState = EThreadState::None;
+                } else {
+                    targetState = EThreadState::Sleep;
+                    countAsSleeping = true;
+                }
+            } else {
+                Y_ABORT_UNLESS(Waker->TakenTokensToSleep > 0);
+                useSleepToken = true;
+                targetState = EThreadState::Sleep;
+            }
+
+            bool replaced = true;
+            if (isWaker) {
+                wakerState = targetState;
+            } else {
+                EThreadState expected = state;
+                replaced = Threads[workerId].ReplaceState(expected, targetState);
+            }
+            if (!replaced) {
+                continue;
+            }
+
+            if (useWakeupToken) {
+                --Waker->TakenTokensToWakeup;
+            }
+            if (useSleepToken) {
+                --Waker->TakenTokensToSleep;
+            }
+            if (targetState == EThreadState::None) {
+                if (!isWaker) {
+                    --budget;
+                    Threads[workerId].WaitingPad.Unpark();
+                }
+            } else {
+                Waker->SleepingStack.push_back(workerId);
+                if (countAsSleeping) {
+                    ++previousSleepingCount;
                 }
             }
+        }
 
-            if (newlySleeping) {
-                SleepingCount.fetch_add(newlySleeping, std::memory_order_release);
+        ui64 currentReductions = CheckToSleepWorkers.load(std::memory_order_acquire);
+        while (true) {
+            Y_ABORT_UNLESS((currentReductions & WakerReductionMask) == 0);
+            if (CheckToSleepWorkers.compare_exchange_weak(currentReductions, remainingReductions,
+                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+                break;
             }
+        }
+        Waker->PreviousReductions = remainingReductions;
 
-            while (budget > 0) {
-                bool wokeWorker = false;
-                for (size_t idx = Waker->SleepingStack.size(); idx > 0; --idx) {
-                    const i16 workerId = Waker->SleepingStack[idx - 1];
-                    if (workerId == wakerWorkerId || !Waker->ActiveMask[workerId]) {
+        while (budget > 0 && previousSleepingCount > 0) {
+            bool wokeWorker = false;
+            for (size_t idx = Waker->SleepingStack.size(); idx > 0; --idx) {
+                const i16 workerId = Waker->SleepingStack[idx - 1];
+                if (workerId == wakerWorkerId) {
+                    if (wakerState != EThreadState::Sleep) {
                         continue;
                     }
-                    if (Threads[workerId].WakeFromWaker()) {
-                        Waker->SleepingStack.erase(Waker->SleepingStack.begin() + idx - 1);
-                        SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
-                        --budget;
-                        wokeWorker = true;
+                    wakerState = EThreadState::None;
+                } else {
+                    EThreadState state = Threads[workerId].GetState<EThreadState>();
+                    const EThreadState logicalState = getLogicalState(state);
+                    if (logicalState != EThreadState::Sleep) {
+                        continue;
                     }
-                    break;
+                    EThreadState expected = state;
+                    if (!Threads[workerId].ReplaceState(expected, EThreadState::None)) {
+                        continue;
+                    }
+                    --budget;
+                    Threads[workerId].WaitingPad.Unpark();
                 }
-                if (!wokeWorker) {
-                    break;
-                }
+                Waker->SleepingStack.erase(Waker->SleepingStack.begin() + idx - 1);
+                --previousSleepingCount;
+                wokeWorker = true;
+                break;
             }
+            if (!wokeWorker) {
+                break;
+            }
+        }
 
-            if (budget > 0 && Waker->ActiveMask[wakerWorkerId] && wakerState == EThreadState::Sleep) {
-                auto it = std::find(Waker->SleepingStack.begin(), Waker->SleepingStack.end(), wakerWorkerId);
-                Y_ABORT_UNLESS(it != Waker->SleepingStack.end());
-                Waker->SleepingStack.erase(it);
-                SleepingCount.fetch_sub(1, std::memory_order_acq_rel);
-                wakerState = EThreadState::None;
-                --budget;
-            }
+        SleepingCount.store(previousSleepingCount, std::memory_order_release);
 
-            // A producer may publish a credit before the corresponding
-            // sleeping worker becomes visible through SleepingCount.
-            if (ActivationCredits.load(std::memory_order_acquire) > previousActivationCredits) {
-                RequestWaker(false);
-            }
-        Threads[wakerWorkerId].SetWakerResumeState(wakerState);
+        // A producer publishes its credit before the corresponding queue item.
+        // If the credit appeared while SleepingCount was hidden, repeat the pass.
+        if (ActivationCredits.load(std::memory_order_acquire) > previousActivationCredits) {
+            WakerPending.store(true, std::memory_order_release);
+        }
+        *resumeState = wakerState;
     }
 
     inline void TBasicExecutorPool::WakeUpLoop(i16 currentThreadCount) {

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -17,6 +17,7 @@
 #include <library/cpp/threading/chunk_queue/queue.h>
 
 #include <util/system/mutex.h>
+#include <util/generic/vector.h>
 
 namespace NActors {
 
@@ -158,6 +159,7 @@ namespace NActors {
         std::atomic<ui64> SpinningTimeUs;
 
         TAtomic ThreadCount;
+        TAtomic SuggestedThreadCount;
         std::atomic<float> SharedCpuQuota = 0.0;
         TMutex ChangeThreadsLock;
 
@@ -176,7 +178,15 @@ namespace NActors {
         const ui32 ActorSystemIndex = NActors::TActorTypeOperator::GetActorSystemIndex();
         TExecutorPoolJail *Jail = nullptr;
         TSharedExecutorPool *SharedPool = nullptr;
+        class TWaker;
         std::unique_ptr<TBasicExecutorPoolSanitizer> Sanitizer;
+        std::unique_ptr<TWaker> Waker;
+
+        const bool EnableWaker;
+        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i64>> ActivationCredits = 0;
+        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i16>> SleepingCount = 0;
+        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic_bool> WakerPending = false;
+        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<TThreadParkPad> WakerPad;
 
     public:
         struct TSemaphore {
@@ -229,6 +239,7 @@ namespace NActors {
         TMailbox* GetReadyActivation(ui64 revolvingReadCounter) override;
         TMailbox* GetReadyActivationShared(ui64 revolvingReadCounter);
         TMailbox* GetReadyActivationRingQueue(ui64 revolvingReadCounter);
+        TMailbox* GetReadyActivationWaker(ui64 revolvingReadCounter);
 
         void Schedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie, TWorkerId workerId) override;
         void Schedule(TMonotonic deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie, TWorkerId workerId) override;
@@ -236,6 +247,7 @@ namespace NActors {
 
         void ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingWriteCounter) override;
         void ScheduleActivationExRingQueue(TMailbox* mailbox, ui64 revolvingWriteCounter, std::optional<TAtomic> semaphoreValue);
+        void ScheduleActivationExWaker(TMailbox* mailbox, ui64 revolvingWriteCounter);
         void Prepare(TActorSystem* actorSystem, NSchedulerQueue::TReader** scheduleReaders, ui32* scheduleSz) override;
         void Start() override;
         void PrepareStop() override;
@@ -282,6 +294,8 @@ namespace NActors {
 
         void WakeUpLoop(i16 currentThreadCount);
         bool WakeUpLoopShared();
+        void RequestWaker();
+        void WakerLoop();
 
     };
 }

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -301,7 +301,7 @@ namespace NActors {
         bool TryRequestWaker(bool requireSleepingWorkers);
         void RequestWaker(bool persistent);
         void RunWaker(TWorkerId workerId);
-        void WakerLoop(TWorkerId workerId);
+        void WakerLoop(TWorkerId workerId, EThreadState* resumeState);
 
     };
 }

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -182,11 +182,15 @@ namespace NActors {
         std::unique_ptr<TBasicExecutorPoolSanitizer> Sanitizer;
         std::unique_ptr<TWaker> Waker;
 
+        static constexpr i16 InvalidWakerWorkerId = -1;
+        static constexpr ui64 WakerRequestBit = ui64(1) << 63;
+        static constexpr ui64 WakerReductionMask = ~WakerRequestBit;
+
         const bool EnableWaker;
         alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i64>> ActivationCredits = 0;
         alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i16>> SleepingCount = 0;
         alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic_bool> WakerPending = false;
-        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<TThreadParkPad> WakerPad;
+        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i16>> WakerWorkerId = InvalidWakerWorkerId;
 
     public:
         struct TSemaphore {
@@ -294,8 +298,10 @@ namespace NActors {
 
         void WakeUpLoop(i16 currentThreadCount);
         bool WakeUpLoopShared();
-        void RequestWaker();
-        void WakerLoop();
+        bool TryRequestWaker(bool requireSleepingWorkers);
+        void RequestWaker(bool persistent);
+        void RunWaker(TWorkerId workerId);
+        void WakerLoop(TWorkerId workerId);
 
     };
 }

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -187,10 +187,14 @@ namespace NActors {
         static constexpr ui64 WakerReductionMask = ~WakerRequestBit;
 
         const bool EnableWaker;
-        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i64>> ActivationCredits = 0;
-        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i16>> SleepingCount = 0;
-        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic_bool> WakerPending = false;
-        alignas(PLATFORM_CACHE_LINE) NThreading::TPadded<std::atomic<i16>> WakerWorkerId = InvalidWakerWorkerId;
+    public:
+        const EASProfile ActorSystemProfile;
+
+    private:
+        alignas(PLATFORM_CACHE_LINE) std::atomic<i64> ActivationCredits = 0;
+        alignas(PLATFORM_CACHE_LINE) std::atomic<i16> SleepingCount = 0;
+        alignas(PLATFORM_CACHE_LINE) std::atomic_bool WakerPending = false;
+        alignas(PLATFORM_CACHE_LINE) std::atomic<i16> WakerWorkerId = InvalidWakerWorkerId;
 
     public:
         struct TSemaphore {
@@ -216,7 +220,6 @@ namespace NActors {
             }
         };
 
-        const EASProfile ActorSystemProfile;
         static constexpr TDuration DEFAULT_TIME_PER_MAILBOX = TBasicExecutorPoolConfig::DEFAULT_TIME_PER_MAILBOX;
         static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = TBasicExecutorPoolConfig::DEFAULT_EVENTS_PER_MAILBOX;
 

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -135,6 +135,8 @@ namespace NActors {
                     }
                     break;
                 case EThreadState::Blocking:
+                case EThreadState::NeedToBeWaker:
+                case EThreadState::Waker:
                     return false;
                 default:
                     Y_ABORT();

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -87,8 +87,7 @@ namespace NActors {
         return Sleep(stopFlag);
     }
 
-    bool TExecutorThreadCtx::WaitForWaker(ui64 spinThresholdCycles, std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits) {
-        Y_UNUSED(spinThresholdCycles);
+    bool TExecutorThreadCtx::WaitForWaker(std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits) {
         EThreadState state = GetState<EThreadState>();
         while (state == EThreadState::Spin && !stopFlag->load(std::memory_order_relaxed)) {
             if (activationCredits->load(std::memory_order_acquire) > 0) {
@@ -136,6 +135,8 @@ namespace NActors {
                     break;
                 case EThreadState::Blocking:
                 case EThreadState::NeedToBeWaker:
+                case EThreadState::NeedToBeWakerFromSleep:
+                case EThreadState::NeedToBeWakerFromBlocking:
                 case EThreadState::Waker:
                     return false;
                 default:

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -105,11 +105,28 @@ namespace NActors {
             state = GetState<EThreadState>();
         }
 
-        while ((state == EThreadState::Sleep || state == EThreadState::Blocking) && !stopFlag.load(std::memory_order_relaxed)) {
-            if (WaitingPad.Park()) {
-                return true;
-            }
-            state = GetState<EThreadState>();
+        if ((state == EThreadState::Sleep || state == EThreadState::Blocking) &&
+                !stopFlag.load(std::memory_order_relaxed)) {
+            Y_DEBUG_ABORT_UNLESS(TlsThreadContext);
+
+            NHPTimer::STime hpnow = GetCycleCountFast();
+            NHPTimer::STime hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
+            ui32 prevActivity = TlsThreadContext->ActivityContext.ElapsingActorActivity.exchange(
+                SleepActivity, std::memory_order_acq_rel);
+            TlsThreadContext->ExecutionStats->AddElapsedCycles(prevActivity, hpnow - hpprev);
+            do {
+                if (WaitingPad.Park()) {
+                    return true;
+                }
+                hpnow = GetCycleCountFast();
+                hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
+                TlsThreadContext->ExecutionStats->AddParkedCycles(hpnow - hpprev);
+                state = GetState<EThreadState>();
+            } while ((state == EThreadState::Sleep || state == EThreadState::Blocking) &&
+                !stopFlag.load(std::memory_order_relaxed));
+            TlsThreadContext->ActivityContext.ActivationStartTS.store(hpnow, std::memory_order_release);
+            TlsThreadContext->ActivityContext.ElapsingActorActivity.store(
+                TlsThreadContext->ActivityContext.ActorSystemIndex, std::memory_order_release);
         }
         return stopFlag.load(std::memory_order_relaxed);
     }

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -90,10 +90,12 @@ namespace NActors {
     bool TExecutorThreadCtx::WaitForWaker(
             const std::atomic<bool>& stopFlag,
             const std::atomic<i64>& activationCredits,
-            const std::atomic<ui64>& reductions) {
+            const std::atomic<ui64>& reductions,
+            ui64 wakerRequestBit) {
         EThreadState state = GetState<EThreadState>();
         while (state == EThreadState::Spin && !stopFlag.load(std::memory_order_relaxed)) {
-            if (activationCredits.load(std::memory_order_acquire) > 0 || reductions.load(std::memory_order_acquire) > 0) {
+            if (activationCredits.load(std::memory_order_acquire) > 0 ||
+                    (reductions.load(std::memory_order_acquire) & wakerRequestBit)) {
                 if (ReplaceState(state, EThreadState::None)) {
                     return false;
                 }
@@ -136,6 +138,7 @@ namespace NActors {
                     break;
                 case EThreadState::Blocking:
                 case EThreadState::NeedToBeWaker:
+                case EThreadState::NeedToBeWakerFromSpin:
                 case EThreadState::NeedToBeWakerFromSleep:
                 case EThreadState::NeedToBeWakerFromBlocking:
                 case EThreadState::Waker:

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -87,6 +87,31 @@ namespace NActors {
         return Sleep(stopFlag);
     }
 
+    bool TExecutorThreadCtx::WaitForWaker(ui64 spinThresholdCycles, std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits) {
+        Y_UNUSED(spinThresholdCycles);
+        EThreadState state = GetState<EThreadState>();
+        while (state == EThreadState::Spin && !stopFlag->load(std::memory_order_relaxed)) {
+            if (activationCredits->load(std::memory_order_acquire) > 0) {
+                EThreadState expected = EThreadState::Spin;
+                if (ReplaceState(expected, EThreadState::None)) {
+                    return false;
+                }
+                state = expected;
+                continue;
+            }
+            SpinLockPause();
+            state = GetState<EThreadState>();
+        }
+
+        while ((state == EThreadState::Sleep || state == EThreadState::Blocking) && !stopFlag->load(std::memory_order_relaxed)) {
+            if (WaitingPad.Park()) {
+                return true;
+            }
+            state = GetState<EThreadState>();
+        }
+        return stopFlag->load(std::memory_order_relaxed);
+    }
+
     bool TExecutorThreadCtx::WakeUp() {
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_WAKE_UP, false> activityGuard;
         for (ui32 i = 0; i < 2; ++i) {
@@ -109,6 +134,8 @@ namespace NActors {
                         return true;
                     }
                     break;
+                case EThreadState::Blocking:
+                    return false;
                 default:
                     Y_ABORT();
             }

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -93,16 +93,19 @@ namespace NActors {
             const std::atomic<ui64>& reductions,
             ui64 wakerRequestBit) {
         EThreadState state = GetState<EThreadState>();
-        while (state == EThreadState::Spin && !stopFlag.load(std::memory_order_relaxed)) {
-            if (activationCredits.load(std::memory_order_acquire) > 0 ||
-                    (reductions.load(std::memory_order_acquire) & wakerRequestBit)) {
-                if (ReplaceState(state, EThreadState::None)) {
-                    return false;
+        if (state == EThreadState::Spin) {
+            TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_SPIN> activityGuard;
+            while (state == EThreadState::Spin && !stopFlag.load(std::memory_order_relaxed)) {
+                if (activationCredits.load(std::memory_order_acquire) > 0 ||
+                        (reductions.load(std::memory_order_acquire) & wakerRequestBit)) {
+                    if (ReplaceState(state, EThreadState::None)) {
+                        return false;
+                    }
+                    continue;
                 }
-                continue;
+                SpinLockPause();
+                state = GetState<EThreadState>();
             }
-            SpinLockPause();
-            state = GetState<EThreadState>();
         }
 
         if ((state == EThreadState::Sleep || state == EThreadState::Blocking) &&

--- a/ydb/library/actors/core/executor_thread_ctx.cpp
+++ b/ydb/library/actors/core/executor_thread_ctx.cpp
@@ -87,28 +87,29 @@ namespace NActors {
         return Sleep(stopFlag);
     }
 
-    bool TExecutorThreadCtx::WaitForWaker(std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits) {
+    bool TExecutorThreadCtx::WaitForWaker(
+            const std::atomic<bool>& stopFlag,
+            const std::atomic<i64>& activationCredits,
+            const std::atomic<ui64>& reductions) {
         EThreadState state = GetState<EThreadState>();
-        while (state == EThreadState::Spin && !stopFlag->load(std::memory_order_relaxed)) {
-            if (activationCredits->load(std::memory_order_acquire) > 0) {
-                EThreadState expected = EThreadState::Spin;
-                if (ReplaceState(expected, EThreadState::None)) {
+        while (state == EThreadState::Spin && !stopFlag.load(std::memory_order_relaxed)) {
+            if (activationCredits.load(std::memory_order_acquire) > 0 || reductions.load(std::memory_order_acquire) > 0) {
+                if (ReplaceState(state, EThreadState::None)) {
                     return false;
                 }
-                state = expected;
                 continue;
             }
             SpinLockPause();
             state = GetState<EThreadState>();
         }
 
-        while ((state == EThreadState::Sleep || state == EThreadState::Blocking) && !stopFlag->load(std::memory_order_relaxed)) {
+        while ((state == EThreadState::Sleep || state == EThreadState::Blocking) && !stopFlag.load(std::memory_order_relaxed)) {
             if (WaitingPad.Park()) {
                 return true;
             }
             state = GetState<EThreadState>();
         }
-        return stopFlag->load(std::memory_order_relaxed);
+        return stopFlag.load(std::memory_order_relaxed);
     }
 
     bool TExecutorThreadCtx::WakeUp() {

--- a/ydb/library/actors/core/executor_thread_ctx.h
+++ b/ydb/library/actors/core/executor_thread_ctx.h
@@ -19,7 +19,9 @@ namespace NActors {
         Spin,
         Sleep,
         Work,
-        Blocking
+        Blocking,
+        NeedToBeWaker,
+        Waker
     };
 
     struct TGenericExecutorThreadCtx {
@@ -31,7 +33,19 @@ namespace NActors {
         TThreadParkPad WaitingPad;
 
     private:
-        std::atomic<ui64> WaitingFlag = static_cast<ui64>(EThreadState::None);
+        static constexpr ui64 StateMask = 0xff;
+        static constexpr ui64 ResumeStateShift = 8;
+        static constexpr ui64 InvalidResumeState = 0xff;
+
+        static constexpr ui64 EncodeState(EThreadState state, ui64 resumeState = InvalidResumeState) {
+            return static_cast<ui64>(state) | (resumeState << ResumeStateShift);
+        }
+
+        static constexpr EThreadState DecodeState(ui64 state) {
+            return static_cast<EThreadState>(state & StateMask);
+        }
+
+        std::atomic<ui64> WaitingFlag = EncodeState(EThreadState::None);
 
     public:
         ~TGenericExecutorThreadCtx(); // in executor_thread.cpp
@@ -39,26 +53,82 @@ namespace NActors {
         ui64 StartWakingTs = 0;
 
         ui64 GetStateInt() {
-            return WaitingFlag.load();
+            return static_cast<ui64>(DecodeState(WaitingFlag.load()));
         }
 
     protected:
         template <typename TWaitState>
         TWaitState GetState() {
-            return TWaitState(WaitingFlag.load());
+            return TWaitState(DecodeState(WaitingFlag.load()));
         }
 
         template <typename TWaitState>
         TWaitState ExchangeState(TWaitState state) {
-            return TWaitState(WaitingFlag.exchange(static_cast<ui64>(state)));
+            return TWaitState(DecodeState(WaitingFlag.exchange(EncodeState(static_cast<EThreadState>(state)))));
         }
 
         template <typename TWaitState>
         bool ReplaceState(TWaitState &expected, TWaitState state) {
-            ui64 expectedInt = static_cast<ui64>(expected);
-            bool result = WaitingFlag.compare_exchange_strong(expectedInt, static_cast<ui64>(state));
-            expected = TWaitState(expectedInt);
-            return result;
+            ui64 expectedInt = WaitingFlag.load();
+            while (true) {
+                const EThreadState current = DecodeState(expectedInt);
+                if (current != static_cast<EThreadState>(expected)) {
+                    expected = TWaitState(current);
+                    return false;
+                }
+                if (WaitingFlag.compare_exchange_weak(expectedInt, EncodeState(static_cast<EThreadState>(state)))) {
+                    return true;
+                }
+            }
+        }
+
+        bool ReplaceStateWithResume(EThreadState& expected, EThreadState state, EThreadState resumeState) {
+            ui64 expectedInt = WaitingFlag.load();
+            while (true) {
+                const EThreadState current = DecodeState(expectedInt);
+                if (current != expected) {
+                    expected = current;
+                    return false;
+                }
+                const ui64 desired = EncodeState(state, static_cast<ui64>(resumeState));
+                if (WaitingFlag.compare_exchange_weak(expectedInt, desired)) {
+                    return true;
+                }
+            }
+        }
+
+        bool ReplaceStatePreservingResume(EThreadState& expected, EThreadState state) {
+            ui64 expectedInt = WaitingFlag.load();
+            while (true) {
+                const EThreadState current = DecodeState(expectedInt);
+                if (current != expected) {
+                    expected = current;
+                    return false;
+                }
+                const ui64 desired = static_cast<ui64>(state) | (expectedInt & ~StateMask);
+                if (WaitingFlag.compare_exchange_weak(expectedInt, desired)) {
+                    return true;
+                }
+            }
+        }
+
+        EThreadState GetResumeState() {
+            const ui64 state = WaitingFlag.load();
+            const ui64 resumeState = (state >> ResumeStateShift) & StateMask;
+            Y_ABORT_UNLESS(resumeState != InvalidResumeState);
+            return static_cast<EThreadState>(resumeState);
+        }
+
+        void SetResumeState(EThreadState resumeState) {
+            ui64 state = WaitingFlag.load();
+            while (true) {
+                const EThreadState current = DecodeState(state);
+                Y_ABORT_UNLESS(current == EThreadState::Waker || current == EThreadState::NeedToBeWaker);
+                const ui64 desired = EncodeState(current, static_cast<ui64>(resumeState));
+                if (WaitingFlag.compare_exchange_weak(state, desired)) {
+                    return;
+                }
+            }
         }
 
         template <typename TDerived, typename TWaitState>
@@ -91,14 +161,34 @@ namespace NActors {
 
         bool WakeUp();
 
-        bool StartWakerWait() {
-            EThreadState expected = EThreadState::None;
-            return ReplaceState(expected, EThreadState::Spin);
+        bool StartWaker(EThreadState expected, EThreadState resumeState) {
+            return ReplaceStateWithResume(expected, EThreadState::NeedToBeWaker, resumeState);
         }
 
-        bool StartWakerBlocking() {
-            EThreadState expected = EThreadState::None;
-            return ReplaceState(expected, EThreadState::Blocking);
+        bool BecomeWaker() {
+            EThreadState expected = EThreadState::NeedToBeWaker;
+            return ReplaceStatePreservingResume(expected, EThreadState::Waker);
+        }
+
+        bool RequestAnotherWakerPass() {
+            EThreadState expected = EThreadState::Waker;
+            if (ReplaceStatePreservingResume(expected, EThreadState::NeedToBeWaker)) {
+                return true;
+            }
+            return expected == EThreadState::NeedToBeWaker;
+        }
+
+        EThreadState GetWakerResumeState() {
+            return GetResumeState();
+        }
+
+        void SetWakerResumeState(EThreadState state) {
+            SetResumeState(state);
+        }
+
+        bool RestoreWakerResumeState() {
+            EThreadState expected = EThreadState::NeedToBeWaker;
+            return ReplaceState(expected, GetResumeState());
         }
 
         bool WakeFromWaker() {

--- a/ydb/library/actors/core/executor_thread_ctx.h
+++ b/ydb/library/actors/core/executor_thread_ctx.h
@@ -86,54 +86,6 @@ namespace NActors {
             }
         }
 
-        bool BecomeWakerState(EThreadState* resumeState) {
-            Y_ABORT_UNLESS(resumeState);
-            ui64 state = WaitingFlag.load();
-            while (true) {
-                EThreadState currentResumeState;
-                switch (DecodeState(state)) {
-                    case EThreadState::NeedToBeWaker:
-                        currentResumeState = EThreadState::None;
-                        break;
-                    case EThreadState::NeedToBeWakerFromSleep:
-                        currentResumeState = EThreadState::Sleep;
-                        break;
-                    case EThreadState::NeedToBeWakerFromBlocking:
-                        currentResumeState = EThreadState::Blocking;
-                        break;
-                    default:
-                        return false;
-                }
-                if (WaitingFlag.compare_exchange_weak(state, EncodeState(EThreadState::Waker))) {
-                    *resumeState = currentResumeState;
-                    return true;
-                }
-            }
-        }
-
-        bool RestoreNeedToBeWakerState() {
-            ui64 state = WaitingFlag.load();
-            while (true) {
-                EThreadState restoredState;
-                switch (DecodeState(state)) {
-                    case EThreadState::NeedToBeWaker:
-                        restoredState = EThreadState::None;
-                        break;
-                    case EThreadState::NeedToBeWakerFromSleep:
-                        restoredState = EThreadState::Sleep;
-                        break;
-                    case EThreadState::NeedToBeWakerFromBlocking:
-                        restoredState = EThreadState::Blocking;
-                        break;
-                    default:
-                        return false;
-                }
-                if (WaitingFlag.compare_exchange_weak(state, EncodeState(restoredState))) {
-                    return true;
-                }
-            }
-        }
-
         template <typename TDerived, typename TWaitState>
         void Spin(ui64 spinThresholdCycles, std::atomic<bool> *stopFlag);
 
@@ -144,6 +96,47 @@ namespace NActors {
     struct TExecutorThreadCtx : public TGenericExecutorThreadCtx {
         using TBase = TGenericExecutorThreadCtx;
 
+    private:
+        static bool TryGetNeedToBeWakerState(EThreadState state, EThreadState* wakerState) {
+            Y_ABORT_UNLESS(wakerState);
+            switch (state) {
+                case EThreadState::None:
+                case EThreadState::Spin:
+                    *wakerState = EThreadState::NeedToBeWaker;
+                    return true;
+                case EThreadState::Sleep:
+                    *wakerState = EThreadState::NeedToBeWakerFromSleep;
+                    return true;
+                case EThreadState::Blocking:
+                    *wakerState = EThreadState::NeedToBeWakerFromBlocking;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        static bool TryGetWakerResumeState(EThreadState state, EThreadState* resumeState) {
+            Y_ABORT_UNLESS(resumeState);
+            switch (state) {
+                case EThreadState::None:
+                case EThreadState::Spin:
+                case EThreadState::NeedToBeWaker:
+                    *resumeState = EThreadState::None;
+                    return true;
+                case EThreadState::Sleep:
+                case EThreadState::NeedToBeWakerFromSleep:
+                    *resumeState = EThreadState::Sleep;
+                    return true;
+                case EThreadState::Blocking:
+                case EThreadState::NeedToBeWakerFromBlocking:
+                    *resumeState = EThreadState::Blocking;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+    public:
         void SetWork() {
             ExchangeState(EThreadState::Work);
         }
@@ -164,34 +157,63 @@ namespace NActors {
 
         bool WakeUp();
 
-        bool TrySetNeedToBeWaker(EThreadState expected) {
+        bool TrySetNeedToBeWaker(EThreadState* expected) {
+            Y_ABORT_UNLESS(expected);
             EThreadState wakerState;
-            switch (expected) {
-                case EThreadState::None:
-                case EThreadState::Spin:
-                    wakerState = EThreadState::NeedToBeWaker;
-                    break;
-                case EThreadState::Sleep:
-                    wakerState = EThreadState::NeedToBeWakerFromSleep;
-                    break;
-                case EThreadState::Blocking:
-                    wakerState = EThreadState::NeedToBeWakerFromBlocking;
-                    break;
-                default:
-                    return false;
+            if (!TryGetNeedToBeWakerState(*expected, &wakerState)) {
+                return false;
             }
-            return ReplaceState(expected, wakerState);
+            return ReplaceState(*expected, wakerState);
         }
 
-        bool BecomeWaker(EThreadState* resumeState) {
-            return BecomeWakerState(resumeState);
+        bool TrySetNeedToBeWaker() {
+            EThreadState state = GetState<EThreadState>();
+            while (true) {
+                if (IsNeedToBeWaker(state) || state == EThreadState::Waker) {
+                    return true;
+                }
+                if (state != EThreadState::None && state != EThreadState::Spin &&
+                        state != EThreadState::Sleep && state != EThreadState::Blocking) {
+                    return false;
+                }
+                if (TrySetNeedToBeWaker(&state)) {
+                    return true;
+                }
+            }
         }
 
-        bool RestoreWakerResumeState() {
-            return RestoreNeedToBeWakerState();
+        bool TryBecomeWaker(EThreadState* resumeState) {
+            EThreadState state = GetState<EThreadState>();
+            while (true) {
+                EThreadState currentResumeState;
+                if (!TryGetWakerResumeState(state, &currentResumeState)) {
+                    return false;
+                }
+                if (ReplaceState(state, EThreadState::Waker)) {
+                    *resumeState = currentResumeState;
+                    return true;
+                }
+            }
         }
 
-        bool WaitForWaker(std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits);
+        bool CancelWakerRequest() {
+            EThreadState state = GetState<EThreadState>();
+            while (true) {
+                if (!IsNeedToBeWaker(state)) {
+                    return false;
+                }
+                EThreadState resumeState;
+                Y_ABORT_UNLESS(TryGetWakerResumeState(state, &resumeState));
+                if (ReplaceState(state, resumeState)) {
+                    return true;
+                }
+            }
+        }
+
+        bool WaitForWaker(
+            const std::atomic<bool>& stopFlag,
+            const std::atomic<i64>& activationCredits,
+            const std::atomic<ui64>& reductions);
 
         void Interrupt() {
             WaitingPad.Interrupt();

--- a/ydb/library/actors/core/executor_thread_ctx.h
+++ b/ydb/library/actors/core/executor_thread_ctx.h
@@ -11,19 +11,22 @@
 
 namespace NActors {
     class TExecutorThread;
+    class TBasicExecutorPool;
     class IExecutorPool;
 
     enum class EThreadState : ui64 {
         None,
         Spin,
         Sleep,
-        Work
+        Work,
+        Blocking
     };
 
     struct TGenericExecutorThreadCtx {
         std::unique_ptr<TExecutorThread> Thread;
 
     protected:
+        friend class TBasicExecutorPool;
         friend class TIOExecutorPool;
         TThreadParkPad WaitingPad;
 
@@ -87,6 +90,27 @@ namespace NActors {
         bool Wait(ui64 spinThresholdCycles, std::atomic<bool> *stopFlag); // in executor_pool_basic.cpp
 
         bool WakeUp();
+
+        bool StartWakerWait() {
+            EThreadState expected = EThreadState::None;
+            return ReplaceState(expected, EThreadState::Spin);
+        }
+
+        bool StartWakerBlocking() {
+            EThreadState expected = EThreadState::None;
+            return ReplaceState(expected, EThreadState::Blocking);
+        }
+
+        bool WakeFromWaker() {
+            EThreadState expected = EThreadState::Sleep;
+            if (!ReplaceState(expected, EThreadState::None)) {
+                return false;
+            }
+            WaitingPad.Unpark();
+            return true;
+        }
+
+        bool WaitForWaker(ui64 spinThresholdCycles, std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits);
 
         void Interrupt() {
             WaitingPad.Interrupt();

--- a/ydb/library/actors/core/executor_thread_ctx.h
+++ b/ydb/library/actors/core/executor_thread_ctx.h
@@ -43,15 +43,7 @@ namespace NActors {
         TThreadParkPad WaitingPad;
 
     private:
-        static constexpr ui64 EncodeState(EThreadState state) {
-            return static_cast<ui64>(state);
-        }
-
-        static constexpr EThreadState DecodeState(ui64 state) {
-            return static_cast<EThreadState>(state);
-        }
-
-        std::atomic<ui64> WaitingFlag = EncodeState(EThreadState::None);
+        std::atomic<ui64> WaitingFlag = static_cast<ui64>(EThreadState::None);
 
     public:
         ~TGenericExecutorThreadCtx(); // in executor_thread.cpp
@@ -59,33 +51,26 @@ namespace NActors {
         ui64 StartWakingTs = 0;
 
         ui64 GetStateInt() {
-            return static_cast<ui64>(DecodeState(WaitingFlag.load()));
+            return WaitingFlag.load();
         }
 
     protected:
         template <typename TWaitState>
         TWaitState GetState() {
-            return TWaitState(DecodeState(WaitingFlag.load()));
+            return TWaitState(WaitingFlag.load());
         }
 
         template <typename TWaitState>
         TWaitState ExchangeState(TWaitState state) {
-            return TWaitState(DecodeState(WaitingFlag.exchange(EncodeState(static_cast<EThreadState>(state)))));
+            return TWaitState(WaitingFlag.exchange(static_cast<ui64>(state)));
         }
 
         template <typename TWaitState>
         bool ReplaceState(TWaitState &expected, TWaitState state) {
-            ui64 expectedInt = WaitingFlag.load();
-            while (true) {
-                const EThreadState current = DecodeState(expectedInt);
-                if (current != static_cast<EThreadState>(expected)) {
-                    expected = TWaitState(current);
-                    return false;
-                }
-                if (WaitingFlag.compare_exchange_weak(expectedInt, EncodeState(static_cast<EThreadState>(state)))) {
-                    return true;
-                }
-            }
+            ui64 expectedInt = static_cast<ui64>(expected);
+            bool result = WaitingFlag.compare_exchange_strong(expectedInt, static_cast<ui64>(state));
+            expected = TWaitState(expectedInt);
+            return result;
         }
 
         template <typename TDerived, typename TWaitState>

--- a/ydb/library/actors/core/executor_thread_ctx.h
+++ b/ydb/library/actors/core/executor_thread_ctx.h
@@ -21,6 +21,7 @@ namespace NActors {
         Work,
         Blocking,
         NeedToBeWaker,
+        NeedToBeWakerFromSpin,
         NeedToBeWakerFromSleep,
         NeedToBeWakerFromBlocking,
         Waker
@@ -28,6 +29,7 @@ namespace NActors {
 
     constexpr bool IsNeedToBeWaker(EThreadState state) {
         return state == EThreadState::NeedToBeWaker ||
+            state == EThreadState::NeedToBeWakerFromSpin ||
             state == EThreadState::NeedToBeWakerFromSleep ||
             state == EThreadState::NeedToBeWakerFromBlocking;
     }
@@ -101,8 +103,10 @@ namespace NActors {
             Y_ABORT_UNLESS(wakerState);
             switch (state) {
                 case EThreadState::None:
-                case EThreadState::Spin:
                     *wakerState = EThreadState::NeedToBeWaker;
+                    return true;
+                case EThreadState::Spin:
+                    *wakerState = EThreadState::NeedToBeWakerFromSpin;
                     return true;
                 case EThreadState::Sleep:
                     *wakerState = EThreadState::NeedToBeWakerFromSleep;
@@ -119,9 +123,12 @@ namespace NActors {
             Y_ABORT_UNLESS(resumeState);
             switch (state) {
                 case EThreadState::None:
-                case EThreadState::Spin:
                 case EThreadState::NeedToBeWaker:
                     *resumeState = EThreadState::None;
+                    return true;
+                case EThreadState::Spin:
+                case EThreadState::NeedToBeWakerFromSpin:
+                    *resumeState = EThreadState::Spin;
                     return true;
                 case EThreadState::Sleep:
                 case EThreadState::NeedToBeWakerFromSleep:
@@ -213,7 +220,8 @@ namespace NActors {
         bool WaitForWaker(
             const std::atomic<bool>& stopFlag,
             const std::atomic<i64>& activationCredits,
-            const std::atomic<ui64>& reductions);
+            const std::atomic<ui64>& reductions,
+            ui64 wakerRequestBit);
 
         void Interrupt() {
             WaitingPad.Interrupt();

--- a/ydb/library/actors/core/executor_thread_ctx.h
+++ b/ydb/library/actors/core/executor_thread_ctx.h
@@ -21,8 +21,16 @@ namespace NActors {
         Work,
         Blocking,
         NeedToBeWaker,
+        NeedToBeWakerFromSleep,
+        NeedToBeWakerFromBlocking,
         Waker
     };
+
+    constexpr bool IsNeedToBeWaker(EThreadState state) {
+        return state == EThreadState::NeedToBeWaker ||
+            state == EThreadState::NeedToBeWakerFromSleep ||
+            state == EThreadState::NeedToBeWakerFromBlocking;
+    }
 
     struct TGenericExecutorThreadCtx {
         std::unique_ptr<TExecutorThread> Thread;
@@ -33,16 +41,12 @@ namespace NActors {
         TThreadParkPad WaitingPad;
 
     private:
-        static constexpr ui64 StateMask = 0xff;
-        static constexpr ui64 ResumeStateShift = 8;
-        static constexpr ui64 InvalidResumeState = 0xff;
-
-        static constexpr ui64 EncodeState(EThreadState state, ui64 resumeState = InvalidResumeState) {
-            return static_cast<ui64>(state) | (resumeState << ResumeStateShift);
+        static constexpr ui64 EncodeState(EThreadState state) {
+            return static_cast<ui64>(state);
         }
 
         static constexpr EThreadState DecodeState(ui64 state) {
-            return static_cast<EThreadState>(state & StateMask);
+            return static_cast<EThreadState>(state);
         }
 
         std::atomic<ui64> WaitingFlag = EncodeState(EThreadState::None);
@@ -82,51 +86,50 @@ namespace NActors {
             }
         }
 
-        bool ReplaceStateWithResume(EThreadState& expected, EThreadState state, EThreadState resumeState) {
-            ui64 expectedInt = WaitingFlag.load();
-            while (true) {
-                const EThreadState current = DecodeState(expectedInt);
-                if (current != expected) {
-                    expected = current;
-                    return false;
-                }
-                const ui64 desired = EncodeState(state, static_cast<ui64>(resumeState));
-                if (WaitingFlag.compare_exchange_weak(expectedInt, desired)) {
-                    return true;
-                }
-            }
-        }
-
-        bool ReplaceStatePreservingResume(EThreadState& expected, EThreadState state) {
-            ui64 expectedInt = WaitingFlag.load();
-            while (true) {
-                const EThreadState current = DecodeState(expectedInt);
-                if (current != expected) {
-                    expected = current;
-                    return false;
-                }
-                const ui64 desired = static_cast<ui64>(state) | (expectedInt & ~StateMask);
-                if (WaitingFlag.compare_exchange_weak(expectedInt, desired)) {
-                    return true;
-                }
-            }
-        }
-
-        EThreadState GetResumeState() {
-            const ui64 state = WaitingFlag.load();
-            const ui64 resumeState = (state >> ResumeStateShift) & StateMask;
-            Y_ABORT_UNLESS(resumeState != InvalidResumeState);
-            return static_cast<EThreadState>(resumeState);
-        }
-
-        void SetResumeState(EThreadState resumeState) {
+        bool BecomeWakerState(EThreadState* resumeState) {
+            Y_ABORT_UNLESS(resumeState);
             ui64 state = WaitingFlag.load();
             while (true) {
-                const EThreadState current = DecodeState(state);
-                Y_ABORT_UNLESS(current == EThreadState::Waker || current == EThreadState::NeedToBeWaker);
-                const ui64 desired = EncodeState(current, static_cast<ui64>(resumeState));
-                if (WaitingFlag.compare_exchange_weak(state, desired)) {
-                    return;
+                EThreadState currentResumeState;
+                switch (DecodeState(state)) {
+                    case EThreadState::NeedToBeWaker:
+                        currentResumeState = EThreadState::None;
+                        break;
+                    case EThreadState::NeedToBeWakerFromSleep:
+                        currentResumeState = EThreadState::Sleep;
+                        break;
+                    case EThreadState::NeedToBeWakerFromBlocking:
+                        currentResumeState = EThreadState::Blocking;
+                        break;
+                    default:
+                        return false;
+                }
+                if (WaitingFlag.compare_exchange_weak(state, EncodeState(EThreadState::Waker))) {
+                    *resumeState = currentResumeState;
+                    return true;
+                }
+            }
+        }
+
+        bool RestoreNeedToBeWakerState() {
+            ui64 state = WaitingFlag.load();
+            while (true) {
+                EThreadState restoredState;
+                switch (DecodeState(state)) {
+                    case EThreadState::NeedToBeWaker:
+                        restoredState = EThreadState::None;
+                        break;
+                    case EThreadState::NeedToBeWakerFromSleep:
+                        restoredState = EThreadState::Sleep;
+                        break;
+                    case EThreadState::NeedToBeWakerFromBlocking:
+                        restoredState = EThreadState::Blocking;
+                        break;
+                    default:
+                        return false;
+                }
+                if (WaitingFlag.compare_exchange_weak(state, EncodeState(restoredState))) {
+                    return true;
                 }
             }
         }
@@ -161,46 +164,34 @@ namespace NActors {
 
         bool WakeUp();
 
-        bool StartWaker(EThreadState expected, EThreadState resumeState) {
-            return ReplaceStateWithResume(expected, EThreadState::NeedToBeWaker, resumeState);
-        }
-
-        bool BecomeWaker() {
-            EThreadState expected = EThreadState::NeedToBeWaker;
-            return ReplaceStatePreservingResume(expected, EThreadState::Waker);
-        }
-
-        bool RequestAnotherWakerPass() {
-            EThreadState expected = EThreadState::Waker;
-            if (ReplaceStatePreservingResume(expected, EThreadState::NeedToBeWaker)) {
-                return true;
+        bool TrySetNeedToBeWaker(EThreadState expected) {
+            EThreadState wakerState;
+            switch (expected) {
+                case EThreadState::None:
+                case EThreadState::Spin:
+                    wakerState = EThreadState::NeedToBeWaker;
+                    break;
+                case EThreadState::Sleep:
+                    wakerState = EThreadState::NeedToBeWakerFromSleep;
+                    break;
+                case EThreadState::Blocking:
+                    wakerState = EThreadState::NeedToBeWakerFromBlocking;
+                    break;
+                default:
+                    return false;
             }
-            return expected == EThreadState::NeedToBeWaker;
+            return ReplaceState(expected, wakerState);
         }
 
-        EThreadState GetWakerResumeState() {
-            return GetResumeState();
-        }
-
-        void SetWakerResumeState(EThreadState state) {
-            SetResumeState(state);
+        bool BecomeWaker(EThreadState* resumeState) {
+            return BecomeWakerState(resumeState);
         }
 
         bool RestoreWakerResumeState() {
-            EThreadState expected = EThreadState::NeedToBeWaker;
-            return ReplaceState(expected, GetResumeState());
+            return RestoreNeedToBeWakerState();
         }
 
-        bool WakeFromWaker() {
-            EThreadState expected = EThreadState::Sleep;
-            if (!ReplaceState(expected, EThreadState::None)) {
-                return false;
-            }
-            WaitingPad.Unpark();
-            return true;
-        }
-
-        bool WaitForWaker(ui64 spinThresholdCycles, std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits);
+        bool WaitForWaker(std::atomic<bool>* stopFlag, std::atomic<i64>* activationCredits);
 
         void Interrupt() {
             WaitingPad.Interrupt();

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -8,8 +8,8 @@
  *  - workers preferring a reduction request over taking an activation;
  *  - independent infinite producers keeping the queue bounded by MAX_QUEUE;
  *  - None -> Blocking -> Sleep and immediate parking;
- *  - waker-local ActiveMask and sleeping-stack membership;
- *  - SleepingCount containing active sleeping workers only;
+ *  - SleepingStack abstracted as the set of all workers in Sleep;
+ *  - SleepingCount as the number of sleepers currently eligible for wakeup;
  *  - coalesced RequestWaker notifications.
  *
  * Abstracted away:
@@ -28,9 +28,6 @@
 #define BLOCKING 4
 
 byte state[N];
-bool active_mask[N];
-bool in_sleeping_stack[N];
-bool counted_sleeping[N];
 
 byte suggested_thread_count = N;
 byte thread_count = N;
@@ -154,6 +151,8 @@ proctype Waker() {
     byte taken_tokens_to_wakeup;
     byte previous_sleeping_count;
     byte activations;
+    byte sleep_workers;
+    byte non_sleep_workers;
     bool found;
 
     do
@@ -181,8 +180,9 @@ proctype Waker() {
         };
 
         /* thread_count is the target accepted by the previous waker pass,
-         * while active_count is the physical ActiveWorkers size. Claimed and
-         * unclaimed reduction tokens account for their temporary difference. */
+         * while active_count is the number of worker slots still eligible to
+         * execute. Claimed and unclaimed reduction tokens account for their
+         * temporary difference. */
         if
         :: desired > thread_count ->
             delta = desired - thread_count;
@@ -202,26 +202,26 @@ proctype Waker() {
             remaining_reductions = remaining_reductions - converted;
             delta = delta - converted;
 
-            /* Any growth left after cancelling reductions must reactivate a
-             * concrete inactive sleeper. Reactivation does not unpark it. */
+            /* Sleeping workers are symmetric. Growth only increases the
+             * number of sleepers eligible for wakeup; no worker identity has
+             * to be added to a separate active set. */
+            sleep_workers = 0;
             i = 0;
             do
-            :: i < N && delta > 0 ->
+            :: i < N ->
                 if
-                :: !active_mask[i] && in_sleeping_stack[i] && state[i] == SLEEP ->
-                    atomic {
-                        active_mask[i] = true;
-                        active_count++;
-                        counted_sleeping[i] = true;
-                        previous_sleeping_count++;
-                        delta--
-                    }
+                :: state[i] == SLEEP -> sleep_workers++
                 :: else -> skip
                 fi;
                 i++
             :: else -> break
             od;
-            assert(delta == 0)
+            atomic {
+                assert(sleep_workers >= previous_sleeping_count + delta);
+                previous_sleeping_count = previous_sleeping_count + delta;
+                active_count = active_count + delta;
+                delta = 0
+            }
 
         :: desired < thread_count ->
             delta = thread_count - desired;
@@ -232,6 +232,18 @@ proctype Waker() {
             taken_tokens_to_wakeup = taken_tokens_to_wakeup - converted;
             taken_tokens_to_sleep = taken_tokens_to_sleep + converted;
             delta = delta - converted;
+
+            /* Retire already sleeping slots before asking an awake worker to
+             * claim a new reduction token. */
+            if
+            :: previous_sleeping_count < delta -> converted = previous_sleeping_count
+            :: else -> converted = delta
+            fi;
+            atomic {
+                previous_sleeping_count = previous_sleeping_count - converted;
+                active_count = active_count - converted;
+                delta = delta - converted
+            };
             remaining_reductions = remaining_reductions + delta
 
         :: else -> skip
@@ -247,13 +259,13 @@ proctype Waker() {
         do
         :: i < N ->
             if
-            :: active_mask[i] && state[i] == NONE ->
+            :: state[i] == NONE ->
                 if
                 :: activations > 0 -> activations--
                 :: else -> skip
                 fi
 
-            :: active_mask[i] && state[i] == SPIN ->
+            :: state[i] == SPIN ->
                 if
                 :: activations > 0 ->
                     atomic {
@@ -270,8 +282,6 @@ proctype Waker() {
                         if
                         :: state[i] == SPIN ->
                             state[i] = SLEEP;
-                            in_sleeping_stack[i] = true;
-                            counted_sleeping[i] = true;
                             previous_sleeping_count++
                         :: else ->
                             assert(state[i] == NONE || state[i] == WORK)
@@ -279,7 +289,7 @@ proctype Waker() {
                     }
                 fi
 
-            :: active_mask[i] && state[i] == BLOCKING ->
+            :: state[i] == BLOCKING ->
                 if
                 :: taken_tokens_to_wakeup > 0 ->
                     if
@@ -292,8 +302,6 @@ proctype Waker() {
                     :: activations == 0 ->
                         atomic {
                             state[i] = SLEEP;
-                            in_sleeping_stack[i] = true;
-                            counted_sleeping[i] = true;
                             previous_sleeping_count++;
                             taken_tokens_to_wakeup--
                         }
@@ -303,9 +311,6 @@ proctype Waker() {
                     assert(taken_tokens_to_sleep > 0);
                     atomic {
                         state[i] = SLEEP;
-                        in_sleeping_stack[i] = true;
-                        counted_sleeping[i] = false;
-                        active_mask[i] = false;
                         active_count--;
                         taken_tokens_to_sleep--
                     }
@@ -317,9 +322,8 @@ proctype Waker() {
         :: else -> break
         od;
 
-        /* Only the waker mutates SLEEP. Waking therefore needs no CAS, but it
-         * must update stack membership, the local count and activation budget
-         * together with the state transition. */
+        /* Only the waker mutates SLEEP. Any sleeping worker may consume an
+         * eligible sleeping slot because worker identities are symmetric. */
         i = 0;
         do
         :: activations > 0 && previous_sleeping_count > 0 ->
@@ -328,11 +332,9 @@ proctype Waker() {
             do
             :: i < N && !found ->
                 if
-                :: active_mask[i] && in_sleeping_stack[i] && state[i] == SLEEP ->
+                :: state[i] == SLEEP ->
                     atomic {
                         state[i] = NONE;
-                        in_sleeping_stack[i] = false;
-                        counted_sleeping[i] = false;
                         previous_sleeping_count--;
                         activations--;
                         found = true
@@ -368,19 +370,20 @@ proctype Waker() {
          */
 
         check_safety();
+        sleep_workers = 0;
+        non_sleep_workers = 0;
         i = 0;
         do
         :: i < N ->
-            assert(!counted_sleeping[i]
-                || (active_mask[i] && state[i] == SLEEP));
-            assert(active_mask[i] || state[i] == SLEEP);
             if
-            :: !active_mask[i] -> assert(in_sleeping_stack[i])
-            :: else -> skip
+            :: state[i] == SLEEP -> sleep_workers++
+            :: else -> non_sleep_workers++
             fi;
             i++
         :: else -> break
-        od
+        od;
+        assert(previous_sleeping_count <= sleep_workers);
+        assert(active_count == non_sleep_workers + previous_sleeping_count)
     od
 }
 
@@ -401,7 +404,6 @@ init {
         do
         :: i < N ->
             state[i] = WORK;
-            active_mask[i] = true;
             run Worker(i);
             i++
         :: else -> break

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -75,32 +75,38 @@ proctype Worker(byte id) {
             reductions > 0 ->
             reductions--
         };
-        state[id] = BLOCKING;
-        request_waker()
+            state[id] = BLOCKING;
+            request_waker();
+
+            /* WaitForWaker parks while the state is BLOCKING or SLEEP. Once
+             * the waker releases this worker, continue with the queue rather
+             * than attempting to claim another reduction. */
+            state[id] != BLOCKING && state[id] != SLEEP
 
         /* Reduction has priority over looking in the activation queue. Once
          * the worker observes no reduction, the waker may publish one before
          * the worker completes Pop, SetWork and the credit decrement. */
-        :: reductions == 0 ->
-            if
-            :: atomic {
-                queued_activations > 0 ->
-                queued_activations--;
-                queue_epoch = !queue_epoch
-            };
-                state[id] = WORK;
-                atomic {
-                    assert(activation_credits > 0);
-                    activation_credits--
-                }
-            :: queued_activations == 0 && activation_credits > 0 ->
-                /* A producer published a credit but has not pushed yet, or
-                 * another worker popped the corresponding activation. */
-                skip
-            :: activation_credits == 0 ->
-                state[id] = SPIN;
-                request_waker()
-            fi
+        :: reductions == 0 -> skip
+        fi;
+
+        if
+        :: atomic {
+            queued_activations > 0 ->
+            queued_activations--;
+            queue_epoch = !queue_epoch
+        };
+            state[id] = WORK;
+            atomic {
+                assert(activation_credits > 0);
+                activation_credits--
+            }
+        :: queued_activations == 0 && activation_credits > 0 ->
+            /* A producer published a credit but has not pushed yet, or
+             * another worker popped the corresponding activation. */
+            skip
+        :: activation_credits == 0 ->
+            state[id] = SPIN;
+            request_waker()
         fi
 
     /* BLOCKING and SLEEP are parked; only the waker changes them. */

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -69,9 +69,9 @@ proctype Worker(byte id) {
         if
         :: atomic {
             reductions > 0 ->
-            reductions--;
-            state[id] = BLOCKING
+            reductions--
         };
+        state[id] = BLOCKING;
         request_waker()
 
         /* Reduction has priority over taking the next activation. */

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -173,12 +173,12 @@ proctype Waker() {
          * BLOCKING already or are between the claim and that state change. */
         atomic {
             remaining_reductions = reductions;
-            reductions = 0
+            reductions = 0;
+            assert(previous_reductions >= remaining_reductions);
+            taken_tokens_to_sleep = (taken_tokens_to_sleep
+                + previous_reductions) - remaining_reductions;
+            previous_reductions = 0
         };
-        assert(previous_reductions >= remaining_reductions);
-        taken_tokens_to_sleep = (taken_tokens_to_sleep
-            + previous_reductions) - remaining_reductions;
-        previous_reductions = 0;
 
         /* thread_count is the target accepted by the previous waker pass,
          * while active_count is the physical ActiveWorkers size. Claimed and

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -490,7 +490,11 @@ pop_activation:
                 if
                 :: worker_state[id] == SPIN ->
                     worker_state[id] = NEED
-                :: else -> skip
+                :: worker_state[id] == SLEEP ->
+                    worker_state[id] = NEED_FROM_SLEEP
+                :: worker_state[id] == NONE ->
+                    worker_state[id] = NEED
+                :: IS_NEED(worker_state[id]) -> skip
                 fi
             }
         :: else -> skip;
@@ -548,6 +552,7 @@ proctype Producer() {
     bool done;
     produser_iteration:
     do
+    :: true -> break
     :: true ->
         atomic { activation_credits < MAX_QUEUE ->
             activation_credits++
@@ -605,10 +610,11 @@ proctype Producer() {
 proctype Controller() {
     byte i;
     bool notified;
-    bool notify;
+    bool bit_setted = false;
     controller_iteration:
     do
-    :: true ->
+    :: true -> break
+    :: suggested_thread_count == thread_count || !waker_pending ->
         atomic {
             if
             :: suggested_thread_count == N ->
@@ -642,12 +648,16 @@ proctype Controller() {
         atomic {
             if
             :: reductions & REDUCTION_WAKER_BIT -> goto controller_iteration
-            :: else -> reductions = reductions | REDUCTION_WAKER_BIT
+            :: else ->
+                reductions = reductions | REDUCTION_WAKER_BIT
+                bit_setted = true
             fi
         }
         atomic {
             if
-            :: sleeping_count == 0 -> goto controller_iteration
+            :: sleeping_count == 0 ->
+                bit_setted = false
+                goto controller_iteration
             :: else -> goto controller_wake_up
             fi
         }
@@ -655,11 +665,23 @@ proctype Controller() {
         controller_wake_up:
         try_request_waker(i, notified, false);
 
-        atomic {
+        if
+        :: atomic { !notified && !bit_setted ->
             i = 0;
             notified = false;
-            notify = false
+            bit_setted = false;
+            if
+            :: reductions & REDUCTION_WAKER_BIT ->
+                goto controller_iteration
+            :: else -> reductions = reductions | REDUCTION_WAKER_BIT
+            fi
         }
+        :: atomic { else ->
+            i = 0;
+            notified = false;
+            bit_setted = false;
+        }
+        fi
     od
 }
 
@@ -674,6 +696,10 @@ proctype Controller() {
             producer_epoch == p && controller_epoch == c) -> \
         <> (queued_activations < q || \
             producer_epoch != p || controller_epoch != c)))
+
+#define WAKER_PENDING_CLEARS_WITH_PRODUCER_EPOCH(p) \
+    ([] ((waker_pending && producer_epoch == p) -> \
+        <> (!waker_pending || producer_epoch != p)))
 
 ltl live_resize_reconciles {
     RESIZE_RECONCILES_WITH_EPOCHS(false, false) &&
@@ -691,6 +717,11 @@ ltl live_queue_changes {
     QUEUE_DECREASES_WITH_EPOCHS(2, false, true) &&
     QUEUE_DECREASES_WITH_EPOCHS(2, true, false) &&
     QUEUE_DECREASES_WITH_EPOCHS(2, true, true)
+}
+
+ltl live_waker_pending_clears {
+    WAKER_PENDING_CLEARS_WITH_PRODUCER_EPOCH(false) &&
+    WAKER_PENDING_CLEARS_WITH_PRODUCER_EPOCH(true)
 }
 
 init {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -38,6 +38,7 @@ byte active_count = N;
 byte sleeping_count = 0;
 byte reductions = 0;
 byte activation_credits = 0;
+byte queued_activations = 0;
 bool waker_pending = false;
 bool work_epoch = false;
 
@@ -57,6 +58,7 @@ inline check_safety() {
     assert(sleeping_count <= active_count);
     assert(reductions <= N);
     assert(activation_credits <= MAX_QUEUE);
+    assert(queued_activations <= activation_credits);
 }
 
 proctype Worker(byte id) {
@@ -74,17 +76,28 @@ proctype Worker(byte id) {
         state[id] = BLOCKING;
         request_waker()
 
-        /* Reduction has priority over taking the next activation. */
-        :: atomic {
-            reductions == 0 && activation_credits > 0 ->
-            activation_credits--;
-            state[id] = WORK
-        }
-        :: atomic {
-            reductions == 0 && activation_credits == 0 ->
-            state[id] = SPIN
-        };
-        request_waker()
+        /* Reduction has priority over looking in the activation queue. Once
+         * the worker observes no reduction, the waker may publish one before
+         * the worker completes Pop, SetWork and the credit decrement. */
+        :: reductions == 0 ->
+            if
+            :: atomic {
+                queued_activations > 0 ->
+                queued_activations--
+            };
+                state[id] = WORK;
+                atomic {
+                    activation_credits > 0 ->
+                    activation_credits--
+                }
+            :: queued_activations == 0 && activation_credits > 0 ->
+                /* A producer published a credit but has not pushed yet, or
+                 * another worker popped the corresponding activation. */
+                skip
+            :: activation_credits == 0 ->
+                state[id] = SPIN;
+                request_waker()
+            fi
         fi
 
     /* BLOCKING and SLEEP are parked; only the waker changes them. */
@@ -97,6 +110,7 @@ proctype Producer() {
         activation_credits < MAX_QUEUE ->
         activation_credits++
     };
+        queued_activations++;
         if
         :: sleeping_count > 0 -> request_waker()
         :: else -> skip

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -4,7 +4,7 @@
  *
  * Deliberately modeled:
  *  - SuggestedThreadCount updates by the controller;
- *  - ThreadCount and CheckToSleepWorkers updates owned by the waker;
+ *  - ThreadCount and reduction-token updates owned by the waker;
  *  - workers preferring a reduction request over taking an activation;
  *  - independent infinite producers keeping the queue bounded by MAX_QUEUE;
  *  - None -> Blocking -> Sleep and immediate parking;
@@ -28,7 +28,7 @@
 #define BLOCKING 4
 
 byte state[N];
-bool worker_enabled[N];
+bool active_mask[N];
 bool in_sleeping_stack[N];
 bool counted_sleeping[N];
 
@@ -65,13 +65,13 @@ inline check_safety() {
 
 proctype Worker(byte id) {
     do
-    :: worker_enabled[id] && state[id] == WORK ->
+    :: state[id] == WORK ->
         atomic {
             state[id] = NONE;
             work_epoch = !work_epoch
         }
 
-    :: worker_enabled[id] && state[id] == NONE ->
+    :: state[id] == NONE ->
         if
         :: atomic {
             reductions > 0 ->
@@ -146,165 +146,238 @@ proctype Controller() {
 proctype Waker() {
     byte desired;
     byte i;
-    byte searching;
-    byte budget;
+    byte delta;
+    byte converted;
+    byte remaining_reductions;
+    byte previous_reductions;
+    byte taken_tokens_to_sleep;
+    byte taken_tokens_to_wakeup;
+    byte previous_sleeping_count;
+    byte activations;
+    bool found;
 
     do
     :: waker_pending ->
-        /* Matches clearing WakerPending before loading ThreadCount. */
+        /* SleepingCount is temporarily owned by the waker. Producers which
+         * publish during this window deliberately observe zero. */
+        atomic {
+            previous_sleeping_count = sleeping_count;
+            sleeping_count = 0
+        };
+
         waker_pending = false;
         desired = suggested_thread_count;
 
-        /* Unclaimed tokens belong to an older reconciliation pass. A worker
-         * which claimed one is represented explicitly by BLOCKING. */
-        reductions = 0;
+        /* Exchange the published reduction tokens. The difference from the
+         * previous publication was claimed by workers which are either
+         * BLOCKING already or are between the claim and that state change. */
+        atomic {
+            remaining_reductions = reductions;
+            reductions = 0
+        };
+        assert(previous_reductions >= remaining_reductions);
+        taken_tokens_to_sleep = (taken_tokens_to_sleep
+            + previous_reductions) - remaining_reductions;
+        previous_reductions = 0;
 
-        /* Resolve workers which have already claimed a reduction token. */
+        /* thread_count is the target accepted by the previous waker pass,
+         * while active_count is the physical ActiveWorkers size. Claimed and
+         * unclaimed reduction tokens account for their temporary difference. */
+        if
+        :: desired > thread_count ->
+            delta = desired - thread_count;
+
+            if
+            :: taken_tokens_to_sleep < delta -> converted = taken_tokens_to_sleep
+            :: else -> converted = delta
+            fi;
+            taken_tokens_to_sleep = taken_tokens_to_sleep - converted;
+            taken_tokens_to_wakeup = taken_tokens_to_wakeup + converted;
+            delta = delta - converted;
+
+            if
+            :: remaining_reductions < delta -> converted = remaining_reductions
+            :: else -> converted = delta
+            fi;
+            remaining_reductions = remaining_reductions - converted;
+            delta = delta - converted;
+
+            /* Any growth left after cancelling reductions must reactivate a
+             * concrete inactive sleeper. Reactivation does not unpark it. */
+            i = 0;
+            do
+            :: i < N && delta > 0 ->
+                if
+                :: !active_mask[i] && in_sleeping_stack[i] && state[i] == SLEEP ->
+                    atomic {
+                        active_mask[i] = true;
+                        active_count++;
+                        counted_sleeping[i] = true;
+                        previous_sleeping_count++;
+                        delta--
+                    }
+                :: else -> skip
+                fi;
+                i++
+            :: else -> break
+            od;
+            assert(delta == 0)
+
+        :: desired < thread_count ->
+            delta = thread_count - desired;
+            if
+            :: taken_tokens_to_wakeup < delta -> converted = taken_tokens_to_wakeup
+            :: else -> converted = delta
+            fi;
+            taken_tokens_to_wakeup = taken_tokens_to_wakeup - converted;
+            taken_tokens_to_sleep = taken_tokens_to_sleep + converted;
+            delta = delta - converted;
+            remaining_reductions = remaining_reductions + delta
+
+        :: else -> skip
+        fi;
+        thread_count = desired;
+
+        activations = activation_credits;
+
+        /* Resolve every active worker once. activations is a local budget: a
+         * NONE worker, or a worker which leaves SPIN by itself, consumes one
+         * unit without reserving the corresponding queue item. */
         i = 0;
         do
         :: i < N ->
             if
-            :: worker_enabled[i] && state[i] == BLOCKING ->
-                atomic {
+            :: active_mask[i] && state[i] == NONE ->
+                if
+                :: activations > 0 -> activations--
+                :: else -> skip
+                fi
+
+            :: active_mask[i] && state[i] == SPIN ->
+                if
+                :: activations > 0 ->
+                    atomic {
+                        if
+                        :: state[i] == SPIN -> state[i] = NONE
+                        :: else ->
+                            assert(state[i] == NONE || state[i] == WORK)
+                        fi
+                    };
+                    activations--
+
+                :: activations == 0 ->
+                    atomic {
+                        if
+                        :: state[i] == SPIN ->
+                            state[i] = SLEEP;
+                            in_sleeping_stack[i] = true;
+                            counted_sleeping[i] = true;
+                            previous_sleeping_count++
+                        :: else ->
+                            assert(state[i] == NONE || state[i] == WORK)
+                        fi
+                    }
+                fi
+
+            :: active_mask[i] && state[i] == BLOCKING ->
+                if
+                :: taken_tokens_to_wakeup > 0 ->
                     if
-                    :: active_count > desired ->
+                    :: activations > 0 ->
+                        atomic {
+                            state[i] = NONE;
+                            taken_tokens_to_wakeup--
+                        };
+                        activations--
+                    :: activations == 0 ->
+                        atomic {
+                            state[i] = SLEEP;
+                            in_sleeping_stack[i] = true;
+                            counted_sleeping[i] = true;
+                            previous_sleeping_count++;
+                            taken_tokens_to_wakeup--
+                        }
+                    fi
+
+                :: taken_tokens_to_wakeup == 0 ->
+                    assert(taken_tokens_to_sleep > 0);
+                    atomic {
                         state[i] = SLEEP;
                         in_sleeping_stack[i] = true;
-                        worker_enabled[i] = false;
-                        active_count--
-                    :: else -> state[i] = NONE
-                    fi
-                }
+                        counted_sleeping[i] = false;
+                        active_mask[i] = false;
+                        active_count--;
+                        taken_tokens_to_sleep--
+                    }
+                fi
+
             :: else -> skip
             fi;
             i++
         :: else -> break
         od;
 
-        /* Retire additional already idle workers. No reduction token is
-         * needed: only the waker mutates its local active set. */
+        /* Only the waker mutates SLEEP. Waking therefore needs no CAS, but it
+         * must update stack membership, the local count and activation budget
+         * together with the state transition. */
         i = 0;
         do
-        :: i < N && active_count > desired ->
+        :: activations > 0 && previous_sleeping_count > 0 ->
+            found = false;
+            i = 0;
+            do
+            :: i < N && !found ->
+                if
+                :: active_mask[i] && in_sleeping_stack[i] && state[i] == SLEEP ->
+                    atomic {
+                        state[i] = NONE;
+                        in_sleeping_stack[i] = false;
+                        counted_sleeping[i] = false;
+                        previous_sleeping_count--;
+                        activations--;
+                        found = true
+                    }
+                :: else -> skip
+                fi;
+                i++
+            :: else -> break
+            od;
             if
-            :: worker_enabled[i] && state[i] == SLEEP ->
-                counted_sleeping[i] = false;
-                sleeping_count--;
-                worker_enabled[i] = false;
-                active_count--
-            :: worker_enabled[i] && state[i] == SPIN ->
-                state[i] = SLEEP;
-                in_sleeping_stack[i] = true;
-                worker_enabled[i] = false;
-                active_count--
-            :: else -> skip
-            fi;
-            i++
-        :: else -> break
-        od;
-
-        /* Publish requests only for workers which could not be retired by the
-         * waker because they are currently in Work or None. */
-        atomic {
-            if
-            :: active_count > desired -> reductions = active_count - desired
-            :: else -> reductions = 0
+            :: found -> skip
+            :: else -> break
             fi
+        :: else -> break
+        od;
+
+        /* Publish both the remaining reductions and the baseline used to
+         * detect claims on the next pass. The baseline is waker-local. */
+        assert(active_count == thread_count
+            + remaining_reductions + taken_tokens_to_sleep);
+        atomic {
+            reductions = remaining_reductions;
+            previous_reductions = remaining_reductions
         };
+        sleeping_count = previous_sleeping_count;
 
-        /* Re-enable disabled sleeping workers after a count increase. */
-        i = 0;
-        do
-        :: i < N && active_count < desired ->
-            if
-            :: !worker_enabled[i] && in_sleeping_stack[i] ->
-                worker_enabled[i] = true;
-                active_count++;
-                counted_sleeping[i] = true;
-                sleeping_count++
-            :: else -> skip
-            fi;
-            i++
-        :: else -> break
-        od;
-
-        thread_count = active_count;
-
-        searching = 0;
-        i = 0;
-        do
-        :: i < N ->
-            if
-            :: worker_enabled[i] && state[i] == NONE -> searching++
-            :: else -> skip
-            fi;
-            i++
-        :: else -> break
-        od;
-        if
-        :: activation_credits > searching -> budget = activation_credits - searching
-        :: else -> budget = 0
-        fi;
-
-        /* Resolve ordinary spinners using the current activation budget. */
-        i = 0;
-        do
-        :: i < N ->
-            if
-            :: worker_enabled[i] && state[i] == SPIN && budget > 0 ->
-                state[i] = NONE;
-                budget--
-            :: worker_enabled[i] && state[i] == SPIN && budget == 0 ->
-                state[i] = SLEEP;
-                in_sleeping_stack[i] = true;
-                counted_sleeping[i] = true;
-                sleeping_count++
-            :: else -> skip
-            fi;
-            i++
-        :: else -> break
-        od;
-
-        /* Reload credits after publishing sleepers, then wake as many active
-         * sleepers as are needed for the remaining work. */
-        searching = 0;
-        i = 0;
-        do
-        :: i < N ->
-            if
-            :: worker_enabled[i] && state[i] == NONE -> searching++
-            :: else -> skip
-            fi;
-            i++
-        :: else -> break
-        od;
-        if
-        :: activation_credits > searching -> budget = activation_credits - searching
-        :: else -> budget = 0
-        fi;
-
-        i = 0;
-        do
-        :: i < N ->
-            if
-            :: worker_enabled[i] && state[i] == SLEEP && budget > 0 ->
-                state[i] = NONE;
-                in_sleeping_stack[i] = false;
-                counted_sleeping[i] = false;
-                sleeping_count--;
-                budget--
-            :: else -> skip
-            fi;
-            i++
-        :: else -> break
-        od;
+        /* Deliberately omitted for now so Spin can expose the missed-wakeup
+         * race this reload is intended to close:
+         *
+         * previous_activations = activations; // before scanning workers
+         * if (activation_credits > previous_activations)
+         *     request_waker();
+         */
 
         check_safety();
         i = 0;
         do
         :: i < N ->
-            assert(!counted_sleeping[i] || (worker_enabled[i] && state[i] == SLEEP));
-            assert(worker_enabled[i] || state[i] == SLEEP);
+            assert(!counted_sleeping[i]
+                || (active_mask[i] && state[i] == SLEEP));
+            assert(active_mask[i] || state[i] == SLEEP);
+            if
+            :: !active_mask[i] -> assert(in_sleeping_stack[i])
+            :: else -> skip
+            fi;
             i++
         :: else -> break
         od
@@ -328,7 +401,7 @@ init {
         do
         :: i < N ->
             state[i] = WORK;
-            worker_enabled[i] = true;
+            active_mask[i] = true;
             run Worker(i);
             i++
         :: else -> break

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -31,7 +31,7 @@ byte state[N];
 
 byte suggested_thread_count = N;
 byte thread_count = N;
-byte active_count = N;
+byte awake_workers = N;
 byte sleeping_count = 0;
 byte reductions = 0;
 byte activation_credits = 0;
@@ -52,8 +52,8 @@ inline check_safety() {
     atomic {
         assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
         assert(thread_count >= 1 && thread_count <= N);
-        assert(active_count <= N);
-        assert(sleeping_count <= active_count);
+        assert(awake_workers <= N);
+        assert(awake_workers + sleeping_count <= N);
         assert(reductions <= N);
         assert(activation_credits <= MAX_QUEUE);
         assert(queued_activations <= activation_credits)
@@ -172,9 +172,9 @@ proctype Waker() {
         };
 
         /* The waker owns all mutable values in this reconciliation block.
-         * thread_count is the previously accepted target, active_count is the
-         * number of slots still eligible to execute, and sleep_workers is the
-         * total number of workers in Sleep. */
+         * thread_count is the previously accepted target, awake_workers is
+         * the number of workers outside Sleep, and sleep_workers is the total
+         * number of workers in Sleep. */
         atomic {
             if
             :: desired > thread_count ->
@@ -199,7 +199,6 @@ proctype Waker() {
                  * assigning that eligibility to concrete worker identities. */
                 assert(sleep_workers >= previous_sleeping_count + delta);
                 previous_sleeping_count = previous_sleeping_count + delta;
-                active_count = active_count + delta;
                 delta = 0
 
             :: desired < thread_count ->
@@ -219,7 +218,6 @@ proctype Waker() {
                 :: else -> converted = delta
                 fi;
                 previous_sleeping_count = previous_sleeping_count - converted;
-                active_count = active_count - converted;
                 delta = delta - converted;
                 remaining_reductions = remaining_reductions + delta;
                 delta = 0
@@ -262,6 +260,7 @@ proctype Waker() {
                         if
                         :: state[i] == SPIN ->
                             state[i] = SLEEP;
+                            awake_workers--;
                             previous_sleeping_count++;
                             sleep_workers++
                         :: else ->
@@ -283,6 +282,7 @@ proctype Waker() {
                     :: activations == 0 ->
                         atomic {
                             state[i] = SLEEP;
+                            awake_workers--;
                             previous_sleeping_count++;
                             sleep_workers++;
                             taken_tokens_to_wakeup--
@@ -293,7 +293,7 @@ proctype Waker() {
                     assert(taken_tokens_to_sleep > 0);
                     atomic {
                         state[i] = SLEEP;
-                        active_count--;
+                        awake_workers--;
                         sleep_workers++;
                         taken_tokens_to_sleep--
                     }
@@ -318,6 +318,7 @@ proctype Waker() {
                 :: state[i] == SLEEP ->
                     atomic {
                         state[i] = NONE;
+                        awake_workers++;
                         previous_sleeping_count--;
                         sleep_workers--;
                         activations--;
@@ -337,7 +338,7 @@ proctype Waker() {
 
         /* Publish both the remaining reductions and the baseline used to
          * detect claims on the next pass. The baseline is waker-local. */
-        assert(active_count == thread_count
+        assert(awake_workers + previous_sleeping_count == thread_count
             + remaining_reductions + taken_tokens_to_sleep);
         atomic {
             reductions = remaining_reductions;
@@ -356,15 +357,15 @@ proctype Waker() {
         check_safety();
         atomic {
             assert(previous_sleeping_count <= sleep_workers);
-            assert(active_count == N - sleep_workers + previous_sleeping_count)
+            assert(awake_workers == N - sleep_workers)
         }
     od
 }
 
 #define target_one (suggested_thread_count == 1)
 #define target_max (suggested_thread_count == N)
-#define reconciled_one (thread_count == 1 && active_count == 1 && reductions == 0)
-#define reconciled_max (thread_count == N && active_count == N && reductions == 0)
+#define reconciled_one (thread_count == 1 && awake_workers + sleeping_count == 1 && reductions == 0)
+#define reconciled_max (thread_count == N && awake_workers + sleeping_count == N && reductions == 0)
 ltl live_reconcile_stable {
     ((<>[] target_one) ->
         ((<>[] reconciled_one) && ([]<> work_epoch) && ([]<> !work_epoch))) &&

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -162,6 +162,7 @@ proctype Waker() {
     byte taken_tokens_to_sleep;
     byte taken_tokens_to_wakeup;
     byte eligible_sleepers;
+    byte previous_activations;
     byte activations;
     byte sleep_workers;
     bool found;
@@ -181,9 +182,15 @@ proctype Waker() {
         atomic {
             remaining_reductions = reductions;
             reductions = 0;
+            assert(remaining_reductions <= N);
+            assert(previous_reductions <= N);
+            assert(taken_tokens_to_sleep <= N);
+            assert(taken_tokens_to_wakeup <= N);
             assert(previous_reductions >= remaining_reductions);
+            assert(taken_tokens_to_sleep + previous_reductions <= N);
             taken_tokens_to_sleep = (taken_tokens_to_sleep
                 + previous_reductions) - remaining_reductions;
+            assert(taken_tokens_to_sleep <= N);
             previous_reductions = 0
         };
 
@@ -206,6 +213,7 @@ proctype Waker() {
                 :: else -> converted = delta
                 fi;
                 taken_tokens_to_sleep = taken_tokens_to_sleep - converted;
+                assert(taken_tokens_to_wakeup + converted <= N);
                 taken_tokens_to_wakeup = taken_tokens_to_wakeup + converted;
                 delta = delta - converted;
 
@@ -227,6 +235,7 @@ proctype Waker() {
                 :: else -> converted = delta
                 fi;
                 taken_tokens_to_wakeup = taken_tokens_to_wakeup - converted;
+                assert(taken_tokens_to_sleep + converted <= N);
                 taken_tokens_to_sleep = taken_tokens_to_sleep + converted;
                 delta = delta - converted;
 
@@ -237,6 +246,7 @@ proctype Waker() {
                 :: else -> converted = delta
                 fi;
                 delta = delta - converted;
+                assert(remaining_reductions + delta <= N);
                 remaining_reductions = remaining_reductions + delta;
                 delta = 0
 
@@ -247,11 +257,17 @@ proctype Waker() {
                 + taken_tokens_to_sleep >= awake_workers);
             assert(((thread_count + remaining_reductions)
                 + taken_tokens_to_sleep) - awake_workers <= sleep_workers);
+            assert(taken_tokens_to_sleep <= N);
+            assert(taken_tokens_to_wakeup <= N);
+            assert(remaining_reductions <= N);
+            assert(sleep_workers <= N);
+            assert(awake_workers <= N);
             converted = 0;
             eligible_sleepers = 0
         };
 
-        activations = activation_credits;
+        previous_activations = activation_credits;
+        activations = previous_activations;
 
         /* Resolve every active worker once. activations is a local budget: a
          * NONE worker, or a worker which leaves SPIN by itself, consumes one
@@ -282,6 +298,8 @@ proctype Waker() {
                     atomic {
                         if
                         :: state[i] == SPIN ->
+                            assert(awake_workers > 0);
+                            assert(sleep_workers < N);
                             state[i] = SLEEP;
                             awake_workers--;
                             sleep_workers++
@@ -303,6 +321,8 @@ proctype Waker() {
                         activations--
                     :: activations == 0 ->
                         atomic {
+                            assert(awake_workers > 0);
+                            assert(sleep_workers < N);
                             state[i] = SLEEP;
                             awake_workers--;
                             sleep_workers++;
@@ -313,6 +333,8 @@ proctype Waker() {
                 :: taken_tokens_to_wakeup == 0 ->
                     assert(taken_tokens_to_sleep > 0);
                     atomic {
+                        assert(awake_workers > 0);
+                        assert(sleep_workers < N);
                         state[i] = SLEEP;
                         awake_workers--;
                         sleep_workers++;
@@ -339,6 +361,8 @@ proctype Waker() {
                 :: i < N && !found ->
                     if
                     :: state[i] == SLEEP ->
+                        assert(awake_workers < N);
+                        assert(sleep_workers > 0);
                         state[i] = NONE;
                         awake_workers++;
                         sleep_workers--;
@@ -370,13 +394,10 @@ proctype Waker() {
             eligible_sleepers = 0
         };
 
-        /* Deliberately omitted for now so Spin can expose the missed-wakeup
-         * race this reload is intended to close:
-         *
-         * previous_activations = activations; // before scanning workers
-         * if (activation_credits > previous_activations)
-         *     request_waker();
-         */
+        if
+        :: activation_credits > previous_activations -> request_waker()
+        :: else -> skip
+        fi;
 
         check_safety();
         atomic {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -131,14 +131,22 @@ proctype Producer() {
 }
 
 proctype Controller() {
+    bit counter = 0;
+
     do
-    :: true -> check_safety()
-    :: true ->
+    :: counter == 0 ->
+        awake_workers == suggested_thread_count;
+        check_safety();
+        counter = 1
+
+    :: counter == 1 ->
+        check_safety();
         atomic {
             if
             :: suggested_thread_count == 1 -> suggested_thread_count = N
             :: suggested_thread_count == N -> suggested_thread_count = 1
-            fi
+            fi;
+            counter = 0
         };
         request_waker()
     od

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -13,7 +13,9 @@
  *  - a local activation budget which does not reserve queue items;
  *  - preservation of the elected worker's intended post-waker state;
  *  - dynamic thread-count changes, including claimed and unclaimed
- *    reduction tokens overtaken by a later resize.
+ *    reduction tokens overtaken by a later resize;
+ *  - a waker-request bit packed with the reduction count, which delegates a
+ *    missed resize request to the next worker entering the idle path.
  *
  * Abstracted away:
  *  - SleepingStack order (sleeping membership is sufficient here);
@@ -36,6 +38,8 @@
 #define WAKER 6
 
 #define INVALID_WAKER N
+#define REDUCTION_WAKER_BIT 4
+#define REDUCTION_COUNT_MASK (REDUCTION_WAKER_BIT - 1)
 
 byte state[N];
 
@@ -63,6 +67,17 @@ bool waker_pending = false;
  * interval which is allowed to mutate the persistent waker data. */
 byte waker_passes = 0;
 
+/* A worker owns these scratch variables only while waker_passes == 1.
+ * Keeping one global set models the single logical waker instance even when
+ * its worker owner changes, and avoids multiplying private waker state by N. */
+byte waker_i = 0;
+byte waker_budget = 0;
+byte waker_final = NONE;
+byte waker_desired = N;
+byte waker_delta = 0;
+byte waker_converted = 0;
+bool waker_found = false;
+
 inline check_local_safety() {
     atomic {
         assert(waker_worker_id <= INVALID_WAKER);
@@ -74,7 +89,8 @@ inline check_local_safety() {
         assert(thread_count >= 1 && thread_count <= N);
         assert(suggested_thread_count >= 1 &&
             suggested_thread_count <= N);
-        assert(reductions <= N);
+        assert((reductions & REDUCTION_COUNT_MASK) <= N);
+        assert(reductions < 2 * REDUCTION_WAKER_BIT);
         assert(claimed_reductions <= N);
         assert(cancelled_claimed_reductions <= claimed_reductions);
         assert(activation_credits <= MAX_QUEUE);
@@ -91,15 +107,19 @@ inline check_local_safety() {
 /* Publish the final state of the worker which has already released the waker
  * index. A producer may concurrently change WAKER to NEED_TO_BE_WAKER; in
  * that case the caller must return to election instead of publishing final. */
-inline publish_waker_final(id, final, published) {
+inline publish_waker_final(id, final) {
     atomic {
         if
-        :: state[id] == WAKER ->
+        :: state[id] == WAKER &&
+                (reductions & REDUCTION_WAKER_BIT) ->
+            reductions = reductions & REDUCTION_COUNT_MASK;
             resume_state[id] = final;
-            state[id] = final;
-            published = true
-        :: state[id] == NEED_TO_BE_WAKER ->
-            published = false
+            state[id] = NEED_TO_BE_WAKER
+        :: state[id] == WAKER &&
+                !(reductions & REDUCTION_WAKER_BIT) ->
+            resume_state[id] = final;
+            state[id] = final
+        :: state[id] == NEED_TO_BE_WAKER -> skip
         fi
     }
 }
@@ -150,15 +170,7 @@ inline try_request_waker(owner, candidate, notified, require_sleepers) {
 
 proctype Worker(byte id) {
     byte owner;
-    byte i;
-    byte budget;
-    byte final;
-    byte desired;
-    byte delta;
-    byte converted;
     bool done;
-    bool found;
-    bool published;
 
     do
     :: state[id] == WORK ->
@@ -166,10 +178,21 @@ proctype Worker(byte id) {
 
     :: state[id] == NONE ->
         if
+        /* The controller could not find an existing waker or a parked
+         * candidate. The first idle worker clears only the request bit and
+         * enters election, preserving any numeric reduction count. */
+        :: atomic {
+            reductions & REDUCTION_WAKER_BIT ->
+            reductions = reductions & REDUCTION_COUNT_MASK
+        };
+            resume_state[id] = NONE;
+            state[id] = NEED_TO_BE_WAKER;
+            atomic { waker_pending = true }
+
         /* A reduction claim and its ownership accounting are one abstract
          * operation. Publishing BLOCKING remains a separate transition. */
         :: atomic {
-            reductions > 0 ->
+            reductions > 0 && reductions < REDUCTION_WAKER_BIT ->
             reductions--;
             claimed_reductions++
         };
@@ -256,92 +279,100 @@ proctype Worker(byte id) {
         atomic {
             assert(waker_passes == 0);
             waker_passes = 1;
-            waker_pending = false
+            waker_pending = false;
+            if
+            :: reductions & REDUCTION_WAKER_BIT ->
+                reductions = reductions & REDUCTION_COUNT_MASK
+            :: else -> skip
+            fi
         };
 
         /* Reconcile the latest target. Sleeping identities are symmetric:
          * sleeping_count is derived from thread_count and awake_workers, and
          * any SLEEP worker may represent an eligible sleeping slot. */
-        desired = suggested_thread_count;
+        waker_desired = suggested_thread_count;
         atomic {
             if
-            :: desired < thread_count ->
-                delta = thread_count - desired;
+            :: waker_desired < thread_count ->
+                waker_delta = thread_count - waker_desired;
                 if
-                :: sleeping_count < delta -> converted = sleeping_count
-                :: else -> converted = delta
+                :: sleeping_count < waker_delta ->
+                    waker_converted = sleeping_count
+                :: else -> waker_converted = waker_delta
                 fi;
-                delta = delta - converted;
-                assert(reductions + delta <= N);
-                reductions = reductions + delta;
-                thread_count = desired
+                waker_delta = waker_delta - waker_converted;
+                assert(reductions + waker_delta <= N);
+                reductions = reductions + waker_delta;
+                thread_count = waker_desired
 
-            :: desired > thread_count ->
-                delta = desired - thread_count;
+            :: waker_desired > thread_count ->
+                waker_delta = waker_desired - thread_count;
                 if
-                :: reductions < delta -> converted = reductions
-                :: else -> converted = delta
+                :: reductions < waker_delta -> waker_converted = reductions
+                :: else -> waker_converted = waker_delta
                 fi;
-                reductions = reductions - converted;
-                delta = delta - converted;
+                reductions = reductions - waker_converted;
+                waker_delta = waker_delta - waker_converted;
                 assert(claimed_reductions >= cancelled_claimed_reductions);
                 if
-                :: claimed_reductions - cancelled_claimed_reductions < delta ->
-                    converted = claimed_reductions -
+                :: claimed_reductions - cancelled_claimed_reductions <
+                        waker_delta ->
+                    waker_converted = claimed_reductions -
                         cancelled_claimed_reductions
-                :: else -> converted = delta
+                :: else -> waker_converted = waker_delta
                 fi;
-                assert(cancelled_claimed_reductions + converted <= N);
+                assert(cancelled_claimed_reductions + waker_converted <= N);
                 cancelled_claimed_reductions =
-                    cancelled_claimed_reductions + converted;
-                delta = delta - converted;
-                thread_count = desired
+                    cancelled_claimed_reductions + waker_converted;
+                waker_delta = waker_delta - waker_converted;
+                thread_count = waker_desired
 
             :: else -> skip
             fi;
             sleeping_count = 0;
-            delta = 0;
-            converted = 0
+            waker_delta = 0;
+            waker_converted = 0
         };
 
-        budget = activation_credits;
+        waker_budget = activation_credits;
 
         /* Account for workers which are already searching before changing
          * SPIN/BLOCKING states. The budget is local and never reserves the
          * corresponding queue item. */
-        i = 0;
+        waker_i = 0;
         do
-        :: i < N ->
+        :: waker_i < N ->
             if
-            :: i != id && state[i] == NONE && budget > 0 -> budget--
+            :: waker_i != id && state[waker_i] == NONE &&
+                    waker_budget > 0 -> waker_budget--
             :: else -> skip
             fi;
-            i++
+            waker_i++
         :: else -> break
         od;
 
-        i = 0;
+        waker_i = 0;
         do
-        :: i < N ->
+        :: waker_i < N ->
             if
-            :: i != id && state[i] == SPIN ->
+            :: waker_i != id && state[waker_i] == SPIN ->
                 if
-                :: budget > 0 ->
+                :: waker_budget > 0 ->
                     atomic {
                         if
-                        :: state[i] == SPIN ->
-                            resume_state[i] = NONE;
-                            state[i] = NONE;
-                            budget--
+                        :: state[waker_i] == SPIN ->
+                            resume_state[waker_i] = NONE;
+                            state[waker_i] = NONE;
+                            waker_budget--
                         :: else -> skip
                         fi
                     }
-                :: budget == 0 ->
+                :: waker_budget == 0 ->
                     atomic {
                         if
-                        :: state[i] == SPIN ->
-                            resume_state[i] = SLEEP;
-                            state[i] = SLEEP;
+                        :: state[waker_i] == SPIN ->
+                            resume_state[waker_i] = SLEEP;
+                            state[waker_i] = SLEEP;
                             assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
@@ -350,30 +381,30 @@ proctype Worker(byte id) {
                     }
                 fi
 
-            :: i != id && state[i] == BLOCKING ->
+            :: waker_i != id && state[waker_i] == BLOCKING ->
                 if
-                :: cancelled_claimed_reductions > 0 && budget > 0 ->
+                :: cancelled_claimed_reductions > 0 && waker_budget > 0 ->
                     atomic {
                         if
-                        :: state[i] == BLOCKING ->
+                        :: state[waker_i] == BLOCKING ->
                             assert(claimed_reductions > 0);
                             claimed_reductions--;
                             cancelled_claimed_reductions--;
-                            resume_state[i] = NONE;
-                            state[i] = NONE;
-                            budget--
+                            resume_state[waker_i] = NONE;
+                            state[waker_i] = NONE;
+                            waker_budget--
                         :: else -> skip
                         fi
                     }
-                :: cancelled_claimed_reductions > 0 && budget == 0 ->
+                :: cancelled_claimed_reductions > 0 && waker_budget == 0 ->
                     atomic {
                         if
-                        :: state[i] == BLOCKING ->
+                        :: state[waker_i] == BLOCKING ->
                             assert(claimed_reductions > 0);
                             claimed_reductions--;
                             cancelled_claimed_reductions--;
-                            resume_state[i] = SLEEP;
-                            state[i] = SLEEP;
+                            resume_state[waker_i] = SLEEP;
+                            state[waker_i] = SLEEP;
                             assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
@@ -383,11 +414,11 @@ proctype Worker(byte id) {
                 :: cancelled_claimed_reductions == 0 ->
                     atomic {
                         if
-                        :: state[i] == BLOCKING ->
+                        :: state[waker_i] == BLOCKING ->
                             assert(claimed_reductions > 0);
                             claimed_reductions--;
-                            resume_state[i] = SLEEP;
-                            state[i] = SLEEP;
+                            resume_state[waker_i] = SLEEP;
+                            state[waker_i] = SLEEP;
                             assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
@@ -397,7 +428,7 @@ proctype Worker(byte id) {
                 fi
             :: else -> skip
             fi;
-            i++
+            waker_i++
         :: else -> break
         od;
 
@@ -405,32 +436,32 @@ proctype Worker(byte id) {
          * worker temporarily in NEED_TO_BE_WAKER remains counted and will be
          * resolved by either this owner or the next owner. */
         do
-        :: budget > 0 && thread_count > awake_workers ->
-            found = false;
-            i = 0;
+        :: waker_budget > 0 && thread_count > awake_workers ->
+            waker_found = false;
+            waker_i = 0;
             atomic {
                 do
-                :: i < N && !found ->
+                :: waker_i < N && !waker_found ->
                     if
-                    :: i != id && state[i] == SLEEP ->
-                        state[i] = NONE;
-                        resume_state[i] = NONE;
+                    :: waker_i != id && state[waker_i] == SLEEP ->
+                        state[waker_i] = NONE;
+                        resume_state[waker_i] = NONE;
                         assert(sleep_workers > 0);
                         sleep_workers--;
                         awake_workers++;
-                        budget--;
-                        found = true
+                        waker_budget--;
+                        waker_found = true
                     :: else -> skip
                     fi;
-                    i++
+                    waker_i++
                 :: else -> break
                 od
             };
             if
-            :: found -> skip
+            :: waker_found -> skip
             /* The eligible sleeper is the current owner or a worker which is
              * temporarily participating in election. */
-            :: !found -> break
+            :: !waker_found -> break
             fi
         :: else -> break
         od;
@@ -441,47 +472,47 @@ proctype Worker(byte id) {
         :: resume_state[id] == BLOCKING ->
             assert(claimed_reductions > 0);
             if
-            :: cancelled_claimed_reductions > 0 && budget > 0 ->
+            :: cancelled_claimed_reductions > 0 && waker_budget > 0 ->
                 atomic {
                     claimed_reductions--;
                     cancelled_claimed_reductions--
                 };
-                final = NONE;
-                budget--
-            :: cancelled_claimed_reductions > 0 && budget == 0 ->
+                waker_final = NONE;
+                waker_budget--
+            :: cancelled_claimed_reductions > 0 && waker_budget == 0 ->
                 atomic {
                     claimed_reductions--;
                     cancelled_claimed_reductions--
                 };
-                final = SLEEP
+                waker_final = SLEEP
             :: cancelled_claimed_reductions == 0 ->
                 claimed_reductions--;
-                final = SLEEP
+                waker_final = SLEEP
             fi
-        :: resume_state[id] != BLOCKING && budget > 0 ->
-            final = NONE;
-            budget--
-        :: resume_state[id] != BLOCKING && budget == 0 ->
+        :: resume_state[id] != BLOCKING && waker_budget > 0 ->
+            waker_final = NONE;
+            waker_budget--
+        :: resume_state[id] != BLOCKING && waker_budget == 0 ->
             if
             :: resume_state[id] == NONE || resume_state[id] == WORK ->
-                final = NONE
-            :: else -> final = SLEEP
+                waker_final = NONE
+            :: else -> waker_final = SLEEP
             fi
         fi;
 
         atomic {
             if
-            :: resume_state[id] == SLEEP && final != SLEEP ->
+            :: resume_state[id] == SLEEP && waker_final != SLEEP ->
                 assert(sleep_workers > 0);
                 sleep_workers--;
                 awake_workers++
-            :: resume_state[id] != SLEEP && final == SLEEP ->
+            :: resume_state[id] != SLEEP && waker_final == SLEEP ->
                 assert(awake_workers > 0);
                 awake_workers--;
                 sleep_workers++
             :: else -> skip
             fi;
-            resume_state[id] = final;
+            resume_state[id] = waker_final;
             if
             :: thread_count > awake_workers ->
                 sleeping_count = thread_count - awake_workers
@@ -505,8 +536,10 @@ proctype Worker(byte id) {
                 assert(waker_worker_id == id);
                 waker_worker_id = INVALID_WAKER
             };
-            published = false;
-            publish_waker_final(id, final, published)
+            /* waker_final is shared scratch and may already belong to the
+             * next owner. The retiring owner published its own final value
+             * to resume_state[id] before releasing waker_worker_id. */
+            publish_waker_final(id, resume_state[id])
         fi;
 
         check_local_safety()
@@ -624,6 +657,25 @@ proctype Controller() {
         };
 
         try_request_waker(owner, i, notified, false);
+        if
+        /* No owner or parked candidate was stable during the scan. Preserve
+         * the reduction count and publish a bit which the next idle worker
+         * will consume before trying to block. */
+        :: !notified ->
+            atomic {
+                if
+                :: waker_worker_id == INVALID_WAKER ->
+                    reductions = reductions | REDUCTION_WAKER_BIT
+                :: else -> skip
+                fi
+            };
+            /* A worker may have become parked between the first scan and
+             * publishing the request bit. Scan again for both grow and
+             * shrink; the bit keeps the request durable if this scan also
+             * races with waker completion. */
+            try_request_waker(owner, i, notified, false)
+        :: else -> skip
+        fi;
         /* Do not publish another target until the waker has observed this
          * one. This makes a lost resize request observable independently of
          * later controller updates. */

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -11,14 +11,15 @@
  *  - workers entering SPIN and BLOCKING asking for reconciliation;
  *  - selecting and unparking a SPIN, BLOCKING, or SLEEP worker;
  *  - a local activation budget which does not reserve queue items;
- *  - preservation of the elected worker's intended post-waker state;
+ *  - an orthogonal worker state and waker role, so a worker selected from
+ *    SLEEP remains logically sleeping throughout election;
  *  - dynamic thread-count changes, including claimed and unclaimed
  *    reduction tokens overtaken by a later resize;
  *  - a waker-request bit packed with the reduction count, which delegates a
  *    missed resize request to the next worker entering the idle path.
  *
  * Abstracted away:
- *  - SleepingStack order (sleeping membership is sufficient here);
+ *  - exact SleepingStack order (worker ids provide a deterministic order);
  *  - the futex itself (NEED_TO_BE_WAKER enables a parked worker);
  *  - memory-order syntax; atomic blocks mark the C++ CAS/exchange edges.
  */
@@ -34,19 +35,16 @@
 #define SLEEP 2
 #define WORK 3
 #define BLOCKING 4
-#define NEED_TO_BE_WAKER 5
-#define WAKER 6
+#define ORDINARY 0
+#define NEED_TO_BE_WAKER 1
+#define WAKER 2
 
 #define INVALID_WAKER N
 #define REDUCTION_WAKER_BIT 4
 #define REDUCTION_COUNT_MASK (REDUCTION_WAKER_BIT - 1)
 
-byte state[N];
-
-/* State to publish when a worker stops participating in waker election. It
- * also preserves whether a candidate selected from SLEEP remains logically
- * counted as sleeping while its public state is NEED_TO_BE_WAKER/WAKER. */
-byte resume_state[N];
+byte worker_state[N];
+byte waker_role[N];
 
 byte activation_credits = 0;
 byte queued_activations = 0;
@@ -72,16 +70,20 @@ byte waker_passes = 0;
  * its worker owner changes, and avoids multiplying private waker state by N. */
 byte waker_i = 0;
 byte waker_budget = 0;
+byte waker_previous_activations = 0;
 byte waker_final = NONE;
 byte waker_desired = 0;
 byte waker_delta = 0;
 byte waker_converted = 0;
 bool waker_found = false;
+bool waker_woke = false;
 
 inline check_local_safety() {
     atomic {
         assert(waker_worker_id <= INVALID_WAKER);
         assert(waker_passes <= 1);
+        assert(waker_role[0] <= WAKER);
+        assert(waker_role[1] <= WAKER);
         assert(sleeping_count <= N);
         assert(awake_workers <= N);
         assert(sleep_workers <= N);
@@ -99,17 +101,19 @@ inline check_local_safety() {
         :: waker_passes == 0 ->
             assert(waker_i == 0);
             assert(waker_budget == 0);
+            assert(waker_previous_activations == 0);
             assert(waker_final == NONE);
             assert(waker_desired == 0);
             assert(waker_delta == 0);
             assert(waker_converted == 0);
-            assert(!waker_found)
+            assert(!waker_found);
+            assert(!waker_woke)
         :: else -> skip
         fi;
         if
         :: waker_worker_id < N ->
-            assert(state[waker_worker_id] == WAKER ||
-                state[waker_worker_id] == NEED_TO_BE_WAKER)
+            assert(waker_role[waker_worker_id] == WAKER ||
+                waker_role[waker_worker_id] == NEED_TO_BE_WAKER)
         :: else -> skip
         fi
     }
@@ -121,16 +125,17 @@ inline check_local_safety() {
 inline publish_waker_final(id, final) {
     atomic {
         if
-        :: state[id] == WAKER &&
+        :: waker_role[id] == WAKER &&
                 (reductions & REDUCTION_WAKER_BIT) ->
             reductions = reductions & REDUCTION_COUNT_MASK;
-            resume_state[id] = final;
-            state[id] = NEED_TO_BE_WAKER
-        :: state[id] == WAKER &&
+            worker_state[id] = final;
+            waker_role[id] = NEED_TO_BE_WAKER
+        :: waker_role[id] == WAKER &&
                 !(reductions & REDUCTION_WAKER_BIT) ->
-            resume_state[id] = final;
-            state[id] = final
-        :: state[id] == NEED_TO_BE_WAKER -> skip
+            worker_state[id] = final;
+            waker_role[id] = ORDINARY
+        :: waker_role[id] == NEED_TO_BE_WAKER ->
+            worker_state[id] = final
         fi
     }
 }
@@ -145,10 +150,10 @@ inline try_request_waker(owner, candidate, notified, require_sleepers) {
     :: owner < N ->
         atomic {
             if
-            :: state[owner] == WAKER ->
-                state[owner] = NEED_TO_BE_WAKER;
+            :: waker_role[owner] == WAKER ->
+                waker_role[owner] = NEED_TO_BE_WAKER;
                 notified = true
-            :: state[owner] == NEED_TO_BE_WAKER ->
+            :: waker_role[owner] == NEED_TO_BE_WAKER ->
                 notified = true
             :: else -> skip
             fi
@@ -162,11 +167,15 @@ inline try_request_waker(owner, candidate, notified, require_sleepers) {
             :: candidate < N && !notified ->
                 atomic {
                     if
-                    :: waker_worker_id == INVALID_WAKER &&
-                            (state[candidate] == SPIN ||
-                                state[candidate] == BLOCKING ||
-                                state[candidate] == SLEEP) ->
-                        state[candidate] = NEED_TO_BE_WAKER;
+                    :: require_sleepers &&
+                            waker_role[candidate] == WAKER ->
+                        waker_role[candidate] = NEED_TO_BE_WAKER;
+                        notified = true
+                    :: waker_role[candidate] == ORDINARY &&
+                            (worker_state[candidate] == SPIN ||
+                                worker_state[candidate] == BLOCKING ||
+                                worker_state[candidate] == SLEEP) ->
+                        waker_role[candidate] = NEED_TO_BE_WAKER;
                         notified = true
                     :: else -> skip
                     fi
@@ -184,10 +193,10 @@ proctype Worker(byte id) {
     bool done;
 
     do
-    :: state[id] == WORK ->
-        state[id] = NONE
+    :: waker_role[id] == ORDINARY && worker_state[id] == WORK ->
+        worker_state[id] = NONE
 
-    :: state[id] == NONE ->
+    :: waker_role[id] == ORDINARY && worker_state[id] == NONE ->
         if
         /* The controller could not find an existing waker or a parked
          * candidate. The first idle worker clears only the request bit and
@@ -196,9 +205,12 @@ proctype Worker(byte id) {
             reductions & REDUCTION_WAKER_BIT ->
             reductions = reductions & REDUCTION_COUNT_MASK
         };
-            resume_state[id] = NONE;
-            state[id] = NEED_TO_BE_WAKER;
-            atomic { waker_pending = true }
+            atomic {
+                assert(waker_role[id] == ORDINARY &&
+                    worker_state[id] == NONE);
+                waker_role[id] = NEED_TO_BE_WAKER;
+                waker_pending = true
+            }
 
         /* A reduction claim and its ownership accounting are one abstract
          * operation. Publishing BLOCKING remains a separate transition. */
@@ -207,9 +219,13 @@ proctype Worker(byte id) {
             reductions--;
             claimed_reductions++
         };
-            resume_state[id] = BLOCKING;
-            state[id] = NEED_TO_BE_WAKER;
-            atomic { waker_pending = true }
+            atomic {
+                assert(waker_role[id] == ORDINARY &&
+                    worker_state[id] == NONE);
+                worker_state[id] = BLOCKING;
+                waker_role[id] = NEED_TO_BE_WAKER;
+                waker_pending = true
+            }
 
         :: reductions == 0 && suggested_thread_count == thread_count &&
                 queued_activations > 0 ->
@@ -218,28 +234,32 @@ proctype Worker(byte id) {
                 queued_activations--;
                 assert(activation_credits > 0);
                 activation_credits--;
-                resume_state[id] = WORK;
-                state[id] = WORK
+                worker_state[id] = WORK
             }
 
         :: reductions == 0 && suggested_thread_count == thread_count &&
                 activation_credits == 0 ->
-            resume_state[id] = SPIN;
-            state[id] = NEED_TO_BE_WAKER;
-            atomic { waker_pending = true }
+            atomic {
+                assert(waker_role[id] == ORDINARY &&
+                    worker_state[id] == NONE);
+                worker_state[id] = SPIN;
+                waker_role[id] = NEED_TO_BE_WAKER;
+                waker_pending = true
+            }
         fi
 
-    :: state[id] == SPIN && activation_credits > 0 ->
+    :: waker_role[id] == ORDINARY && worker_state[id] == SPIN &&
+            activation_credits > 0 ->
         atomic {
             if
-            :: state[id] == SPIN && activation_credits > 0 ->
-                resume_state[id] = NONE;
-                state[id] = NONE
+            :: waker_role[id] == ORDINARY &&
+                    worker_state[id] == SPIN && activation_credits > 0 ->
+                worker_state[id] = NONE
             :: else -> skip
             fi
         }
 
-    :: state[id] == NEED_TO_BE_WAKER ->
+    :: waker_role[id] == NEED_TO_BE_WAKER ->
         done = false;
         do
         :: !done ->
@@ -249,35 +269,49 @@ proctype Worker(byte id) {
                 atomic {
                     if
                     :: waker_worker_id == INVALID_WAKER &&
-                            state[id] == NEED_TO_BE_WAKER ->
+                            waker_role[id] == NEED_TO_BE_WAKER ->
                         waker_worker_id = id;
-                        state[id] = WAKER;
                         done = true
                     :: else -> skip
                     fi
-                }
+                };
+                if
+                :: done ->
+                    atomic {
+                        assert(waker_worker_id == id);
+                        assert(waker_role[id] == NEED_TO_BE_WAKER);
+                        waker_role[id] = WAKER
+                    }
+                :: else -> skip
+                fi
 
             :: owner < N && owner != id ->
                 atomic {
                     if
-                    :: state[owner] == WAKER ->
-                        state[owner] = NEED_TO_BE_WAKER;
-                        state[id] = resume_state[id];
+                    :: waker_role[owner] == WAKER ->
+                        waker_role[owner] = NEED_TO_BE_WAKER;
                         done = true
-                    :: state[owner] == NEED_TO_BE_WAKER ->
-                        state[id] = resume_state[id];
+                    :: waker_role[owner] == NEED_TO_BE_WAKER ->
                         done = true
                     :: else -> skip
                     fi
-                }
+                };
+                if
+                :: done ->
+                    atomic {
+                        assert(waker_role[id] == NEED_TO_BE_WAKER);
+                        waker_role[id] = ORDINARY
+                    }
+                :: else -> skip
+                fi
 
             :: owner == id ->
                 atomic {
                     if
-                    :: state[id] == NEED_TO_BE_WAKER ->
-                        state[id] = WAKER;
+                    :: waker_role[id] == NEED_TO_BE_WAKER ->
+                        waker_role[id] = WAKER;
                         done = true
-                    :: state[id] == WAKER ->
+                    :: waker_role[id] == WAKER ->
                         done = true
                     fi
                 }
@@ -290,7 +324,7 @@ proctype Worker(byte id) {
             done = false
         }
 
-    :: state[id] == WAKER && waker_worker_id == id ->
+    :: waker_role[id] == WAKER && waker_worker_id == id ->
         atomic {
             assert(waker_passes == 0);
             waker_passes = 1;
@@ -349,7 +383,8 @@ proctype Worker(byte id) {
             waker_converted = 0
         };
 
-        waker_budget = activation_credits;
+        waker_previous_activations = activation_credits;
+        waker_budget = waker_previous_activations;
 
         /* Observe every worker once. NONE only consumes the local budget at
          * the point where it is seen; it does not reserve a queue item and
@@ -358,17 +393,19 @@ proctype Worker(byte id) {
         do
         :: waker_i < N ->
             if
-            :: waker_i != id && state[waker_i] == NONE &&
+            :: waker_i != id && waker_role[waker_i] == ORDINARY &&
+                    worker_state[waker_i] == NONE &&
                     waker_budget > 0 -> waker_budget--
 
-            :: waker_i != id && state[waker_i] == SPIN ->
+            :: waker_i != id && waker_role[waker_i] == ORDINARY &&
+                    worker_state[waker_i] == SPIN ->
                 if
                 :: waker_budget > 0 ->
                     atomic {
                         if
-                        :: state[waker_i] == SPIN ->
-                            resume_state[waker_i] = NONE;
-                            state[waker_i] = NONE;
+                        :: waker_role[waker_i] == ORDINARY &&
+                                worker_state[waker_i] == SPIN ->
+                            worker_state[waker_i] = NONE;
                             waker_budget--
                         :: else -> skip
                         fi
@@ -376,9 +413,9 @@ proctype Worker(byte id) {
                 :: waker_budget == 0 ->
                     atomic {
                         if
-                        :: state[waker_i] == SPIN ->
-                            resume_state[waker_i] = SLEEP;
-                            state[waker_i] = SLEEP;
+                        :: waker_role[waker_i] == ORDINARY &&
+                                worker_state[waker_i] == SPIN ->
+                            worker_state[waker_i] = SLEEP;
                             assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
@@ -387,17 +424,18 @@ proctype Worker(byte id) {
                     }
                 fi
 
-            :: waker_i != id && state[waker_i] == BLOCKING ->
+            :: waker_i != id && waker_role[waker_i] == ORDINARY &&
+                    worker_state[waker_i] == BLOCKING ->
                 if
                 :: cancelled_claimed_reductions > 0 && waker_budget > 0 ->
                     atomic {
                         if
-                        :: state[waker_i] == BLOCKING ->
+                        :: waker_role[waker_i] == ORDINARY &&
+                                worker_state[waker_i] == BLOCKING ->
                             assert(claimed_reductions > 0);
                             claimed_reductions--;
                             cancelled_claimed_reductions--;
-                            resume_state[waker_i] = NONE;
-                            state[waker_i] = NONE;
+                            worker_state[waker_i] = NONE;
                             waker_budget--
                         :: else -> skip
                         fi
@@ -405,12 +443,12 @@ proctype Worker(byte id) {
                 :: cancelled_claimed_reductions > 0 && waker_budget == 0 ->
                     atomic {
                         if
-                        :: state[waker_i] == BLOCKING ->
+                        :: waker_role[waker_i] == ORDINARY &&
+                                worker_state[waker_i] == BLOCKING ->
                             assert(claimed_reductions > 0);
                             claimed_reductions--;
                             cancelled_claimed_reductions--;
-                            resume_state[waker_i] = SLEEP;
-                            state[waker_i] = SLEEP;
+                            worker_state[waker_i] = SLEEP;
                             assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
@@ -420,11 +458,11 @@ proctype Worker(byte id) {
                 :: cancelled_claimed_reductions == 0 ->
                     atomic {
                         if
-                        :: state[waker_i] == BLOCKING ->
+                        :: waker_role[waker_i] == ORDINARY &&
+                                worker_state[waker_i] == BLOCKING ->
                             assert(claimed_reductions > 0);
                             claimed_reductions--;
-                            resume_state[waker_i] = SLEEP;
-                            state[waker_i] = SLEEP;
+                            worker_state[waker_i] = SLEEP;
                             assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
@@ -444,38 +482,47 @@ proctype Worker(byte id) {
         do
         :: waker_budget > 0 && thread_count > awake_workers ->
             waker_found = false;
+            waker_woke = false;
             waker_i = 0;
-            atomic {
-                do
-                :: waker_i < N && !waker_found ->
+            do
+            :: waker_i < N && !waker_found ->
+                if
+                :: waker_i != id && worker_state[waker_i] == SLEEP ->
+                    waker_found = true
+                :: else -> waker_i++
+                fi
+            :: else -> break
+            od;
+            if
+            :: waker_found ->
+                atomic {
                     if
-                    :: waker_i != id && state[waker_i] == SLEEP ->
-                        state[waker_i] = NONE;
-                        resume_state[waker_i] = NONE;
+                    :: waker_role[waker_i] == ORDINARY &&
+                            worker_state[waker_i] == SLEEP ->
+                        worker_state[waker_i] = NONE;
                         assert(sleep_workers > 0);
                         sleep_workers--;
                         awake_workers++;
                         waker_budget--;
-                        waker_found = true
+                        waker_woke = true
                     :: else -> skip
-                    fi;
-                    waker_i++
-                :: else -> break
-                od
-            };
-            if
-            :: waker_found -> skip
-            /* The eligible sleeper is the current owner or a worker which is
-             * temporarily participating in election. */
+                    fi
+                };
+                if
+                :: waker_woke -> skip
+                /* Match the current C++ loop: a failed SLEEP -> NONE CAS
+                 * stops this pass instead of scanning another stack entry. */
+                :: !waker_woke -> break
+                fi
+            /* The only eligible sleeper may be the current owner. */
             :: !waker_found -> break
             fi
         :: else -> break
         od;
 
-        /* Treat the owner as its saved logical state while its public state
-         * is WAKER/NEED_TO_BE_WAKER. */
+        /* The waker role is orthogonal to the worker's logical state. */
         if
-        :: resume_state[id] == BLOCKING ->
+        :: worker_state[id] == BLOCKING ->
             assert(claimed_reductions > 0);
             if
             :: cancelled_claimed_reductions > 0 && waker_budget > 0 ->
@@ -495,12 +542,12 @@ proctype Worker(byte id) {
                 claimed_reductions--;
                 waker_final = SLEEP
             fi
-        :: resume_state[id] != BLOCKING && waker_budget > 0 ->
+        :: worker_state[id] != BLOCKING && waker_budget > 0 ->
             waker_final = NONE;
             waker_budget--
-        :: resume_state[id] != BLOCKING && waker_budget == 0 ->
+        :: worker_state[id] != BLOCKING && waker_budget == 0 ->
             if
-            :: resume_state[id] == NONE || resume_state[id] == WORK ->
+            :: worker_state[id] == NONE || worker_state[id] == WORK ->
                 waker_final = NONE
             :: else -> waker_final = SLEEP
             fi
@@ -508,17 +555,17 @@ proctype Worker(byte id) {
 
         atomic {
             if
-            :: resume_state[id] == SLEEP && waker_final != SLEEP ->
+            :: worker_state[id] == SLEEP && waker_final != SLEEP ->
                 assert(sleep_workers > 0);
                 sleep_workers--;
                 awake_workers++
-            :: resume_state[id] != SLEEP && waker_final == SLEEP ->
+            :: worker_state[id] != SLEEP && waker_final == SLEEP ->
                 assert(awake_workers > 0);
                 awake_workers--;
                 sleep_workers++
             :: else -> skip
             fi;
-            resume_state[id] = waker_final;
+            worker_state[id] = waker_final;
             if
             :: thread_count > awake_workers ->
                 sleeping_count = thread_count - awake_workers
@@ -526,38 +573,53 @@ proctype Worker(byte id) {
             fi
         };
 
+        /* Close the publication race where a producer increments credits
+         * before this pass publishes the corresponding sleeping worker. */
+        if
+        :: activation_credits > waker_previous_activations ->
+            atomic {
+                waker_pending = true;
+                if
+                :: waker_role[id] == WAKER ->
+                    waker_role[id] = NEED_TO_BE_WAKER
+                :: waker_role[id] == NEED_TO_BE_WAKER -> skip
+                fi
+            }
+        :: else -> skip
+        fi;
+
         atomic {
             assert(waker_passes == 1);
             waker_i = 0;
             waker_budget = 0;
+            waker_previous_activations = 0;
             waker_final = NONE;
             waker_desired = 0;
             waker_delta = 0;
             waker_converted = 0;
             waker_found = false;
+            waker_woke = false;
             waker_passes = 0
         };
 
         if
-        :: state[id] == NEED_TO_BE_WAKER ->
+        :: waker_role[id] == NEED_TO_BE_WAKER ->
             atomic {
-                state[id] == NEED_TO_BE_WAKER -> state[id] = WAKER
+                waker_role[id] == NEED_TO_BE_WAKER ->
+                waker_role[id] = WAKER
             }
 
-        :: state[id] == WAKER ->
+        :: waker_role[id] == WAKER ->
             atomic {
                 assert(waker_worker_id == id);
                 waker_worker_id = INVALID_WAKER
             };
-            /* waker_final is shared scratch and may already belong to the
-             * next owner. The retiring owner published its own final value
-             * to resume_state[id] before releasing waker_worker_id. */
-            publish_waker_final(id, resume_state[id])
+            publish_waker_final(id, worker_state[id])
         fi;
 
         check_local_safety()
 
-    /* SLEEP and BLOCKING are parked. Changing either state to
+    /* SLEEP and BLOCKING are parked. Changing waker_role to
      * NEED_TO_BE_WAKER models the matching Unpark(). */
     od
 }
@@ -570,6 +632,7 @@ proctype Producer() {
     bool done;
 
     do
+    :: true -> break
     :: round < PRODUCER_ROUNDS ->
         atomic {
         activation_credits < MAX_QUEUE -> activation_credits++
@@ -602,33 +665,14 @@ proctype Producer() {
                 :: !done && owner == INVALID_WAKER ->
                     if
                     :: sleeping_count > 0 ->
-                        /* An eligible sleeper may already be between its
-                         * candidate transition and index publication. */
-                        i = 0;
-                        do
-                        :: i < N && !done ->
+                        atomic {
                             if
-                            :: resume_state[i] == SLEEP &&
-                                    (state[i] == NEED_TO_BE_WAKER ||
-                                        state[i] == WAKER) ->
+                            :: waker_worker_id == INVALID_WAKER ->
+                                waker_pending = false;
                                 done = true
                             :: else -> skip
-                            fi;
-                            i++
-                        :: else -> break
-                        od;
-                        if
-                        :: done -> skip
-                        :: else ->
-                            atomic {
-                                if
-                                :: waker_worker_id == INVALID_WAKER ->
-                                    waker_pending = false;
-                                    done = true
-                                :: else -> skip
-                                fi
-                            }
-                        fi
+                            fi
+                        }
 
                     :: sleeping_count == 0 ->
                         atomic {
@@ -666,6 +710,7 @@ proctype Controller() {
     bool notified;
 
     do
+    :: true -> break
     :: round < CONTROLLER_ROUNDS ->
         atomic {
             if
@@ -714,13 +759,22 @@ ltl live_resize_reconciles {
         <> (suggested_thread_count == thread_count))
 }
 
+/* With MAX_QUEUE == N == 2, express queue progress using only its size. A
+ * single queued activation must eventually be either consumed or joined by
+ * another activation; a full queue must eventually lose one activation. */
+ltl live_queue_changes {
+    ([] (queued_activations == 1 ->
+        <> (queued_activations == 0 || queued_activations == 2))) &&
+    ([] (queued_activations == 2 -> <> (queued_activations == 1)))
+}
+
 init {
     atomic {
         byte i = 0;
         do
         :: i < N ->
-            state[i] = WORK;
-            resume_state[i] = WORK;
+            worker_state[i] = WORK;
+            waker_role[i] = ORDINARY;
             run Worker(i);
             i++
         :: else -> break

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -1,0 +1,324 @@
+/*
+ * Finite-state model of dynamic thread-count changes in TBasicExecutorPool
+ * waker. All processes run indefinitely.
+ *
+ * Deliberately modeled:
+ *  - SuggestedThreadCount updates by the controller;
+ *  - ThreadCount and CheckToSleepWorkers updates owned by the waker;
+ *  - workers preferring a reduction request over taking an activation;
+ *  - independent infinite producers keeping the queue bounded by N + 1;
+ *  - None -> Blocking -> Sleep and immediate parking;
+ *  - waker-local ActiveMask and sleeping-stack membership;
+ *  - SleepingCount containing active sleeping workers only;
+ *  - coalesced RequestWaker notifications.
+ *
+ * Abstracted away:
+ *  - actor/mailbox identity, affinity, harmonizer, metrics and memory orders;
+ *  - stack order (membership is sufficient for these properties);
+ *  - the spin duration (Spin is a state from which the waker may decide).
+ */
+
+#define N 2
+#define PRODUCERS 2
+#define MAX_QUEUE (N + 1)
+#define NONE 0
+#define SPIN 1
+#define SLEEP 2
+#define WORK 3
+#define BLOCKING 4
+
+byte state[N];
+bool worker_enabled[N];
+bool in_sleeping_stack[N];
+bool counted_sleeping[N];
+
+byte suggested_thread_count = N;
+byte thread_count = N;
+byte active_count = N;
+byte sleeping_count = 0;
+byte reductions = 0;
+byte activation_credits = 0;
+bool waker_pending = false;
+bool work_epoch = false;
+
+inline request_waker() {
+    atomic {
+        if
+        :: !waker_pending -> waker_pending = true
+        :: else -> skip
+        fi
+    }
+}
+
+inline check_safety() {
+    assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
+    assert(thread_count >= 1 && thread_count <= N);
+    assert(active_count <= N);
+    assert(sleeping_count <= active_count);
+    assert(reductions <= N);
+    assert(activation_credits <= MAX_QUEUE);
+}
+
+proctype Worker(byte id) {
+    do
+    :: worker_enabled[id] && state[id] == WORK ->
+        state[id] = NONE;
+        work_epoch = !work_epoch
+
+    :: worker_enabled[id] && state[id] == NONE ->
+        if
+        :: atomic {
+            reductions > 0 ->
+            reductions--;
+            state[id] = BLOCKING
+        };
+        request_waker()
+
+        /* Reduction has priority over taking the next activation. */
+        :: atomic {
+            reductions == 0 && activation_credits > 0 ->
+            activation_credits--;
+            state[id] = WORK
+        }
+        :: atomic {
+            reductions == 0 && activation_credits == 0 ->
+            state[id] = SPIN
+        };
+        request_waker()
+        fi
+
+    /* BLOCKING and SLEEP are parked; only the waker changes them. */
+    od
+}
+
+proctype Producer() {
+    do
+    :: atomic {
+        activation_credits < MAX_QUEUE ->
+        activation_credits++
+    };
+        if
+        :: sleeping_count > 0 -> request_waker()
+        :: else -> skip
+        fi
+    od
+}
+
+proctype Controller() {
+    byte next;
+
+    do
+    :: true ->
+        if
+        :: next = 1
+        :: next = N
+        fi;
+        if
+        :: next != suggested_thread_count ->
+            suggested_thread_count = next;
+            request_waker()
+        :: else -> skip
+        fi;
+        check_safety()
+    od
+}
+
+proctype Waker() {
+    byte desired;
+    byte i;
+    byte searching;
+    byte budget;
+
+    do
+    :: waker_pending ->
+        /* Matches clearing WakerPending before loading ThreadCount. */
+        waker_pending = false;
+        desired = suggested_thread_count;
+
+        /* Unclaimed tokens belong to an older reconciliation pass. A worker
+         * which claimed one is represented explicitly by BLOCKING. */
+        reductions = 0;
+
+        /* Resolve workers which have already claimed a reduction token. */
+        i = 0;
+        do
+        :: i < N ->
+            if
+            :: worker_enabled[i] && state[i] == BLOCKING ->
+                if
+                :: active_count > desired ->
+                    state[i] = SLEEP;
+                    in_sleeping_stack[i] = true;
+                    worker_enabled[i] = false;
+                    active_count--
+                :: else -> state[i] = NONE
+                fi
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+
+        /* Retire additional already idle workers. No reduction token is
+         * needed: only the waker mutates its local active set. */
+        i = 0;
+        do
+        :: i < N && active_count > desired ->
+            if
+            :: worker_enabled[i] && state[i] == SLEEP ->
+                counted_sleeping[i] = false;
+                sleeping_count--;
+                worker_enabled[i] = false;
+                active_count--
+            :: worker_enabled[i] && state[i] == SPIN ->
+                state[i] = SLEEP;
+                in_sleeping_stack[i] = true;
+                worker_enabled[i] = false;
+                active_count--
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+
+        /* Publish requests only for workers which could not be retired by the
+         * waker because they are currently in Work or None. */
+        atomic {
+            if
+            :: active_count > desired -> reductions = active_count - desired
+            :: else -> reductions = 0
+            fi
+        };
+
+        /* Re-enable disabled sleeping workers after a count increase. */
+        i = 0;
+        do
+        :: i < N && active_count < desired ->
+            if
+            :: !worker_enabled[i] && in_sleeping_stack[i] ->
+                worker_enabled[i] = true;
+                active_count++;
+                counted_sleeping[i] = true;
+                sleeping_count++
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+
+        thread_count = active_count;
+
+        searching = 0;
+        i = 0;
+        do
+        :: i < N ->
+            if
+            :: worker_enabled[i] && state[i] == NONE -> searching++
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+        if
+        :: activation_credits > searching -> budget = activation_credits - searching
+        :: else -> budget = 0
+        fi;
+
+        /* Resolve ordinary spinners using the current activation budget. */
+        i = 0;
+        do
+        :: i < N ->
+            if
+            :: worker_enabled[i] && state[i] == SPIN && budget > 0 ->
+                state[i] = NONE;
+                budget--
+            :: worker_enabled[i] && state[i] == SPIN && budget == 0 ->
+                state[i] = SLEEP;
+                in_sleeping_stack[i] = true;
+                counted_sleeping[i] = true;
+                sleeping_count++
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+
+        /* Reload credits after publishing sleepers, then wake as many active
+         * sleepers as are needed for the remaining work. */
+        searching = 0;
+        i = 0;
+        do
+        :: i < N ->
+            if
+            :: worker_enabled[i] && state[i] == NONE -> searching++
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+        if
+        :: activation_credits > searching -> budget = activation_credits - searching
+        :: else -> budget = 0
+        fi;
+
+        i = 0;
+        do
+        :: i < N ->
+            if
+            :: worker_enabled[i] && state[i] == SLEEP && budget > 0 ->
+                state[i] = NONE;
+                in_sleeping_stack[i] = false;
+                counted_sleeping[i] = false;
+                sleeping_count--;
+                budget--
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+
+        check_safety();
+        i = 0;
+        do
+        :: i < N ->
+            assert(!counted_sleeping[i] || (worker_enabled[i] && state[i] == SLEEP));
+            assert(worker_enabled[i] || state[i] == SLEEP);
+            i++
+        :: else -> break
+        od
+    od
+}
+
+#define target_one (suggested_thread_count == 1)
+#define target_max (suggested_thread_count == N)
+#define reconciled_one (thread_count == 1 && active_count == 1 && reductions == 0)
+#define reconciled_max (thread_count == N && active_count == N && reductions == 0)
+ltl live_reconcile_stable {
+    ((<>[] target_one) ->
+        ((<>[] reconciled_one) && ([]<> work_epoch) && ([]<> !work_epoch))) &&
+    ((<>[] target_max) ->
+        ((<>[] reconciled_max) && ([]<> work_epoch) && ([]<> !work_epoch)))
+}
+
+init {
+    atomic {
+        byte i = 0;
+        do
+        :: i < N ->
+            state[i] = WORK;
+            worker_enabled[i] = true;
+            run Worker(i);
+            i++
+        :: else -> break
+        od;
+        i = 0;
+        do
+        :: i < PRODUCERS ->
+            run Producer();
+            i++
+        :: else -> break
+        od;
+        run Controller();
+        run Waker()
+    }
+}

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -104,6 +104,50 @@ inline publish_waker_final(id, final, published) {
     }
 }
 
+/* Make one non-blocking attempt to request a waker pass. The owner load is
+ * deliberately outside atomic: the model must preserve the completion race
+ * between observing waker_worker_id and forwarding the request. */
+inline try_request_waker(owner, candidate, notified, require_sleepers) {
+    notified = false;
+    owner = waker_worker_id;
+    if
+    :: owner < N ->
+        atomic {
+            if
+            :: state[owner] == WAKER ->
+                state[owner] = NEED_TO_BE_WAKER;
+                notified = true
+            :: state[owner] == NEED_TO_BE_WAKER ->
+                notified = true
+            :: else -> skip
+            fi
+        }
+
+    :: owner == INVALID_WAKER ->
+        if
+        :: !require_sleepers || sleeping_count > 0 ->
+            candidate = 0;
+            do
+            :: candidate < N && !notified ->
+                atomic {
+                    if
+                    :: waker_worker_id == INVALID_WAKER &&
+                            (state[candidate] == SPIN ||
+                                state[candidate] == BLOCKING ||
+                                state[candidate] == SLEEP) ->
+                        state[candidate] = NEED_TO_BE_WAKER;
+                        notified = true
+                    :: else -> skip
+                    fi
+                };
+                candidate++
+            :: else -> break
+            od
+        :: require_sleepers && sleeping_count == 0 -> skip
+        fi
+    fi
+}
+
 proctype Worker(byte id) {
     byte owner;
     byte i;
@@ -483,7 +527,6 @@ proctype Producer() {
     byte round = 0;
     bool notify;
     bool done;
-    bool found;
 
     do
     :: round < PRODUCER_ROUNDS ->
@@ -511,72 +554,39 @@ proctype Producer() {
             done = false;
             do
             :: !done ->
-                owner = waker_worker_id;
+                try_request_waker(owner, i, done, true);
                 if
-                :: owner < N ->
-                    atomic {
-                        if
-                        :: state[owner] == WAKER ->
-                            state[owner] = NEED_TO_BE_WAKER;
-                            done = true
-                        :: state[owner] == NEED_TO_BE_WAKER ->
-                            done = true
-                        :: else -> skip
-                        fi
-                    }
-
-                :: owner == INVALID_WAKER ->
+                :: done -> skip
+                :: !done && owner < N -> skip
+                :: !done && owner == INVALID_WAKER ->
                     if
                     :: sleeping_count > 0 ->
-                        found = false;
+                        /* An eligible sleeper may already be between its
+                         * candidate transition and index publication. */
                         i = 0;
                         do
-                        :: i < N && !found ->
-                            atomic {
-                                if
-                                :: waker_worker_id == INVALID_WAKER &&
-                                        (state[i] == SPIN ||
-                                            state[i] == BLOCKING ||
-                                            state[i] == SLEEP) ->
-                                    state[i] = NEED_TO_BE_WAKER;
-                                    found = true;
-                                    done = true
-                                :: else -> skip
-                                fi
-                            };
+                        :: i < N && !done ->
+                            if
+                            :: resume_state[i] == SLEEP &&
+                                    (state[i] == NEED_TO_BE_WAKER ||
+                                        state[i] == WAKER) ->
+                                done = true
+                            :: else -> skip
+                            fi;
                             i++
                         :: else -> break
                         od;
                         if
-                        :: found -> skip
-                        :: !found ->
-                            /* A counted sleeper may already be between its
-                             * candidate transition and index publication. */
-                            i = 0;
-                            do
-                            :: i < N && !done ->
+                        :: done -> skip
+                        :: else ->
+                            atomic {
                                 if
-                                :: resume_state[i] == SLEEP &&
-                                        (state[i] == NEED_TO_BE_WAKER ||
-                                            state[i] == WAKER) ->
+                                :: waker_worker_id == INVALID_WAKER ->
+                                    waker_pending = false;
                                     done = true
                                 :: else -> skip
-                                fi;
-                                i++
-                            :: else -> break
-                            od;
-                            if
-                            :: done -> skip
-                            :: else ->
-                                atomic {
-                                    if
-                                    :: waker_worker_id == INVALID_WAKER ->
-                                        waker_pending = false;
-                                        done = true
-                                    :: else -> skip
-                                    fi
-                                }
-                            fi
+                                fi
+                            }
                         fi
 
                     :: sleeping_count == 0 ->
@@ -606,7 +616,7 @@ proctype Controller() {
     byte round = 0;
     byte owner;
     byte i;
-    bool found;
+    bool notified;
 
     do
     :: round < CONTROLLER_ROUNDS ->
@@ -618,36 +628,7 @@ proctype Controller() {
             waker_pending = true
         };
 
-        owner = waker_worker_id;
-        if
-        :: owner < N ->
-            atomic {
-                if
-                :: state[owner] == WAKER ->
-                    state[owner] = NEED_TO_BE_WAKER
-                :: state[owner] == NEED_TO_BE_WAKER -> skip
-                :: else -> skip
-                fi
-            }
-        :: owner == INVALID_WAKER ->
-            found = false;
-            i = 0;
-            do
-            :: i < N && !found ->
-                atomic {
-                    if
-                    :: waker_worker_id == INVALID_WAKER &&
-                            (state[i] == SPIN || state[i] == BLOCKING ||
-                                state[i] == SLEEP) ->
-                        state[i] = NEED_TO_BE_WAKER;
-                        found = true
-                    :: else -> skip
-                    fi
-                };
-                i++
-            :: else -> break
-            od
-        fi;
+        try_request_waker(owner, i, notified, false);
         round++
     :: else -> break
     od

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -91,7 +91,7 @@ proctype Worker(byte id) {
             };
                 state[id] = WORK;
                 atomic {
-                    activation_credits > 0 ->
+                    assert(activation_credits > 0);
                     activation_credits--
                 }
             :: queued_activations == 0 && activation_credits > 0 ->

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -103,6 +103,14 @@ proctype Worker(byte id) {
             request_waker()
         fi
 
+    :: state[id] == SPIN && activation_credits > 0 ->
+        atomic {
+            if
+            :: state[id] == SPIN && activation_credits > 0 -> state[id] = NONE
+            :: else -> skip
+            fi
+        }
+
     /* BLOCKING and SLEEP are parked; only the waker changes them. */
     od
 }
@@ -262,46 +270,14 @@ proctype Waker() {
         previous_activations = activation_credits;
         activations = previous_activations;
 
-        /* Resolve every active worker once. activations is a local budget: a
-         * NONE worker, or a worker which leaves SPIN by itself, consumes one
-         * unit without reserving the corresponding queue item. */
+        /* Resolve workers which claimed reductions published by an earlier
+         * pass. Reductions for the new target are not visible yet, so a
+         * worker which becomes BLOCKING after this loop is deferred until the
+         * next waker pass, matching the ordering in WakerLoop(). */
         i = 0;
         do
         :: i < N ->
             if
-            :: state[i] == NONE ->
-                if
-                :: activations > 0 -> activations--
-                :: else -> skip
-                fi
-
-            :: state[i] == SPIN ->
-                if
-                :: activations > 0 ->
-                    atomic {
-                        if
-                        :: state[i] == SPIN -> state[i] = NONE
-                        :: else ->
-                            assert(state[i] == NONE || state[i] == WORK)
-                        fi
-                    };
-                    activations--
-
-                :: activations == 0 ->
-                    atomic {
-                        if
-                        :: state[i] == SPIN ->
-                            assert(awake_workers > 0);
-                            assert(sleep_workers < N);
-                            state[i] = SLEEP;
-                            awake_workers--;
-                            sleep_workers++
-                        :: else ->
-                            assert(state[i] == NONE || state[i] == WORK)
-                        fi
-                    }
-                fi
-
             :: state[i] == BLOCKING ->
                 if
                 :: taken_tokens_to_wakeup > 0 ->
@@ -341,6 +317,65 @@ proctype Waker() {
         :: else -> break
         od;
 
+        /* C++ publishes CheckToSleepWorkers before it computes the activation
+         * budget and scans SPIN workers. Claims made from this publication are
+         * intentionally handled by the next pass. */
+        atomic {
+            reductions = remaining_reductions;
+            previous_reductions = remaining_reductions
+        };
+
+        /* Resolve every active worker once. activations is a local budget: a
+         * NONE worker, or a worker which leaves SPIN by itself, consumes one
+         * unit without reserving the corresponding queue item. */
+        i = 0;
+        do
+        :: i < N ->
+            if
+            :: state[i] == NONE ->
+                if
+                :: activations > 0 -> activations--
+                :: else -> skip
+                fi
+
+            :: state[i] == SPIN ->
+                if
+                :: activations > 0 ->
+                    atomic {
+                        if
+                        :: state[i] == SPIN ->
+                            state[i] = NONE;
+                            activations--
+                        :: else ->
+                            assert(state[i] == NONE || state[i] == WORK || state[i] == BLOCKING);
+                            if
+                            :: state[i] == NONE || state[i] == WORK -> activations--
+                            :: state[i] == BLOCKING -> skip
+                            fi
+                        fi
+                    }
+
+                :: activations == 0 ->
+                    atomic {
+                        if
+                        :: state[i] == SPIN ->
+                            assert(awake_workers > 0);
+                            assert(sleep_workers < N);
+                            state[i] = SLEEP;
+                            awake_workers--;
+                            sleep_workers++
+                        :: else ->
+                            assert(state[i] == NONE || state[i] == WORK || state[i] == BLOCKING)
+                        fi
+                    }
+                fi
+
+            :: else -> skip
+            fi;
+            i++
+        :: else -> break
+        od;
+
         /* Only the waker mutates SLEEP. Any sleeping worker may consume an
          * eligible sleeping slot because worker identities are symmetric. */
         i = 0;
@@ -371,16 +406,15 @@ proctype Waker() {
         :: else -> break
         od;
 
-        /* Publish both the remaining reductions and the baseline used to
-         * detect claims on the next pass. The baseline is waker-local. */
+        /* Recompute the number of eligible sleepers. Reductions were already
+         * published before the worker scan; previous_reductions remains the
+         * baseline used to detect claims on the next pass. */
         atomic {
             assert((thread_count + remaining_reductions)
                 + taken_tokens_to_sleep >= awake_workers);
             eligible_sleepers = ((thread_count + remaining_reductions)
                 + taken_tokens_to_sleep) - awake_workers;
-            assert(eligible_sleepers <= sleep_workers);
-            reductions = remaining_reductions;
-            previous_reductions = remaining_reductions
+            assert(eligible_sleepers <= sleep_workers)
         };
         atomic {
             sleeping_count = eligible_sleepers;

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -142,19 +142,16 @@ proctype Waker() {
     byte previous_reductions;
     byte taken_tokens_to_sleep;
     byte taken_tokens_to_wakeup;
-    byte previous_sleeping_count;
+    byte eligible_sleepers;
     byte activations;
     byte sleep_workers;
     bool found;
 
     do
     :: waker_pending ->
-        /* SleepingCount is temporarily owned by the waker. Producers which
-         * publish during this window deliberately observe zero. */
-        atomic {
-            previous_sleeping_count = sleeping_count;
-            sleeping_count = 0
-        };
+        /* SleepingCount is withdrawn while the waker recomputes it. Producers
+         * which publish during this window deliberately observe zero. */
+        sleeping_count = 0;
 
         waker_pending = false;
         desired = suggested_thread_count;
@@ -176,6 +173,11 @@ proctype Waker() {
          * the number of workers outside Sleep, and sleep_workers is the total
          * number of workers in Sleep. */
         atomic {
+            assert((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep >= awake_workers);
+            eligible_sleepers = ((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep) - awake_workers;
+
             if
             :: desired > thread_count ->
                 delta = desired - thread_count;
@@ -197,8 +199,6 @@ proctype Waker() {
 
                 /* Growth makes existing sleepers eligible for wakeup without
                  * assigning that eligibility to concrete worker identities. */
-                assert(sleep_workers >= previous_sleeping_count + delta);
-                previous_sleeping_count = previous_sleeping_count + delta;
                 delta = 0
 
             :: desired < thread_count ->
@@ -214,10 +214,9 @@ proctype Waker() {
                 /* Retire already sleeping slots before asking an awake worker
                  * to claim a new reduction token. */
                 if
-                :: previous_sleeping_count < delta -> converted = previous_sleeping_count
+                :: eligible_sleepers < delta -> converted = eligible_sleepers
                 :: else -> converted = delta
                 fi;
-                previous_sleeping_count = previous_sleeping_count - converted;
                 delta = delta - converted;
                 remaining_reductions = remaining_reductions + delta;
                 delta = 0
@@ -225,7 +224,12 @@ proctype Waker() {
             :: else -> skip
             fi;
             thread_count = desired;
-            converted = 0
+            assert((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep >= awake_workers);
+            assert(((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep) - awake_workers <= sleep_workers);
+            converted = 0;
+            eligible_sleepers = 0
         };
 
         activations = activation_credits;
@@ -261,7 +265,6 @@ proctype Waker() {
                         :: state[i] == SPIN ->
                             state[i] = SLEEP;
                             awake_workers--;
-                            previous_sleeping_count++;
                             sleep_workers++
                         :: else ->
                             assert(state[i] == NONE || state[i] == WORK)
@@ -283,7 +286,6 @@ proctype Waker() {
                         atomic {
                             state[i] = SLEEP;
                             awake_workers--;
-                            previous_sleeping_count++;
                             sleep_workers++;
                             taken_tokens_to_wakeup--
                         }
@@ -309,7 +311,8 @@ proctype Waker() {
          * eligible sleeping slot because worker identities are symmetric. */
         i = 0;
         do
-        :: activations > 0 && previous_sleeping_count > 0 ->
+        :: activations > 0 && ((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep) > awake_workers ->
             found = false;
             i = 0;
             do
@@ -319,7 +322,6 @@ proctype Waker() {
                     atomic {
                         state[i] = NONE;
                         awake_workers++;
-                        previous_sleeping_count--;
                         sleep_workers--;
                         activations--;
                         found = true
@@ -338,13 +340,19 @@ proctype Waker() {
 
         /* Publish both the remaining reductions and the baseline used to
          * detect claims on the next pass. The baseline is waker-local. */
-        assert(awake_workers + previous_sleeping_count == thread_count
-            + remaining_reductions + taken_tokens_to_sleep);
+        assert((thread_count + remaining_reductions)
+            + taken_tokens_to_sleep >= awake_workers);
+        eligible_sleepers = ((thread_count + remaining_reductions)
+            + taken_tokens_to_sleep) - awake_workers;
+        assert(eligible_sleepers <= sleep_workers);
         atomic {
             reductions = remaining_reductions;
             previous_reductions = remaining_reductions
         };
-        sleeping_count = previous_sleeping_count;
+        atomic {
+            sleeping_count = eligible_sleepers;
+            eligible_sleepers = 0
+        };
 
         /* Deliberately omitted for now so Spin can expose the missed-wakeup
          * race this reload is intended to close:
@@ -356,7 +364,6 @@ proctype Waker() {
 
         check_safety();
         atomic {
-            assert(previous_sleeping_count <= sleep_workers);
             assert(awake_workers == N - sleep_workers)
         }
     od

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -73,7 +73,7 @@ byte waker_passes = 0;
 byte waker_i = 0;
 byte waker_budget = 0;
 byte waker_final = NONE;
-byte waker_desired = N;
+byte waker_desired = 0;
 byte waker_delta = 0;
 byte waker_converted = 0;
 bool waker_found = false;
@@ -95,6 +95,17 @@ inline check_local_safety() {
         assert(cancelled_claimed_reductions <= claimed_reductions);
         assert(activation_credits <= MAX_QUEUE);
         assert(queued_activations <= activation_credits);
+        if
+        :: waker_passes == 0 ->
+            assert(waker_i == 0);
+            assert(waker_budget == 0);
+            assert(waker_final == NONE);
+            assert(waker_desired == 0);
+            assert(waker_delta == 0);
+            assert(waker_converted == 0);
+            assert(!waker_found)
+        :: else -> skip
+        fi;
         if
         :: waker_worker_id < N ->
             assert(state[waker_worker_id] == WAKER ||
@@ -273,7 +284,11 @@ proctype Worker(byte id) {
             fi
         :: else -> break
         od;
-        assert(done)
+        atomic {
+            assert(done);
+            owner = 0;
+            done = false
+        }
 
     :: state[id] == WAKER && waker_worker_id == id ->
         atomic {
@@ -522,6 +537,13 @@ proctype Worker(byte id) {
 
         atomic {
             assert(waker_passes == 1);
+            waker_i = 0;
+            waker_budget = 0;
+            waker_final = NONE;
+            waker_desired = 0;
+            waker_delta = 0;
+            waker_converted = 0;
+            waker_found = false;
             waker_passes = 0
         };
 
@@ -635,7 +657,13 @@ proctype Producer() {
         fi;
 
         check_local_safety();
-        round++
+        atomic {
+            owner = 0;
+            i = 0;
+            notify = false;
+            done = false;
+            round++
+        }
     :: else -> break
     od
 }
@@ -680,7 +708,12 @@ proctype Controller() {
          * one. This makes a lost resize request observable independently of
          * later controller updates. */
         thread_count == suggested_thread_count;
-        round++
+        atomic {
+            owner = 0;
+            i = 0;
+            notified = false;
+            round++
+        }
     :: else -> break
     od
 }

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -1,445 +1,656 @@
 /*
- * Finite-state model of dynamic thread-count changes in TBasicExecutorPool
- * waker. All processes run indefinitely.
+ * Finite-state model of a BasicExecutorPool where an executor worker
+ * temporarily assumes the waker role. There is no dedicated waker thread.
  *
  * Deliberately modeled:
- *  - SuggestedThreadCount updates by the controller;
- *  - ThreadCount and reduction-token updates owned by the waker;
- *  - workers preferring a reduction request over taking an activation;
- *  - independent infinite producers keeping the queue bounded by MAX_QUEUE;
- *  - None -> Blocking -> Sleep and immediate parking;
- *  - SleepingStack abstracted as the set of all workers in Sleep;
- *  - SleepingCount as the number of sleepers currently eligible for wakeup;
- *  - coalesced RequestWaker notifications.
+ *  - producer publication order: credit, queue item, wake request;
+ *  - coalescing through waker_pending;
+ *  - election through waker_worker_id;
+ *  - forwarding a request with WAKER -> NEED_TO_BE_WAKER;
+ *  - the completion race after the owner releases waker_worker_id;
+ *  - workers entering SPIN and BLOCKING asking for reconciliation;
+ *  - selecting and unparking a SPIN, BLOCKING, or SLEEP worker;
+ *  - a local activation budget which does not reserve queue items;
+ *  - preservation of the elected worker's intended post-waker state;
+ *  - dynamic thread-count changes, including claimed and unclaimed
+ *    reduction tokens overtaken by a later resize.
  *
  * Abstracted away:
- *  - actor/mailbox identity, affinity, harmonizer, metrics and memory orders;
- *  - stack order (membership is sufficient for these properties);
- *  - the spin duration (Spin is a state from which the waker may decide).
+ *  - SleepingStack order (sleeping membership is sufficient here);
+ *  - the futex itself (NEED_TO_BE_WAKER enables a parked worker);
+ *  - memory-order syntax; atomic blocks mark the C++ CAS/exchange edges.
  */
 
 #define N 2
-#define PRODUCERS 2
+#define PRODUCERS 1
+#define PRODUCER_ROUNDS 2
+#define CONTROLLER_ROUNDS 2
 #define MAX_QUEUE N
+
 #define NONE 0
 #define SPIN 1
 #define SLEEP 2
 #define WORK 3
 #define BLOCKING 4
+#define NEED_TO_BE_WAKER 5
+#define WAKER 6
+
+#define INVALID_WAKER N
 
 byte state[N];
 
-byte suggested_thread_count = N;
-byte thread_count = N;
-byte awake_workers = N;
-byte sleeping_count = 0;
-byte reductions = 0;
+/* State to publish when a worker stops participating in waker election. It
+ * also preserves whether a candidate selected from SLEEP remains logically
+ * counted as sleeping while its public state is NEED_TO_BE_WAKER/WAKER. */
+byte resume_state[N];
+
 byte activation_credits = 0;
 byte queued_activations = 0;
+byte sleeping_count = 0;
+byte awake_workers = N;
+byte sleep_workers = 0;
+
+byte suggested_thread_count = N;
+byte thread_count = N;
+byte reductions = 0;
+byte claimed_reductions = 0;
+byte cancelled_claimed_reductions = 0;
+
+byte waker_worker_id = INVALID_WAKER;
 bool waker_pending = false;
 
-inline request_waker() {
+/* Instrumentation state: unlike EThreadState::WAKER, this covers only the
+ * interval which is allowed to mutate the persistent waker data. */
+byte waker_passes = 0;
+
+inline check_local_safety() {
     atomic {
+        assert(waker_worker_id <= INVALID_WAKER);
+        assert(waker_passes <= 1);
+        assert(sleeping_count <= N);
+        assert(awake_workers <= N);
+        assert(sleep_workers <= N);
+        assert(awake_workers + sleep_workers == N);
+        assert(thread_count >= 1 && thread_count <= N);
+        assert(suggested_thread_count >= 1 &&
+            suggested_thread_count <= N);
+        assert(reductions <= N);
+        assert(claimed_reductions <= N);
+        assert(cancelled_claimed_reductions <= claimed_reductions);
+        assert(activation_credits <= MAX_QUEUE);
+        assert(queued_activations <= activation_credits);
         if
-        :: !waker_pending -> waker_pending = true
+        :: waker_worker_id < N ->
+            assert(state[waker_worker_id] == WAKER ||
+                state[waker_worker_id] == NEED_TO_BE_WAKER)
         :: else -> skip
         fi
     }
 }
 
-inline check_safety() {
+/* Publish the final state of the worker which has already released the waker
+ * index. A producer may concurrently change WAKER to NEED_TO_BE_WAKER; in
+ * that case the caller must return to election instead of publishing final. */
+inline publish_waker_final(id, final, published) {
     atomic {
-        assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
-        assert(thread_count >= 1 && thread_count <= N);
-        assert(awake_workers <= N);
-        assert(awake_workers + sleeping_count <= N);
-        assert(reductions <= N);
-        assert(activation_credits <= MAX_QUEUE);
-        assert(queued_activations <= activation_credits)
+        if
+        :: state[id] == WAKER ->
+            resume_state[id] = final;
+            state[id] = final;
+            published = true
+        :: state[id] == NEED_TO_BE_WAKER ->
+            published = false
+        fi
     }
 }
 
 proctype Worker(byte id) {
+    byte owner;
+    byte i;
+    byte budget;
+    byte final;
+    byte desired;
+    byte delta;
+    byte converted;
+    bool done;
+    bool found;
+    bool published;
+
     do
     :: state[id] == WORK ->
         state[id] = NONE
 
     :: state[id] == NONE ->
         if
+        /* A reduction claim and its ownership accounting are one abstract
+         * operation. Publishing BLOCKING remains a separate transition. */
         :: atomic {
             reductions > 0 ->
-            reductions--
+            reductions--;
+            claimed_reductions++
         };
-            state[id] = BLOCKING;
-            request_waker();
+            resume_state[id] = BLOCKING;
+            state[id] = NEED_TO_BE_WAKER;
+            atomic { waker_pending = true }
 
-            /* WaitForWaker parks while the state is BLOCKING or SLEEP. Once
-             * the waker releases this worker, continue with the queue rather
-             * than attempting to claim another reduction. */
-            state[id] != BLOCKING && state[id] != SLEEP
+        :: suggested_thread_count != thread_count ->
+            resume_state[id] = NONE;
+            state[id] = NEED_TO_BE_WAKER;
+            atomic { waker_pending = true }
 
-        /* Reduction has priority over looking in the activation queue. Once
-         * the worker observes no reduction, the waker may publish one before
-         * the worker completes Pop, SetWork and the credit decrement. */
-        :: reductions == 0 -> skip
-        fi;
-
-        if
-        :: atomic {
-            queued_activations > 0 ->
-            queued_activations--
-        };
-            state[id] = WORK;
+        :: reductions == 0 && suggested_thread_count == thread_count &&
+                queued_activations > 0 ->
             atomic {
+                queued_activations > 0 ->
+                queued_activations--;
                 assert(activation_credits > 0);
-                activation_credits--
+                activation_credits--;
+                resume_state[id] = WORK;
+                state[id] = WORK
             }
-        :: queued_activations == 0 && activation_credits > 0 ->
-            /* A producer published a credit but has not pushed yet, or
-             * another worker popped the corresponding activation. */
-            skip
-        :: activation_credits == 0 ->
-            state[id] = SPIN;
-            request_waker()
+
+        :: reductions == 0 && suggested_thread_count == thread_count &&
+                activation_credits == 0 ->
+            resume_state[id] = SPIN;
+            state[id] = NEED_TO_BE_WAKER;
+            atomic { waker_pending = true }
         fi
 
     :: state[id] == SPIN && activation_credits > 0 ->
         atomic {
             if
-            :: state[id] == SPIN && activation_credits > 0 -> state[id] = NONE
+            :: state[id] == SPIN && activation_credits > 0 ->
+                resume_state[id] = NONE;
+                state[id] = NONE
             :: else -> skip
             fi
         }
 
-    /* BLOCKING and SLEEP are parked; only the waker changes them. */
-    od
-}
-
-proctype Producer() {
-    do
-    :: atomic {
-        activation_credits < MAX_QUEUE ->
-        activation_credits++
-    };
-        atomic {
-            queued_activations++
-        };
-        if
-        :: sleeping_count > 0 -> request_waker()
-        :: else -> skip
-        fi
-    od
-}
-
-proctype Controller() {
-    bit counter = 0;
-
-    do
-    :: counter == 0 ->
-        awake_workers == suggested_thread_count;
-        check_safety();
-        counter = 1
-
-    :: counter == 1 ->
-        check_safety();
-        atomic {
+    :: state[id] == NEED_TO_BE_WAKER ->
+        done = false;
+        do
+        :: !done ->
+            owner = waker_worker_id;
             if
-            :: suggested_thread_count == 1 -> suggested_thread_count = N
-            :: suggested_thread_count == N -> suggested_thread_count = 1
-            fi;
-            counter = 0
+            :: owner == INVALID_WAKER ->
+                atomic {
+                    if
+                    :: waker_worker_id == INVALID_WAKER &&
+                            state[id] == NEED_TO_BE_WAKER ->
+                        waker_worker_id = id;
+                        state[id] = WAKER;
+                        done = true
+                    :: else -> skip
+                    fi
+                }
+
+            :: owner < N && owner != id ->
+                atomic {
+                    if
+                    :: state[owner] == WAKER ->
+                        state[owner] = NEED_TO_BE_WAKER;
+                        state[id] = resume_state[id];
+                        done = true
+                    :: state[owner] == NEED_TO_BE_WAKER ->
+                        state[id] = resume_state[id];
+                        done = true
+                    :: else -> skip
+                    fi
+                }
+
+            :: owner == id ->
+                atomic {
+                    if
+                    :: state[id] == NEED_TO_BE_WAKER ->
+                        state[id] = WAKER;
+                        done = true
+                    :: state[id] == WAKER ->
+                        done = true
+                    fi
+                }
+            fi
+        :: else -> break
+        od;
+        assert(done)
+
+    :: state[id] == WAKER && waker_worker_id == id ->
+        atomic {
+            assert(waker_passes == 0);
+            waker_passes = 1;
+            waker_pending = false
         };
-        request_waker()
-    od
-}
 
-proctype Waker() {
-    byte desired;
-    byte i;
-    byte delta;
-    byte converted;
-    byte remaining_reductions;
-    byte previous_reductions;
-    byte taken_tokens_to_sleep;
-    byte taken_tokens_to_wakeup;
-    byte eligible_sleepers;
-    byte previous_activations;
-    byte activations;
-    byte sleep_workers;
-    bool found;
-
-    do
-    :: waker_pending ->
-        /* SleepingCount is withdrawn while the waker recomputes it. Producers
-         * which publish during this window deliberately observe zero. */
-        sleeping_count = 0;
-
-        waker_pending = false;
+        /* Reconcile the latest target. Sleeping identities are symmetric:
+         * sleeping_count is derived from thread_count and awake_workers, and
+         * any SLEEP worker may represent an eligible sleeping slot. */
         desired = suggested_thread_count;
-
-        /* Exchange the published reduction tokens. The difference from the
-         * previous publication was claimed by workers which are either
-         * BLOCKING already or are between the claim and that state change. */
         atomic {
-            remaining_reductions = reductions;
-            reductions = 0;
-            assert(remaining_reductions <= N);
-            assert(previous_reductions <= N);
-            assert(taken_tokens_to_sleep <= N);
-            assert(taken_tokens_to_wakeup <= N);
-            assert(previous_reductions >= remaining_reductions);
-            assert(taken_tokens_to_sleep + previous_reductions <= N);
-            taken_tokens_to_sleep = (taken_tokens_to_sleep
-                + previous_reductions) - remaining_reductions;
-            assert(taken_tokens_to_sleep <= N);
-            previous_reductions = 0
-        };
-
-        /* The waker owns all mutable values in this reconciliation block.
-         * thread_count is the previously accepted target, awake_workers is
-         * the number of workers outside Sleep, and sleep_workers is the total
-         * number of workers in Sleep. */
-        atomic {
-            assert((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep >= awake_workers);
-            eligible_sleepers = ((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep) - awake_workers;
-
             if
-            :: desired > thread_count ->
-                delta = desired - thread_count;
-
-                if
-                :: taken_tokens_to_sleep < delta -> converted = taken_tokens_to_sleep
-                :: else -> converted = delta
-                fi;
-                taken_tokens_to_sleep = taken_tokens_to_sleep - converted;
-                assert(taken_tokens_to_wakeup + converted <= N);
-                taken_tokens_to_wakeup = taken_tokens_to_wakeup + converted;
-                delta = delta - converted;
-
-                if
-                :: remaining_reductions < delta -> converted = remaining_reductions
-                :: else -> converted = delta
-                fi;
-                remaining_reductions = remaining_reductions - converted;
-                delta = delta - converted;
-
-                /* Growth makes existing sleepers eligible for wakeup without
-                 * assigning that eligibility to concrete worker identities. */
-                delta = 0
-
             :: desired < thread_count ->
                 delta = thread_count - desired;
                 if
-                :: taken_tokens_to_wakeup < delta -> converted = taken_tokens_to_wakeup
+                :: sleeping_count < delta -> converted = sleeping_count
                 :: else -> converted = delta
                 fi;
-                taken_tokens_to_wakeup = taken_tokens_to_wakeup - converted;
-                assert(taken_tokens_to_sleep + converted <= N);
-                taken_tokens_to_sleep = taken_tokens_to_sleep + converted;
                 delta = delta - converted;
+                assert(reductions + delta <= N);
+                reductions = reductions + delta;
+                thread_count = desired
 
-                /* Retire already sleeping slots before asking an awake worker
-                 * to claim a new reduction token. */
+            :: desired > thread_count ->
+                delta = desired - thread_count;
                 if
-                :: eligible_sleepers < delta -> converted = eligible_sleepers
+                :: reductions < delta -> converted = reductions
                 :: else -> converted = delta
                 fi;
+                reductions = reductions - converted;
                 delta = delta - converted;
-                assert(remaining_reductions + delta <= N);
-                remaining_reductions = remaining_reductions + delta;
-                delta = 0
+                assert(claimed_reductions >= cancelled_claimed_reductions);
+                if
+                :: claimed_reductions - cancelled_claimed_reductions < delta ->
+                    converted = claimed_reductions -
+                        cancelled_claimed_reductions
+                :: else -> converted = delta
+                fi;
+                assert(cancelled_claimed_reductions + converted <= N);
+                cancelled_claimed_reductions =
+                    cancelled_claimed_reductions + converted;
+                delta = delta - converted;
+                thread_count = desired
 
             :: else -> skip
             fi;
-            thread_count = desired;
-            assert((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep >= awake_workers);
-            assert(((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep) - awake_workers <= sleep_workers);
-            assert(taken_tokens_to_sleep <= N);
-            assert(taken_tokens_to_wakeup <= N);
-            assert(remaining_reductions <= N);
-            assert(sleep_workers <= N);
-            assert(awake_workers <= N);
-            converted = 0;
-            eligible_sleepers = 0
+            sleeping_count = 0;
+            delta = 0;
+            converted = 0
         };
 
-        previous_activations = activation_credits;
-        activations = previous_activations;
+        budget = activation_credits;
 
-        /* Resolve workers which claimed reductions published by an earlier
-         * pass. Reductions for the new target are not visible yet, so a
-         * worker which becomes BLOCKING after this loop is deferred until the
-         * next waker pass, matching the ordering in WakerLoop(). */
+        /* Account for workers which are already searching before changing
+         * SPIN/BLOCKING states. The budget is local and never reserves the
+         * corresponding queue item. */
         i = 0;
         do
         :: i < N ->
             if
-            :: state[i] == BLOCKING ->
-                if
-                :: taken_tokens_to_wakeup > 0 ->
-                    if
-                    :: activations > 0 ->
-                        atomic {
-                            state[i] = NONE;
-                            taken_tokens_to_wakeup--
-                        };
-                        activations--
-                    :: activations == 0 ->
-                        atomic {
-                            assert(awake_workers > 0);
-                            assert(sleep_workers < N);
-                            state[i] = SLEEP;
-                            awake_workers--;
-                            sleep_workers++;
-                            taken_tokens_to_wakeup--
-                        }
-                    fi
-
-                :: taken_tokens_to_wakeup == 0 ->
-                    assert(taken_tokens_to_sleep > 0);
-                    atomic {
-                        assert(awake_workers > 0);
-                        assert(sleep_workers < N);
-                        state[i] = SLEEP;
-                        awake_workers--;
-                        sleep_workers++;
-                        taken_tokens_to_sleep--
-                    }
-                fi
-
+            :: i != id && state[i] == NONE && budget > 0 -> budget--
             :: else -> skip
             fi;
             i++
         :: else -> break
         od;
 
-        /* C++ publishes CheckToSleepWorkers before it computes the activation
-         * budget and scans SPIN workers. Claims made from this publication are
-         * intentionally handled by the next pass. */
-        atomic {
-            reductions = remaining_reductions;
-            previous_reductions = remaining_reductions
-        };
-
-        /* Resolve every active worker once. activations is a local budget: a
-         * NONE worker, or a worker which leaves SPIN by itself, consumes one
-         * unit without reserving the corresponding queue item. */
         i = 0;
         do
         :: i < N ->
             if
-            :: state[i] == NONE ->
+            :: i != id && state[i] == SPIN ->
                 if
-                :: activations > 0 -> activations--
-                :: else -> skip
-                fi
-
-            :: state[i] == SPIN ->
-                if
-                :: activations > 0 ->
+                :: budget > 0 ->
                     atomic {
                         if
                         :: state[i] == SPIN ->
+                            resume_state[i] = NONE;
                             state[i] = NONE;
-                            activations--
-                        :: else ->
-                            assert(state[i] == NONE || state[i] == WORK || state[i] == BLOCKING);
-                            if
-                            :: state[i] == NONE || state[i] == WORK -> activations--
-                            :: state[i] == BLOCKING -> skip
-                            fi
+                            budget--
+                        :: else -> skip
                         fi
                     }
-
-                :: activations == 0 ->
+                :: budget == 0 ->
                     atomic {
                         if
                         :: state[i] == SPIN ->
-                            assert(awake_workers > 0);
-                            assert(sleep_workers < N);
+                            resume_state[i] = SLEEP;
                             state[i] = SLEEP;
+                            assert(awake_workers > 0);
                             awake_workers--;
                             sleep_workers++
-                        :: else ->
-                            assert(state[i] == NONE || state[i] == WORK || state[i] == BLOCKING)
+                        :: else -> skip
                         fi
                     }
                 fi
 
+            :: i != id && state[i] == BLOCKING ->
+                if
+                :: cancelled_claimed_reductions > 0 && budget > 0 ->
+                    atomic {
+                        if
+                        :: state[i] == BLOCKING ->
+                            assert(claimed_reductions > 0);
+                            claimed_reductions--;
+                            cancelled_claimed_reductions--;
+                            resume_state[i] = NONE;
+                            state[i] = NONE;
+                            budget--
+                        :: else -> skip
+                        fi
+                    }
+                :: cancelled_claimed_reductions > 0 && budget == 0 ->
+                    atomic {
+                        if
+                        :: state[i] == BLOCKING ->
+                            assert(claimed_reductions > 0);
+                            claimed_reductions--;
+                            cancelled_claimed_reductions--;
+                            resume_state[i] = SLEEP;
+                            state[i] = SLEEP;
+                            assert(awake_workers > 0);
+                            awake_workers--;
+                            sleep_workers++
+                        :: else -> skip
+                        fi
+                    }
+                :: cancelled_claimed_reductions == 0 ->
+                    atomic {
+                        if
+                        :: state[i] == BLOCKING ->
+                            assert(claimed_reductions > 0);
+                            claimed_reductions--;
+                            resume_state[i] = SLEEP;
+                            state[i] = SLEEP;
+                            assert(awake_workers > 0);
+                            awake_workers--;
+                            sleep_workers++
+                        :: else -> skip
+                        fi
+                    }
+                fi
             :: else -> skip
             fi;
             i++
         :: else -> break
         od;
 
-        /* Only the waker mutates SLEEP. Any sleeping worker may consume an
-         * eligible sleeping slot because worker identities are symmetric. */
-        i = 0;
+        /* Wake eligible sleepers until the activation budget is covered. A
+         * worker temporarily in NEED_TO_BE_WAKER remains counted and will be
+         * resolved by either this owner or the next owner. */
         do
-        :: activations > 0 && ((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep) > awake_workers ->
+        :: budget > 0 && thread_count > awake_workers ->
+            found = false;
+            i = 0;
             atomic {
-                found = false;
-                i = 0;
                 do
                 :: i < N && !found ->
                     if
-                    :: state[i] == SLEEP ->
-                        assert(awake_workers < N);
-                        assert(sleep_workers > 0);
+                    :: i != id && state[i] == SLEEP ->
                         state[i] = NONE;
-                        awake_workers++;
+                        resume_state[i] = NONE;
+                        assert(sleep_workers > 0);
                         sleep_workers--;
-                        activations--;
+                        awake_workers++;
+                        budget--;
                         found = true
                     :: else -> skip
                     fi;
                     i++
                 :: else -> break
-                od;
-                assert(found)
-            }
+                od
+            };
+            if
+            :: found -> skip
+            /* The eligible sleeper is the current owner or a worker which is
+             * temporarily participating in election. */
+            :: !found -> break
+            fi
         :: else -> break
         od;
 
-        /* Recompute the number of eligible sleepers. Reductions were already
-         * published before the worker scan; previous_reductions remains the
-         * baseline used to detect claims on the next pass. */
+        /* Treat the owner as its saved logical state while its public state
+         * is WAKER/NEED_TO_BE_WAKER. */
+        if
+        :: resume_state[id] == BLOCKING ->
+            assert(claimed_reductions > 0);
+            if
+            :: cancelled_claimed_reductions > 0 && budget > 0 ->
+                atomic {
+                    claimed_reductions--;
+                    cancelled_claimed_reductions--
+                };
+                final = NONE;
+                budget--
+            :: cancelled_claimed_reductions > 0 && budget == 0 ->
+                atomic {
+                    claimed_reductions--;
+                    cancelled_claimed_reductions--
+                };
+                final = SLEEP
+            :: cancelled_claimed_reductions == 0 ->
+                claimed_reductions--;
+                final = SLEEP
+            fi
+        :: resume_state[id] != BLOCKING && budget > 0 ->
+            final = NONE;
+            budget--
+        :: resume_state[id] != BLOCKING && budget == 0 ->
+            if
+            :: resume_state[id] == NONE || resume_state[id] == WORK ->
+                final = NONE
+            :: else -> final = SLEEP
+            fi
+        fi;
+
         atomic {
-            assert((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep >= awake_workers);
-            eligible_sleepers = ((thread_count + remaining_reductions)
-                + taken_tokens_to_sleep) - awake_workers;
-            assert(eligible_sleepers <= sleep_workers)
+            if
+            :: resume_state[id] == SLEEP && final != SLEEP ->
+                assert(sleep_workers > 0);
+                sleep_workers--;
+                awake_workers++
+            :: resume_state[id] != SLEEP && final == SLEEP ->
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++
+            :: else -> skip
+            fi;
+            resume_state[id] = final;
+            if
+            :: thread_count > awake_workers ->
+                sleeping_count = thread_count - awake_workers
+            :: else -> sleeping_count = 0
+            fi
         };
+
         atomic {
-            sleeping_count = eligible_sleepers;
-            eligible_sleepers = 0
+            assert(waker_passes == 1);
+            waker_passes = 0
         };
 
         if
-        :: activation_credits > previous_activations -> request_waker()
-        :: else -> skip
+        :: state[id] == NEED_TO_BE_WAKER ->
+            atomic {
+                state[id] == NEED_TO_BE_WAKER -> state[id] = WAKER
+            }
+
+        :: state[id] == WAKER ->
+            atomic {
+                assert(waker_worker_id == id);
+                waker_worker_id = INVALID_WAKER
+            };
+            published = false;
+            publish_waker_final(id, final, published)
         fi;
 
-        check_safety();
-        atomic {
-            assert(awake_workers == N - sleep_workers)
-        }
+        check_local_safety()
+
+    /* SLEEP and BLOCKING are parked. Changing either state to
+     * NEED_TO_BE_WAKER models the matching Unpark(). */
     od
 }
 
-/* With MAX_QUEUE == 2, express queue progress directly without an observer
- * epoch: one queued activation must eventually become zero or two, while a
- * full queue must eventually lose an activation. */
-ltl live_queue_changes {
-    ([] (queued_activations == 1 ->
-        <> (queued_activations == 0 || queued_activations == 2))) &&
-    ([] (queued_activations == 2 -> <> (queued_activations == 1)))
+proctype Producer() {
+    byte owner;
+    byte i;
+    byte round = 0;
+    bool notify;
+    bool done;
+    bool found;
+
+    do
+    :: round < PRODUCER_ROUNDS ->
+        atomic {
+        activation_credits < MAX_QUEUE -> activation_credits++
+        };
+        atomic { queued_activations++ };
+
+        notify = false;
+        if
+        :: sleeping_count > 0 ->
+            atomic {
+                if
+                :: !waker_pending ->
+                    waker_pending = true;
+                    notify = true
+                :: else -> skip
+                fi
+            }
+        :: else -> skip
+        fi;
+
+        if
+        :: notify ->
+            done = false;
+            do
+            :: !done ->
+                owner = waker_worker_id;
+                if
+                :: owner < N ->
+                    atomic {
+                        if
+                        :: state[owner] == WAKER ->
+                            state[owner] = NEED_TO_BE_WAKER;
+                            done = true
+                        :: state[owner] == NEED_TO_BE_WAKER ->
+                            done = true
+                        :: else -> skip
+                        fi
+                    }
+
+                :: owner == INVALID_WAKER ->
+                    if
+                    :: sleeping_count > 0 ->
+                        found = false;
+                        i = 0;
+                        do
+                        :: i < N && !found ->
+                            atomic {
+                                if
+                                :: waker_worker_id == INVALID_WAKER &&
+                                        (state[i] == SPIN ||
+                                            state[i] == BLOCKING ||
+                                            state[i] == SLEEP) ->
+                                    state[i] = NEED_TO_BE_WAKER;
+                                    found = true;
+                                    done = true
+                                :: else -> skip
+                                fi
+                            };
+                            i++
+                        :: else -> break
+                        od;
+                        if
+                        :: found -> skip
+                        :: !found ->
+                            /* A counted sleeper may already be between its
+                             * candidate transition and index publication. */
+                            i = 0;
+                            do
+                            :: i < N && !done ->
+                                if
+                                :: resume_state[i] == SLEEP &&
+                                        (state[i] == NEED_TO_BE_WAKER ||
+                                            state[i] == WAKER) ->
+                                    done = true
+                                :: else -> skip
+                                fi;
+                                i++
+                            :: else -> break
+                            od;
+                            if
+                            :: done -> skip
+                            :: else ->
+                                atomic {
+                                    if
+                                    :: waker_worker_id == INVALID_WAKER ->
+                                        waker_pending = false;
+                                        done = true
+                                    :: else -> skip
+                                    fi
+                                }
+                            fi
+                        fi
+
+                    :: sleeping_count == 0 ->
+                        atomic {
+                            if
+                            :: waker_worker_id == INVALID_WAKER &&
+                                    sleeping_count == 0 ->
+                                waker_pending = false;
+                                done = true
+                            :: else -> skip
+                            fi
+                        }
+                    fi
+                fi
+            :: else -> break
+            od
+        :: else -> skip
+        fi;
+
+        check_local_safety();
+        round++
+    :: else -> break
+    od
+}
+
+proctype Controller() {
+    byte round = 0;
+    byte owner;
+    byte i;
+    bool found;
+
+    do
+    :: round < CONTROLLER_ROUNDS ->
+        atomic {
+            if
+            :: suggested_thread_count == N -> suggested_thread_count = 1
+            :: suggested_thread_count == 1 -> suggested_thread_count = N
+            fi;
+            waker_pending = true
+        };
+
+        owner = waker_worker_id;
+        if
+        :: owner < N ->
+            atomic {
+                if
+                :: state[owner] == WAKER ->
+                    state[owner] = NEED_TO_BE_WAKER
+                :: state[owner] == NEED_TO_BE_WAKER -> skip
+                :: else -> skip
+                fi
+            }
+        :: owner == INVALID_WAKER ->
+            found = false;
+            i = 0;
+            do
+            :: i < N && !found ->
+                atomic {
+                    if
+                    :: waker_worker_id == INVALID_WAKER &&
+                            (state[i] == SPIN || state[i] == BLOCKING ||
+                                state[i] == SLEEP) ->
+                        state[i] = NEED_TO_BE_WAKER;
+                        found = true
+                    :: else -> skip
+                    fi
+                };
+                i++
+            :: else -> break
+            od
+        fi;
+        round++
+    :: else -> break
+    od
 }
 
 init {
@@ -448,6 +659,7 @@ init {
         do
         :: i < N ->
             state[i] = WORK;
+            resume_state[i] = WORK;
             run Worker(i);
             i++
         :: else -> break
@@ -459,7 +671,6 @@ init {
             i++
         :: else -> break
         od;
-        run Controller();
-        run Waker()
+        run Controller()
     }
 }

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -6,7 +6,7 @@
  *  - SuggestedThreadCount updates by the controller;
  *  - ThreadCount and CheckToSleepWorkers updates owned by the waker;
  *  - workers preferring a reduction request over taking an activation;
- *  - independent infinite producers keeping the queue bounded by N + 1;
+ *  - independent infinite producers keeping the queue bounded by MAX_QUEUE;
  *  - None -> Blocking -> Sleep and immediate parking;
  *  - waker-local ActiveMask and sleeping-stack membership;
  *  - SleepingCount containing active sleeping workers only;
@@ -20,7 +20,7 @@
 
 #define N 2
 #define PRODUCERS 2
-#define MAX_QUEUE (N + 1)
+#define MAX_QUEUE N
 #define NONE 0
 #define SPIN 1
 #define SLEEP 2

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -57,35 +57,6 @@ byte waker_delta = 0;
 byte waker_converted = 0;
 byte waker_remaining_reductions = 0;
 
-inline check_safety() {
-    atomic {
-        assert(waker_worker_id <= INVALID_WAKER);
-        assert(worker_state[0] <= WAKER);
-        assert(worker_state[1] <= WAKER);
-        assert(sleeping_count <= N);
-        assert(awake_workers <= N);
-        assert(sleep_workers <= N);
-        assert(awake_workers + sleep_workers == N);
-        assert(thread_count >= 1 && thread_count <= N);
-        assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
-        assert((reductions & REDUCTION_COUNT_MASK) <= N);
-        assert(reductions < 2 * REDUCTION_WAKER_BIT);
-        assert(previous_reductions <= N);
-        assert(taken_tokens_to_sleep <= N);
-        assert(taken_tokens_to_wakeup <= N);
-        assert(taken_tokens_to_sleep + taken_tokens_to_wakeup <= N);
-        assert(waker_previous_sleeping <= N);
-        assert(activation_credits <= MAX_QUEUE);
-        assert(queued_activations <= activation_credits);
-        if
-        :: waker_worker_id < N ->
-            assert(worker_state[waker_worker_id] == WAKER ||
-                IS_NEED(worker_state[waker_worker_id]))
-        :: else -> skip
-        fi
-    }
-}
-
 /* One non-blocking attempt to notify or select a waker. */
 inline try_request_waker(candidate, notified, require_sleepers) {
     if
@@ -198,7 +169,7 @@ inline reconcile_workers(id, resume_state) {
                 (waker_i == id && (resume_state == NEED || resume_state == NONE)) ->
             if 
             :: waker_i != id -> worker_state[waker_i] = NONE;
-            :: else -> resume_state == NONE
+            :: else -> resume_state = NONE
             fi
             if
             :: waker_budget > 0 -> waker_budget--
@@ -274,7 +245,7 @@ inline reconcile_workers(id, resume_state) {
         :: else -> skip
         fi
         if
-        :: waker_i < N ->
+        :: waker_i < N - 1 ->
             waker_i++;
         :: else ->
             waker_i = 0;
@@ -286,7 +257,7 @@ inline reconcile_workers(id, resume_state) {
 
 inline wake_sleeping_workers(id, resume_state) {
     do
-    :: atomic { true ->
+    :: atomic { waker_budget > 0 ->
         waker_i = 0;
         do
         :: waker_i < N ->
@@ -311,9 +282,11 @@ inline wake_sleeping_workers(id, resume_state) {
         if
         :: waker_budget == 0 || waker_previous_sleeping == 0 ->
             waker_budget = 0;
+            break
         :: else -> skip
         fi
     }
+    :: else -> break
     od
 }
 
@@ -343,17 +316,17 @@ inline run_waker_pass(id, resume_state) {
         previous_reductions = 0
     };
     reconcile_thread_count();
+    atomic {
+        waker_previous_activations = activation_credits;
+        waker_budget = waker_previous_activations;
+    }
+    reconcile_workers(id, resume_state);
     atomic { // cas reductions
         assert((reductions & REDUCTION_COUNT_MASK) == 0);
         reductions = waker_remaining_reductions; // reset REDUCTION_WAKER_BIT (because we have waker_pending)
         previous_reductions = waker_remaining_reductions;
         waker_remaining_reductions = 0
     };
-    atomic {
-        waker_previous_activations = activation_credits;
-        waker_budget = waker_previous_activations;
-    }
-    reconcile_workers(id, resume_state);
     wake_sleeping_workers(id, resume_state);
     atomic {
         sleeping_count = waker_previous_sleeping;
@@ -378,8 +351,8 @@ inline run_waker(id, resume_state) {
     :: atomic { waker_worker_id == INVALID_WAKER ->
         waker_worker_id = id;
     }
+        run_waker_acquire_save_state_label:
         atomic {
-            run_waker_acquire_save_state_label:
             if
             :: IS_SLEEP(worker_state[id]) -> resume_state = SLEEP
             :: IS_BLOCKING(worker_state[id]) -> resume_state = BLOCKING
@@ -415,8 +388,12 @@ inline run_waker(id, resume_state) {
             if
             :: !IS_NEED(worker_state[id]) ->
                 break
-            :: else ->
-                worker_state[id] = resume_state;
+            :: worker_state[id] == NEED_FROM_SLEEP ->
+                worker_state[id] = SLEEP;
+            :: worker_state[id] == NEED_FROM_BLOCKING ->
+                worker_state[id] = BLOCKING
+            :: worker_state[id] == NEED ->
+                worker_state[id] = NONE
             fi
         }
     od;
@@ -490,7 +467,7 @@ pop_activation:
     if
     :: atomic { activation_credits > 0 -> goto worker_iteration }
     :: activation_credits == 0 ->
-        resume_state = SPIN;
+        worker_state[id] = SPIN;
         if
         :: atomic { !waker_pending ->
             waker_pending = true;
@@ -648,8 +625,7 @@ proctype Controller() {
         atomic {
             i = 0;
             notified = false;
-            notify = false;
-            round++
+            notify = false
         }
     od
 }

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -16,19 +16,23 @@
 #define WORK 3
 #define BLOCKING 4
 #define NEED 5
-#define NEED_FROM_SLEEP 6
-#define NEED_FROM_BLOCKING 7
-#define WAKER 8
+#define NEED_FROM_SPIN 6
+#define NEED_FROM_SLEEP 7
+#define NEED_FROM_BLOCKING 8
+#define WAKER 9
 
-#define IS_NEED(s) ((s) == NEED || \
+#define IS_NEED(s) ((s) == NEED || (s) == NEED_FROM_SPIN || \
     (s) == NEED_FROM_SLEEP || (s) == NEED_FROM_BLOCKING)
-#define IS_SPIN(s) ((s) == SPIN)
+#define IS_SPIN(s) ((s) == SPIN || (s) == NEED_FROM_SPIN)
 #define IS_SLEEP(s) ((s) == SLEEP || (s) == NEED_FROM_SLEEP)
 #define IS_BLOCKING(s) ((s) == BLOCKING || (s) == NEED_FROM_BLOCKING)
 #define IS_PARKED(s) ((s) == SLEEP || (s) == BLOCKING)
 #define ALL_WORKERS_PARKED \
     (worker_parked[0] && IS_PARKED(worker_state[0]) && \
         worker_parked[1] && IS_PARKED(worker_state[1]))
+#define ALL_WORKERS_SLEEPING \
+    (worker_parked[0] && worker_state[0] == SLEEP && \
+        worker_parked[1] && worker_state[1] == SLEEP)
 
 #define INVALID_WAKER N
 #define REDUCTION_WAKER_BIT 4
@@ -82,7 +86,7 @@ inline try_request_waker(candidate, notified, require_sleepers) {
             :: worker_state[candidate] == WAKER || IS_NEED(worker_state[candidate]) ->
                 notified = true
             :: worker_state[candidate] == SPIN ->
-                worker_state[candidate] = NEED;
+                worker_state[candidate] = NEED_FROM_SPIN;
                 notified = true
             :: worker_state[candidate] == SLEEP ->
                 worker_state[candidate] = NEED_FROM_SLEEP;
@@ -176,10 +180,16 @@ inline reconcile_workers(id, resume_state) {
             resume_state = NONE
         :: waker_i != id && IS_SPIN(worker_state[waker_i]) ->
             if
-            :: waker_budget > 0 ->
+            :: waker_remaining_reductions > 0 ->
+                worker_state[waker_i] = SLEEP;
+                waker_remaining_reductions--;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++
+            :: waker_remaining_reductions == 0 && waker_budget > 0 ->
                 worker_state[waker_i] = NONE;
                 waker_budget--
-            :: waker_budget == 0 ->
+            :: waker_remaining_reductions == 0 && waker_budget == 0 ->
                 worker_state[waker_i] = SLEEP;
                 assert(awake_workers > 0);
                 awake_workers--;
@@ -188,9 +198,15 @@ inline reconcile_workers(id, resume_state) {
             fi
         :: waker_i == id && IS_SPIN(resume_state) ->
             if
-            :: waker_budget > 0 ->
+            :: waker_remaining_reductions > 0 ->
+                resume_state = SLEEP;
+                waker_remaining_reductions--;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++
+            :: waker_remaining_reductions == 0 && waker_budget > 0 ->
                 resume_state = NONE;
-            :: waker_budget == 0 ->
+            :: waker_remaining_reductions == 0 && waker_budget == 0 ->
                 resume_state = SLEEP;
                 assert(awake_workers > 0);
                 awake_workers--;
@@ -357,7 +373,8 @@ inline run_waker(id, resume_state) {
             if
             :: IS_SLEEP(worker_state[id]) -> resume_state = SLEEP
             :: IS_BLOCKING(worker_state[id]) -> resume_state = BLOCKING
-            :: worker_state[id] == NONE || worker_state[id] == SPIN || worker_state[id] == NEED -> resume_state = NONE
+            :: worker_state[id] == NONE || worker_state[id] == NEED -> resume_state = NONE
+            :: IS_SPIN(worker_state[id]) -> resume_state = SPIN
             :: else -> skip
             fi;
             worker_state[id] = WAKER
@@ -394,6 +411,8 @@ inline run_waker(id, resume_state) {
                 worker_state[id] = SLEEP;
             :: worker_state[id] == NEED_FROM_BLOCKING ->
                 worker_state[id] = BLOCKING
+            :: worker_state[id] == NEED_FROM_SPIN ->
+                worker_state[id] = SPIN
             :: worker_state[id] == NEED ->
                 worker_state[id] = NONE
             fi
@@ -483,7 +502,7 @@ pop_activation:
             atomic {
                 if
                 :: worker_state[id] == SPIN ->
-                    worker_state[id] = NEED
+                    worker_state[id] = NEED_FROM_SPIN
                 :: worker_state[id] == SLEEP ->
                     worker_state[id] = NEED_FROM_SLEEP
                 :: worker_state[id] == NONE ->
@@ -515,17 +534,21 @@ settle_waker_state:
                 fi
             }
         :: activation_credits == 0 ->
-            worker_state[id] != SPIN || activation_credits > 0 || reductions > 0
+            worker_state[id] != SPIN || activation_credits > 0 ||
+                (reductions & REDUCTION_WAKER_BIT);
             if
-            :: reductions > 0 ->
+            :: reductions & REDUCTION_WAKER_BIT ->
                 atomic {
                     if
-                    :: worker_state[id] == BLOCKING || worker_state[id] == SPIN -> worker_state[id] = NONE
-                    :: worker_state[id] == SLEEP -> goto sleep_state_label
-                    :: IS_NEED(worker_state[id]) -> goto settle_waker_state
+                    :: worker_state[id] == SPIN ->
+                        worker_state[id] = NONE
+                    :: worker_state[id] == SLEEP ->
+                        goto sleep_state_label
+                    :: IS_NEED(worker_state[id]) ->
+                        goto settle_waker_state
                     :: else -> skip
                     fi
-                }
+                };
                 goto check_blocking
             :: else -> goto settle_waker_state
             fi
@@ -708,6 +731,12 @@ proctype FinalStateChecker() {
     ([] ((waker_pending && producer_epoch == p) -> \
         <> (!waker_pending || producer_epoch != p)))
 
+#define ZERO_ACTIVATIONS_SETTLES_WITH_EPOCHS(p, c) \
+    ([] ((activation_credits == 0 && producer_epoch == p && \
+            controller_epoch == c) -> \
+        <> (ALL_WORKERS_SLEEPING || activation_credits != 0 || \
+            producer_epoch != p || controller_epoch != c)))
+
 ltl live_resize_reconciles {
     RESIZE_RECONCILES_WITH_EPOCHS(false, false) &&
     RESIZE_RECONCILES_WITH_EPOCHS(false, true) &&
@@ -729,6 +758,13 @@ ltl live_queue_changes {
 ltl live_waker_pending_clears {
     WAKER_PENDING_CLEARS_WITH_PRODUCER_EPOCH(false) &&
     WAKER_PENDING_CLEARS_WITH_PRODUCER_EPOCH(true)
+}
+
+ltl live_zero_activations_sleep {
+    ZERO_ACTIVATIONS_SETTLES_WITH_EPOCHS(false, false) &&
+    ZERO_ACTIVATIONS_SETTLES_WITH_EPOCHS(false, true) &&
+    ZERO_ACTIVATIONS_SETTLES_WITH_EPOCHS(true, false) &&
+    ZERO_ACTIVATIONS_SETTLES_WITH_EPOCHS(true, true)
 }
 
 init {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -37,8 +37,6 @@ byte reductions = 0;
 byte activation_credits = 0;
 byte queued_activations = 0;
 bool waker_pending = false;
-bool work_epoch = false;
-bool queue_epoch = false;
 
 inline request_waker() {
     atomic {
@@ -64,10 +62,7 @@ inline check_safety() {
 proctype Worker(byte id) {
     do
     :: state[id] == WORK ->
-        atomic {
-            state[id] = NONE;
-            work_epoch = !work_epoch
-        }
+        state[id] = NONE
 
     :: state[id] == NONE ->
         if
@@ -92,8 +87,7 @@ proctype Worker(byte id) {
         if
         :: atomic {
             queued_activations > 0 ->
-            queued_activations--;
-            queue_epoch = !queue_epoch
+            queued_activations--
         };
             state[id] = WORK;
             atomic {
@@ -120,8 +114,7 @@ proctype Producer() {
         activation_credits++
     };
         atomic {
-            queued_activations++;
-            queue_epoch = !queue_epoch
+            queued_activations++
         };
         if
         :: sleeping_count > 0 -> request_waker()
@@ -406,22 +399,13 @@ proctype Waker() {
     od
 }
 
-#define target_one (suggested_thread_count == 1)
-#define target_max (suggested_thread_count == N)
-#define reconciled_one (thread_count == 1 && awake_workers + sleeping_count == 1 && reductions == 0)
-#define reconciled_max (thread_count == N && awake_workers + sleeping_count == N && reductions == 0)
-ltl live_reconcile_stable {
-    ((<>[] target_one) ->
-        ((<>[] reconciled_one) && ([]<> work_epoch) && ([]<> !work_epoch))) &&
-    ((<>[] target_max) ->
-        ((<>[] reconciled_max) && ([]<> work_epoch) && ([]<> !work_epoch)))
-}
-
-/* Once the queue is non-empty, its size must eventually change. Every queue
- * mutation is exactly one push or one pop and toggles queue_epoch atomically. */
+/* With MAX_QUEUE == 2, express queue progress directly without an observer
+ * epoch: one queued activation must eventually become zero or two, while a
+ * full queue must eventually lose an activation. */
 ltl live_queue_changes {
-    ([] ((queued_activations != 0 && !queue_epoch) -> <> queue_epoch)) &&
-    ([] ((queued_activations != 0 && queue_epoch) -> <> !queue_epoch))
+    ([] (queued_activations == 1 ->
+        <> (queued_activations == 0 || queued_activations == 2))) &&
+    ([] (queued_activations == 2 -> <> (queued_activations == 1)))
 }
 
 init {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -120,23 +120,16 @@ proctype Producer() {
 }
 
 proctype Controller() {
-    byte next;
-
     do
+    :: true -> check_safety()
     :: true ->
-        if
-        :: next = 1
-        :: next = N
-        fi;
-        if
-        :: atomic {
-            next != suggested_thread_count ->
-            suggested_thread_count = next
+        atomic {
+            if
+            :: suggested_thread_count == 1 -> suggested_thread_count = N
+            :: suggested_thread_count == N -> suggested_thread_count = 1
+            fi
         };
-            request_waker()
-        :: else -> skip
-        fi;
-        check_safety()
+        request_waker()
     od
 }
 

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -52,20 +52,24 @@ inline request_waker() {
 }
 
 inline check_safety() {
-    assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
-    assert(thread_count >= 1 && thread_count <= N);
-    assert(active_count <= N);
-    assert(sleeping_count <= active_count);
-    assert(reductions <= N);
-    assert(activation_credits <= MAX_QUEUE);
-    assert(queued_activations <= activation_credits);
+    atomic {
+        assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
+        assert(thread_count >= 1 && thread_count <= N);
+        assert(active_count <= N);
+        assert(sleeping_count <= active_count);
+        assert(reductions <= N);
+        assert(activation_credits <= MAX_QUEUE);
+        assert(queued_activations <= activation_credits)
+    }
 }
 
 proctype Worker(byte id) {
     do
     :: worker_enabled[id] && state[id] == WORK ->
-        state[id] = NONE;
-        work_epoch = !work_epoch
+        atomic {
+            state[id] = NONE;
+            work_epoch = !work_epoch
+        }
 
     :: worker_enabled[id] && state[id] == NONE ->
         if
@@ -128,8 +132,10 @@ proctype Controller() {
         :: next = N
         fi;
         if
-        :: next != suggested_thread_count ->
-            suggested_thread_count = next;
+        :: atomic {
+            next != suggested_thread_count ->
+            suggested_thread_count = next
+        };
             request_waker()
         :: else -> skip
         fi;
@@ -159,14 +165,16 @@ proctype Waker() {
         :: i < N ->
             if
             :: worker_enabled[i] && state[i] == BLOCKING ->
-                if
-                :: active_count > desired ->
-                    state[i] = SLEEP;
-                    in_sleeping_stack[i] = true;
-                    worker_enabled[i] = false;
-                    active_count--
-                :: else -> state[i] = NONE
-                fi
+                atomic {
+                    if
+                    :: active_count > desired ->
+                        state[i] = SLEEP;
+                        in_sleeping_stack[i] = true;
+                        worker_enabled[i] = false;
+                        active_count--
+                    :: else -> state[i] = NONE
+                    fi
+                }
             :: else -> skip
             fi;
             i++

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -46,6 +46,8 @@ byte taken_tokens_to_wakeup = 0;
 
 byte waker_worker_id = INVALID_WAKER;
 bool waker_pending = false;
+bool producer_epoch = false;
+bool controller_epoch = false;
 
 /* Single persistent waker scratch space. */
 byte waker_i = 0;
@@ -110,22 +112,18 @@ inline reconcile_thread_count() {
                 waker_converted = taken_tokens_to_wakeup
             :: else -> waker_converted = waker_delta
             fi;
-            taken_tokens_to_wakeup = taken_tokens_to_wakeup -
-                waker_converted;
-            taken_tokens_to_sleep = taken_tokens_to_sleep +
-                waker_converted;
+            taken_tokens_to_wakeup = taken_tokens_to_wakeup - waker_converted;
+            taken_tokens_to_sleep = taken_tokens_to_sleep + waker_converted;
             waker_delta = waker_delta - waker_converted;
             if
             :: waker_previous_sleeping < waker_delta ->
                 waker_converted = waker_previous_sleeping
             :: else -> waker_converted = waker_delta
             fi;
-            waker_previous_sleeping = waker_previous_sleeping -
-                waker_converted;
+            waker_previous_sleeping = waker_previous_sleeping - waker_converted;
             waker_delta = waker_delta - waker_converted;
             assert(waker_remaining_reductions + waker_delta <= N);
-            waker_remaining_reductions =
-                waker_remaining_reductions + waker_delta;
+            waker_remaining_reductions = waker_remaining_reductions + waker_delta;
             thread_count = waker_desired
         :: waker_desired > thread_count ->
             waker_delta = waker_desired - thread_count;
@@ -134,22 +132,18 @@ inline reconcile_thread_count() {
                 waker_converted = taken_tokens_to_sleep
             :: else -> waker_converted = waker_delta
             fi;
-            taken_tokens_to_sleep = taken_tokens_to_sleep -
-                waker_converted;
-            taken_tokens_to_wakeup = taken_tokens_to_wakeup +
-                waker_converted;
+            taken_tokens_to_sleep = taken_tokens_to_sleep - waker_converted;
+            taken_tokens_to_wakeup = taken_tokens_to_wakeup + waker_converted;
             waker_delta = waker_delta - waker_converted;
             if
             :: waker_remaining_reductions < waker_delta ->
                 waker_converted = waker_remaining_reductions
             :: else -> waker_converted = waker_delta
             fi;
-            waker_remaining_reductions = waker_remaining_reductions -
-                waker_converted;
+            waker_remaining_reductions = waker_remaining_reductions - waker_converted;
             waker_delta = waker_delta - waker_converted;
             assert(waker_previous_sleeping + waker_delta <= N);
-            waker_previous_sleeping = waker_previous_sleeping +
-                waker_delta;
+            waker_previous_sleeping = waker_previous_sleeping + waker_delta;
             thread_count = waker_desired
         :: else -> skip
         fi;
@@ -165,16 +159,14 @@ inline reconcile_workers(id, resume_state) {
     do
     :: atomic { true ->
         if
-        :: (waker_i != id && (worker_state[waker_i] == NEED || worker_state[waker_i] == NONE)) ||
-                (waker_i == id && (resume_state == NEED || resume_state == NONE)) ->
-            if 
-            :: waker_i != id -> worker_state[waker_i] = NONE;
-            :: else -> resume_state = NONE
-            fi
+        :: (waker_i != id && (worker_state[waker_i] == NEED || worker_state[waker_i] == NONE))->
+            worker_state[waker_i] = NONE;
             if
             :: waker_budget > 0 -> waker_budget--
             :: else -> skip
             fi
+        :: (waker_i == id && (resume_state == NEED || resume_state == NONE)) ->
+            resume_state = NONE
         :: waker_i != id && IS_SPIN(worker_state[waker_i]) ->
             if
             :: waker_budget > 0 ->
@@ -191,7 +183,6 @@ inline reconcile_workers(id, resume_state) {
             if
             :: waker_budget > 0 ->
                 resume_state = NONE;
-                waker_budget--
             :: waker_budget == 0 ->
                 resume_state = SLEEP;
                 assert(awake_workers > 0);
@@ -218,7 +209,6 @@ inline reconcile_workers(id, resume_state) {
                 assert(awake_workers > 0);
                 awake_workers--;
                 sleep_workers++
-            :: taken_tokens_to_wakeup == 0 && taken_tokens_to_sleep == 0 -> assert(false) // impossible
             fi
         :: waker_i == id && IS_BLOCKING(resume_state) ->
             assert(taken_tokens_to_wakeup != 0 || taken_tokens_to_sleep != 0);
@@ -226,7 +216,6 @@ inline reconcile_workers(id, resume_state) {
             :: taken_tokens_to_wakeup > 0 && waker_budget > 0 ->
                 resume_state = NONE;
                 taken_tokens_to_wakeup--;
-                waker_budget--
             :: taken_tokens_to_wakeup > 0 && waker_budget == 0 ->
                 resume_state = SLEEP;
                 taken_tokens_to_wakeup--;
@@ -240,7 +229,6 @@ inline reconcile_workers(id, resume_state) {
                 assert(awake_workers > 0);
                 awake_workers--;
                 sleep_workers++
-            :: taken_tokens_to_wakeup == 0 && taken_tokens_to_sleep == 0 -> assert(false) // impossible
             fi
         :: else -> skip
         fi
@@ -257,10 +245,10 @@ inline reconcile_workers(id, resume_state) {
 
 inline wake_sleeping_workers(id, resume_state) {
     do
-    :: atomic { waker_budget > 0 ->
+    :: atomic { waker_budget > 0 && waker_previous_sleeping > 0 ->
         waker_i = 0;
         do
-        :: waker_i < N ->
+        :: waker_i < N && waker_budget > 0 && waker_previous_sleeping > 0->
             if
             :: waker_i != id && IS_SLEEP(worker_state[waker_i]) ||
                    waker_i == id && IS_SLEEP(resume_state) ->
@@ -273,7 +261,10 @@ inline wake_sleeping_workers(id, resume_state) {
                 sleep_workers--;
                 waker_previous_sleeping--;
                 awake_workers++;
-                waker_budget--;
+                if
+                :: waker_i != id -> waker_budget--;
+                :: else ->
+                fi
             :: else -> waker_i++
             fi
         :: else -> break
@@ -286,7 +277,10 @@ inline wake_sleeping_workers(id, resume_state) {
         :: else -> skip
         fi
     }
-    :: else -> break
+    :: atomic { else ->
+        waker_budget = 0
+        break
+    }
     od
 }
 
@@ -356,6 +350,7 @@ inline run_waker(id, resume_state) {
             if
             :: IS_SLEEP(worker_state[id]) -> resume_state = SLEEP
             :: IS_BLOCKING(worker_state[id]) -> resume_state = BLOCKING
+            :: worker_state[id] == NONE || worker_state[id] == SPIN || worker_state[id] == NEED -> resume_state = NONE
             :: else -> skip
             fi;
             worker_state[id] = WAKER
@@ -364,20 +359,20 @@ inline run_waker(id, resume_state) {
         run_waker_pass(id, resume_state);
         atomic {
             if
-            :: waker_pending -> goto run_waker_acquire_save_state_label
+            :: waker_pending -> goto run_waker_pass_label
             :: else -> skip
             fi
         }
         worker_state[id] = resume_state;
         if
-        :: waker_pending -> goto run_waker_pass_label
+        :: waker_pending -> goto run_waker_acquire_save_state_label
         :: else -> skip
         fi
         waker_worker_id = INVALID_WAKER
         atomic {
             if
             :: waker_pending -> goto run_waker_again_label
-            :: else -> skip
+            :: else -> break
             fi
         }
     :: atomic { waker_worker_id == id ->
@@ -430,13 +425,29 @@ check_blocking:
     };
         worker_state[id] = BLOCKING
         if
+        :: atomic {reductions & REDUCTION_WAKER_BIT ->
+            reductions = reductions & REDUCTION_COUNT_MASK
+        }
+            atomic {
+                if
+                :: worker_state[id] == BLOCKING -> worker_state[id] = NEED_FROM_BLOCKING
+                :: worker_state[id] == SLEEP -> worker_state[id] = NEED_FROM_SLEEP
+                :: worker_state[id] == NONE -> worker_state[id] = NEED
+                :: else -> skip
+                fi
+                goto settle_waker_state
+            }
+        :: else -> skip
+        fi
+        if
         :: atomic { !waker_pending ->
             waker_pending = true;
         }
             atomic {
                 if
-                :: worker_state[id] == BLOCKING ->
-                    worker_state[id] = NEED_FROM_BLOCKING
+                :: worker_state[id] == BLOCKING -> worker_state[id] = NEED_FROM_BLOCKING
+                :: worker_state[id] == SLEEP -> worker_state[id] = NEED_FROM_SLEEP
+                :: worker_state[id] == NONE -> worker_state[id] = NEED
                 :: else -> skip
                 fi
             }
@@ -465,7 +476,10 @@ pop_activation:
     /* A producer publishes the credit before the queue item. */
     
     if
-    :: atomic { activation_credits > 0 -> goto worker_iteration }
+    :: atomic { activation_credits > 0 -> 
+        queued_activations != 0 || reductions != 0 // endless loop with activation_credits > 0 && queued_activations == 0 && reductions == 0 
+        goto worker_iteration
+    }
     :: activation_credits == 0 ->
         worker_state[id] = SPIN;
         if
@@ -503,8 +517,20 @@ settle_waker_state:
                 fi
             }
         :: activation_credits == 0 ->
-            worker_state[id] != SPIN || activation_credits > 0
-            goto settle_waker_state
+            worker_state[id] != SPIN || activation_credits > 0 || reductions > 0
+            if
+            :: reductions > 0 ->
+                atomic {
+                    if
+                    :: worker_state[id] == BLOCKING || worker_state[id] == SPIN -> worker_state[id] = NONE
+                    :: worker_state[id] == SLEEP -> goto sleep_state_label
+                    :: IS_NEED(worker_state[id]) -> goto settle_waker_state
+                    :: else -> skip
+                    fi
+                }
+                goto check_blocking
+            :: else -> goto settle_waker_state
+            fi
         fi
     :: worker_state[id] == SLEEP || worker_state[id] == BLOCKING ->
         /* Park until the waker changes the public state. */
@@ -522,10 +548,14 @@ proctype Producer() {
     bool done;
     produser_iteration:
     do
-    :: true -> break
     :: true ->
-        atomic { activation_credits < MAX_QUEUE -> activation_credits++ };
-        atomic { queued_activations++ };
+        atomic { activation_credits < MAX_QUEUE ->
+            activation_credits++
+            producer_epoch = !producer_epoch
+        };
+        atomic {
+            queued_activations++;
+        };
         if
         :: atomic { sleeping_count == 0 -> goto produser_iteration }
         :: else ->
@@ -578,12 +608,15 @@ proctype Controller() {
     bool notify;
     controller_iteration:
     do
-    :: true -> break
-    :: suggested_thread_count == thread_count ->
+    :: true ->
         atomic {
             if
-            :: suggested_thread_count == N -> suggested_thread_count = 1
-            :: suggested_thread_count == 1 -> suggested_thread_count = N
+            :: suggested_thread_count == N ->
+                suggested_thread_count = 1;
+                controller_epoch = !controller_epoch
+            :: suggested_thread_count == 1 ->
+                suggested_thread_count = N;
+                controller_epoch = !controller_epoch
             fi;
         };
         atomic {
@@ -630,15 +663,34 @@ proctype Controller() {
     od
 }
 
+#define RESIZE_RECONCILES_WITH_EPOCHS(p, c) \
+    ([] ((suggested_thread_count != thread_count && \
+            producer_epoch == p && controller_epoch == c) -> \
+        <> (suggested_thread_count == thread_count || \
+            producer_epoch != p || controller_epoch != c)))
+
+#define QUEUE_DECREASES_WITH_EPOCHS(q, p, c) \
+    ([] ((queued_activations == q && \
+            producer_epoch == p && controller_epoch == c) -> \
+        <> (queued_activations < q || \
+            producer_epoch != p || controller_epoch != c)))
+
 ltl live_resize_reconciles {
-    [] ((suggested_thread_count != thread_count) ->
-        <> (suggested_thread_count == thread_count))
+    RESIZE_RECONCILES_WITH_EPOCHS(false, false) &&
+    RESIZE_RECONCILES_WITH_EPOCHS(false, true) &&
+    RESIZE_RECONCILES_WITH_EPOCHS(true, false) &&
+    RESIZE_RECONCILES_WITH_EPOCHS(true, true)
 }
 
 ltl live_queue_changes {
-    ([] (queued_activations == 1 ->
-        <> (queued_activations == 0 || queued_activations == 2))) &&
-    ([] (queued_activations == 2 -> <> (queued_activations == 1)))
+    QUEUE_DECREASES_WITH_EPOCHS(1, false, false) &&
+    QUEUE_DECREASES_WITH_EPOCHS(1, false, true) &&
+    QUEUE_DECREASES_WITH_EPOCHS(1, true, false) &&
+    QUEUE_DECREASES_WITH_EPOCHS(1, true, true) &&
+    QUEUE_DECREASES_WITH_EPOCHS(2, false, false) &&
+    QUEUE_DECREASES_WITH_EPOCHS(2, false, true) &&
+    QUEUE_DECREASES_WITH_EPOCHS(2, true, false) &&
+    QUEUE_DECREASES_WITH_EPOCHS(2, true, true)
 }
 
 init {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -1,32 +1,12 @@
 /*
- * Finite-state model of a BasicExecutorPool where an executor worker
- * temporarily assumes the waker role. There is no dedicated waker thread.
- *
- * Deliberately modeled:
- *  - producer publication order: credit, queue item, wake request;
- *  - coalescing through waker_pending;
- *  - election through waker_worker_id;
- *  - forwarding a request with WAKER -> NEED_TO_BE_WAKER;
- *  - the completion race after the owner releases waker_worker_id;
- *  - workers entering SPIN and BLOCKING asking for reconciliation;
- *  - selecting and unparking a SPIN, BLOCKING, or SLEEP worker;
- *  - a local activation budget which does not reserve queue items;
- *  - an orthogonal worker state and waker role, so a worker selected from
- *    SLEEP remains logically sleeping throughout election;
- *  - dynamic thread-count changes, including claimed and unclaimed
- *    reduction tokens overtaken by a later resize;
- *  - a waker-request bit packed with the reduction count, which delegates a
- *    missed resize request to the next worker entering the idle path.
- *
- * Abstracted away:
- *  - exact SleepingStack order (worker ids provide a deterministic order);
- *  - the futex itself (NEED_TO_BE_WAKER enables a parked worker);
- *  - memory-order syntax; atomic blocks mark the C++ CAS/exchange edges.
+ * Model of a BasicExecutorPool where a worker temporarily owns the waker.
+ * worker_state is the only public per-worker atomic. NEED_FROM_* preserves
+ * the logical source state during election. The owner keeps that state in a
+ * private resume_state while its public state is WAKER.
  */
 
 #define N 2
 #define PRODUCERS 1
-#define PRODUCER_ROUNDS 2
 #define CONTROLLER_ROUNDS 2
 #define MAX_QUEUE N
 
@@ -35,17 +15,22 @@
 #define SLEEP 2
 #define WORK 3
 #define BLOCKING 4
-#define ORDINARY 0
-#define NEED_TO_BE_WAKER 1
-#define WAKER 2
+#define NEED 5
+#define NEED_FROM_SLEEP 6
+#define NEED_FROM_BLOCKING 7
+#define WAKER 8
+
+#define IS_NEED(s) ((s) == NEED || \
+    (s) == NEED_FROM_SLEEP || (s) == NEED_FROM_BLOCKING)
+#define IS_SPIN(s) ((s) == SPIN)
+#define IS_SLEEP(s) ((s) == SLEEP || (s) == NEED_FROM_SLEEP)
+#define IS_BLOCKING(s) ((s) == BLOCKING || (s) == NEED_FROM_BLOCKING)
 
 #define INVALID_WAKER N
 #define REDUCTION_WAKER_BIT 4
 #define REDUCTION_COUNT_MASK (REDUCTION_WAKER_BIT - 1)
 
 byte worker_state[N];
-byte waker_role[N];
-
 byte activation_credits = 0;
 byte queued_activations = 0;
 byte sleeping_count = 0;
@@ -55,702 +40,617 @@ byte sleep_workers = 0;
 byte suggested_thread_count = N;
 byte thread_count = N;
 byte reductions = 0;
-byte claimed_reductions = 0;
-byte cancelled_claimed_reductions = 0;
+byte previous_reductions = 0;
+byte taken_tokens_to_sleep = 0;
+byte taken_tokens_to_wakeup = 0;
 
 byte waker_worker_id = INVALID_WAKER;
 bool waker_pending = false;
 
-/* Instrumentation state: unlike EThreadState::WAKER, this covers only the
- * interval which is allowed to mutate the persistent waker data. */
-byte waker_passes = 0;
-
-/* A worker owns these scratch variables only while waker_passes == 1.
- * Keeping one global set models the single logical waker instance even when
- * its worker owner changes, and avoids multiplying private waker state by N. */
+/* Single persistent waker scratch space. */
 byte waker_i = 0;
 byte waker_budget = 0;
 byte waker_previous_activations = 0;
-byte waker_final = NONE;
+byte waker_previous_sleeping = 0;
 byte waker_desired = 0;
 byte waker_delta = 0;
 byte waker_converted = 0;
-bool waker_found = false;
-bool waker_woke = false;
+byte waker_remaining_reductions = 0;
 
-inline check_local_safety() {
+inline check_safety() {
     atomic {
         assert(waker_worker_id <= INVALID_WAKER);
-        assert(waker_passes <= 1);
-        assert(waker_role[0] <= WAKER);
-        assert(waker_role[1] <= WAKER);
+        assert(worker_state[0] <= WAKER);
+        assert(worker_state[1] <= WAKER);
         assert(sleeping_count <= N);
         assert(awake_workers <= N);
         assert(sleep_workers <= N);
         assert(awake_workers + sleep_workers == N);
         assert(thread_count >= 1 && thread_count <= N);
-        assert(suggested_thread_count >= 1 &&
-            suggested_thread_count <= N);
+        assert(suggested_thread_count >= 1 && suggested_thread_count <= N);
         assert((reductions & REDUCTION_COUNT_MASK) <= N);
         assert(reductions < 2 * REDUCTION_WAKER_BIT);
-        assert(claimed_reductions <= N);
-        assert(cancelled_claimed_reductions <= claimed_reductions);
+        assert(previous_reductions <= N);
+        assert(taken_tokens_to_sleep <= N);
+        assert(taken_tokens_to_wakeup <= N);
+        assert(taken_tokens_to_sleep + taken_tokens_to_wakeup <= N);
+        assert(waker_previous_sleeping <= N);
         assert(activation_credits <= MAX_QUEUE);
         assert(queued_activations <= activation_credits);
         if
-        :: waker_passes == 0 ->
-            assert(waker_i == 0);
-            assert(waker_budget == 0);
-            assert(waker_previous_activations == 0);
-            assert(waker_final == NONE);
-            assert(waker_desired == 0);
-            assert(waker_delta == 0);
-            assert(waker_converted == 0);
-            assert(!waker_found);
-            assert(!waker_woke)
-        :: else -> skip
-        fi;
-        if
         :: waker_worker_id < N ->
-            assert(waker_role[waker_worker_id] == WAKER ||
-                waker_role[waker_worker_id] == NEED_TO_BE_WAKER)
+            assert(worker_state[waker_worker_id] == WAKER ||
+                IS_NEED(worker_state[waker_worker_id]))
         :: else -> skip
         fi
     }
 }
 
-/* Publish the final state of the worker which has already released the waker
- * index. A producer may concurrently change WAKER to NEED_TO_BE_WAKER; in
- * that case the caller must return to election instead of publishing final. */
-inline publish_waker_final(id, final) {
-    atomic {
-        if
-        :: waker_role[id] == WAKER &&
-                (reductions & REDUCTION_WAKER_BIT) ->
-            reductions = reductions & REDUCTION_COUNT_MASK;
-            worker_state[id] = final;
-            waker_role[id] = NEED_TO_BE_WAKER
-        :: waker_role[id] == WAKER &&
-                !(reductions & REDUCTION_WAKER_BIT) ->
-            worker_state[id] = final;
-            waker_role[id] = ORDINARY
-        :: waker_role[id] == NEED_TO_BE_WAKER ->
-            worker_state[id] = final
-        fi
-    }
-}
-
-/* Make one non-blocking attempt to request a waker pass. The owner load is
- * deliberately outside atomic: the model must preserve the completion race
- * between observing waker_worker_id and forwarding the request. */
-inline try_request_waker(owner, candidate, notified, require_sleepers) {
-    notified = false;
-    owner = waker_worker_id;
+/* One non-blocking attempt to notify or select a waker. */
+inline try_request_waker(candidate, notified, require_sleepers) {
     if
-    :: owner < N ->
-        atomic {
+    :: atomic { waker_worker_id != INVALID_WAKER ->
+        notified = true
+    }
+    :: atomic { waker_worker_id == INVALID_WAKER && (!require_sleepers || sleeping_count > 0) ->
+        notified = false;
+        candidate = 0;
+    }
+        do
+        :: atomic { true ->
             if
-            :: waker_role[owner] == WAKER ->
-                waker_role[owner] = NEED_TO_BE_WAKER;
+            :: worker_state[candidate] == WAKER || IS_NEED(worker_state[candidate]) ->
                 notified = true
-            :: waker_role[owner] == NEED_TO_BE_WAKER ->
+            :: worker_state[candidate] == SPIN ->
+                worker_state[candidate] = NEED;
+                notified = true
+            :: worker_state[candidate] == SLEEP ->
+                worker_state[candidate] = NEED_FROM_SLEEP;
+                notified = true
+            :: worker_state[candidate] == BLOCKING ->
+                worker_state[candidate] = NEED_FROM_BLOCKING;
                 notified = true
             :: else -> skip
             fi
-        }
-
-    :: owner == INVALID_WAKER ->
-        if
-        :: !require_sleepers || sleeping_count > 0 ->
-            candidate = 0;
-            do
-            :: candidate < N && !notified ->
-                atomic {
-                    if
-                    :: require_sleepers &&
-                            waker_role[candidate] == WAKER ->
-                        waker_role[candidate] = NEED_TO_BE_WAKER;
-                        notified = true
-                    :: waker_role[candidate] == ORDINARY &&
-                            (worker_state[candidate] == SPIN ||
-                                worker_state[candidate] == BLOCKING ||
-                                worker_state[candidate] == SLEEP) ->
-                        waker_role[candidate] = NEED_TO_BE_WAKER;
-                        notified = true
-                    :: else -> skip
-                    fi
-                };
+            if
+            :: candidate + 1 == N || notified ->
+                candidate = 0;
+                break;
+            :: else ->
                 candidate++
-            :: else -> break
-            od
-        :: require_sleepers && sleeping_count == 0 -> skip
-        fi
+            fi
+        };
+        od
+    :: atomic { else ->
+        notified = false;
+    }
     fi
 }
 
-proctype Worker(byte id) {
-    byte owner;
-    bool done;
-
-    do
-    :: waker_role[id] == ORDINARY && worker_state[id] == WORK ->
-        worker_state[id] = NONE
-
-    :: waker_role[id] == ORDINARY && worker_state[id] == NONE ->
+/* Reconcile the resize counters captured by one waker pass. */
+inline reconcile_thread_count() {
+    waker_desired = suggested_thread_count;
+    atomic {
         if
-        /* The controller could not find an existing waker or a parked
-         * candidate. The first idle worker clears only the request bit and
-         * enters election, preserving any numeric reduction count. */
-        :: atomic {
-            reductions & REDUCTION_WAKER_BIT ->
-            reductions = reductions & REDUCTION_COUNT_MASK
-        };
-            atomic {
-                assert(waker_role[id] == ORDINARY &&
-                    worker_state[id] == NONE);
-                waker_role[id] = NEED_TO_BE_WAKER;
-                waker_pending = true
-            }
-
-        /* A reduction claim and its ownership accounting are one abstract
-         * operation. Publishing BLOCKING remains a separate transition. */
-        :: atomic {
-            reductions > 0 && reductions < REDUCTION_WAKER_BIT ->
-            reductions--;
-            claimed_reductions++
-        };
-            atomic {
-                assert(waker_role[id] == ORDINARY &&
-                    worker_state[id] == NONE);
-                worker_state[id] = BLOCKING;
-                waker_role[id] = NEED_TO_BE_WAKER;
-                waker_pending = true
-            }
-
-        :: reductions == 0 && suggested_thread_count == thread_count &&
-                queued_activations > 0 ->
-            atomic {
-                queued_activations > 0 ->
-                queued_activations--;
-                assert(activation_credits > 0);
-                activation_credits--;
-                worker_state[id] = WORK
-            }
-
-        :: reductions == 0 && suggested_thread_count == thread_count &&
-                activation_credits == 0 ->
-            atomic {
-                assert(waker_role[id] == ORDINARY &&
-                    worker_state[id] == NONE);
-                worker_state[id] = SPIN;
-                waker_role[id] = NEED_TO_BE_WAKER;
-                waker_pending = true
-            }
-        fi
-
-    :: waker_role[id] == ORDINARY && worker_state[id] == SPIN &&
-            activation_credits > 0 ->
-        atomic {
+        :: waker_desired < thread_count ->
+            waker_delta = thread_count - waker_desired;
             if
-            :: waker_role[id] == ORDINARY &&
-                    worker_state[id] == SPIN && activation_credits > 0 ->
-                worker_state[id] = NONE
-            :: else -> skip
-            fi
-        }
-
-    :: waker_role[id] == NEED_TO_BE_WAKER ->
-        done = false;
-        do
-        :: !done ->
-            owner = waker_worker_id;
-            if
-            :: owner == INVALID_WAKER ->
-                atomic {
-                    if
-                    :: waker_worker_id == INVALID_WAKER &&
-                            waker_role[id] == NEED_TO_BE_WAKER ->
-                        waker_worker_id = id;
-                        done = true
-                    :: else -> skip
-                    fi
-                };
-                if
-                :: done ->
-                    atomic {
-                        assert(waker_worker_id == id);
-                        assert(waker_role[id] == NEED_TO_BE_WAKER);
-                        waker_role[id] = WAKER
-                    }
-                :: else -> skip
-                fi
-
-            :: owner < N && owner != id ->
-                atomic {
-                    if
-                    :: waker_role[owner] == WAKER ->
-                        waker_role[owner] = NEED_TO_BE_WAKER;
-                        done = true
-                    :: waker_role[owner] == NEED_TO_BE_WAKER ->
-                        done = true
-                    :: else -> skip
-                    fi
-                };
-                if
-                :: done ->
-                    atomic {
-                        assert(waker_role[id] == NEED_TO_BE_WAKER);
-                        waker_role[id] = ORDINARY
-                    }
-                :: else -> skip
-                fi
-
-            :: owner == id ->
-                atomic {
-                    if
-                    :: waker_role[id] == NEED_TO_BE_WAKER ->
-                        waker_role[id] = WAKER;
-                        done = true
-                    :: waker_role[id] == WAKER ->
-                        done = true
-                    fi
-                }
-            fi
-        :: else -> break
-        od;
-        atomic {
-            assert(done);
-            owner = 0;
-            done = false
-        }
-
-    :: waker_role[id] == WAKER && waker_worker_id == id ->
-        atomic {
-            assert(waker_passes == 0);
-            waker_passes = 1;
-            waker_pending = false;
-            if
-            :: reductions & REDUCTION_WAKER_BIT ->
-                reductions = reductions & REDUCTION_COUNT_MASK
-            :: else -> skip
-            fi
-        };
-
-        /* Reconcile the latest target. Sleeping identities are symmetric:
-         * sleeping_count is derived from thread_count and awake_workers, and
-         * any SLEEP worker may represent an eligible sleeping slot. */
-        waker_desired = suggested_thread_count;
-        atomic {
-            if
-            :: waker_desired < thread_count ->
-                waker_delta = thread_count - waker_desired;
-                if
-                :: sleeping_count < waker_delta ->
-                    waker_converted = sleeping_count
-                :: else -> waker_converted = waker_delta
-                fi;
-                waker_delta = waker_delta - waker_converted;
-                assert(reductions + waker_delta <= N);
-                reductions = reductions + waker_delta;
-                thread_count = waker_desired
-
-            :: waker_desired > thread_count ->
-                waker_delta = waker_desired - thread_count;
-                if
-                :: reductions < waker_delta -> waker_converted = reductions
-                :: else -> waker_converted = waker_delta
-                fi;
-                reductions = reductions - waker_converted;
-                waker_delta = waker_delta - waker_converted;
-                assert(claimed_reductions >= cancelled_claimed_reductions);
-                if
-                :: claimed_reductions - cancelled_claimed_reductions <
-                        waker_delta ->
-                    waker_converted = claimed_reductions -
-                        cancelled_claimed_reductions
-                :: else -> waker_converted = waker_delta
-                fi;
-                assert(cancelled_claimed_reductions + waker_converted <= N);
-                cancelled_claimed_reductions =
-                    cancelled_claimed_reductions + waker_converted;
-                waker_delta = waker_delta - waker_converted;
-                thread_count = waker_desired
-
-            :: else -> skip
+            :: taken_tokens_to_wakeup < waker_delta ->
+                waker_converted = taken_tokens_to_wakeup
+            :: else -> waker_converted = waker_delta
             fi;
-            sleeping_count = 0;
-            waker_delta = 0;
-            waker_converted = 0
-        };
+            taken_tokens_to_wakeup = taken_tokens_to_wakeup -
+                waker_converted;
+            taken_tokens_to_sleep = taken_tokens_to_sleep +
+                waker_converted;
+            waker_delta = waker_delta - waker_converted;
+            if
+            :: waker_previous_sleeping < waker_delta ->
+                waker_converted = waker_previous_sleeping
+            :: else -> waker_converted = waker_delta
+            fi;
+            waker_previous_sleeping = waker_previous_sleeping -
+                waker_converted;
+            waker_delta = waker_delta - waker_converted;
+            assert(waker_remaining_reductions + waker_delta <= N);
+            waker_remaining_reductions =
+                waker_remaining_reductions + waker_delta;
+            thread_count = waker_desired
+        :: waker_desired > thread_count ->
+            waker_delta = waker_desired - thread_count;
+            if
+            :: taken_tokens_to_sleep < waker_delta ->
+                waker_converted = taken_tokens_to_sleep
+            :: else -> waker_converted = waker_delta
+            fi;
+            taken_tokens_to_sleep = taken_tokens_to_sleep -
+                waker_converted;
+            taken_tokens_to_wakeup = taken_tokens_to_wakeup +
+                waker_converted;
+            waker_delta = waker_delta - waker_converted;
+            if
+            :: waker_remaining_reductions < waker_delta ->
+                waker_converted = waker_remaining_reductions
+            :: else -> waker_converted = waker_delta
+            fi;
+            waker_remaining_reductions = waker_remaining_reductions -
+                waker_converted;
+            waker_delta = waker_delta - waker_converted;
+            assert(waker_previous_sleeping + waker_delta <= N);
+            waker_previous_sleeping = waker_previous_sleeping +
+                waker_delta;
+            thread_count = waker_desired
+        :: else -> skip
+        fi;
+        waker_delta = 0;
+        waker_converted = 0
+        waker_desired = 0
+    }
+}
 
-        waker_previous_activations = activation_credits;
-        waker_budget = waker_previous_activations;
+/* Observe each non-owner worker once, as WakerLoop does in C++. */
+inline reconcile_workers(id, resume_state) {
+    waker_i = 0;
+    do
+    :: atomic { true ->
+        if
+        :: (waker_i != id && (worker_state[waker_i] == NEED || worker_state[waker_i] == NONE)) ||
+                (waker_i == id && (resume_state == NEED || resume_state == NONE)) ->
+            if 
+            :: waker_i != id -> worker_state[waker_i] = NONE;
+            :: else -> resume_state == NONE
+            fi
+            if
+            :: waker_budget > 0 -> waker_budget--
+            :: else -> skip
+            fi
+        :: waker_i != id && IS_SPIN(worker_state[waker_i]) ->
+            if
+            :: waker_budget > 0 ->
+                worker_state[waker_i] = NONE;
+                waker_budget--
+            :: waker_budget == 0 ->
+                worker_state[waker_i] = SLEEP;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++;
+                waker_previous_sleeping++
+            fi
+        :: waker_i == id && IS_SPIN(resume_state) ->
+            if
+            :: waker_budget > 0 ->
+                resume_state = NONE;
+                waker_budget--
+            :: waker_budget == 0 ->
+                resume_state = SLEEP;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++;
+                waker_previous_sleeping++
+            fi
+        :: waker_i != id && IS_BLOCKING(worker_state[waker_i]) ->
+            if
+            :: taken_tokens_to_wakeup > 0 && waker_budget > 0 ->
+                worker_state[waker_i] = NONE;
+                taken_tokens_to_wakeup--;
+                waker_budget--
+            :: taken_tokens_to_wakeup > 0 && waker_budget == 0 ->
+                worker_state[waker_i] = SLEEP;
+                taken_tokens_to_wakeup--;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++;
+                waker_previous_sleeping++
+            :: taken_tokens_to_wakeup == 0 && taken_tokens_to_sleep > 0 ->
+                worker_state[waker_i] = SLEEP;
+                taken_tokens_to_sleep--;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++
+            :: taken_tokens_to_wakeup == 0 && taken_tokens_to_sleep == 0 -> assert(false) // impossible
+            fi
+        :: waker_i == id && IS_BLOCKING(resume_state) ->
+            assert(taken_tokens_to_wakeup != 0 || taken_tokens_to_sleep != 0);
+            if
+            :: taken_tokens_to_wakeup > 0 && waker_budget > 0 ->
+                resume_state = NONE;
+                taken_tokens_to_wakeup--;
+                waker_budget--
+            :: taken_tokens_to_wakeup > 0 && waker_budget == 0 ->
+                resume_state = SLEEP;
+                taken_tokens_to_wakeup--;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++;
+                waker_previous_sleeping++
+            :: taken_tokens_to_wakeup == 0 && taken_tokens_to_sleep > 0 ->
+                resume_state = SLEEP;
+                taken_tokens_to_sleep--;
+                assert(awake_workers > 0);
+                awake_workers--;
+                sleep_workers++
+            :: taken_tokens_to_wakeup == 0 && taken_tokens_to_sleep == 0 -> assert(false) // impossible
+            fi
+        :: else -> skip
+        fi
+        if
+        :: waker_i < N ->
+            waker_i++;
+        :: else ->
+            waker_i = 0;
+            break;
+        fi
+    }
+    od
+}
 
-        /* Observe every worker once. NONE only consumes the local budget at
-         * the point where it is seen; it does not reserve a queue item and
-         * may concurrently move to WORK or back into the idle path. */
+inline wake_sleeping_workers(id, resume_state) {
+    do
+    :: atomic { true ->
         waker_i = 0;
         do
         :: waker_i < N ->
             if
-            :: waker_i != id && waker_role[waker_i] == ORDINARY &&
-                    worker_state[waker_i] == NONE &&
-                    waker_budget > 0 -> waker_budget--
-
-            :: waker_i != id && waker_role[waker_i] == ORDINARY &&
-                    worker_state[waker_i] == SPIN ->
+            :: waker_i != id && IS_SLEEP(worker_state[waker_i]) ||
+                   waker_i == id && IS_SLEEP(resume_state) ->
                 if
-                :: waker_budget > 0 ->
-                    atomic {
-                        if
-                        :: waker_role[waker_i] == ORDINARY &&
-                                worker_state[waker_i] == SPIN ->
-                            worker_state[waker_i] = NONE;
-                            waker_budget--
-                        :: else -> skip
-                        fi
-                    }
-                :: waker_budget == 0 ->
-                    atomic {
-                        if
-                        :: waker_role[waker_i] == ORDINARY &&
-                                worker_state[waker_i] == SPIN ->
-                            worker_state[waker_i] = SLEEP;
-                            assert(awake_workers > 0);
-                            awake_workers--;
-                            sleep_workers++
-                        :: else -> skip
-                        fi
-                    }
+                :: waker_i != id -> worker_state[waker_i] = NONE;
+                :: else -> resume_state = NONE;
                 fi
-
-            :: waker_i != id && waker_role[waker_i] == ORDINARY &&
-                    worker_state[waker_i] == BLOCKING ->
-                if
-                :: cancelled_claimed_reductions > 0 && waker_budget > 0 ->
-                    atomic {
-                        if
-                        :: waker_role[waker_i] == ORDINARY &&
-                                worker_state[waker_i] == BLOCKING ->
-                            assert(claimed_reductions > 0);
-                            claimed_reductions--;
-                            cancelled_claimed_reductions--;
-                            worker_state[waker_i] = NONE;
-                            waker_budget--
-                        :: else -> skip
-                        fi
-                    }
-                :: cancelled_claimed_reductions > 0 && waker_budget == 0 ->
-                    atomic {
-                        if
-                        :: waker_role[waker_i] == ORDINARY &&
-                                worker_state[waker_i] == BLOCKING ->
-                            assert(claimed_reductions > 0);
-                            claimed_reductions--;
-                            cancelled_claimed_reductions--;
-                            worker_state[waker_i] = SLEEP;
-                            assert(awake_workers > 0);
-                            awake_workers--;
-                            sleep_workers++
-                        :: else -> skip
-                        fi
-                    }
-                :: cancelled_claimed_reductions == 0 ->
-                    atomic {
-                        if
-                        :: waker_role[waker_i] == ORDINARY &&
-                                worker_state[waker_i] == BLOCKING ->
-                            assert(claimed_reductions > 0);
-                            claimed_reductions--;
-                            worker_state[waker_i] = SLEEP;
-                            assert(awake_workers > 0);
-                            awake_workers--;
-                            sleep_workers++
-                        :: else -> skip
-                        fi
-                    }
-                fi
-            :: else -> skip
-            fi;
-            waker_i++
-        :: else -> break
-        od;
-
-        /* Wake eligible sleepers until the activation budget is covered. A
-         * worker temporarily in NEED_TO_BE_WAKER remains counted and will be
-         * resolved by either this owner or the next owner. */
-        do
-        :: waker_budget > 0 && thread_count > awake_workers ->
-            waker_found = false;
-            waker_woke = false;
-            waker_i = 0;
-            do
-            :: waker_i < N && !waker_found ->
-                if
-                :: waker_i != id && worker_state[waker_i] == SLEEP ->
-                    waker_found = true
-                :: else -> waker_i++
-                fi
-            :: else -> break
-            od;
-            if
-            :: waker_found ->
-                atomic {
-                    if
-                    :: waker_role[waker_i] == ORDINARY &&
-                            worker_state[waker_i] == SLEEP ->
-                        worker_state[waker_i] = NONE;
-                        assert(sleep_workers > 0);
-                        sleep_workers--;
-                        awake_workers++;
-                        waker_budget--;
-                        waker_woke = true
-                    :: else -> skip
-                    fi
-                };
-                if
-                :: waker_woke -> skip
-                /* Match the current C++ loop: a failed SLEEP -> NONE CAS
-                 * stops this pass instead of scanning another stack entry. */
-                :: !waker_woke -> break
-                fi
-            /* The only eligible sleeper may be the current owner. */
-            :: !waker_found -> break
-            fi
-        :: else -> break
-        od;
-
-        /* The waker role is orthogonal to the worker's logical state. */
-        if
-        :: worker_state[id] == BLOCKING ->
-            assert(claimed_reductions > 0);
-            if
-            :: cancelled_claimed_reductions > 0 && waker_budget > 0 ->
-                atomic {
-                    claimed_reductions--;
-                    cancelled_claimed_reductions--
-                };
-                waker_final = NONE;
-                waker_budget--
-            :: cancelled_claimed_reductions > 0 && waker_budget == 0 ->
-                atomic {
-                    claimed_reductions--;
-                    cancelled_claimed_reductions--
-                };
-                waker_final = SLEEP
-            :: cancelled_claimed_reductions == 0 ->
-                claimed_reductions--;
-                waker_final = SLEEP
-            fi
-        :: worker_state[id] != BLOCKING && waker_budget > 0 ->
-            waker_final = NONE;
-            waker_budget--
-        :: worker_state[id] != BLOCKING && waker_budget == 0 ->
-            if
-            :: worker_state[id] == NONE || worker_state[id] == WORK ->
-                waker_final = NONE
-            :: else -> waker_final = SLEEP
-            fi
-        fi;
-
-        atomic {
-            if
-            :: worker_state[id] == SLEEP && waker_final != SLEEP ->
                 assert(sleep_workers > 0);
+                assert(waker_previous_sleeping > 0);
                 sleep_workers--;
-                awake_workers++
-            :: worker_state[id] != SLEEP && waker_final == SLEEP ->
-                assert(awake_workers > 0);
-                awake_workers--;
-                sleep_workers++
-            :: else -> skip
-            fi;
-            worker_state[id] = waker_final;
-            if
-            :: thread_count > awake_workers ->
-                sleeping_count = thread_count - awake_workers
-            :: else -> sleeping_count = 0
+                waker_previous_sleeping--;
+                awake_workers++;
+                waker_budget--;
+            :: else -> waker_i++
             fi
-        };
-
-        /* Close the publication race where a producer increments credits
-         * before this pass publishes the corresponding sleeping worker. */
+        :: else -> break
+        od;
+        waker_i = 0;
         if
-        :: activation_credits > waker_previous_activations ->
-            atomic {
-                waker_pending = true;
-                if
-                :: waker_role[id] == WAKER ->
-                    waker_role[id] = NEED_TO_BE_WAKER
-                :: waker_role[id] == NEED_TO_BE_WAKER -> skip
-                fi
-            }
-        :: else -> skip
-        fi;
-
-        atomic {
-            assert(waker_passes == 1);
-            waker_i = 0;
+        :: waker_budget == 0 || waker_previous_sleeping == 0 ->
             waker_budget = 0;
-            waker_previous_activations = 0;
-            waker_final = NONE;
-            waker_desired = 0;
-            waker_delta = 0;
-            waker_converted = 0;
-            waker_found = false;
-            waker_woke = false;
-            waker_passes = 0
-        };
-
-        if
-        :: waker_role[id] == NEED_TO_BE_WAKER ->
-            atomic {
-                waker_role[id] == NEED_TO_BE_WAKER ->
-                waker_role[id] = WAKER
-            }
-
-        :: waker_role[id] == WAKER ->
-            atomic {
-                assert(waker_worker_id == id);
-                waker_worker_id = INVALID_WAKER
-            };
-            publish_waker_final(id, worker_state[id])
-        fi;
-
-        check_local_safety()
-
-    /* SLEEP and BLOCKING are parked. Changing waker_role to
-     * NEED_TO_BE_WAKER models the matching Unpark(). */
+        :: else -> skip
+        fi
+    }
     od
 }
 
-proctype Producer() {
-    byte owner;
-    byte i;
-    byte round = 0;
-    bool notify;
-    bool done;
+/* One call corresponds to one C++ WakerLoop invocation. */
+inline run_waker_pass(id, resume_state) {
+    atomic { // exchange sleeping_count
+        assert(waker_i == 0);
+        assert(waker_budget == 0);
+        assert(waker_previous_activations == 0);
+        assert(waker_previous_sleeping == 0);
+        assert(waker_desired == 0);
+        assert(waker_delta == 0);
+        assert(waker_converted == 0);
+        assert(waker_remaining_reductions == 0);
+        waker_previous_sleeping = sleeping_count;
+        sleeping_count = 0
+    };
+    waker_pending = false
+    atomic { // exchange reductions
+        waker_remaining_reductions = reductions & REDUCTION_COUNT_MASK;
+        reductions = 0;
+        assert(previous_reductions >= waker_remaining_reductions);
+        assert(taken_tokens_to_sleep + taken_tokens_to_wakeup +
+            previous_reductions - waker_remaining_reductions <= N);
+        taken_tokens_to_sleep = taken_tokens_to_sleep +
+            previous_reductions - waker_remaining_reductions;
+        previous_reductions = 0
+    };
+    reconcile_thread_count();
+    atomic { // cas reductions
+        assert((reductions & REDUCTION_COUNT_MASK) == 0);
+        reductions = waker_remaining_reductions; // reset REDUCTION_WAKER_BIT (because we have waker_pending)
+        previous_reductions = waker_remaining_reductions;
+        waker_remaining_reductions = 0
+    };
+    atomic {
+        waker_previous_activations = activation_credits;
+        waker_budget = waker_previous_activations;
+    }
+    reconcile_workers(id, resume_state);
+    wake_sleeping_workers(id, resume_state);
+    atomic {
+        sleeping_count = waker_previous_sleeping;
+        waker_previous_sleeping = 0;
+    }
+    atomic {
+        if
+        :: activation_credits > waker_previous_activations ->
+            waker_pending = true
+        :: else -> skip
+        fi
+        waker_previous_activations = 0;
+        waker_delta = 0;
+        waker_converted = 0;
+    }
+}
 
+/* The C++ RunWaker loop: elect/forward, run a pass, then publish resume. */
+inline run_waker(id, resume_state) {
+    run_waker_again_label:
+    do
+    :: atomic { waker_worker_id == INVALID_WAKER ->
+        waker_worker_id = id;
+    }
+        atomic {
+            run_waker_acquire_save_state_label:
+            if
+            :: IS_SLEEP(worker_state[id]) -> resume_state = SLEEP
+            :: IS_BLOCKING(worker_state[id]) -> resume_state = BLOCKING
+            :: else -> skip
+            fi;
+            worker_state[id] = WAKER
+        }
+        run_waker_pass_label:
+        run_waker_pass(id, resume_state);
+        atomic {
+            if
+            :: waker_pending -> goto run_waker_acquire_save_state_label
+            :: else -> skip
+            fi
+        }
+        worker_state[id] = resume_state;
+        if
+        :: waker_pending -> goto run_waker_pass_label
+        :: else -> skip
+        fi
+        waker_worker_id = INVALID_WAKER
+        atomic {
+            if
+            :: waker_pending -> goto run_waker_again_label
+            :: else -> skip
+            fi
+        }
+    :: atomic { waker_worker_id == id ->
+        goto run_waker_acquire_save_state_label
+    }
+    :: waker_worker_id != INVALID_WAKER && waker_worker_id != id ->
+        atomic { 
+            if
+            :: !IS_NEED(worker_state[id]) ->
+                break
+            :: else ->
+                worker_state[id] = resume_state;
+            fi
+        }
+    od;
+}
+
+proctype Worker(byte id) {
+    byte resume_state = NONE;
+
+worker_iteration:
+    /* Returning an activation to the executor eventually re-enters
+     * GetReadyActivationWaker and clears WORK. */
+    if
+    :: worker_state[id] == WORK ->
+        atomic {
+            worker_state[id] == WORK ->
+            worker_state[id] = NONE;
+        }
+    :: else -> skip
+    fi;
+
+check_blocking:
+    /* Match the C++ order: consume a pending persistent request or a
+     * reduction before attempting to pop an activation. */
+    if
+    :: atomic {
+        reductions & REDUCTION_WAKER_BIT ->
+        reductions = reductions & REDUCTION_COUNT_MASK
+    };
+        worker_state[id] = NEED
+        goto settle_waker_state
+    :: atomic {
+        reductions > 0 && reductions < REDUCTION_WAKER_BIT ->
+        reductions--
+    };
+        worker_state[id] = BLOCKING
+        if
+        :: atomic { !waker_pending ->
+            waker_pending = true;
+        }
+            atomic {
+                if
+                :: worker_state[id] == BLOCKING ->
+                    worker_state[id] = NEED_FROM_BLOCKING
+                :: else -> skip
+                fi
+            }
+        :: else -> skip;
+        fi
+        goto settle_waker_state
+    :: reductions == 0 -> skip
+    fi;
+
+pop_activation:
+    if
+    :: atomic { queued_activations > 0 ->
+        queued_activations--;
+    }
+        atomic {
+            assert(activation_credits > 0);
+            activation_credits--;
+        }
+        atomic {
+            worker_state[id] = WORK;
+            goto worker_iteration
+        }
+    :: queued_activations == 0 -> skip
+    fi;
+
+    /* A producer publishes the credit before the queue item. */
+    
+    if
+    :: atomic { activation_credits > 0 -> goto worker_iteration }
+    :: activation_credits == 0 ->
+        resume_state = SPIN;
+        if
+        :: atomic { !waker_pending ->
+            waker_pending = true;
+        }
+            atomic {
+                if
+                :: worker_state[id] == SPIN ->
+                    worker_state[id] = NEED
+                :: else -> skip
+                fi
+            }
+        :: else -> skip;
+        fi
+    fi
+
+settle_waker_state:
+    /* This is settleWakerState() followed by RunWaker() in C++. */
+    if
+    :: IS_NEED(worker_state[id]) ->
+        run_waker(id, resume_state);
+        goto settle_waker_state
+    :: worker_state[id] == SPIN ->
+        if
+        :: activation_credits > 0 ->
+            atomic {
+                if
+                :: worker_state[id] == SPIN ->
+                    worker_state[id] = NONE
+                    goto settle_waker_state
+                :: IS_NEED(worker_state[id]) -> goto settle_waker_state
+                :: worker_state[id] == SLEEP -> goto sleep_state_label
+                :: worker_state[id] == NONE -> goto worker_iteration
+                fi
+            }
+        :: activation_credits == 0 ->
+            worker_state[id] != SPIN || activation_credits > 0
+            goto settle_waker_state
+        fi
+    :: worker_state[id] == SLEEP || worker_state[id] == BLOCKING ->
+        /* Park until the waker changes the public state. */
+        sleep_state_label:
+        worker_state[id] != SLEEP && worker_state[id] != BLOCKING;
+        goto settle_waker_state
+    :: worker_state[id] == NONE -> skip
+    fi;
+
+    goto worker_iteration
+}
+
+proctype Producer() {
+    byte i;
+    bool done;
+    produser_iteration:
     do
     :: true -> break
-    :: round < PRODUCER_ROUNDS ->
-        atomic {
-        activation_credits < MAX_QUEUE -> activation_credits++
-        };
+    :: true ->
+        atomic { activation_credits < MAX_QUEUE -> activation_credits++ };
         atomic { queued_activations++ };
-
-        notify = false;
         if
-        :: sleeping_count > 0 ->
+        :: atomic { sleeping_count == 0 -> goto produser_iteration }
+        :: else ->
             atomic {
                 if
                 :: !waker_pending ->
                     waker_pending = true;
-                    notify = true
-                :: else -> skip
+                :: else -> goto produser_iteration
                 fi
             }
-        :: else -> skip
-        fi;
-
-        if
-        :: notify ->
-            done = false;
-            do
-            :: !done ->
-                try_request_waker(owner, i, done, true);
-                if
-                :: done -> skip
-                :: !done && owner < N -> skip
-                :: !done && owner == INVALID_WAKER ->
-                    if
-                    :: sleeping_count > 0 ->
-                        atomic {
-                            if
-                            :: waker_worker_id == INVALID_WAKER ->
-                                waker_pending = false;
-                                done = true
-                            :: else -> skip
-                            fi
-                        }
-
-                    :: sleeping_count == 0 ->
-                        atomic {
-                            if
-                            :: waker_worker_id == INVALID_WAKER &&
-                                    sleeping_count == 0 ->
-                                waker_pending = false;
-                                done = true
-                            :: else -> skip
-                            fi
-                        }
-                    fi
-                fi
-            :: else -> break
-            od
-        :: else -> skip
-        fi;
-
-        check_local_safety();
+        fi
         atomic {
-            owner = 0;
-            i = 0;
-            notify = false;
-            done = false;
-            round++
+            if
+            :: waker_worker_id != INVALID_WAKER -> goto produser_iteration
+            :: else -> skip
+            fi
         }
-    :: else -> break
+
+        producer_wake_up_loop:
+        if
+        :: sleeping_count == 0 ->
+            atomic {
+                if
+                :: reductions & REDUCTION_WAKER_BIT -> goto produser_iteration
+                :: else -> reductions = reductions | REDUCTION_WAKER_BIT
+                fi
+            }
+            atomic {
+                if
+                :: sleeping_count == 0 -> goto produser_iteration
+                :: else -> goto producer_wake_up_iteration
+                fi
+            }
+        :: else ->
+            producer_wake_up_iteration:
+            try_request_waker(i, done, true);
+            atomic {
+                if
+                :: done -> goto produser_iteration
+                :: else -> goto producer_wake_up_loop
+                fi
+            }
+        fi
     od
 }
 
 proctype Controller() {
-    byte round = 0;
-    byte owner;
     byte i;
     bool notified;
-
+    bool notify;
+    controller_iteration:
     do
     :: true -> break
-    :: round < CONTROLLER_ROUNDS ->
+    :: suggested_thread_count == thread_count ->
         atomic {
             if
             :: suggested_thread_count == N -> suggested_thread_count = 1
             :: suggested_thread_count == 1 -> suggested_thread_count = N
             fi;
-            waker_pending = true
+        };
+        atomic {
+            if
+            :: !waker_pending ->
+                waker_pending = true;
+            :: else -> goto controller_iteration
+            fi
         };
 
-        try_request_waker(owner, i, notified, false);
-        if
-        /* No owner or parked candidate was stable during the scan. Preserve
-         * the reduction count and publish a bit which the next idle worker
-         * will consume before trying to block. */
-        :: !notified ->
-            atomic {
-                if
-                :: waker_worker_id == INVALID_WAKER ->
-                    reductions = reductions | REDUCTION_WAKER_BIT
-                :: else -> skip
-                fi
-            };
-            /* A worker may have become parked between the first scan and
-             * publishing the request bit. Scan again for both grow and
-             * shrink; the bit keeps the request durable if this scan also
-             * races with waker completion. */
-            try_request_waker(owner, i, notified, false)
-        :: else -> skip
-        fi;
-        /* Do not publish another target until the waker has observed this
-         * one. This makes a lost resize request observable independently of
-         * later controller updates. */
-        thread_count == suggested_thread_count;
         atomic {
-            owner = 0;
+            if
+            :: suggested_thread_count == N -> goto controller_wake_up
+            :: else ->
+                if
+                :: sleeping_count == 0 -> goto controller_reduciton_bit
+                :: else -> goto controller_wake_up
+                fi
+            fi
+        }
+
+        controller_reduciton_bit:
+        atomic {
+            if
+            :: reductions & REDUCTION_WAKER_BIT -> goto controller_iteration
+            :: else -> reductions = reductions | REDUCTION_WAKER_BIT
+            fi
+        }
+        atomic {
+            if
+            :: sleeping_count == 0 -> goto controller_iteration
+            :: else -> goto controller_wake_up
+            fi
+        }
+
+        controller_wake_up:
+        try_request_waker(i, notified, false);
+
+        atomic {
             i = 0;
             notified = false;
+            notify = false;
             round++
         }
-    :: else -> break
     od
 }
 
@@ -759,9 +659,6 @@ ltl live_resize_reconciles {
         <> (suggested_thread_count == thread_count))
 }
 
-/* With MAX_QUEUE == N == 2, express queue progress using only its size. A
- * single queued activation must eventually be either consumed or joined by
- * another activation; a full queue must eventually lose one activation. */
 ltl live_queue_changes {
     ([] (queued_activations == 1 ->
         <> (queued_activations == 0 || queued_activations == 2))) &&
@@ -774,7 +671,6 @@ init {
         do
         :: i < N ->
             worker_state[i] = WORK;
-            waker_role[i] = ORDINARY;
             run Worker(i);
             i++
         :: else -> break

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -25,12 +25,17 @@
 #define IS_SPIN(s) ((s) == SPIN)
 #define IS_SLEEP(s) ((s) == SLEEP || (s) == NEED_FROM_SLEEP)
 #define IS_BLOCKING(s) ((s) == BLOCKING || (s) == NEED_FROM_BLOCKING)
+#define IS_PARKED(s) ((s) == SLEEP || (s) == BLOCKING)
+#define ALL_WORKERS_PARKED \
+    (worker_parked[0] && IS_PARKED(worker_state[0]) && \
+        worker_parked[1] && IS_PARKED(worker_state[1]))
 
 #define INVALID_WAKER N
 #define REDUCTION_WAKER_BIT 4
 #define REDUCTION_COUNT_MASK (REDUCTION_WAKER_BIT - 1)
 
 byte worker_state[N];
+bool worker_parked[N];
 byte activation_credits = 0;
 byte queued_activations = 0;
 byte sleeping_count = 0;
@@ -48,6 +53,8 @@ byte waker_worker_id = INVALID_WAKER;
 bool waker_pending = false;
 bool producer_epoch = false;
 bool controller_epoch = false;
+bool producer_done = false;
+bool controller_done = false;
 
 /* Single persistent waker scratch space. */
 byte waker_i = 0;
@@ -425,21 +432,6 @@ check_blocking:
     };
         worker_state[id] = BLOCKING
         if
-        :: atomic {reductions & REDUCTION_WAKER_BIT ->
-            reductions = reductions & REDUCTION_COUNT_MASK
-        }
-            atomic {
-                if
-                :: worker_state[id] == BLOCKING -> worker_state[id] = NEED_FROM_BLOCKING
-                :: worker_state[id] == SLEEP -> worker_state[id] = NEED_FROM_SLEEP
-                :: worker_state[id] == NONE -> worker_state[id] = NEED
-                :: else -> skip
-                fi
-                goto settle_waker_state
-            }
-        :: else -> skip
-        fi
-        if
         :: atomic { !waker_pending ->
             waker_pending = true;
         }
@@ -476,10 +468,12 @@ pop_activation:
     /* A producer publishes the credit before the queue item. */
     
     if
-    :: atomic { activation_credits > 0 -> 
-        queued_activations != 0 || reductions != 0 // endless loop with activation_credits > 0 && queued_activations == 0 && reductions == 0 
+    :: activation_credits > 0 ->
+        if
+        :: queued_activations != 0 || reductions != 0 -> skip // endless loop with activation_credits > 0 && queued_activations == 0 && reductions == 0
+        :: activation_credits == 0 -> skip
+        fi
         goto worker_iteration
-    }
     :: activation_credits == 0 ->
         worker_state[id] = SPIN;
         if
@@ -539,7 +533,10 @@ settle_waker_state:
     :: worker_state[id] == SLEEP || worker_state[id] == BLOCKING ->
         /* Park until the waker changes the public state. */
         sleep_state_label:
+        worker_parked[id] = true;
+        end_worker_parked:
         worker_state[id] != SLEEP && worker_state[id] != BLOCKING;
+        worker_parked[id] = false;
         goto settle_waker_state
     :: worker_state[id] == NONE -> skip
     fi;
@@ -552,7 +549,7 @@ proctype Producer() {
     bool done;
     produser_iteration:
     do
-    :: true -> break
+    :: atomic { true -> producer_done = true }; break
     :: true ->
         atomic { activation_credits < MAX_QUEUE ->
             activation_credits++
@@ -613,7 +610,7 @@ proctype Controller() {
     bool bit_setted = false;
     controller_iteration:
     do
-    :: true -> break
+    :: atomic { true -> controller_done = true }; break
     :: suggested_thread_count == thread_count || !waker_pending ->
         atomic {
             if
@@ -685,6 +682,16 @@ proctype Controller() {
     od
 }
 
+/* Once external changes stop, a globally parked pool is a valid end state
+ * only when neither a queued activation nor its published credit remains. */
+proctype FinalStateChecker() {
+    producer_done && controller_done && ALL_WORKERS_PARKED;
+    atomic {
+        assert(queued_activations == 0);
+        assert(activation_credits == 0)
+    }
+}
+
 #define RESIZE_RECONCILES_WITH_EPOCHS(p, c) \
     ([] ((suggested_thread_count != thread_count && \
             producer_epoch == p && controller_epoch == c) -> \
@@ -741,6 +748,7 @@ init {
             i++
         :: else -> break
         od;
-        run Controller()
+        run Controller();
+        run FinalStateChecker()
     }
 }

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -38,6 +38,7 @@ byte activation_credits = 0;
 byte queued_activations = 0;
 bool waker_pending = false;
 bool work_epoch = false;
+bool queue_epoch = false;
 
 inline request_waker() {
     atomic {
@@ -84,7 +85,8 @@ proctype Worker(byte id) {
             if
             :: atomic {
                 queued_activations > 0 ->
-                queued_activations--
+                queued_activations--;
+                queue_epoch = !queue_epoch
             };
                 state[id] = WORK;
                 atomic {
@@ -111,7 +113,10 @@ proctype Producer() {
         activation_credits < MAX_QUEUE ->
         activation_credits++
     };
-        queued_activations++;
+        atomic {
+            queued_activations++;
+            queue_epoch = !queue_epoch
+        };
         if
         :: sleeping_count > 0 -> request_waker()
         :: else -> skip
@@ -375,6 +380,13 @@ ltl live_reconcile_stable {
         ((<>[] reconciled_one) && ([]<> work_epoch) && ([]<> !work_epoch))) &&
     ((<>[] target_max) ->
         ((<>[] reconciled_max) && ([]<> work_epoch) && ([]<> !work_epoch)))
+}
+
+/* Once the queue is non-empty, its size must eventually change. Every queue
+ * mutation is exactly one push or one pop and toggles queue_epoch atomically. */
+ltl live_queue_changes {
+    ([] ((queued_activations != 0 && !queue_epoch) -> <> queue_epoch)) &&
+    ([] ((queued_activations != 0 && queue_epoch) -> <> !queue_epoch))
 }
 
 init {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -177,11 +177,6 @@ proctype Worker(byte id) {
             state[id] = NEED_TO_BE_WAKER;
             atomic { waker_pending = true }
 
-        :: suggested_thread_count != thread_count ->
-            resume_state[id] = NONE;
-            state[id] = NEED_TO_BE_WAKER;
-            atomic { waker_pending = true }
-
         :: reductions == 0 && suggested_thread_count == thread_count &&
                 queued_activations > 0 ->
             atomic {
@@ -629,9 +624,18 @@ proctype Controller() {
         };
 
         try_request_waker(owner, i, notified, false);
+        /* Do not publish another target until the waker has observed this
+         * one. This makes a lost resize request observable independently of
+         * later controller updates. */
+        thread_count == suggested_thread_count;
         round++
     :: else -> break
     od
+}
+
+ltl live_resize_reconciles {
+    [] ((suggested_thread_count != thread_count) ->
+        <> (suggested_thread_count == thread_count))
 }
 
 init {

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -351,25 +351,16 @@ proctype Worker(byte id) {
 
         waker_budget = activation_credits;
 
-        /* Account for workers which are already searching before changing
-         * SPIN/BLOCKING states. The budget is local and never reserves the
-         * corresponding queue item. */
+        /* Observe every worker once. NONE only consumes the local budget at
+         * the point where it is seen; it does not reserve a queue item and
+         * may concurrently move to WORK or back into the idle path. */
         waker_i = 0;
         do
         :: waker_i < N ->
             if
             :: waker_i != id && state[waker_i] == NONE &&
                     waker_budget > 0 -> waker_budget--
-            :: else -> skip
-            fi;
-            waker_i++
-        :: else -> break
-        od;
 
-        waker_i = 0;
-        do
-        :: waker_i < N ->
-            if
             :: waker_i != id && state[waker_i] == SPIN ->
                 if
                 :: waker_budget > 0 ->

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -313,39 +313,36 @@ proctype Waker() {
         do
         :: activations > 0 && ((thread_count + remaining_reductions)
                 + taken_tokens_to_sleep) > awake_workers ->
-            found = false;
-            i = 0;
-            do
-            :: i < N && !found ->
-                if
-                :: state[i] == SLEEP ->
-                    atomic {
+            atomic {
+                found = false;
+                i = 0;
+                do
+                :: i < N && !found ->
+                    if
+                    :: state[i] == SLEEP ->
                         state[i] = NONE;
                         awake_workers++;
                         sleep_workers--;
                         activations--;
                         found = true
-                    }
-                :: else -> skip
-                fi;
-                i++
-            :: else -> break
-            od;
-            if
-            :: found -> skip
-            :: else -> break
-            fi
+                    :: else -> skip
+                    fi;
+                    i++
+                :: else -> break
+                od;
+                assert(found)
+            }
         :: else -> break
         od;
 
         /* Publish both the remaining reductions and the baseline used to
          * detect claims on the next pass. The baseline is waker-local. */
-        assert((thread_count + remaining_reductions)
-            + taken_tokens_to_sleep >= awake_workers);
-        eligible_sleepers = ((thread_count + remaining_reductions)
-            + taken_tokens_to_sleep) - awake_workers;
-        assert(eligible_sleepers <= sleep_workers);
         atomic {
+            assert((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep >= awake_workers);
+            eligible_sleepers = ((thread_count + remaining_reductions)
+                + taken_tokens_to_sleep) - awake_workers;
+            assert(eligible_sleepers <= sleep_workers);
             reductions = remaining_reductions;
             previous_reductions = remaining_reductions
         };

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.pml
@@ -152,7 +152,6 @@ proctype Waker() {
     byte previous_sleeping_count;
     byte activations;
     byte sleep_workers;
-    byte non_sleep_workers;
     bool found;
 
     do
@@ -179,76 +178,64 @@ proctype Waker() {
             previous_reductions = 0
         };
 
-        /* thread_count is the target accepted by the previous waker pass,
-         * while active_count is the number of worker slots still eligible to
-         * execute. Claimed and unclaimed reduction tokens account for their
-         * temporary difference. */
-        if
-        :: desired > thread_count ->
-            delta = desired - thread_count;
-
+        /* The waker owns all mutable values in this reconciliation block.
+         * thread_count is the previously accepted target, active_count is the
+         * number of slots still eligible to execute, and sleep_workers is the
+         * total number of workers in Sleep. */
+        atomic {
             if
-            :: taken_tokens_to_sleep < delta -> converted = taken_tokens_to_sleep
-            :: else -> converted = delta
-            fi;
-            taken_tokens_to_sleep = taken_tokens_to_sleep - converted;
-            taken_tokens_to_wakeup = taken_tokens_to_wakeup + converted;
-            delta = delta - converted;
+            :: desired > thread_count ->
+                delta = desired - thread_count;
 
-            if
-            :: remaining_reductions < delta -> converted = remaining_reductions
-            :: else -> converted = delta
-            fi;
-            remaining_reductions = remaining_reductions - converted;
-            delta = delta - converted;
-
-            /* Sleeping workers are symmetric. Growth only increases the
-             * number of sleepers eligible for wakeup; no worker identity has
-             * to be added to a separate active set. */
-            sleep_workers = 0;
-            i = 0;
-            do
-            :: i < N ->
                 if
-                :: state[i] == SLEEP -> sleep_workers++
-                :: else -> skip
+                :: taken_tokens_to_sleep < delta -> converted = taken_tokens_to_sleep
+                :: else -> converted = delta
                 fi;
-                i++
-            :: else -> break
-            od;
-            atomic {
+                taken_tokens_to_sleep = taken_tokens_to_sleep - converted;
+                taken_tokens_to_wakeup = taken_tokens_to_wakeup + converted;
+                delta = delta - converted;
+
+                if
+                :: remaining_reductions < delta -> converted = remaining_reductions
+                :: else -> converted = delta
+                fi;
+                remaining_reductions = remaining_reductions - converted;
+                delta = delta - converted;
+
+                /* Growth makes existing sleepers eligible for wakeup without
+                 * assigning that eligibility to concrete worker identities. */
                 assert(sleep_workers >= previous_sleeping_count + delta);
                 previous_sleeping_count = previous_sleeping_count + delta;
                 active_count = active_count + delta;
                 delta = 0
-            }
 
-        :: desired < thread_count ->
-            delta = thread_count - desired;
-            if
-            :: taken_tokens_to_wakeup < delta -> converted = taken_tokens_to_wakeup
-            :: else -> converted = delta
-            fi;
-            taken_tokens_to_wakeup = taken_tokens_to_wakeup - converted;
-            taken_tokens_to_sleep = taken_tokens_to_sleep + converted;
-            delta = delta - converted;
+            :: desired < thread_count ->
+                delta = thread_count - desired;
+                if
+                :: taken_tokens_to_wakeup < delta -> converted = taken_tokens_to_wakeup
+                :: else -> converted = delta
+                fi;
+                taken_tokens_to_wakeup = taken_tokens_to_wakeup - converted;
+                taken_tokens_to_sleep = taken_tokens_to_sleep + converted;
+                delta = delta - converted;
 
-            /* Retire already sleeping slots before asking an awake worker to
-             * claim a new reduction token. */
-            if
-            :: previous_sleeping_count < delta -> converted = previous_sleeping_count
-            :: else -> converted = delta
-            fi;
-            atomic {
+                /* Retire already sleeping slots before asking an awake worker
+                 * to claim a new reduction token. */
+                if
+                :: previous_sleeping_count < delta -> converted = previous_sleeping_count
+                :: else -> converted = delta
+                fi;
                 previous_sleeping_count = previous_sleeping_count - converted;
                 active_count = active_count - converted;
-                delta = delta - converted
-            };
-            remaining_reductions = remaining_reductions + delta
+                delta = delta - converted;
+                remaining_reductions = remaining_reductions + delta;
+                delta = 0
 
-        :: else -> skip
-        fi;
-        thread_count = desired;
+            :: else -> skip
+            fi;
+            thread_count = desired;
+            converted = 0
+        };
 
         activations = activation_credits;
 
@@ -282,7 +269,8 @@ proctype Waker() {
                         if
                         :: state[i] == SPIN ->
                             state[i] = SLEEP;
-                            previous_sleeping_count++
+                            previous_sleeping_count++;
+                            sleep_workers++
                         :: else ->
                             assert(state[i] == NONE || state[i] == WORK)
                         fi
@@ -303,6 +291,7 @@ proctype Waker() {
                         atomic {
                             state[i] = SLEEP;
                             previous_sleeping_count++;
+                            sleep_workers++;
                             taken_tokens_to_wakeup--
                         }
                     fi
@@ -312,6 +301,7 @@ proctype Waker() {
                     atomic {
                         state[i] = SLEEP;
                         active_count--;
+                        sleep_workers++;
                         taken_tokens_to_sleep--
                     }
                 fi
@@ -336,6 +326,7 @@ proctype Waker() {
                     atomic {
                         state[i] = NONE;
                         previous_sleeping_count--;
+                        sleep_workers--;
                         activations--;
                         found = true
                     }
@@ -370,20 +361,10 @@ proctype Waker() {
          */
 
         check_safety();
-        sleep_workers = 0;
-        non_sleep_workers = 0;
-        i = 0;
-        do
-        :: i < N ->
-            if
-            :: state[i] == SLEEP -> sleep_workers++
-            :: else -> non_sleep_workers++
-            fi;
-            i++
-        :: else -> break
-        od;
-        assert(previous_sleeping_count <= sleep_workers);
-        assert(active_count == non_sleep_workers + previous_sleeping_count)
+        atomic {
+            assert(previous_sleeping_count <= sleep_workers);
+            assert(active_count == N - sleep_workers + previous_sleeping_count)
+        }
     od
 }
 

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -1,0 +1,47 @@
+Model: executor_pool_basic_waker.pml
+Model SHA-256: a63bf79a035f7b0719dab458e77c58a76f05a17f0da9c419f1b622c1962d0aaa
+Host: mr-nvme-testing-004.ydb.yandex.net
+Started: 2026-08-18T19:00:58+03:00
+Spin: Spin Version 6.5.2 -- 6 December 2019
+
+Commands:
+  spin -a executor_pool_basic_waker.pml
+  cc -O3 -DCOLLAPSE -o pan pan.c
+  ./pan -a -N live_queue_changes -m800000000 -w30 -n -Q60
+
+Result: HOLDS (full state-space search completed with errors: 0)
+
+Full statespace search for:
+  never claim             + (live_queue_changes)
+  assertion violations    + (if within scope of claim)
+  acceptance cycles       + (fairness disabled)
+  invalid end states      - (disabled by never claim)
+
+State-vector 96 byte, depth reached 116414149, errors: 0
+4.1833897e+08 states, stored (5.63613e+08 visited)
+1.5828258e+09 states, matched
+2.1464386e+09 transitions (= visited+matched)
+3.495041e+08 atomic steps
+hash conflicts: 2.3104401e+08 (resolved)
+
+Stats on memory usage (in Megabytes):
+52662.605  equivalent memory usage for states (stored*(State-vector + overhead))
+22497.175  actual memory usage for states (compression: 42.72%)
+            state-vector as stored = 20 byte + 36 byte overhead
+ 8192.000  memory used for hash table (-w30)
+42724.610  memory used for DFS stack (-m800000000)
+    6.159  memory lost to fragmentation
+73407.625  total actual memory usage
+
+nr of templates: [ 0:globals 1:chans 2:procs ]
+collapse counts: [ 0:3121 2:28 3:5 4:7 5:4033 6:2 7:3 ]
+
+pan: elapsed time 887 seconds
+pan: rate 635543.54 states/second
+
+User time (seconds): 879.54
+System time (seconds): 29.90
+Percent of CPU this job got: 99%
+Elapsed (wall clock) time: 15:10.23
+Maximum resident set size (kbytes): 75174792
+Exit status: 0

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -1,47 +1,39 @@
 Model: executor_pool_basic_waker.pml
-Model SHA-256: a63bf79a035f7b0719dab458e77c58a76f05a17f0da9c419f1b622c1962d0aaa
-Host: mr-nvme-testing-004.ydb.yandex.net
-Started: 2026-08-18T19:00:58+03:00
+Commit: d20fb5b5fbc97ebe4a938e371822ffeff34f365b
+Model SHA-256: f55b5b00f00e118218de0278c87baa30bce74bb44c252c5ab4534c3771bd1a61
+Host: build-host-004
+Started: 2026-08-19T01:13:49+03:00
+Finished: 2026-08-19T01:31:24+03:00
 Spin: Spin Version 6.5.2 -- 6 December 2019
 
 Commands:
   spin -a executor_pool_basic_waker.pml
-  cc -O3 -DCOLLAPSE -o pan pan.c
-  ./pan -a -N live_queue_changes -m800000000 -w30 -n -Q60
+  cc -O3 -DNFAIR=2 -o pan pan.c
+  ./pan -a -m1000000 -w27
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
 Full statespace search for:
-  never claim             + (live_queue_changes)
+  never claim             + (live_resize_reconciles)
   assertion violations    + (if within scope of claim)
   acceptance cycles       + (fairness disabled)
   invalid end states      - (disabled by never claim)
 
-State-vector 96 byte, depth reached 116414149, errors: 0
-4.1833897e+08 states, stored (5.63613e+08 visited)
-1.5828258e+09 states, matched
-2.1464386e+09 transitions (= visited+matched)
-3.495041e+08 atomic steps
-hash conflicts: 2.3104401e+08 (resolved)
+State-vector 80 byte, depth reached 1110, errors: 0
+1.0814687e+09 states, stored (1.24102e+09 visited)
+1.2619889e+09 states, matched
+2.5030137e+09 transitions (= visited+matched)
+7.1116546e+08 atomic steps
+hash conflicts: 9.3187647e+08 (resolved)
 
 Stats on memory usage (in Megabytes):
-52662.605  equivalent memory usage for states (stored*(State-vector + overhead))
-22497.175  actual memory usage for states (compression: 42.72%)
-            state-vector as stored = 20 byte + 36 byte overhead
- 8192.000  memory used for hash table (-w30)
-42724.610  memory used for DFS stack (-m800000000)
-    6.159  memory lost to fragmentation
-73407.625  total actual memory usage
+111387.842  equivalent memory usage for states (stored*(State-vector + overhead))
+ 86860.349  actual memory usage for states (compression: 77.98%)
+            state-vector as stored = 56 byte + 28 byte overhead
+ 16384.000  memory used for hash table (-w31)
+    53.406  memory used for DFS stack (-m1000000)
+     3.142  memory lost to fragmentation
+103294.613  total actual memory usage
 
-nr of templates: [ 0:globals 1:chans 2:procs ]
-collapse counts: [ 0:3121 2:28 3:5 4:7 5:4033 6:2 7:3 ]
-
-pan: elapsed time 887 seconds
-pan: rate 635543.54 states/second
-
-User time (seconds): 879.54
-System time (seconds): 29.90
-Percent of CPU this job got: 99%
-Elapsed (wall clock) time: 15:10.23
-Maximum resident set size (kbytes): 75174792
-Exit status: 0
+pan: elapsed time 1.05e+03 seconds
+pan: rate 1180163.8 states/second

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -6,10 +6,14 @@ Started: 2026-08-19T01:13:49+03:00
 Finished: 2026-08-19T01:31:24+03:00
 Spin: Spin Version 6.5.2 -- 6 December 2019
 
-Commands:
+Equivalent reproduction commands for the recorded claim:
   spin -a executor_pool_basic_waker.pml
-  cc -O3 -DNFAIR=2 -o pan pan.c
-  ./pan -a -m1000000 -w27
+  cc -O3 -o pan pan.c
+  ./pan -a -N live_resize_reconciles -m1000000 -w31
+
+The recorded result covers live_resize_reconciles. The live_queue_changes
+claim was added later and requires a separate run with:
+  ./pan -a -N live_queue_changes -m1000000 -w31
 
 Result: HOLDS (full state-space search completed with errors: 0)
 

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -1,68 +1,65 @@
 Model: executor_pool_basic_waker.pml
-Committed model SHA-256:
-  99035a3b16cc3363159e4e3a97dd21be7670670c6b8413e1fcb3377cb81c6330
-Verified source model SHA-256:
-  325548bb2179349843aa0b59549cb8e608c0ab91358424842ec1394acf7b9aeb
-Whitespace-normalized SHA-256 for both files:
-  eb0da4f2238db7383252414c30ec8d9001d384e383c4b3bb2e9dba798db22a1c
+Source model SHA-256:
+  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
 
-After the runs, two trailing spaces were removed from the model. This changes
-the file SHA-256 but no Promela tokens or transitions; the normalized files
-are identical.
+All runs used a one-hour timeout, a maximum search depth of 1,000,000,000,
+and no fairness. Every run completed the full state-space search before the
+timeout with errors: 0. No run produced a trail.
 
-All runs used a one-hour timeout and completed before the timeout.
-Fairness was disabled for all runs.
+Spin 6.4.9 cannot expand all three embedded LTL claims together. Each run
+therefore used a derived model.pml with unused LTL blocks removed. This does
+not change the Promela transition system. The source and derived SHA-256
+values are recorded below.
+
+-------------------------------------------------------------------------------
 
 Safety verification (no LTL claim)
 
-Spin: Spin Version 6.5.2 -- 6 December 2019
+Started: 2026-08-20T21:07:02+00:00
+Spin: Spin Version 6.4.9 -- 17 December 2018
+Source SHA-256:
+  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+Derived model SHA-256:
+  8d32acd5473f46462b6e5dc726336ff866d7bec2c97230cfcea21925f051eba2
+
+The derived model removes all three LTL blocks.
+
 Commands:
-  spin -a executor_pool_basic_waker.pml
+  spin -a model.pml
   cc -O3 -DSAFETY -DNOCLAIM -DMEMLIM=220000 -o pan pan.c
   timeout --signal=INT --kill-after=30s 3600 \
       ./pan -m1000000000 -w30
 
-Result: VIOLATED (invalid end state, errors: 1)
+Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 68 byte, depth reached 586, errors: 1
-438 states, stored
-14 states, matched
-452 transitions (= stored+matched)
-152 atomic steps
-61598.055 MB total actual memory usage
-pan: elapsed time 0 seconds
-wall clock time 0:25.97
-maximum resident set size 63078152 kbytes
-
-The trail ends in a quiescent state after Producer and Controller stop:
-the queue and activation credits are empty, waker_pending is false,
-waker_worker_id is invalid, and both workers are in SLEEP. Spin reports this
-as an invalid end state because the parked Worker processes are not marked as
-valid end states in the model.
+State-vector 76 byte, depth reached 40512739, errors: 0
+3.8172498e+08 states, stored
+7.9115333e+08 states, matched
+1.1728783e+09 transitions (= stored+matched)
+4.8573154e+08 atomic steps
+88075.203 MB total actual memory usage
+pan: elapsed time 424 seconds
+wall clock time 7:35.87
+maximum resident set size 90195256 kbytes
 
 Run directory:
-  build-host-002:/tmp/waker-hour-safety-325548-v1
+  build-host-001:/tmp/waker_full_db0d2eca_safety
 
 -------------------------------------------------------------------------------
 
 Claim: live_resize_reconciles
 
-Spin: Spin Version 6.4.9 -- 17 December 2018
-
-Spin 6.4.9 cannot expand all embedded LTL claims in this model. The verified
-temporary model.pml differs only by removal of the unused live_queue_changes
-and live_waker_pending_clears blocks. The transition system and
-live_resize_reconciles claim are unchanged.
-
-Verified source model SHA-256:
-  325548bb2179349843aa0b59549cb8e608c0ab91358424842ec1394acf7b9aeb
+Started: 2026-08-20T21:07:04+00:00
+Spin: Spin Version 6.5.2 -- 6 December 2019
+Source SHA-256:
+  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
 Derived model SHA-256:
-  b2035a837de9ec41039a9d1c96acd72f956d880516ac05025bf5d62091883499
+  521882066a819b6f3fc58347090faf6bc2e092f8a68fad7bbf1bf4ee9ca486c0
+
+The derived model removes live_queue_changes and
+live_waker_pending_clears.
 
 Commands:
-  sed -e '/^ltl live_queue_changes {$/,/^}$/d' \
-      -e '/^ltl live_waker_pending_clears {$/,/^}$/d' \
-      executor_pool_basic_waker.pml > model.pml
   spin -a model.pml
   cc -O3 -DMEMLIM=220000 -o pan pan.c
   timeout --signal=INT --kill-after=30s 3600 \
@@ -70,74 +67,89 @@ Commands:
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 76 byte, depth reached 68073091, errors: 0
-5.4910992e+08 states, stored (6.89582e+08 visited)
-1.5536961e+09 states, matched
-2.2432776e+09 transitions (= visited+matched)
-8.1757716e+08 atomic steps
-107759.195 MB total actual memory usage
-pan: elapsed time 671 seconds
-wall clock time 11:40.39
-maximum resident set size 110353324 kbytes
+State-vector 92 byte, depth reached 69644203, errors: 0
+5.1435801e+08 states, stored (6.45339e+08 visited)
+1.6884789e+09 states, matched
+2.333818e+09 transitions (= visited+matched)
+8.9180497e+08 atomic steps
+109301.774 MB total actual memory usage
+pan: elapsed time 907 seconds
+wall clock time 15:43.35
+maximum resident set size 111933276 kbytes
 
 Run directory:
-  build-host-003:/tmp/waker-hour-resize-325548-v1
+  build-host-002:/tmp/waker_full_db0d2eca_resize
 
 -------------------------------------------------------------------------------
 
 Claim: live_queue_changes
 
-Spin: Spin Version 6.5.2 -- 6 December 2019
+Started: 2026-08-20T21:10:06+00:00
+Generator: Spin Version 6.5.2 -- 6 December 2019
+Source SHA-256:
+  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+Derived model SHA-256:
+  caabd321cd9013bd277af2e8a44d849802e9c18d49528f5ca0046d4a5b66c725
+Generated pan.c SHA-256:
+  b36cb905cc08ba2f4e48e7177f319a49e64bda46a366931cadc2bffe833cfb76
+Verifier binary SHA-256:
+  e3531cab45b71f1008777c39137a14c3190313646d075bcd3bbdb71e5aecdf21
+
+The derived model removes live_resize_reconciles and
+live_waker_pending_clears. Spin generated pan.c locally, build-host-002
+compiled the Linux verifier, and the exhaustive search ran on amd7713-host.
+
 Commands:
-  spin -a executor_pool_basic_waker.pml
-  cc -O3 -DMEMLIM=220000 -o pan pan.c
+  spin -a model.pml
+  cc -O3 -DMEMLIM=900000 -o pan pan.c
   timeout --signal=INT --kill-after=30s 3600 \
-      ./pan -a -N live_queue_changes -m1000000000 -w31
+      ./pan -a -m1000000000 -w31
 
-Result: VIOLATED (acceptance cycle, errors: 1)
+Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 76 byte, depth reached 629246, errors: 1
-12424846 states, stored (1.77702e+07 visited)
-30698199 states, matched
-48468412 transitions (= visited+matched)
-12379405 atomic steps
-70727.262 MB total actual memory usage
-pan: elapsed time 12.4 seconds
-wall clock time 0:42.17
-maximum resident set size 72426640 kbytes
-
-The trail ends with one queued activation and one activation credit. One
-worker is in SLEEP and the other is in BLOCKING, waker_worker_id is invalid,
-and waker_pending is false. The blocking worker consumed the persistent
-waker bit while another worker still owned the waker role. It then restored
-BLOCKING without transferring the request to the current owner. After that
-owner released the role, no request remained to process the queued activation.
+State-vector 92 byte, depth reached 69644203, errors: 0
+7.2626704e+08 states, stored (1.06914e+09 visited)
+2.9666421e+09 states, matched
+4.0357836e+09 transitions (= visited+matched)
+1.5731353e+09 atomic steps
+125470.719 MB total actual memory usage
+pan: elapsed time 1.12e+03 seconds
+wall clock time 19:21.67
+maximum resident set size 128492736 kbytes
 
 Run directory:
-  build-host-002:/tmp/waker-hour-queue-325548-v1
+  amd7713-host:/tmp/waker_full_db0d2eca_queue
 
 -------------------------------------------------------------------------------
 
 Claim: live_waker_pending_clears
 
+Started: 2026-08-21T00:07:04+03:00
 Spin: Spin Version 6.5.2 -- 6 December 2019
+Source SHA-256:
+  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+Derived model SHA-256:
+  e40120092061f297b64017c4221e3993489b121e2169e3785366ad30789c33e2
+
+The derived model removes live_resize_reconciles and live_queue_changes.
+
 Commands:
-  spin -a executor_pool_basic_waker.pml
+  spin -a model.pml
   cc -O3 -DMEMLIM=220000 -o pan pan.c
   timeout --signal=INT --kill-after=30s 3600 \
-      ./pan -a -N live_waker_pending_clears -m1000000000 -w31
+      ./pan -a -m1000000000 -w31
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 76 byte, depth reached 68073091, errors: 0
-6.9149223e+08 states, stored (9.74426e+08 visited)
-2.4768724e+09 states, matched
-3.4512985e+09 transitions (= visited+matched)
-1.2624514e+09 atomic steps
-122763.785 MB total actual memory usage
-pan: elapsed time 1.04e+03 seconds
-wall clock time 17:50.93
-maximum resident set size 125720512 kbytes
+State-vector 92 byte, depth reached 69644203, errors: 0
+6.5644374e+08 states, stored (9.29583e+08 visited)
+2.7441691e+09 states, matched
+3.6737522e+09 transitions (= visited+matched)
+1.4093236e+09 atomic steps
+120143.473 MB total actual memory usage
+pan: elapsed time 1.12e+03 seconds
+wall clock time 19:11.50
+maximum resident set size 123036872 kbytes
 
 Run directory:
-  build-host-004:/tmp/waker-hour-pending-325548-v1
+  build-host-004:/tmp/waker_full_db0d2eca_pending

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -1,43 +1,90 @@
 Model: executor_pool_basic_waker.pml
-Commit: d20fb5b5fbc97ebe4a938e371822ffeff34f365b
-Model SHA-256: f55b5b00f00e118218de0278c87baa30bce74bb44c252c5ab4534c3771bd1a61
-Host: build-host-004
-Started: 2026-08-19T01:13:49+03:00
-Finished: 2026-08-19T01:31:24+03:00
+Model SHA-256: 49df29e5e9e5fdfb431fa106dc2e40136fc65aa62a3aa7a7939f151556b509ee
+
+The model uses producer_epoch and controller_epoch to scope liveness
+obligations to intervals without new producer or controller events.
+Fairness was disabled for all runs.
+
+Safety verification
+
 Spin: Spin Version 6.5.2 -- 6 December 2019
-
-Equivalent reproduction commands for the recorded claim:
+Commands:
   spin -a executor_pool_basic_waker.pml
-  cc -O3 -o pan pan.c
-  ./pan -a -N live_resize_reconciles -m1000000 -w31
-
-The recorded result covers live_resize_reconciles. The live_queue_changes
-claim was added later and requires a separate run with:
-  ./pan -a -N live_queue_changes -m1000000 -w31
+  cc -O3 -DSAFETY -DNOCLAIM -o pan pan.c
+  ./pan -m1000000000 -w30
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-Full statespace search for:
-  never claim             + (live_resize_reconciles)
-  assertion violations    + (if within scope of claim)
-  acceptance cycles       + (fairness disabled)
-  invalid end states      - (disabled by never claim)
+State-vector 68 byte, depth reached 36617377, errors: 0
+2.3948236e+08 states, stored
+3.92915e+08 states, matched
+6.3239735e+08 transitions (= stored+matched)
+2.4393238e+08 atomic steps
+78283.113 MB total actual memory usage
+pan: elapsed time 229 seconds
+wall clock time 4:16.73
+maximum resident set size 80166384 kbytes
 
-State-vector 80 byte, depth reached 1110, errors: 0
-1.0814687e+09 states, stored (1.24102e+09 visited)
-1.2619889e+09 states, matched
-2.5030137e+09 transitions (= visited+matched)
-7.1116546e+08 atomic steps
-hash conflicts: 9.3187647e+08 (resolved)
+Run directory:
+  build-host-002:/tmp/waker-hour-safety-49df29.4tyFN5
 
-Stats on memory usage (in Megabytes):
-111387.842  equivalent memory usage for states (stored*(State-vector + overhead))
- 86860.349  actual memory usage for states (compression: 77.98%)
-            state-vector as stored = 56 byte + 28 byte overhead
- 16384.000  memory used for hash table (-w31)
-    53.406  memory used for DFS stack (-m1000000)
-     3.142  memory lost to fragmentation
-103294.613  total actual memory usage
+-------------------------------------------------------------------------------
 
-pan: elapsed time 1.05e+03 seconds
-pan: rate 1180163.8 states/second
+Claim: live_resize_reconciles
+
+Spin: Spin Version 6.4.9 -- 17 December 2018
+
+Spin 6.4.9 aborted while expanding both embedded LTL claims. The verified
+temporary resize_model.pml differs only by removal of the unused
+live_queue_changes block. The transition system and live_resize_reconciles
+claim are unchanged.
+
+Derived model SHA-256:
+  20bbe205f97bd249cfe9f2400778c40276a2d77cf59d811bab2cc501dd2c2a67
+
+Commands:
+  sed '/^ltl live_queue_changes {$/,/^}$/d' \
+      executor_pool_basic_waker.pml > resize_model.pml
+  spin -a resize_model.pml
+  cc -O3 -o pan pan.c
+  ./pan -a -m1000000000 -w31
+
+Result: HOLDS (full state-space search completed with errors: 0)
+
+State-vector 76 byte, depth reached 63745162, errors: 0
+3.4296727e+08 states, stored (4.44681e+08 visited)
+9.1690385e+08 states, matched
+1.3615853e+09 transitions (= visited+matched)
+4.8041475e+08 atomic steps
+93586.246 MB total actual memory usage
+pan: elapsed time 442 seconds
+wall clock time 7:53.36
+maximum resident set size 95837940 kbytes
+
+Run directory:
+  build-host-003:/tmp/waker-hour-resize-49df29-only.k3DhsR
+
+-------------------------------------------------------------------------------
+
+Claim: live_queue_changes
+
+Spin: Spin Version 6.5.2 -- 6 December 2019
+Commands:
+  spin -a executor_pool_basic_waker.pml
+  cc -O3 -o pan pan.c
+  ./pan -a -N live_queue_changes -m1000000000 -w31
+
+Result: HOLDS (full state-space search completed with errors: 0)
+
+State-vector 76 byte, depth reached 63745162, errors: 0
+4.4512455e+08 states, stored (6.48952e+08 visited)
+1.3541268e+09 states, matched
+2.0030785e+09 transitions (= visited+matched)
+7.1283045e+08 atomic steps
+103997.184 MB total actual memory usage
+pan: elapsed time 636 seconds
+wall clock time 11:08.63
+maximum resident set size 106500436 kbytes
+
+Run directory:
+  build-host-004:/tmp/waker-hour-queue-49df29.nDfslj

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -1,28 +1,31 @@
 Model: executor_pool_basic_waker.pml
 Source model SHA-256:
-  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+  c77e4ccd89aa5dd1a9cdda6cf08d33325ea2c0e1b1d02acca2e85f13a9aa4333
 
 All runs used a one-hour timeout, a maximum search depth of 1,000,000,000,
-and no fairness. Every run completed the full state-space search before the
-timeout with errors: 0. No run produced a trail.
+a 220,000 MB verifier memory limit, partial-order reduction, and no fairness.
+Every run completed the full state-space search before the timeout with
+errors: 0 and exit status 0. No run produced a trail.
 
-Spin 6.4.9 cannot expand all three embedded LTL claims together. Each run
-therefore used a derived model.pml with unused LTL blocks removed. This does
-not change the Promela transition system. The source and derived SHA-256
-values are recorded below.
+Each run used a derived model.pml. The safety model removes all four LTL
+blocks. Each liveness model retains only the selected LTL block and removes
+the other three. This filtering does not change the Promela transition
+system. The source and derived SHA-256 values are recorded below.
 
 -------------------------------------------------------------------------------
 
 Safety verification (no LTL claim)
 
-Started: 2026-08-20T21:07:02+00:00
-Spin: Spin Version 6.4.9 -- 17 December 2018
+Started: 2026-08-21T23:43:38+03:00
+Finished: 2026-08-21T23:49:58+03:00
+Host: mr-nvme-testing-004.ydb.yandex.net
+Spin: Spin Version 6.5.2 -- 6 December 2019
 Source SHA-256:
-  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+  c77e4ccd89aa5dd1a9cdda6cf08d33325ea2c0e1b1d02acca2e85f13a9aa4333
 Derived model SHA-256:
-  8d32acd5473f46462b6e5dc726336ff866d7bec2c97230cfcea21925f051eba2
+  4f7b8a58101e5da4ce554005471dd968fe1c806ce27cf79cd86507a6a85d0950
 
-The derived model removes all three LTL blocks.
+The derived model removes all four LTL blocks.
 
 Commands:
   spin -a model.pml
@@ -32,32 +35,34 @@ Commands:
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 76 byte, depth reached 40512739, errors: 0
-3.8172498e+08 states, stored
-7.9115333e+08 states, matched
-1.1728783e+09 transitions (= stored+matched)
-4.8573154e+08 atomic steps
-88075.203 MB total actual memory usage
-pan: elapsed time 424 seconds
-wall clock time 7:35.87
-maximum resident set size 90195256 kbytes
+State-vector 76 byte, depth reached 37827442, errors: 0
+3.325185e+08 states, stored
+7.0017207e+08 states, matched
+1.0326906e+09 transitions (= stored+matched)
+4.0752544e+08 atomic steps
+84683.211 MB total actual memory usage
+pan: elapsed time 350 seconds
+wall clock time 6:15.88
+maximum resident set size 86721244 kbytes
 
 Run directory:
-  build-host-001:/tmp/waker_full_db0d2eca_safety
+  mr-nvme-testing-004.ydb.yandex.net:/tmp/waker_safety_c77e4ccd_WOR7Bo
 
 -------------------------------------------------------------------------------
 
 Claim: live_resize_reconciles
 
-Started: 2026-08-20T21:07:04+00:00
-Spin: Spin Version 6.5.2 -- 6 December 2019
+Started: 2026-08-21T23:43:38+03:00
+Finished: 2026-08-21T23:55:59+03:00
+Host: mr-nvme-testing-003.ydb.yandex.net
+Spin: Spin Version 6.4.9 -- 17 December 2018
 Source SHA-256:
-  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+  c77e4ccd89aa5dd1a9cdda6cf08d33325ea2c0e1b1d02acca2e85f13a9aa4333
 Derived model SHA-256:
-  521882066a819b6f3fc58347090faf6bc2e092f8a68fad7bbf1bf4ee9ca486c0
+  e58de16114058639916ba0321f239a39649f6531e06df4a4b22d718e8c246941
 
-The derived model removes live_queue_changes and
-live_waker_pending_clears.
+The derived model removes live_queue_changes,
+live_waker_pending_clears, and live_zero_activations_sleep.
 
 Commands:
   spin -a model.pml
@@ -67,71 +72,34 @@ Commands:
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 92 byte, depth reached 69644203, errors: 0
-5.1435801e+08 states, stored (6.45339e+08 visited)
-1.6884789e+09 states, matched
-2.333818e+09 transitions (= visited+matched)
-8.9180497e+08 atomic steps
-109301.774 MB total actual memory usage
-pan: elapsed time 907 seconds
-wall clock time 15:43.35
-maximum resident set size 111933276 kbytes
+State-vector 92 byte, depth reached 64697006, errors: 0
+4.6634965e+08 states, stored (5.98753e+08 visited)
+1.592931e+09 states, matched
+2.191684e+09 transitions (= visited+matched)
+8.1110927e+08 atomic steps
+105625.797 MB total actual memory usage
+pan: elapsed time 703 seconds
+wall clock time 12:16.09
+maximum resident set size 108168392 kbytes
 
 Run directory:
-  build-host-002:/tmp/waker_full_db0d2eca_resize
+  mr-nvme-testing-003.ydb.yandex.net:/tmp/waker_resize_c77e4ccd_nOwA4P
 
 -------------------------------------------------------------------------------
 
 Claim: live_queue_changes
 
-Started: 2026-08-20T21:10:06+00:00
-Generator: Spin Version 6.5.2 -- 6 December 2019
-Source SHA-256:
-  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
-Derived model SHA-256:
-  caabd321cd9013bd277af2e8a44d849802e9c18d49528f5ca0046d4a5b66c725
-Generated pan.c SHA-256:
-  b36cb905cc08ba2f4e48e7177f319a49e64bda46a366931cadc2bffe833cfb76
-Verifier binary SHA-256:
-  e3531cab45b71f1008777c39137a14c3190313646d075bcd3bbdb71e5aecdf21
-
-The derived model removes live_resize_reconciles and
-live_waker_pending_clears. Spin generated pan.c locally, build-host-002
-compiled the Linux verifier, and the exhaustive search ran on amd7713-host.
-
-Commands:
-  spin -a model.pml
-  cc -O3 -DMEMLIM=900000 -o pan pan.c
-  timeout --signal=INT --kill-after=30s 3600 \
-      ./pan -a -m1000000000 -w31
-
-Result: HOLDS (full state-space search completed with errors: 0)
-
-State-vector 92 byte, depth reached 69644203, errors: 0
-7.2626704e+08 states, stored (1.06914e+09 visited)
-2.9666421e+09 states, matched
-4.0357836e+09 transitions (= visited+matched)
-1.5731353e+09 atomic steps
-125470.719 MB total actual memory usage
-pan: elapsed time 1.12e+03 seconds
-wall clock time 19:21.67
-maximum resident set size 128492736 kbytes
-
-Run directory:
-  amd7713-host:/tmp/waker_full_db0d2eca_queue
-
--------------------------------------------------------------------------------
-
-Claim: live_waker_pending_clears
-
-Started: 2026-08-21T00:07:04+03:00
+Started: 2026-08-21T20:43:38+00:00
+Finished: 2026-08-21T21:00:37+00:00
+Host: mr-nvme-testing-002.ydb.yandex.net
 Spin: Spin Version 6.5.2 -- 6 December 2019
 Source SHA-256:
-  db0d2eca4b4d24c14c7f1582485fabf1f6f0a6afaf16d6d98eaa3709b0b98805
+  c77e4ccd89aa5dd1a9cdda6cf08d33325ea2c0e1b1d02acca2e85f13a9aa4333
 Derived model SHA-256:
-  e40120092061f297b64017c4221e3993489b121e2169e3785366ad30789c33e2
+  d10b41adc0208e6610ff2a4d32ef0428141aca358a0549679827c270e4df3505
 
-The derived model removes live_resize_reconciles and live_queue_changes.
+The derived model removes live_resize_reconciles,
+live_waker_pending_clears, and live_zero_activations_sleep.
 
 Commands:
   spin -a model.pml
@@ -141,15 +109,89 @@ Commands:
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 92 byte, depth reached 69644203, errors: 0
-6.5644374e+08 states, stored (9.29583e+08 visited)
-2.7441691e+09 states, matched
-3.6737522e+09 transitions (= visited+matched)
-1.4093236e+09 atomic steps
-120143.473 MB total actual memory usage
-pan: elapsed time 1.12e+03 seconds
-wall clock time 19:11.50
-maximum resident set size 123036872 kbytes
+State-vector 92 byte, depth reached 64697006, errors: 0
+6.2989756e+08 states, stored (9.2585e+08 visited)
+2.5841678e+09 states, matched
+3.5100178e+09 transitions (= visited+matched)
+1.2995753e+09 atomic steps
+118104.801 MB total actual memory usage
+pan: elapsed time 983 seconds
+wall clock time 16:54.17
+maximum resident set size 120948736 kbytes
 
 Run directory:
-  build-host-004:/tmp/waker_full_db0d2eca_pending
+  mr-nvme-testing-002.ydb.yandex.net:/tmp/waker_queue_c77e4ccd_2SSPF3
+
+-------------------------------------------------------------------------------
+
+Claim: live_waker_pending_clears
+
+Started: 2026-08-21T23:50:49+03:00
+Finished: 2026-08-22T00:07:23+03:00
+Host: mr-nvme-testing-004.ydb.yandex.net
+Spin: Spin Version 6.5.2 -- 6 December 2019
+Source SHA-256:
+  c77e4ccd89aa5dd1a9cdda6cf08d33325ea2c0e1b1d02acca2e85f13a9aa4333
+Derived model SHA-256:
+  7ba43f070d27668f7b5c2ede7b8d5794fcc6a0f8ad33db2d0dbf9d59b41fc149
+
+The derived model removes live_resize_reconciles,
+live_queue_changes, and live_zero_activations_sleep.
+
+Commands:
+  spin -a model.pml
+  cc -O3 -DMEMLIM=220000 -o pan pan.c
+  timeout --signal=INT --kill-after=30s 3600 \
+      ./pan -a -m1000000000 -w31
+
+Result: HOLDS (full state-space search completed with errors: 0)
+
+State-vector 92 byte, depth reached 64697006, errors: 0
+5.7819066e+08 states, stored (8.22524e+08 visited)
+2.4596306e+09 states, matched
+3.2821549e+09 transitions (= visited+matched)
+1.2051436e+09 atomic steps
+114159.586 MB total actual memory usage
+pan: elapsed time 959 seconds
+wall clock time 16:29.46
+maximum resident set size 116908496 kbytes
+
+Run directory:
+  mr-nvme-testing-004.ydb.yandex.net:/tmp/waker_pending_c77e4ccd_RFKvfo
+
+-------------------------------------------------------------------------------
+
+Claim: live_zero_activations_sleep
+
+Started: 2026-08-21T23:57:12+03:00
+Finished: 2026-08-22T00:10:01+03:00
+Host: mr-nvme-testing-003.ydb.yandex.net
+Spin: Spin Version 6.4.9 -- 17 December 2018
+Source SHA-256:
+  c77e4ccd89aa5dd1a9cdda6cf08d33325ea2c0e1b1d02acca2e85f13a9aa4333
+Derived model SHA-256:
+  c22fd9e5cae3f799bf69ddb750c8b2b1afa01688e0bfa1566cb75f6713afd261
+
+The derived model removes live_resize_reconciles,
+live_queue_changes, and live_waker_pending_clears.
+
+Commands:
+  spin -a model.pml
+  cc -O3 -DMEMLIM=220000 -o pan pan.c
+  timeout --signal=INT --kill-after=30s 3600 \
+      ./pan -a -m1000000000 -w31
+
+Result: HOLDS (full state-space search completed with errors: 0)
+
+State-vector 92 byte, depth reached 64697006, errors: 0
+4.6021482e+08 states, stored (5.8657e+08 visited)
+1.5405887e+09 states, matched
+2.1271591e+09 transitions (= visited+matched)
+7.9938958e+08 atomic steps
+105156.949 MB total actual memory usage
+pan: elapsed time 734 seconds
+wall clock time 12:44.51
+maximum resident set size 107688176 kbytes
+
+Run directory:
+  mr-nvme-testing-003.ydb.yandex.net:/tmp/waker_zero_sleep_c77e4ccd_qeEXwZ

--- a/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
+++ b/ydb/library/actors/core/spin/executor_pool_basic_waker.verification.txt
@@ -1,32 +1,47 @@
 Model: executor_pool_basic_waker.pml
-Model SHA-256: 49df29e5e9e5fdfb431fa106dc2e40136fc65aa62a3aa7a7939f151556b509ee
+Committed model SHA-256:
+  99035a3b16cc3363159e4e3a97dd21be7670670c6b8413e1fcb3377cb81c6330
+Verified source model SHA-256:
+  325548bb2179349843aa0b59549cb8e608c0ab91358424842ec1394acf7b9aeb
+Whitespace-normalized SHA-256 for both files:
+  eb0da4f2238db7383252414c30ec8d9001d384e383c4b3bb2e9dba798db22a1c
 
-The model uses producer_epoch and controller_epoch to scope liveness
-obligations to intervals without new producer or controller events.
+After the runs, two trailing spaces were removed from the model. This changes
+the file SHA-256 but no Promela tokens or transitions; the normalized files
+are identical.
+
+All runs used a one-hour timeout and completed before the timeout.
 Fairness was disabled for all runs.
 
-Safety verification
+Safety verification (no LTL claim)
 
 Spin: Spin Version 6.5.2 -- 6 December 2019
 Commands:
   spin -a executor_pool_basic_waker.pml
-  cc -O3 -DSAFETY -DNOCLAIM -o pan pan.c
-  ./pan -m1000000000 -w30
+  cc -O3 -DSAFETY -DNOCLAIM -DMEMLIM=220000 -o pan pan.c
+  timeout --signal=INT --kill-after=30s 3600 \
+      ./pan -m1000000000 -w30
 
-Result: HOLDS (full state-space search completed with errors: 0)
+Result: VIOLATED (invalid end state, errors: 1)
 
-State-vector 68 byte, depth reached 36617377, errors: 0
-2.3948236e+08 states, stored
-3.92915e+08 states, matched
-6.3239735e+08 transitions (= stored+matched)
-2.4393238e+08 atomic steps
-78283.113 MB total actual memory usage
-pan: elapsed time 229 seconds
-wall clock time 4:16.73
-maximum resident set size 80166384 kbytes
+State-vector 68 byte, depth reached 586, errors: 1
+438 states, stored
+14 states, matched
+452 transitions (= stored+matched)
+152 atomic steps
+61598.055 MB total actual memory usage
+pan: elapsed time 0 seconds
+wall clock time 0:25.97
+maximum resident set size 63078152 kbytes
+
+The trail ends in a quiescent state after Producer and Controller stop:
+the queue and activation credits are empty, waker_pending is false,
+waker_worker_id is invalid, and both workers are in SLEEP. Spin reports this
+as an invalid end state because the parked Worker processes are not marked as
+valid end states in the model.
 
 Run directory:
-  build-host-002:/tmp/waker-hour-safety-49df29.4tyFN5
+  build-host-002:/tmp/waker-hour-safety-325548-v1
 
 -------------------------------------------------------------------------------
 
@@ -34,35 +49,39 @@ Claim: live_resize_reconciles
 
 Spin: Spin Version 6.4.9 -- 17 December 2018
 
-Spin 6.4.9 aborted while expanding both embedded LTL claims. The verified
-temporary resize_model.pml differs only by removal of the unused
-live_queue_changes block. The transition system and live_resize_reconciles
-claim are unchanged.
+Spin 6.4.9 cannot expand all embedded LTL claims in this model. The verified
+temporary model.pml differs only by removal of the unused live_queue_changes
+and live_waker_pending_clears blocks. The transition system and
+live_resize_reconciles claim are unchanged.
 
+Verified source model SHA-256:
+  325548bb2179349843aa0b59549cb8e608c0ab91358424842ec1394acf7b9aeb
 Derived model SHA-256:
-  20bbe205f97bd249cfe9f2400778c40276a2d77cf59d811bab2cc501dd2c2a67
+  b2035a837de9ec41039a9d1c96acd72f956d880516ac05025bf5d62091883499
 
 Commands:
-  sed '/^ltl live_queue_changes {$/,/^}$/d' \
-      executor_pool_basic_waker.pml > resize_model.pml
-  spin -a resize_model.pml
-  cc -O3 -o pan pan.c
-  ./pan -a -m1000000000 -w31
+  sed -e '/^ltl live_queue_changes {$/,/^}$/d' \
+      -e '/^ltl live_waker_pending_clears {$/,/^}$/d' \
+      executor_pool_basic_waker.pml > model.pml
+  spin -a model.pml
+  cc -O3 -DMEMLIM=220000 -o pan pan.c
+  timeout --signal=INT --kill-after=30s 3600 \
+      ./pan -a -m1000000000 -w31
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 76 byte, depth reached 63745162, errors: 0
-3.4296727e+08 states, stored (4.44681e+08 visited)
-9.1690385e+08 states, matched
-1.3615853e+09 transitions (= visited+matched)
-4.8041475e+08 atomic steps
-93586.246 MB total actual memory usage
-pan: elapsed time 442 seconds
-wall clock time 7:53.36
-maximum resident set size 95837940 kbytes
+State-vector 76 byte, depth reached 68073091, errors: 0
+5.4910992e+08 states, stored (6.89582e+08 visited)
+1.5536961e+09 states, matched
+2.2432776e+09 transitions (= visited+matched)
+8.1757716e+08 atomic steps
+107759.195 MB total actual memory usage
+pan: elapsed time 671 seconds
+wall clock time 11:40.39
+maximum resident set size 110353324 kbytes
 
 Run directory:
-  build-host-003:/tmp/waker-hour-resize-49df29-only.k3DhsR
+  build-host-003:/tmp/waker-hour-resize-325548-v1
 
 -------------------------------------------------------------------------------
 
@@ -71,20 +90,54 @@ Claim: live_queue_changes
 Spin: Spin Version 6.5.2 -- 6 December 2019
 Commands:
   spin -a executor_pool_basic_waker.pml
-  cc -O3 -o pan pan.c
-  ./pan -a -N live_queue_changes -m1000000000 -w31
+  cc -O3 -DMEMLIM=220000 -o pan pan.c
+  timeout --signal=INT --kill-after=30s 3600 \
+      ./pan -a -N live_queue_changes -m1000000000 -w31
+
+Result: VIOLATED (acceptance cycle, errors: 1)
+
+State-vector 76 byte, depth reached 629246, errors: 1
+12424846 states, stored (1.77702e+07 visited)
+30698199 states, matched
+48468412 transitions (= visited+matched)
+12379405 atomic steps
+70727.262 MB total actual memory usage
+pan: elapsed time 12.4 seconds
+wall clock time 0:42.17
+maximum resident set size 72426640 kbytes
+
+The trail ends with one queued activation and one activation credit. One
+worker is in SLEEP and the other is in BLOCKING, waker_worker_id is invalid,
+and waker_pending is false. The blocking worker consumed the persistent
+waker bit while another worker still owned the waker role. It then restored
+BLOCKING without transferring the request to the current owner. After that
+owner released the role, no request remained to process the queued activation.
+
+Run directory:
+  build-host-002:/tmp/waker-hour-queue-325548-v1
+
+-------------------------------------------------------------------------------
+
+Claim: live_waker_pending_clears
+
+Spin: Spin Version 6.5.2 -- 6 December 2019
+Commands:
+  spin -a executor_pool_basic_waker.pml
+  cc -O3 -DMEMLIM=220000 -o pan pan.c
+  timeout --signal=INT --kill-after=30s 3600 \
+      ./pan -a -N live_waker_pending_clears -m1000000000 -w31
 
 Result: HOLDS (full state-space search completed with errors: 0)
 
-State-vector 76 byte, depth reached 63745162, errors: 0
-4.4512455e+08 states, stored (6.48952e+08 visited)
-1.3541268e+09 states, matched
-2.0030785e+09 transitions (= visited+matched)
-7.1283045e+08 atomic steps
-103997.184 MB total actual memory usage
-pan: elapsed time 636 seconds
-wall clock time 11:08.63
-maximum resident set size 106500436 kbytes
+State-vector 76 byte, depth reached 68073091, errors: 0
+6.9149223e+08 states, stored (9.74426e+08 visited)
+2.4768724e+09 states, matched
+3.4512985e+09 transitions (= visited+matched)
+1.2624514e+09 atomic steps
+122763.785 MB total actual memory usage
+pan: elapsed time 1.04e+03 seconds
+wall clock time 17:50.93
+maximum resident set size 125720512 kbytes
 
 Run directory:
-  build-host-004:/tmp/waker-hour-queue-49df29.nDfslj
+  build-host-004:/tmp/waker-hour-pending-325548-v1

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -17,6 +17,9 @@
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
 
+#include <array>
+#include <chrono>
+
 using namespace NActors;
 using namespace NActors::NTests;
 
@@ -25,6 +28,145 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
     using TActorBenchmark = ::NActors::NTests::TActorBenchmark<>;
     using TSettings = TActorBenchmark::TSettings;
     using TSendReceiveActorParams = TActorBenchmark::TSendReceiveActorParams;
+
+    struct TWakerBurstCounters {
+        std::atomic<ui32> Remaining = 0;
+        TThreadParkPad Completed;
+    };
+
+    class TWakerBurstActor : public TActor<TWakerBurstActor> {
+    public:
+        explicit TWakerBurstActor(TWakerBurstCounters* counters)
+            : TActor<TWakerBurstActor>(&TWakerBurstActor::StateFunc)
+            , Counters(counters)
+        {}
+
+        STFUNC(StateFunc) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvPing, Handle);
+            }
+        }
+
+    private:
+        void Handle(TEvents::TEvPing::TPtr&) {
+            if (Counters->Remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                Counters->Completed.Unpark();
+            }
+        }
+
+        TWakerBurstCounters* const Counters;
+    };
+
+    struct TWakerBurstStats {
+        ui64 Mean = 0;
+        ui64 P50 = 0;
+        ui64 P99 = 0;
+    };
+
+    TWakerBurstStats CalculateWakerBurstStats(TVector<ui64> values) {
+        Sort(values);
+        ui64 sum = 0;
+        for (ui64 value : values) {
+            sum += value;
+        }
+        return {
+            .Mean = sum / values.size(),
+            .P50 = values[values.size() / 2],
+            .P99 = values[(values.size() * 99) / 100],
+        };
+    }
+
+    void RunWakerMessageBurstsBenchmark(bool enableWaker) {
+        constexpr ui32 Threads = 8;
+        constexpr ui32 Rounds = 100;
+        const TDuration idleDuration = TDuration::MilliSeconds(10);
+        constexpr std::array<ui32, 3> MessageCounts = {Threads, 10 * Threads, 100 * Threads};
+
+        auto setup = TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, Threads, false, false);
+        auto& config = setup->CpuManager.Basic.back();
+        config.EnableWaker = enableWaker;
+        config.SpinThreshold = 0;
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TWakerBurstCounters counters;
+        TVector<TActorId> actors;
+        actors.reserve(Threads);
+        for (ui32 i = 0; i < Threads; ++i) {
+            actors.push_back(actorSystem.Register(new TWakerBurstActor(&counters)));
+        }
+
+        for (ui32 messageCount : MessageCounts) {
+            TVector<ui64> sendTimes;
+            TVector<ui64> completionTimes;
+            sendTimes.reserve(Rounds);
+            completionTimes.reserve(Rounds);
+
+            for (ui32 round = 0; round < Rounds; ++round) {
+                TVector<THolder<TEvents::TEvPing>> events;
+                events.reserve(messageCount);
+                for (ui32 i = 0; i < messageCount; ++i) {
+                    events.emplace_back(MakeHolder<TEvents::TEvPing>());
+                }
+
+                Sleep(idleDuration);
+                counters.Remaining.store(messageCount, std::memory_order_release);
+
+                const auto started = std::chrono::steady_clock::now();
+                for (ui32 i = 0; i < messageCount; ++i) {
+                    actorSystem.Send(actors[i % Threads], events[i].Release());
+                }
+                const auto sent = std::chrono::steady_clock::now();
+                counters.Completed.Park();
+                const auto completed = std::chrono::steady_clock::now();
+
+                sendTimes.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(sent - started).count());
+                completionTimes.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(completed - started).count());
+            }
+
+            const auto sendStats = CalculateWakerBurstStats(std::move(sendTimes));
+            const auto completionStats = CalculateWakerBurstStats(std::move(completionTimes));
+            Cout << "waker=" << (enableWaker ? "on" : "off")
+                 << ",messages=" << messageCount
+                 << ",send_mean_ns=" << sendStats.Mean
+                 << ",send_p50_ns=" << sendStats.P50
+                 << ",send_p99_ns=" << sendStats.P99
+                 << ",completion_mean_ns=" << completionStats.Mean
+                 << ",completion_p50_ns=" << completionStats.P50
+                 << ",completion_p99_ns=" << completionStats.P99
+                 << Endl;
+        }
+
+        actorSystem.Stop();
+    }
+
+    void RunWakerSaturatedBenchmark(bool enableWaker) {
+        constexpr ui32 Threads = 8;
+        constexpr ui32 ActorPairs = 2 * Threads;
+        constexpr ui32 InFlight = 1;
+        const TDuration duration = TDuration::Seconds(1);
+
+        const auto stats = TActorBenchmark::CountStats([=] {
+            return TActorBenchmark::BenchContentedThreads(
+                Threads,
+                ActorPairs,
+                TActorBenchmark::EPoolType::Basic,
+                ESendingType::Common,
+                duration,
+                InFlight,
+                enableWaker);
+        });
+        const double elapsedSeconds = stats.ElapsedTime.Mean / 1e9;
+        const ui64 eventsPerSecond = stats.SentEvents.Mean / elapsedSeconds;
+        Cout << "waker=" << (enableWaker ? "on" : "off")
+             << ",threads=" << Threads
+             << ",actor_pairs=" << ActorPairs
+             << ",in_flight=" << InFlight
+             << ",messages_per_second=" << eventsPerSecond
+             << Endl;
+    }
 
     class TLongRunningActor : public TActorBootstrapped<TLongRunningActor> {
         public:
@@ -440,6 +582,16 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
             });
             Cerr << stats.ToString() << " " << mType << " Tail" << Endl;
         }
+    }
+
+    Y_UNIT_TEST(WakerMessageBurstsBenchmark) {
+        RunWakerMessageBurstsBenchmark(false);
+        RunWakerMessageBurstsBenchmark(true);
+    }
+
+    Y_UNIT_TEST(WakerSaturatedBenchmark) {
+        RunWakerSaturatedBenchmark(false);
+        RunWakerSaturatedBenchmark(true);
     }
 
     Y_UNIT_TEST(SendReceive1Pool1ThreadNoAlloc) {

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -594,6 +594,44 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
         RunWakerSaturatedBenchmark(true);
     }
 
+    Y_UNIT_TEST(WakerIdleStatistics) {
+        constexpr ui64 SampleDurationUs = 200'000;
+
+        auto setup = TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, 1, false, false);
+        auto& config = setup->CpuManager.Basic.back();
+        config.EnableWaker = true;
+        config.SpinThreshold = 0;
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        const auto getThreadStats = [&] {
+            TExecutorPoolStats poolStats;
+            TVector<TExecutorThreadStats> threadStats;
+            GetActorSystemStats(actorSystem).GetPoolStats(0, poolStats, threadStats);
+            UNIT_ASSERT_VALUES_EQUAL(threadStats.size(), 2);
+            return threadStats[1];
+        };
+
+        Sleep(TDuration::MilliSeconds(50));
+        const TExecutorThreadStats before = getThreadStats();
+        Sleep(TDuration::MicroSeconds(SampleDurationUs));
+        const TExecutorThreadStats after = getThreadStats();
+
+        actorSystem.Stop();
+
+        const ui64 parkedUs = Ts2Us(after.SafeParkedTicks - before.SafeParkedTicks);
+        const ui64 elapsedUs = Ts2Us(after.SafeElapsedTicks - before.SafeElapsedTicks);
+        const ui64 cpuUs = after.CpuUs - before.CpuUs;
+        UNIT_ASSERT_GE_C(parkedUs, SampleDurationUs / 2,
+            "parked_us# " << parkedUs << " elapsed_us# " << elapsedUs << " cpu_us# " << cpuUs);
+        UNIT_ASSERT_LT_C(elapsedUs, SampleDurationUs / 2,
+            "parked_us# " << parkedUs << " elapsed_us# " << elapsedUs << " cpu_us# " << cpuUs);
+        UNIT_ASSERT_LT_C(cpuUs, SampleDurationUs / 2,
+            "parked_us# " << parkedUs << " elapsed_us# " << elapsedUs << " cpu_us# " << cpuUs);
+    }
+
     Y_UNIT_TEST(SendReceive1Pool1ThreadNoAlloc) {
         for (const auto& mType : TSettings::MailboxTypes) {
             auto stats =  TActorBenchmark::CountStats([mType] {

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -60,7 +60,7 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
     struct TWakerBurstStats {
         ui64 Mean = 0;
         ui64 P50 = 0;
-        ui64 P99 = 0;
+        ui64 P95 = 0;
     };
 
     TWakerBurstStats CalculateWakerBurstStats(TVector<ui64> values) {
@@ -72,7 +72,7 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
         return {
             .Mean = sum / values.size(),
             .P50 = values[values.size() / 2],
-            .P99 = values[(values.size() * 99) / 100],
+            .P95 = values[(values.size() * 95) / 100],
         };
     }
 
@@ -132,10 +132,10 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
                  << ",messages=" << messageCount
                  << ",send_mean_ns=" << sendStats.Mean
                  << ",send_p50_ns=" << sendStats.P50
-                 << ",send_p99_ns=" << sendStats.P99
+                 << ",send_p95_ns=" << sendStats.P95
                  << ",completion_mean_ns=" << completionStats.Mean
                  << ",completion_p50_ns=" << completionStats.P50
-                 << ",completion_p99_ns=" << completionStats.P99
+                 << ",completion_p95_ns=" << completionStats.P95
                  << Endl;
         }
 

--- a/ydb/library/actors/core/ut_fat/executor_pool_basic_waker.cpp
+++ b/ydb/library/actors/core/ut_fat/executor_pool_basic_waker.cpp
@@ -1,0 +1,119 @@
+#include "actor_bootstrapped.h"
+#include "actorsystem.h"
+#include "executor_pool_basic.h"
+#include "hfunc.h"
+#include "scheduler_basic.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <atomic>
+#include <thread>
+
+using namespace NActors;
+
+namespace {
+
+    struct TEvCount : TEventLocal<TEvCount, 10348> {};
+
+    class TCountingActor : public TActorBootstrapped<TCountingActor> {
+    public:
+        explicit TCountingActor(std::atomic<ui64>* completed)
+            : Completed(completed)
+        {}
+
+        void Bootstrap() {
+            Become(&TCountingActor::StateWork);
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvCount, Handle);
+        )
+
+        void Handle(TEvCount::TPtr&) {
+            Completed->fetch_add(1, std::memory_order_relaxed);
+        }
+
+    private:
+        std::atomic<ui64>* const Completed;
+    };
+
+    THolder<TActorSystemSetup> GetActorSystemSetup(TBasicExecutorPool* pool) {
+        auto setup = MakeHolder<TActorSystemSetup>();
+        setup->NodeId = 1;
+        setup->ExecutorsCount = 1;
+        setup->Executors.Reset(new TAutoPtr<IExecutorPool>[1]);
+        setup->Executors[0] = pool;
+        setup->Scheduler = new TBasicSchedulerThread(TSchedulerConfig(512, 0));
+        return setup;
+    }
+
+}
+
+Y_UNIT_TEST_SUITE(BasicExecutorPoolWaker) {
+
+    Y_UNIT_TEST(StressManual) {
+        if (const char* testMode = getenv("ACTORSYSTEM_TEST_MODE"); !testMode || TString(testMode) != "manual") {
+            return;
+        }
+
+        constexpr ui32 threads = 4;
+        constexpr ui32 actors = 64;
+        constexpr ui32 producers = 8;
+        constexpr ui32 burstSize = 5'000;
+        constexpr ui32 rounds = 40;
+        constexpr ui32 idleMs = 100;
+
+        TBasicExecutorPoolConfig config;
+        config.Threads = threads;
+        config.MinThreadCount = 1;
+        config.MaxThreadCount = threads;
+        config.DefaultThreadCount = threads;
+        config.SpinThreshold = 0;
+        config.EnableWaker = true;
+
+        auto* executorPool = new TBasicExecutorPool(config, nullptr, nullptr);
+        auto setup = GetActorSystemSetup(executorPool);
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        std::atomic<ui64> completed = 0;
+        TVector<TActorId> actorIds;
+        actorIds.reserve(actors);
+        for (ui32 actor = 0; actor < actors; ++actor) {
+            actorIds.push_back(actorSystem.Register(new TCountingActor(&completed), TMailboxType::HTSwap));
+        }
+
+        for (ui32 round = 0; round < rounds; ++round) {
+            const i16 threadCount = round % threads + 1;
+            executorPool->SetFullThreadCount(threadCount);
+            Sleep(TDuration::MilliSeconds(idleMs));
+            UNIT_ASSERT_VALUES_EQUAL_C(executorPool->GetFullThreadCount(), threadCount,
+                "thread count did not converge in round# " << round);
+            const ui64 expected = completed.load(std::memory_order_relaxed) + burstSize;
+
+            TVector<std::thread> producerThreads;
+            producerThreads.reserve(producers);
+            for (ui32 producer = 0; producer < producers; ++producer) {
+                producerThreads.emplace_back([&, producer] {
+                    for (ui32 event = producer; event < burstSize; event += producers) {
+                        actorSystem.Send(actorIds[event % actors], new TEvCount());
+                    }
+                });
+            }
+            for (auto& producer : producerThreads) {
+                producer.join();
+            }
+
+            const TInstant deadline = TInstant::Now() + TDuration::Seconds(2);
+            while (completed.load(std::memory_order_relaxed) < expected && TInstant::Now() < deadline) {
+                Sleep(TDuration::MilliSeconds(1));
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(completed.load(std::memory_order_relaxed), expected,
+                "round# " << round);
+            Cerr << "round# " << round << " threads# " << threadCount << " completed# " << expected << Endl;
+        }
+
+        actorSystem.Stop();
+    }
+
+}

--- a/ydb/library/actors/core/ut_fat/sources.inc
+++ b/ydb/library/actors/core/ut_fat/sources.inc
@@ -1,4 +1,5 @@
 SRCS(
     actor_benchmark.cpp
+    executor_pool_basic_waker.cpp
     waiting_benchs.cpp
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added an optional waker for non-shared Basic executor pools.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The per-pool path is disabled by default and keeps the legacy wakeup implementation available. An executor worker is elected to reconcile sleeping-worker states and perform physical unparks; no dedicated waker thread is created. The change includes a Spin model for dynamic thread-count transitions and actor benchmarks comparing idle bursts and saturated throughput with the waker enabled and disabled.

All benchmark executions used the current PR head in relwithdebinfo mode with the whole test process pinned by `taskset`. Each result is the median across three independent test executions; every burst execution contains 100 rounds for each message count.

Burst latency with 16 CPUs across two chiplets (`0-15`):

| Messages | Send p50 off / on, us | Send p95 off / on, us | Completion p50 off / on, us | Completion p95 off / on, us |
|---:|---:|---:|---:|---:|
| 8 | 21.0 / 6.49 | 26.8 / 7.11 | 36.7 / 73.7 | 41.9 / 79.2 |
| 80 | 33.8 / 13.5 | 47.1 / 16.7 | 65.8 / 82.6 | 74.7 / 91.6 |
| 800 | 1,405 / 80.9 | 1,534 / 92.2 | 1,405 / 155 | 1,541 / 167 |

Burst latency with 8 CPUs in one chiplet (`0-7`):

| Messages | Send p50 off / on, us | Send p95 off / on, us | Completion p50 off / on, us | Completion p95 off / on, us |
|---:|---:|---:|---:|---:|
| 8 | 14.0 / 4.51 | 20.1 / 5.20 | 19.3 / 46.8 | 25.1 / 55.1 |
| 80 | 18.1 / 8.94 | 30.7 / 10.2 | 39.6 / 51.3 | 52.6 / 61.2 |
| 800 | 922 / 33.5 | 962 / 62.4 | 924 / 83.9 | 965 / 111 |

Burst latency with 4 CPUs in each of two chiplets (`0-3,8-11`):

| Messages | Send p50 off / on, us | Send p95 off / on, us | Completion p50 off / on, us | Completion p95 off / on, us |
|---:|---:|---:|---:|---:|
| 8 | 24.8 / 5.41 | 33.6 / 6.63 | 33.6 / 43.7 | 51.0 / 54.4 |
| 80 | 86.3 / 9.94 | 214 / 12.0 | 94.4 / 52.1 | 218 / 63.1 |
| 800 | 1,421 / 321 | 1,555 / 467 | 1,422 / 334 | 1,558 / 488 |

The saturated benchmark uses 8 executor threads, 16 actor pairs, in-flight 1, and five one-second samples per execution:

| CPU affinity | Throughput off, median (range), M msg/s | Throughput on, median (range), M msg/s | Difference |
|---|---:|---:|---:|
| 16 CPUs, two chiplets (`0-15`) | 7.49 (7.31–7.56) | 7.56 (7.50–7.66) | +0.9% |
| 8 CPUs, one chiplet (`0-7`) | 16.52 (16.06–16.54) | 16.00 (15.96–16.13) | -3.2% |
| 4+4 CPUs, two chiplets (`0-3,8-11`) | 7.91 (7.79–7.94) | 7.87 (7.86–7.97) | -0.5% |
