### PR TITLE
TEvLockRows: wait until locked rows are visible to head reads

### DIFF
--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -416,12 +416,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         setWaiting(true);
         const auto& protoSnapshot = msg->Record.GetSnapshot();
         snapshot = TRowVersion(protoSnapshot.GetStep(), protoSnapshot.GetTxId());
-        bool success = co_await Pipeline.WaitForSnapshot(snapshot);
-        if (!success) {
-            sendError(NKikimrDataEvents::TEvLockRowsResult::STATUS_OVERLOADED, TStringBuilder()
-                << "Shard " << TabletID() << " has too many concurrent requests");
-            co_return;
-        }
+        co_await Pipeline.WaitForSnapshot(snapshot);
     }
 
     setWaiting(false);
@@ -536,8 +531,9 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
     TRuntimeLockHolder runtimeLock;
     TVector<TRawTypeValue> typedKey;
     size_t processedKeys = 0;
+    TRowVersion maxVersionOfLockedRow = TRowVersion::Min();
 
-    auto success = std::make_unique<NEvents::TDataEvents::TEvLockRowsResult>(
+    auto pendingResult = std::make_unique<NEvents::TDataEvents::TEvLockRowsResult>(
             TabletID(), requestId.RequestId, NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
 
     ui64 globalTxId = 0;
@@ -553,6 +549,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
     while (!state.Result) {
         bool reschedule = false;
         bool needGlobalTxId = false;
+        bool pendingResultReady = false;
         TLockInfo::TPtr waitForLock;
 
         // We need to run each iteration in a transaction
@@ -675,16 +672,18 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     for (ui64 txId : observer->ReadConflicts) {
                         SysLocksTable().AddReadConflict(txId);
                     }
-                    success->Record.AddLockedKeys(processedKeys);
+                    pendingResult->Record.AddLockedKeys(processedKeys);
                     if (modified) {
-                        success->Record.AddModifiedKeys(processedKeys);
+                        pendingResult->Record.AddModifiedKeys(processedKeys);
                     }
+                    maxVersionOfLockedRow = std::max(maxVersionOfLockedRow, row.RowVersion);
+                    maxVersionOfLockedRow = std::max(maxVersionOfLockedRow, observer->VolatileVersion);
                     runtimeLock.Reset();
                     ++processedKeys;
                 };
 
                 auto finishSkippedLocked = [&]() {
-                    success->Record.AddSkippedLockedKeys(processedKeys);
+                    pendingResult->Record.AddSkippedLockedKeys(processedKeys);
                     runtimeLock.Reset();
                     ++processedKeys;
                 };
@@ -776,7 +775,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                 // transaction we inserted the row, so it should be able to do other operations
                 // to it, and we shouldn't skip even if no committed row exists.
                 if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
-                    success->Record.AddSkippedAbsentKeys(processedKeys);
+                    pendingResult->Record.AddSkippedAbsentKeys(processedKeys);
                     runtimeLock.Reset();
                     ++processedKeys;
                     continue;
@@ -880,15 +879,30 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
             applyLocks();
 
             for (const auto& lock : takenLocks) {
-                success->AddLock(lock.LockId, lock.DataShard, lock.Generation, lock.Counter,
-                                lock.SchemeShard, lock.PathId, lock.HasWrites);
+                pendingResult->AddLock(
+                    lock.LockId, lock.DataShard, lock.Generation, lock.Counter,
+                    lock.SchemeShard, lock.PathId, lock.HasWrites);
                 if (lock.IsError()) {
-                    success->Record.SetStatus(NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+                    pendingResult->Record.SetStatus(NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
                 }
             }
-            state.Result = std::move(success);
+            pendingResultReady = true;
             return ETxLockRows::CommitSync;
         });
+
+        if (pendingResultReady) {
+            if (pendingResult->Record.GetStatus() == NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS) {
+                // We may have encountered rows committed by immediate writes "in the future"
+                // relative to the mediator time. For any external observer those rows are still
+                // invisible and datashard will delay sending confirmations for those writes
+                // (see also: ImmediateWriteEdgeReplied version). If the current request encountered
+                // such rows and locked the corresponding keys, we must delay sending the successful
+                // response as well until the corresponding version is visible to head reads.
+                setWaiting(true);
+                co_await Pipeline.WaitForSnapshot(maxVersionOfLockedRow);
+            }
+            state.Result = std::move(pendingResult);
+        }
 
         if (state.Result) {
             break;

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -2121,25 +2121,20 @@ private:
     TPipeline& Pipeline;
 };
 
-async<bool> TPipeline::WaitForSnapshot(const TRowVersion& snapshot) {
+async<void> TPipeline::WaitForSnapshot(const TRowVersion& snapshot) {
     TRowVersion unreadableEdge = GetUnreadableEdge();
     if (snapshot < unreadableEdge) {
-        co_return true;
-    }
-
-    if (!CheckInflightLimit()) {
-        co_return false;
+        co_return;
     }
 
     const ui64 waitStep = snapshot.Step;
     if (!Self->WaitPlanStep(waitStep) && snapshot < (unreadableEdge = GetUnreadableEdge())) {
         // Async MediatorTimeCastEntry update, active current queue and return
         ActivateWaitingTxOps(unreadableEdge, Self->ActorContext());
-        co_return true;
+        co_return;
     }
 
     co_await TWaitForSnapshotAwaiter(*this, snapshot);
-    co_return true;
 }
 
 void TPipeline::ActivateWaitingTxOps(TRowVersion edge, const TActorContext& ctx) {

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -390,11 +390,12 @@ public:
     size_t WaitingCoroutinesCount() const { return WaitingCoroutines.Size(); }
 
     /**
-     * Waits until the specified snapshot is potentially readable
-     *
-     * Returns true on success and false when there are too many waiting requests already.
+     * Waits until the specified snapshot is potentially readable. This means that a read
+     * operation at this snapshot will be allowed to enter the pipeline and that the dependency
+     * tracker has all the info about planned writes at or below the snapshot. Note that this
+     * does *not* mean that all relevant changes are already executed against the localdb.
      */
-    async<bool> WaitForSnapshot(const TRowVersion& snapshot);
+    async<void> WaitForSnapshot(const TRowVersion& snapshot);
 
     TRowVersion GetReadEdge() const;
     TRowVersion GetUnreadableEdge() const;

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -63,7 +63,9 @@ NTable::EReady TDataShardUserDb::SelectRow(
         GetReadTxMap(tableId),
         GetReadTxObserver(tableId));
 
-    if (LockMode == ELockMode::Optimistic && stats.InvisibleRowSkips > 0) {
+    if (LockMode != ELockMode::OptimisticSnapshotIsolation && stats.InvisibleRowSkips > 0) {
+        // In PessimisticNone lock mode this shouldn't happen, but we still
+        // break the lock to avoid data corruption.
         if (LockTxId) {
             Self.SysLocksTable().BreakSetLocks();
         }

--- a/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
@@ -417,7 +417,7 @@ Y_UNIT_TEST(ReadAfterSplit) {
 Y_UNIT_TEST(LockRowsWithImmediateWritesAboveMediatorTime) {
     // This is a regression test that checks behavior in case of rows written by immediate
     // writes "into the future" (i.e. after the current mediator time).
-    // A transactions should be able to observe these rows immediately after successfully
+    // A transaction should be able to observe these rows immediately after successfully
     // locking corresponding keys.
 
     TTestEnv env;

--- a/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
@@ -414,6 +414,76 @@ Y_UNIT_TEST(ReadAfterSplit) {
     WaitTxNotification(server, sender, splitTxId);
 }
 
+Y_UNIT_TEST(LockRowsWithImmediateWritesAboveMediatorTime) {
+    // This is a regression test that checks behavior in case of rows written by immediate
+    // writes "into the future" (i.e. after the current mediator time).
+    // A transactions should be able to observe these rows immediately after successfully
+    // locking corresponding keys.
+
+    TTestEnv env;
+    auto [server, runtime, sender, tableId, shards] = env.GetAll();
+
+    TTransactionState tx1(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+    TTransactionState tx2(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+
+    // tx1 locks key 1 and inserts a row with this key.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.LockRows(tableId, shards.at(0), {1}),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.size(), 1);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.Write(tableId, shards.at(0), TWriteOperation::Insert(1, 101)),
+        "OK");
+
+    // Establish snapshot for tx2. This will promote UnprotectedReadEdge
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.ReadKey(tableId, shards.at(0), 1),
+        "");
+
+    // Block mediator time updates to keep the window open:
+    // after tx1 commits, its reply is delayed and ImmediateWriteEdgeReplied stays stale.
+    TBlockEvents<TEvMediatorTimecast::TEvUpdate> blockUpdate(runtime);
+    TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranular(runtime);
+
+    // Try committing tx1. The shard will execute the commit, but will reply only after
+    // the next mediator update.
+    auto tx1CommitFut = tx1.SendWriteCommit(tableId, shards.at(0));
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1CommitFut.NextString(TDuration::Seconds(1)),
+        "<timeout>");
+
+    // tx2 locks key 1, but the reply should be delayed until the write by tx1
+    // becomes visible to reads.
+    auto tx2LockFut = tx2.SendLockRows(tableId, shards.at(0), {1});
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2LockFut.NextString(TDuration::Seconds(1)),
+        "<timeout>");
+
+    blockUpdate.Stop().Unblock();
+    blockGranular.Stop().Unblock();
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1CommitFut.NextString(),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2LockFut.NextString(TDuration::Seconds(1)),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.size(), 1);
+
+    // Write by tx2 will fail with STATUS_CONSTRAINT_VIOLATION.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.Write(tableId, shards.at(0), TWriteOperation::Insert(1, 102)),
+        "ERROR: STATUS_CONSTRAINT_VIOLATION");
+
+    // We should now observe the commit by tx1.
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSimpleExec(runtime, R"(
+            SELECT key, value FROM `/Root/table` ORDER BY key;
+        )"),
+        "{ items { uint32_value: 1 } items { int32_value: 101 } }");
+}
+
 } // Y_UNIT_TEST_SUITE(DataShardReadCommitted)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -121,7 +121,7 @@ public:
         req->Record.SetLockTxId(LockTxId);
         req->Record.SetLockNodeId(LockNodeId);
         req->Record.SetLockMode(LockMode);
-        if (Snapshot) {
+        if (Snapshot && LockMode != NKikimrDataEvents::ELockMode::PESSIMISTIC_NONE) {
             req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
             req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Фикс ошибки, найденной jepsen-ом. Datashard может перемещать immediate записи "в будущее" относительно текущего медиаторного времени (дополнительная информация: https://nda.ya.ru/t/baooocXU7n4Yep). Если read committed транзакция заблокирует ключ такой строки с помощью TEvLockRows и выполнит вставку, вставка не увидит предыдущую запись несмотря на то, что по идее должна видеть последнюю версию строки. Чтобы это поправить, добавил задержку в TEvLockRows.

Также в целях defense-in-depth сделал, чтобы, если мы в TEvWrite детектим такую ситуацию, лок всё-таки ломался, несмотря на режим PESSIMISTIC_NONE.
