### PR TITLE
Restrict cluster-scope query params of `/viewer/tenantinfo` and `/viewer/describe`

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1024,7 +1024,7 @@ bool TViewerPipeClient::IsDatabaseRequest() const {
 }
 
 bool TViewerPipeClient::IsStrictDatabaseOnlyRequest() {
-    if (!StrictDatabaseOnlyRequest) {
+    if (!StrictDatabaseOnlyRequest.has_value()) {
         StrictDatabaseOnlyRequest = IsStrictDatabaseOnlyToken(AppData(), GetRequest().GetUserTokenObject());
     }
     return *StrictDatabaseOnlyRequest;

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1031,7 +1031,11 @@ bool TViewerPipeClient::IsStrictDatabaseOnlyRequest() {
 }
 
 TString TViewerPipeClient::GetUserSID() const {
-    return NACLib::TUserToken(GetRequest().GetUserTokenObject()).GetUserSID();
+    NACLibProto::TUserToken userToken;
+    if (!userToken.ParseFromString(GetRequest().GetUserTokenObject())) {
+        return {};
+    }
+    return userToken.GetUserSID();
 }
 
 void TViewerPipeClient::InitConfig(const TCgiParameters& params) {

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1,5 +1,6 @@
 #include "json_pipe_req.h"
 #include "log.h"
+#include <ydb/core/base/auth.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
 #include <util/generic/overloaded.h>
@@ -1020,6 +1021,17 @@ std::vector<TNodeId> TViewerPipeClient::GetDatabaseNodes() {
 
 bool TViewerPipeClient::IsDatabaseRequest() const {
     return DatabaseBoardInfoResponse || ResourceBoardInfoResponse;
+}
+
+bool TViewerPipeClient::IsStrictDatabaseOnlyRequest() {
+    if (!StrictDatabaseOnlyRequest) {
+        StrictDatabaseOnlyRequest = IsStrictDatabaseOnlyToken(AppData(), GetRequest().GetUserTokenObject());
+    }
+    return *StrictDatabaseOnlyRequest;
+}
+
+TString TViewerPipeClient::GetUserSID() const {
+    return NACLib::TUserToken(GetRequest().GetUserTokenObject()).GetUserSID();
 }
 
 void TViewerPipeClient::InitConfig(const TCgiParameters& params) {

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -342,11 +342,8 @@ protected:
     std::vector<TNodeId> GetDatabaseNodes();
     bool IsDatabaseRequest() const;
 
-    // True for a token whose highest access level is EAccessLevel::Database: such a user is allowed
-    // to see the information about its own database only, never about the cluster.
+    // Such a user is allowed to see the information about its own database only
     bool IsStrictDatabaseOnlyRequest();
-
-    // The SID of the user who sent the request, for logging of the denied requests.
     TString GetUserSID() const;
 
     void InitConfig(const TCgiParameters& params);

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -47,6 +47,7 @@ protected:
     i32 DataRequests = 0; // how many requests we wait to process data
     bool PassedAway = false;
     bool ReplySent = false;
+    std::optional<bool> StrictDatabaseOnlyRequest; // lazily calculated by IsStrictDatabaseOnlyRequest()
     bool UseCache = false;
     bool CheckDatabase = true;
     TDuration CachedDataMaxAge;
@@ -340,6 +341,14 @@ protected:
     std::vector<TNodeId> GetNodesFromBoardReply(const TEvStateStorage::TEvBoardInfo& ev);
     std::vector<TNodeId> GetDatabaseNodes();
     bool IsDatabaseRequest() const;
+
+    // True for a token whose highest access level is EAccessLevel::Database: such a user is allowed
+    // to see the information about its own database only, never about the cluster.
+    bool IsStrictDatabaseOnlyRequest();
+
+    // The SID of the user who sent the request, for logging of the denied requests.
+    TString GetUserSID() const;
+
     void InitConfig(const TCgiParameters& params);
     void InitConfig(const TRequestSettings& settings);
     void BuildParamsFromJson(TStringBuf data);

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -140,7 +140,7 @@ public:
         if (Params.Has("path_id") || Params.Has("schemeshard_id")) {
             if (!Viewer->CheckAccessMonitoring(GetRequest())) {
                 // it's dangerous because we don't check access to scoped ids here
-                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: `path_id`/`schemeshard_id` require the monitoring access level",
+                YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Access denied: `path_id`/`schemeshard_id` require the monitoring access level",
                     {"logPrefix", GetLogPrefix()},
                     {"user", GetUserSID()},
                     {"database", Database},

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -137,9 +137,15 @@ public:
         if (NeedToRedirect()) {
             return;
         }
-        if (Params.Has("path_id")) {
+        if (Params.Has("path_id") || Params.Has("schemeshard_id")) {
             if (!Viewer->CheckAccessMonitoring(GetRequest())) {
-                // it's dangerous because we don't check access to specific path here
+                // it's dangerous because we don't check access to scoped ids here
+                YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: `path_id`/`schemeshard_id` require the monitoring access level",
+                    {"logPrefix", GetLogPrefix()},
+                    {"user", GetUserSID()},
+                    {"database", Database},
+                    {"pathId", Params.Get("path_id")},
+                    {"schemeShardId", Params.Get("schemeshard_id")});
                 ReplyAndPassAway(GETHTTPACCESSDENIED("text/html", "<html><body><h1>403 Forbidden</h1></body></html>"), "Access denied");
                 return;
             }

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -146,7 +146,9 @@ public:
                     {"database", Database},
                     {"pathId", Params.Get("path_id")},
                     {"schemeShardId", Params.Get("schemeshard_id")});
-                ReplyAndPassAway(GETHTTPACCESSDENIED("text/html", "<html><body><h1>403 Forbidden</h1></body></html>"), "Access denied");
+                ReplyAndPassAway(
+                    GETHTTPACCESSDENIED("text/plain", "`path_id` and `schemeshard_id` require monitoring access level"),
+                    "Access denied");
                 return;
             }
         }

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -135,7 +135,7 @@ public:
         MetadataCache = FromStringWithDefault<bool>(Params.Get("metadata_cache"), MetadataCache);
         ShowAllDatabases = FromStringWithDefault<bool>(Params.Get("show_all_databases"), ShowAllDatabases);
         if (ShowAllDatabases && IsStrictDatabaseOnlyRequest()) {
-            YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: `show_all_databases` is not allowed for database-scoped access",
+            YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Access denied: `show_all_databases` is not allowed for database-scoped access",
                 {"logPrefix", GetLogPrefix()},
                 {"user", GetUserSID()},
                 {"database", Database});

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -134,6 +134,16 @@ public:
         OffloadMerge = FromStringWithDefault<bool>(Params.Get("offload_merge"), OffloadMerge);
         MetadataCache = FromStringWithDefault<bool>(Params.Get("metadata_cache"), MetadataCache);
         ShowAllDatabases = FromStringWithDefault<bool>(Params.Get("show_all_databases"), ShowAllDatabases);
+        if (ShowAllDatabases && IsStrictDatabaseOnlyRequest()) {
+            YDB_LOG_INFO_COMP(NKikimrServices::VIEWER, "Access denied: `show_all_databases` is not allowed for database-scoped access",
+                {"logPrefix", GetLogPrefix()},
+                {"user", GetUserSID()},
+                {"database", Database});
+            ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain", "`show_all_databases` is not allowed for database-scoped access"),
+                "Access denied");
+            return;
+        }
 
         TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
         auto* domain = domains->GetDomain();

--- a/ydb/tests/functional/secrets/test_secrets_monitoring.py
+++ b/ydb/tests/functional/secrets/test_secrets_monitoring.py
@@ -3,6 +3,7 @@
 import logging
 
 from ydb.tests.functional.secrets.lib.secrets_plugin import create_secrets, DATABASE, ROOT
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
 import requests
 
 logger = logging.getLogger(__name__)
@@ -12,15 +13,6 @@ CLUSTER_CONFIG = dict(
         # 'TX_PROXY': LogLevels.DEBUG,
     },
 )
-
-
-def get_tenant_schemeshard_id(ydb_cluster, root_path, database_path):
-    mon_url = f"http://{cluster_http_endpoint(ydb_cluster)}"
-    response = requests.get(f"{mon_url}/viewer/json/describe?database={root_path}&path={database_path}", timeout=10)
-    response.raise_for_status()
-    data = response.json()
-
-    return int(data["PathDescription"]["Self"]["SchemeshardId"])
 
 
 def cluster_http_endpoint(cluster):

--- a/ydb/tests/functional/secrets/ya.make
+++ b/ydb/tests/functional/secrets/ya.make
@@ -27,6 +27,7 @@ PEERDIR(
     contrib/python/boto3
     contrib/python/requests
     ydb/tests/functional/secrets/lib
+    ydb/tests/functional/security/lib
     ydb/tests/library
     ydb/tests/library/fixtures
     ydb/tests/library/flavours

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -89,9 +89,6 @@ def mon_base_url(cluster, node_index=1):
     return f'https://{node.host}:{node.mon_port}'
 
 
-# use_tls only picks the scheme, and token only decides whether the request is authenticated:
-# a cluster without authentication rejects a request with an Authorization header with 400,
-# and a cluster with authentication rejects a request without it with 401.
 def describe_path_self(cluster, root_path, database_path, use_tls=False, token=None):
     node = cluster.nodes[1]
     scheme = 'https' if use_tls else 'http'

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -89,6 +89,31 @@ def mon_base_url(cluster, node_index=1):
     return f'https://{node.host}:{node.mon_port}'
 
 
+# use_tls only picks the scheme, and token only decides whether the request is authenticated:
+# a cluster without authentication rejects a request with an Authorization header with 400,
+# and a cluster with authentication rejects a request without it with 401.
+def describe_path_self(cluster, root_path, database_path, use_tls=False, token=None):
+    node = cluster.nodes[1]
+    scheme = 'https' if use_tls else 'http'
+    response = requests.get(
+        f'{scheme}://{node.host}:{node.mon_port}/viewer/json/describe',
+        params={'database': root_path, 'path': database_path},
+        headers={'Authorization': token} if token is not None else {},
+        verify=False,
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()['PathDescription']['Self']
+
+
+def get_tenant_schemeshard_id(cluster, root_path, database_path, use_tls=False, token=None):
+    return int(describe_path_self(cluster, root_path, database_path, use_tls, token)['SchemeshardId'])
+
+
+def get_tenant_path_id(cluster, root_path, database_path, use_tls=False, token=None):
+    return int(describe_path_self(cluster, root_path, database_path, use_tls, token)['PathId'])
+
+
 def wait_for_viewer_ready(
     base_url,
     database=DATABASE,

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -8,6 +8,9 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.functional.security.lib.cluster_config import create_ydb_configurator, generate_certificates
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import grant_describe_schema_provided
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
+from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
+from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 pytest_plugins = ['ydb.tests.library.fixtures', 'ydb.tests.library.flavours']
@@ -183,6 +186,38 @@ def ydb_cluster_with_extra_sids_controls(certificates):
     cluster.start()
     yield cluster
     cluster.stop()
+
+
+TENANT_DATABASE = '/Root/Tenant'
+
+
+@pytest.fixture(scope='module')
+def tenant_database(ydb_cluster_with_extra_sids_controls):
+    cluster = ydb_cluster_with_extra_sids_controls
+    cluster.create_database(
+        TENANT_DATABASE,
+        storage_pool_units_count={'hdd': 1},
+        token='root@builtin',
+    )
+    slots = cluster.register_and_start_slots(TENANT_DATABASE, count=1)
+    cluster.wait_tenant_up(TENANT_DATABASE, token='root@builtin')
+    tenant_node = slots[0]
+    run_viewer_query(
+        f'https://{tenant_node.host}:{tenant_node.mon_port}',
+        f"GRANT 'ydb.granular.describe_schema' ON `{TENANT_DATABASE}` "
+        f"TO `database@builtin`, `viewer@builtin`, `monitoring@builtin`, `root@builtin`;",
+        database=TENANT_DATABASE,
+    )
+    return TENANT_DATABASE
+
+
+@pytest.fixture(scope='module')
+def tenant_describe_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
+    cluster = ydb_cluster_with_extra_sids_controls
+    return {
+        'path_id': get_tenant_path_id(cluster, tenant_database, tenant_database, use_tls=True, token='root@builtin'),
+        'schemeshard_id': get_tenant_schemeshard_id(cluster, tenant_database, tenant_database, use_tls=True, token='root@builtin'),
+    }
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -11,6 +11,7 @@ from ydb.tests.functional.security.lib.security_test_helpers import grant_descri
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
+from ydb.tests.functional.security.lib.security_test_helpers import wait_for_viewer_ready
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 pytest_plugins = ['ydb.tests.library.fixtures', 'ydb.tests.library.flavours']
@@ -202,6 +203,10 @@ def tenant_database(ydb_cluster_with_extra_sids_controls):
     slots = cluster.register_and_start_slots(TENANT_DATABASE, count=1)
     cluster.wait_tenant_up(TENANT_DATABASE, token='root@builtin')
     tenant_node = slots[0]
+    wait_for_viewer_ready(
+        f'https://{tenant_node.host}:{tenant_node.mon_port}',
+        database=TENANT_DATABASE,
+    )
     run_viewer_query(
         f'https://{tenant_node.host}:{tenant_node.mon_port}',
         f"GRANT 'ydb.granular.describe_schema' ON `{TENANT_DATABASE}` "

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -363,7 +363,8 @@ def test_viewer_describe_path_id_forbidden_for_strict_database_token(
             _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
             _assert_status(mon_base_url_with_extra_sids_control, path, 'monitoring@builtin', 200)
 
-        # schemeshard_id alone without path_id: handler gives 403 for strict database users and rejects other with 400
+        # schemeshard_id alone without path_id: handler gives 403 for users below monitoring level
+        # and rejects monitoring+ with 400 (missing path_id)
         path = _build_endpoint_path(
             ep,
             with_database_cgi=True,
@@ -372,6 +373,7 @@ def test_viewer_describe_path_id_forbidden_for_strict_database_token(
         )
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 403)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'viewer@builtin', 403)
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'monitoring@builtin', 400)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
 
 

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -55,10 +55,10 @@ def _assert_viewer_query_post(base_url, token, status=200, database=DATABASE):
     assert response.status_code == status, response.text
 
 
-def _build_endpoint_path(endpoint, with_database_cgi, extra_params=None):
+def _build_endpoint_path(endpoint, with_database_cgi, extra_params=None, database=DATABASE):
     params = dict(extra_params or {})
     if with_database_cgi:
-        params = {'database': DATABASE, **params}
+        params = {'database': database, **params}
     if not params:
         return endpoint
     separator = '&' if '?' in endpoint else '?'
@@ -274,11 +274,58 @@ def test_topic_data_access_controls(mon_base_url_with_extra_sids_control, topic_
                 _assert_status(mon_base_url_with_extra_sids_control, _build_topic_path(ep, with_database_cgi=False), token, 200)
 
 
+def test_viewer_tenantinfo_show_all_databases_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+):
+    for ep in ['/viewer/tenantinfo', '/viewer/json/tenantinfo']:
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'show_all_databases': 'true'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 403)
+        # Scope-param validation must not block users above database level.
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, token, 200)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
+        allowed_path_false = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'show_all_databases': 'false'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path_false, 'database@builtin', 200)
+
+
 # database@builtin is a strict database-only token and must be rejected when path is out of database scope.
-def test_viewer_describe_out_of_scope_path(mon_base_url_with_extra_sids_control):
+def test_viewer_describe_out_of_scope_path(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+):
     for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path': '/Other'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': '/Other'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, forbidden_path, 'database@builtin', 400)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': tenant_database},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'root@builtin', 200)
 
 
 # Only CGI params that bypass regular path validation (e.g. path_id, schemeshard_id) are forbidden.
@@ -289,13 +336,43 @@ def test_viewer_describe_strict_database_token_extra_params(mon_base_url_with_ex
         _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
 
 
-# path_id CGI param bypasses regular path validation, so handler validation rejects it as a bad request.
-def test_viewer_describe_strict_database_token_forbidden_params(mon_base_url_with_extra_sids_control):
+# path_id/schemeshard_id params require monitoring+ level access; strict database and viewer tokens get 4xx.
+def test_viewer_describe_path_id_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_describe_ids,
+):
     for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path_id': '1'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-        # path_id is rejected only for some access levels
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
+        # path_id alone is accepted for monitoring+ access level,
+        # as well as both params together: path_id and schemeshard_id
+        for extra_params in (
+            {'path_id': str(tenant_describe_ids['path_id'])},
+            {
+                'path_id': str(tenant_describe_ids['path_id']),
+                'schemeshard_id': str(tenant_describe_ids['schemeshard_id']),
+            },
+        ):
+            path = _build_endpoint_path(
+                ep,
+                with_database_cgi=True,
+                extra_params=extra_params,
+                database=tenant_database,
+            )
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 403)
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'viewer@builtin', 403)
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 200)
+            _assert_status(mon_base_url_with_extra_sids_control, path, 'monitoring@builtin', 200)
+
+        # schemeshard_id alone without path_id: handler gives 403 for strict database users and rejects other with 400
+        path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'schemeshard_id': str(tenant_describe_ids['schemeshard_id'])},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 403)
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'viewer@builtin', 403)
+        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)
 
 
 # Path outside database scope gives endpoint validation error (400), not role-denied (403).
@@ -303,12 +380,3 @@ def test_out_of_scope_path_nodes_gives_400(mon_base_url_with_extra_sids_control)
     for ep in ['/viewer/nodes', '/viewer/json/nodes']:
         path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path': '/Other'})
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-
-
-# schemeshard_id CGI param bypasses regular path validation, so handler validation rejects it as a bad request.
-def test_viewer_describe_schemeshard_id_forbidden(mon_base_url_with_extra_sids_control):
-    for ep in ['/viewer/describe', '/viewer/json/describe']:
-        path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'schemeshard_id': '1'})
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
-        # An administrator also gets 400, but from handler validation
-        _assert_status(mon_base_url_with_extra_sids_control, path, 'root@builtin', 400)


### PR DESCRIPTION
### Description for reviewers
* `/viewer/tenantinfo?show_all_databases=true` отвечает всеми базами кластера. Сейчас такие запросы будут возвращать 403 для пользователей уровня database; UI этот параметр шлёт, поэтому для пользователей ничего не изменится.
* `/viewer/describe?schemeshard_id=...` отдельно не проверяется. Сейчас параметр будет требовать ту же проверку, что уже делается для параметра `path_id`: оба параметра будут доступны только для пользователей уровня monitoring и выше. По логам видно, что запросы с path_id реально отклоняются у внешних пользователей вьюера https://nda.ya.ru/t/tbvpkfyr7n35bR, а `schemeshard_id` всегда шлют вместе с `path_id`, поэтому для пользователей ничего не изменится.

Оба отказа логируются уровнем `NOTICE`.

Поведение для пользователей уровня viewer+ не меняется, кроме того, что параметр `schemeshard_id` без `path_id` для уровня viewer начнёт получать 403 вместо 400.