### PR TITLE
More evident filtering of database nodes in `/viewer/nodes` and `/viewer/peers`

### DIFF
--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "json_pipe_req.h"
+#include "log.h"
 #include "viewer.h"
 #include "viewer_helper.h"
 #include "wb_group.h"
@@ -129,6 +130,7 @@ class TJsonNodes : public TViewerPipeClient {
     std::vector<TString> FilterStoragePools;
     std::vector<std::pair<ui64, ui64>> FilterStoragePoolsIds;
     std::unordered_set<TNodeId> RestrictedNodeIds; // due to access rights
+    bool RestrictToDatabaseNodes = false; // the filter by RestrictedNodeIds is required, even if the set is empty
     std::unordered_set<TNodeId> FilterNodeIds;
     std::unordered_set<ui32> FilterGroupIds;
     std::optional<std::size_t> Offset;
@@ -1170,6 +1172,9 @@ public:
         if (IsDatabaseRequest() && !Viewer->CheckAccessViewer(TBase::GetRequest())) {
             auto nodes = GetDatabaseNodes();
             RestrictedNodeIds = std::unordered_set<TNodeId>(nodes.begin(), nodes.end());
+            // The filter must be applied even when the database has no nodes at all,
+            // otherwise a database user would get the nodes of the whole cluster.
+            RestrictToDatabaseNodes = true;
             NeedFilter = true;
         }
 
@@ -1367,7 +1372,12 @@ public:
             InvalidateNodes();
             AddEvent("Type Filter Applied");
         }
-        if (!RestrictedNodeIds.empty() && FieldsAvailable.test(+ENodeFields::NodeId)) {
+        if (RestrictToDatabaseNodes && FieldsAvailable.test(+ENodeFields::NodeId)) {
+            if (RestrictedNodeIds.empty()) {
+                YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Empty response: the database has no nodes to show",
+                    {"logPrefix", GetLogPrefix()},
+                    {"database", Database});
+            }
             TNodeView nodeView;
             for (TNode* node : NodeView) {
                 if (RestrictedNodeIds.count(node->GetNodeId()) > 0) {
@@ -1378,6 +1388,7 @@ public:
             FoundNodes = TotalNodes = NodeView.size();
             InvalidateNodes();
             RestrictedNodeIds.clear();
+            RestrictToDatabaseNodes = false;
             AddEvent("Restricted Filter Applied");
         }
 
@@ -1490,7 +1501,7 @@ public:
                 InvalidateNodes();
                 AddEvent("Group Filter Applied");
             }
-            NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0 || !FilterGroup.empty() || !RestrictedNodeIds.empty();
+            NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0 || !FilterGroup.empty() || RestrictToDatabaseNodes;
             FoundNodes = NodeView.size();
         }
     }

--- a/ydb/core/viewer/viewer_peers.h
+++ b/ydb/core/viewer/viewer_peers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "json_pipe_req.h"
+#include "log.h"
 #include "viewer.h"
 #include "viewer_helper.h"
 #include <ydb/core/viewer/yaml/yaml.h>
@@ -52,6 +53,7 @@ class TJsonPeers : public TViewerPipeClient {
     std::unordered_map<TNodeId, TRequestResponse<TEvViewer::TEvViewerResponse>> PeersViewerResponse;
 
     std::unordered_set<TNodeId> RestrictedNodeIds; // due to access rights
+    bool RestrictToDatabaseNodes = false; // the filter by RestrictedNodeIds is required, even if the set is empty
     TNodeId NodeId = 0;
     std::optional<std::size_t> Offset;
     std::optional<std::size_t> Limit;
@@ -351,6 +353,9 @@ class TJsonPeers : public TViewerPipeClient {
         if (IsDatabaseRequest() && !Viewer->CheckAccessViewer(TBase::GetRequest())) {
             auto nodes = GetDatabaseNodes();
             RestrictedNodeIds = std::unordered_set<TNodeId>(nodes.begin(), nodes.end());
+            // The filter must be applied even when the database has no nodes at all,
+            // otherwise a database user would get the peers of the whole cluster.
+            RestrictToDatabaseNodes = true;
             NeedFilter = true;
         }
         NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
@@ -387,7 +392,12 @@ class TJsonPeers : public TViewerPipeClient {
     }
 
     void ApplyFilter() {
-        if (!RestrictedNodeIds.empty()) {
+        if (RestrictToDatabaseNodes) {
+            if (RestrictedNodeIds.empty()) {
+                YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Empty response: the database has no nodes to show",
+                    {"logPrefix", GetLogPrefix()},
+                    {"database", Database});
+            }
             TPeerView peerView;
             for (TPeer* peer : PeerView) {
                 if (RestrictedNodeIds.count(peer->GetPeerId()) > 0) {
@@ -398,6 +408,7 @@ class TJsonPeers : public TViewerPipeClient {
             FoundPeers = TotalPeers = PeerView.size();
             InvalidatePeers();
             RestrictedNodeIds.clear();
+            RestrictToDatabaseNodes = false;
             AddEvent("Restricted Filter Applied");
         }
 


### PR DESCRIPTION
### Description for reviewers
The filter by the database nodes was applied only when the set of the database nodes was not empty, so an empty set meant "nothing to filter by" and a strict database user would get the nodes of the whole cluster. The new `RestrictToDatabaseNodes` flag makes the filter unconditional.

In real HTTP-queries such case is not reachable, however it's better to handle. 