### PR TITLE
Retry topic describe with SyncVersion when partition or consumer is missing from cache

### DIFF
--- a/ydb/core/persqueue/public/schema/describe_operation.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation.cpp
@@ -56,7 +56,16 @@ public:
         LOG_D("Bootstrap " << Settings.Path);
         RequestStartTime = TActivationContext::Now();
         Schedule(RequestTimeout, new TEvents::TEvWakeup(RequestTimeoutWakeupTag));
+        Become(&TDescribeOperationActor::StateDescribe);
 
+        ReadSessionsReceived = !Settings.IncludeStats;
+        LocationsReceived = !Settings.IncludeLocation && !Settings.IncludeStats;
+        StartDescribe();
+    }
+
+    void StartDescribe() {
+        LOG_D("StartDescribe path=" << Settings.Path
+                                    << " forceSyncVersion=" << Settings.ForceSyncVersion);
         DescriberActorId = RegisterWithSameMailbox(NDescriber::CreateDescriberActor(
             SelfId(),
             CanonizePath(Settings.Database),
@@ -64,11 +73,8 @@ public:
             {
                 .UserToken = Settings.UserToken,
                 .AccessRights = Settings.AccessRights,
+                .ForceSyncVersion = Settings.ForceSyncVersion,
             }));
-        Become(&TDescribeOperationActor::StateDescribe);
-
-        ReadSessionsReceived = !Settings.IncludeStats;
-        LocationsReceived = !Settings.IncludeLocation && !Settings.IncludeStats;
     }
 
     TStringBuilder LogBuilder() const {
@@ -134,6 +140,7 @@ private:
         response->SelfEntry = std::move(SelfEntry);
         response->Partitions = std::move(Partitions);
         response->ConsumerName = std::move(ConsumerName);
+        response->UsedSyncVersion = UsedSyncVersion;
         Send(Parent, response.release());
         IsDead = true;
         PassAway();
@@ -173,7 +180,9 @@ private:
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
         DescriberActorId = {};
         TopicInfo = std::move(ev->Get()->Topics.begin()->second);
-        LOG_D("Handle TEvDescribeTopicsResponse. Status=" << TopicInfo.Status);
+        UsedSyncVersion = ev->Get()->UsedSyncVersion;
+        LOG_D("Handle TEvDescribeTopicsResponse. Status=" << TopicInfo.Status
+                                                         << " usedSyncVersion=" << UsedSyncVersion);
 
         if (TopicInfo.Status != NDescriber::EStatus::SUCCESS) {
             const auto status = [&]() {
@@ -212,6 +221,13 @@ private:
 
         auto schemaResult = Strategy->ValidateSchema(TopicInfo);
         if (schemaResult.Error) {
+            if (schemaResult.Error->RetryWithSync && !UsedSyncVersion) {
+                LOG_D("Schema validation failed without sync version, retrying describe. "
+                      << schemaResult.Error->Message);
+                Settings.ForceSyncVersion = true;
+                StartDescribe();
+                return;
+            }
             return ReplyWithError(
                 schemaResult.Error->Status,
                 schemaResult.Error->Message,
@@ -562,6 +578,7 @@ private:
     absl::flat_hash_map<ui64, TBackoff> StatsBackoff;
     absl::flat_hash_set<ui64> StatsRetryPending;
     NActors::TActorId DescriberActorId;
+    bool UsedSyncVersion = false;
 };
 
 } // namespace

--- a/ydb/core/persqueue/public/schema/describe_operation.h
+++ b/ydb/core/persqueue/public/schema/describe_operation.h
@@ -22,6 +22,7 @@ struct TDescribeOperationSettings {
     NDescriber::TAccessRights AccessRights;
     bool IncludeStats = false;
     bool IncludeLocation = false;
+    bool ForceSyncVersion = false;
 };
 
 struct TPartitionDescribeInfo {
@@ -42,12 +43,14 @@ struct TEvDescribeOperationResponse
     Ydb::Scheme::Entry SelfEntry;
     absl::flat_hash_map<ui32, TPartitionDescribeInfo> Partitions;
     TString ConsumerName;
+    bool UsedSyncVersion = false;
 };
 
 struct TDescribeSchemaError {
     Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::BAD_REQUEST;
     TString Message;
     Ydb::PersQueue::ErrorCode::ErrorCode IssueCode = Ydb::PersQueue::ErrorCode::BAD_REQUEST;
+    bool RetryWithSync = false;
 };
 
 struct TDescribeSchemaResult {

--- a/ydb/core/persqueue/public/schema/describe_operation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation_ut.cpp
@@ -111,7 +111,8 @@ struct TTestDescribeStrategyOptions {
     bool WithReadSessions = false;
     bool WithStatus = false;
     TString ConsumerName;
-    ui32 FailValidateTimes = 0;
+    // Unset: fail on every ValidateSchema call while ValidateError is set.
+    std::optional<ui32> FailValidateTimes;
     ui32* ValidateCalls = nullptr;
 };
 
@@ -133,8 +134,8 @@ public:
             ++*Options.ValidateCalls;
         }
         if (Options.ValidateError) {
-            const bool shouldFail = Options.FailValidateTimes == 0
-                || (Options.ValidateCalls && *Options.ValidateCalls <= Options.FailValidateTimes);
+            const bool shouldFail = !Options.FailValidateTimes
+                || (Options.ValidateCalls && *Options.ValidateCalls <= *Options.FailValidateTimes);
             if (shouldFail) {
                 return {.Error = Options.ValidateError};
             }

--- a/ydb/core/persqueue/public/schema/describe_operation_ut.cpp
+++ b/ydb/core/persqueue/public/schema/describe_operation_ut.cpp
@@ -111,6 +111,8 @@ struct TTestDescribeStrategyOptions {
     bool WithReadSessions = false;
     bool WithStatus = false;
     TString ConsumerName;
+    ui32 FailValidateTimes = 0;
+    ui32* ValidateCalls = nullptr;
 };
 
 class TTestDescribeStrategy: public IDescribeStrategy {
@@ -127,8 +129,15 @@ public:
     }
 
     TDescribeSchemaResult ValidateSchema(const NDescriber::TTopicInfo&) override {
+        if (Options.ValidateCalls) {
+            ++*Options.ValidateCalls;
+        }
         if (Options.ValidateError) {
-            return {.Error = Options.ValidateError};
+            const bool shouldFail = Options.FailValidateTimes == 0
+                || (Options.ValidateCalls && *Options.ValidateCalls <= Options.FailValidateTimes);
+            if (shouldFail) {
+                return {.Error = Options.ValidateError};
+            }
         }
         return {.ConsumerName = Options.ConsumerName};
     }
@@ -321,6 +330,54 @@ Y_UNIT_TEST(MissingTopic) {
 
     UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SCHEME_ERROR);
     UNIT_ASSERT(!response->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(RetriesWithSyncOnStaleSchemaValidation) {
+    auto setup = CreateSetup("DescribeOpRetrySync");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_describe_op_retry_sync";
+    CreateTopic(runtime, path);
+
+    ui32 validateCalls = 0;
+    auto response = RunDescribeOperation(
+        runtime,
+        MakeSettings(path),
+        std::make_unique<TTestDescribeStrategy>(TTestDescribeStrategyOptions{
+            .ValidateError = TDescribeSchemaError{
+                .Status = Ydb::StatusIds::BAD_REQUEST,
+                .Message = "missing in stale cache",
+                .RetryWithSync = true,
+            },
+            .FailValidateTimes = 1,
+            .ValidateCalls = &validateCalls,
+        }));
+
+    UNIT_ASSERT_VALUES_EQUAL(validateCalls, 2u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT(response->UsedSyncVersion);
+}
+
+Y_UNIT_TEST(DoesNotRetryValidateErrorWithoutRetryWithSync) {
+    auto setup = CreateSetup("DescribeOpNoRetrySync");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_describe_op_no_retry_sync";
+    CreateTopic(runtime, path);
+
+    ui32 validateCalls = 0;
+    auto response = RunDescribeOperation(
+        runtime,
+        MakeSettings(path),
+        std::make_unique<TTestDescribeStrategy>(TTestDescribeStrategyOptions{
+            .ValidateError = TDescribeSchemaError{
+                .Status = Ydb::StatusIds::BAD_REQUEST,
+                .Message = "hard validation error",
+            },
+            .ValidateCalls = &validateCalls,
+        }));
+
+    UNIT_ASSERT_VALUES_EQUAL(validateCalls, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Status, Ydb::StatusIds::BAD_REQUEST);
+    UNIT_ASSERT_STRING_CONTAINS(response->ErrorMessage, "hard validation error");
 }
 
 Y_UNIT_TEST(StrategyValidateError) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_consumer.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_consumer.cpp
@@ -33,6 +33,7 @@ public:
                 .Error = TDescribeSchemaError{
                     .Status = Ydb::StatusIds::SCHEME_ERROR,
                     .Message = TStringBuilder() << "no consumer '" << RequestedConsumer << "' in topic",
+                    .RetryWithSync = true,
                 },
             };
         }

--- a/ydb/services/persqueue_v1/actors/schema/topic/describe_partition.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/describe_partition.cpp
@@ -28,6 +28,7 @@ public:
                 .Error = TDescribeSchemaError{
                     .Status = Ydb::StatusIds::BAD_REQUEST,
                     .Message = TStringBuilder() << "No partition " << PartitionId << " in topic",
+                    .RetryWithSync = true,
                 },
             };
         }

--- a/ydb/services/persqueue_v1/actors/schema/topic/partitions_location.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/partitions_location.cpp
@@ -39,6 +39,7 @@ public:
                         .Status = Ydb::StatusIds::BAD_REQUEST,
                         .Message = TStringBuilder() << "No partition " << partitionId << " in topic",
                         .IssueCode = Ydb::PersQueue::ErrorCode::BAD_REQUEST,
+                        .RetryWithSync = true,
                     },
                 };
             }

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -261,6 +261,32 @@ void StripPartitionFromNavigateResult(
     }
 }
 
+void StripConsumerFromNavigateResult(
+    TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev,
+    const TString& consumerName,
+    bool onlyWithoutSync)
+{
+    if (!ev || !ev->Get()->Request) {
+        return;
+    }
+    for (auto& entry : ev->Get()->Request->ResultSet) {
+        if (!entry.PQGroupInfo) {
+            continue;
+        }
+        if (onlyWithoutSync && entry.SyncVersion) {
+            continue;
+        }
+        auto copy = MakeIntrusive<NSchemeCache::TSchemeCacheNavigate::TPQGroupInfo>(*entry.PQGroupInfo);
+        auto* consumers = copy->Description.MutablePQTabletConfig()->MutableConsumers();
+        for (int i = consumers->size() - 1; i >= 0; --i) {
+            if (consumers->Get(i).GetName() == consumerName) {
+                consumers->DeleteSubrange(i, 1);
+            }
+        }
+        entry.PQGroupInfo = copy;
+    }
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(SchemaOps_TopicAPI) {
@@ -622,6 +648,75 @@ Y_UNIT_TEST(DescribeUnknownConsumer) {
     AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR);
 }
 
+Y_UNIT_TEST(DescribeConsumerRetriesWithSyncWhenStaleCache) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_consumer_stale_cache";
+    CreateTopic(runtime, path);
+
+    size_t staleNavigates = 0;
+    size_t syncNavigates = 0;
+    auto observer = runtime.AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+        [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            if (!ev || !ev->Get()->Request) {
+                return;
+            }
+            for (const auto& entry : ev->Get()->Request->ResultSet) {
+                if (!entry.PQGroupInfo) {
+                    continue;
+                }
+                if (entry.SyncVersion) {
+                    ++syncNavigates;
+                } else {
+                    ++staleNavigates;
+                }
+            }
+            StripConsumerFromNavigateResult(ev, /*consumerName=*/"user", /*onlyWithoutSync=*/true);
+        });
+
+    Ydb::Topic::DescribeConsumerRequest request;
+    request.set_path(path);
+    request.set_consumer("user");
+    auto result = DoActorRequest<Ydb::Topic::DescribeConsumerRequest, Ydb::Topic::DescribeConsumerResponse>(
+        runtime, request, CreateDescribeConsumerActor, path);
+
+    UNIT_ASSERT_GT(staleNavigates, 0u);
+    UNIT_ASSERT_GT(syncNavigates, 0u);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    const auto& describeResult = GetResult<Ydb::Topic::DescribeConsumerResult>(result);
+    UNIT_ASSERT_VALUES_EQUAL(describeResult.consumer().name(), "user");
+}
+
+Y_UNIT_TEST(DescribeConsumerMissingAfterSync) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_consumer_missing_after_sync";
+    CreateTopic(runtime, path);
+
+    size_t syncNavigates = 0;
+    auto observer = runtime.AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+        [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            if (!ev || !ev->Get()->Request) {
+                return;
+            }
+            for (const auto& entry : ev->Get()->Request->ResultSet) {
+                if (entry.PQGroupInfo && entry.SyncVersion) {
+                    ++syncNavigates;
+                }
+            }
+            StripConsumerFromNavigateResult(ev, /*consumerName=*/"user", /*onlyWithoutSync=*/false);
+        });
+
+    Ydb::Topic::DescribeConsumerRequest request;
+    request.set_path(path);
+    request.set_consumer("user");
+    auto result = DoActorRequest<Ydb::Topic::DescribeConsumerRequest, Ydb::Topic::DescribeConsumerResponse>(
+        runtime, request, CreateDescribeConsumerActor, path);
+
+    UNIT_ASSERT_GT(syncNavigates, 0u);
+    AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR, "no consumer 'user' in topic");
+}
+
 Y_UNIT_TEST(DescribeConsumerRetriesOnLocationDeliveryProblem) {
     auto server = CreateSimulatedServer();
     auto& runtime = server->GetRuntime();
@@ -961,6 +1056,66 @@ Y_UNIT_TEST(PartitionsLocationSmokeAndErrors) {
         auto ev = DoPartitionsLocationRequest(runtime, {"/Root/missing_topic", "/Root", "", {}});
         UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
     }
+}
+
+Y_UNIT_TEST(PartitionsLocationRetriesWithSyncWhenStaleCache) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_partitions_location_stale_cache";
+    CreateTopic(runtime, path, /*partitions=*/2);
+
+    size_t staleNavigates = 0;
+    size_t syncNavigates = 0;
+    auto observer = runtime.AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+        [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            if (!ev || !ev->Get()->Request) {
+                return;
+            }
+            for (const auto& entry : ev->Get()->Request->ResultSet) {
+                if (!entry.PQGroupInfo) {
+                    continue;
+                }
+                if (entry.SyncVersion) {
+                    ++syncNavigates;
+                } else {
+                    ++staleNavigates;
+                }
+            }
+            StripPartitionFromNavigateResult(ev, /*partitionId=*/1, /*onlyWithoutSync=*/true);
+        });
+
+    auto ev = DoPartitionsLocationRequest(runtime, {path, "/Root", "", {1}});
+    UNIT_ASSERT_GT(staleNavigates, 0u);
+    UNIT_ASSERT_GT(syncNavigates, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].PartitionId, 1u);
+}
+
+Y_UNIT_TEST(PartitionsLocationMissingAfterSync) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_partitions_location_missing_after_sync";
+    CreateTopic(runtime, path, /*partitions=*/2);
+
+    size_t syncNavigates = 0;
+    auto observer = runtime.AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+        [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            if (!ev || !ev->Get()->Request) {
+                return;
+            }
+            for (const auto& entry : ev->Get()->Request->ResultSet) {
+                if (entry.PQGroupInfo && entry.SyncVersion) {
+                    ++syncNavigates;
+                }
+            }
+            StripPartitionFromNavigateResult(ev, /*partitionId=*/1, /*onlyWithoutSync=*/false);
+        });
+
+    auto ev = DoPartitionsLocationRequest(runtime, {path, "/Root", "", {1}});
+    UNIT_ASSERT_GT(syncNavigates, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::BAD_REQUEST);
+    UNIT_ASSERT(ev->Issues.ToString().Contains("No partition 1 in topic"));
 }
 
 Y_UNIT_TEST(PartitionsLocationRetriesOnDeliveryProblem) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/testlib/grpc_request/grpc_request.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
@@ -234,6 +235,32 @@ auto InjectFalseLocationStatusOnce(NActors::TTestActorRuntime& runtime, size_t& 
         });
 }
 
+void StripPartitionFromNavigateResult(
+    TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev,
+    ui32 partitionId,
+    bool onlyWithoutSync)
+{
+    if (!ev || !ev->Get()->Request) {
+        return;
+    }
+    for (auto& entry : ev->Get()->Request->ResultSet) {
+        if (!entry.PQGroupInfo) {
+            continue;
+        }
+        if (onlyWithoutSync && entry.SyncVersion) {
+            continue;
+        }
+        auto copy = MakeIntrusive<NSchemeCache::TSchemeCacheNavigate::TPQGroupInfo>(*entry.PQGroupInfo);
+        auto* partitions = copy->Description.MutablePartitions();
+        for (int i = partitions->size() - 1; i >= 0; --i) {
+            if (partitions->Get(i).GetPartitionId() == partitionId) {
+                partitions->DeleteSubrange(i, 1);
+            }
+        }
+        entry.PQGroupInfo = copy;
+    }
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(SchemaOps_TopicAPI) {
@@ -421,6 +448,75 @@ Y_UNIT_TEST(DescribePartitionUnauthenticatedRejectedWhenRequired) {
     auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
         runtime, request, CreateDescribePartitionActor, path);
     AssertStatus(result, Ydb::StatusIds::UNAUTHORIZED, "Unauthenticated access is forbidden");
+}
+
+Y_UNIT_TEST(DescribePartitionRetriesWithSyncWhenStaleCache) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_part_stale_cache";
+    CreateTopic(runtime, path, /*partitions=*/2);
+
+    size_t staleNavigates = 0;
+    size_t syncNavigates = 0;
+    auto observer = runtime.AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+        [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            if (!ev || !ev->Get()->Request) {
+                return;
+            }
+            for (const auto& entry : ev->Get()->Request->ResultSet) {
+                if (!entry.PQGroupInfo) {
+                    continue;
+                }
+                if (entry.SyncVersion) {
+                    ++syncNavigates;
+                } else {
+                    ++staleNavigates;
+                }
+            }
+            StripPartitionFromNavigateResult(ev, /*partitionId=*/1, /*onlyWithoutSync=*/true);
+        });
+
+    Ydb::Topic::DescribePartitionRequest request;
+    request.set_path(path);
+    request.set_partition_id(1);
+    auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
+        runtime, request, CreateDescribePartitionActor, path);
+
+    UNIT_ASSERT_GT(staleNavigates, 0u);
+    UNIT_ASSERT_GT(syncNavigates, 0u);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    const auto& describeResult = GetResult<Ydb::Topic::DescribePartitionResult>(result);
+    UNIT_ASSERT_VALUES_EQUAL(describeResult.partition().partition_id(), 1u);
+}
+
+Y_UNIT_TEST(DescribePartitionMissingAfterSync) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_part_missing_after_sync";
+    CreateTopic(runtime, path, /*partitions=*/2);
+
+    size_t syncNavigates = 0;
+    auto observer = runtime.AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+        [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            if (!ev || !ev->Get()->Request) {
+                return;
+            }
+            for (const auto& entry : ev->Get()->Request->ResultSet) {
+                if (entry.PQGroupInfo && entry.SyncVersion) {
+                    ++syncNavigates;
+                }
+            }
+            StripPartitionFromNavigateResult(ev, /*partitionId=*/1, /*onlyWithoutSync=*/false);
+        });
+
+    Ydb::Topic::DescribePartitionRequest request;
+    request.set_path(path);
+    request.set_partition_id(1);
+    auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
+        runtime, request, CreateDescribePartitionActor, path);
+
+    UNIT_ASSERT_GT(syncNavigates, 0u);
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "No partition 1 in topic");
 }
 
 Y_UNIT_TEST(DescribeConsumerSmokeAndMissingTopic) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Topic DescribePartition / DescribeConsumer no longer fail on a stale scheme cache: if the requested partition or consumer is missing and the cache was read without SyncVersion, describe is retried with a synced scheme version.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Scheme cache can return a topic that exists but still has a stale partition/consumer list (after alter/split). Describer already retries with `SyncVersion` only on path miss, so `DescribePartition` used to answer `BAD_REQUEST` immediately.

`ValidateSchema` now marks such misses as `RetryWithSync`. `TDescribeOperationActor` repeats describe with `ForceSyncVersion` **before** opening tablet pipes. If the entity is still missing after sync, the original error is returned.

The same retry applies to DescribeConsumer and PartitionsLocation. DescribeTopic is unchanged: the request has no entity besides path, and path miss is already synced by describer.

Retry does not reset the 30s describe timeout. Miss paths (wrong partition id / unknown consumer) now pay an extra SyncVersion Navigate.

Tests:
- stale cache without the partition → sync retry succeeds
- partition still missing after sync → `BAD_REQUEST`
- `RetryWithSync` vs hard validation error in `describe_operation`
