### PR TITLE
Restore topic_description.h include in PQv1 schema_actors

### DIFF
--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/persqueue/public/constants.h>
+#include <ydb/core/ydb_convert/topic_description.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
 #include <ydb/public/sdk/cpp/src/library/persqueue/obfuscate/obfuscate.h>
 


### PR DESCRIPTION
## Summary

Restore `#include <ydb/core/ydb_convert/topic_description.h>` in `ydb/services/persqueue_v1/actors/schema_actors.cpp` so `ResolveConsumerServiceType` is visible again after the DescribeTopic rewrite.

### Cause

Commit `d520c8a090a` / `d520c8a090ae44ec580078d5dd6455cebde878b8` ("Rewrite DescribeTopic actor", #49915) by Nikolay Shestakov removed `#include <ydb/core/ydb_convert/topic_description.h>` from `schema_actors.cpp` while leaving `TPQDescribeTopicActor` and its call to `ResolveConsumerServiceType` (declared in that header). That produced:

```
ydb/services/persqueue_v1/actors/schema_actors.cpp:153:18: error: use of undeclared identifier 'ResolveConsumerServiceType'
```

The rewrite dropped the include as unused from the actor's new include set, but `ResolveConsumerServiceType` is still used in the same file.

### Background

The call itself was introduced earlier in `f3674463da7` ("Reduce msgbus usage in PQ tests…", #49687) and compiled then because the include was still present. After `d520c8a090a` nobody else touched `schema_actors.cpp`, so the missing declaration only showed up on a later build.

### Fix

Restore `#include <ydb/core/ydb_convert/topic_description.h>` in `schema_actors.cpp`. No other call sites or logic changes.

## Test plan

- [x] `./ya make --build relwithdebinfo ydb/services/persqueue_v1` succeeded (compile error gone)
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)