### PR TITLE
[DO NOT MERGE][REPRO][NEW RBO] Slow compilation of trivial queries

### DIFF
--- a/ydb/core/kqp/ut/rbo/data/repro/small/query.sql
+++ b/ydb/core/kqp/ut/rbo/data/repro/small/query.sql
@@ -1,0 +1,2 @@
+PRAGMA TablePathPrefix = "/Root/small-rbo/";
+select 1 from table limit 1;

--- a/ydb/core/kqp/ut/rbo/data/repro/small/schema.sql
+++ b/ydb/core/kqp/ut/rbo/data/repro/small/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `/Root/small-rbo/table` (
+    key Int32 NOT NULL,
+    PRIMARY KEY (key)
+);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_small_repro_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_small_repro_ut.cpp
@@ -1,0 +1,62 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/stream/file.h>
+
+namespace NKikimr::NKqp {
+namespace {
+
+using namespace NYdb;
+using namespace NYdb::NTable;
+
+constexpr TStringBuf SchemaPath = "data/repro/small/schema.sql";
+constexpr TStringBuf QueryPath = "data/repro/small/query.sql";
+
+TString ReadFixture(TStringBuf path) {
+    TFileInput input(SRC_(TString(path)));
+    return input.ReadAll();
+}
+
+Y_UNIT_TEST_SUITE(KqpRboSmallRepro) {
+    Y_UNIT_TEST(SelectFromTableLimitUsesNewRbo) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
+        appConfig.MutableTableServiceConfig()->SetBackportMode(
+            NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig).SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto schemeResult = session.ExecuteSchemeQuery(ReadFixture(SchemaPath)).GetValueSync();
+        UNIT_ASSERT_C(schemeResult.IsSuccess(), schemeResult.GetIssues().ToString());
+
+        NYdb::TValueBuilder rows;
+        rows.BeginList()
+            .AddListItem()
+            .BeginStruct()
+            .AddMember("key").Int32(1)
+            .EndStruct()
+            .EndList();
+        auto upsertResult = db.BulkUpsert("/Root/small-rbo/table", rows.Build()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult.IsSuccess(), upsertResult.GetIssues().ToString());
+
+        const TString query = ReadFixture(QueryPath);
+
+        // Repeat compilation so a focused perf capture contains query-planning samples.
+        constexpr ui32 ExplainRuns = 10;
+        for (ui32 i = 0; i < ExplainRuns; ++i) {
+            auto explainResult = session.ExplainDataQuery(query).GetValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+        }
+
+        auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(FormatResultSetYson(result.GetResultSet(0)), R"([[1]])");
+    }
+}
+
+} // namespace
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_small_repro_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_small_repro_ut.cpp
@@ -18,6 +18,22 @@ TString ReadFixture(TStringBuf path) {
     return input.ReadAll();
 }
 
+TString ExplainGenericQuery(TKikimrRunner& kikimr, const TString& query,
+    const NYdb::NQuery::TExecuteQuerySettings& settings)
+{
+    auto result = kikimr.GetQueryClient().ExecuteQuery(
+        query,
+        NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+        settings
+    ).GetValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    UNIT_ASSERT_C(result.GetStats().has_value(), "Expected explain stats");
+    if (auto plan = result.GetStats()->GetPlan()) {
+        return TString(*plan);
+    }
+    return {};
+}
+
 Y_UNIT_TEST_SUITE(KqpRboSmallRepro) {
     Y_UNIT_TEST(SelectFromTableLimitUsesNewRbo) {
         NKikimrConfig::TAppConfig appConfig;
@@ -44,12 +60,15 @@ Y_UNIT_TEST_SUITE(KqpRboSmallRepro) {
         UNIT_ASSERT_C(upsertResult.IsSuccess(), upsertResult.GetIssues().ToString());
 
         const TString query = ReadFixture(QueryPath);
+        const auto explainSettings = NYdb::NQuery::TExecuteQuerySettings()
+            .Syntax(NYdb::NQuery::ESyntax::YqlV1)
+            .ExecMode(NYdb::NQuery::EExecMode::Explain);
 
         // Repeat compilation so a focused perf capture contains query-planning samples.
         constexpr ui32 ExplainRuns = 10;
         for (ui32 i = 0; i < ExplainRuns; ++i) {
-            auto explainResult = session.ExplainDataQuery(query).GetValueSync();
-            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+            const auto plan = ExplainGenericQuery(kikimr, query, explainSettings);
+            UNIT_ASSERT_C(!plan.empty(), "Expected a non-empty explain plan");
         }
 
         auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();

--- a/ydb/core/kqp/ut/rbo/ya.make
+++ b/ydb/core/kqp/ut/rbo/ya.make
@@ -6,6 +6,7 @@ SIZE(MEDIUM)
 REQUIREMENTS(cpu:2)
 
 SRCS(
+    kqp_rbo_small_repro_ut.cpp
     kqp_rbo_yql_ut.cpp
     kqp_rbo_olap_ut.cpp
 )


### PR DESCRIPTION
Query: `select 1 limit 1`
Test does 10 runs in loop, but I did 100'000, here is a flame:

<img width="1200" height="1742" alt="select-1-flame" src="https://github.com/user-attachments/assets/b02dd2bc-a84a-4106-b3f7-972e4542a522" />
