### PR TITLE
Fix ReadToBlobEnd mixed-version compatibility for DirectRead retries

### DIFF
--- a/ydb/core/backup/impl/local_partition_reader.cpp
+++ b/ydb/core/backup/impl/local_partition_reader.cpp
@@ -95,6 +95,7 @@ private:
         read.SetClientId(OFFLOAD_ACTOR_CLIENT_ID);
         read.SetTimeoutMs(READ_TIMEOUT_MS);
         read.SetBytes(READ_LIMIT_BYTES);
+        read.SetReadToBlobEnd(false);
 
         return request;
     }

--- a/ydb/core/backup/impl/local_partition_reader.cpp
+++ b/ydb/core/backup/impl/local_partition_reader.cpp
@@ -95,7 +95,6 @@ private:
         read.SetClientId(OFFLOAD_ACTOR_CLIENT_ID);
         read.SetTimeoutMs(READ_TIMEOUT_MS);
         read.SetBytes(READ_LIMIT_BYTES);
-        read.SetReadToBlobEnd(false);
 
         return request;
     }

--- a/ydb/core/client/server/msgbus_server_persqueue.cpp
+++ b/ydb/core/client/server/msgbus_server_persqueue.cpp
@@ -1316,6 +1316,7 @@ public:
         read->SetCount(1000000);
         read->SetTimeoutMs(0);
         read->SetBytes(Min<ui32>(maxBytes, FetchRequestBytesLeft));
+        read->SetReadToBlobEnd(false);
         read->SetReadTimestampMs(readTimestampMs);
         NTabletPipe::SendData(ctx, jt->second.PipeClient, preq.Release());
     }

--- a/ydb/core/client/server/msgbus_server_persqueue.cpp
+++ b/ydb/core/client/server/msgbus_server_persqueue.cpp
@@ -1316,7 +1316,6 @@ public:
         read->SetCount(1000000);
         read->SetTimeoutMs(0);
         read->SetBytes(Min<ui32>(maxBytes, FetchRequestBytesLeft));
-        read->SetReadToBlobEnd(false);
         read->SetReadTimestampMs(readTimestampMs);
         NTabletPipe::SendData(ctx, jt->second.PipeClient, preq.Release());
     }

--- a/ydb/core/driver_lib/cli_utils/cli_persqueue_stress.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_persqueue_stress.cpp
@@ -132,6 +132,7 @@ int PersQueueStress(TCommandConfig &cmdConf, int argc, char** argv) {
                 read->SetOffset(offset);
                 read->SetCount(config.BatchSize);
                 read->SetClientId("user");
+                read->SetReadToBlobEnd(false);
                 TAutoPtr<NBus::TBusMessage> reply;
                 NBus::EMessageStatus status = config.SyncCall(request, reply);
                 Y_ABORT_UNLESS(status == NBus::MESSAGE_OK);

--- a/ydb/core/driver_lib/cli_utils/cli_persqueue_stress.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_persqueue_stress.cpp
@@ -132,7 +132,6 @@ int PersQueueStress(TCommandConfig &cmdConf, int argc, char** argv) {
                 read->SetOffset(offset);
                 read->SetCount(config.BatchSize);
                 read->SetClientId("user");
-                read->SetReadToBlobEnd(false);
                 TAutoPtr<NBus::TBusMessage> reply;
                 NBus::EMessageStatus status = config.SyncCall(request, reply);
                 Y_ABORT_UNLESS(status == NBus::MESSAGE_OK);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_common.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_common.cpp
@@ -19,6 +19,7 @@ std::unique_ptr<TEvPersQueue::TEvRequest> MakeEvPQRead(
     read->SetOffset(startOffset);
     read->SetTimeoutMs(0);
     read->SetCanReadBatches(true);
+    read->SetReadToBlobEnd(false);
     if (count) {
         read->SetCount(count.value());
     }

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -2433,7 +2433,7 @@ void TPersQueue::HandleReadRequest(
                                        cmd.GetClientId(),
                                        cmd.HasTimeoutMs() ? cmd.GetTimeoutMs() : 0,
                                        bytes,
-                                       cmd.GetReadToBlobEnd(),
+                                       cmd.HasReadToBlobEnd() ? cmd.GetReadToBlobEnd() : true,
                                        cmd.HasMaxTimeLagMs() ? cmd.GetMaxTimeLagMs() : 0,
                                        cmd.HasReadTimestampMs() ? cmd.GetReadTimestampMs() : 0,
                                        clientDC,

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -560,6 +560,7 @@ public:
         read->SetCount(1000000);
         read->SetTimeoutMs(0);
         read->SetBytes(Min<ui32>(fetchRequest.MaxBytes, FetchRequestBytesLeft));
+        read->SetReadToBlobEnd(false);
         read->SetReadTimestampMs(fetchRequest.ReadTimestampMs);
         read->SetCanReadBatches(Settings.CanReadBatches);
         read->SetExternalOperation(true);

--- a/ydb/core/persqueue/ut/common/pq_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.cpp
@@ -1263,6 +1263,20 @@ void CmdReadWithoutReadToBlobEnd(
     CmdRead(settings, tc);
 }
 
+void CmdReadOmittingReadToBlobEndField(
+    const ui32 partition,
+    const ui64 offset,
+    const ui32 count,
+    const ui32 size,
+    const ui32 resCount,
+    bool timeouted,
+    TTestContext& tc
+) {
+    TPQCmdReadSettings settings("", partition, offset, count, size, resCount, timeouted);
+    settings.OmitReadToBlobEndField = true;
+    CmdRead(settings, tc);
+}
+
 ui64 GetSizeLag(const ui32 partition,
                 const ui64 offset,
                 bool isEndOffset,
@@ -1291,7 +1305,9 @@ void BeginCmdRead(const TPQCmdReadSettings& settings, TTestContext& tc)
     read->SetClientId(settings.User);
     read->SetCount(settings.Count);
     read->SetBytes(settings.Size);
-    read->SetReadToBlobEnd(settings.ReadToBlobEnd);
+    if (!settings.OmitReadToBlobEndField) {
+        read->SetReadToBlobEnd(settings.ReadToBlobEnd);
+    }
     read->SetCanReadBatches(settings.CanReadBatches);
     if (settings.MaxTimeLagMs > 0) {
         read->SetMaxTimeLagMs(settings.MaxTimeLagMs);

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -501,6 +501,7 @@ struct TPQCmdReadSettings : public TPQCmdSettingsBase {
     ui32 Count = 0;
     ui32 Size = 0;
     bool ReadToBlobEnd = true;
+    bool OmitReadToBlobEndField = false;
     ui32 ResCount = 0;
     bool Timeout = false;
     TVector<i32> Offsets;
@@ -587,6 +588,15 @@ void CmdRead(
     ui64* sizeLag = nullptr);
 
 void CmdReadWithoutReadToBlobEnd(
+    const ui32 partition,
+    const ui64 offset,
+    const ui32 count,
+    const ui32 size,
+    const ui32 resCount,
+    bool timeouted,
+    TTestContext& tc);
+
+void CmdReadOmittingReadToBlobEndField(
     const ui32 partition,
     const ui64 offset,
     const ui32 count,

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -3429,6 +3429,49 @@ Y_UNIT_TEST(TestPQRead) {
     });
 }
 
+Y_UNIT_TEST(TestPQReadOmittingReadToBlobEndFieldMatchesReadToBlobEnd) {
+    TTestContext tc;
+    RunTestWithReboots(tc.TabletIds, [&]() {
+        return tc.InitialEventsFilter.Prepare();
+    }, [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+        TFinalizer finalizer(tc);
+        tc.Prepare(dispatchName, setup, activeZone);
+
+        tc.Runtime->SetScheduledLimit(200);
+        tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+
+        PQTabletPrepare({}, {{"aaa", true}}, tc);
+
+        activeZone = false;
+        TVector<std::pair<ui64, TString>> data;
+
+        ui32 pp =  4 + 8 + 2 + 9 + 100 + 40;
+        TString tmp{1_MB - pp - 2, '-'};
+        char k = 0;
+        for (ui32 i = 0; i < 26_MB;) {
+            TString ss = "";
+            ss += k;
+            ss += tmp;
+            ss += char((i + 1) % 256);
+            ++k;
+            data.push_back({i + 1, ss});
+            i += ss.size() + pp;
+        }
+        CmdWrite(0, "sourceid0", data, tc, false, {}, true);
+        PQGetPartInfo(0, 26, tc);
+
+        // Size-limited reads: explicit false stops mid-blob (1 or 3 msgs).
+        // Absent field must match ReadToBlobEnd=true (drain the blob: 12 / 14 msgs).
+        CmdReadWithoutReadToBlobEnd(0, 3, 1000, 511_KB, 1, false, tc);
+        CmdRead(0, 3, 1000, 511_KB, 12, false, tc);
+        CmdReadOmittingReadToBlobEndField(0, 3, 1000, 511_KB, 12, false, tc);
+
+        CmdReadWithoutReadToBlobEnd(0, 9, 1000, 3_MB, 3, false, tc);
+        CmdRead(0, 9, 1000, 3_MB, 14, false, tc);
+        CmdReadOmittingReadToBlobEndField(0, 9, 1000, 3_MB, 14, false, tc);
+    });
+}
+
 Y_UNIT_TEST(TestPQReadWithoutReadToBlobEnd) {
     TTestContext tc;
     RunTestWithReboots(tc.TabletIds, [&]() {
@@ -3801,6 +3844,7 @@ Y_UNIT_TEST(TestReadSubscription) {
         read->SetClientId("user1");
         read->SetCount(5);
         read->SetBytes(1'000'000);
+        read->SetReadToBlobEnd(false);
         read->SetTimeoutMs(5000);
 
         tc.Runtime->SendToPipe(tc.TabletId, tc.Edge, request.Release(), 0, GetPipeConfigWithRetries());
@@ -3820,6 +3864,7 @@ Y_UNIT_TEST(TestReadSubscription) {
         read->SetClientId("user1");
         read->SetCount(3);
         read->SetBytes(1'000'000);
+        read->SetReadToBlobEnd(false);
         read->SetTimeoutMs(5000);
 
         tc.Runtime->SendToPipe(tc.TabletId, tc.Edge, request.Release(), 0, GetPipeConfigWithRetries()); //got read
@@ -3841,6 +3886,7 @@ Y_UNIT_TEST(TestReadSubscription) {
         read->SetClientId("user1");
         read->SetCount(55);
         read->SetBytes(1'000'000);
+        read->SetReadToBlobEnd(false);
         read->SetTimeoutMs(5000);
 
         tc.Runtime->SendToPipe(tc.TabletId, tc.Edge, request.Release(), 0, GetPipeConfigWithRetries()); //got read
@@ -4250,6 +4296,7 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
             read->SetClientId("user1");
             read->SetCount(1);
             read->SetBytes(1'000'000);
+            read->SetReadToBlobEnd(false);
             read->SetTimeoutMs(5000);
         }
 

--- a/ydb/core/protos/msgbus_pq.proto
+++ b/ydb/core/protos/msgbus_pq.proto
@@ -38,6 +38,7 @@ message TPersQueuePartitionRequest {
         optional int64 LastOffset = 17;
 
         optional uint64 SizeEstimate = 18;
+        // Proto default is false. Tablet treats an absent field as true (old 26-2 read-to-blob-end).
         optional bool ReadToBlobEnd = 19 [default = false];
         optional bool CanReadBatches = 20 [default = false];
     }

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -349,7 +349,6 @@ struct TRequestReadPQ {
         read->SetCount(Count);
         read->SetClientId(User);
         read->SetReadTimestampMs(ReadTimestampMs);
-        read->SetReadToBlobEnd(false);
         return request;
     }
 };

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -349,6 +349,7 @@ struct TRequestReadPQ {
         read->SetCount(Count);
         read->SetClientId(User);
         read->SetReadTimestampMs(ReadTimestampMs);
+        read->SetReadToBlobEnd(false);
         return request;
     }
 };

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -2511,6 +2511,7 @@ Y_UNIT_TEST_SUITE(Cdc) {
         cmd.SetOffset(0);
         cmd.SetReadTimestampMs(0);
         cmd.SetExternalOperation(true);
+        cmd.SetReadToBlobEnd(false);
 
         auto req = MakeHolder<TEvPersQueue::TEvRequest>();
         req->Record = std::move(request);

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -2511,7 +2511,6 @@ Y_UNIT_TEST_SUITE(Cdc) {
         cmd.SetOffset(0);
         cmd.SetReadTimestampMs(0);
         cmd.SetExternalOperation(true);
-        cmd.SetReadToBlobEnd(false);
 
         auto req = MakeHolder<TEvPersQueue::TEvRequest>();
         req->Record = std::move(request);

--- a/ydb/core/tx/datashard/datashard_ut_common_pq.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_common_pq.cpp
@@ -49,7 +49,6 @@ namespace NKikimr {
         cmd.SetOffset(0);
         cmd.SetReadTimestampMs(0);
         cmd.SetExternalOperation(true);
-        cmd.SetReadToBlobEnd(false);
 
         auto req = MakeHolder<TEvPersQueue::TEvRequest>();
         req->Record = std::move(request);

--- a/ydb/core/tx/datashard/datashard_ut_common_pq.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_common_pq.cpp
@@ -49,6 +49,7 @@ namespace NKikimr {
         cmd.SetOffset(0);
         cmd.SetReadTimestampMs(0);
         cmd.SetExternalOperation(true);
+        cmd.SetReadToBlobEnd(false);
 
         auto req = MakeHolder<TEvPersQueue::TEvRequest>();
         req->Record = std::move(request);

--- a/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
@@ -119,6 +119,7 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
         cmd.SetOffset(0);
         cmd.SetReadTimestampMs(0);
         cmd.SetExternalOperation(true);
+        cmd.SetReadToBlobEnd(false);
 
         auto req = MakeHolder<TEvPersQueue::TEvRequest>();
         req->Record = std::move(request);

--- a/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
@@ -119,7 +119,6 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
         cmd.SetOffset(0);
         cmd.SetReadTimestampMs(0);
         cmd.SetExternalOperation(true);
-        cmd.SetReadToBlobEnd(false);
 
         auto req = MakeHolder<TEvPersQueue::TEvRequest>();
         req->Record = std::move(request);

--- a/ydb/core/tx/replication/ydb_proxy/local_proxy/local_partition_reader.cpp
+++ b/ydb/core/tx/replication/ydb_proxy/local_proxy/local_partition_reader.cpp
@@ -202,6 +202,7 @@ private:
         read.SetClientId(Consumer);
         read.SetTimeoutMs(ReadTimeout.MilliSeconds());
         read.SetBytes(ReadLimitBytes);
+        read.SetReadToBlobEnd(false);
 
         return request;
     }

--- a/ydb/core/tx/replication/ydb_proxy/local_proxy/local_partition_reader.cpp
+++ b/ydb/core/tx/replication/ydb_proxy/local_proxy/local_partition_reader.cpp
@@ -202,7 +202,6 @@ private:
         read.SetClientId(Consumer);
         read.SetTimeoutMs(ReadTimeout.MilliSeconds());
         read.SetBytes(ReadLimitBytes);
-        read.SetReadToBlobEnd(false);
 
         return request;
     }

--- a/ydb/core/viewer/viewer_topic_data.cpp
+++ b/ydb/core/viewer/viewer_topic_data.cpp
@@ -127,7 +127,6 @@ void TTopicData::SendPQReadRequest() {
     cmdRead->SetTimeoutMs(READ_TIMEOUT_MS);
     cmdRead->SetExternalOperation(true);
     cmdRead->SetCanReadBatches(true);
-    cmdRead->SetReadToBlobEnd(false);
 
     auto req = MakeHolder<TEvPersQueue::TEvRequest>();
     req->Record.Swap(&request);

--- a/ydb/core/viewer/viewer_topic_data.cpp
+++ b/ydb/core/viewer/viewer_topic_data.cpp
@@ -127,6 +127,7 @@ void TTopicData::SendPQReadRequest() {
     cmdRead->SetTimeoutMs(READ_TIMEOUT_MS);
     cmdRead->SetExternalOperation(true);
     cmdRead->SetCanReadBatches(true);
+    cmdRead->SetReadToBlobEnd(false);
 
     auto req = MakeHolder<TEvPersQueue::TEvRequest>();
     req->Record.Swap(&request);

--- a/ydb/services/datastreams/datastreams_proxy.cpp
+++ b/ydb/services/datastreams/datastreams_proxy.cpp
@@ -1508,6 +1508,7 @@ namespace NKikimr::NDataStreams::V1 {
         cmdRead->SetTimeoutMs(READ_TIMEOUT_MS);
         cmdRead->SetExternalOperation(true);
         cmdRead->SetCanReadBatches(true);
+        cmdRead->SetReadToBlobEnd(false);
 
         TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
         req->Record.Swap(&request);

--- a/ydb/services/datastreams/datastreams_proxy.cpp
+++ b/ydb/services/datastreams/datastreams_proxy.cpp
@@ -1508,7 +1508,6 @@ namespace NKikimr::NDataStreams::V1 {
         cmdRead->SetTimeoutMs(READ_TIMEOUT_MS);
         cmdRead->SetExternalOperation(true);
         cmdRead->SetCanReadBatches(true);
-        cmdRead->SetReadToBlobEnd(false);
 
         TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
         req->Record.Swap(&request);


### PR DESCRIPTION
Fixes #50054

## Summary
- Fix mixed-version compatibility of `CmdRead.ReadToBlobEnd` during 26-2 ↔ 26-3 rollout.
- On the tablet, an **absent** field is treated as `true` (26-2 read-to-blob-end). Call sites in persqueue that previously omitted the field now set `false` explicitly. Topic/PQv0 already send `true`.
- Scenario: a DirectRead retry can land on a node with a newer version (26-3). 26-2 proxies do not set the field; proto default is `false`, so 26-3 `GetReadToBlobEnd()` stops mid-blob on Size and the retry returns a **different** set of messages. DirectRead retries must always return the same records.

## Test plan
- [x] `TestPQReadOmittingReadToBlobEndFieldMatchesReadToBlobEnd` — omitted field matches explicit `true` (12/14 msgs), not explicit `false` (1/3 msgs)