### PR TITLE
[KIKIMR-26790] (+) CutHistory in CS

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2951,6 +2951,17 @@ message TColumnShardConfig {
     optional TReadRetryPolicy ReadRetryPolicy = 70;
     optional uint64 BulkUpsertShardWriteChunkLimitBytes = 71 [default = 50331648]; // 48 MiB
     optional bool EnableBulkUpsertValidation = 72 [default = true];
+
+    // 75 and 76 held MoveDataEnabled/CutHistoryEnabled as bools in an earlier iteration of
+    // this feature; both moved to FeatureFlags. Not reused: an old binary in a rolling
+    // upgrade would misparse a uint32 written under a number it still reads as a bool.
+    reserved 75, 76;
+
+    // CutHistory nomination pacing. Defaults match the previous hardcoded constants; they
+    // bound IsDrained() queue scans to CutHistoryMaxDrainChecksPerNomination per cadence
+    // per tablet, which is the cost that scales with ColumnShards per node.
+    optional uint32 CutHistoryNominateCadenceSeconds = 77 [default = 60];
+    optional uint32 CutHistoryMaxDrainChecksPerNomination = 78 [default = 8];
     optional uint64 NodePortionsCountLimit = 73;
 
     message TFlowControlConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2980,8 +2980,9 @@ message TColumnShardConfig {
     }
 
     optional TFlowControlConfig FlowControl = 74;
-    // 75/76: group-decommission features (75 = MoveDataEnabled in the sibling PR, 76 = CutHistory).
-    optional bool CutHistoryEnabled = 76 [default = false];
+    // 75/76: group-decommission features. Both are gated by feature flags
+    // (EnableColumnshardMoveData / EnableCutHistory), not by this config.
+    reserved 76;
 }
 
 // Cluster config for the database-wide small-blobs quota. Per-database limits are derived from

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2980,6 +2980,8 @@ message TColumnShardConfig {
     }
 
     optional TFlowControlConfig FlowControl = 74;
+    // 75/76: group-decommission features (75 = MoveDataEnabled in the sibling PR, 76 = CutHistory).
+    optional bool CutHistoryEnabled = 76 [default = false];
 }
 
 // Cluster config for the database-wide small-blobs quota. Per-database limits are derived from

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2980,9 +2980,6 @@ message TColumnShardConfig {
     }
 
     optional TFlowControlConfig FlowControl = 74;
-    // 75/76: group-decommission features. Both are gated by feature flags
-    // (EnableColumnshardMoveData / EnableCutHistory), not by this config.
-    reserved 76;
 }
 
 // Cluster config for the database-wide small-blobs quota. Per-database limits are derived from

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2982,8 +2982,6 @@ message TColumnShardConfig {
     optional TFlowControlConfig FlowControl = 74;
     // 75/76: group-decommission features (75 = MoveDataEnabled in the sibling PR, 76 = CutHistory).
     optional bool CutHistoryEnabled = 76 [default = false];
-    // 75/76: group-decommission features (75 = MoveDataEnabled in the sibling PR, 76 = CutHistory).
-    optional bool CutHistoryEnabled = 76 [default = false];
 }
 
 // Cluster config for the database-wide small-blobs quota. Per-database limits are derived from

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2982,6 +2982,8 @@ message TColumnShardConfig {
     optional TFlowControlConfig FlowControl = 74;
     // 75/76: group-decommission features (75 = MoveDataEnabled in the sibling PR, 76 = CutHistory).
     optional bool CutHistoryEnabled = 76 [default = false];
+    // 75/76: group-decommission features (75 = MoveDataEnabled in the sibling PR, 76 = CutHistory).
+    optional bool CutHistoryEnabled = 76 [default = false];
 }
 
 // Cluster config for the database-wide small-blobs quota. Per-database limits are derived from

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2952,14 +2952,10 @@ message TColumnShardConfig {
     optional uint64 BulkUpsertShardWriteChunkLimitBytes = 71 [default = 50331648]; // 48 MiB
     optional bool EnableBulkUpsertValidation = 72 [default = true];
 
-    // 75 and 76 held MoveDataEnabled/CutHistoryEnabled as bools in an earlier iteration of
-    // this feature; both moved to FeatureFlags. Not reused: an old binary in a rolling
-    // upgrade would misparse a uint32 written under a number it still reads as a bool.
+    // Not reused: an old binary would misparse a uint32 written under a number it reads as a bool.
     reserved 75, 76;
 
-    // CutHistory nomination pacing. Defaults match the previous hardcoded constants; they
-    // bound IsDrained() queue scans to CutHistoryMaxDrainChecksPerNomination per cadence
-    // per tablet, which is the cost that scales with ColumnShards per node.
+    // Bound IsDrained() queue scans per tablet — the cost that scales with ColumnShards per node.
     optional uint32 CutHistoryNominateCadenceSeconds = 77 [default = 60];
     optional uint32 CutHistoryMaxDrainChecksPerNomination = 78 [default = 8];
     optional uint64 NodePortionsCountLimit = 73;

--- a/ydb/core/protos/counters_columnshard.proto
+++ b/ydb/core/protos/counters_columnshard.proto
@@ -214,5 +214,5 @@ enum ETxTypes {
     TXTYPE_CLEANUP_SCHEMAS = 43                             [(TxTypeOpts) = {Name: "TxCleanupSchemasWithnoData"}];
     TXTYPE_ABORT_LOCK = 44                                  [(TxTypeOpts) = {Name: "TxAbortLock"}];
     TXTYPE_TX_ABORT = 45                                    [(TxTypeOpts) = {Name: "TxTxAbort"}];
-    TXTYPE_CUT_HISTORY_SWEEP = 46                           [(TxTypeOpts) = {Name: "TxCutHistorySweep"}];   // reserved — superseded by in-memory portion list before release
+    reserved 46;   // was TXTYPE_CUT_HISTORY_SWEEP — superseded by the in-memory portion list before release
 }

--- a/ydb/core/protos/counters_columnshard.proto
+++ b/ydb/core/protos/counters_columnshard.proto
@@ -214,4 +214,5 @@ enum ETxTypes {
     TXTYPE_CLEANUP_SCHEMAS = 43                             [(TxTypeOpts) = {Name: "TxCleanupSchemasWithnoData"}];
     TXTYPE_ABORT_LOCK = 44                                  [(TxTypeOpts) = {Name: "TxAbortLock"}];
     TXTYPE_TX_ABORT = 45                                    [(TxTypeOpts) = {Name: "TxTxAbort"}];
+    TXTYPE_CUT_HISTORY_SWEEP = 46                           [(TxTypeOpts) = {Name: "TxCutHistorySweep"}];
 }

--- a/ydb/core/protos/counters_columnshard.proto
+++ b/ydb/core/protos/counters_columnshard.proto
@@ -214,5 +214,4 @@ enum ETxTypes {
     TXTYPE_CLEANUP_SCHEMAS = 43                             [(TxTypeOpts) = {Name: "TxCleanupSchemasWithnoData"}];
     TXTYPE_ABORT_LOCK = 44                                  [(TxTypeOpts) = {Name: "TxAbortLock"}];
     TXTYPE_TX_ABORT = 45                                    [(TxTypeOpts) = {Name: "TxTxAbort"}];
-    reserved 46;   // was TXTYPE_CUT_HISTORY_SWEEP — superseded by the in-memory portion list before release
 }

--- a/ydb/core/protos/counters_columnshard.proto
+++ b/ydb/core/protos/counters_columnshard.proto
@@ -214,5 +214,5 @@ enum ETxTypes {
     TXTYPE_CLEANUP_SCHEMAS = 43                             [(TxTypeOpts) = {Name: "TxCleanupSchemasWithnoData"}];
     TXTYPE_ABORT_LOCK = 44                                  [(TxTypeOpts) = {Name: "TxAbortLock"}];
     TXTYPE_TX_ABORT = 45                                    [(TxTypeOpts) = {Name: "TxTxAbort"}];
-    TXTYPE_CUT_HISTORY_SWEEP = 46                           [(TxTypeOpts) = {Name: "TxCutHistorySweep"}];
+    TXTYPE_CUT_HISTORY_SWEEP = 46                           [(TxTypeOpts) = {Name: "TxCutHistorySweep"}];   // reserved — superseded by in-memory portion list before release
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -384,4 +384,8 @@ message TFeatureFlags {
     optional bool EnableCheckpointsCompression = 325 [default = false];
     optional bool EnableDataShardLocksTransferOnSplit = 326 [default = false];
     optional bool EnableDqSourceStreamLookupJoinLocalLookups = 327 [default = false];
+    // Gates both legs of ColumnShard group decommission: the MoveData rewrite and the
+    // CutHistory wrapper. Deliberately not EnableCutHistory, which governs the tablet_sys
+    // and tablet_executor cutters on channels 0/1.
+    optional bool EnableColumnshardGroupDecommission = 328 [default = false];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -384,8 +384,6 @@ message TFeatureFlags {
     optional bool EnableCheckpointsCompression = 325 [default = false];
     optional bool EnableDataShardLocksTransferOnSplit = 326 [default = false];
     optional bool EnableDqSourceStreamLookupJoinLocalLookups = 327 [default = false];
-    // Gates both legs of ColumnShard group decommission: the MoveData rewrite and the
-    // CutHistory wrapper. Deliberately not EnableCutHistory, which governs the tablet_sys
-    // and tablet_executor cutters on channels 0/1.
+    // Gates both ColumnShard decommission legs; EnableCutHistory governs channels 0/1 instead.
     optional bool EnableColumnshardGroupDecommission = 328 [default = false];
 }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -502,6 +502,7 @@ void TExecutor::Active(const TActorContext &ctx) {
     Database = loadedState->Database;
     LogicSnap = loadedState->Snap;
     GcLogic = loadedState->GcLogic;
+    GcLogic->SetOwner(Owner);
     LogicRedo = loadedState->Redo;
     LogicAlter = loadedState->Alter;
     BorrowLogic = loadedState->Loans;

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -243,6 +243,9 @@ void TExecutorGCLogic::ApplyDelta(TGCTime time, TGCBlobDelta &delta) {
     for (const TLogoBlobID &blobId : delta.Deleted) {
         auto &channel = ChannelInfo[blobId.Channel()];
         channel.CommittedDelta[time].Deleted.push_back(blobId);
+        // A DoNotKeep mark still pins its entry: the flag is delivered to the group the
+        // blob's generation resolves to, and cutting the entry makes that unresolvable.
+        HistoryCutter.SeenBlob(blobId);
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -113,7 +113,8 @@ void TExecutorGCLogic::SnapToLog(NKikimrExecutorFlat::TLogSnapshot &snap, ui32 s
             x->SetSetToGeneration(chIt.second.CommitedGcBarrier.Generation);
             x->SetSetToStep(chIt.second.CommitedGcBarrier.Step);
 
-            if (chIt.second.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::None && chIt.second.GcWaitFor == 0) {
+            if (chIt.second.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::None && chIt.second.GcWaitFor == 0 &&
+                    IsHistoryCuttingSound(*TabletStorageInfo)) {
                 ChannelsToCutHistory.insert(chIt.first);
             }
         }
@@ -146,7 +147,8 @@ TDuration TExecutorGCLogic::OnCollectGarbageResult(TEvBlobStorage::TEvCollectGar
     ui32 channelId = ev->Channel;
     TChannelInfo& channel = ChannelInfo[channelId];
     if (ev->Status == NKikimrProto::EReplyStatus::OK) {
-        if (channel.OnCollectGarbageSuccess() && channel.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::SentBarrier) {
+        if (channel.OnCollectGarbageSuccess() && channel.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::SentBarrier &&
+                IsHistoryCuttingSound(*TabletStorageInfo)) {
             auto historyToCut = HistoryCutter.GetHistoryToCut(channelId);
             for (const auto* historyEntry : historyToCut) {
                 TAutoPtr<TEvTablet::TEvCutTabletHistory> request(new TEvTablet::TEvCutTabletHistory);
@@ -198,8 +200,12 @@ void TExecutorGCLogic::FollowersSyncComplete(bool isBoot) {
     AllowGarbageCollection = true;
 }
 
+bool TExecutorGCLogic::IsHistoryCuttingSound(const TTabletStorageInfo& info) {
+    return info.TabletType != TTabletTypes::ColumnShard;
+}
+
 void TExecutorGCLogic::Confirm(const TActorContext &ctx) {
-    if (!AppData()->FeatureFlags.GetEnableCutHistory()) {
+    if (!AppData()->FeatureFlags.GetEnableCutHistory() || !IsHistoryCuttingSound(*TabletStorageInfo)) {
         return;
     }
     for (auto channelId : ChannelsToCutHistory) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -238,15 +238,11 @@ void TExecutorGCLogic::ApplyDelta(TGCTime time, TGCBlobDelta &delta) {
         TGCTime gcTime(blobId.Generation(), blobId.Step());
         Y_ENSURE(channel.KnownGcBarrier < gcTime);
         channel.CommittedDelta[gcTime].Created.push_back(blobId);
-        HistoryCutter.SeenBlob(blobId);
     }
 
     for (const TLogoBlobID &blobId : delta.Deleted) {
         auto &channel = ChannelInfo[blobId.Channel()];
         channel.CommittedDelta[time].Deleted.push_back(blobId);
-        // A DoNotKeep mark still pins its entry: the flag is delivered to the group the
-        // blob's generation resolves to, and cutting the entry makes that unresolvable.
-        HistoryCutter.SeenBlob(blobId);
     }
 }
 
@@ -518,13 +514,11 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
             ui32 activeGroup = Max<ui32>();
             TVector<TLogoBlobID> *vec = nullptr;
 
-            // Below the first surviving entry the generation resolves to the sentinel group:
-            // the blob was collected with the cut entry, and the flag would fail forever.
             for (const auto &blobId : keep) {
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();
                     activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
-                    vec = activeGroup == Max<ui32>() ? nullptr : &affectedGroups[activeGroup].first;
+                    vec = &affectedGroups[activeGroup].first;
                 }
 
                 if (vec) {
@@ -542,7 +536,7 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();
                     activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
-                    vec = activeGroup == Max<ui32>() ? nullptr : &affectedGroups[activeGroup].second;
+                    vec = &affectedGroups[activeGroup].second;
                 }
 
                 if (vec) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -521,7 +521,7 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();
                     activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
-                    vec = &affectedGroups[activeGroup].first;
+                    vec = activeGroup == Max<ui32>() ? nullptr : &affectedGroups[activeGroup].first;
                 }
 
                 if (vec) {
@@ -539,7 +539,7 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();
                     activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
-                    vec = &affectedGroups[activeGroup].second;
+                    vec = activeGroup == Max<ui32>() ? nullptr : &affectedGroups[activeGroup].second;
                 }
 
                 if (vec) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -518,9 +518,8 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
             ui32 activeGroup = Max<ui32>();
             TVector<TLogoBlobID> *vec = nullptr;
 
-            // A generation below the first surviving history entry resolves to the sentinel
-            // group: the entry was cut, so the blob is already collected and its flag has
-            // nowhere to go. Sending it anyway fails forever and blocks the channel's GC.
+            // Below the first surviving entry the generation resolves to the sentinel group:
+            // the blob was collected with the cut entry, and the flag would fail forever.
             for (const auto &blobId : keep) {
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -237,6 +237,7 @@ void TExecutorGCLogic::ApplyDelta(TGCTime time, TGCBlobDelta &delta) {
         TGCTime gcTime(blobId.Generation(), blobId.Step());
         Y_ENSURE(channel.KnownGcBarrier < gcTime);
         channel.CommittedDelta[gcTime].Created.push_back(blobId);
+        HistoryCutter.SeenBlob(blobId);
     }
 
     for (const TLogoBlobID &blobId : delta.Deleted) {
@@ -516,6 +517,9 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
             ui32 activeGroup = Max<ui32>();
             TVector<TLogoBlobID> *vec = nullptr;
 
+            // A generation below the first surviving history entry resolves to the sentinel
+            // group: the entry was cut, so the blob is already collected and its flag has
+            // nowhere to go. Sending it anyway fails forever and blocks the channel's GC.
             for (const auto &blobId : keep) {
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -1,5 +1,6 @@
 #include "flat_executor_gclogic.h"
 #include "flat_bio_eggs.h"
+#include "tablet_flat_executor.h"
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 #include <ydb/core/base/appdata.h>
@@ -114,7 +115,7 @@ void TExecutorGCLogic::SnapToLog(NKikimrExecutorFlat::TLogSnapshot &snap, ui32 s
             x->SetSetToStep(chIt.second.CommitedGcBarrier.Step);
 
             if (chIt.second.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::None && chIt.second.GcWaitFor == 0 &&
-                    IsHistoryCuttingSound(*TabletStorageInfo, chIt.first)) {
+                    IsHistoryCuttingSound(chIt.first)) {
                 ChannelsToCutHistory.insert(chIt.first);
             }
         }
@@ -148,7 +149,7 @@ TDuration TExecutorGCLogic::OnCollectGarbageResult(TEvBlobStorage::TEvCollectGar
     TChannelInfo& channel = ChannelInfo[channelId];
     if (ev->Status == NKikimrProto::EReplyStatus::OK) {
         if (channel.OnCollectGarbageSuccess() && channel.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::SentBarrier &&
-                IsHistoryCuttingSound(*TabletStorageInfo, channelId)) {
+                IsHistoryCuttingSound(channelId)) {
             auto historyToCut = HistoryCutter.GetHistoryToCut(channelId);
             for (const auto* historyEntry : historyToCut) {
                 TAutoPtr<TEvTablet::TEvCutTabletHistory> request(new TEvTablet::TEvCutTabletHistory);
@@ -200,8 +201,8 @@ void TExecutorGCLogic::FollowersSyncComplete(bool isBoot) {
     AllowGarbageCollection = true;
 }
 
-bool TExecutorGCLogic::IsHistoryCuttingSound(const TTabletStorageInfo& info, ui32 channel) {
-    return info.TabletType != TTabletTypes::ColumnShard || channel < 2;
+bool TExecutorGCLogic::IsHistoryCuttingSound(ui32 channel) const {
+    return !Owner || !Owner->HasExternallyWrittenBlobs(channel);
 }
 
 void TExecutorGCLogic::Confirm(const TActorContext &ctx) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -114,7 +114,7 @@ void TExecutorGCLogic::SnapToLog(NKikimrExecutorFlat::TLogSnapshot &snap, ui32 s
             x->SetSetToStep(chIt.second.CommitedGcBarrier.Step);
 
             if (chIt.second.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::None && chIt.second.GcWaitFor == 0 &&
-                    IsHistoryCuttingSound(*TabletStorageInfo)) {
+                    IsHistoryCuttingSound(*TabletStorageInfo, chIt.first)) {
                 ChannelsToCutHistory.insert(chIt.first);
             }
         }
@@ -148,7 +148,7 @@ TDuration TExecutorGCLogic::OnCollectGarbageResult(TEvBlobStorage::TEvCollectGar
     TChannelInfo& channel = ChannelInfo[channelId];
     if (ev->Status == NKikimrProto::EReplyStatus::OK) {
         if (channel.OnCollectGarbageSuccess() && channel.CutHistoryStatus == TChannelInfo::ECutHistoryStatus::SentBarrier &&
-                IsHistoryCuttingSound(*TabletStorageInfo)) {
+                IsHistoryCuttingSound(*TabletStorageInfo, channelId)) {
             auto historyToCut = HistoryCutter.GetHistoryToCut(channelId);
             for (const auto* historyEntry : historyToCut) {
                 TAutoPtr<TEvTablet::TEvCutTabletHistory> request(new TEvTablet::TEvCutTabletHistory);
@@ -200,12 +200,12 @@ void TExecutorGCLogic::FollowersSyncComplete(bool isBoot) {
     AllowGarbageCollection = true;
 }
 
-bool TExecutorGCLogic::IsHistoryCuttingSound(const TTabletStorageInfo& info) {
-    return info.TabletType != TTabletTypes::ColumnShard;
+bool TExecutorGCLogic::IsHistoryCuttingSound(const TTabletStorageInfo& info, ui32 channel) {
+    return info.TabletType != TTabletTypes::ColumnShard || channel < 2;
 }
 
 void TExecutorGCLogic::Confirm(const TActorContext &ctx) {
-    if (!AppData()->FeatureFlags.GetEnableCutHistory() || !IsHistoryCuttingSound(*TabletStorageInfo)) {
+    if (!AppData()->FeatureFlags.GetEnableCutHistory()) {
         return;
     }
     for (auto channelId : ChannelsToCutHistory) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -45,8 +45,9 @@ public:
     // executor — ColumnShard's portions go through TBlobManager — has channel
     // contents the criterion cannot see, so cutting there strands those blobs below
     // the surviving history and GroupFor() resolves them to the Max<ui32> sentinel
-    // forever. Such tablets run their own drain-gated cutter instead.
-    static bool IsHistoryCuttingSound(const TTabletStorageInfo& info);
+    // forever. Such tablets run their own drain-gated cutter on their data channels;
+    // channels 0 and 1 hold only executor-written blobs and stay with this cutter.
+    static bool IsHistoryCuttingSound(const TTabletStorageInfo& info, ui32 channel);
 
     TExecutorGCLogic(TIntrusiveConstPtr<TTabletStorageInfo>, TAutoPtr<NPageCollection::TSteppedCookieAllocator>);
     void WriteToLog(TLogCommit &logEntry);

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -39,6 +39,15 @@ struct TGCLogEntry {
 
 class TExecutorGCLogic {
 public:
+    // The executor's history cutter judges an entry cuttable when no executor-known
+    // blob generation falls in its range, but it is seeded only from the local DB
+    // parts (bootlogic ExtractState). A tablet that writes channel blobs outside the
+    // executor — ColumnShard's portions go through TBlobManager — has channel
+    // contents the criterion cannot see, so cutting there strands those blobs below
+    // the surviving history and GroupFor() resolves them to the Max<ui32> sentinel
+    // forever. Such tablets run their own drain-gated cutter instead.
+    static bool IsHistoryCuttingSound(const TTabletStorageInfo& info);
+
     TExecutorGCLogic(TIntrusiveConstPtr<TTabletStorageInfo>, TAutoPtr<NPageCollection::TSteppedCookieAllocator>);
     void WriteToLog(TLogCommit &logEntry);
     TGCLogEntry SnapshotLog(ui32 step);

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -43,13 +43,9 @@ struct TGCLogEntry {
 
 class TExecutorGCLogic {
 public:
-    // The executor's history cutter judges an entry cuttable when no executor-known
-    // blob generation falls in its range, but it is seeded only from the local DB
-    // parts (bootlogic ExtractState). A tablet that writes channel blobs outside the
-    // executor — ColumnShard's portions go through TBlobManager — has channel
-    // contents the criterion cannot see, so cutting there strands those blobs below
-    // the surviving history and GroupFor() resolves them to the Max<ui32> sentinel
-    // forever. The tablet declares such channels through ITablet::HasExternallyWrittenBlobs.
+    // False for channels the tablet writes past the executor (ITablet::
+    // HasExternallyWrittenBlobs): cutting those strands their blobs below the surviving
+    // history, where GroupFor() resolves them to the Max<ui32> sentinel forever.
     bool IsHistoryCuttingSound(ui32 channel) const;
 
     TExecutorGCLogic(TIntrusiveConstPtr<TTabletStorageInfo>, TAutoPtr<NPageCollection::TSteppedCookieAllocator>);

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -12,6 +12,10 @@
 namespace NKikimr {
 namespace NTabletFlatExecutor {
 
+namespace NFlatExecutorSetup {
+    struct ITablet;
+}
+
 struct TGCTime {
     ui32 Generation;
     ui32 Step;
@@ -45,11 +49,11 @@ public:
     // executor — ColumnShard's portions go through TBlobManager — has channel
     // contents the criterion cannot see, so cutting there strands those blobs below
     // the surviving history and GroupFor() resolves them to the Max<ui32> sentinel
-    // forever. Such tablets run their own drain-gated cutter on their data channels;
-    // channels 0 and 1 hold only executor-written blobs and stay with this cutter.
-    static bool IsHistoryCuttingSound(const TTabletStorageInfo& info, ui32 channel);
+    // forever. The tablet declares such channels through ITablet::HasExternallyWrittenBlobs.
+    bool IsHistoryCuttingSound(ui32 channel) const;
 
     TExecutorGCLogic(TIntrusiveConstPtr<TTabletStorageInfo>, TAutoPtr<NPageCollection::TSteppedCookieAllocator>);
+    void SetOwner(NFlatExecutorSetup::ITablet* owner) { Owner = owner; }
     void WriteToLog(TLogCommit &logEntry);
     TGCLogEntry SnapshotLog(ui32 step);
     void SnapToLog(NKikimrExecutorFlat::TLogSnapshot &logSnapshot, ui32 step);
@@ -102,6 +106,9 @@ public:
     TIntrospection IntrospectStateSize() const;
 protected:
     const TIntrusiveConstPtr<TTabletStorageInfo> TabletStorageInfo;
+    // Not owned; set by the executor once it adopts this logic. Null during boot and
+    // in unit tests, where no channel is externally written.
+    NFlatExecutorSetup::ITablet* Owner = nullptr;
     const TAutoPtr<NPageCollection::TSteppedCookieAllocator> Cookies;
     const ui32 Generation;
     NPageCollection::TSlicer Slicer;

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -43,9 +43,7 @@ struct TGCLogEntry {
 
 class TExecutorGCLogic {
 public:
-    // False for channels the tablet writes past the executor (ITablet::
-    // HasExternallyWrittenBlobs): cutting those strands their blobs below the surviving
-    // history, where GroupFor() resolves them to the Max<ui32> sentinel forever.
+    // False for externally written channels: cutting those strands their blobs under a Max<ui32> group.
     bool IsHistoryCuttingSound(ui32 channel) const;
 
     TExecutorGCLogic(TIntrusiveConstPtr<TTabletStorageInfo>, TAutoPtr<NPageCollection::TSteppedCookieAllocator>);
@@ -102,8 +100,7 @@ public:
     TIntrospection IntrospectStateSize() const;
 protected:
     const TIntrusiveConstPtr<TTabletStorageInfo> TabletStorageInfo;
-    // Not owned; set by the executor once it adopts this logic. Null during boot and
-    // in unit tests, where no channel is externally written.
+    // Not owned; null during boot and in unit tests, where no channel is externally written.
     NFlatExecutorSetup::ITablet* Owner = nullptr;
     const TAutoPtr<NPageCollection::TSteppedCookieAllocator> Cookies;
     const ui32 Generation;

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -1,6 +1,7 @@
 #include "flat_boot_cookie.h"
 #include "flat_boot_oven.h"
 #include "flat_executor_gclogic.h"
+#include "tablet_flat_executor.h"
 #include "flat_sausage_grind.h"
 #include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/testlib/basics/runtime.h>
@@ -424,24 +425,36 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
     Y_UNIT_TEST(HistoryCuttingUnsoundForExternalBlobWriters) {
         // The seen-generations criterion only covers executor-written blobs; a tablet
         // whose channels also hold externally-written blobs (ColumnShard portions via
-        // TBlobManager) must not be cut by the executor at all. Observed live: entries
+        // TBlobManager) must not be cut by the executor there. Observed live: entries
         // cut under external blobs leave GroupFor() resolving to Max<ui32> and GC
-        // retrying an invalid group until the tablet is unusable.
-        auto makeInfo = [](TTabletTypes::EType type) {
-            auto info = MakeIntrusive<TTabletStorageInfo>();
-            info->TabletID = 1;
-            info->TabletType = type;
-            return info;
+        // retrying an invalid group until the tablet is unusable. The tablet declares
+        // those channels itself, so this asserts the hook, not a tablet type.
+        struct TExternalWriter: public NFlatExecutorSetup::ITablet {
+            explicit TExternalWriter(TTabletStorageInfo* info)
+                : ITablet(info, TActorId())
+            {
+            }
+            void ActivateExecutor(const TActorContext&) override {}
+            void Detach(const TActorContext&) override {}
+            bool HasExternallyWrittenBlobs(ui32 channel) const override {
+                return channel >= 2;
+            }
         };
-        using NTabletFlatExecutor::TExecutorGCLogic;
-        const auto columnShard = makeInfo(TTabletTypes::ColumnShard);
-        // Channels 0/1 carry only executor blobs even on ColumnShard, so they stay with this cutter.
-        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 0));
-        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 1));
-        UNIT_ASSERT(!TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 2));
-        UNIT_ASSERT(!TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 65));
-        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::DataShard), 2));
-        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::KeyValue), 2));
+        auto info = MakeIntrusive<TTabletStorageInfo>();
+        info->TabletID = 1;
+        // Deliberately not ColumnShard: the split follows the declared channels, not the type.
+        info->TabletType = TTabletTypes::Dummy;
+        NBoot::TSteppedCookieAllocatorFactory cookies(*info, 1);
+        TExecutorGCLogic gcLogic(info, cookies.Sys(NBoot::TCookie::EIdx::GCExt));
+        UNIT_ASSERT_C(gcLogic.IsHistoryCuttingSound(2), "without an owner every channel is the executor's");
+
+        TExternalWriter external(info.Get());
+        gcLogic.SetOwner(&external);
+        // Channels 0/1 carry only executor blobs, so they stay with this cutter.
+        UNIT_ASSERT(gcLogic.IsHistoryCuttingSound(0));
+        UNIT_ASSERT(gcLogic.IsHistoryCuttingSound(1));
+        UNIT_ASSERT(!gcLogic.IsHistoryCuttingSound(2));
+        UNIT_ASSERT(!gcLogic.IsHistoryCuttingSound(65));
     }
 
     // A blob that is deleted but not yet collected keeps its DoNotKeep mark in the GC

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -452,46 +452,6 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
         UNIT_ASSERT(!gcLogic.IsHistoryCuttingSound(65));
     }
 
-    // Cutting an entry under a not-yet-collected DoNotKeep mark strands the mark:
-    // observed live as GC retrying the sentinel group forever on channel 1.
-    Y_UNIT_TEST(PendingDeleteDeltaPinsHistoryEntry) {
-        static constexpr ui64 TabletId = 42;
-        static constexpr ui32 Channel = 1;
-        auto info = MakeIntrusive<TTabletStorageInfo>(TabletId, TTabletTypes::Dummy);
-        info->Channels.resize(Channel + 1);
-        info->Channels[Channel].Channel = Channel;
-        info->Channels[Channel].History.emplace_back(0, 100);
-        info->Channels[Channel].History.emplace_back(10, 200);
-
-        NBoot::TSteppedCookieAllocatorFactory cookies(*info, /*gen=*/10);
-        TExecutorGCLogic gcLogic(info, cookies.Sys(NBoot::TCookie::EIdx::GCExt));
-        UNIT_ASSERT_VALUES_EQUAL(gcLogic.HistoryCutter.GetHistoryToCut(Channel).size(), 1);
-
-        TGCLogEntry entry(TGCTime(10, 1));
-        entry.Delta.Deleted.push_back(TLogoBlobID(TabletId, /*gen=*/3, /*step=*/1, Channel, HistoryCutterUtBlobSize, 0));
-        gcLogic.ApplyLogEntry(entry);
-        UNIT_ASSERT_C(gcLogic.HistoryCutter.GetHistoryToCut(Channel).empty(),
-            "an entry with a pending DoNotKeep mark must not be cuttable");
-    }
-
-    Y_UNIT_TEST(CreatedDeltaPinsHistoryEntry) {
-        static constexpr ui64 TabletId = 43;
-        static constexpr ui32 Channel = 1;
-        auto info = MakeIntrusive<TTabletStorageInfo>(TabletId, TTabletTypes::Dummy);
-        info->Channels.resize(Channel + 1);
-        info->Channels[Channel].Channel = Channel;
-        info->Channels[Channel].History.emplace_back(0, 100);
-        info->Channels[Channel].History.emplace_back(10, 200);
-
-        NBoot::TSteppedCookieAllocatorFactory cookies(*info, /*gen=*/10);
-        TExecutorGCLogic gcLogic(info, cookies.Sys(NBoot::TCookie::EIdx::GCExt));
-
-        TGCLogEntry entry(TGCTime(10, 1));
-        entry.Delta.Created.push_back(TLogoBlobID(TabletId, /*gen=*/3, /*step=*/1, Channel, HistoryCutterUtBlobSize, 0));
-        gcLogic.ApplyLogEntry(entry);
-        UNIT_ASSERT_C(gcLogic.HistoryCutter.GetHistoryToCut(Channel).empty(),
-            "an entry with a live blob must not be cuttable");
-    }
 }
 
 }

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -431,9 +431,15 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
             info->TabletType = type;
             return info;
         };
-        UNIT_ASSERT(!NTabletFlatExecutor::TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::ColumnShard)));
-        UNIT_ASSERT(NTabletFlatExecutor::TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::DataShard)));
-        UNIT_ASSERT(NTabletFlatExecutor::TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::KeyValue)));
+        using NTabletFlatExecutor::TExecutorGCLogic;
+        const auto columnShard = makeInfo(TTabletTypes::ColumnShard);
+        // Channels 0/1 carry only executor blobs even on ColumnShard, so they stay with this cutter.
+        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 0));
+        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 1));
+        UNIT_ASSERT(!TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 2));
+        UNIT_ASSERT(!TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 65));
+        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::DataShard), 2));
+        UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::KeyValue), 2));
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -1,3 +1,5 @@
+#include "flat_boot_cookie.h"
+#include "flat_boot_oven.h"
 #include "flat_executor_gclogic.h"
 #include "flat_sausage_grind.h"
 #include <ydb/core/testlib/actors/test_runtime.h>
@@ -440,6 +442,48 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
         UNIT_ASSERT(!TExecutorGCLogic::IsHistoryCuttingSound(*columnShard, 65));
         UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::DataShard), 2));
         UNIT_ASSERT(TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::KeyValue), 2));
+    }
+
+    // A blob that is deleted but not yet collected keeps its DoNotKeep mark in the GC
+    // deltas; cutting its entry makes the mark undeliverable, so the delta must feed
+    // the cutter. Observed live: GC to the sentinel group retried forever on channel 1.
+    Y_UNIT_TEST(PendingDeleteDeltaPinsHistoryEntry) {
+        static constexpr ui64 TabletId = 42;
+        static constexpr ui32 Channel = 1;
+        auto info = MakeIntrusive<TTabletStorageInfo>(TabletId, TTabletTypes::Dummy);
+        info->Channels.resize(Channel + 1);
+        info->Channels[Channel].Channel = Channel;
+        info->Channels[Channel].History.emplace_back(0, 100);
+        info->Channels[Channel].History.emplace_back(10, 200);
+
+        NBoot::TSteppedCookieAllocatorFactory cookies(*info, /*gen=*/10);
+        TExecutorGCLogic gcLogic(info, cookies.Sys(NBoot::TCookie::EIdx::GCExt));
+        UNIT_ASSERT_VALUES_EQUAL(gcLogic.HistoryCutter.GetHistoryToCut(Channel).size(), 1);
+
+        TGCLogEntry entry(TGCTime(10, 1));
+        entry.Delta.Deleted.push_back(TLogoBlobID(TabletId, /*gen=*/3, /*step=*/1, Channel, HistoryCutterUtBlobSize, 0));
+        gcLogic.ApplyLogEntry(entry);
+        UNIT_ASSERT_C(gcLogic.HistoryCutter.GetHistoryToCut(Channel).empty(),
+            "an entry with a pending DoNotKeep mark must not be cuttable");
+    }
+
+    Y_UNIT_TEST(CreatedDeltaPinsHistoryEntry) {
+        static constexpr ui64 TabletId = 43;
+        static constexpr ui32 Channel = 1;
+        auto info = MakeIntrusive<TTabletStorageInfo>(TabletId, TTabletTypes::Dummy);
+        info->Channels.resize(Channel + 1);
+        info->Channels[Channel].Channel = Channel;
+        info->Channels[Channel].History.emplace_back(0, 100);
+        info->Channels[Channel].History.emplace_back(10, 200);
+
+        NBoot::TSteppedCookieAllocatorFactory cookies(*info, /*gen=*/10);
+        TExecutorGCLogic gcLogic(info, cookies.Sys(NBoot::TCookie::EIdx::GCExt));
+
+        TGCLogEntry entry(TGCTime(10, 1));
+        entry.Delta.Created.push_back(TLogoBlobID(TabletId, /*gen=*/3, /*step=*/1, Channel, HistoryCutterUtBlobSize, 0));
+        gcLogic.ApplyLogEntry(entry);
+        UNIT_ASSERT_C(gcLogic.HistoryCutter.GetHistoryToCut(Channel).empty(),
+            "an entry with a live blob must not be cuttable");
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -418,6 +418,23 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
         // (the gen-5 keep and the gen-6 delete) as dropped.
         UNIT_ASSERT_VALUES_EQUAL(gcLogic.TakeSentinelDroppedMarks(), 2u);
     }
+
+    Y_UNIT_TEST(HistoryCuttingUnsoundForExternalBlobWriters) {
+        // The seen-generations criterion only covers executor-written blobs; a tablet
+        // whose channels also hold externally-written blobs (ColumnShard portions via
+        // TBlobManager) must not be cut by the executor at all. Observed live: entries
+        // cut under external blobs leave GroupFor() resolving to Max<ui32> and GC
+        // retrying an invalid group until the tablet is unusable.
+        auto makeInfo = [](TTabletTypes::EType type) {
+            auto info = MakeIntrusive<TTabletStorageInfo>();
+            info->TabletID = 1;
+            info->TabletType = type;
+            return info;
+        };
+        UNIT_ASSERT(!NTabletFlatExecutor::TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::ColumnShard)));
+        UNIT_ASSERT(NTabletFlatExecutor::TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::DataShard)));
+        UNIT_ASSERT(NTabletFlatExecutor::TExecutorGCLogic::IsHistoryCuttingSound(*makeInfo(TTabletTypes::KeyValue)));
+    }
 }
 
 }

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -423,12 +423,8 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
     }
 
     Y_UNIT_TEST(HistoryCuttingUnsoundForExternalBlobWriters) {
-        // The seen-generations criterion only covers executor-written blobs; a tablet
-        // whose channels also hold externally-written blobs (ColumnShard portions via
-        // TBlobManager) must not be cut by the executor there. Observed live: entries
-        // cut under external blobs leave GroupFor() resolving to Max<ui32> and GC
-        // retrying an invalid group until the tablet is unusable. The tablet declares
-        // those channels itself, so this asserts the hook, not a tablet type.
+        // Observed live: entries cut under externally-written blobs left GroupFor()
+        // resolving to Max<ui32> and GC retrying an invalid group forever.
         struct TExternalWriter: public NFlatExecutorSetup::ITablet {
             explicit TExternalWriter(TTabletStorageInfo* info)
                 : ITablet(info, TActorId())
@@ -450,16 +446,14 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
 
         TExternalWriter external(info.Get());
         gcLogic.SetOwner(&external);
-        // Channels 0/1 carry only executor blobs, so they stay with this cutter.
         UNIT_ASSERT(gcLogic.IsHistoryCuttingSound(0));
         UNIT_ASSERT(gcLogic.IsHistoryCuttingSound(1));
         UNIT_ASSERT(!gcLogic.IsHistoryCuttingSound(2));
         UNIT_ASSERT(!gcLogic.IsHistoryCuttingSound(65));
     }
 
-    // A blob that is deleted but not yet collected keeps its DoNotKeep mark in the GC
-    // deltas; cutting its entry makes the mark undeliverable, so the delta must feed
-    // the cutter. Observed live: GC to the sentinel group retried forever on channel 1.
+    // Cutting an entry under a not-yet-collected DoNotKeep mark strands the mark:
+    // observed live as GC retrying the sentinel group forever on channel 1.
     Y_UNIT_TEST(PendingDeleteDeltaPinsHistoryEntry) {
         static constexpr ui64 TabletId = 42;
         static constexpr ui32 Channel = 1;

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -423,8 +423,7 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
     }
 
     Y_UNIT_TEST(HistoryCuttingUnsoundForExternalBlobWriters) {
-        // Observed live: entries cut under externally-written blobs left GroupFor()
-        // resolving to Max<ui32> and GC retrying an invalid group forever.
+        // Cutting under externally-written blobs leaves GroupFor() at Max<ui32> and GC retrying forever.
         struct TExternalWriter: public NFlatExecutorSetup::ITablet {
             explicit TExternalWriter(TTabletStorageInfo* info)
                 : ITablet(info, TActorId())

--- a/ydb/core/tablet_flat/tablet_flat_executor.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executor.cpp
@@ -52,6 +52,10 @@ namespace NFlatExecutorSetup {
         return true;
     }
 
+    bool ITablet::HasExternallyWrittenBlobs(ui32 /*channel*/) const {
+        return false;
+    }
+
     void ITablet::OnYellowChannelsChanged() {
         // nothing by default
     }

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -513,6 +513,10 @@ namespace NFlatExecutorSetup {
         virtual void ScanComplete(NTable::EStatus status, TAutoPtr<IDestructable> prod, ui64 cookie, const TActorContext &ctx);
 
         virtual bool ReassignChannelsEnabled() const;
+        // True for a channel whose blobs the tablet writes itself, bypassing the
+        // executor: the executor's seen-generation criterion cannot see them, so it
+        // must not cut that channel's history. Such a tablet cuts the channel itself.
+        virtual bool HasExternallyWrittenBlobs(ui32 channel) const;
         virtual void OnYellowChannelsChanged();
         virtual void OnRejectProbabilityRelaxed();
 

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -513,9 +513,7 @@ namespace NFlatExecutorSetup {
         virtual void ScanComplete(NTable::EStatus status, TAutoPtr<IDestructable> prod, ui64 cookie, const TActorContext &ctx);
 
         virtual bool ReassignChannelsEnabled() const;
-        // True for a channel whose blobs the tablet writes itself, bypassing the
-        // executor: the executor's seen-generation criterion cannot see them, so it
-        // must not cut that channel's history. Such a tablet cuts the channel itself.
+        // True when the tablet writes the channel itself: the executor cannot see those blobs, so it must not cut.
         virtual bool HasExternallyWrittenBlobs(ui32 channel) const;
         virtual void OnYellowChannelsChanged();
         virtual void OnRejectProbabilityRelaxed();

--- a/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
@@ -7,6 +7,7 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 
+#include <util/generic/algorithm.h>
 #include <util/generic/guid.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/string.h>
@@ -85,12 +86,9 @@ public:
 
     // Returns true if no blob in the set has the given channel and generation in [fromGen, nextFromGen).
     bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const {
-        for (const auto& blob : Blobs) {
-            if (blob.Channel() == channel && blob.Generation() >= fromGen && blob.Generation() < nextFromGen) {
-                return false;
-            }
-        }
-        return true;
+        return FindIf(Blobs, [&](const TLogoBlobID& blob) {
+            return blob.Channel() == channel && blob.Generation() >= fromGen && blob.Generation() < nextFromGen;
+        }) == Blobs.end();
     }
 
     template <class TActor>

--- a/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
@@ -84,10 +84,8 @@ public:
         return TGenStep(*Blobs.begin());
     }
 
-    // Returns true if no blob in the set has the given channel and generation in [fromGen, nextFromGen).
-    // The set is ordered by (generation, step), so only that slice is scanned: a sentinel
-    // with all other fields zeroed is the smallest possible id of its generation, which
-    // makes lower_bound land on the first blob of each bound.
+    // Ordered by (generation, step), so only that slice is scanned: a sentinel with all other
+    // fields zeroed is the smallest id of its generation, so lower_bound lands on each bound.
     bool HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
         const auto rangeBegin = Blobs.lower_bound(TLogoBlobID(0, fromGen, 0, 0, 0, 0));
         const auto rangeEnd = Blobs.lower_bound(TLogoBlobID(0, nextFromGen, 0, 0, 0, 0));

--- a/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
@@ -85,15 +85,15 @@ public:
     }
 
     // Returns true if no blob in the set has the given channel and generation in [fromGen, nextFromGen).
-    // The set is ordered by (generation, step), so only the [fromGen, nextFromGen) slice is scanned.
+    // The set is ordered by (generation, step), so only that slice is scanned: a sentinel
+    // with all other fields zeroed is the smallest possible id of its generation, which
+    // makes lower_bound land on the first blob of each bound.
     bool HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
-        const TLogoBlobID sentinel(0, fromGen, 0, 0, 0, 0);
-        for (auto it = Blobs.lower_bound(sentinel); it != Blobs.end() && it->Generation() < nextFromGen; ++it) {
-            if (it->Channel() == channel) {
-                return false;
-            }
-        }
-        return true;
+        const auto rangeBegin = Blobs.lower_bound(TLogoBlobID(0, fromGen, 0, 0, 0, 0));
+        const auto rangeEnd = Blobs.lower_bound(TLogoBlobID(0, nextFromGen, 0, 0, 0, 0));
+        return !AnyOf(rangeBegin, rangeEnd, [channel](const TLogoBlobID& blobId) {
+            return blobId.Channel() == channel;
+        });
     }
 
     template <class TActor>

--- a/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
@@ -83,6 +83,16 @@ public:
         return TGenStep(*Blobs.begin());
     }
 
+    // Returns true if no blob in the set has the given channel and generation in [fromGen, nextFromGen).
+    bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const {
+        for (const auto& blob : Blobs) {
+            if (blob.Channel() == channel && blob.Generation() >= fromGen && blob.Generation() < nextFromGen) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     template <class TActor>
         requires std::invocable<TActor&, const TGenStep&, const TLogoBlobID&>
     bool ExtractTo(const TGenStep& lessOrEqualThan, const ui32 countLimit, const TActor& actor) {

--- a/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
@@ -85,10 +85,15 @@ public:
     }
 
     // Returns true if no blob in the set has the given channel and generation in [fromGen, nextFromGen).
-    bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const {
-        return FindIf(Blobs, [&](const TLogoBlobID& blob) {
-            return blob.Channel() == channel && blob.Generation() >= fromGen && blob.Generation() < nextFromGen;
-        }) == Blobs.end();
+    // The set is ordered by (generation, step), so only the [fromGen, nextFromGen) slice is scanned.
+    bool HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
+        const TLogoBlobID sentinel(0, fromGen, 0, 0, 0, 0);
+        for (auto it = Blobs.lower_bound(sentinel); it != Blobs.end() && it->Generation() < nextFromGen; ++it) {
+            if (it->Channel() == channel) {
+                return false;
+            }
+        }
+        return true;
     }
 
     template <class TActor>

--- a/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h
@@ -84,8 +84,7 @@ public:
         return TGenStep(*Blobs.begin());
     }
 
-    // Ordered by (generation, step), so only that slice is scanned: a sentinel with all other
-    // fields zeroed is the smallest id of its generation, so lower_bound lands on each bound.
+    // Ordered by (generation, step): a zeroed sentinel is the smallest id of its generation.
     bool HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
         const auto rangeBegin = Blobs.lower_bound(TLogoBlobID(0, fromGen, 0, 0, 0, 0));
         const auto rangeEnd = Blobs.lower_bound(TLogoBlobID(0, nextFromGen, 0, 0, 0, 0));

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -1,5 +1,6 @@
 #include "blob_manager.h"
 #include "gc.h"
+#include "history_cutter.h"
 
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/core/tx/columnshard/blobs_action/blob_manager_db.h>
@@ -144,6 +145,17 @@ TBlobManager::TBlobManager(TIntrusivePtr<TTabletStorageInfo> tabletInfo, ui32 ge
 {
     BlobsManagerCounters.CurrentGen->Set(CurrentGen);
     BlobsManagerCounters.CurrentStep->Set(CurrentStep);
+    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, this, TActorId{});
+}
+
+TBlobManager::~TBlobManager() = default;
+
+void TBlobManager::InitHistoryCutter(const TActorId& tabletActorId) {
+    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, this, tabletActorId);
+}
+
+NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCutter() {
+    return HistoryCutter.get();
 }
 
 void TBlobManager::RegisterControls(NKikimr::TControlBoard& /*icb*/) {
@@ -545,6 +557,30 @@ void TBlobManager::OnGCStartOnComplete(const std::optional<TGenStep>& genStep) {
         AFL_VERIFY(GCBarrierPreparation <= *genStep)("last", GCBarrierPreparation)("prepared", genStep);
         GCBarrierPreparation = *genStep;
     }
+}
+
+bool TBlobManager::HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
+    // BlobsToKeep is a sorted set — we can scan only the relevant portion.
+    // TBlobsByGenStep::Blobs is private; iterate via the set (no public begin/end on range).
+    // We walk BlobsToDelete and BlobsToDeleteDelayed via their public begin/end.
+    const auto checkTabletsByBlob = [&](const TTabletsByBlob& m) {
+        for (const auto& [blobId, _] : m) {
+            const TLogoBlobID& lid = blobId.GetLogoBlobId();
+            if (lid.Channel() == channel && lid.Generation() >= fromGen && lid.Generation() < nextFromGen) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if (!checkTabletsByBlob(BlobsToDelete)) {
+        return false;
+    }
+    if (!checkTabletsByBlob(BlobsToDeleteDelayed)) {
+        return false;
+    }
+    // BlobsToKeep: use a lambda via ExtractTo — but that's destructive.
+    // Instead expose a const scan via HasBlobForChannelRange.
+    return BlobsToKeep.HasNoBlobsInRange(channel, fromGen, nextFromGen);
 }
 
 void TBlobManager::OnBlobFree(const TUnifiedBlobId& blobId) {

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -12,6 +12,17 @@
 
 namespace NKikimr::NOlap {
 
+namespace {
+// Shared monotonic counter for ALL TEvCollectGarbage requests issued by this process
+// (both regular GC batches and CutHistory hard barriers). BS enforces monotonicity per
+// (tablet, generation) space; using one counter ensures no collisions.
+static TAtomicCounter SharedGCPerGenerationCounter = 1;
+}   // namespace
+
+ui32 TBlobManager::AllocateGCPerGenerationCounter(const ui32 step) {
+    return static_cast<ui32>(SharedGCPerGenerationCounter.Add(step));
+}
+
 TLogoBlobID ParseLogoBlobId(TString blobId) {
     TLogoBlobID logoBlobId;
     TString err;

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -307,6 +307,13 @@ void TBlobManager::DrainDeleteTo(const TGenStep& dest, TGCContext& gcContext) {
         const auto& unifiedBlobId = it.GetBlobId();
         TBlobAddress bAddress(unifiedBlobId.GetDsGroup(), unifiedBlobId.GetLogoBlobId().Channel());
         auto logoBlobId = unifiedBlobId.GetLogoBlobId();
+        // Below the first surviving history entry: already collected by the barrier that cut it.
+        if (unifiedBlobId.GetDsGroup() == Max<ui32>()) {
+            YDB_LOG_WARN("",
+                {"event", "orphaned_delete_mark_under_cut_history"},
+                {"blobId", unifiedBlobId.ToStringNew()});
+            continue;
+        }
         if (!gcContext.GetSharedBlobsManager()->BuildStoreCategories({ unifiedBlobId }).GetDirect().IsEmpty()) {
             YDB_LOG_INFO("",
                 {"toDeleteGc", unifiedBlobId.ToStringNew()});
@@ -332,6 +339,13 @@ bool TBlobManager::DrainKeepTo(const TGenStep& dest, TGCContext& gcContext) {
         TBlobAddress bAddress(blobGroup, logoBlobId.Channel());
         const TUnifiedBlobId keepUnified(blobGroup, logoBlobId);
         gcContext.MutableKeepsToErase().emplace_back(keepUnified);
+        if (blobGroup == Max<ui32>()) {
+            BlobsToDelete.ExtractBlobTo(keepUnified, gcContext.MutableExtractedToRemoveFromDB());
+            YDB_LOG_WARN("",
+                {"event", "orphaned_keep_mark_under_cut_history"},
+                {"blobId", keepUnified.ToStringNew()});
+            return;
+        }
         if (BlobsToDelete.ExtractBlobTo(keepUnified, gcContext.MutableExtractedToRemoveFromDB())) {
             if (logoBlobId.Generation() == CurrentGen) {
                 YDB_LOG_INFO("",
@@ -438,6 +452,7 @@ std::shared_ptr<NBlobOperations::NBlobStorage::TGCTask> TBlobManager::BuildGCTas
         return nullptr;
     }
 
+    GCTaskInFlight = true;
     return result;
 }
 
@@ -555,6 +570,7 @@ void TBlobManager::OnGCFinishedOnExecute(const std::optional<TGenStep>& genStep,
 }
 
 void TBlobManager::OnGCFinishedOnComplete(const std::optional<TGenStep>& genStep) {
+    GCTaskInFlight = false;
     if (genStep) {
         LastCollectedGenStep = *genStep;
         AFL_VERIFY(GCBarrierPreparation == LastCollectedGenStep)("prepare", GCBarrierPreparation)("last", LastCollectedGenStep);
@@ -579,6 +595,9 @@ void TBlobManager::OnGCStartOnComplete(const std::optional<TGenStep>& genStep) {
 }
 
 bool TBlobManager::HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
+    if (GCTaskInFlight) {
+        return false;
+    }
     const auto inRange = [&](const auto& blob) {
         const TLogoBlobID& logoBlobId = blob.first.GetLogoBlobId();
         return logoBlobId.Channel() == channel && logoBlobId.Generation() >= fromGen && logoBlobId.Generation() < nextFromGen;

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -19,7 +19,7 @@ namespace {
 // (both regular GC batches and CutHistory hard barriers). BS enforces monotonicity per
 // (tablet, generation) space; using one counter ensures no collisions.
 static TAtomicCounter SharedGCPerGenerationCounter = 1;
-}   // namespace
+}   // anonymous namespace
 
 ui32 TBlobManager::AllocateGCPerGenerationCounter(const ui32 step) {
     return static_cast<ui32>(SharedGCPerGenerationCounter.Add(step));

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -173,10 +173,6 @@ NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCu
     return HistoryCutter.get();
 }
 
-const NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCutter() const {
-    return HistoryCutter.get();
-}
-
 void TBlobManager::RegisterControls(NKikimr::TControlBoard& /*icb*/) {
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -8,6 +8,8 @@
 
 #include <ydb/library/actors/struct_log/log_stack.h>
 
+#include <util/generic/algorithm.h>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD_BLOBS_BS
 
 namespace NKikimr::NOlap {
@@ -156,16 +158,20 @@ TBlobManager::TBlobManager(TIntrusivePtr<TTabletStorageInfo> tabletInfo, ui32 ge
 {
     BlobsManagerCounters.CurrentGen->Set(CurrentGen);
     BlobsManagerCounters.CurrentStep->Set(CurrentStep);
-    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, this, TActorId{});
 }
 
 TBlobManager::~TBlobManager() = default;
 
-void TBlobManager::InitHistoryCutter(const TActorId& tabletActorId) {
-    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, this, tabletActorId);
+void TBlobManager::InitHistoryCutter(const std::shared_ptr<TBlobManager>& self, const TActorId& tabletActorId) {
+    AFL_VERIFY(self.get() == this);
+    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, self, tabletActorId);
 }
 
 NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCutter() {
+    return HistoryCutter.get();
+}
+
+const NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCutter() const {
     return HistoryCutter.get();
 }
 
@@ -571,27 +577,14 @@ void TBlobManager::OnGCStartOnComplete(const std::optional<TGenStep>& genStep) {
 }
 
 bool TBlobManager::HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
-    // BlobsToKeep is a sorted set — we can scan only the relevant portion.
-    // TBlobsByGenStep::Blobs is private; iterate via the set (no public begin/end on range).
-    // We walk BlobsToDelete and BlobsToDeleteDelayed via their public begin/end.
-    const auto checkTabletsByBlob = [&](const TTabletsByBlob& m) {
-        for (const auto& [blobId, _] : m) {
-            const TLogoBlobID& lid = blobId.GetLogoBlobId();
-            if (lid.Channel() == channel && lid.Generation() >= fromGen && lid.Generation() < nextFromGen) {
-                return false;
-            }
-        }
-        return true;
+    const auto hasNoBlobsInRange = [&](const TTabletsByBlob& blobs) {
+        return FindIf(blobs, [&](const auto& item) {
+            const TLogoBlobID& logoBlobId = item.first.GetLogoBlobId();
+            return logoBlobId.Channel() == channel && logoBlobId.Generation() >= fromGen && logoBlobId.Generation() < nextFromGen;
+        }) == blobs.end();
     };
-    if (!checkTabletsByBlob(BlobsToDelete)) {
-        return false;
-    }
-    if (!checkTabletsByBlob(BlobsToDeleteDelayed)) {
-        return false;
-    }
-    // BlobsToKeep: use a lambda via ExtractTo — but that's destructive.
-    // Instead expose a const scan via HasBlobForChannelRange.
-    return BlobsToKeep.HasNoBlobsInRange(channel, fromGen, nextFromGen);
+    return hasNoBlobsInRange(BlobsToDelete) && hasNoBlobsInRange(BlobsToDeleteDelayed) &&
+           BlobsToKeep.HasNoBlobsInRange(channel, fromGen, nextFromGen);
 }
 
 void TBlobManager::OnBlobFree(const TUnifiedBlobId& blobId) {

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -162,9 +162,11 @@ TBlobManager::TBlobManager(TIntrusivePtr<TTabletStorageInfo> tabletInfo, ui32 ge
 
 TBlobManager::~TBlobManager() = default;
 
-void TBlobManager::InitHistoryCutter(const std::shared_ptr<TBlobManager>& self, const TActorId& tabletActorId) {
+void TBlobManager::InitHistoryCutter(const std::shared_ptr<TBlobManager>& self,
+    const std::shared_ptr<NDataSharing::TStorageSharedBlobsManager>& sharedBlobs, const TActorId& tabletActorId) {
     AFL_VERIFY(self.get() == this);
-    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, self, tabletActorId);
+    HistoryCutter =
+        std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, self, sharedBlobs, tabletActorId);
 }
 
 NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCutter() {

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -165,8 +165,8 @@ TBlobManager::~TBlobManager() = default;
 void TBlobManager::InitHistoryCutter(const std::shared_ptr<TBlobManager>& self,
     const std::shared_ptr<NDataSharing::TStorageSharedBlobsManager>& sharedBlobs, const TActorId& tabletActorId) {
     AFL_VERIFY(self.get() == this);
-    HistoryCutter =
-        std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(TabletInfo, CurrentGen, self, sharedBlobs, tabletActorId);
+    HistoryCutter = std::make_unique<NBlobOperations::NBlobStorage::THistoryCutterWrapper>(
+        TabletInfo, CurrentGen, self, sharedBlobs, tabletActorId, BlobsManagerCounters.HistoryCutterCounters);
 }
 
 NBlobOperations::NBlobStorage::THistoryCutterWrapper* TBlobManager::GetHistoryCutter() {

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -579,13 +579,11 @@ void TBlobManager::OnGCStartOnComplete(const std::optional<TGenStep>& genStep) {
 }
 
 bool TBlobManager::HasNoBlobsInRange(const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
-    const auto hasNoBlobsInRange = [&](const TTabletsByBlob& blobs) {
-        return FindIf(blobs, [&](const auto& item) {
-            const TLogoBlobID& logoBlobId = item.first.GetLogoBlobId();
-            return logoBlobId.Channel() == channel && logoBlobId.Generation() >= fromGen && logoBlobId.Generation() < nextFromGen;
-        }) == blobs.end();
+    const auto inRange = [&](const auto& blob) {
+        const TLogoBlobID& logoBlobId = blob.first.GetLogoBlobId();
+        return logoBlobId.Channel() == channel && logoBlobId.Generation() >= fromGen && logoBlobId.Generation() < nextFromGen;
     };
-    return hasNoBlobsInRange(BlobsToDelete) && hasNoBlobsInRange(BlobsToDeleteDelayed) &&
+    return !AnyOf(BlobsToDelete, inRange) && !AnyOf(BlobsToDeleteDelayed, inRange) &&
            BlobsToKeep.HasNoBlobsInRange(channel, fromGen, nextFromGen);
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -15,9 +15,7 @@
 namespace NKikimr::NOlap {
 
 namespace {
-// Shared monotonic counter for ALL TEvCollectGarbage requests issued by this process
-// (both regular GC batches and CutHistory hard barriers). BS enforces monotonicity per
-// (tablet, generation) space; using one counter ensures no collisions.
+// One counter for every TEvCollectGarbage of this process: BS demands monotonicity per (tablet, generation).
 static TAtomicCounter SharedGCPerGenerationCounter = 1;
 }   // anonymous namespace
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -23,6 +23,10 @@ class THistoryCutterWrapper;
 
 namespace NKikimr::NOlap {
 
+namespace NDataSharing {
+class TStorageSharedBlobsManager;
+}   // namespace NDataSharing
+
 using NKikimrTxColumnShard::TEvictMetadata;
 
 // A batch of blobs that are written by a single task.
@@ -256,7 +260,8 @@ public:
 
     // Called by TColumnShard after boot to wire up the cutter.
     // Takes the owning shared_ptr so the cutter can hold the manager weakly (no raw this).
-    void InitHistoryCutter(const std::shared_ptr<TBlobManager>& self, const TActorId& tabletActorId);
+    void InitHistoryCutter(const std::shared_ptr<TBlobManager>& self,
+        const std::shared_ptr<NDataSharing::TStorageSharedBlobsManager>& sharedBlobs, const TActorId& tabletActorId);
 
 private:
     // Forward-declared to avoid circular include; defined in blob_manager.cpp.

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -252,9 +252,11 @@ public:
 
     // Access to the cut history cutter (null if not initialized).
     NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter();
+    const NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter() const;
 
     // Called by TColumnShard after boot to wire up the cutter.
-    void InitHistoryCutter(const TActorId& tabletActorId);
+    // Takes the owning shared_ptr so the cutter can hold the manager weakly (no raw this).
+    void InitHistoryCutter(const std::shared_ptr<TBlobManager>& self, const TActorId& tabletActorId);
 
 private:
     // Forward-declared to avoid circular include; defined in blob_manager.cpp.

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -149,6 +149,8 @@ private:
     const ui32 CurrentGen;
     ui32 CurrentStep;
     std::optional<TGenStep> CollectGenStepInFlight;
+    // Blobs handed to the task are in no queue below until it commits.
+    bool GCTaskInFlight = false;
     // Lists of blobs that need Keep flag to be set
     TBlobsByGenStep BlobsToKeep;
     // Lists of blobs that need DoNotKeep flag to be set

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -258,7 +258,6 @@ public:
 
     // Access to the cut history cutter (null if not initialized).
     NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter();
-    const NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter() const;
 
     // Called by TColumnShard after boot to wire up the cutter.
     // Takes the owning shared_ptr so the cutter can hold the manager weakly (no raw this).

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -246,20 +246,15 @@ public:
     virtual void DeleteBlobOnExecute(const TTabletId tabletId, const TUnifiedBlobId& blobId, IBlobManagerDb& db) override;
     virtual void DeleteBlobOnComplete(const TTabletId tabletId, const TUnifiedBlobId& blobId) override;
 
-    // Returns true if none of BlobsToKeep / BlobsToDelete / BlobsToDeleteDelayed contains a
-    // blob with the given channel and generation in [fromGen, nextFromGen).
+    // Scans BlobsToKeep, BlobsToDelete and BlobsToDeleteDelayed.
     bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const;
 
-    // Shared monotonic PerGenerationCounter for all TEvCollectGarbage requests sent by this
-    // tablet's blob operations (both regular GC and CutHistory barriers).  Callers pass the
-    // event's PerGenerationCounterStepSize() as `step` and store the returned value into
-    // result->PerGenerationCounter.
+    // One monotonic counter for every TEvCollectGarbage this tablet sends, regular GC and
+    // CutHistory barriers alike; pass PerGenerationCounterStepSize() as `step`.
     static ui32 AllocateGCPerGenerationCounter(ui32 step);
 
-    // Access to the cut history cutter (null if not initialized).
     NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter();
 
-    // Called by TColumnShard after boot to wire up the cutter.
     // Takes the owning shared_ptr so the cutter can hold the manager weakly (no raw this).
     void InitHistoryCutter(const std::shared_ptr<TBlobManager>& self,
         const std::shared_ptr<NDataSharing::TStorageSharedBlobsManager>& sharedBlobs, const TActorId& tabletActorId);

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -18,7 +18,8 @@
 
 namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
 class TGCTask;
-}
+class THistoryCutterWrapper;
+}   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage
 
 namespace NKikimr::NOlap {
 
@@ -177,6 +178,7 @@ private:
 
 public:
     TBlobManager(TIntrusivePtr<TTabletStorageInfo> tabletInfo, const ui32 gen, const TTabletId selfTabletId);
+    ~TBlobManager();
 
     bool HasToDelete(const TUnifiedBlobId& blobId, const TTabletId tabletId) const {
         return BlobsToDelete.Contains(tabletId, blobId) || BlobsToDeleteDelayed.Contains(tabletId, blobId);
@@ -238,7 +240,19 @@ public:
     virtual void DeleteBlobOnExecute(const TTabletId tabletId, const TUnifiedBlobId& blobId, IBlobManagerDb& db) override;
     virtual void DeleteBlobOnComplete(const TTabletId tabletId, const TUnifiedBlobId& blobId) override;
 
+    // Returns true if none of BlobsToKeep / BlobsToDelete / BlobsToDeleteDelayed contains a
+    // blob with the given channel and generation in [fromGen, nextFromGen).
+    bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const;
+
+    // Access to the cut history cutter (null if not initialized).
+    NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter();
+
+    // Called by TColumnShard after boot to wire up the cutter.
+    void InitHistoryCutter(const TActorId& tabletActorId);
+
 private:
+    // Forward-declared to avoid circular include; defined in blob_manager.cpp.
+    std::unique_ptr<NBlobOperations::NBlobStorage::THistoryCutterWrapper> HistoryCutter;
     std::deque<TGenStep> FindNewGCBarriers();
     void PopGCBarriers(const TGenStep gs);
     void PopGCBarriers(const ui32 count);

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -249,8 +249,7 @@ public:
     // Scans BlobsToKeep, BlobsToDelete and BlobsToDeleteDelayed.
     bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const;
 
-    // One monotonic counter for every TEvCollectGarbage this tablet sends, regular GC and
-    // CutHistory barriers alike; pass PerGenerationCounterStepSize() as `step`.
+    // Shared by regular GC and CutHistory barriers alike; pass PerGenerationCounterStepSize().
     static ui32 AllocateGCPerGenerationCounter(ui32 step);
 
     NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter();
@@ -260,7 +259,6 @@ public:
         const std::shared_ptr<NDataSharing::TStorageSharedBlobsManager>& sharedBlobs, const TActorId& tabletActorId);
 
 private:
-    // Forward-declared to avoid circular include; defined in blob_manager.cpp.
     std::unique_ptr<NBlobOperations::NBlobStorage::THistoryCutterWrapper> HistoryCutter;
     std::deque<TGenStep> FindNewGCBarriers();
     void PopGCBarriers(const TGenStep gs);

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h
@@ -244,6 +244,12 @@ public:
     // blob with the given channel and generation in [fromGen, nextFromGen).
     bool HasNoBlobsInRange(ui32 channel, ui32 fromGen, ui32 nextFromGen) const;
 
+    // Shared monotonic PerGenerationCounter for all TEvCollectGarbage requests sent by this
+    // tablet's blob operations (both regular GC and CutHistory barriers).  Callers pass the
+    // event's PerGenerationCounterStepSize() as `step` and store the returned value into
+    // result->PerGenerationCounter.
+    static ui32 AllocateGCPerGenerationCounter(ui32 step);
+
     // Access to the cut history cutter (null if not initialized).
     NBlobOperations::NBlobStorage::THistoryCutterWrapper* GetHistoryCutter();
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -1,4 +1,5 @@
 #include "gc.h"
+#include "history_cutter.h"
 #include "storage.h"
 
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
@@ -23,6 +24,9 @@ void TGCTask::DoOnExecuteTxAfterCleaning(NColumnShard::TColumnShard& /*self*/, T
 
 bool TGCTask::DoOnCompleteTxAfterCleaning(NColumnShard::TColumnShard& /*self*/, const std::shared_ptr<IBlobsGCAction>& /*taskAction*/) {
     Manager->OnGCFinishedOnComplete(CollectGenStepInFlight);
+    if (auto* cutter = Manager->GetHistoryCutter()) {
+        cutter->TryNominate(NActors::TActivationContext::AsActorContext());
+    }
     return true;
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -62,10 +62,6 @@ void TGCTask::OnGCResult(TEvBlobStorage::TEvCollectGarbageResult::TPtr ev) {
     ListsByGroupId.erase(itGroup);
 }
 
-namespace {
-static TAtomicCounter PerGenerationCounter = 1;
-}
-
 std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> TGCTask::BuildRequest(const TBlobAddress& address) const {
     auto it = ListsByGroupId.find(address);
     AFL_VERIFY(it != ListsByGroupId.end());
@@ -84,13 +80,12 @@ std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> TGCTask::BuildRequest(const T
         {"currentGen", CurrentGen},
         {"gen", CollectGenStepInFlight},
         {"count", it->second.RequestsCount});
-    auto result = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, PerGenerationCounter.Val(), address.GetChannelId(),
-        !!CollectGenStepInFlight, CollectGenStepInFlight ? CollectGenStepInFlight->Generation() : 0,
-        CollectGenStepInFlight ? CollectGenStepInFlight->Step() : 0,
+    auto result = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, 0, address.GetChannelId(), !!CollectGenStepInFlight,
+        CollectGenStepInFlight ? CollectGenStepInFlight->Generation() : 0, CollectGenStepInFlight ? CollectGenStepInFlight->Step() : 0,
         new TVector<TLogoBlobID>(it->second.KeepList.begin(), it->second.KeepList.end()),
         new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()), TInstant::Max(), true,
         TWriteSource::ColumnShardGC);
-    result->PerGenerationCounter = PerGenerationCounter.Add(result->PerGenerationCounterStepSize());
+    result->PerGenerationCounter = TBlobManager::AllocateGCPerGenerationCounter(result->PerGenerationCounterStepSize());
     return std::move(result);
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -80,13 +80,14 @@ std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> TGCTask::BuildRequest(const T
         {"currentGen", CurrentGen},
         {"gen", CollectGenStepInFlight},
         {"count", it->second.RequestsCount});
-    auto result = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, 0, address.GetChannelId(), !!CollectGenStepInFlight,
-        CollectGenStepInFlight ? CollectGenStepInFlight->Generation() : 0, CollectGenStepInFlight ? CollectGenStepInFlight->Step() : 0,
-        new TVector<TLogoBlobID>(it->second.KeepList.begin(), it->second.KeepList.end()),
-        new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()), TInstant::Max(), true,
+    auto keep = std::make_unique<TVector<TLogoBlobID>>(it->second.KeepList.begin(), it->second.KeepList.end());
+    auto doNotKeep = std::make_unique<TVector<TLogoBlobID>>(it->second.DontKeepList.begin(), it->second.DontKeepList.end());
+    const ui32 perGenerationCounter = TBlobManager::AllocateGCPerGenerationCounter(
+        TEvBlobStorage::TEvCollectGarbage::PerGenerationCounterStepSize(keep.get(), doNotKeep.get()));
+    return std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, perGenerationCounter, address.GetChannelId(),
+        !!CollectGenStepInFlight, CollectGenStepInFlight ? CollectGenStepInFlight->Generation() : 0,
+        CollectGenStepInFlight ? CollectGenStepInFlight->Step() : 0, keep.release(), doNotKeep.release(), TInstant::Max(), true,
         TWriteSource::ColumnShardGC);
-    result->PerGenerationCounter = TBlobManager::AllocateGCPerGenerationCounter(result->PerGenerationCounterStepSize());
-    return std::move(result);
 }
 
 }   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h>
 #include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
 #include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
@@ -102,10 +103,12 @@ private:
 }   // anonymous namespace
 
 THistoryCutterWrapper::THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, const ui32 currentGen,
-    const std::weak_ptr<NOlap::TBlobManager>& manager, const TActorId& tabletActorId)
+    const std::weak_ptr<NOlap::TBlobManager>& manager, const std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>& sharedBlobs,
+    const TActorId& tabletActorId)
     : TabletInfo(tabletInfo)
     , CurrentGen(currentGen)
     , Manager(manager)
+    , SharedBlobs(sharedBlobs)
     , TabletActorId(tabletActorId)
 {
 }
@@ -172,7 +175,16 @@ bool THistoryCutterWrapper::IsDrained(const TEntryKey& key) const {
     if (!manager) {
         return false;
     }
-    return manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen);
+    if (!manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen)) {
+        return false;
+    }
+    // Our blobs shared out to other tablets sit in no GC queue while shared; a hard
+    // barrier would collect them under the borrower, so they pin the entry too.
+    const auto sharedBlobs = SharedBlobs.lock();
+    if (!sharedBlobs) {
+        return false;
+    }
+    return !sharedBlobs->HasSharedBlobsInRange(TabletInfo->TabletID, key.Channel, key.FromGeneration, nextGen);
 }
 
 bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const {

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -253,6 +253,9 @@ void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUni
     CutState.clear();
     PoisonedChannels.clear();
     PortionKeys.clear();
+    DisprovedAt.clear();
+    LastNominateAt = TInstant::Zero();
+    NextChannelToCheck = 2;
     SweepInFlight = false;
     SweepCandidates.reset();
     SweepSurvivors.clear();

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -29,10 +29,17 @@ public:
         , FromGen(fromGen)
         , NextFromGen(nextFromGen)
     {
+        // NextFromGen - 1 is the hard collect generation; 0 would underflow to a
+        // collect-everything barrier. Callers must resolve a real next generation.
+        AFL_VERIFY(NextFromGen > 0);
     }
 
     void Bootstrap(const TActorContext& ctx) {
         Become(&TThis::StateWait);
+        SendBarrier(ctx);
+    }
+
+    void HandleWakeup(const TActorContext& ctx) {
         SendBarrier(ctx);
     }
 
@@ -57,11 +64,15 @@ public:
             Die(ctx);
             return;
         }
-        SendBarrier(ctx);
+        // Linear backoff: an immediate retry against an overloaded group would only add load.
+        ctx.Schedule(TDuration::Seconds(1) * Retries, new NActors::TEvents::TEvWakeup());
     }
 
     STFUNC(StateWait) {
-        switch (ev->GetTypeRewrite()) { HFunc(TEvBlobStorage::TEvCollectGarbageResult, Handle); }
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvBlobStorage::TEvCollectGarbageResult, Handle);
+            CFunc(NActors::TEvents::TEvWakeup::EventType, HandleWakeup);
+        }
     }
 
 private:
@@ -105,7 +116,8 @@ bool THistoryCutterWrapper::IsEnabled() const {
     return HasAppData() && AppData()->FeatureFlags.GetEnableCutHistory() && AppData()->ColumnShardConfig.GetCutHistoryEnabled();
 }
 
-bool THistoryCutterWrapper::SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration) {
+bool THistoryCutterWrapper::SeenGroupsCheckPasses(
+    const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration, const std::unordered_set<ui32>& cutFromGenerations) {
     ui32 targetGroup = 0;
     bool found = false;
     std::unordered_set<ui32> seenGroups;
@@ -114,6 +126,9 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(const std::vector<TTabletChann
             targetGroup = entry.GroupID;
             found = true;
             break;
+        }
+        if (cutFromGenerations.contains(entry.FromGeneration)) {
+            continue;
         }
         seenGroups.insert(entry.GroupID);
     }
@@ -124,7 +139,13 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
     if (key.Channel >= static_cast<ui32>(TabletInfo->Channels.size())) {
         return false;
     }
-    return SeenGroupsCheckPasses(TabletInfo->Channels[key.Channel].History, key.FromGeneration);
+    std::unordered_set<ui32> cutFromGenerations;
+    for (const auto& [stateKey, state] : CutState) {
+        if (stateKey.Channel == key.Channel && state == ECutState::Cut) {
+            cutFromGenerations.insert(stateKey.FromGeneration);
+        }
+    }
+    return SeenGroupsCheckPasses(TabletInfo->Channels[key.Channel].History, key.FromGeneration, cutFromGenerations);
 }
 
 ui32 THistoryCutterWrapper::GetNextFromGeneration(const TEntryKey& key) const {
@@ -230,7 +251,7 @@ void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUni
     PoisonedChannels.clear();
     PortionKeys.clear();
     SweepInFlight = false;
-    SweepCandidates.clear();
+    SweepCandidates.reset();
     SweepSurvivors.clear();
     SweepPortionIds.clear();
     SweepPortionOffset = 0;
@@ -277,6 +298,10 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
             if (cntIt != Counters.end() && cntIt->second != 0) {
                 continue;
             }
+            const auto disprovedIt = DisprovedAt.find(key);
+            if (disprovedIt != DisprovedAt.end() && ctx.Now() - disprovedIt->second < DisprovedRetryCooldown) {
+                continue;
+            }
             if (!IsDrained(key)) {
                 continue;
             }
@@ -296,8 +321,8 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
         CutState[key] = ECutState::Verifying;
     }
     SweepInFlight = true;
-    SweepCandidates = batch;
-    SweepSurvivors = std::move(batch);
+    SweepSurvivors = batch;
+    SweepCandidates = std::make_shared<const TVector<TEntryKey>>(std::move(batch));
     SweepPortionIds.clear();
     SweepPortionOffset = 0;
 
@@ -323,6 +348,9 @@ TVector<std::pair<TInternalPathId, ui64>> THistoryCutterWrapper::GetNextBatch(si
 }
 
 void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved, bool exhausted, const TActorContext& ctx) {
+    for (const auto& key : disproved) {
+        DisprovedAt[key] = ctx.Now();
+    }
     // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
         TVector<TEntryKey> kept;
@@ -343,7 +371,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 
     // Cursor exhausted: re-check each survivor and send hard barrier if still safe.
     SweepInFlight = false;
-    SweepCandidates.clear();
+    SweepCandidates.reset();
     SweepPortionIds.clear();
     SweepPortionOffset = 0;
 
@@ -355,6 +383,12 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
             continue;
         }
         if (!IsDrained(key)) {
+            CutState[key] = ECutState::None;
+            continue;
+        }
+        // The history may have changed between nomination and this point — the
+        // same-group safety gate must hold at barrier-send time, not only at nomination.
+        if (!SeenGroupsCheckPasses(key)) {
             CutState[key] = ECutState::None;
             continue;
         }
@@ -389,6 +423,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     for (auto& [key, state] : CutState) {
         if (state == ECutState::Verifying) {
             state = ECutState::None;
+            DisprovedAt[key] = ctx.Now();
         }
     }
 }

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -119,7 +119,7 @@ bool THistoryCutterWrapper::IsEnabled() const {
     if (NYDBTest::TControllers::GetColumnShardController()->IsCSCutHistoryEnabled()) {
         return true;
     }
-    return HasAppData() && AppData()->FeatureFlags.GetEnableCutHistory() && AppData()->ColumnShardConfig.GetCutHistoryEnabled();
+    return HasAppData() && AppData()->FeatureFlags.GetEnableCutHistory();
 }
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -78,10 +78,11 @@ private:
     static constexpr int MaxRetries = 3;
 
     void SendBarrier(const TActorContext& ctx) {
-        auto ev = MakeHolder<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, 0, Channel, /*collect=*/true,
+        const ui32 perGenerationCounter =
+            TBlobManager::AllocateGCPerGenerationCounter(TEvBlobStorage::TEvCollectGarbage::PerGenerationCounterStepSize(nullptr, nullptr));
+        auto ev = MakeHolder<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, perGenerationCounter, Channel, /*collect=*/true,
             /*collectGeneration=*/NextFromGen - 1, /*collectStep=*/Max<ui32>(), /*keep=*/nullptr, /*doNotKeep=*/nullptr, TInstant::Max(),
             /*issueKeepFlag=*/false, TWriteSource::ColumnShardGC, /*hard=*/true);
-        ev->PerGenerationCounter = TBlobManager::AllocateGCPerGenerationCounter(ev->PerGenerationCounterStepSize());
         SendToBSProxy(ctx, Group, ev.Release());
     }
 
@@ -108,6 +109,22 @@ THistoryCutterWrapper::THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageI
     , SharedBlobs(sharedBlobs)
     , TabletActorId(tabletActorId)
 {
+}
+
+TDuration THistoryCutterWrapper::GetNominateCadence() {
+    if (!HasAppData()) {
+        return DefaultNominateCadence;
+    }
+    const ui32 seconds = AppDataVerified().ColumnShardConfig.GetCutHistoryNominateCadenceSeconds();
+    return seconds ? TDuration::Seconds(seconds) : DefaultNominateCadence;
+}
+
+ui32 THistoryCutterWrapper::GetMaxDrainChecksPerNomination() {
+    if (!HasAppData()) {
+        return DefaultMaxDrainChecksPerNomination;
+    }
+    const ui32 checks = AppDataVerified().ColumnShardConfig.GetCutHistoryMaxDrainChecksPerNomination();
+    return checks ? checks : DefaultMaxDrainChecksPerNomination;
 }
 
 bool THistoryCutterWrapper::IsEnabled() const {
@@ -304,7 +321,7 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     }
     // Evaluating candidates scans the GC queues, and background enqueues fire every few
     // seconds: rate-limit rather than scan per enqueue.
-    if (LastNominateAt && ctx.Now() - LastNominateAt < NominateCadence) {
+    if (LastNominateAt && ctx.Now() - LastNominateAt < GetNominateCadence()) {
         return false;
     }
     LastNominateAt = ctx.Now();
@@ -323,7 +340,7 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     TVector<TEntryKey> batch;
     for (ui32 idx = 0; idx < dataChannels; ++idx) {
         const ui32 ch = TGlobal::FirstDataChannel + (firstChannel - TGlobal::FirstDataChannel + idx) % dataChannels;
-        if (drainChecks >= MaxDrainChecksPerNomination) {
+        if (drainChecks >= GetMaxDrainChecksPerNomination()) {
             NextChannelToCheck = ch;
             break;
         }
@@ -347,7 +364,7 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
             if (!SeenGroupsCheckPasses(key)) {
                 continue;
             }
-            if (drainChecks >= MaxDrainChecksPerNomination) {
+            if (drainChecks >= GetMaxDrainChecksPerNomination()) {
                 break;
             }
             ++drainChecks;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -88,8 +88,8 @@ private:
 
 }   // anonymous namespace
 
-THistoryCutterWrapper::THistoryCutterWrapper(
-    const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, const ui32 currentGen, NOlap::TBlobManager* manager, const TActorId& tabletActorId)
+THistoryCutterWrapper::THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, const ui32 currentGen,
+    const std::weak_ptr<NOlap::TBlobManager>& manager, const TActorId& tabletActorId)
     : TabletInfo(tabletInfo)
     , CurrentGen(currentGen)
     , Manager(manager)
@@ -145,7 +145,11 @@ bool THistoryCutterWrapper::IsDrained(const TEntryKey& key) const {
     if (!nextGen) {
         return false;
     }
-    return Manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen);
+    const auto manager = Manager.lock();
+    if (!manager) {
+        return false;
+    }
+    return manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen);
 }
 
 bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const {

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -16,8 +16,6 @@ namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
 
 namespace {
 
-static TAtomicCounter CutHistoryPGCounter = 1;
-
 class TCutHistoryBarrierActor: public TActorBootstrapped<TCutHistoryBarrierActor> {
 public:
     TCutHistoryBarrierActor(const TActorId& tabletActorId, const TActorId& launcherActorId, ui64 tabletId, ui32 currentGen, ui32 channel,
@@ -40,7 +38,8 @@ public:
 
     void Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr& ev, const TActorContext& ctx) {
         const auto status = ev->Get()->Status;
-        if (status == NKikimrProto::OK) {
+        if (status == NKikimrProto::OK || status == NKikimrProto::ALREADY) {
+            // ALREADY means the barrier is already at or beyond the requested level — safe to cut.
             // Send cut request to Hive.
             auto req = MakeHolder<TEvTablet::TEvCutTabletHistory>();
             req->Record.SetTabletID(TabletId);
@@ -69,10 +68,10 @@ private:
     static constexpr int MaxRetries = 3;
 
     void SendBarrier(const TActorContext& ctx) {
-        auto ev = MakeHolder<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, CutHistoryPGCounter.Val(), Channel, /*collect=*/true,
+        auto ev = MakeHolder<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, 0, Channel, /*collect=*/true,
             /*collectGeneration=*/NextFromGen - 1, /*collectStep=*/Max<ui32>(), /*keep=*/nullptr, /*doNotKeep=*/nullptr, TInstant::Max(),
             /*issueKeepFlag=*/false, TWriteSource::ColumnShardGC, /*hard=*/true);
-        CutHistoryPGCounter.Add(ev->PerGenerationCounterStepSize());
+        ev->PerGenerationCounter = TBlobManager::AllocateGCPerGenerationCounter(ev->PerGenerationCounterStepSize());
         SendToBSProxy(ctx, Group, ev.Release());
     }
 
@@ -112,24 +111,12 @@ bool THistoryCutterWrapper::IsEnabled() const {
     return AppData()->ColumnShardConfig.GetCutHistoryEnabled();
 }
 
-bool THistoryCutterWrapper::IsActiveEntry(const TEntryKey& key) const {
-    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
-        return false;
-    }
-    const auto& hist = TabletInfo->Channels[key.Channel].History;
-    return !hist.empty() && hist.back().FromGeneration == key.FromGeneration;
-}
-
-bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
-    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
-        return false;
-    }
-    const auto& hist = TabletInfo->Channels[key.Channel].History;
+bool THistoryCutterWrapper::SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration) {
     ui32 targetGroup = 0;
     bool found = false;
     std::unordered_set<ui32> seenGroups;
     for (const auto& e : hist) {
-        if (e.FromGeneration == key.FromGeneration) {
+        if (e.FromGeneration == fromGeneration) {
             targetGroup = e.GroupID;
             found = true;
             break;
@@ -137,6 +124,13 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
         seenGroups.insert(e.GroupID);
     }
     return found && !seenGroups.contains(targetGroup);
+}
+
+bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
+    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
+        return false;
+    }
+    return SeenGroupsCheckPasses(TabletInfo->Channels[key.Channel].History, key.FromGeneration);
 }
 
 ui32 THistoryCutterWrapper::GetNextFromGeneration(const TEntryKey& key) const {

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -402,6 +402,9 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
         auto& state = DisprovedAt[key];
         state.At = ctx.Now();
         ++state.Attempts;
+        // Settle the entry now: otherwise it lingers as Verifying until the exhausted
+        // batch and the safety-net reset below would bump Attempts a second time.
+        CutState[key] = ECutState::None;
     }
     // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
@@ -467,13 +470,12 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
     SweepSurvivors.clear();
 
-    // Reset any remaining Verifying entries (disproved during scan).
+    // Safety net: disproved entries were already settled (and their backoff bumped)
+    // in the disproved loop above, so any Verifying leftover here is an unexpected
+    // state — reset it without counting a disproval attempt.
     for (auto& [key, state] : CutState) {
         if (state == ECutState::Verifying) {
             state = ECutState::None;
-            auto& disprovalState = DisprovedAt[key];
-            disprovalState.At = ctx.Now();
-            ++disprovalState.Attempts;
         }
     }
 }

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -120,7 +120,7 @@ bool THistoryCutterWrapper::IsEnabled() const {
 }
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(
-    const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration, const std::unordered_set<ui32>& cutFromGenerations) {
+    const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration, const THashSet<ui32>& cutFromGenerations) {
     const auto target = FindIf(hist, [fromGeneration](const TTabletChannelInfo::THistoryEntry& entry) {
         return entry.FromGeneration == fromGeneration;
     });
@@ -138,7 +138,7 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
     if (key.Channel >= static_cast<ui32>(TabletInfo->Channels.size())) {
         return false;
     }
-    std::unordered_set<ui32> cutFromGenerations;
+    THashSet<ui32> cutFromGenerations;
     for (const auto& [stateKey, state] : CutState) {
         if (stateKey.Channel == key.Channel && state == ECutState::Cut) {
             cutFromGenerations.insert(stateKey.FromGeneration);

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -109,13 +109,13 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(const std::vector<TTabletChann
     ui32 targetGroup = 0;
     bool found = false;
     std::unordered_set<ui32> seenGroups;
-    for (const auto& e : hist) {
-        if (e.FromGeneration == fromGeneration) {
-            targetGroup = e.GroupID;
+    for (const auto& entry : hist) {
+        if (entry.FromGeneration == fromGeneration) {
+            targetGroup = entry.GroupID;
             found = true;
             break;
         }
-        seenGroups.insert(e.GroupID);
+        seenGroups.insert(entry.GroupID);
     }
     return found && !seenGroups.contains(targetGroup);
 }
@@ -367,9 +367,9 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 
         ui32 groupId = 0;
         if (key.Channel < static_cast<ui32>(TabletInfo->Channels.size())) {
-            for (const auto& e : TabletInfo->Channels[key.Channel].History) {
-                if (e.FromGeneration == key.FromGeneration) {
-                    groupId = e.GroupID;
+            for (const auto& entry : TabletInfo->Channels[key.Channel].History) {
+                if (entry.FromGeneration == key.FromGeneration) {
+                    groupId = entry.GroupID;
                     break;
                 }
             }

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -124,21 +124,17 @@ bool THistoryCutterWrapper::IsEnabled() const {
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(
     const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration, const std::unordered_set<ui32>& cutFromGenerations) {
-    ui32 targetGroup = 0;
-    bool found = false;
-    std::unordered_set<ui32> seenGroups;
-    for (const auto& entry : hist) {
-        if (entry.FromGeneration == fromGeneration) {
-            targetGroup = entry.GroupID;
-            found = true;
-            break;
-        }
-        if (cutFromGenerations.contains(entry.FromGeneration)) {
-            continue;
-        }
-        seenGroups.insert(entry.GroupID);
+    const auto target = FindIf(hist, [fromGeneration](const TTabletChannelInfo::THistoryEntry& entry) {
+        return entry.FromGeneration == fromGeneration;
+    });
+    if (target == hist.end()) {
+        return false;
     }
-    return found && !seenGroups.contains(targetGroup);
+    // No entry before the target may still be live in the target's group: a hard barrier
+    // for the target's range would collect that entry's blobs too.
+    return !AnyOf(hist.begin(), target, [&](const TTabletChannelInfo::THistoryEntry& entry) {
+        return entry.GroupID == target->GroupID && !cutFromGenerations.contains(entry.FromGeneration);
+    });
 }
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
@@ -159,12 +155,15 @@ ui32 THistoryCutterWrapper::GetNextFromGeneration(const TEntryKey& key) const {
         return 0;
     }
     const auto& hist = TabletInfo->Channels[key.Channel].History;
-    for (int i = 0; i < static_cast<int>(hist.size()) - 1; ++i) {
-        if (hist[i].FromGeneration == key.FromGeneration) {
-            return hist[i + 1].FromGeneration;
-        }
+    // History is ascending by FromGeneration, so the successor is one past the entry
+    // itself; TCmp is the comparator TTabletChannelInfo::GroupForGeneration uses for
+    // the same search. `next == end()` means the entry is the active one, which has no
+    // successor and is therefore never a cut candidate.
+    const auto next = UpperBound(hist.begin(), hist.end(), key.FromGeneration, TTabletChannelInfo::THistoryEntry::TCmp());
+    if (next == hist.begin() || next == hist.end() || (next - 1)->FromGeneration != key.FromGeneration) {
+        return 0;
     }
-    return 0;
+    return next->FromGeneration;
 }
 
 bool THistoryCutterWrapper::IsDrained(const TEntryKey& key) const {
@@ -200,17 +199,16 @@ bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& ou
         return false;
     }
     const auto& hist = TabletInfo->Channels[ch].History;
-    for (int i = static_cast<int>(hist.size()) - 2; i >= 0; --i) {
-        if (hist[i].FromGeneration <= blobId.Generation()) {
-            // Check it falls in [hist[i].FromGen, hist[i+1].FromGen).
-            if (blobId.Generation() < hist[i + 1].FromGeneration) {
-                out = TEntryKey{ ch, hist[i].FromGeneration };
-                return true;
-            }
-            break;
-        }
+    // The same search TTabletChannelInfo::GroupForGeneration performs, but the entry's
+    // FromGeneration is the key here rather than its group. `entry` is one past the
+    // owning history entry: at begin() no entry covers the generation, and at end() the
+    // owner is the active entry, which is never a cut candidate.
+    const auto entry = UpperBound(hist.begin(), hist.end(), blobId.Generation(), TTabletChannelInfo::THistoryEntry::TCmp());
+    if (entry == hist.begin() || entry == hist.end()) {
+        return false;
     }
-    return false;
+    out = TEntryKey{ ch, (entry - 1)->FromGeneration };
+    return true;
 }
 
 void THistoryCutterWrapper::PublishLevels(const std::optional<ui64> sweepCandidates) {
@@ -348,16 +346,14 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
         // All entries except the last (active) are candidates.
         for (int i = 0; i < static_cast<int>(hist.size()) - 1; ++i) {
             const TEntryKey key{ ch, hist[i].FromGeneration };
-            const auto stateIt = CutState.find(key);
-            if (stateIt != CutState.end() && stateIt->second != ECutState::None) {
+            if (const auto* state = CutState.FindPtr(key); state && *state != ECutState::None) {
                 continue;
             }
-            const auto cntIt = Counters.find(key);
-            if (cntIt != Counters.end() && cntIt->second != 0) {
+            if (const auto* count = Counters.FindPtr(key); count && *count != 0) {
                 continue;
             }
-            const auto disprovedIt = DisprovedAt.find(key);
-            if (disprovedIt != DisprovedAt.end() && ctx.Now() - disprovedIt->second.At < GetDisprovedCooldown(disprovedIt->second.Attempts)) {
+            if (const auto* disproval = DisprovedAt.FindPtr(key);
+                disproval && ctx.Now() - disproval->At < GetDisprovedCooldown(disproval->Attempts)) {
                 continue;
             }
             // Cheap history walk first; the queue scans in IsDrained run only for
@@ -446,8 +442,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 
     for (const auto& key : SweepSurvivors) {
         // Re-check: counter must still be zero and no blobs in flight.
-        const auto cntIt = Counters.find(key);
-        if (cntIt != Counters.end() && cntIt->second != 0) {
+        if (const auto* count = Counters.FindPtr(key); count && *count != 0) {
             CutState[key] = ECutState::None;
             continue;
         }
@@ -470,11 +465,14 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 
         std::optional<ui32> groupId;
         if (key.Channel < static_cast<ui32>(TabletInfo->Channels.size())) {
-            for (const auto& entry : TabletInfo->Channels[key.Channel].History) {
-                if (entry.FromGeneration == key.FromGeneration) {
-                    groupId = entry.GroupID;
-                    break;
-                }
+            // Exact match rather than GroupForGeneration: once the entry has been cut
+            // away, the entry that covers its generation belongs to a different, live
+            // group, and barriering that one would collect blobs still in use.
+            if (const auto* entry =
+                    FindIfPtr(TabletInfo->Channels[key.Channel].History, [&key](const TTabletChannelInfo::THistoryEntry& historyEntry) {
+                        return historyEntry.FromGeneration == key.FromGeneration;
+                    })) {
+                groupId = entry->GroupID;
             }
         }
         if (!groupId) {
@@ -501,16 +499,16 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 }
 
 void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok) {
-    auto it = CutState.find(key);
-    if (it == CutState.end()) {
+    auto* state = CutState.FindPtr(key);
+    if (!state) {
         return;
     }
     Signals.OnBarrierResult(ok);
     if (ok) {
-        it->second = ECutState::Cut;
+        *state = ECutState::Cut;
         NYDBTest::TControllers::GetColumnShardController()->OnHistoryEntryCut(key.Channel, key.FromGeneration);
     } else {
-        it->second = ECutState::None;
+        *state = ECutState::None;
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -131,7 +131,7 @@ bool THistoryCutterWrapper::IsEnabled() const {
     if (NYDBTest::TControllers::GetColumnShardController()->IsCSCutHistoryEnabled()) {
         return true;
     }
-    return HasAppData() && AppData()->FeatureFlags.GetEnableCutHistory();
+    return HasAppData() && AppData()->FeatureFlags.GetEnableColumnshardGroupDecommission();
 }
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(
@@ -236,6 +236,11 @@ void THistoryCutterWrapper::IncrementCounter(const TEntryKey& key) {
 
 void THistoryCutterWrapper::DecrementCounter(const TEntryKey& key) {
     auto it = Counters.find(key);
+    // Unreachable by design: OnPortionRemoved is fenced by PortionKeys, and PortionKeys and
+    // Counters are written and cleared together, so a portion that was never counted is never
+    // decremented. Poisoning guards against a future divergence between the two maps rather
+    // than any known scenario - if this warning ever fires in production, that divergence is
+    // the bug, not the channel.
     if (it == Counters.end() || it->second == 0) {
         if (PoisonedChannels.insert(key.Channel).second) {
             AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "cut_history_channel_poisoned")("channel", key.Channel)(

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -205,7 +205,10 @@ void THistoryCutterWrapper::IncrementCounter(const TEntryKey& key) {
 void THistoryCutterWrapper::DecrementCounter(const TEntryKey& key) {
     auto it = Counters.find(key);
     if (it == Counters.end() || it->second == 0) {
-        PoisonedChannels.insert(key.Channel);
+        if (PoisonedChannels.insert(key.Channel).second) {
+            AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "cut_history_channel_poisoned")("channel", key.Channel)(
+                "from_generation", key.FromGeneration)("reason", "counter_underflow");
+        }
         return;
     }
     if (--it->second == 0) {
@@ -288,8 +291,25 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     }
     LastNominateAt = ctx.Now();
 
+    // Channel rotation + hard cap: at most MaxDrainChecksPerNomination queue scans per
+    // round; the next round resumes from the first channel that was not fully serviced.
+    ui32 drainChecks = 0;
+    const ui32 channelCount = static_cast<ui32>(TabletInfo->Channels.size());
+    if (channelCount <= 2) {
+        return false;
+    }
+    if (NextChannelToCheck < 2 || NextChannelToCheck >= channelCount) {
+        NextChannelToCheck = 2;
+    }
+    const ui32 firstChannel = NextChannelToCheck;
     TVector<TEntryKey> batch;
-    for (ui32 ch = 2; ch < static_cast<ui32>(TabletInfo->Channels.size()); ++ch) {
+    for (ui32 idx = 0; idx < channelCount - 2; ++idx) {
+        const ui32 ch = 2 + (firstChannel - 2 + idx) % (channelCount - 2);
+        if (drainChecks >= MaxDrainChecksPerNomination) {
+            NextChannelToCheck = ch;
+            break;
+        }
+        NextChannelToCheck = 2 + (ch - 2 + 1) % (channelCount - 2);
         if (PoisonedChannels.contains(ch)) {
             continue;
         }
@@ -314,6 +334,10 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
             if (!SeenGroupsCheckPasses(key)) {
                 continue;
             }
+            if (drainChecks >= MaxDrainChecksPerNomination) {
+                break;
+            }
+            ++drainChecks;
             if (!IsDrained(key)) {
                 continue;
             }

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -1,0 +1,417 @@
+#include "blob_manager.h"
+#include "history_cutter.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/tablet.h>
+#include <ydb/core/protos/config.pb.h>
+#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
+#include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
+#include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
+
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD_BLOBS_BS
+
+namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
+
+namespace {
+
+static TAtomicCounter CutHistoryPGCounter = 1;
+
+class TCutHistoryBarrierActor: public TActorBootstrapped<TCutHistoryBarrierActor> {
+public:
+    TCutHistoryBarrierActor(const TActorId& tabletActorId, const TActorId& launcherActorId, ui64 tabletId, ui32 currentGen, ui32 channel,
+        ui32 group, ui32 fromGen, ui32 nextFromGen)
+        : TabletActorId(tabletActorId)
+        , LauncherActorId(launcherActorId)
+        , TabletId(tabletId)
+        , CurrentGen(currentGen)
+        , Channel(channel)
+        , Group(group)
+        , FromGen(fromGen)
+        , NextFromGen(nextFromGen)
+    {
+    }
+
+    void Bootstrap(const TActorContext& ctx) {
+        Become(&TThis::StateWait);
+        SendBarrier(ctx);
+    }
+
+    void Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr& ev, const TActorContext& ctx) {
+        const auto status = ev->Get()->Status;
+        if (status == NKikimrProto::OK) {
+            // Send cut request to Hive.
+            auto req = MakeHolder<TEvTablet::TEvCutTabletHistory>();
+            req->Record.SetTabletID(TabletId);
+            req->Record.SetChannel(Channel);
+            req->Record.SetFromGeneration(FromGen);
+            req->Record.SetGroupID(Group);
+            ctx.Send(LauncherActorId, req.Release());
+            // Notify tablet.
+            ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvCutHistoryBarrierDone(Channel, FromGen, true));
+            Die(ctx);
+            return;
+        }
+        if (status == NKikimrProto::BLOCKED || ++Retries >= MaxRetries) {
+            ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvCutHistoryBarrierDone(Channel, FromGen, false));
+            Die(ctx);
+            return;
+        }
+        SendBarrier(ctx);
+    }
+
+    STFUNC(StateWait) {
+        switch (ev->GetTypeRewrite()) { HFunc(TEvBlobStorage::TEvCollectGarbageResult, Handle); }
+    }
+
+private:
+    static constexpr int MaxRetries = 3;
+
+    void SendBarrier(const TActorContext& ctx) {
+        auto ev = MakeHolder<TEvBlobStorage::TEvCollectGarbage>(TabletId, CurrentGen, CutHistoryPGCounter.Val(), Channel, /*collect=*/true,
+            /*collectGeneration=*/NextFromGen - 1, /*collectStep=*/Max<ui32>(), /*keep=*/nullptr, /*doNotKeep=*/nullptr, TInstant::Max(),
+            /*issueKeepFlag=*/false, TWriteSource::ColumnShardGC, /*hard=*/true);
+        CutHistoryPGCounter.Add(ev->PerGenerationCounterStepSize());
+        SendToBSProxy(ctx, Group, ev.Release());
+    }
+
+    TActorId TabletActorId;
+    TActorId LauncherActorId;
+    ui64 TabletId;
+    ui32 CurrentGen;
+    ui32 Channel;
+    ui32 Group;
+    ui32 FromGen;
+    ui32 NextFromGen;
+    int Retries = 0;
+};
+
+}   // anonymous namespace
+
+THistoryCutterWrapper::THistoryCutterWrapper(
+    const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, const ui32 currentGen, NOlap::TBlobManager* manager, const TActorId& tabletActorId)
+    : TabletInfo(tabletInfo)
+    , CurrentGen(currentGen)
+    , Manager(manager)
+    , TabletActorId(tabletActorId)
+{
+}
+
+bool THistoryCutterWrapper::IsEnabled() const {
+    // Test hook takes priority over feature flags (allows enabling without AppData).
+    if (NYDBTest::TControllers::GetColumnShardController()->IsCSCutHistoryEnabled()) {
+        return true;
+    }
+    if (!HasAppData()) {
+        return false;
+    }
+    if (!AppData()->FeatureFlags.GetEnableCutHistory()) {
+        return false;
+    }
+    return AppData()->ColumnShardConfig.GetCutHistoryEnabled();
+}
+
+bool THistoryCutterWrapper::IsActiveEntry(const TEntryKey& key) const {
+    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
+        return false;
+    }
+    const auto& hist = TabletInfo->Channels[key.Channel].History;
+    return !hist.empty() && hist.back().FromGeneration == key.FromGeneration;
+}
+
+bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
+    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
+        return false;
+    }
+    const auto& hist = TabletInfo->Channels[key.Channel].History;
+    ui32 targetGroup = 0;
+    bool found = false;
+    std::unordered_set<ui32> seenGroups;
+    for (const auto& e : hist) {
+        if (e.FromGeneration == key.FromGeneration) {
+            targetGroup = e.GroupID;
+            found = true;
+            break;
+        }
+        seenGroups.insert(e.GroupID);
+    }
+    return found && !seenGroups.contains(targetGroup);
+}
+
+ui32 THistoryCutterWrapper::GetNextFromGeneration(const TEntryKey& key) const {
+    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
+        return 0;
+    }
+    const auto& hist = TabletInfo->Channels[key.Channel].History;
+    for (int i = 0; i < (int)hist.size() - 1; ++i) {
+        if (hist[i].FromGeneration == key.FromGeneration) {
+            return hist[i + 1].FromGeneration;
+        }
+    }
+    return 0;
+}
+
+bool THistoryCutterWrapper::IsDrained(const TEntryKey& key) const {
+    const ui32 nextGen = GetNextFromGeneration(key);
+    if (!nextGen) {
+        return false;
+    }
+    return Manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen);
+}
+
+bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& lid, TEntryKey& out) const {
+    if (lid.TabletID() != TabletInfo->TabletID) {
+        return false;
+    }
+    const ui32 ch = lid.Channel();
+    if (ch < 2 || ch >= (ui32)TabletInfo->Channels.size()) {
+        return false;
+    }
+    if (lid.Generation() == CurrentGen) {
+        return false;
+    }
+    const auto& hist = TabletInfo->Channels[ch].History;
+    for (int i = (int)hist.size() - 2; i >= 0; --i) {
+        if (hist[i].FromGeneration <= lid.Generation()) {
+            // Check it falls in [hist[i].FromGen, hist[i+1].FromGen).
+            if (lid.Generation() < hist[i + 1].FromGeneration) {
+                out = TEntryKey{ ch, hist[i].FromGeneration };
+                return true;
+            }
+            break;
+        }
+    }
+    return false;
+}
+
+void THistoryCutterWrapper::IncrementCounter(const TEntryKey& key) {
+    ++Counters[key];
+}
+
+void THistoryCutterWrapper::DecrementCounter(const TEntryKey& key) {
+    auto it = Counters.find(key);
+    if (it == Counters.end() || it->second == 0) {
+        PoisonedChannels.insert(key.Channel);
+        return;
+    }
+    if (--it->second == 0) {
+        Counters.erase(it);
+    }
+}
+
+void THistoryCutterWrapper::OnPortionAdded(const TPortionDataAccessor& accessor) {
+    if (!IsEnabled()) {
+        return;
+    }
+    const ui64 portionId = accessor.GetPortionInfo().GetPortionId();
+    THashSet<TEntryKey>& portionKeySet = PortionKeys[portionId];
+    for (const auto& blobId : accessor.GetBlobIds()) {
+        TEntryKey key;
+        if (!GetEntryKey(blobId.GetLogoBlobId(), key)) {
+            continue;
+        }
+        if (portionKeySet.insert(key).second) {
+            // First time this portion maps to this entry.
+            IncrementCounter(key);
+        }
+    }
+}
+
+void THistoryCutterWrapper::OnPortionRemoved(const ui64 portionId) {
+    if (!IsEnabled()) {
+        return;
+    }
+    auto it = PortionKeys.find(portionId);
+    if (it == PortionKeys.end()) {
+        return;
+    }
+    for (const auto& key : it->second) {
+        DecrementCounter(key);
+    }
+    PortionKeys.erase(it);
+}
+
+void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUnifiedBlobId>>& portionBlobIds) {
+    Counters.clear();
+    CutState.clear();
+    PoisonedChannels.clear();
+    PortionKeys.clear();
+    SweepInFlight_ = false;
+    SweepCandidates_.clear();
+    SweepSurvivors_.clear();
+    SweepPortionIds_.clear();
+    SweepPortionOffset_ = 0;
+
+    if (!IsEnabled()) {
+        return;
+    }
+    for (const auto& [portionId, blobIds] : portionBlobIds) {
+        THashSet<TEntryKey>& portionKeySet = PortionKeys[portionId];
+        for (const auto& blobId : blobIds) {
+            TEntryKey key;
+            if (!GetEntryKey(blobId.GetLogoBlobId(), key)) {
+                continue;
+            }
+            if (portionKeySet.insert(key).second) {
+                IncrementCounter(key);
+            }
+        }
+    }
+}
+
+bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
+    if (!IsEnabled()) {
+        return false;
+    }
+    if (SweepInFlight_) {
+        return false;
+    }
+
+    TVector<TEntryKey> batch;
+    for (ui32 ch = 2; ch < (ui32)TabletInfo->Channels.size(); ++ch) {
+        if (PoisonedChannels.contains(ch)) {
+            continue;
+        }
+        const auto& hist = TabletInfo->Channels[ch].History;
+        // All entries except the last (active) are candidates.
+        for (int i = 0; i < (int)hist.size() - 1; ++i) {
+            const TEntryKey key{ ch, hist[i].FromGeneration };
+            const auto stateIt = CutState.find(key);
+            if (stateIt != CutState.end() && stateIt->second != ECutState::None) {
+                continue;
+            }
+            const auto cntIt = Counters.find(key);
+            if (cntIt != Counters.end() && cntIt->second != 0) {
+                continue;
+            }
+            if (!IsDrained(key)) {
+                continue;
+            }
+            if (!SeenGroupsCheckPasses(key)) {
+                continue;
+            }
+            batch.push_back(key);
+            NYDBTest::TControllers::GetColumnShardController()->OnHistoryEntryNominated(key.Channel, key.FromGeneration);
+        }
+    }
+
+    if (batch.empty()) {
+        return false;
+    }
+
+    for (const auto& key : batch) {
+        CutState[key] = ECutState::Verifying;
+    }
+    SweepInFlight_ = true;
+    SweepCandidates_ = batch;
+    SweepSurvivors_ = std::move(batch);
+    SweepPortionIds_.clear();
+    SweepPortionOffset_ = 0;
+
+    ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvStartCutHistorySweep());
+    return true;
+}
+
+void THistoryCutterWrapper::SetPortionSnapshot(TVector<std::pair<TInternalPathId, ui64>>&& ids) {
+    SweepPortionIds_ = std::move(ids);
+    SweepPortionOffset_ = 0;
+}
+
+TVector<std::pair<TInternalPathId, ui64>> THistoryCutterWrapper::GetNextBatch(size_t batchSize, bool& isLast) {
+    TVector<std::pair<TInternalPathId, ui64>> batch;
+    const size_t remaining = SweepPortionIds_.size() - SweepPortionOffset_;
+    const size_t take = (remaining > batchSize) ? batchSize : remaining;
+    for (size_t i = 0; i < take; ++i) {
+        batch.push_back(SweepPortionIds_[SweepPortionOffset_ + i]);
+    }
+    SweepPortionOffset_ += take;
+    isLast = (SweepPortionOffset_ >= SweepPortionIds_.size());
+    return batch;
+}
+
+void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved, bool exhausted, const TActorContext& ctx) {
+    // Remove disproved entries from in-progress survivors list.
+    if (!disproved.empty()) {
+        TVector<TEntryKey> kept;
+        kept.reserve(SweepSurvivors_.size());
+        for (const auto& key : SweepSurvivors_) {
+            if (!disproved.contains(key)) {
+                kept.push_back(key);
+            }
+        }
+        SweepSurvivors_ = std::move(kept);
+    }
+
+    if (!exhausted) {
+        // More portion batches to check — schedule next batch.
+        ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvStartCutHistorySweep());
+        return;
+    }
+
+    // Cursor exhausted: re-check each survivor and send hard barrier if still safe.
+    SweepInFlight_ = false;
+    SweepCandidates_.clear();
+    SweepPortionIds_.clear();
+    SweepPortionOffset_ = 0;
+
+    for (const auto& key : SweepSurvivors_) {
+        // Re-check: counter must still be zero and no blobs in flight.
+        const auto cntIt = Counters.find(key);
+        if (cntIt != Counters.end() && cntIt->second != 0) {
+            CutState[key] = ECutState::None;
+            continue;
+        }
+        if (!IsDrained(key)) {
+            CutState[key] = ECutState::None;
+            continue;
+        }
+
+        const ui32 nextFromGen = GetNextFromGeneration(key);
+        if (!nextFromGen) {
+            CutState[key] = ECutState::None;
+            continue;
+        }
+
+        ui32 groupId = 0;
+        if (key.Channel < (ui32)TabletInfo->Channels.size()) {
+            for (const auto& e : TabletInfo->Channels[key.Channel].History) {
+                if (e.FromGeneration == key.FromGeneration) {
+                    groupId = e.GroupID;
+                    break;
+                }
+            }
+        }
+        if (!groupId) {
+            CutState[key] = ECutState::None;
+            continue;
+        }
+
+        CutState[key] = ECutState::SentBarrier;
+        ctx.Register(new TCutHistoryBarrierActor(
+            TabletActorId, LauncherActorId, TabletInfo->TabletID, CurrentGen, key.Channel, groupId, key.FromGeneration, nextFromGen));
+    }
+    SweepSurvivors_.clear();
+
+    // Reset any remaining Verifying entries (disproved during scan).
+    for (auto& [key, state] : CutState) {
+        if (state == ECutState::Verifying) {
+            state = ECutState::None;
+        }
+    }
+}
+
+void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok) {
+    auto it = CutState.find(key);
+    if (it == CutState.end()) {
+        return;
+    }
+    if (ok) {
+        it->second = ECutState::Cut;
+        NYDBTest::TControllers::GetColumnShardController()->OnHistoryEntryCut(key.Channel, key.FromGeneration);
+    } else {
+        it->second = ECutState::None;
+    }
+}
+
+}   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -343,7 +343,7 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
                 continue;
             }
             const auto disprovedIt = DisprovedAt.find(key);
-            if (disprovedIt != DisprovedAt.end() && ctx.Now() - disprovedIt->second < DisprovedRetryCooldown) {
+            if (disprovedIt != DisprovedAt.end() && ctx.Now() - disprovedIt->second.At < GetDisprovedCooldown(disprovedIt->second.Attempts)) {
                 continue;
             }
             // Cheap history walk first; the queue scans in IsDrained run only for
@@ -399,7 +399,9 @@ TVector<std::pair<TInternalPathId, ui64>> THistoryCutterWrapper::GetNextBatch(si
 
 void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved, bool exhausted, const TActorContext& ctx) {
     for (const auto& key : disproved) {
-        DisprovedAt[key] = ctx.Now();
+        auto& state = DisprovedAt[key];
+        state.At = ctx.Now();
+        ++state.Attempts;
     }
     // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
@@ -444,7 +446,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
             continue;
         }
 
-        ui32 groupId = 0;
+        std::optional<ui32> groupId;
         if (key.Channel < static_cast<ui32>(TabletInfo->Channels.size())) {
             for (const auto& entry : TabletInfo->Channels[key.Channel].History) {
                 if (entry.FromGeneration == key.FromGeneration) {
@@ -458,9 +460,10 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
             continue;
         }
 
+        DisprovedAt.erase(key);
         CutState[key] = ECutState::SentBarrier;
         ctx.Register(new TCutHistoryBarrierActor(
-            TabletActorId, LauncherActorId, TabletInfo->TabletID, CurrentGen, key.Channel, groupId, key.FromGeneration, nextFromGen));
+            TabletActorId, LauncherActorId, TabletInfo->TabletID, CurrentGen, key.Channel, *groupId, key.FromGeneration, nextFromGen));
     }
     SweepSurvivors.clear();
 
@@ -468,7 +471,9 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     for (auto& [key, state] : CutState) {
         if (state == ECutState::Verifying) {
             state = ECutState::None;
-            DisprovedAt[key] = ctx.Now();
+            auto& disprovalState = DisprovedAt[key];
+            disprovalState.At = ctx.Now();
+            ++disprovalState.Attempts;
         }
     }
 }

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -280,6 +280,13 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     if (SweepInFlight) {
         return false;
     }
+    // Full candidate evaluation scans the GC queues (IsDrained); background activity
+    // enqueues run every few seconds, so cap the evaluation cadence for this rare
+    // maintenance operation instead of scanning per enqueue.
+    if (LastNominateAt && ctx.Now() - LastNominateAt < NominateCadence) {
+        return false;
+    }
+    LastNominateAt = ctx.Now();
 
     TVector<TEntryKey> batch;
     for (ui32 ch = 2; ch < static_cast<ui32>(TabletInfo->Channels.size()); ++ch) {
@@ -302,10 +309,12 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
             if (disprovedIt != DisprovedAt.end() && ctx.Now() - disprovedIt->second < DisprovedRetryCooldown) {
                 continue;
             }
-            if (!IsDrained(key)) {
+            // Cheap history walk first; the queue scans in IsDrained run only for
+            // entries that already passed every in-memory gate.
+            if (!SeenGroupsCheckPasses(key)) {
                 continue;
             }
-            if (!SeenGroupsCheckPasses(key)) {
+            if (!IsDrained(key)) {
                 continue;
             }
             batch.push_back(key);

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -32,9 +32,7 @@ public:
         , FromGen(fromGen)
         , NextFromGen(nextFromGen)
     {
-        // NextFromGen - 1 is the hard collect generation; 0 would underflow to a
-        // collect-everything barrier. Callers must resolve a real next generation.
-        AFL_VERIFY(NextFromGen > 0);
+        AFL_VERIFY(NextFromGen > 0);   // NextFromGen - 1 below would underflow to collect-everything
     }
 
     void Bootstrap(const TActorContext& ctx) {
@@ -127,8 +125,6 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(
     if (target == hist.end()) {
         return false;
     }
-    // No entry before the target may still be live in the target's group: a hard barrier
-    // for the target's range would collect that entry's blobs too.
     return !AnyOf(hist.begin(), target, [&](const TTabletChannelInfo::THistoryEntry& entry) {
         return entry.GroupID == target->GroupID && !cutFromGenerations.contains(entry.FromGeneration);
     });
@@ -196,10 +192,8 @@ bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& ou
         return false;
     }
     const auto& hist = TabletInfo->Channels[ch].History;
-    // The same search TTabletChannelInfo::GroupForGeneration performs, but the entry's
-    // FromGeneration is the key here rather than its group. `entry` is one past the
-    // owning history entry: at begin() no entry covers the generation, and at end() the
-    // owner is the active entry, which is never a cut candidate.
+    // UpperBound lands one past the owning entry: begin() means no entry covers the
+    // generation, end() means the owner is the active entry, never a cut candidate.
     const auto entry = UpperBound(hist.begin(), hist.end(), blobId.Generation(), TTabletChannelInfo::THistoryEntry::TCmp());
     if (entry == hist.begin() || entry == hist.end()) {
         return false;
@@ -276,7 +270,7 @@ void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUni
     PortionKeys.clear();
     DisprovedAt.clear();
     LastNominateAt = TInstant::Zero();
-    NextChannelToCheck = 2;
+    NextChannelToCheck = TGlobal::FirstDataChannel;
     SweepInFlight = false;
     SweepCandidates.reset();
     SweepSurvivors.clear();
@@ -308,33 +302,32 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     if (SweepInFlight) {
         return false;
     }
-    // Full candidate evaluation scans the GC queues (IsDrained); background activity
-    // enqueues run every few seconds, so cap the evaluation cadence for this rare
-    // maintenance operation instead of scanning per enqueue.
+    // Evaluating candidates scans the GC queues, and background enqueues fire every few
+    // seconds: rate-limit rather than scan per enqueue.
     if (LastNominateAt && ctx.Now() - LastNominateAt < NominateCadence) {
         return false;
     }
     LastNominateAt = ctx.Now();
 
-    // Channel rotation + hard cap: at most MaxDrainChecksPerNomination queue scans per
-    // round; the next round resumes from the first channel that was not fully serviced.
+    // The next round resumes from the first channel this one did not fully service.
     ui32 drainChecks = 0;
     const ui32 channelCount = static_cast<ui32>(TabletInfo->Channels.size());
-    if (channelCount <= 2) {
+    if (channelCount <= TGlobal::FirstDataChannel) {
         return false;
     }
-    if (NextChannelToCheck < 2 || NextChannelToCheck >= channelCount) {
-        NextChannelToCheck = 2;
+    if (NextChannelToCheck < TGlobal::FirstDataChannel || NextChannelToCheck >= channelCount) {
+        NextChannelToCheck = TGlobal::FirstDataChannel;
     }
+    const ui32 dataChannels = channelCount - TGlobal::FirstDataChannel;
     const ui32 firstChannel = NextChannelToCheck;
     TVector<TEntryKey> batch;
-    for (ui32 idx = 0; idx < channelCount - 2; ++idx) {
-        const ui32 ch = 2 + (firstChannel - 2 + idx) % (channelCount - 2);
+    for (ui32 idx = 0; idx < dataChannels; ++idx) {
+        const ui32 ch = TGlobal::FirstDataChannel + (firstChannel - TGlobal::FirstDataChannel + idx) % dataChannels;
         if (drainChecks >= MaxDrainChecksPerNomination) {
             NextChannelToCheck = ch;
             break;
         }
-        NextChannelToCheck = 2 + (ch - 2 + 1) % (channelCount - 2);
+        NextChannelToCheck = TGlobal::FirstDataChannel + (ch - TGlobal::FirstDataChannel + 1) % dataChannels;
         if (PoisonedChannels.contains(ch)) {
             continue;
         }
@@ -351,8 +344,6 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
                 disproval && ctx.Now() - disproval->At < GetDisprovedCooldown(disproval->Attempts)) {
                 continue;
             }
-            // Cheap history walk first; the queue scans in IsDrained run only for
-            // entries that already passed every in-memory gate.
             if (!SeenGroupsCheckPasses(key)) {
                 continue;
             }
@@ -409,8 +400,6 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
         auto& state = DisprovedAt[key];
         state.At = ctx.Now();
         ++state.Attempts;
-        // Settle the entry now: otherwise it lingers as Verifying until the exhausted
-        // batch and the safety-net reset below would bump Attempts a second time.
         CutState[key] = ECutState::None;
     }
     if (!disproved.empty()) {
@@ -479,9 +468,8 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
     SweepSurvivors.clear();
 
-    // Safety net: disproved entries were already settled (and their backoff bumped)
-    // in the disproved loop above, so any Verifying leftover here is an unexpected
-    // state — reset it without counting a disproval attempt.
+    // Safety net: the disproved loop settled those already, so anything still Verifying
+    // is unexpected — reset it without counting an attempt.
     for (auto& [key, state] : CutState) {
         if (state == ECutState::Verifying) {
             state = ECutState::None;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -77,12 +77,12 @@ private:
 
     TActorId TabletActorId;
     TActorId LauncherActorId;
-    ui64 TabletId;
-    ui32 CurrentGen;
-    ui32 Channel;
-    ui32 Group;
-    ui32 FromGen;
-    ui32 NextFromGen;
+    ui64 TabletId = 0;
+    ui32 CurrentGen = 0;
+    ui32 Channel = 0;
+    ui32 Group = 0;
+    ui32 FromGen = 0;
+    ui32 NextFromGen = 0;
     int Retries = 0;
 };
 
@@ -102,13 +102,7 @@ bool THistoryCutterWrapper::IsEnabled() const {
     if (NYDBTest::TControllers::GetColumnShardController()->IsCSCutHistoryEnabled()) {
         return true;
     }
-    if (!HasAppData()) {
-        return false;
-    }
-    if (!AppData()->FeatureFlags.GetEnableCutHistory()) {
-        return false;
-    }
-    return AppData()->ColumnShardConfig.GetCutHistoryEnabled();
+    return HasAppData() && AppData()->FeatureFlags.GetEnableCutHistory() && AppData()->ColumnShardConfig.GetCutHistoryEnabled();
 }
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, const ui32 fromGeneration) {
@@ -127,18 +121,18 @@ bool THistoryCutterWrapper::SeenGroupsCheckPasses(const std::vector<TTabletChann
 }
 
 bool THistoryCutterWrapper::SeenGroupsCheckPasses(const TEntryKey& key) const {
-    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
+    if (key.Channel >= static_cast<ui32>(TabletInfo->Channels.size())) {
         return false;
     }
     return SeenGroupsCheckPasses(TabletInfo->Channels[key.Channel].History, key.FromGeneration);
 }
 
 ui32 THistoryCutterWrapper::GetNextFromGeneration(const TEntryKey& key) const {
-    if (key.Channel >= (ui32)TabletInfo->Channels.size()) {
+    if (key.Channel >= static_cast<ui32>(TabletInfo->Channels.size())) {
         return 0;
     }
     const auto& hist = TabletInfo->Channels[key.Channel].History;
-    for (int i = 0; i < (int)hist.size() - 1; ++i) {
+    for (int i = 0; i < static_cast<int>(hist.size()) - 1; ++i) {
         if (hist[i].FromGeneration == key.FromGeneration) {
             return hist[i + 1].FromGeneration;
         }
@@ -154,22 +148,22 @@ bool THistoryCutterWrapper::IsDrained(const TEntryKey& key) const {
     return Manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen);
 }
 
-bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& lid, TEntryKey& out) const {
-    if (lid.TabletID() != TabletInfo->TabletID) {
+bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const {
+    if (blobId.TabletID() != TabletInfo->TabletID) {
         return false;
     }
-    const ui32 ch = lid.Channel();
-    if (ch < 2 || ch >= (ui32)TabletInfo->Channels.size()) {
+    const ui32 ch = blobId.Channel();
+    if (ch < 2 || ch >= static_cast<ui32>(TabletInfo->Channels.size())) {
         return false;
     }
-    if (lid.Generation() == CurrentGen) {
+    if (blobId.Generation() == CurrentGen) {
         return false;
     }
     const auto& hist = TabletInfo->Channels[ch].History;
-    for (int i = (int)hist.size() - 2; i >= 0; --i) {
-        if (hist[i].FromGeneration <= lid.Generation()) {
+    for (int i = static_cast<int>(hist.size()) - 2; i >= 0; --i) {
+        if (hist[i].FromGeneration <= blobId.Generation()) {
             // Check it falls in [hist[i].FromGen, hist[i+1].FromGen).
-            if (lid.Generation() < hist[i + 1].FromGeneration) {
+            if (blobId.Generation() < hist[i + 1].FromGeneration) {
                 out = TEntryKey{ ch, hist[i].FromGeneration };
                 return true;
             }
@@ -216,14 +210,14 @@ void THistoryCutterWrapper::OnPortionRemoved(const ui64 portionId) {
     if (!IsEnabled()) {
         return;
     }
-    auto it = PortionKeys.find(portionId);
-    if (it == PortionKeys.end()) {
+    const THashSet<TEntryKey>* keys = PortionKeys.FindPtr(portionId);
+    if (!keys) {
         return;
     }
-    for (const auto& key : it->second) {
+    for (const auto& key : *keys) {
         DecrementCounter(key);
     }
-    PortionKeys.erase(it);
+    PortionKeys.erase(portionId);
 }
 
 void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUnifiedBlobId>>& portionBlobIds) {
@@ -231,11 +225,11 @@ void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUni
     CutState.clear();
     PoisonedChannels.clear();
     PortionKeys.clear();
-    SweepInFlight_ = false;
-    SweepCandidates_.clear();
-    SweepSurvivors_.clear();
-    SweepPortionIds_.clear();
-    SweepPortionOffset_ = 0;
+    SweepInFlight = false;
+    SweepCandidates.clear();
+    SweepSurvivors.clear();
+    SweepPortionIds.clear();
+    SweepPortionOffset = 0;
 
     if (!IsEnabled()) {
         return;
@@ -258,18 +252,18 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     if (!IsEnabled()) {
         return false;
     }
-    if (SweepInFlight_) {
+    if (SweepInFlight) {
         return false;
     }
 
     TVector<TEntryKey> batch;
-    for (ui32 ch = 2; ch < (ui32)TabletInfo->Channels.size(); ++ch) {
+    for (ui32 ch = 2; ch < static_cast<ui32>(TabletInfo->Channels.size()); ++ch) {
         if (PoisonedChannels.contains(ch)) {
             continue;
         }
         const auto& hist = TabletInfo->Channels[ch].History;
         // All entries except the last (active) are candidates.
-        for (int i = 0; i < (int)hist.size() - 1; ++i) {
+        for (int i = 0; i < static_cast<int>(hist.size()) - 1; ++i) {
             const TEntryKey key{ ch, hist[i].FromGeneration };
             const auto stateIt = CutState.find(key);
             if (stateIt != CutState.end() && stateIt->second != ECutState::None) {
@@ -297,30 +291,30 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     for (const auto& key : batch) {
         CutState[key] = ECutState::Verifying;
     }
-    SweepInFlight_ = true;
-    SweepCandidates_ = batch;
-    SweepSurvivors_ = std::move(batch);
-    SweepPortionIds_.clear();
-    SweepPortionOffset_ = 0;
+    SweepInFlight = true;
+    SweepCandidates = batch;
+    SweepSurvivors = std::move(batch);
+    SweepPortionIds.clear();
+    SweepPortionOffset = 0;
 
     ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvStartCutHistorySweep());
     return true;
 }
 
 void THistoryCutterWrapper::SetPortionSnapshot(TVector<std::pair<TInternalPathId, ui64>>&& ids) {
-    SweepPortionIds_ = std::move(ids);
-    SweepPortionOffset_ = 0;
+    SweepPortionIds = std::move(ids);
+    SweepPortionOffset = 0;
 }
 
 TVector<std::pair<TInternalPathId, ui64>> THistoryCutterWrapper::GetNextBatch(size_t batchSize, bool& isLast) {
     TVector<std::pair<TInternalPathId, ui64>> batch;
-    const size_t remaining = SweepPortionIds_.size() - SweepPortionOffset_;
+    const size_t remaining = SweepPortionIds.size() - SweepPortionOffset;
     const size_t take = (remaining > batchSize) ? batchSize : remaining;
     for (size_t i = 0; i < take; ++i) {
-        batch.push_back(SweepPortionIds_[SweepPortionOffset_ + i]);
+        batch.push_back(SweepPortionIds[SweepPortionOffset + i]);
     }
-    SweepPortionOffset_ += take;
-    isLast = (SweepPortionOffset_ >= SweepPortionIds_.size());
+    SweepPortionOffset += take;
+    isLast = (SweepPortionOffset >= SweepPortionIds.size());
     return batch;
 }
 
@@ -328,13 +322,13 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
         TVector<TEntryKey> kept;
-        kept.reserve(SweepSurvivors_.size());
-        for (const auto& key : SweepSurvivors_) {
+        kept.reserve(SweepSurvivors.size());
+        for (const auto& key : SweepSurvivors) {
             if (!disproved.contains(key)) {
                 kept.push_back(key);
             }
         }
-        SweepSurvivors_ = std::move(kept);
+        SweepSurvivors = std::move(kept);
     }
 
     if (!exhausted) {
@@ -344,12 +338,12 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
 
     // Cursor exhausted: re-check each survivor and send hard barrier if still safe.
-    SweepInFlight_ = false;
-    SweepCandidates_.clear();
-    SweepPortionIds_.clear();
-    SweepPortionOffset_ = 0;
+    SweepInFlight = false;
+    SweepCandidates.clear();
+    SweepPortionIds.clear();
+    SweepPortionOffset = 0;
 
-    for (const auto& key : SweepSurvivors_) {
+    for (const auto& key : SweepSurvivors) {
         // Re-check: counter must still be zero and no blobs in flight.
         const auto cntIt = Counters.find(key);
         if (cntIt != Counters.end() && cntIt->second != 0) {
@@ -368,7 +362,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
         }
 
         ui32 groupId = 0;
-        if (key.Channel < (ui32)TabletInfo->Channels.size()) {
+        if (key.Channel < static_cast<ui32>(TabletInfo->Channels.size())) {
             for (const auto& e : TabletInfo->Channels[key.Channel].History) {
                 if (e.FromGeneration == key.FromGeneration) {
                     groupId = e.GroupID;
@@ -385,7 +379,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
         ctx.Register(new TCutHistoryBarrierActor(
             TabletActorId, LauncherActorId, TabletInfo->TabletID, CurrentGen, key.Channel, groupId, key.FromGeneration, nextFromGen));
     }
-    SweepSurvivors_.clear();
+    SweepSurvivors.clear();
 
     // Reset any remaining Verifying entries (disproved during scan).
     for (auto& [key, state] : CutState) {

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -499,7 +499,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
 }
 
-void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok) {
+void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok, TInstant now) {
     auto* state = CutState.FindPtr(key);
     if (!state) {
         return;
@@ -510,6 +510,15 @@ void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok) {
         NYDBTest::TControllers::GetColumnShardController()->OnHistoryEntryCut(key.Channel, key.FromGeneration);
     } else {
         *state = ECutState::None;
+        // Without this a failed barrier retried every nomination cadence against the
+        // same obstacle: ~190 wasted sweep+barrier rounds/min measured on a drained
+        // pool. A failure re-enters the disproval cooldown instead. Attempts restarts
+        // at 1 because nomination erased the record right before SentBarrier, so
+        // consecutive failures plateau at cooldown(1) rather than escalating.
+        auto& disproval = DisprovedAt[key];
+        disproval.At = now;
+        ++disproval.Attempts;
+        PublishLevels();
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -104,8 +104,9 @@ private:
 
 THistoryCutterWrapper::THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, const ui32 currentGen,
     const std::weak_ptr<NOlap::TBlobManager>& manager, const std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>& sharedBlobs,
-    const TActorId& tabletActorId)
-    : TabletInfo(tabletInfo)
+    const TActorId& tabletActorId, const NColumnShard::THistoryCutterCounters& signals)
+    : Signals(signals)
+    , TabletInfo(tabletInfo)
     , CurrentGen(currentGen)
     , Manager(manager)
     , SharedBlobs(sharedBlobs)
@@ -212,6 +213,17 @@ bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& ou
     return false;
 }
 
+void THistoryCutterWrapper::PublishLevels(const std::optional<ui64> sweepCandidates) {
+    const ui64 candidates = sweepCandidates.value_or(Published.SweepCandidates);
+    const ui64 poisoned = PoisonedChannels.size();
+    const ui64 disproved = DisprovedAt.size();
+    Signals.OnLevelsDelta((i64)candidates - (i64)Published.SweepCandidates, (i64)poisoned - (i64)Published.ChannelsPoisoned,
+        (i64)disproved - (i64)Published.EntriesDisproved);
+    Published.SweepCandidates = candidates;
+    Published.ChannelsPoisoned = poisoned;
+    Published.EntriesDisproved = disproved;
+}
+
 void THistoryCutterWrapper::IncrementCounter(const TEntryKey& key) {
     ++Counters[key];
 }
@@ -222,6 +234,7 @@ void THistoryCutterWrapper::DecrementCounter(const TEntryKey& key) {
         if (PoisonedChannels.insert(key.Channel).second) {
             AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "cut_history_channel_poisoned")("channel", key.Channel)(
                 "from_generation", key.FromGeneration)("reason", "counter_underflow");
+            PublishLevels();
         }
         return;
     }
@@ -275,6 +288,7 @@ void THistoryCutterWrapper::OnBootComplete(const THashMap<ui64, std::vector<TUni
     SweepSurvivors.clear();
     SweepPortionIds.clear();
     SweepPortionOffset = 0;
+    PublishLevels(0);
 
     if (!IsEnabled()) {
         return;
@@ -371,6 +385,8 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
         CutState[key] = ECutState::Verifying;
     }
     SweepInFlight = true;
+    Signals.OnNomination();
+    PublishLevels(batch.size());
     SweepSurvivors = batch;
     SweepCandidates = std::make_shared<const TVector<TEntryKey>>(std::move(batch));
     SweepPortionIds.clear();
@@ -408,6 +424,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
     // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
+        PublishLevels();
         EraseIf(SweepSurvivors, [&](const TEntryKey& key) {
             return disproved.contains(key);
         });
@@ -421,6 +438,8 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 
     // Cursor exhausted: re-check each survivor and send hard barrier if still safe.
     SweepInFlight = false;
+    Signals.OnSweepCompleted();
+    PublishLevels(0);
     SweepCandidates.reset();
     SweepPortionIds.clear();
     SweepPortionOffset = 0;
@@ -464,6 +483,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
         }
 
         DisprovedAt.erase(key);
+        PublishLevels();
         CutState[key] = ECutState::SentBarrier;
         ctx.Register(new TCutHistoryBarrierActor(
             TabletActorId, LauncherActorId, TabletInfo->TabletID, CurrentGen, key.Channel, *groupId, key.FromGeneration, nextFromGen));
@@ -485,6 +505,7 @@ void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok) {
     if (it == CutState.end()) {
         return;
     }
+    Signals.OnBarrierResult(ok);
     if (ok) {
         it->second = ECutState::Cut;
         NYDBTest::TControllers::GetColumnShardController()->OnHistoryEntryCut(key.Channel, key.FromGeneration);

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -50,14 +50,12 @@ public:
         const auto status = ev->Get()->Status;
         if (status == NKikimrProto::OK || status == NKikimrProto::ALREADY) {
             // ALREADY means the barrier is already at or beyond the requested level — safe to cut.
-            // Send cut request to Hive.
             auto req = MakeHolder<TEvTablet::TEvCutTabletHistory>();
             req->Record.SetTabletID(TabletId);
             req->Record.SetChannel(Channel);
             req->Record.SetFromGeneration(FromGen);
             req->Record.SetGroupID(Group);
             ctx.Send(LauncherActorId, req.Release());
-            // Notify tablet.
             ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvCutHistoryBarrierDone(Channel, FromGen, true));
             Die(ctx);
             return;
@@ -115,7 +113,6 @@ THistoryCutterWrapper::THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageI
 }
 
 bool THistoryCutterWrapper::IsEnabled() const {
-    // Test hook takes priority over feature flags (allows enabling without AppData).
     if (NYDBTest::TControllers::GetColumnShardController()->IsCSCutHistoryEnabled()) {
         return true;
     }
@@ -253,7 +250,6 @@ void THistoryCutterWrapper::OnPortionAdded(const TPortionDataAccessor& accessor)
             continue;
         }
         if (portionKeySet.insert(key).second) {
-            // First time this portion maps to this entry.
             IncrementCounter(key);
         }
     }
@@ -343,7 +339,6 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
             continue;
         }
         const auto& hist = TabletInfo->Channels[ch].History;
-        // All entries except the last (active) are candidates.
         for (int i = 0; i < static_cast<int>(hist.size()) - 1; ++i) {
             const TEntryKey key{ ch, hist[i].FromGeneration };
             if (const auto* state = CutState.FindPtr(key); state && *state != ECutState::None) {
@@ -418,7 +413,6 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
         // batch and the safety-net reset below would bump Attempts a second time.
         CutState[key] = ECutState::None;
     }
-    // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
         PublishLevels();
         EraseIf(SweepSurvivors, [&](const TEntryKey& key) {
@@ -427,12 +421,10 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
 
     if (!exhausted) {
-        // More portion batches to check — schedule next batch.
         ctx.Send(TabletActorId, new NColumnShard::TEvPrivate::TEvStartCutHistorySweep());
         return;
     }
 
-    // Cursor exhausted: re-check each survivor and send hard barrier if still safe.
     SweepInFlight = false;
     Signals.OnSweepCompleted();
     PublishLevels(0);
@@ -441,7 +433,6 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     SweepPortionOffset = 0;
 
     for (const auto& key : SweepSurvivors) {
-        // Re-check: counter must still be zero and no blobs in flight.
         if (const auto* count = Counters.FindPtr(key); count && *count != 0) {
             CutState[key] = ECutState::None;
             continue;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -10,6 +10,8 @@
 #include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 
+#include <util/generic/algorithm.h>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD_BLOBS_BS
 
 namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
@@ -389,14 +391,9 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
     // Remove disproved entries from in-progress survivors list.
     if (!disproved.empty()) {
-        TVector<TEntryKey> kept;
-        kept.reserve(SweepSurvivors.size());
-        for (const auto& key : SweepSurvivors) {
-            if (!disproved.contains(key)) {
-                kept.push_back(key);
-            }
-        }
-        SweepSurvivors = std::move(kept);
+        EraseIf(SweepSurvivors, [&](const TEntryKey& key) {
+            return disproved.contains(key);
+        });
     }
 
     if (!exhausted) {

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.cpp
@@ -165,10 +165,7 @@ ui32 THistoryCutterWrapper::GetNextFromGeneration(const TEntryKey& key) const {
         return 0;
     }
     const auto& hist = TabletInfo->Channels[key.Channel].History;
-    // History is ascending by FromGeneration, so the successor is one past the entry
-    // itself; TCmp is the comparator TTabletChannelInfo::GroupForGeneration uses for
-    // the same search. `next == end()` means the entry is the active one, which has no
-    // successor and is therefore never a cut candidate.
+    // History ascends by FromGeneration; end() means the active entry, never a cut candidate.
     const auto next = UpperBound(hist.begin(), hist.end(), key.FromGeneration, TTabletChannelInfo::THistoryEntry::TCmp());
     if (next == hist.begin() || next == hist.end() || (next - 1)->FromGeneration != key.FromGeneration) {
         return 0;
@@ -188,8 +185,7 @@ bool THistoryCutterWrapper::IsDrained(const TEntryKey& key) const {
     if (!manager->HasNoBlobsInRange(key.Channel, key.FromGeneration, nextGen)) {
         return false;
     }
-    // Our blobs shared out to other tablets sit in no GC queue while shared; a hard
-    // barrier would collect them under the borrower, so they pin the entry too.
+    // Shared-out blobs sit in no GC queue, but a hard barrier would collect them under the borrower.
     const auto sharedBlobs = SharedBlobs.lock();
     if (!sharedBlobs) {
         return false;
@@ -209,8 +205,7 @@ bool THistoryCutterWrapper::GetEntryKey(const TLogoBlobID& blobId, TEntryKey& ou
         return false;
     }
     const auto& hist = TabletInfo->Channels[ch].History;
-    // UpperBound lands one past the owning entry: begin() means no entry covers the
-    // generation, end() means the owner is the active entry, never a cut candidate.
+    // UpperBound lands one past the owner: begin() means uncovered, end() means the active entry.
     const auto entry = UpperBound(hist.begin(), hist.end(), blobId.Generation(), TTabletChannelInfo::THistoryEntry::TCmp());
     if (entry == hist.begin() || entry == hist.end()) {
         return false;
@@ -236,11 +231,7 @@ void THistoryCutterWrapper::IncrementCounter(const TEntryKey& key) {
 
 void THistoryCutterWrapper::DecrementCounter(const TEntryKey& key) {
     auto it = Counters.find(key);
-    // Unreachable by design: OnPortionRemoved is fenced by PortionKeys, and PortionKeys and
-    // Counters are written and cleared together, so a portion that was never counted is never
-    // decremented. Poisoning guards against a future divergence between the two maps rather
-    // than any known scenario - if this warning ever fires in production, that divergence is
-    // the bug, not the channel.
+    // Unreachable while PortionKeys fences OnPortionRemoved; poisoning guards a future divergence of the two maps.
     if (it == Counters.end() || it->second == 0) {
         if (PoisonedChannels.insert(key.Channel).second) {
             AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "cut_history_channel_poisoned")("channel", key.Channel)(
@@ -324,8 +315,7 @@ bool THistoryCutterWrapper::TryNominate(const TActorContext& ctx) {
     if (SweepInFlight) {
         return false;
     }
-    // Evaluating candidates scans the GC queues, and background enqueues fire every few
-    // seconds: rate-limit rather than scan per enqueue.
+    // Candidate evaluation scans the GC queues, so rate-limit rather than scan per enqueue.
     if (LastNominateAt && ctx.Now() - LastNominateAt < GetNominateCadence()) {
         return false;
     }
@@ -452,8 +442,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
             CutState[key] = ECutState::None;
             continue;
         }
-        // The history may have changed between nomination and this point — the
-        // same-group safety gate must hold at barrier-send time, not only at nomination.
+        // History may have changed since nomination: the same-group gate must hold at barrier-send time.
         if (!SeenGroupsCheckPasses(key)) {
             CutState[key] = ECutState::None;
             continue;
@@ -467,9 +456,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
 
         std::optional<ui32> groupId;
         if (key.Channel < static_cast<ui32>(TabletInfo->Channels.size())) {
-            // Exact match rather than GroupForGeneration: once the entry has been cut
-            // away, the entry that covers its generation belongs to a different, live
-            // group, and barriering that one would collect blobs still in use.
+            // Exact match, not GroupForGeneration: once cut, that generation resolves to a different live group.
             if (const auto* entry =
                     FindIfPtr(TabletInfo->Channels[key.Channel].History, [&key](const TTabletChannelInfo::THistoryEntry& historyEntry) {
                         return historyEntry.FromGeneration == key.FromGeneration;
@@ -490,8 +477,7 @@ void THistoryCutterWrapper::OnBatchComplete(const THashSet<TEntryKey>& disproved
     }
     SweepSurvivors.clear();
 
-    // Safety net: the disproved loop settled those already, so anything still Verifying
-    // is unexpected — reset it without counting an attempt.
+    // Safety net: the disproved loop settled these already, so reset without counting an attempt.
     for (auto& [key, state] : CutState) {
         if (state == ECutState::Verifying) {
             state = ECutState::None;
@@ -510,11 +496,8 @@ void THistoryCutterWrapper::OnBarrierResult(const TEntryKey& key, bool ok, TInst
         NYDBTest::TControllers::GetColumnShardController()->OnHistoryEntryCut(key.Channel, key.FromGeneration);
     } else {
         *state = ECutState::None;
-        // Without this a failed barrier retried every nomination cadence against the
-        // same obstacle: ~190 wasted sweep+barrier rounds/min measured on a drained
-        // pool. A failure re-enters the disproval cooldown instead. Attempts restarts
-        // at 1 because nomination erased the record right before SentBarrier, so
-        // consecutive failures plateau at cooldown(1) rather than escalating.
+        // A failure enters the disproval cooldown instead of retrying every cadence; Attempts restarts
+        // at 1 because nomination erased the record, so repeated failures plateau at cooldown(1).
         auto& disproval = DisprovedAt[key];
         disproval.At = now;
         ++disproval.Attempts;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -26,8 +26,8 @@ class TStorageSharedBlobsManager;
 namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
 
 struct TEntryKey {
-    ui32 Channel;
-    ui32 FromGeneration;
+    ui32 Channel = 0;
+    ui32 FromGeneration = 0;
 
     bool operator==(const TEntryKey& o) const noexcept {
         return Channel == o.Channel && FromGeneration == o.FromGeneration;
@@ -76,9 +76,8 @@ public:
         return SweepCandidates ? SweepCandidates : empty;
     }
 
-    // Candidates still alive in the current sweep: entries disproved by earlier
-    // batches are excluded, so later batches neither re-examine nor re-disprove
-    // them (which would also inflate the disproval backoff counter).
+    // Excludes entries disproved by earlier batches, so later batches neither re-examine
+    // nor re-disprove them.
     std::shared_ptr<const TVector<TEntryKey>> GetActiveSweepCandidates() const {
         return std::make_shared<const TVector<TEntryKey>>(SweepSurvivors);
     }
@@ -92,9 +91,13 @@ public:
         return Min(cooldown, DisprovedRetryMaxCooldown);
     }
 
-    static constexpr TDuration NominateCadence = TDuration::Minutes(1);
-    // With NominateCadence this bounds IsDrained() queue scans to 8 per minute.
-    static constexpr ui32 MaxDrainChecksPerNomination = 8;
+    // Defaults for TColumnShardConfig.CutHistory*; together they bound IsDrained() queue
+    // scans per tablet, which is the cost that scales with ColumnShards per node.
+    static constexpr TDuration DefaultNominateCadence = TDuration::Minutes(1);
+    static constexpr ui32 DefaultMaxDrainChecksPerNomination = 8;
+
+    static TDuration GetNominateCadence();
+    static ui32 GetMaxDrainChecksPerNomination();
 
 protected:
     void StartSweepForTest(TVector<TEntryKey>&& candidates) {
@@ -125,8 +128,7 @@ protected:
         return count ? *count : 0;
     }
 
-    // Protected rather than private so unit tests can force the underflow branch
-    // (no public call sequence reaches it: OnPortionRemoved is fenced by PortionKeys).
+    // protected for tests: no public call sequence reaches the underflow branch.
     void DecrementCounter(const TEntryKey& key);
 
 public:
@@ -145,15 +147,13 @@ public:
     }
 
     bool HasPortionSnapshot() const {
-        // True from SetPortionSnapshot until the cursor is fully consumed AND reset:
-        // a non-empty vector covers the not-yet-started case, a positive offset covers
-        // the tail where GetNextBatch already handed out every id.
+        // Non-empty vector covers the not-yet-started case; a positive offset covers the
+        // tail where GetNextBatch already handed out every id.
         return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 
     // True when no earlier entry shares the target's GroupID. Already-cut entries are
-    // transparent: they survive in the boot-time TTabletStorageInfo and would otherwise
-    // block a later same-group entry until the next restart.
+    // transparent: they survive in the boot-time TTabletStorageInfo.
     static bool SeenGroupsCheckPasses(
         const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration, const THashSet<ui32>& cutFromGenerations = {});
 
@@ -181,7 +181,6 @@ private:
 
     TPublishedLevels Published;
 
-    // Named Signals because `Counters` below is the per-entry portion refcount map.
     const NColumnShard::THistoryCutterCounters Signals;
 
     TIntrusivePtr<TTabletStorageInfo> TabletInfo;
@@ -205,10 +204,8 @@ private:
     // Shared with per-batch sweep callbacks — one allocation per sweep, not per batch.
     std::shared_ptr<const TVector<TEntryKey>> SweepCandidates;
 
-    // Sweep-disproved entries: re-nomination is pointless until state changes, so it
-    // is suppressed with exponential backoff (base cooldown doubling per consecutive
-    // disproval, capped) — an entry pinned by long-lived portions converges to one
-    // sweep per DisprovedRetryMaxCooldown instead of one per base cooldown forever.
+    // Sweep-disproved entries, suppressed with exponential backoff: an entry pinned by
+    // long-lived portions converges to one sweep per DisprovedRetryMaxCooldown.
     struct TDisprovalState {
         TInstant At;
         ui32 Attempts = 0;
@@ -217,8 +214,6 @@ private:
     THashMap<TEntryKey, TDisprovalState> DisprovedAt;
 
     TInstant LastNominateAt;
-    // First channel to service in the next nomination round (rotation under the
-    // MaxDrainChecksPerNomination cap).
     ui32 NextChannelToCheck = TGlobal::FirstDataChannel;
     TVector<TEntryKey> SweepSurvivors;
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -11,6 +11,7 @@
 #include <util/generic/vector.h>
 
 #include <optional>
+#include <unordered_set>
 
 namespace NKikimr::NOlap {
 class TPortionDataAccessor;
@@ -73,10 +74,30 @@ public:
     bool TryNominate(const TActorContext& ctx);
 
     // Returns current sweep candidates (non-empty while sweep in flight).
-    const TVector<TEntryKey>& GetSweepCandidates() const {
-        return SweepCandidates;
+    std::shared_ptr<const TVector<TEntryKey>> GetSweepCandidates() const {
+        return SweepCandidates ? SweepCandidates : std::make_shared<const TVector<TEntryKey>>();
     }
 
+    static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
+
+protected:
+    // Enters the sweeping state directly (unit tests subclass to reach this; TryNominate
+    // needs a live actor context to send the sweep event, which unit tests do not have).
+    void StartSweepForTest(TVector<TEntryKey>&& candidates) {
+        SweepInFlight = true;
+        SweepSurvivors = candidates;
+        for (const auto& key : SweepSurvivors) {
+            CutState[key] = ECutState::Verifying;
+        }
+        SweepCandidates = std::make_shared<const TVector<TEntryKey>>(std::move(candidates));
+    }
+
+    ECutState GetCutStateForTest(const TEntryKey& key) const {
+        const auto it = CutState.find(key);
+        return it == CutState.end() ? ECutState::None : it->second;
+    }
+
+public:
     // Sets the snapshot of all engine portion IDs that tier-2 will scan.
     // Called by TColumnShard::Handle(TEvStartCutHistorySweep) before the first accessor request.
     void SetPortionSnapshot(TVector<std::pair<TInternalPathId, ui64>>&& ids);
@@ -104,14 +125,19 @@ public:
     }
 
     // Public accessor used by Handle(TEvStartCutHistorySweep) to build nextGenMap for the callback.
-    ui32 GetNextFromGenerationPublic(const TEntryKey& key) const {
+    ui32 GetNextFromGenerationForSweep(const TEntryKey& key) const {
         return GetNextFromGeneration(key);
     }
 
     // Pure function: returns true if no earlier entry in `hist` (all entries before the one
     // with fromGeneration == key.FromGeneration) uses the same GroupID as that entry.
     // Testable without an actor context or THistoryCutterWrapper instance.
-    static bool SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration);
+    // Entries whose FromGeneration is in cutFromGenerations are already barriered and
+    // cut — they are transparent for the same-group safety walk (otherwise a cut entry
+    // still visible in the boot-time TTabletStorageInfo would block a later same-group
+    // entry until the next restart).
+    static bool SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration,
+        const std::unordered_set<ui32>& cutFromGenerations = {});
 
 private:
     bool SeenGroupsCheckPasses(const TEntryKey& key) const;
@@ -142,7 +168,12 @@ private:
     bool SweepInFlight = false;
 
     // Tier-2 sweep state (all in-memory; reset on restart/completion).
-    TVector<TEntryKey> SweepCandidates;
+    // Shared with per-batch sweep callbacks — one allocation per sweep, not per batch.
+    std::shared_ptr<const TVector<TEntryKey>> SweepCandidates;
+    // Sweep-disproved entries: re-nomination is pointless until state changes, so it is
+    // suppressed for DisprovedRetryCooldown to avoid a perpetual nominate/sweep cycle
+    // (tier-1 counters start empty at boot and cannot veto for boot-loaded portions).
+    THashMap<TEntryKey, TInstant> DisprovedAt;
     TVector<TEntryKey> SweepSurvivors;
 
     // Cursor over the engine's in-memory portion snapshot (snapshotted once per sweep).

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -74,7 +74,7 @@ public:
 
     // Returns current sweep candidates (non-empty while sweep in flight).
     const TVector<TEntryKey>& GetSweepCandidates() const {
-        return SweepCandidates_;
+        return SweepCandidates;
     }
 
     // Sets the snapshot of all engine portion IDs that tier-2 will scan.
@@ -95,12 +95,12 @@ public:
 
     bool IsEnabled() const;
 
-    bool SweepInFlight() const {
-        return SweepInFlight_;
+    bool IsSweepInFlight() const {
+        return SweepInFlight;
     }
 
     bool HasPortionSnapshot() const {
-        return SweepPortionOffset_ > 0 || !SweepPortionIds_.empty();
+        return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 
     // Public accessor used by Handle(TEvStartCutHistorySweep) to build nextGenMap for the callback.
@@ -120,7 +120,7 @@ private:
 
     // Computes the entry key (channel, fromGen) for a blob id.
     // Returns false if the blob belongs to the active entry or is foreign.
-    bool GetEntryKey(const TLogoBlobID& lid, TEntryKey& out) const;
+    bool GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const;
 
     void IncrementCounter(const TEntryKey& key);
     void DecrementCounter(const TEntryKey& key);
@@ -139,15 +139,15 @@ private:
     // portionId -> set of TEntryKey the portion contributes to (for decrement at erase).
     THashMap<ui64, THashSet<TEntryKey>> PortionKeys;
 
-    bool SweepInFlight_ = false;
+    bool SweepInFlight = false;
 
     // Tier-2 sweep state (all in-memory; reset on restart/completion).
-    TVector<TEntryKey> SweepCandidates_;
-    TVector<TEntryKey> SweepSurvivors_;
+    TVector<TEntryKey> SweepCandidates;
+    TVector<TEntryKey> SweepSurvivors;
 
     // Cursor over the engine's in-memory portion snapshot (snapshotted once per sweep).
-    TVector<std::pair<TInternalPathId, ui64>> SweepPortionIds_;
-    size_t SweepPortionOffset_ = 0;
+    TVector<std::pair<TInternalPathId, ui64>> SweepPortionIds;
+    size_t SweepPortionOffset = 0;
 };
 
 }   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -81,6 +81,10 @@ public:
 
     static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
     static constexpr TDuration NominateCadence = TDuration::Minutes(1);
+    // Hard cap on IsDrained() queue scans per nomination round: with the cadence this
+    // bounds tablet-thread scan work to MaxDrainChecksPerNomination scans per minute
+    // regardless of how many history entries are eligible.
+    static constexpr ui32 MaxDrainChecksPerNomination = 8;
 
 protected:
     // Enters the sweeping state directly (unit tests subclass to reach this; TryNominate
@@ -178,6 +182,9 @@ private:
     THashMap<TEntryKey, TInstant> DisprovedAt;
     // Last full candidate evaluation; see NominateCadence in TryNominate.
     TInstant LastNominateAt;
+    // First channel to service in the next nomination round (rotation under the
+    // MaxDrainChecksPerNomination cap).
+    ui32 NextChannelToCheck = 2;
     TVector<TEntryKey> SweepSurvivors;
 
     // Cursor over the engine's in-memory portion snapshot (snapshotted once per sweep).

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -5,6 +5,7 @@
 #include <ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h>
 #include <ydb/core/tx/columnshard/common/blob.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
+#include <ydb/core/tx/columnshard/counters/blobs_manager.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
@@ -57,7 +58,7 @@ class THistoryCutterWrapper {
 public:
     THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen,
         const std::weak_ptr<NOlap::TBlobManager>& manager, const std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>& sharedBlobs,
-        const TActorId& tabletActorId);
+        const TActorId& tabletActorId, const NColumnShard::THistoryCutterCounters& signals);
 
     void SetLauncherActorId(const TActorId& id) {
         LauncherActorId = id;
@@ -175,6 +176,22 @@ private:
 
     void IncrementCounter(const TEntryKey& key);
     void DecrementCounter(const TEntryKey& key);
+
+    // Publishes the level sensors as deltas (see OnLevelsDelta). Call after any
+    // change to PoisonedChannels or DisprovedAt; an omitted sweepCandidates
+    // leaves that level unchanged.
+    void PublishLevels(std::optional<ui64> sweepCandidates = {});
+
+    struct TPublishedLevels {
+        ui64 SweepCandidates = 0;
+        ui64 ChannelsPoisoned = 0;
+        ui64 EntriesDisproved = 0;
+    };
+
+    TPublishedLevels Published;
+
+    // Named Signals because `Counters` below is the per-entry portion refcount map.
+    const NColumnShard::THistoryCutterCounters Signals;
 
     TIntrusivePtr<TTabletStorageInfo> TabletInfo;
     ui32 CurrentGen;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -12,7 +12,6 @@
 #include <util/generic/vector.h>
 
 #include <optional>
-#include <unordered_set>
 
 namespace NKikimr::NOlap {
 class TPortionDataAccessor;
@@ -157,25 +156,22 @@ public:
         return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 
-    ui32 GetNextFromGenerationForSweep(const TEntryKey& key) const {
-        return GetNextFromGeneration(key);
-    }
-
     // Pure function: returns true if no earlier entry in `hist` (all entries before the one
     // with fromGeneration == key.FromGeneration) uses the same GroupID as that entry.
     // Entries whose FromGeneration is in cutFromGenerations are already barriered and
     // cut — they are transparent for the same-group safety walk (otherwise a cut entry
     // still visible in the boot-time TTabletStorageInfo would block a later same-group
     // entry until the next restart).
-    static bool SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration,
-        const std::unordered_set<ui32>& cutFromGenerations = {});
+    static bool SeenGroupsCheckPasses(
+        const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration, const THashSet<ui32>& cutFromGenerations = {});
+
+    ui32 GetNextFromGeneration(const TEntryKey& key) const;
 
 protected:
     bool IsDrained(const TEntryKey& key) const;
 
 private:
     bool SeenGroupsCheckPasses(const TEntryKey& key) const;
-    ui32 GetNextFromGeneration(const TEntryKey& key) const;
 
     bool GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const;
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -94,6 +94,15 @@ public:
 
     static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
     static constexpr TDuration DisprovedRetryMaxCooldown = TDuration::Hours(6);
+
+    // Pure function of the attempt count (shift clamped, then capped), public so the
+    // backoff formula is testable without an instance.
+    static TDuration GetDisprovedCooldown(const ui32 attempts) {
+        const ui64 shift = Min<ui32>(attempts, 12);
+        const TDuration cooldown = DisprovedRetryCooldown * (1ull << shift);
+        return Min(cooldown, DisprovedRetryMaxCooldown);
+    }
+
     static constexpr TDuration NominateCadence = TDuration::Minutes(1);
     // Hard cap on IsDrained() queue scans per nomination round: with the cadence this
     // bounds tablet-thread scan work to MaxDrainChecksPerNomination scans per minute
@@ -116,6 +125,24 @@ protected:
         const auto* state = CutState.FindPtr(key);
         return state ? *state : ECutState::None;
     }
+
+    ui32 GetDisprovalAttemptsForTest(const TEntryKey& key) const {
+        const auto* state = DisprovedAt.FindPtr(key);
+        return state ? state->Attempts : 0;
+    }
+
+    bool IsChannelPoisonedForTest(const ui32 channel) const {
+        return PoisonedChannels.contains(channel);
+    }
+
+    ui64 GetCounterForTest(const TEntryKey& key) const {
+        const auto* count = Counters.FindPtr(key);
+        return count ? *count : 0;
+    }
+
+    // Protected rather than private so unit tests can force the underflow branch
+    // (no public call sequence reaches it: OnPortionRemoved is fenced by PortionKeys).
+    void DecrementCounter(const TEntryKey& key);
 
 public:
     // Sets the snapshot of all engine portion IDs that tier-2 will scan.
@@ -175,7 +202,6 @@ private:
     bool GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const;
 
     void IncrementCounter(const TEntryKey& key);
-    void DecrementCounter(const TEntryKey& key);
 
     // Publishes the level sensors as deltas (see OnLevelsDelta). Call after any
     // change to PoisonedChannels or DisprovedAt; an omitted sweepCandidates
@@ -226,12 +252,6 @@ private:
     };
 
     THashMap<TEntryKey, TDisprovalState> DisprovedAt;
-
-    TDuration GetDisprovedCooldown(const ui32 attempts) const {
-        const ui64 shift = Min<ui32>(attempts, 12);
-        const TDuration cooldown = DisprovedRetryCooldown * (1ull << shift);
-        return Min(cooldown, DisprovedRetryMaxCooldown);
-    }
 
     // Last full candidate evaluation; see NominateCadence in TryNominate.
     TInstant LastNominateAt;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -127,6 +127,9 @@ public:
     }
 
     bool HasPortionSnapshot() const {
+        // True from SetPortionSnapshot until the cursor is fully consumed AND reset:
+        // a non-empty vector covers the not-yet-started case, a positive offset covers
+        // the tail where GetNextBatch already handed out every id.
         return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -3,6 +3,7 @@
 
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h>
+#include <ydb/core/tx/columnshard/blobs_action/common/const.h>
 #include <ydb/core/tx/columnshard/common/blob.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/counters/blobs_manager.h>
@@ -51,7 +52,7 @@ enum class ECutState {
     Cut,
 };
 
-// Two-tier engine for CutTabletHistory on ColumnShard data channels (channels >= 2).
+// Two-tier engine for CutTabletHistory on the ColumnShard data channels.
 class THistoryCutterWrapper {
 public:
     THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen,
@@ -228,7 +229,7 @@ private:
     TInstant LastNominateAt;
     // First channel to service in the next nomination round (rotation under the
     // MaxDrainChecksPerNomination cap).
-    ui32 NextChannelToCheck = 2;
+    ui32 NextChannelToCheck = TGlobal::FirstDataChannel;
     TVector<TEntryKey> SweepSurvivors;
 
     TVector<std::pair<TInternalPathId, ui64>> SweepPortionIds;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -161,9 +161,12 @@ public:
     static bool SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration,
         const std::unordered_set<ui32>& cutFromGenerations = {});
 
+protected:
+    // Also reachable from the unit-test subclass (drain-gate integration tests).
+    bool IsDrained(const TEntryKey& key) const;
+
 private:
     bool SeenGroupsCheckPasses(const TEntryKey& key) const;
-    bool IsDrained(const TEntryKey& key) const;
     ui32 GetNextFromGeneration(const TEntryKey& key) const;
 
     // Computes the entry key (channel, fromGen) for a blob id.

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -75,10 +75,12 @@ public:
 
     // Returns current sweep candidates (non-empty while sweep in flight).
     std::shared_ptr<const TVector<TEntryKey>> GetSweepCandidates() const {
-        return SweepCandidates ? SweepCandidates : std::make_shared<const TVector<TEntryKey>>();
+        static const auto empty = std::make_shared<const TVector<TEntryKey>>();
+        return SweepCandidates ? SweepCandidates : empty;
     }
 
     static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
+    static constexpr TDuration NominateCadence = TDuration::Minutes(1);
 
 protected:
     // Enters the sweeping state directly (unit tests subclass to reach this; TryNominate
@@ -174,6 +176,8 @@ private:
     // suppressed for DisprovedRetryCooldown to avoid a perpetual nominate/sweep cycle
     // (tier-1 counters start empty at boot and cannot veto for boot-loaded portions).
     THashMap<TEntryKey, TInstant> DisprovedAt;
+    // Last full candidate evaluation; see NominateCadence in TryNominate.
+    TInstant LastNominateAt;
     TVector<TEntryKey> SweepSurvivors;
 
     // Cursor over the engine's in-memory portion snapshot (snapshotted once per sweep).

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -1,0 +1,149 @@
+#pragma once
+#include "address.h"
+
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/tx/columnshard/blobs_action/abstract/blob_set.h>
+#include <ydb/core/tx/columnshard/common/blob.h>
+#include <ydb/core/tx/columnshard/common/path_id.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
+
+#include <optional>
+
+namespace NKikimr::NOlap {
+class TPortionDataAccessor;
+class TBlobManager;
+}   // namespace NKikimr::NOlap
+
+namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
+
+struct TEntryKey {
+    ui32 Channel;
+    ui32 FromGeneration;
+
+    bool operator==(const TEntryKey& o) const noexcept {
+        return Channel == o.Channel && FromGeneration == o.FromGeneration;
+    }
+};
+
+}   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage
+
+template <>
+struct THash<NKikimr::NOlap::NBlobOperations::NBlobStorage::TEntryKey> {
+    size_t operator()(const NKikimr::NOlap::NBlobOperations::NBlobStorage::TEntryKey& k) const noexcept {
+        return CombineHashes<ui32>(k.Channel, k.FromGeneration);
+    }
+};
+
+namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
+
+enum class ECutState {
+    None,
+    Verifying,
+    SentBarrier,
+    Cut,
+};
+
+// Two-tier engine for CutTabletHistory on ColumnShard data channels (channels >= 2).
+// Owned by TBlobManager; accessed from TColumnShard for nomination and sweep callbacks.
+class THistoryCutterWrapper {
+public:
+    THistoryCutterWrapper(
+        const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen, NOlap::TBlobManager* manager, const TActorId& tabletActorId);
+
+    void SetLauncherActorId(const TActorId& id) {
+        LauncherActorId = id;
+    }
+
+    // Called on write-index-complete path when a portion is added to the engine.
+    void OnPortionAdded(const TPortionDataAccessor& accessor);
+
+    // Called on cleanup-complete path when a portion is durably erased from the engine.
+    void OnPortionRemoved(ui64 portionId);
+
+    // One-shot rebuild after all granules finish loading at boot.
+    // portionBlobIds: portionId -> blob ids for that portion.
+    void OnBootComplete(const THashMap<ui64, std::vector<TUnifiedBlobId>>& portionBlobIds);
+
+    // Nominates candidates for cutting. Starts tier-2 cursor scan by sending
+    // TEvStartCutHistorySweep to the tablet actor and returning true.
+    // Returns false when sweep already in flight or no candidates.
+    bool TryNominate(const TActorContext& ctx);
+
+    // Returns current sweep candidates (non-empty while sweep in flight).
+    const TVector<TEntryKey>& GetSweepCandidates() const {
+        return SweepCandidates_;
+    }
+
+    // Sets the snapshot of all engine portion IDs that tier-2 will scan.
+    // Called by TColumnShard::Handle(TEvStartCutHistorySweep) before the first accessor request.
+    void SetPortionSnapshot(TVector<std::pair<TInternalPathId, ui64>>&& ids);
+
+    // Returns the next batch of at most batchSize portion IDs, advancing the internal offset.
+    // isLast is set to true if this is the last batch (offset reaches end).
+    TVector<std::pair<TInternalPathId, ui64>> GetNextBatch(size_t batchSize, bool& isLast);
+
+    // Called by Handle(TEvCutHistorySweepBatchDone) after each accessor batch.
+    // disproved: {channel, fromGeneration} pairs whose blobs were found in this batch.
+    // exhausted: true when the portion snapshot is fully consumed.
+    void OnBatchComplete(const THashSet<TEntryKey>& disproved, bool exhausted, const TActorContext& ctx);
+
+    // Called by barrier actor result handler in TColumnShard.
+    void OnBarrierResult(const TEntryKey& key, bool ok);
+
+    bool IsEnabled() const;
+
+    bool SweepInFlight() const {
+        return SweepInFlight_;
+    }
+
+    bool HasPortionSnapshot() const {
+        return SweepPortionOffset_ > 0 || !SweepPortionIds_.empty();
+    }
+
+    // Public accessor used by Handle(TEvStartCutHistorySweep) to build nextGenMap for the callback.
+    ui32 GetNextFromGenerationPublic(const TEntryKey& key) const {
+        return GetNextFromGeneration(key);
+    }
+
+private:
+    bool IsActiveEntry(const TEntryKey& key) const;
+    bool SeenGroupsCheckPasses(const TEntryKey& key) const;
+    bool IsDrained(const TEntryKey& key) const;
+    ui32 GetNextFromGeneration(const TEntryKey& key) const;
+
+    // Computes the entry key (channel, fromGen) for a blob id.
+    // Returns false if the blob belongs to the active entry or is foreign.
+    bool GetEntryKey(const TLogoBlobID& lid, TEntryKey& out) const;
+
+    void IncrementCounter(const TEntryKey& key);
+    void DecrementCounter(const TEntryKey& key);
+
+    TIntrusivePtr<TTabletStorageInfo> TabletInfo;
+    ui32 CurrentGen;
+    NOlap::TBlobManager* Manager;   // not owned
+    TActorId TabletActorId;
+    TActorId LauncherActorId;
+
+    // Tier-1 state (all ephemeral — reconstructed on restart).
+    THashMap<TEntryKey, ui64> Counters;
+    THashMap<TEntryKey, ECutState> CutState;
+    THashSet<ui32> PoisonedChannels;
+
+    // portionId -> set of TEntryKey the portion contributes to (for decrement at erase).
+    THashMap<ui64, THashSet<TEntryKey>> PortionKeys;
+
+    bool SweepInFlight_ = false;
+
+    // Tier-2 sweep state (all in-memory; reset on restart/completion).
+    TVector<TEntryKey> SweepCandidates_;
+    TVector<TEntryKey> SweepSurvivors_;
+
+    // Cursor over the engine's in-memory portion snapshot (snapshotted once per sweep).
+    TVector<std::pair<TInternalPathId, ui64>> SweepPortionIds_;
+    size_t SweepPortionOffset_ = 0;
+};
+
+}   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -16,6 +16,10 @@
 namespace NKikimr::NOlap {
 class TPortionDataAccessor;
 class TBlobManager;
+
+namespace NDataSharing {
+class TStorageSharedBlobsManager;
+}   // namespace NDataSharing
 }   // namespace NKikimr::NOlap
 
 namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
@@ -52,7 +56,8 @@ enum class ECutState {
 class THistoryCutterWrapper {
 public:
     THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen,
-        const std::weak_ptr<NOlap::TBlobManager>& manager, const TActorId& tabletActorId);
+        const std::weak_ptr<NOlap::TBlobManager>& manager, const std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>& sharedBlobs,
+        const TActorId& tabletActorId);
 
     void SetLauncherActorId(const TActorId& id) {
         LauncherActorId = id;
@@ -163,6 +168,9 @@ private:
     TIntrusivePtr<TTabletStorageInfo> TabletInfo;
     ui32 CurrentGen;
     std::weak_ptr<NOlap::TBlobManager> Manager;
+    // Our blobs shared out to other tablets are in no GC queue while shared; the
+    // drain gate consults this registry before a hard barrier.
+    std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> SharedBlobs;
     TActorId TabletActorId;
     TActorId LauncherActorId;
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -84,6 +84,13 @@ public:
         return SweepCandidates ? SweepCandidates : empty;
     }
 
+    // Candidates still alive in the current sweep: entries disproved by earlier
+    // batches are excluded, so later batches neither re-examine nor re-disprove
+    // them (which would also inflate the disproval backoff counter).
+    std::shared_ptr<const TVector<TEntryKey>> GetActiveSweepCandidates() const {
+        return std::make_shared<const TVector<TEntryKey>>(SweepSurvivors);
+    }
+
     static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
     static constexpr TDuration DisprovedRetryMaxCooldown = TDuration::Hours(6);
     static constexpr TDuration NominateCadence = TDuration::Minutes(1);

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -86,8 +86,6 @@ public:
     static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
     static constexpr TDuration DisprovedRetryMaxCooldown = TDuration::Hours(6);
 
-    // Pure function of the attempt count (shift clamped, then capped), public so the
-    // backoff formula is testable without an instance.
     static TDuration GetDisprovedCooldown(const ui32 attempts) {
         const ui64 shift = Min<ui32>(attempts, 12);
         const TDuration cooldown = DisprovedRetryCooldown * (1ull << shift);
@@ -95,14 +93,10 @@ public:
     }
 
     static constexpr TDuration NominateCadence = TDuration::Minutes(1);
-    // Hard cap on IsDrained() queue scans per nomination round: with the cadence this
-    // bounds tablet-thread scan work to MaxDrainChecksPerNomination scans per minute
-    // regardless of how many history entries are eligible.
+    // With NominateCadence this bounds IsDrained() queue scans to 8 per minute.
     static constexpr ui32 MaxDrainChecksPerNomination = 8;
 
 protected:
-    // Enters the sweeping state directly (unit tests subclass to reach this; TryNominate
-    // needs a live actor context to send the sweep event, which unit tests do not have).
     void StartSweepForTest(TVector<TEntryKey>&& candidates) {
         SweepInFlight = true;
         SweepSurvivors = candidates;
@@ -157,12 +151,9 @@ public:
         return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 
-    // Pure function: returns true if no earlier entry in `hist` (all entries before the one
-    // with fromGeneration == key.FromGeneration) uses the same GroupID as that entry.
-    // Entries whose FromGeneration is in cutFromGenerations are already barriered and
-    // cut — they are transparent for the same-group safety walk (otherwise a cut entry
-    // still visible in the boot-time TTabletStorageInfo would block a later same-group
-    // entry until the next restart).
+    // True when no earlier entry shares the target's GroupID. Already-cut entries are
+    // transparent: they survive in the boot-time TTabletStorageInfo and would otherwise
+    // block a later same-group entry until the next restart.
     static bool SeenGroupsCheckPasses(
         const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration, const THashSet<ui32>& cutFromGenerations = {});
 
@@ -178,9 +169,8 @@ private:
 
     void IncrementCounter(const TEntryKey& key);
 
-    // Publishes the level sensors as deltas (see OnLevelsDelta). Call after any
-    // change to PoisonedChannels or DisprovedAt; an omitted sweepCandidates
-    // leaves that level unchanged.
+    // Call after any change to PoisonedChannels or DisprovedAt; an omitted
+    // sweepCandidates leaves that level unchanged.
     void PublishLevels(std::optional<ui64> sweepCandidates = {});
 
     struct TPublishedLevels {

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -53,7 +53,6 @@ enum class ECutState {
 };
 
 // Two-tier engine for CutTabletHistory on ColumnShard data channels (channels >= 2).
-// Owned by TBlobManager; accessed from TColumnShard for nomination and sweep callbacks.
 class THistoryCutterWrapper {
 public:
     THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen,
@@ -64,22 +63,14 @@ public:
         LauncherActorId = id;
     }
 
-    // Called on write-index-complete path when a portion is added to the engine.
     void OnPortionAdded(const TPortionDataAccessor& accessor);
 
-    // Called on cleanup-complete path when a portion is durably erased from the engine.
     void OnPortionRemoved(ui64 portionId);
 
-    // One-shot rebuild after all granules finish loading at boot.
-    // portionBlobIds: portionId -> blob ids for that portion.
     void OnBootComplete(const THashMap<ui64, std::vector<TUnifiedBlobId>>& portionBlobIds);
 
-    // Nominates candidates for cutting. Starts tier-2 cursor scan by sending
-    // TEvStartCutHistorySweep to the tablet actor and returning true.
-    // Returns false when sweep already in flight or no candidates.
     bool TryNominate(const TActorContext& ctx);
 
-    // Returns current sweep candidates (non-empty while sweep in flight).
     std::shared_ptr<const TVector<TEntryKey>> GetSweepCandidates() const {
         static const auto empty = std::make_shared<const TVector<TEntryKey>>();
         return SweepCandidates ? SweepCandidates : empty;
@@ -145,20 +136,12 @@ protected:
     void DecrementCounter(const TEntryKey& key);
 
 public:
-    // Sets the snapshot of all engine portion IDs that tier-2 will scan.
-    // Called by TColumnShard::Handle(TEvStartCutHistorySweep) before the first accessor request.
     void SetPortionSnapshot(TVector<std::pair<TInternalPathId, ui64>>&& ids);
 
-    // Returns the next batch of at most batchSize portion IDs, advancing the internal offset.
-    // isLast is set to true if this is the last batch (offset reaches end).
     TVector<std::pair<TInternalPathId, ui64>> GetNextBatch(size_t batchSize, bool& isLast);
 
-    // Called by Handle(TEvCutHistorySweepBatchDone) after each accessor batch.
-    // disproved: {channel, fromGeneration} pairs whose blobs were found in this batch.
-    // exhausted: true when the portion snapshot is fully consumed.
     void OnBatchComplete(const THashSet<TEntryKey>& disproved, bool exhausted, const TActorContext& ctx);
 
-    // Called by barrier actor result handler in TColumnShard.
     void OnBarrierResult(const TEntryKey& key, bool ok);
 
     bool IsEnabled() const;
@@ -174,14 +157,12 @@ public:
         return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 
-    // Public accessor used by Handle(TEvStartCutHistorySweep) to build nextGenMap for the callback.
     ui32 GetNextFromGenerationForSweep(const TEntryKey& key) const {
         return GetNextFromGeneration(key);
     }
 
     // Pure function: returns true if no earlier entry in `hist` (all entries before the one
     // with fromGeneration == key.FromGeneration) uses the same GroupID as that entry.
-    // Testable without an actor context or THistoryCutterWrapper instance.
     // Entries whose FromGeneration is in cutFromGenerations are already barriered and
     // cut — they are transparent for the same-group safety walk (otherwise a cut entry
     // still visible in the boot-time TTabletStorageInfo would block a later same-group
@@ -190,15 +171,12 @@ public:
         const std::unordered_set<ui32>& cutFromGenerations = {});
 
 protected:
-    // Also reachable from the unit-test subclass (drain-gate integration tests).
     bool IsDrained(const TEntryKey& key) const;
 
 private:
     bool SeenGroupsCheckPasses(const TEntryKey& key) const;
     ui32 GetNextFromGeneration(const TEntryKey& key) const;
 
-    // Computes the entry key (channel, fromGen) for a blob id.
-    // Returns false if the blob belongs to the active entry or is foreign.
     bool GetEntryKey(const TLogoBlobID& blobId, TEntryKey& out) const;
 
     void IncrementCounter(const TEntryKey& key);
@@ -233,12 +211,10 @@ private:
     THashMap<TEntryKey, ECutState> CutState;
     THashSet<ui32> PoisonedChannels;
 
-    // portionId -> set of TEntryKey the portion contributes to (for decrement at erase).
     THashMap<ui64, THashSet<TEntryKey>> PortionKeys;
 
     bool SweepInFlight = false;
 
-    // Tier-2 sweep state (all in-memory; reset on restart/completion).
     // Shared with per-batch sweep callbacks — one allocation per sweep, not per batch.
     std::shared_ptr<const TVector<TEntryKey>> SweepCandidates;
 
@@ -253,14 +229,12 @@ private:
 
     THashMap<TEntryKey, TDisprovalState> DisprovedAt;
 
-    // Last full candidate evaluation; see NominateCadence in TryNominate.
     TInstant LastNominateAt;
     // First channel to service in the next nomination round (rotation under the
     // MaxDrainChecksPerNomination cap).
     ui32 NextChannelToCheck = 2;
     TVector<TEntryKey> SweepSurvivors;
 
-    // Cursor over the engine's in-memory portion snapshot (snapshotted once per sweep).
     TVector<std::pair<TInternalPathId, ui64>> SweepPortionIds;
     size_t SweepPortionOffset = 0;
 };

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -108,8 +108,12 @@ public:
         return GetNextFromGeneration(key);
     }
 
+    // Pure function: returns true if no earlier entry in `hist` (all entries before the one
+    // with fromGeneration == key.FromGeneration) uses the same GroupID as that entry.
+    // Testable without an actor context or THistoryCutterWrapper instance.
+    static bool SeenGroupsCheckPasses(const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration);
+
 private:
-    bool IsActiveEntry(const TEntryKey& key) const;
     bool SeenGroupsCheckPasses(const TEntryKey& key) const;
     bool IsDrained(const TEntryKey& key) const;
     ui32 GetNextFromGeneration(const TEntryKey& key) const;

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -85,6 +85,7 @@ public:
     }
 
     static constexpr TDuration DisprovedRetryCooldown = TDuration::Minutes(5);
+    static constexpr TDuration DisprovedRetryMaxCooldown = TDuration::Hours(6);
     static constexpr TDuration NominateCadence = TDuration::Minutes(1);
     // Hard cap on IsDrained() queue scans per nomination round: with the cadence this
     // bounds tablet-thread scan work to MaxDrainChecksPerNomination scans per minute
@@ -187,10 +188,24 @@ private:
     // Tier-2 sweep state (all in-memory; reset on restart/completion).
     // Shared with per-batch sweep callbacks — one allocation per sweep, not per batch.
     std::shared_ptr<const TVector<TEntryKey>> SweepCandidates;
-    // Sweep-disproved entries: re-nomination is pointless until state changes, so it is
-    // suppressed for DisprovedRetryCooldown to avoid a perpetual nominate/sweep cycle
-    // (tier-1 counters start empty at boot and cannot veto for boot-loaded portions).
-    THashMap<TEntryKey, TInstant> DisprovedAt;
+
+    // Sweep-disproved entries: re-nomination is pointless until state changes, so it
+    // is suppressed with exponential backoff (base cooldown doubling per consecutive
+    // disproval, capped) — an entry pinned by long-lived portions converges to one
+    // sweep per DisprovedRetryMaxCooldown instead of one per base cooldown forever.
+    struct TDisprovalState {
+        TInstant At;
+        ui32 Attempts = 0;
+    };
+
+    THashMap<TEntryKey, TDisprovalState> DisprovedAt;
+
+    TDuration GetDisprovedCooldown(const ui32 attempts) const {
+        const ui64 shift = Min<ui32>(attempts, 12);
+        const TDuration cooldown = DisprovedRetryCooldown * (1ull << shift);
+        return Min(cooldown, DisprovedRetryMaxCooldown);
+    }
+
     // Last full candidate evaluation; see NominateCadence in TryNominate.
     TInstant LastNominateAt;
     // First channel to service in the next nomination round (rotation under the

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -50,8 +50,8 @@ enum class ECutState {
 // Owned by TBlobManager; accessed from TColumnShard for nomination and sweep callbacks.
 class THistoryCutterWrapper {
 public:
-    THistoryCutterWrapper(
-        const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen, NOlap::TBlobManager* manager, const TActorId& tabletActorId);
+    THistoryCutterWrapper(const TIntrusivePtr<TTabletStorageInfo>& tabletInfo, ui32 currentGen,
+        const std::weak_ptr<NOlap::TBlobManager>& manager, const TActorId& tabletActorId);
 
     void SetLauncherActorId(const TActorId& id) {
         LauncherActorId = id;
@@ -127,7 +127,7 @@ private:
 
     TIntrusivePtr<TTabletStorageInfo> TabletInfo;
     ui32 CurrentGen;
-    NOlap::TBlobManager* Manager;   // not owned
+    std::weak_ptr<NOlap::TBlobManager> Manager;
     TActorId TabletActorId;
     TActorId LauncherActorId;
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -138,7 +138,7 @@ public:
 
     void OnBatchComplete(const THashSet<TEntryKey>& disproved, bool exhausted, const TActorContext& ctx);
 
-    void OnBarrierResult(const TEntryKey& key, bool ok);
+    void OnBarrierResult(const TEntryKey& key, bool ok, TInstant now);
 
     bool IsEnabled() const;
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -113,8 +113,8 @@ protected:
     }
 
     ECutState GetCutStateForTest(const TEntryKey& key) const {
-        const auto it = CutState.find(key);
-        return it == CutState.end() ? ECutState::None : it->second;
+        const auto* state = CutState.FindPtr(key);
+        return state ? *state : ECutState::None;
     }
 
 public:

--- a/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h
@@ -76,8 +76,7 @@ public:
         return SweepCandidates ? SweepCandidates : empty;
     }
 
-    // Excludes entries disproved by earlier batches, so later batches neither re-examine
-    // nor re-disprove them.
+    // Excludes entries disproved by earlier batches, so later ones neither re-examine nor re-disprove them.
     std::shared_ptr<const TVector<TEntryKey>> GetActiveSweepCandidates() const {
         return std::make_shared<const TVector<TEntryKey>>(SweepSurvivors);
     }
@@ -91,8 +90,7 @@ public:
         return Min(cooldown, DisprovedRetryMaxCooldown);
     }
 
-    // Defaults for TColumnShardConfig.CutHistory*; together they bound IsDrained() queue
-    // scans per tablet, which is the cost that scales with ColumnShards per node.
+    // Defaults for TColumnShardConfig.CutHistory*: they bound IsDrained() queue scans per tablet.
     static constexpr TDuration DefaultNominateCadence = TDuration::Minutes(1);
     static constexpr ui32 DefaultMaxDrainChecksPerNomination = 8;
 
@@ -147,13 +145,11 @@ public:
     }
 
     bool HasPortionSnapshot() const {
-        // Non-empty vector covers the not-yet-started case; a positive offset covers the
-        // tail where GetNextBatch already handed out every id.
+        // Non-empty covers the not-yet-started case; a positive offset covers the fully handed-out tail.
         return SweepPortionOffset > 0 || !SweepPortionIds.empty();
     }
 
-    // True when no earlier entry shares the target's GroupID. Already-cut entries are
-    // transparent: they survive in the boot-time TTabletStorageInfo.
+    // True when no earlier entry shares the target's GroupID; already-cut entries are transparent.
     static bool SeenGroupsCheckPasses(
         const std::vector<TTabletChannelInfo::THistoryEntry>& hist, ui32 fromGeneration, const THashSet<ui32>& cutFromGenerations = {});
 
@@ -169,8 +165,7 @@ private:
 
     void IncrementCounter(const TEntryKey& key);
 
-    // Call after any change to PoisonedChannels or DisprovedAt; an omitted
-    // sweepCandidates leaves that level unchanged.
+    // Call after any change to PoisonedChannels or DisprovedAt; omitted sweepCandidates leaves it unchanged.
     void PublishLevels(std::optional<ui64> sweepCandidates = {});
 
     struct TPublishedLevels {
@@ -186,8 +181,7 @@ private:
     TIntrusivePtr<TTabletStorageInfo> TabletInfo;
     ui32 CurrentGen;
     std::weak_ptr<NOlap::TBlobManager> Manager;
-    // Our blobs shared out to other tablets are in no GC queue while shared; the
-    // drain gate consults this registry before a hard barrier.
+    // Shared-out blobs are in no GC queue, so the drain gate consults this registry before a hard barrier.
     std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> SharedBlobs;
     TActorId TabletActorId;
     TActorId LauncherActorId;
@@ -204,8 +198,7 @@ private:
     // Shared with per-batch sweep callbacks — one allocation per sweep, not per batch.
     std::shared_ptr<const TVector<TEntryKey>> SweepCandidates;
 
-    // Sweep-disproved entries, suppressed with exponential backoff: an entry pinned by
-    // long-lived portions converges to one sweep per DisprovedRetryMaxCooldown.
+    // Sweep-disproved entries with exponential backoff, converging to one sweep per DisprovedRetryMaxCooldown.
     struct TDisprovalState {
         TInstant At;
         ui32 Attempts = 0;

--- a/ydb/core/tx/columnshard/blobs_action/bs/storage.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/storage.h
@@ -62,10 +62,6 @@ public:
         return Manager->GetHistoryCutter();
     }
 
-    const THistoryCutterWrapper* GetHistoryCutter() const {
-        return std::as_const(*Manager).GetHistoryCutter();
-    }
-
     void InitHistoryCutter(const TActorId& tabletActorId) {
         Manager->InitHistoryCutter(Manager, GetSharedBlobs(), tabletActorId);
     }

--- a/ydb/core/tx/columnshard/blobs_action/bs/storage.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/storage.h
@@ -62,8 +62,12 @@ public:
         return Manager->GetHistoryCutter();
     }
 
+    const THistoryCutterWrapper* GetHistoryCutter() const {
+        return std::as_const(*Manager).GetHistoryCutter();
+    }
+
     void InitHistoryCutter(const TActorId& tabletActorId) {
-        Manager->InitHistoryCutter(tabletActorId);
+        Manager->InitHistoryCutter(Manager, tabletActorId);
     }
 };
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/storage.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/storage.h
@@ -67,7 +67,7 @@ public:
     }
 
     void InitHistoryCutter(const TActorId& tabletActorId) {
-        Manager->InitHistoryCutter(Manager, tabletActorId);
+        Manager->InitHistoryCutter(Manager, GetSharedBlobs(), tabletActorId);
     }
 };
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/storage.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/storage.h
@@ -57,6 +57,14 @@ public:
     virtual bool IsReady() const override {
         return true;
     }
+
+    THistoryCutterWrapper* GetHistoryCutter() {
+        return Manager->GetHistoryCutter();
+    }
+
+    void InitHistoryCutter(const TActorId& tabletActorId) {
+        Manager->InitHistoryCutter(tabletActorId);
+    }
 };
 
 }   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage

--- a/ydb/core/tx/columnshard/blobs_action/bs/ya.make
+++ b/ydb/core/tx/columnshard/blobs_action/bs/ya.make
@@ -4,6 +4,7 @@ SRCS(
     address.cpp
     gc.cpp
     gc_actor.cpp
+    history_cutter.cpp
     write.cpp
     read.cpp
     storage.cpp
@@ -16,6 +17,7 @@ PEERDIR(
     contrib/libs/apache/arrow
     ydb/core/tablet_flat
     ydb/core/tx/tiering
+    ydb/core/tx/columnshard/common
     ydb/core/tx/columnshard/data_sharing/protos
     ydb/core/tx/columnshard/blobs_action/abstract
 )

--- a/ydb/core/tx/columnshard/blobs_action/common/const.h
+++ b/ydb/core/tx/columnshard/blobs_action/common/const.h
@@ -1,10 +1,14 @@
 #pragma once
 #include <util/generic/string.h>
+#include <util/system/types.h>
 
 namespace NKikimr::NOlap::NBlobOperations {
 
 class TGlobal {
 public:
+    // Channels 0 and 1 belong to the executor (log, local database); portions start here.
+    static constexpr ui32 FirstDataChannel = 2;
+
     static const inline TString DefaultStorageId = "__DEFAULT";
     static const inline TString MemoryStorageId = "__MEMORY";
     static const inline TString LocalMetadataStorageId = "__LOCAL_METADATA";

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.cpp
@@ -1,0 +1,2 @@
+// TTxCutHistorySweep is superseded by the in-memory portion list + accessor path (Spec #3).
+// Kept as an empty translation unit so ya.make compilation unit stays valid.

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.cpp
@@ -1,2 +1,0 @@
-// TTxCutHistorySweep is superseded by the in-memory portion list + accessor path (Spec #3).
-// Kept as an empty translation unit so ya.make compilation unit stays valid.

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.h
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.h
@@ -1,0 +1,3 @@
+#pragma once
+// TTxCutHistorySweep is superseded by the in-memory portion list + accessor path (Spec #3).
+// Kept as a stub so ya.make compilation unit stays valid.

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.h
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_cut_history_sweep.h
@@ -1,3 +1,0 @@
-#pragma once
-// TTxCutHistorySweep is superseded by the in-memory portion list + accessor path (Spec #3).
-// Kept as a stub so ya.make compilation unit stays valid.

--- a/ydb/core/tx/columnshard/blobs_action/transaction/ya.make
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    tx_cut_history_sweep.cpp
     tx_draft.cpp
     tx_write_index.cpp
     tx_gc_indexed.cpp

--- a/ydb/core/tx/columnshard/blobs_action/transaction/ya.make
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/ya.make
@@ -1,7 +1,6 @@
 LIBRARY()
 
 SRCS(
-    tx_cut_history_sweep.cpp
     tx_draft.cpp
     tx_write_index.cpp
     tx_gc_indexed.cpp

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -90,6 +90,7 @@ void TColumnShard::TrySwitchToWork(const TActorContext& ctx) {
             {"event", "initialize_shard"},
             {"step", "SwitchToWork"});
         Become(&TThis::StateWork);
+        SetupCutHistory();
         SignalTabletActive(ctx);
         YDB_LOG_INFO("",
             {"event", "initialize_shard"},

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -39,37 +39,42 @@ public:
     }
 
     void OnAccessorsFetched(std::vector<std::shared_ptr<NOlap::TPortionDataAccessor>>&& accessors) override {
-        TVector<std::pair<ui32, ui32>> disproved;
+        THashSet<TEntryKey> disprovedKeys;
 
         for (const auto& accessor : accessors) {
             if (!accessor) {
                 continue;
             }
+            if (disprovedKeys.size() == Candidates->size()) {
+                break;
+            }
             for (const auto& blobId : accessor->GetBlobIds()) {
-                const TLogoBlobID& lid = blobId.GetLogoBlobId();
+                const TLogoBlobID& logoBlobId = blobId.GetLogoBlobId();
                 // Skip blobs from other tablets (shared/borrowed) — they must not disprove our candidates.
-                if (lid.TabletID() != OurTabletId) {
+                if (logoBlobId.TabletID() != OurTabletId) {
                     continue;
                 }
                 for (const auto& key : *Candidates) {
-                    if (lid.Channel() != key.Channel) {
+                    if (logoBlobId.Channel() != key.Channel || disprovedKeys.contains(key)) {
                         continue;
                     }
-                    const ui32 gen = lid.Generation();
+                    const ui32 gen = logoBlobId.Generation();
                     if (gen < key.FromGeneration) {
                         continue;
                     }
                     const auto it = NextGenMap.find(key);
                     if (it != NextGenMap.end() && gen < it->second) {
-                        disproved.emplace_back(key.Channel, key.FromGeneration);
+                        disprovedKeys.emplace(key);
                     }
                 }
             }
         }
 
-        // Deduplicate disproved (multiple blobs from same entry).
-        std::sort(disproved.begin(), disproved.end());
-        disproved.erase(std::unique(disproved.begin(), disproved.end()), disproved.end());
+        TVector<std::pair<ui32, ui32>> disproved;
+        disproved.reserve(disprovedKeys.size());
+        for (const auto& key : disprovedKeys) {
+            disproved.emplace_back(key.Channel, key.FromGeneration);
+        }
 
         NActors::TActivationContext::AsActorContext().Send(
             TabletActorId, new TEvPrivate::TEvCutHistorySweepBatchDone(std::move(disproved), Exhausted));

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -1,0 +1,193 @@
+#include "columnshard_impl.h"
+
+#include <ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h>
+#include <ydb/core/tx/columnshard/blobs_action/bs/storage.h>
+#include <ydb/core/tx/columnshard/blobs_action/counters/storage.h>
+#include <ydb/core/tx/columnshard/data_accessor/abstract/collector.h>
+#include <ydb/core/tx/columnshard/engines/column_engine_logs.h>
+#include <ydb/core/tx/columnshard/engines/storage/granule/granule.h>
+
+#include <ydb/library/actors/core/actor.h>
+
+#include <algorithm>
+
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
+
+namespace NKikimr::NColumnShard {
+
+namespace {
+
+using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
+using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
+
+// ---- TCutHistorySweepCallback -----------------------------------------------
+//
+// Runs on the conveyor thread after TTxAskPortionChunks delivers accessor objects.
+// Inspects each portion's blob IDs against the current sweep candidates and
+// sends TEvCutHistorySweepBatchDone back to the tablet.
+//
+class TCutHistorySweepCallback: public NOlap::NDataAccessorControl::IAccessorCallback {
+public:
+    TCutHistorySweepCallback(
+        const TActorId& tabletActorId, TVector<TEntryKey>&& candidates, THashMap<TEntryKey, ui32>&& nextGenMap, bool exhausted)
+        : TabletActorId(tabletActorId)
+        , Candidates(std::move(candidates))
+        , NextGenMap(std::move(nextGenMap))
+        , Exhausted(exhausted)
+    {
+    }
+
+    void OnAccessorsFetched(std::vector<std::shared_ptr<NOlap::TPortionDataAccessor>>&& accessors) override {
+        TVector<std::pair<ui32, ui32>> disproved;
+
+        for (const auto& accessor : accessors) {
+            if (!accessor) {
+                continue;
+            }
+            for (const auto& blobId : accessor->GetBlobIds()) {
+                const TLogoBlobID& lid = blobId.GetLogoBlobId();
+                for (const auto& key : Candidates) {
+                    if (lid.Channel() != key.Channel) {
+                        continue;
+                    }
+                    const ui32 gen = lid.Generation();
+                    if (gen < key.FromGeneration) {
+                        continue;
+                    }
+                    const auto it = NextGenMap.find(key);
+                    if (it != NextGenMap.end() && gen < it->second) {
+                        disproved.emplace_back(key.Channel, key.FromGeneration);
+                    }
+                }
+            }
+        }
+
+        // Deduplicate disproved (multiple blobs from same entry).
+        std::sort(disproved.begin(), disproved.end());
+        disproved.erase(std::unique(disproved.begin(), disproved.end()), disproved.end());
+
+        NActors::TActivationContext::AsActorContext().Send(
+            TabletActorId, new TEvPrivate::TEvCutHistorySweepBatchDone(std::move(disproved), Exhausted));
+    }
+
+private:
+    TActorId TabletActorId;
+    TVector<TEntryKey> Candidates;
+    THashMap<TEntryKey, ui32> NextGenMap;
+    bool Exhausted;
+};
+
+}   // anonymous namespace
+
+// ---- TColumnShard methods ---------------------------------------------------
+
+void TColumnShard::SetupCutHistory() {
+    if (CutHistoryCutter) {
+        // Periodic nomination trigger.
+        CutHistoryCutter->TryNominate(NActors::TActivationContext::AsActorContext());
+        return;
+    }
+    // One-time initialization on first call (from TrySwitchToWork).
+    auto op = std::dynamic_pointer_cast<NOlap::NBlobOperations::NBlobStorage::TOperator>(
+        StoragesManager->GetOperatorOptional(NOlap::IStoragesManager::DefaultStorageId));
+    if (!op) {
+        return;
+    }
+    op->InitHistoryCutter(SelfId());
+    auto* cutter = op->GetHistoryCutter();
+    if (!cutter) {
+        return;
+    }
+    cutter->SetLauncherActorId(LauncherID());
+    CutHistoryCutter = cutter;
+    // Boot feed: empty map is safe — IsDrained + tier-2 sweep guard correctness.
+    cutter->OnBootComplete({});
+}
+
+void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, const TActorContext& ctx) {
+    if (!CutHistoryCutter) {
+        return;
+    }
+    if (!CutHistoryCutter->SweepInFlight()) {
+        return;
+    }
+
+    // Snapshot engine portion list on first batch of this sweep.
+    if (!CutHistoryCutter->HasPortionSnapshot()) {
+        TVector<std::pair<NOlap::TInternalPathId, ui64>> ids;
+        if (HasIndex()) {
+            const auto& idx = GetIndexAs<NOlap::TColumnEngineForLogs>();
+            for (const auto& [pathId, granule] : idx.GetTables()) {
+                for (const auto& [portionId, _] : granule->GetPortions()) {
+                    ids.emplace_back(pathId, portionId);
+                }
+            }
+        }
+        CutHistoryCutter->SetPortionSnapshot(std::move(ids));
+    }
+
+    bool isLast = false;
+    auto batch = CutHistoryCutter->GetNextBatch(/*batchSize=*/1000, isLast);
+
+    if (batch.empty()) {
+        // No portions — treat as fully exhausted.
+        CutHistoryCutter->OnBatchComplete({}, /*exhausted=*/true, ctx);
+        return;
+    }
+
+    // Build per-path consumer map.
+    THashMap<NOlap::TInternalPathId, NOlap::NDataAccessorControl::TPortionsByConsumer> portionsMap;
+    for (const auto& [pathId, portionId] : batch) {
+        portionsMap[pathId].UpsertConsumer(NOlap::NBlobOperations::EConsumer::SCAN).AddPortion(portionId);
+    }
+
+    // Build nextGenMap for the callback.
+    const auto& candidates = CutHistoryCutter->GetSweepCandidates();
+    THashMap<TEntryKey, ui32> nextGenMap;
+    for (const auto& key : candidates) {
+        nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGenerationPublic(key));
+    }
+
+    auto callback = std::make_shared<TCutHistorySweepCallback>(SelfId(), TVector<TEntryKey>(candidates), std::move(nextGenMap), isLast);
+
+    ctx.Send(SelfId(), new TEvPrivate::TEvAskTabletDataAccessors(std::move(portionsMap), callback));
+}
+
+void TColumnShard::Handle(TEvPrivate::TEvCutHistorySweepBatchDone::TPtr& ev, const TActorContext& ctx) {
+    if (!CutHistoryCutter) {
+        return;
+    }
+    const auto* msg = ev->Get();
+
+    // Convert flat pairs to THashSet<TEntryKey>.
+    THashSet<TEntryKey> disproved;
+    disproved.reserve(msg->Disproved.size());
+    for (const auto& [ch, fromGen] : msg->Disproved) {
+        disproved.insert(TEntryKey{ ch, fromGen });
+    }
+
+    CutHistoryCutter->OnBatchComplete(disproved, msg->Exhausted, ctx);
+}
+
+void TColumnShard::Handle(TEvPrivate::TEvCutHistoryBarrierDone::TPtr& ev, const TActorContext& /*ctx*/) {
+    if (!CutHistoryCutter) {
+        return;
+    }
+    const auto* msg = ev->Get();
+    TEntryKey key{ msg->Channel, msg->FromGeneration };
+    CutHistoryCutter->OnBarrierResult(key, msg->Ok);
+}
+
+void TColumnShard::OnPortionAddedToEngine(const NOlap::TPortionDataAccessor& accessor) {
+    if (CutHistoryCutter) {
+        CutHistoryCutter->OnPortionAdded(accessor);
+    }
+}
+
+void TColumnShard::OnPortionRemovedFromEngine(const ui64 portionId) {
+    if (CutHistoryCutter) {
+        CutHistoryCutter->OnPortionRemoved(portionId);
+    }
+}
+
+}   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -186,7 +186,7 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
     const auto candidates = CutHistoryCutter->GetActiveSweepCandidates();
     THashMap<TEntryKey, ui32> nextGenMap;
     for (const auto& key : *candidates) {
-        nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGenerationForSweep(key));
+        nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGeneration(key));
     }
 
     auto callback = std::make_shared<TCutHistorySweepCallback>(SelfId(), TabletID(), candidates, std::move(nextGenMap), isLast);

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -191,9 +191,9 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         return;
     }
 
-    // Build nextGenMap for the callback; the candidates vector is shared across all
-    // batches of this sweep instead of being copied per batch.
-    const auto candidates = CutHistoryCutter->GetSweepCandidates();
+    // Build nextGenMap for the callback over the entries still alive in this sweep:
+    // earlier batches' disprovals shrink the set, so later batches skip them.
+    const auto candidates = CutHistoryCutter->GetActiveSweepCandidates();
     THashMap<TEntryKey, ui32> nextGenMap;
     for (const auto& key : *candidates) {
         nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGenerationForSweep(key));

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -41,6 +41,12 @@ public:
     void OnAccessorsFetched(std::vector<std::shared_ptr<NOlap::TPortionDataAccessor>>&& accessors) override {
         THashSet<TEntryKey> disprovedKeys;
 
+        // Group candidates by channel once: blobs then check only their channel's slice.
+        THashMap<ui32, TVector<TEntryKey>> candidatesByChannel;
+        for (const auto& key : *Candidates) {
+            candidatesByChannel[key.Channel].push_back(key);
+        }
+
         for (const auto& accessor : accessors) {
             if (!accessor) {
                 continue;
@@ -54,8 +60,12 @@ public:
                 if (logoBlobId.TabletID() != OurTabletId) {
                     continue;
                 }
-                for (const auto& key : *Candidates) {
-                    if (logoBlobId.Channel() != key.Channel || disprovedKeys.contains(key)) {
+                const auto* channelCandidates = candidatesByChannel.FindPtr(logoBlobId.Channel());
+                if (!channelCandidates) {
+                    continue;
+                }
+                for (const auto& key : *channelCandidates) {
+                    if (disprovedKeys.contains(key)) {
                         continue;
                     }
                     const ui32 gen = logoBlobId.Generation();

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -20,8 +20,6 @@ namespace {
 using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
 using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
 
-// ---- TCutHistorySweepCallback -----------------------------------------------
-//
 // Runs on the conveyor thread after TTxAskPortionChunks delivers accessor objects.
 // Inspects each portion's blob IDs against the current sweep candidates and
 // sends TEvCutHistorySweepBatchDone back to the tablet.
@@ -41,7 +39,6 @@ public:
     void OnAccessorsFetched(std::vector<std::shared_ptr<NOlap::TPortionDataAccessor>>&& accessors) override {
         THashSet<TEntryKey> disprovedKeys;
 
-        // Group candidates by channel once: blobs then check only their channel's slice.
         THashMap<ui32, TVector<TEntryKey>> candidatesByChannel;
         for (const auto& key : *Candidates) {
             candidatesByChannel[key.Channel].push_back(key);
@@ -99,15 +96,11 @@ private:
 
 }   // anonymous namespace
 
-// ---- TColumnShard methods ---------------------------------------------------
-
 void TColumnShard::SetupCutHistory() {
     if (CutHistoryCutter) {
-        // Periodic nomination trigger.
         CutHistoryCutter->TryNominate(NActors::TActivationContext::AsActorContext());
         return;
     }
-    // One-time initialization on first call (from TrySwitchToWork).
     auto op = std::dynamic_pointer_cast<NOlap::NBlobOperations::NBlobStorage::TOperator>(
         StoragesManager->GetOperatorOptional(NOlap::IStoragesManager::DefaultStorageId));
     if (!op) {
@@ -139,7 +132,6 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         return;
     }
 
-    // Snapshot engine portion list on first batch of this sweep.
     if (!CutHistoryCutter->HasPortionSnapshot()) {
         TVector<std::pair<NOlap::TInternalPathId, ui64>> ids;
         if (HasIndex()) {
@@ -157,7 +149,6 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
     auto batch = CutHistoryCutter->GetNextBatch(/*batchSize=*/1000, isLast);
 
     if (batch.empty()) {
-        // No portions — treat as fully exhausted.
         CutHistoryCutter->OnBatchComplete({}, /*exhausted=*/true, ctx);
         return;
     }
@@ -209,7 +200,6 @@ void TColumnShard::Handle(TEvPrivate::TEvCutHistorySweepBatchDone::TPtr& ev, con
     }
     const auto* msg = ev->Get();
 
-    // Convert flat pairs to THashSet<TEntryKey>.
     THashSet<TEntryKey> disproved;
     disproved.reserve(msg->Disproved.size());
     for (const auto& [ch, fromGen] : msg->Disproved) {

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -28,11 +28,11 @@ using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutt
 //
 class TCutHistorySweepCallback: public NOlap::NDataAccessorControl::IAccessorCallback {
 public:
-    TCutHistorySweepCallback(
-        const TActorId& tabletActorId, ui64 ourTabletId, TVector<TEntryKey>&& candidates, THashMap<TEntryKey, ui32>&& nextGenMap, bool exhausted)
+    TCutHistorySweepCallback(const TActorId& tabletActorId, ui64 ourTabletId, const std::shared_ptr<const TVector<TEntryKey>>& candidates,
+        THashMap<TEntryKey, ui32>&& nextGenMap, bool exhausted)
         : TabletActorId(tabletActorId)
         , OurTabletId(ourTabletId)
-        , Candidates(std::move(candidates))
+        , Candidates(candidates)
         , NextGenMap(std::move(nextGenMap))
         , Exhausted(exhausted)
     {
@@ -51,7 +51,7 @@ public:
                 if (lid.TabletID() != OurTabletId) {
                     continue;
                 }
-                for (const auto& key : Candidates) {
+                for (const auto& key : *Candidates) {
                     if (lid.Channel() != key.Channel) {
                         continue;
                     }
@@ -78,7 +78,7 @@ public:
 private:
     TActorId TabletActorId;
     ui64 OurTabletId;
-    TVector<TEntryKey> Candidates;
+    std::shared_ptr<const TVector<TEntryKey>> Candidates;
     THashMap<TEntryKey, ui32> NextGenMap;
     bool Exhausted;
 };
@@ -106,14 +106,14 @@ void TColumnShard::SetupCutHistory() {
     }
     cutter->SetLauncherActorId(LauncherID());
     CutHistoryCutter = cutter;
-    // Boot feed with empty map is correct and safe:
-    //   • Old live portions are already in the engine at boot → tier-2 sweep will see them and
-    //     disprove any candidate whose channel/generation range they touch.
-    //   • Portions mid-delete have blobs in BlobsToDelete/Delayed → IsDrained returns false,
-    //     blocking nomination until regular GC completes.
-    //   • Fully-GCed historical ranges have no blobs anywhere → the barrier request is vacuous
-    //     and succeeds immediately (or returns ALREADY, treated as success).
-    // Counter state is rebuilt on-the-fly by OnPortionAdded hooks as the engine loads.
+    // Boot feed starts with EMPTY counters, and that is safe by direction of drift:
+    //   • OnPortionAdded hooks fire only for portions written after boot (compaction/TTL
+    //     output via TChangesWithAppend); boot-loaded portions are NOT counted. Undercount
+    //     can cause a spurious nomination, which the tier-2 sweep then disproves — wasted
+    //     work (bounded by DisprovedRetryCooldown), never an unsafe cut.
+    //   • Removal of an uncounted portion drives the counter to zero/poison — poisoning
+    //     excludes the channel (fail-safe liveness loss, not a safety loss).
+    //   • The authoritative check before any barrier is the tier-2 sweep + final re-check.
     cutter->OnBootComplete({});
 }
 
@@ -176,15 +176,15 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         return;
     }
 
-    // Build nextGenMap for the callback.
-    const auto& candidates = CutHistoryCutter->GetSweepCandidates();
+    // Build nextGenMap for the callback; the candidates vector is shared across all
+    // batches of this sweep instead of being copied per batch.
+    const auto candidates = CutHistoryCutter->GetSweepCandidates();
     THashMap<TEntryKey, ui32> nextGenMap;
-    for (const auto& key : candidates) {
-        nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGenerationPublic(key));
+    for (const auto& key : *candidates) {
+        nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGenerationForSweep(key));
     }
 
-    auto callback =
-        std::make_shared<TCutHistorySweepCallback>(SelfId(), TabletID(), TVector<TEntryKey>(candidates), std::move(nextGenMap), isLast);
+    auto callback = std::make_shared<TCutHistorySweepCallback>(SelfId(), TabletID(), candidates, std::move(nextGenMap), isLast);
 
     ctx.Send(SelfId(), new TEvPrivate::TEvAskTabletDataAccessors(std::move(portionsMap), callback));
 }

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -72,8 +72,7 @@ public:
                     if (gen < key.FromGeneration) {
                         continue;
                     }
-                    const auto it = NextGenMap.find(key);
-                    if (it != NextGenMap.end() && gen < it->second) {
+                    if (const auto* nextGen = NextGenMap.FindPtr(key); nextGen && gen < *nextGen) {
                         disprovedKeys.emplace(key);
                     }
                 }

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -148,10 +148,32 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         return;
     }
 
-    // Build per-path consumer map.
+    // Build per-path consumer map. The snapshot may reference portions (or whole
+    // paths) deleted since the sweep started — filter them out here, and the fetch
+    // tx additionally tolerates the erase-committed-but-still-in-memory window.
+    // A deleted portion cannot pin blobs in an old group, so skipping is correct.
+    if (!HasIndex()) {
+        CutHistoryCutter->OnBatchComplete({}, /*exhausted=*/true, ctx);
+        return;
+    }
+    const auto& engine = GetIndexAs<NOlap::TColumnEngineForLogs>();
     THashMap<NOlap::TInternalPathId, NOlap::NDataAccessorControl::TPortionsByConsumer> portionsMap;
     for (const auto& [pathId, portionId] : batch) {
+        const auto granule = engine.GetGranuleOptional(pathId);
+        if (!granule) {
+            continue;
+        }
+        const auto portion = granule->GetPortionOptional(portionId, false);
+        if (!portion || portion->HasRemoveSnapshot()) {
+            continue;
+        }
         portionsMap[pathId].UpsertConsumer(NOlap::NBlobOperations::EConsumer::SCAN).AddPortion(portionId);
+    }
+    if (portionsMap.empty()) {
+        // Every portion of this batch is gone — report an empty batch instead of
+        // sending a vacuous accessor request.
+        CutHistoryCutter->OnBatchComplete({}, isLast, ctx);
+        return;
     }
 
     // Build nextGenMap for the callback.

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -110,14 +110,9 @@ void TColumnShard::SetupCutHistory() {
     }
     cutter->SetLauncherActorId(LauncherID());
     CutHistoryCutter = cutter;
-    // Boot feed starts with EMPTY counters, and that is safe by direction of drift:
-    //   • OnPortionAdded hooks fire only for portions written after boot (compaction/TTL
-    //     output via TChangesWithAppend); boot-loaded portions are NOT counted. Undercount
-    //     can cause a spurious nomination, which the tier-2 sweep then disproves — wasted
-    //     work (bounded by DisprovedRetryCooldown), never an unsafe cut.
-    //   • Removal of an uncounted portion drives the counter to zero/poison — poisoning
-    //     excludes the channel (fail-safe liveness loss, not a safety loss).
-    //   • The authoritative check before any barrier is the tier-2 sweep + final re-check.
+    // Boot feed starts with EMPTY counters: boot-loaded portions are not counted, so the
+    // tier-1 counter can only undercount. Undercount causes a spurious nomination that the
+    // tier-2 sweep disproves, or poisons the channel — both fail-safe, never an unsafe cut.
     cutter->OnBootComplete({});
 }
 
@@ -150,8 +145,7 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         return;
     }
 
-    // The snapshot may name portions deleted since the sweep started; a deleted portion
-    // cannot pin blobs in an old group, so skipping it is correct.
+    // A portion deleted since the sweep started cannot pin blobs in an old group.
     if (!HasIndex()) {
         CutHistoryCutter->OnBatchComplete({}, /*exhausted=*/true, ctx);
         return;

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -29,8 +29,9 @@ using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutt
 class TCutHistorySweepCallback: public NOlap::NDataAccessorControl::IAccessorCallback {
 public:
     TCutHistorySweepCallback(
-        const TActorId& tabletActorId, TVector<TEntryKey>&& candidates, THashMap<TEntryKey, ui32>&& nextGenMap, bool exhausted)
+        const TActorId& tabletActorId, ui64 ourTabletId, TVector<TEntryKey>&& candidates, THashMap<TEntryKey, ui32>&& nextGenMap, bool exhausted)
         : TabletActorId(tabletActorId)
+        , OurTabletId(ourTabletId)
         , Candidates(std::move(candidates))
         , NextGenMap(std::move(nextGenMap))
         , Exhausted(exhausted)
@@ -46,6 +47,10 @@ public:
             }
             for (const auto& blobId : accessor->GetBlobIds()) {
                 const TLogoBlobID& lid = blobId.GetLogoBlobId();
+                // Skip blobs from other tablets (shared/borrowed) — they must not disprove our candidates.
+                if (lid.TabletID() != OurTabletId) {
+                    continue;
+                }
                 for (const auto& key : Candidates) {
                     if (lid.Channel() != key.Channel) {
                         continue;
@@ -72,6 +77,7 @@ public:
 
 private:
     TActorId TabletActorId;
+    ui64 OurTabletId;
     TVector<TEntryKey> Candidates;
     THashMap<TEntryKey, ui32> NextGenMap;
     bool Exhausted;
@@ -100,7 +106,14 @@ void TColumnShard::SetupCutHistory() {
     }
     cutter->SetLauncherActorId(LauncherID());
     CutHistoryCutter = cutter;
-    // Boot feed: empty map is safe — IsDrained + tier-2 sweep guard correctness.
+    // Boot feed with empty map is correct and safe:
+    //   • Old live portions are already in the engine at boot → tier-2 sweep will see them and
+    //     disprove any candidate whose channel/generation range they touch.
+    //   • Portions mid-delete have blobs in BlobsToDelete/Delayed → IsDrained returns false,
+    //     blocking nomination until regular GC completes.
+    //   • Fully-GCed historical ranges have no blobs anywhere → the barrier request is vacuous
+    //     and succeeds immediately (or returns ALREADY, treated as success).
+    // Counter state is rebuilt on-the-fly by OnPortionAdded hooks as the engine loads.
     cutter->OnBootComplete({});
 }
 
@@ -148,7 +161,8 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         nextGenMap.emplace(key, CutHistoryCutter->GetNextFromGenerationPublic(key));
     }
 
-    auto callback = std::make_shared<TCutHistorySweepCallback>(SelfId(), TVector<TEntryKey>(candidates), std::move(nextGenMap), isLast);
+    auto callback =
+        std::make_shared<TCutHistorySweepCallback>(SelfId(), TabletID(), TVector<TEntryKey>(candidates), std::move(nextGenMap), isLast);
 
     ctx.Send(SelfId(), new TEvPrivate::TEvAskTabletDataAccessors(std::move(portionsMap), callback));
 }

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -121,7 +121,7 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
     if (!CutHistoryCutter) {
         return;
     }
-    if (!CutHistoryCutter->SweepInFlight()) {
+    if (!CutHistoryCutter->IsSweepInFlight()) {
         return;
     }
 

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -177,7 +177,7 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         if (!granule) {
             continue;
         }
-        const auto portion = granule->GetPortionOptional(portionId, false);
+        const auto portion = granule->GetPortionOptional(portionId);
         if (!portion || portion->HasRemoveSnapshot()) {
             continue;
         }

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -194,13 +194,13 @@ void TColumnShard::Handle(TEvPrivate::TEvCutHistorySweepBatchDone::TPtr& ev, con
     CutHistoryCutter->OnBatchComplete(disproved, msg->Exhausted, ctx);
 }
 
-void TColumnShard::Handle(TEvPrivate::TEvCutHistoryBarrierDone::TPtr& ev, const TActorContext& /*ctx*/) {
+void TColumnShard::Handle(TEvPrivate::TEvCutHistoryBarrierDone::TPtr& ev, const TActorContext& ctx) {
     if (!CutHistoryCutter) {
         return;
     }
     const auto* msg = ev->Get();
     TEntryKey key{ msg->Channel, msg->FromGeneration };
-    CutHistoryCutter->OnBarrierResult(key, msg->Ok);
+    CutHistoryCutter->OnBarrierResult(key, msg->Ok, ctx.Now());
 }
 
 void TColumnShard::OnPortionAddedToEngine(const NOlap::TPortionDataAccessor& accessor) {

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -21,9 +21,6 @@ using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
 using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
 
 // Runs on the conveyor thread after TTxAskPortionChunks delivers accessor objects.
-// Inspects each portion's blob IDs against the current sweep candidates and
-// sends TEvCutHistorySweepBatchDone back to the tablet.
-//
 class TCutHistorySweepCallback: public NOlap::NDataAccessorControl::IAccessorCallback {
 public:
     TCutHistorySweepCallback(const TActorId& tabletActorId, ui64 ourTabletId, const std::shared_ptr<const TVector<TEntryKey>>& candidates,
@@ -153,10 +150,8 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         return;
     }
 
-    // Build per-path consumer map. The snapshot may reference portions (or whole
-    // paths) deleted since the sweep started — filter them out here, and the fetch
-    // tx additionally tolerates the erase-committed-but-still-in-memory window.
-    // A deleted portion cannot pin blobs in an old group, so skipping is correct.
+    // The snapshot may name portions deleted since the sweep started; a deleted portion
+    // cannot pin blobs in an old group, so skipping it is correct.
     if (!HasIndex()) {
         CutHistoryCutter->OnBatchComplete({}, /*exhausted=*/true, ctx);
         return;
@@ -175,14 +170,10 @@ void TColumnShard::Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& /*ev*/, con
         portionsMap[pathId].UpsertConsumer(NOlap::NBlobOperations::EConsumer::SCAN).AddPortion(portionId);
     }
     if (portionsMap.empty()) {
-        // Every portion of this batch is gone — report an empty batch instead of
-        // sending a vacuous accessor request.
         CutHistoryCutter->OnBatchComplete({}, isLast, ctx);
         return;
     }
 
-    // Build nextGenMap for the callback over the entries still alive in this sweep:
-    // earlier batches' disprovals shrink the set, so later batches skip them.
     const auto candidates = CutHistoryCutter->GetActiveSweepCandidates();
     THashMap<TEntryKey, ui32> nextGenMap;
     for (const auto& key : *candidates) {

--- a/ydb/core/tx/columnshard/columnshard_cut_history.cpp
+++ b/ydb/core/tx/columnshard/columnshard_cut_history.cpp
@@ -110,9 +110,7 @@ void TColumnShard::SetupCutHistory() {
     }
     cutter->SetLauncherActorId(LauncherID());
     CutHistoryCutter = cutter;
-    // Boot feed starts with EMPTY counters: boot-loaded portions are not counted, so the
-    // tier-1 counter can only undercount. Undercount causes a spurious nomination that the
-    // tier-2 sweep disproves, or poisons the channel — both fail-safe, never an unsafe cut.
+    // Boot starts with empty counters, so tier-1 can only undercount: the sweep disproves or the channel poisons.
     cutter->OnBootComplete({});
 }
 

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -1629,7 +1629,14 @@ public:
         YDB_LOG_CREATE_CONTEXT(
             {"event", "TTxAskPortionChunks::Execute"});
         for (auto&& i : PortionsByPath) {
-            const auto& granule = Self->GetIndexAs<NOlap::TColumnEngineForLogs>().GetGranuleVerified(i.first);
+            // The requested path may have been dropped between the request and this
+            // tx execution (e.g. the cut-history sweep iterates a portion snapshot
+            // without holding a read snapshot) — skip it instead of aborting.
+            const auto granulePtr = Self->GetIndexAs<NOlap::TColumnEngineForLogs>().GetGranuleOptional(i.first);
+            if (!granulePtr) {
+                continue;
+            }
+            const auto& granule = *granulePtr;
             for (auto&& c : i.second.GetConsumers()) {
                 NActors::TLogContextGuard lcGuard = NActors::TLogContextBuilder::Build()("consumer", c.first)("path_id", i.first);
                 YDB_LOG_TRACE_COMP(NKikimrServices::TX_COLUMNSHARD, "Dump size",
@@ -1648,9 +1655,16 @@ public:
                         auto rowset = db.Table<NColumnShard::Schema::IndexColumnsV2>().Key(i.first.GetRawValue(), p).Select();
                         if (!rowset.IsReady()) {
                             reask = true;
-                        } else {
-                            AFL_VERIFY(!rowset.EndOfSet())("path_id", i.first)("portion_id", p)(
+                        } else if (rowset.EndOfSet()) {
+                            // The portion's rows are already erased by cleanup while the
+                            // in-memory object still lingers (remove-marked). Only such
+                            // portions may legitimately lack rows: requesters without a
+                            // read snapshot (cut-history sweep) can race the cleanup.
+                            AFL_VERIFY(itPortionConstructor->second.GetPortionInfo()->HasRemoveSnapshot())("path_id", i.first)("portion_id", p)(
                                 "debug", itPortionConstructor->second.GetPortionInfo()->DebugString(true));
+                            Constructors.erase(itPortionConstructor);
+                            continue;
+                        } else {
                             NOlap::TColumnChunkLoadContextV2 info(rowset, selector);
                             itPortionConstructor->second.SetRecords(std::move(info));
                         }

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -4,6 +4,7 @@
 #include "scan_snapshot_guard.h"
 
 #include "blobs_action/bs/storage.h"
+#include "blobs_action/common/const.h"
 #include "blobs_reader/task.h"
 #include "common/tablet_id.h"
 #include "resource_subscriber/task.h"
@@ -494,6 +495,13 @@ void TColumnShard::RunAlterStore(
         TablesManager.AddSchemaVersion(presetProto.GetId(), version, presetProto.GetSchema(), db);
     }
     ApplyColumnShardConfig();
+}
+
+// Portions live on the data channels and are written by TBlobManager, not by the executor,
+// so only our own drain-gated cutter may cut their history. Channels 0 and 1 hold the log
+// and the local database and stay with the executor's cutter.
+bool TColumnShard::HasExternallyWrittenBlobs(ui32 channel) const {
+    return channel >= NOlap::NBlobOperations::TGlobal::FirstDataChannel;
 }
 
 void TColumnShard::EnqueueBackgroundActivities(const bool periodic) {

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -521,6 +521,7 @@ void TColumnShard::EnqueueBackgroundActivities(const bool periodic) {
     SetupMetadata();
     SetupTtl();
     SetupGC();
+    SetupCutHistory();
 
     RecheckForcedCompactions(NActors::TActivationContext::AsActorContext());
 }
@@ -1935,6 +1936,9 @@ STFUNC(TColumnShard::StateWork) {
         HFunc(TEvPrivate::TEvWriteDraft, Handle);
         HFunc(TEvPrivate::TEvGarbageCollectionFinished, Handle);
         HFunc(TEvPrivate::TEvTieringModified, Handle);
+        HFunc(TEvPrivate::TEvStartCutHistorySweep, Handle);
+        HFunc(TEvPrivate::TEvCutHistoryBarrierDone, Handle);
+        HFunc(TEvPrivate::TEvCutHistorySweepBatchDone, Handle);
 
         HFunc(NActors::TEvents::TEvUndelivered, Handle);
 

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -497,8 +497,7 @@ void TColumnShard::RunAlterStore(
     ApplyColumnShardConfig();
 }
 
-// Portions live on the data channels and are written by TBlobManager, not by the executor,
-// so only our own drain-gated cutter may cut their history. Channels 0 and 1 hold the log
+// Portions are written by TBlobManager, past the executor; channels 0 and 1 hold the log
 // and the local database and stay with the executor's cutter.
 bool TColumnShard::HasExternallyWrittenBlobs(ui32 channel) const {
     return channel >= NOlap::NBlobOperations::TGlobal::FirstDataChannel;

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -497,8 +497,8 @@ void TColumnShard::RunAlterStore(
     ApplyColumnShardConfig();
 }
 
-// Portions are written by TBlobManager, past the executor; channels 0 and 1 hold the log
-// and the local database and stay with the executor's cutter.
+// Portions go through TBlobManager, past the executor; channels 0 and 1 (log, local DB)
+// stay with the executor's cutter.
 bool TColumnShard::HasExternallyWrittenBlobs(ui32 channel) const {
     return channel >= NOlap::NBlobOperations::TGlobal::FirstDataChannel;
 }
@@ -1636,9 +1636,8 @@ public:
         YDB_LOG_CREATE_CONTEXT(
             {"event", "TTxAskPortionChunks::Execute"});
         for (auto&& i : PortionsByPath) {
-            // The requested path may have been dropped between the request and this
-            // tx execution (e.g. the cut-history sweep iterates a portion snapshot
-            // without holding a read snapshot) — skip it instead of aborting.
+            // The cut-history sweep iterates a portion snapshot without a read snapshot, so
+            // the path may have been dropped since the request: skip rather than abort.
             const auto granulePtr = Self->GetIndexAs<NOlap::TColumnEngineForLogs>().GetGranuleOptional(i.first);
             if (!granulePtr) {
                 continue;
@@ -1663,10 +1662,8 @@ public:
                         if (!rowset.IsReady()) {
                             reask = true;
                         } else if (rowset.EndOfSet()) {
-                            // The portion's rows are already erased by cleanup while the
-                            // in-memory object still lingers (remove-marked). Only such
-                            // portions may legitimately lack rows: requesters without a
-                            // read snapshot (cut-history sweep) can race the cleanup.
+                            // Rows erased by cleanup while the in-memory object lingers.
+                            // Only remove-marked portions may legitimately lack rows.
                             AFL_VERIFY(itPortionConstructor->second.GetPortionInfo()->HasRemoveSnapshot())("path_id", i.first)("portion_id", p)(
                                 "debug", itPortionConstructor->second.GetPortionInfo()->DebugString(true));
                             Constructors.erase(itPortionConstructor);

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -497,8 +497,7 @@ void TColumnShard::RunAlterStore(
     ApplyColumnShardConfig();
 }
 
-// Portions go through TBlobManager, past the executor; channels 0 and 1 (log, local DB)
-// stay with the executor's cutter.
+// Portions bypass the executor; channels 0 and 1 stay with the executor's cutter.
 bool TColumnShard::HasExternallyWrittenBlobs(ui32 channel) const {
     return channel >= NOlap::NBlobOperations::TGlobal::FirstDataChannel;
 }
@@ -1636,8 +1635,7 @@ public:
         YDB_LOG_CREATE_CONTEXT(
             {"event", "TTxAskPortionChunks::Execute"});
         for (auto&& i : PortionsByPath) {
-            // The cut-history sweep iterates a portion snapshot without a read snapshot, so
-            // the path may have been dropped since the request: skip rather than abort.
+            // The sweep iterates a portion snapshot without a read snapshot: the path may be gone, so skip.
             const auto granulePtr = Self->GetIndexAs<NOlap::TColumnEngineForLogs>().GetGranuleOptional(i.first);
             if (!granulePtr) {
                 continue;
@@ -1662,8 +1660,7 @@ public:
                         if (!rowset.IsReady()) {
                             reask = true;
                         } else if (rowset.EndOfSet()) {
-                            // Rows erased by cleanup while the in-memory object lingers.
-                            // Only remove-marked portions may legitimately lack rows.
+                            // Cleanup erased the rows while the object lingers: only remove-marked portions may lack them.
                             AFL_VERIFY(itPortionConstructor->second.GetPortionInfo()->HasRemoveSnapshot())("path_id", i.first)("portion_id", p)(
                                 "debug", itPortionConstructor->second.GetPortionInfo()->DebugString(true));
                             Constructors.erase(itPortionConstructor);

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -66,6 +66,10 @@ struct TEvConfigNotificationRequest;
 }
 }   // namespace NKikimr::NConsole
 
+namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
+class THistoryCutterWrapper;
+}   // namespace NKikimr::NOlap::NBlobOperations::NBlobStorage
+
 namespace NKikimr::NOlap {
 class TCleanupPortionsColumnEngineChanges;
 class TCleanupTablesColumnEngineChanges;
@@ -535,6 +539,9 @@ private:
     TActorId StatsReportPipe;
     std::unique_ptr<TEvDataShard::TEvPeriodicTableStats> LastStats;
 
+    // Non-owning pointer to the cut-history engine; set in SetupCutHistory() once per boot.
+    NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper* CutHistoryCutter = nullptr;
+
     // In-flight forced-compaction requests (ALTER TABLE ... COMPACT). Kept in memory only, mirroring
     // DataShard's CompactionWaiters: on restart/move the SchemeShard's persisted queue re-sends
     // TEvCompactTable. Each waiter is answered with OK once the table has no intersecting portions.
@@ -603,6 +610,11 @@ private:
     void SetupCleanupTables(const NOlap::ISnapshotHolders& snapshotHolders);
     void SetupCleanupSchemas();
     void SetupGC();
+    void SetupCutHistory();
+
+    void Handle(TEvPrivate::TEvStartCutHistorySweep::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvCutHistoryBarrierDone::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvCutHistorySweepBatchDone::TPtr& ev, const TActorContext& ctx);
 
     void UpdateIndexCounters();
     void UpdateResourceMetrics(const TActorContext& ctx, const TUsage& usage);
@@ -622,6 +634,10 @@ private:
     ui64 NormalizeSmallBlobsCount(const ui64 rawCount);
 
 public:
+    // Engine portion lifecycle hooks for cut-history counter maintenance.
+    void OnPortionAddedToEngine(const NOlap::TPortionDataAccessor& accessor);
+    void OnPortionRemovedFromEngine(ui64 portionId);
+
     ui64 TabletTxCounter = 0;
 
     std::shared_ptr<const TAtomicCounter> GetTabletActivity() const {

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -9,7 +9,6 @@
 #include "tables_manager.h"
 
 #include "bg_tasks/events/local.h"
-#include "blobs_action/common/const.h"
 #include "blobs_action/events/delete_blobs.h"
 #include "common/path_id.h"
 #include "counters/columnshard.h"
@@ -464,9 +463,7 @@ protected:
     // Portions live on the data channels and are written by TBlobManager, not by the
     // executor, so only our own drain-gated cutter may cut their history. Channels 0
     // and 1 hold the log and the local database and stay with the executor's cutter.
-    bool HasExternallyWrittenBlobs(ui32 channel) const override {
-        return channel >= NOlap::NBlobOperations::TGlobal::FirstDataChannel;
-    }
+    bool HasExternallyWrittenBlobs(ui32 channel) const override;
 
 private:
     std::unique_ptr<TTabletCountersBase> TabletCountersHolder;

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -9,6 +9,7 @@
 #include "tables_manager.h"
 
 #include "bg_tasks/events/local.h"
+#include "blobs_action/common/const.h"
 #include "blobs_action/events/delete_blobs.h"
 #include "common/path_id.h"
 #include "counters/columnshard.h"
@@ -459,6 +460,13 @@ protected:
     }
 
     STFUNC(StateWork);
+
+    // Portions live on the data channels and are written by TBlobManager, not by the
+    // executor, so only our own drain-gated cutter may cut their history. Channels 0
+    // and 1 hold the log and the local database and stay with the executor's cutter.
+    bool HasExternallyWrittenBlobs(ui32 channel) const override {
+        return channel >= NOlap::NBlobOperations::TGlobal::FirstDataChannel;
+    }
 
 private:
     std::unique_ptr<TTabletCountersBase> TabletCountersHolder;

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -460,9 +460,6 @@ protected:
 
     STFUNC(StateWork);
 
-    // Portions live on the data channels and are written by TBlobManager, not by the
-    // executor, so only our own drain-gated cutter may cut their history. Channels 0
-    // and 1 hold the log and the local database and stay with the executor's cutter.
     bool HasExternallyWrittenBlobs(ui32 channel) const override;
 
 private:
@@ -639,7 +636,6 @@ private:
     ui64 NormalizeSmallBlobsCount(const ui64 rawCount);
 
 public:
-    // Engine portion lifecycle hooks for cut-history counter maintenance.
     void OnPortionAddedToEngine(const NOlap::TPortionDataAccessor& accessor);
     void OnPortionRemovedFromEngine(ui64 portionId);
 

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -541,7 +541,7 @@ private:
     TActorId StatsReportPipe;
     std::unique_ptr<TEvDataShard::TEvPeriodicTableStats> LastStats;
 
-    // Non-owning pointer to the cut-history engine; set in SetupCutHistory() once per boot.
+    // Non-owning; set in SetupCutHistory() once per boot.
     NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper* CutHistoryCutter = nullptr;
 
     // In-flight forced-compaction requests (ALTER TABLE ... COMPACT). Kept in memory only, mirroring

--- a/ydb/core/tx/columnshard/columnshard_private_events.h
+++ b/ydb/core/tx/columnshard/columnshard_private_events.h
@@ -520,10 +520,8 @@ struct TEvPrivate {
 
     struct TEvRetryConfigSubscription: public TEventLocal<TEvRetryConfigSubscription, EvRetryConfigSubscription> {};
 
-    // Sent by THistoryCutterWrapper::TryNominate to trigger the tier-2 disk sweep.
     struct TEvStartCutHistorySweep: public TEventLocal<TEvStartCutHistorySweep, EvStartCutHistorySweep> {};
 
-    // Sent by TCutHistoryBarrierActor with the final outcome of the hard GC barrier.
     struct TEvCutHistoryBarrierDone: public TEventLocal<TEvCutHistoryBarrierDone, EvCutHistoryBarrierDone> {
         ui32 Channel;
         ui32 FromGeneration;
@@ -537,9 +535,6 @@ struct TEvPrivate {
         }
     };
 
-    // Sent by TCutHistorySweepCallback (on conveyor) to the tablet after one accessor batch.
-    // Disproved: {channel, fromGeneration} pairs whose blobs were found in this batch.
-    // Exhausted: true when the portion snapshot cursor is fully consumed.
     struct TEvCutHistorySweepBatchDone: public TEventLocal<TEvCutHistorySweepBatchDone, EvCutHistorySweepBatchDone> {
         TVector<std::pair<ui32, ui32>> Disproved;
         bool Exhausted;

--- a/ydb/core/tx/columnshard/columnshard_private_events.h
+++ b/ydb/core/tx/columnshard/columnshard_private_events.h
@@ -94,6 +94,10 @@ struct TEvPrivate {
 
         EvRetryConfigSubscription,
 
+        EvStartCutHistorySweep,
+        EvCutHistoryBarrierDone,
+        EvCutHistorySweepBatchDone,
+
         EvEnd
     };
 
@@ -515,6 +519,37 @@ struct TEvPrivate {
     };
 
     struct TEvRetryConfigSubscription: public TEventLocal<TEvRetryConfigSubscription, EvRetryConfigSubscription> {};
+
+    // Sent by THistoryCutterWrapper::TryNominate to trigger the tier-2 disk sweep.
+    struct TEvStartCutHistorySweep: public TEventLocal<TEvStartCutHistorySweep, EvStartCutHistorySweep> {};
+
+    // Sent by TCutHistoryBarrierActor with the final outcome of the hard GC barrier.
+    struct TEvCutHistoryBarrierDone: public TEventLocal<TEvCutHistoryBarrierDone, EvCutHistoryBarrierDone> {
+        ui32 Channel;
+        ui32 FromGeneration;
+        bool Ok;
+
+        TEvCutHistoryBarrierDone(ui32 channel, ui32 fromGeneration, bool ok)
+            : Channel(channel)
+            , FromGeneration(fromGeneration)
+            , Ok(ok)
+        {
+        }
+    };
+
+    // Sent by TCutHistorySweepCallback (on conveyor) to the tablet after one accessor batch.
+    // Disproved: {channel, fromGeneration} pairs whose blobs were found in this batch.
+    // Exhausted: true when the portion snapshot cursor is fully consumed.
+    struct TEvCutHistorySweepBatchDone: public TEventLocal<TEvCutHistorySweepBatchDone, EvCutHistorySweepBatchDone> {
+        TVector<std::pair<ui32, ui32>> Disproved;
+        bool Exhausted;
+
+        TEvCutHistorySweepBatchDone(TVector<std::pair<ui32, ui32>>&& disproved, bool exhausted)
+            : Disproved(std::move(disproved))
+            , Exhausted(exhausted)
+        {
+        }
+    };
 };
 
 }   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/blobs_manager.cpp
+++ b/ydb/core/tx/columnshard/counters/blobs_manager.cpp
@@ -15,7 +15,20 @@ TBlobsManagerCounters::TBlobsManagerCounters(const TString& module)
     , CurrentGen(TBase::GetValue("CurrentGen"))
     , CurrentStep(TBase::GetValue("CurrentStep"))
     , GCCounters(*this, "GC")
+    , HistoryCutterCounters(*this, "CutHistory")
 
+{
+}
+
+THistoryCutterCounters::THistoryCutterCounters(const TCommonCountersOwner& sameAs, const TString& componentName)
+    : TBase(sameAs, componentName)
+    , Nominations(TBase::GetDeriviative("Nominations/Count"))
+    , SweepsCompleted(TBase::GetDeriviative("Sweeps/Completed/Count"))
+    , EntriesCut(TBase::GetDeriviative("Entries/Cut/Count"))
+    , BarriersFailed(TBase::GetDeriviative("Barriers/Failed/Count"))
+    , SweepCandidates(TBase::GetValue("Sweep/Candidates"))
+    , ChannelsPoisoned(TBase::GetValue("Channels/Poisoned"))
+    , EntriesDisproved(TBase::GetValue("Entries/Disproved"))
 {
 }
 

--- a/ydb/core/tx/columnshard/counters/blobs_manager.h
+++ b/ydb/core/tx/columnshard/counters/blobs_manager.h
@@ -43,10 +43,8 @@ public:
     }
 };
 
-// A stalled cut has several externally indistinguishable causes: GC queues not
-// drained, blobs still shared out, an entry in disproval backoff, a poisoned
-// channel. These separate them. Aggregate rather than per-channel labels — the
-// channel is already in the poison warning.
+// A stalled cut has several externally indistinguishable causes; these separate them.
+// Aggregate labels: the channel is already in the poison warning.
 class THistoryCutterCounters: public TCommonCountersOwner {
 private:
     using TBase = TCommonCountersOwner;

--- a/ydb/core/tx/columnshard/counters/blobs_manager.h
+++ b/ydb/core/tx/columnshard/counters/blobs_manager.h
@@ -77,9 +77,8 @@ public:
         }
     }
 
-    // Deltas, not absolute values: every tablet owns a TBlobsManagerCounters but
-    // they share one module_id=BlobsManager subgroup, so Set() would be
-    // last-tablet-wins. The caller owns the per-tablet last-published state.
+    // Deltas, not absolute values: tablets share one module_id=BlobsManager subgroup,
+    // so Set() would be last-tablet-wins.
     void OnLevelsDelta(const i64 sweepCandidates, const i64 channelsPoisoned, const i64 entriesDisproved) const {
         SweepCandidates->Add(sweepCandidates);
         ChannelsPoisoned->Add(channelsPoisoned);

--- a/ydb/core/tx/columnshard/counters/blobs_manager.h
+++ b/ydb/core/tx/columnshard/counters/blobs_manager.h
@@ -43,6 +43,50 @@ public:
     }
 };
 
+// A stalled cut has several externally indistinguishable causes: GC queues not
+// drained, blobs still shared out, an entry in disproval backoff, a poisoned
+// channel. These separate them. Aggregate rather than per-channel labels — the
+// channel is already in the poison warning.
+class THistoryCutterCounters: public TCommonCountersOwner {
+private:
+    using TBase = TCommonCountersOwner;
+    NMonitoring::TDynamicCounters::TCounterPtr Nominations;
+    NMonitoring::TDynamicCounters::TCounterPtr SweepsCompleted;
+    NMonitoring::TDynamicCounters::TCounterPtr EntriesCut;
+    NMonitoring::TDynamicCounters::TCounterPtr BarriersFailed;
+    NMonitoring::TDynamicCounters::TCounterPtr SweepCandidates;
+    NMonitoring::TDynamicCounters::TCounterPtr ChannelsPoisoned;
+    NMonitoring::TDynamicCounters::TCounterPtr EntriesDisproved;
+
+public:
+    THistoryCutterCounters(const TCommonCountersOwner& sameAs, const TString& componentName);
+
+    void OnNomination() const {
+        Nominations->Add(1);
+    }
+
+    void OnSweepCompleted() const {
+        SweepsCompleted->Add(1);
+    }
+
+    void OnBarrierResult(const bool ok) const {
+        if (ok) {
+            EntriesCut->Add(1);
+        } else {
+            BarriersFailed->Add(1);
+        }
+    }
+
+    // Deltas, not absolute values: every tablet owns a TBlobsManagerCounters but
+    // they share one module_id=BlobsManager subgroup, so Set() would be
+    // last-tablet-wins. The caller owns the per-tablet last-published state.
+    void OnLevelsDelta(const i64 sweepCandidates, const i64 channelsPoisoned, const i64 entriesDisproved) const {
+        SweepCandidates->Add(sweepCandidates);
+        ChannelsPoisoned->Add(channelsPoisoned);
+        EntriesDisproved->Add(entriesDisproved);
+    }
+};
+
 class TBlobsManagerCounters: public TCommonCountersOwner {
 private:
     using TBase = TCommonCountersOwner;
@@ -54,6 +98,7 @@ public:
     const NMonitoring::TDynamicCounters::TCounterPtr CurrentGen;
     const NMonitoring::TDynamicCounters::TCounterPtr CurrentStep;
     const TBlobsManagerGCCounters GCCounters;
+    const THistoryCutterCounters HistoryCutterCounters;
     TBlobsManagerCounters(const TString& module);
 
     void OnBlobsToDelete(const NOlap::TTabletsByBlob& blobs) const {

--- a/ydb/core/tx/columnshard/counters/blobs_manager.h
+++ b/ydb/core/tx/columnshard/counters/blobs_manager.h
@@ -43,8 +43,7 @@ public:
     }
 };
 
-// A stalled cut has several externally indistinguishable causes; these separate them.
-// Aggregate labels: the channel is already in the poison warning.
+// A stalled cut has several indistinguishable causes; these separate them.
 class THistoryCutterCounters: public TCommonCountersOwner {
 private:
     using TBase = TCommonCountersOwner;
@@ -75,8 +74,7 @@ public:
         }
     }
 
-    // Deltas, not absolute values: tablets share one module_id=BlobsManager subgroup,
-    // so Set() would be last-tablet-wins.
+    // Deltas, not absolute values: tablets share one subgroup, so Set() would be last-tablet-wins.
     void OnLevelsDelta(const i64 sweepCandidates, const i64 channelsPoisoned, const i64 entriesDisproved) const {
         SweepCandidates->Add(sweepCandidates);
         ChannelsPoisoned->Add(channelsPoisoned);

--- a/ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h
+++ b/ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h
@@ -56,6 +56,23 @@ public:
         return SelfTabletId;
     }
 
+    // True if any of OUR blobs still shared out to other tablets lives in the given
+    // channel and generation range [fromGen, nextFromGen). Such a blob is in no GC
+    // queue while shared, but a hard barrier for the range would collect it under
+    // the borrower — the cut-history drain gate must see it.
+    bool HasSharedBlobsInRange(const ui64 tabletId, const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
+        for (auto it = SharedBlobIds.GetIterator(); it.IsValid(); ++it) {
+            const TLogoBlobID& logoBlobId = it.GetBlobId().GetLogoBlobId();
+            if (logoBlobId.TabletID() != tabletId || logoBlobId.Channel() != channel) {
+                continue;
+            }
+            if (logoBlobId.Generation() >= fromGen && logoBlobId.Generation() < nextFromGen) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     TBlobsCategories GetBlobCategories() const {
         TBlobsCategories result(SelfTabletId);
         for (auto&& i : BorrowedBlobIds) {

--- a/ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h
+++ b/ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h
@@ -7,6 +7,8 @@
 
 #include <ydb/library/accessor/accessor.h>
 
+#include <util/generic/algorithm.h>
+
 namespace NKikimr::NOlap::NDataSharing {
 
 class TStorageSharedBlobsManager {
@@ -61,16 +63,13 @@ public:
     // queue while shared, but a hard barrier for the range would collect it under
     // the borrower — the cut-history drain gate must see it.
     bool HasSharedBlobsInRange(const ui64 tabletId, const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
-        for (auto it = SharedBlobIds.GetIterator(); it.IsValid(); ++it) {
-            const TLogoBlobID& logoBlobId = it.GetBlobId().GetLogoBlobId();
-            if (logoBlobId.TabletID() != tabletId || logoBlobId.Channel() != channel) {
-                continue;
-            }
-            if (logoBlobId.Generation() >= fromGen && logoBlobId.Generation() < nextFromGen) {
-                return true;
-            }
-        }
-        return false;
+        // Iterating the blob keys rather than TIterator: the predicate only looks at the
+        // blob, and TIterator would revisit it once per tablet it is shared with.
+        return AnyOf(SharedBlobIds, [&](const auto& blob) {
+            const TLogoBlobID& logoBlobId = blob.first.GetLogoBlobId();
+            return logoBlobId.TabletID() == tabletId && logoBlobId.Channel() == channel && logoBlobId.Generation() >= fromGen &&
+                   logoBlobId.Generation() < nextFromGen;
+        });
     }
 
     TBlobsCategories GetBlobCategories() const {

--- a/ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h
+++ b/ydb/core/tx/columnshard/data_sharing/manager/shared_blobs.h
@@ -58,13 +58,9 @@ public:
         return SelfTabletId;
     }
 
-    // True if any of OUR blobs still shared out to other tablets lives in the given
-    // channel and generation range [fromGen, nextFromGen). Such a blob is in no GC
-    // queue while shared, but a hard barrier for the range would collect it under
-    // the borrower — the cut-history drain gate must see it.
+    // Our shared-out blobs in [fromGen, nextFromGen) sit in no GC queue, but a hard barrier would collect them.
     bool HasSharedBlobsInRange(const ui64 tabletId, const ui32 channel, const ui32 fromGen, const ui32 nextFromGen) const {
-        // Iterating the blob keys rather than TIterator: the predicate only looks at the
-        // blob, and TIterator would revisit it once per tablet it is shared with.
+        // Iterate blob keys, not TIterator: the latter revisits a blob once per tablet it is shared with.
         return AnyOf(SharedBlobIds, [&](const auto& blob) {
             const TLogoBlobID& logoBlobId = blob.first.GetLogoBlobId();
             return logoBlobId.TabletID() == tabletId && logoBlobId.Channel() == channel && logoBlobId.Generation() >= fromGen &&

--- a/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
@@ -68,6 +68,7 @@ void TCleanupPortionsColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::T
         self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
         for (auto&& p : PortionsToDrop) {
             self->Counters.GetTabletCounters()->OnDropPortionEvent(p->GetTotalRawBytes(), p->GetTotalBlobBytes(), p->GetRecordsCount());
+            self->OnPortionRemovedFromEngine(p->GetPortionId());
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
@@ -79,6 +79,11 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
     for (auto& portionBuilder : AppendedPortions) {
         context.EngineLogs.AppendPortion(portionBuilder.GetPortionResultPtr());
     }
+    if (self) {
+        for (const auto& portionBuilder : AppendedPortions) {
+            self->OnPortionAddedToEngine(*portionBuilder.GetPortionResultPtr());
+        }
+    }
 }
 
 void TChangesWithAppend::DoCompile(TFinalizationContext& context) {

--- a/ydb/core/tx/columnshard/hooks/abstract/abstract.h
+++ b/ydb/core/tx/columnshard/hooks/abstract/abstract.h
@@ -427,6 +427,17 @@ public:
 
     virtual void OnDeletePathId(const ui64 /* tabletId */, const NColumnShard::TUnifiedPathId& /* pathId */) {
     }
+
+    // CutHistory hooks.
+    virtual bool IsCSCutHistoryEnabled() const {
+        return false;
+    }
+
+    virtual void OnHistoryEntryNominated(const ui32 /*channel*/, const ui32 /*fromGeneration*/) {
+    }
+
+    virtual void OnHistoryEntryCut(const ui32 /*channel*/, const ui32 /*fromGeneration*/) {
+    }
 };
 
 class IKqpController {

--- a/ydb/core/tx/columnshard/hooks/abstract/abstract.h
+++ b/ydb/core/tx/columnshard/hooks/abstract/abstract.h
@@ -428,7 +428,6 @@ public:
     virtual void OnDeletePathId(const ui64 /* tabletId */, const NColumnShard::TUnifiedPathId& /* pathId */) {
     }
 
-    // CutHistory hooks.
     virtual bool IsCSCutHistoryEnabled() const {
         return false;
     }

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -116,9 +116,7 @@ public:
     using THistoryCutterWrapper::THistoryCutterWrapper;
 };
 
-// Runs callbacks under a real actor context inside TTestBasicRuntime, so cutter
-// methods that Send/Register (TryNominate, OnBatchComplete) exercise their
-// production paths against edge actors instead of being stubbed out.
+// Runs callbacks under a real actor context so Send/Register paths execute for real.
 struct TEvRunInActor: public NActors::TEventLocal<TEvRunInActor, EventSpaceBegin(NActors::TEvents::ES_PRIVATE)> {
     std::function<void(const NActors::TActorContext&)> Fn;
 
@@ -155,137 +153,111 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
      */
 
     Y_UNIT_TEST(IncrementOnPortionAdded) {
-        // Tablet: 3 channels, 2 history entries each.
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 111;
-        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, nullptr, TActorId());
-        auto* cutter = bm->GetHistoryCutter();
-        UNIT_ASSERT(cutter);
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
 
-        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
-
-        // A blob on channel 2 at generation 3 falls in entry {ch=2, fromGen=0}.
-        const TLogoBlobID blob = MakeBlob(TabletId, /*ch=*/2, /*gen=*/3);
-        // TPortionDataAccessor is not easily constructible here; test counter
-        // logic via OnBootComplete which calls IncrementCounter internally.
-        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(blob);
+        // TPortionDataAccessor is not constructible here; OnBootComplete drives the
+        // same IncrementCounter path.
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
-        portionBlobs[/*portionId=*/42].push_back(ub);
-
-        cutter->OnBootComplete(portionBlobs);
-
-        // The entry {ch=2, fromGen=0} should have counter=1 now.
-        // Verify indirectly: cutter must NOT nominate it (counter != 0).
-        // GetSweepCandidates() is non-empty only after TryNominate; since we have no actor
-        // context here, just check IsSweepInFlight() is false and no candidates.
-        UNIT_ASSERT(!cutter->IsSweepInFlight());
-        UNIT_ASSERT(cutter->GetSweepCandidates()->empty());
+        portionBlobs[42].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 3)));
+        cutter.OnBootComplete(portionBlobs);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(TEntryKey{ 2, 0 }), 1);
     }
 
     Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 222;
-        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, nullptr, TActorId());
-        auto* cutter = bm->GetHistoryCutter();
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
+        const TEntryKey key{ 2, 0 };
 
-        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
-
-        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(MakeBlob(TabletId, 2, 3));
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
-        portionBlobs[42].push_back(ub);
-        cutter->OnBootComplete(portionBlobs);
+        portionBlobs[42].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 3)));
+        cutter.OnBootComplete(portionBlobs);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 1);
 
-        cutter->OnPortionRemoved(42);
-
-        // Now counter=0 and BlobsToKeep/Delete empty → IsDrained true → entry is nominatable.
-        // We cannot call TryNominate without actor context, but we can verify GetSweepCandidates
-        // is still empty (TryNominate not yet called).
-        UNIT_ASSERT(!cutter->IsSweepInFlight());
+        cutter.OnPortionRemoved(42);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 0);
+        UNIT_ASSERT(!cutter.IsChannelPoisonedForTest(2));
     }
 
     Y_UNIT_TEST(ForeignBlobIgnored) {
-        // Blob from a different tablet should be ignored.
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 333;
-        static constexpr ui64 OtherTablet = 999;
-        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, nullptr, TActorId());
-        auto* cutter = bm->GetHistoryCutter();
-        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
 
-        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(MakeBlob(OtherTablet, 2, 3));
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
-        portionBlobs[55].push_back(ub);
-        cutter->OnBootComplete(portionBlobs);
+        portionBlobs[55].push_back(MakeUnifiedBlob(MakeBlob(/*foreign*/ 999, 2, 3)));
+        cutter.OnBootComplete(portionBlobs);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(TEntryKey{ 2, 0 }), 0);
 
-        // Foreign blob must not increment any counter.
-        // Entry {ch=2, fromGen=0} counter remains 0.
-        // If we remove portion 55 nothing should be poisoned.
-        cutter->OnPortionRemoved(55);
-        // No crash = test passes (no underflow → no poison).
-        UNIT_ASSERT(!cutter->IsSweepInFlight());
+        cutter.OnPortionRemoved(55);
+        UNIT_ASSERT(!cutter.IsChannelPoisonedForTest(2));
     }
 
     Y_UNIT_TEST(ActiveEntryBlobIgnored) {
-        // Blob at current generation should map to active entry and be ignored.
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 444;
         static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { CurrentGen, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, nullptr, TActorId());
-        auto* cutter = bm->GetHistoryCutter();
-        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
 
-        // Blob at generation==CurrentGen → active entry → ignored.
-        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(MakeBlob(TabletId, 2, CurrentGen));
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
-        portionBlobs[77].push_back(ub);
-        cutter->OnBootComplete(portionBlobs);
-        // No assertion other than no crash.
-        UNIT_ASSERT(!cutter->IsSweepInFlight());
+        portionBlobs[77].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, CurrentGen)));
+        cutter.OnBootComplete(portionBlobs);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(TEntryKey{ 2, 0 }), 0);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(TEntryKey{ 2, CurrentGen }), 0);
     }
 
     Y_UNIT_TEST(BootCompleteWithEmptyMap) {
-        // Boot with no portions is valid; cutter starts with zero counters.
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 555;
-        static constexpr ui32 CurrentGen = 3;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 3, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, nullptr, TActorId());
-        auto* cutter = bm->GetHistoryCutter();
-        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, 3, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, 3, bm, shared, TActorId(), TestSignals());
 
-        // Empty boot — all counters zero; entry {ch=2, fromGen=0} is drained.
-        cutter->OnBootComplete({});
-        UNIT_ASSERT(!cutter->IsSweepInFlight());
-        UNIT_ASSERT(cutter->GetSweepCandidates()->empty());
+        cutter.OnBootComplete({});
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(TEntryKey{ 2, 0 }), 0);
+        UNIT_ASSERT(!cutter.IsSweepInFlight());
+        UNIT_ASSERT(cutter.GetSweepCandidates()->empty());
     }
 
     Y_UNIT_TEST(DoubleBlobPerPortionDeduplicates) {
-        // Two blobs in the same portion mapping to the same entry → counter incremented only once.
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 666;
-        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, nullptr, TActorId());
-        auto* cutter = bm->GetHistoryCutter();
-        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
+        const TEntryKey key{ 2, 0 };
 
-        // Two blobs on the same channel/entry in one portion.
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
         portionBlobs[88].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 1, 1, 1)));
         portionBlobs[88].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 2, 1, 2)));
-        cutter->OnBootComplete(portionBlobs);
+        cutter.OnBootComplete(portionBlobs);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 1);
 
-        // Remove the portion → counter should go to 0 (was 1, not 2).
-        cutter->OnPortionRemoved(88);
-        // No poison → removal was clean.
-        UNIT_ASSERT(!cutter->IsSweepInFlight());
+        cutter.OnPortionRemoved(88);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 0);
+        UNIT_ASSERT(!cutter.IsChannelPoisonedForTest(2));
     }
 
     Y_UNIT_TEST(SeenGroupsCheck) {
@@ -429,9 +401,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_C(cutterOtherChannel.IsDrained(key), "a blob on another channel must not pin the entry");
     }
 
-    // Item 5 of the test plan: a counter underflow marks the whole channel poisoned,
-    // and a poisoned channel is excluded from nomination even when its entry passes
-    // every other gate.
+    // Underflow poisons the channel; nomination then skips it though every other gate is open.
     Y_UNIT_TEST(UnderflowPoisonsChannelAndBlocksNomination) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -463,10 +433,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(!cutter.IsSweepInFlight());
     }
 
-    // Item 9 of the test plan: OnBootComplete must clear every piece of ephemeral
-    // state. Each dirtied field is asserted through its own observer; a leak of any
-    // of them (stale CutState hides an entry, stale DisprovedAt means eternal
-    // backoff, stale poison mutes a channel) would keep this test red.
+    // OnBootComplete must clear every piece of ephemeral state; each field is asserted.
     Y_UNIT_TEST(BootCompleteResetsEphemeralState) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -521,8 +488,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(keyMid), 1);
     }
 
-    // Item 8 of the test plan, formula part: base 5m doubling per attempt, shift
-    // clamped at 12, capped at 6h — no overflow for absurd attempt counts.
+    // Backoff formula: 5m doubling per attempt, shift clamped at 12, capped at 6h.
     Y_UNIT_TEST(DisprovedCooldownFormula) {
         UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(0), TDuration::Minutes(5));
         UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(1), TDuration::Minutes(10));
@@ -533,10 +499,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(Max<ui32>()), THistoryCutterWrapper::DisprovedRetryMaxCooldown);
     }
 
-    // Item 6 of the test plan: the full happy path against real actors — nomination
-    // sends the sweep event, a clean exhausted sweep registers the barrier actor,
-    // the barrier is a HARD collect at nextFromGen-1 for the entry's own group, and
-    // an OK result produces TEvCutTabletHistory + TEvCutHistoryBarrierDone(ok).
+    // Happy path against real actors: nominate, sweep, hard barrier at nextFromGen-1, cut.
     Y_UNIT_TEST(SweepHappyPathSendsHardBarrier) {
         TTestBasicRuntime runtime;
         TAppPrepare app;
@@ -613,10 +576,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_VALUES_EQUAL(guard->GetCut().size(), 1);
     }
 
-    // Item 8 of the test plan, behavior part: each disproving sweep increments
-    // Attempts exactly once, the cooldown blocks renomination for exactly
-    // 5m * 2^attempts of mock time, and a sweep that finally survives to the
-    // barrier erases the backoff record entirely.
+    // One Attempts increment per disproving sweep; cooldown gates renomination in mock time.
     Y_UNIT_TEST(DisprovalBackoffGatesRenomination) {
         TTestBasicRuntime runtime;
         TAppPrepare app;

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/testlib/actor_helpers.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h>
+#include <ydb/core/tx/columnshard/blobs_action/common/const.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -103,6 +104,7 @@ using ECutState = NOlap::NBlobOperations::NBlobStorage::ECutState;
 class TTestableHistoryCutter: public THistoryCutterWrapper {
 public:
     using THistoryCutterWrapper::GetCutStateForTest;
+    using THistoryCutterWrapper::IsDrained;
     using THistoryCutterWrapper::StartSweepForTest;
     using THistoryCutterWrapper::THistoryCutterWrapper;
 };
@@ -315,6 +317,32 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(cutter.GetCutStateForTest(keyA) == ECutState::None);
         // Survivor keyB failed the final re-check (IsDrained false) → also None, no barrier.
         UNIT_ASSERT(cutter.GetCutStateForTest(keyB) == ECutState::None);
+    }
+
+    // The drain gate must treat our blobs shared out to other tablets as pinning
+    // the entry: while shared they are in no GC queue, but a hard barrier would
+    // collect them under the borrower.
+    Y_UNIT_TEST(SharedBlobsPinDrainGate) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        const ui64 TabletId = 888;
+        const ui64 BorrowerTabletId = 999;
+        // History: {fromGen=0, group=100}, {fromGen=5, group=200 (active)}.
+        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { 0, 100 }, { 5, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, /*gen=*/5, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+
+        TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId());
+        const TEntryKey key{ /*channel=*/2, /*fromGeneration=*/0 };
+
+        // Empty queues and empty shared registry: the old entry is drained.
+        UNIT_ASSERT(cutter.IsDrained(key));
+
+        // Share out one of OUR blobs living in the old range (channel 2, gen 1 < 5).
+        const NOlap::TUnifiedBlobId sharedOut(/*dsGroup=*/100, TLogoBlobID(TabletId, /*gen=*/1, /*step=*/1, /*channel=*/2, 100, 1));
+        UNIT_ASSERT(shared->UpsertSharedBlobOnLoad(sharedOut, NOlap::TTabletId(BorrowerTabletId)));
+        UNIT_ASSERT_C(!cutter.IsDrained(key), "shared-out blob in the old range must pin the entry");
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -16,6 +16,7 @@
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/size_literals.h>
 #include <util/generic/vector.h>
 
 namespace NKikimr {
@@ -45,9 +46,11 @@ TIntrusivePtr<TTabletStorageInfo> MakeTabletInfo(ui64 tabletId, ui32 nChannels, 
     return info;
 }
 
+static constexpr ui32 BlobSize = 1_KB;
+
 // Build a TLogoBlobID for a blob on a given tablet, channel, and generation.
 TLogoBlobID MakeBlob(ui64 tabletId, ui32 channel, ui32 gen, ui32 step = 1, ui32 cookie = 1) {
-    return TLogoBlobID(tabletId, gen, step, channel, 100, cookie);
+    return TLogoBlobID(tabletId, gen, step, channel, BlobSize, cookie);
 }
 
 // TUnifiedBlobId wrapper from a TLogoBlobID.
@@ -130,8 +133,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
     Y_UNIT_TEST(IncrementOnPortionAdded) {
         // Tablet: 3 channels, 2 history entries each.
-        const ui64 TabletId = 111;
-        const ui32 CurrentGen = 5;
+        static constexpr ui64 TabletId = 111;
+        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
         bm->InitHistoryCutter(bm, nullptr, TActorId());
@@ -160,8 +163,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     }
 
     Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
-        const ui64 TabletId = 222;
-        const ui32 CurrentGen = 5;
+        static constexpr ui64 TabletId = 222;
+        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
         bm->InitHistoryCutter(bm, nullptr, TActorId());
@@ -185,9 +188,9 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
     Y_UNIT_TEST(ForeignBlobIgnored) {
         // Blob from a different tablet should be ignored.
-        const ui64 TabletId = 333;
-        const ui64 OtherTablet = 999;
-        const ui32 CurrentGen = 5;
+        static constexpr ui64 TabletId = 333;
+        static constexpr ui64 OtherTablet = 999;
+        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
         bm->InitHistoryCutter(bm, nullptr, TActorId());
@@ -209,8 +212,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
     Y_UNIT_TEST(ActiveEntryBlobIgnored) {
         // Blob at current generation should map to active entry and be ignored.
-        const ui64 TabletId = 444;
-        const ui32 CurrentGen = 5;
+        static constexpr ui64 TabletId = 444;
+        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { CurrentGen, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
         bm->InitHistoryCutter(bm, nullptr, TActorId());
@@ -228,8 +231,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
     Y_UNIT_TEST(BootCompleteWithEmptyMap) {
         // Boot with no portions is valid; cutter starts with zero counters.
-        const ui64 TabletId = 555;
-        const ui32 CurrentGen = 3;
+        static constexpr ui64 TabletId = 555;
+        static constexpr ui32 CurrentGen = 3;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 3, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
         bm->InitHistoryCutter(bm, nullptr, TActorId());
@@ -244,8 +247,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
     Y_UNIT_TEST(DoubleBlobPerPortionDeduplicates) {
         // Two blobs in the same portion mapping to the same entry → counter incremented only once.
-        const ui64 TabletId = 666;
-        const ui32 CurrentGen = 5;
+        static constexpr ui64 TabletId = 666;
+        static constexpr ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
         bm->InitHistoryCutter(bm, nullptr, TActorId());
@@ -332,8 +335,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     Y_UNIT_TEST(SharedBlobsPinDrainGate) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
-        const ui64 TabletId = 888;
-        const ui64 BorrowerTabletId = 999;
+        static constexpr ui64 TabletId = 888;
+        static constexpr ui64 BorrowerTabletId = 999;
         // History: {fromGen=0, group=100}, {fromGen=5, group=200 (active)}.
         auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, /*gen=*/5, NOlap::TTabletId(TabletId));
@@ -350,6 +353,59 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const NOlap::TUnifiedBlobId sharedOut(/*dsGroup=*/100, TLogoBlobID(TabletId, /*gen=*/1, /*step=*/1, /*channel=*/2, 100, 1));
         UNIT_ASSERT(shared->UpsertSharedBlobOnLoad(sharedOut, NOlap::TTabletId(BorrowerTabletId)));
         UNIT_ASSERT_C(!cutter.IsDrained(key), "shared-out blob in the old range must pin the entry");
+    }
+
+    // The blob-manager arm of the drain gate: an entry whose range still holds queued
+    // blobs must not be nominated. Remove HasNoBlobsInRange() from IsDrained() and this
+    // test must fail.
+    Y_UNIT_TEST(QueuedBlobsPinDrainGate) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        static constexpr ui64 TabletId = 888;
+        static constexpr ui32 ChannelCount = 3;
+        static constexpr ui32 OldFromGen = 0;
+        static constexpr ui32 OldGroup = 100;
+        static constexpr ui32 ActiveFromGen = 5;
+        static constexpr ui32 ActiveGroup = 200;
+        static constexpr ui32 DataChannel = 2;
+        static constexpr ui32 OtherChannel = 1;
+        static constexpr ui32 GenInOldRange = 1;
+        const TVector<std::pair<ui32, ui32>> history{ { OldFromGen, OldGroup }, { ActiveFromGen, ActiveGroup } };
+        const TEntryKey key{ DataChannel, OldFromGen };
+
+        // Both owners must outlive the cutter: it keeps weak_ptrs to them, and IsDrained()
+        // answers false for an expired pointer, which would look exactly like "not drained".
+        auto makeCutter = [&](std::shared_ptr<NOlap::TBlobManager>& bmOut,
+                              std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>& sharedOut) {
+            auto info = MakeTabletInfo(TabletId, ChannelCount, history);
+            bmOut = std::make_shared<NOlap::TBlobManager>(info, ActiveFromGen, NOlap::TTabletId(TabletId));
+            sharedOut = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+                NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+            return TTestableHistoryCutter(info, ActiveFromGen, bmOut, sharedOut, TActorId(), TestSignals());
+        };
+
+        std::shared_ptr<NOlap::TBlobManager> bm;
+        std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> shared;
+        auto cutter = makeCutter(bm, shared);
+        UNIT_ASSERT_C(cutter.IsDrained(key), "empty queues: the old entry starts drained");
+
+        // A blob still awaiting collection, inside the entry's range.
+        bm->DeleteBlobOnComplete(NOlap::TTabletId(TabletId), MakeUnifiedBlob(MakeBlob(TabletId, DataChannel, GenInOldRange)));
+        UNIT_ASSERT_C(!cutter.IsDrained(key), "a blob still in the delete queue must pin the entry");
+
+        // Same channel, but the active entry's generation — outside this range.
+        std::shared_ptr<NOlap::TBlobManager> bmOutside;
+        std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> sharedOutside;
+        auto cutterOutside = makeCutter(bmOutside, sharedOutside);
+        bmOutside->DeleteBlobOnComplete(NOlap::TTabletId(TabletId), MakeUnifiedBlob(MakeBlob(TabletId, DataChannel, ActiveFromGen)));
+        UNIT_ASSERT_C(cutterOutside.IsDrained(key), "a blob outside the range must not pin the entry");
+
+        // Another channel entirely.
+        std::shared_ptr<NOlap::TBlobManager> bmOtherChannel;
+        std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> sharedOtherChannel;
+        auto cutterOtherChannel = makeCutter(bmOtherChannel, sharedOtherChannel);
+        bmOtherChannel->DeleteBlobOnComplete(NOlap::TTabletId(TabletId), MakeUnifiedBlob(MakeBlob(TabletId, OtherChannel, GenInOldRange)));
+        UNIT_ASSERT_C(cutterOtherChannel.IsDrained(key), "a blob on another channel must not pin the entry");
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -111,6 +111,22 @@ public:
     using THistoryCutterWrapper::THistoryCutterWrapper;
 };
 
+struct TCutterEnv {
+    TIntrusivePtr<TTabletStorageInfo> Info;
+    std::shared_ptr<NOlap::TBlobManager> Bm;
+    std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> Shared;
+};
+
+// The cutter keeps weak_ptrs to both managers, so they have to outlive it: keep the
+// returned object in the test's own scope, ahead of the cutter.
+TCutterEnv MakeCutterEnv(
+    const ui64 tabletId, const ui32 gen, const ui32 nChannels = 3, const TVector<std::pair<ui32, ui32>>& history = { { 0, 100 }, { 5, 200 } }) {
+    auto info = MakeTabletInfo(tabletId, nChannels, history);
+    return { info, std::make_shared<NOlap::TBlobManager>(info, gen, NOlap::TTabletId(tabletId)),
+        std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(tabletId)) };
+}
+
 // Runs callbacks under a real actor context so Send/Register paths execute for real.
 struct TEvRunInActor: public NActors::TEventLocal<TEvRunInActor, EventSpaceBegin(NActors::TEvents::ES_PRIVATE)> {
     std::function<void(const NActors::TActorContext&)> Fn;
@@ -148,10 +164,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 222;
-        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, 5);
         TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ 2, 0 };
 
@@ -168,10 +181,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     Y_UNIT_TEST(ForeignBlobIgnored) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 333;
-        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, 5);
         TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
 
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
@@ -187,10 +197,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 444;
         static constexpr ui32 CurrentGen = 5;
-        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { CurrentGen, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, CurrentGen, 3, { { 0, 100 }, { CurrentGen, 200 } });
         TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
 
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
@@ -203,10 +210,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     Y_UNIT_TEST(BootCompleteWithEmptyMap) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 555;
-        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 3, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, 3, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, 3, 3, { { 0, 100 }, { 3, 200 } });
         TTestableHistoryCutter cutter(info, 3, bm, shared, TActorId(), TestSignals());
 
         cutter.OnBootComplete({});
@@ -218,10 +222,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     Y_UNIT_TEST(DoubleBlobPerPortionDeduplicates) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 666;
-        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, 5);
         TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ 2, 0 };
 
@@ -303,10 +304,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         static constexpr ui64 TabletId = 888;
         static constexpr ui64 BorrowerTabletId = 999;
         // History: {fromGen=0, group=100}, {fromGen=5, group=200 (active)}.
-        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, /*gen=*/5, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, /*gen=*/5);
 
         TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ /*channel=*/2, /*fromGeneration=*/0 };
@@ -380,10 +378,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         static constexpr ui64 TabletId = 1010;
         static constexpr ui32 DataChannel = 2;
         static constexpr ui32 OldFromGen = 0;
-        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, /*gen=*/5, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, /*gen=*/5, /*nChannels=*/3, { { OldFromGen, 100 }, { 5, 200 } });
         TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ DataChannel, OldFromGen };
 
@@ -411,10 +406,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
         static constexpr ui64 TabletId = 2020;
         static constexpr ui32 CurrentGen = 10;
-        auto info = MakeTabletInfo(TabletId, /*nChannels=*/4, { { 0, 100 }, { 5, 200 }, { CurrentGen, 300 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, CurrentGen, /*nChannels=*/4, { { 0, 100 }, { 5, 200 }, { CurrentGen, 300 } });
         TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
         const auto ctx = NActors::TActivationContext::AsActorContext();
 
@@ -495,10 +487,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
             runtime.SimulateSleep(TDuration::MilliSeconds(1));
         };
 
-        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, OldGroup }, { ActiveFromGen, ActiveGroup } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] =
+            MakeCutterEnv(TabletId, CurrentGen, /*nChannels=*/3, { { OldFromGen, OldGroup }, { ActiveFromGen, ActiveGroup } });
         TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, edgeTablet, TestSignals());
         cutter.SetLauncherActorId(edgeLauncher);
         const TEntryKey key{ DataChannel, OldFromGen };
@@ -579,10 +569,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
             runtime.SimulateSleep(TDuration::MilliSeconds(1));
         };
 
-        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, OldGroup }, { CurrentGen, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, CurrentGen, /*nChannels=*/3, { { OldFromGen, OldGroup }, { CurrentGen, 200 } });
         TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, edgeTablet, TestSignals());
         const TEntryKey key{ DataChannel, OldFromGen };
 
@@ -706,10 +693,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         static constexpr ui32 CurrentGen = 5;
         static constexpr ui64 PortionId = 77;
 
-        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, 100 }, { CurrentGen, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, CurrentGen, /*nChannels=*/3, { { OldFromGen, 100 }, { CurrentGen, 200 } });
         TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ DataChannel, OldFromGen };
         const auto ctx = NActors::TActivationContext::AsActorContext();

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -1,4 +1,3 @@
-// Unit tests for the CutHistory (KIKIMR-26208) two-tier nomination engine.
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/testlib/actor_helpers.h>
@@ -20,10 +19,6 @@ namespace NKikimr {
 
 namespace {
 
-// ---- helpers ----------------------------------------------------------------
-
-// Build a TTabletStorageInfo with N channels, each having the given history.
-// historySlots: vector of (fromGeneration, groupId) pairs — first is oldest.
 TIntrusivePtr<TTabletStorageInfo> MakeTabletInfo(ui64 tabletId, ui32 nChannels, const TVector<std::pair<ui32, ui32>>& historySlots)
 {
     auto info = MakeIntrusive<TTabletStorageInfo>();
@@ -53,7 +48,6 @@ NOlap::TUnifiedBlobId MakeUnifiedBlob(const TLogoBlobID& logo) {
     return NOlap::TUnifiedBlobId(logo.TabletID(), logo);
 }
 
-// Test controller that enables CutHistory and counts nominated/cut events.
 class TCutHistoryController: public NYDBTest::ICSController {
 public:
     bool IsCSCutHistoryEnabled() const override {
@@ -105,7 +99,6 @@ static const NColumnShard::THistoryCutterCounters& TestSignals() {
     return counters.HistoryCutterCounters;
 }
 
-// Exposes the protected sweep test hooks to this suite only.
 class TTestableHistoryCutter: public THistoryCutterWrapper {
 public:
     using THistoryCutterWrapper::DecrementCounter;
@@ -142,8 +135,6 @@ public:
     }
 };
 
-// ---- tests ------------------------------------------------------------------
-
 Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     /*
      * With 3 channels (0, 1, 2) and two history entries per channel:
@@ -153,23 +144,6 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
      * Generation=5 => blobs written at gen=0..4 are in history[0], gen>=5 in history[1].
      * Only data channels (ch >= 2) are tracked.
      */
-
-    Y_UNIT_TEST(IncrementOnPortionAdded) {
-        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
-        static constexpr ui64 TabletId = 111;
-        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
-        auto bm = std::make_shared<NOlap::TBlobManager>(info, 5, NOlap::TTabletId(TabletId));
-        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
-            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
-        TTestableHistoryCutter cutter(info, 5, bm, shared, TActorId(), TestSignals());
-
-        // TPortionDataAccessor is not constructible here; OnBootComplete drives the
-        // same IncrementCounter path.
-        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
-        portionBlobs[42].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 3)));
-        cutter.OnBootComplete(portionBlobs);
-        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(TEntryKey{ 2, 0 }), 1);
-    }
 
     Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
@@ -284,13 +258,11 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/0));
         UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5));
         UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/10));
-        // Non-existent fromGeneration → not found → false.
         UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/99));
 
         // Entry {5,100} is blocked by {0,100} — unless {0,100} was already cut:
         // cut entries are transparent for the same-group walk.
         UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5, /*cutFromGenerations=*/{ 0 }));
-        // A cut entry of a DIFFERENT generation does not unblock it.
         UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5, /*cutFromGenerations=*/{ 10 }));
     }
 
@@ -314,11 +286,9 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
         const auto ctx = NActors::TActivationContext::AsActorContext();
 
-        // Batch 1 result: keyA disproved (blob found), cursor exhausted.
         cutter.OnBatchComplete({ keyA }, /*exhausted=*/true, ctx);
 
         UNIT_ASSERT(!cutter.IsSweepInFlight());
-        // Disproved entry: back to None, never SentBarrier.
         UNIT_ASSERT(cutter.GetCutStateForTest(keyA) == ECutState::None);
         // Survivor keyB failed the final re-check (IsDrained false) → also None, no barrier.
         UNIT_ASSERT(cutter.GetCutStateForTest(keyB) == ECutState::None);
@@ -341,7 +311,6 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ /*channel=*/2, /*fromGeneration=*/0 };
 
-        // Empty queues and empty shared registry: the old entry is drained.
         UNIT_ASSERT(cutter.IsDrained(key));
 
         // Share out one of OUR blobs living in the old range (channel 2, gen 1 < 5).
@@ -576,6 +545,16 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         cutter.OnBarrierResult(key, done->Get()->Ok);
         UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::Cut);
         UNIT_ASSERT_VALUES_EQUAL(guard->GetCut().size(), 1);
+
+        // Converged: a cut entry is never nominated again, so Hive gets one request per
+        // entry instead of a nominate/cut loop that would never let the group go.
+        const auto nominationsAfterCut = guard->GetNominated().size();
+        runInActor([&](const NActors::TActorContext& ctx) {
+            nominated = cutter.TryNominate(ctx);
+        });
+        UNIT_ASSERT_C(!nominated, "a cut entry must not be renominated");
+        UNIT_ASSERT_VALUES_EQUAL(guard->GetNominated().size(), nominationsAfterCut);
+        UNIT_ASSERT_VALUES_EQUAL(guard->GetCut().size(), 1);
     }
 
     // One Attempts increment per disproving sweep; cooldown gates renomination in mock time.
@@ -713,6 +692,41 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         bm->OnGCStartOnComplete(TGenStep{ CurrentGen, 0 });
         bm->OnGCFinishedOnComplete(TGenStep{ CurrentGen, 0 });
         UNIT_ASSERT_C(bm->HasNoBlobsInRange(DataChannel, 0, 5), "the orphaned mark left the delete queue with the task");
+    }
+
+    // A live portion in the entry's range blocks nomination; MoveData's rewrite reaches
+    // the cutter as the portion erase, and that is what opens the gate.
+    Y_UNIT_TEST(LivePortionBlocksNomination) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        static constexpr ui64 TabletId = 3131;
+        static constexpr ui32 DataChannel = 2;
+        static constexpr ui32 OldFromGen = 0;
+        static constexpr ui32 CurrentGen = 5;
+        static constexpr ui64 PortionId = 77;
+
+        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, 100 }, { CurrentGen, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
+        const TEntryKey key{ DataChannel, OldFromGen };
+        const auto ctx = NActors::TActivationContext::AsActorContext();
+
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
+        portionBlobs[PortionId].push_back(MakeUnifiedBlob(MakeBlob(TabletId, DataChannel, OldFromGen + 3)));
+        cutter.OnBootComplete(portionBlobs);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 1);
+        UNIT_ASSERT(cutter.IsDrained(key));
+
+        // Drained but not empty: the counter alone must hold nomination back.
+        UNIT_ASSERT_C(!cutter.TryNominate(ctx), "a live portion in the range must block nomination");
+        UNIT_ASSERT(guard->GetNominated().empty());
+
+        cutter.OnPortionRemoved(PortionId);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 0);
+        UNIT_ASSERT(!cutter.IsChannelPoisonedForTest(DataChannel));
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -100,6 +100,13 @@ using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
 using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
 using ECutState = NOlap::NBlobOperations::NBlobStorage::ECutState;
 
+// The suite only needs a live sensor instance to write into; values are asserted
+// through the cutter's own state, not through monitoring.
+static const NColumnShard::THistoryCutterCounters& TestSignals() {
+    static const NColumnShard::TBlobsManagerCounters counters("UT_BlobsManager");
+    return counters.HistoryCutterCounters;
+}
+
 // Exposes the protected sweep test hooks to this suite only.
 class TTestableHistoryCutter: public THistoryCutterWrapper {
 public:
@@ -299,7 +306,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // Standalone wrapper: expired manager weak_ptr makes IsDrained() false, so the
         // final re-check can never reach the barrier-send branch in this test.
         TTestableHistoryCutter cutter(info, /*currentGen=*/20, std::weak_ptr<NOlap::TBlobManager>(),
-            std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>(), TActorId());
+            std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>(), TActorId(), TestSignals());
 
         const TEntryKey keyA{ /*channel=*/2, /*fromGeneration=*/0 };
         const TEntryKey keyB{ /*channel=*/2, /*fromGeneration=*/5 };
@@ -333,7 +340,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
             NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
 
-        TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId());
+        TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId(), TestSignals());
         const TEntryKey key{ /*channel=*/2, /*fromGeneration=*/0 };
 
         // Empty queues and empty shared registry: the old entry is drained.

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -1,13 +1,4 @@
-/*
- * Unit tests for the CutHistory (KIKIMR-26208) two-tier nomination engine.
- *
- * Coverage:
- *   1. Counter update correctness: OnPortionAdded / OnPortionRemoved / OnBootComplete.
- *   2. Nomination gating: entry with live portions never nominated; drained+zero-counter -> nominated;
- *      seenGroups blocks a candidate whose group was already seen by a later entry; active entry
- *      (last history slot) never nominated.
- *   3. Tier-2 sweep disproves a candidate that still has blobs on disk -> no barrier sent.
- */
+// Unit tests for the CutHistory (KIKIMR-26208) two-tier nomination engine.
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/core/testlib/actor_helpers.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h>
@@ -48,12 +39,10 @@ TIntrusivePtr<TTabletStorageInfo> MakeTabletInfo(ui64 tabletId, ui32 nChannels, 
 
 static constexpr ui32 BlobSize = 1_KB;
 
-// Build a TLogoBlobID for a blob on a given tablet, channel, and generation.
 TLogoBlobID MakeBlob(ui64 tabletId, ui32 channel, ui32 gen, ui32 step = 1, ui32 cookie = 1) {
     return TLogoBlobID(tabletId, gen, step, channel, BlobSize, cookie);
 }
 
-// TUnifiedBlobId wrapper from a TLogoBlobID.
 NOlap::TUnifiedBlobId MakeUnifiedBlob(const TLogoBlobID& logo) {
     return NOlap::TUnifiedBlobId(logo.TabletID(), logo);
 }
@@ -141,7 +130,6 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         auto* cutter = bm->GetHistoryCutter();
         UNIT_ASSERT(cutter);
 
-        // Register the test controller so IsCSCutHistoryEnabled() returns true.
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
         // A blob on channel 2 at generation 3 falls in entry {ch=2, fromGen=0}.
@@ -177,7 +165,6 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         portionBlobs[42].push_back(ub);
         cutter->OnBootComplete(portionBlobs);
 
-        // Remove the portion — counter should decrement to 0.
         cutter->OnPortionRemoved(42);
 
         // Now counter=0 and BlobsToKeep/Delete empty → IsDrained true → entry is nominatable.

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -115,6 +115,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        bm->InitHistoryCutter(bm, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         UNIT_ASSERT(cutter);
 
@@ -144,6 +145,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        bm->InitHistoryCutter(bm, TActorId());
         auto* cutter = bm->GetHistoryCutter();
 
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
@@ -169,6 +171,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        bm->InitHistoryCutter(bm, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -191,6 +194,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { CurrentGen, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        bm->InitHistoryCutter(bm, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -209,6 +213,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 3;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 3, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        bm->InitHistoryCutter(bm, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -224,6 +229,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        bm->InitHistoryCutter(bm, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -1,0 +1,244 @@
+/*
+ * Unit tests for the CutHistory (KIKIMR-26208) two-tier nomination engine.
+ *
+ * Coverage:
+ *   1. Counter update correctness: OnPortionAdded / OnPortionRemoved / OnBootComplete.
+ *   2. Nomination gating: entry with live portions never nominated; drained+zero-counter -> nominated;
+ *      seenGroups blocks a candidate whose group was already seen by a later entry; active entry
+ *      (last history slot) never nominated.
+ *   3. Tier-2 sweep disproves a candidate that still has blobs on disk -> no barrier sent.
+ */
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h>
+#include <ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h>
+#include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/vector.h>
+
+namespace NKikimr {
+
+namespace {
+
+// ---- helpers ----------------------------------------------------------------
+
+// Build a TTabletStorageInfo with N channels, each having the given history.
+// historySlots: vector of (fromGeneration, groupId) pairs — first is oldest.
+TIntrusivePtr<TTabletStorageInfo> MakeTabletInfo(ui64 tabletId, ui32 nChannels, const TVector<std::pair<ui32, ui32>>& historySlots)
+{
+    auto info = MakeIntrusive<TTabletStorageInfo>();
+    info->TabletID = tabletId;
+    info->TabletType = TTabletTypes::ColumnShard;
+    info->Channels.resize(nChannels);
+    for (ui32 ch = 0; ch < nChannels; ++ch) {
+        info->Channels[ch].Channel = ch;
+        info->Channels[ch].Type = TBlobStorageGroupType(TBlobStorageGroupType::ErasureNone);
+        for (const auto& [fromGen, group] : historySlots) {
+            TTabletChannelInfo::THistoryEntry e;
+            e.FromGeneration = fromGen;
+            e.GroupID = group;
+            info->Channels[ch].History.push_back(e);
+        }
+    }
+    return info;
+}
+
+// Build a TLogoBlobID for a blob on a given tablet, channel, and generation.
+TLogoBlobID MakeBlob(ui64 tabletId, ui32 channel, ui32 gen, ui32 step = 1, ui32 cookie = 1) {
+    return TLogoBlobID(tabletId, gen, step, channel, 100, cookie);
+}
+
+// TUnifiedBlobId wrapper from a TLogoBlobID.
+NOlap::TUnifiedBlobId MakeUnifiedBlob(const TLogoBlobID& logo) {
+    return NOlap::TUnifiedBlobId(logo.TabletID(), logo);
+}
+
+// Test controller that enables CutHistory and counts nominated/cut events.
+class TCutHistoryController: public NYDBTest::ICSController {
+public:
+    bool IsCSCutHistoryEnabled() const override {
+        return true;
+    }
+
+    void OnHistoryEntryNominated(const ui32 channel, const ui32 fromGeneration) override {
+        TGuard<TMutex> g(Mutex);
+        Nominated.emplace_back(channel, fromGeneration);
+    }
+
+    void OnHistoryEntryCut(const ui32 channel, const ui32 fromGeneration) override {
+        TGuard<TMutex> g(Mutex);
+        Cut.emplace_back(channel, fromGeneration);
+    }
+
+    TVector<std::pair<ui32, ui32>> GetNominated() const {
+        TGuard<TMutex> g(Mutex);
+        return Nominated;
+    }
+
+    TVector<std::pair<ui32, ui32>> GetCut() const {
+        TGuard<TMutex> g(Mutex);
+        return Cut;
+    }
+
+    void Reset() {
+        TGuard<TMutex> g(Mutex);
+        Nominated.clear();
+        Cut.clear();
+    }
+
+private:
+    mutable TMutex Mutex;
+    TVector<std::pair<ui32, ui32>> Nominated;
+    TVector<std::pair<ui32, ui32>> Cut;
+};
+
+using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
+using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
+
+}   // anonymous namespace
+
+// ---- tests ------------------------------------------------------------------
+
+Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
+    /*
+     * With 3 channels (0, 1, 2) and two history entries per channel:
+     *   History[0]: fromGen=0, group=100
+     *   History[1]: fromGen=5, group=200  <-- active
+     *
+     * Generation=5 => blobs written at gen=0..4 are in history[0], gen>=5 in history[1].
+     * Only data channels (ch >= 2) are tracked.
+     */
+
+    Y_UNIT_TEST(IncrementOnPortionAdded) {
+        // Tablet: 3 channels, 2 history entries each.
+        const ui64 TabletId = 111;
+        const ui32 CurrentGen = 5;
+        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto* cutter = bm->GetHistoryCutter();
+        UNIT_ASSERT(cutter);
+
+        // Register the test controller so IsCSCutHistoryEnabled() returns true.
+        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        // A blob on channel 2 at generation 3 falls in entry {ch=2, fromGen=0}.
+        const TLogoBlobID blob = MakeBlob(TabletId, /*ch=*/2, /*gen=*/3);
+        // TPortionDataAccessor is not easily constructible here; test counter
+        // logic via OnBootComplete which calls IncrementCounter internally.
+        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(blob);
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
+        portionBlobs[/*portionId=*/42].push_back(ub);
+
+        cutter->OnBootComplete(portionBlobs);
+
+        // The entry {ch=2, fromGen=0} should have counter=1 now.
+        // Verify indirectly: cutter must NOT nominate it (counter != 0).
+        // GetSweepCandidates() is non-empty only after TryNominate; since we have no actor
+        // context here, just check SweepInFlight() is false and no candidates.
+        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(cutter->GetSweepCandidates().empty());
+    }
+
+    Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
+        const ui64 TabletId = 222;
+        const ui32 CurrentGen = 5;
+        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto* cutter = bm->GetHistoryCutter();
+
+        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(MakeBlob(TabletId, 2, 3));
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
+        portionBlobs[42].push_back(ub);
+        cutter->OnBootComplete(portionBlobs);
+
+        // Remove the portion — counter should decrement to 0.
+        cutter->OnPortionRemoved(42);
+
+        // Now counter=0 and BlobsToKeep/Delete empty → IsDrained true → entry is nominatable.
+        // We cannot call TryNominate without actor context, but we can verify GetSweepCandidates
+        // is still empty (TryNominate not yet called).
+        UNIT_ASSERT(!cutter->SweepInFlight());
+    }
+
+    Y_UNIT_TEST(ForeignBlobIgnored) {
+        // Blob from a different tablet should be ignored.
+        const ui64 TabletId = 333;
+        const ui64 OtherTablet = 999;
+        const ui32 CurrentGen = 5;
+        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto* cutter = bm->GetHistoryCutter();
+        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(MakeBlob(OtherTablet, 2, 3));
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
+        portionBlobs[55].push_back(ub);
+        cutter->OnBootComplete(portionBlobs);
+
+        // Foreign blob must not increment any counter.
+        // Entry {ch=2, fromGen=0} counter remains 0.
+        // If we remove portion 55 nothing should be poisoned.
+        cutter->OnPortionRemoved(55);
+        // No crash = test passes (no underflow → no poison).
+        UNIT_ASSERT(!cutter->SweepInFlight());
+    }
+
+    Y_UNIT_TEST(ActiveEntryBlobIgnored) {
+        // Blob at current generation should map to active entry and be ignored.
+        const ui64 TabletId = 444;
+        const ui32 CurrentGen = 5;
+        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { CurrentGen, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto* cutter = bm->GetHistoryCutter();
+        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        // Blob at generation==CurrentGen → active entry → ignored.
+        const NOlap::TUnifiedBlobId ub = MakeUnifiedBlob(MakeBlob(TabletId, 2, CurrentGen));
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
+        portionBlobs[77].push_back(ub);
+        cutter->OnBootComplete(portionBlobs);
+        // No assertion other than no crash.
+        UNIT_ASSERT(!cutter->SweepInFlight());
+    }
+
+    Y_UNIT_TEST(BootCompleteWithEmptyMap) {
+        // Boot with no portions is valid; cutter starts with zero counters.
+        const ui64 TabletId = 555;
+        const ui32 CurrentGen = 3;
+        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 3, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto* cutter = bm->GetHistoryCutter();
+        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        // Empty boot — all counters zero; entry {ch=2, fromGen=0} is drained.
+        cutter->OnBootComplete({});
+        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(cutter->GetSweepCandidates().empty());
+    }
+
+    Y_UNIT_TEST(DoubleBlobPerPortionDeduplicates) {
+        // Two blobs in the same portion mapping to the same entry → counter incremented only once.
+        const ui64 TabletId = 666;
+        const ui32 CurrentGen = 5;
+        auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto* cutter = bm->GetHistoryCutter();
+        NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        // Two blobs on the same channel/entry in one portion.
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> portionBlobs;
+        portionBlobs[88].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 1, 1, 1)));
+        portionBlobs[88].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 2, 1, 2)));
+        cutter->OnBootComplete(portionBlobs);
+
+        // Remove the portion → counter should go to 0 (was 1, not 2).
+        cutter->OnPortionRemoved(88);
+        // No poison → removal was clean.
+        UNIT_ASSERT(!cutter->SweepInFlight());
+    }
+
+}   // TCutHistoryCutterCounters
+
+}   // namespace NKikimr

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -92,10 +92,10 @@ private:
     TVector<std::pair<ui32, ui32>> Cut;
 };
 
+}   // anonymous namespace
+
 using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
 using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
-
-}   // anonymous namespace
 
 // ---- tests ------------------------------------------------------------------
 
@@ -237,6 +237,32 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         cutter->OnPortionRemoved(88);
         // No poison → removal was clean.
         UNIT_ASSERT(!cutter->SweepInFlight());
+    }
+
+    Y_UNIT_TEST(SeenGroupsCheck) {
+        // History: [{fromGen=0, group=100}, {fromGen=5, group=100}, {fromGen=10, group=200}]
+        //   entry {fromGen=0, group=100}: no earlier entries → passes
+        //   entry {fromGen=5, group=100}: earlier entry {0,100} already has group 100 → blocked
+        //   entry {fromGen=10, group=200}: earlier entries have groups {100,100}; 200 not seen → passes
+        //   entry {fromGen=10, group=200} is the active (last) entry — TryNominate skips it via loop
+        //   bound, but SeenGroupsCheckPasses itself does not exclude it.
+        using TEntry = TTabletChannelInfo::THistoryEntry;
+        std::vector<TEntry> hist;
+        auto addEntry = [&](ui32 fromGen, ui32 group) {
+            TEntry e;
+            e.FromGeneration = fromGen;
+            e.GroupID = group;
+            hist.push_back(e);
+        };
+        addEntry(0, 100);
+        addEntry(5, 100);
+        addEntry(10, 200);
+
+        UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/0));
+        UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5));
+        UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/10));
+        // Non-existent fromGeneration → not found → false.
+        UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/99));
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -532,7 +532,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(done);
         UNIT_ASSERT(done->Get()->Ok);
 
-        cutter.OnBarrierResult(key, done->Get()->Ok);
+        cutter.OnBarrierResult(key, done->Get()->Ok, runtime.GetCurrentTime());
         UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::Cut);
         UNIT_ASSERT_VALUES_EQUAL(guard->GetCut().size(), 1);
 
@@ -619,6 +619,86 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(runtime.GrabEdgeEvent<TEvBlobStorage::TEvCollectGarbage>(edgeBs));
         UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::SentBarrier);
         UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 0);
+    }
+
+    // Open item 4: a failed barrier must enter the disproval cooldown (~10m), not
+    // retry the whole sweep + barrier every nomination cadence against the same
+    // obstacle. Observable contract: TryNominate returns false within the window
+    // and true once it lapses. Repeated barrier failures plateau at the same ~10m
+    // window (they do not escalate the way sweep disprovals do, because the
+    // pre-barrier Attempts erase resets the counter back to 0 before each new
+    // OnBarrierResult raises it to 1 again). Assertions are purely behavioral:
+    // TryNominate return value and TEvCollectGarbage reaching the proxy.
+    Y_UNIT_TEST(BarrierFailureEntersDisprovalCooldown) {
+        TTestBasicRuntime runtime;
+        TAppPrepare app;
+        runtime.Initialize(app.Unwrap());
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        static constexpr ui64 TabletId = 4041;
+        static constexpr ui32 DataChannel = 2;
+        static constexpr ui32 OldFromGen = 0;
+        static constexpr ui32 OldGroup = 100;
+        static constexpr ui32 CurrentGen = 5;
+
+        const auto edgeTablet = runtime.AllocateEdgeActor();
+        const auto edgeBs = runtime.AllocateEdgeActor();
+        runtime.RegisterService(MakeBlobStorageProxyID(OldGroup), edgeBs);
+        const auto runner = runtime.Register(new TRunnerActor());
+        auto runInActor = [&](std::function<void(const NActors::TActorContext&)> fn) {
+            runtime.Send(new IEventHandle(runner, edgeTablet, new TEvRunInActor(std::move(fn))));
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+        };
+
+        auto [info, bm, shared] = MakeCutterEnv(TabletId, CurrentGen, /*nChannels=*/3, { { OldFromGen, OldGroup }, { CurrentGen, 200 } });
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, edgeTablet, TestSignals());
+        const TEntryKey key{ DataChannel, OldFromGen };
+
+        auto tryNominate = [&](bool expected) {
+            bool result = !expected;
+            runInActor([&](const NActors::TActorContext& ctx) {
+                result = cutter.TryNominate(ctx);
+            });
+            UNIT_ASSERT_VALUES_EQUAL(result, expected);
+        };
+        // Drives a clean sweep all the way to the barrier message (empty portion
+        // snapshot, no disprovals). The observable outcome is TEvCollectGarbage
+        // going out to the proxy — that is the only assertion inside this lambda.
+        auto sweepCleanToBarrier = [&]() {
+            UNIT_ASSERT(runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvStartCutHistorySweep>(edgeTablet));
+            cutter.SetPortionSnapshot({});
+            runInActor([&](const NActors::TActorContext& ctx) {
+                cutter.OnBatchComplete({}, /*exhausted=*/true, ctx);
+            });
+            UNIT_ASSERT(runtime.GrabEdgeEvent<TEvBlobStorage::TEvCollectGarbage>(edgeBs));
+        };
+
+        // First sweep → barrier → failure → cooldown window (~10m).
+        tryNominate(true);
+        sweepCleanToBarrier();
+        cutter.OnBarrierResult(key, /*ok=*/false, runtime.GetCurrentTime());
+
+        // cooldown(1) ≈ 10m from the failure: 2m and 7m are still inside the
+        // window; 11m clears it.
+        runtime.AdvanceCurrentTime(TDuration::Minutes(2));
+        tryNominate(false);
+        runtime.AdvanceCurrentTime(TDuration::Minutes(5));
+        tryNominate(false);
+        runtime.AdvanceCurrentTime(TDuration::Minutes(4));
+        tryNominate(true);
+
+        // Second sweep → barrier → second failure. The window must stay at ~10m
+        // (not escalate to ~20m), proving that repeated barrier failures plateau
+        // at the same cooldown level.
+        sweepCleanToBarrier();
+        cutter.OnBarrierResult(key, /*ok=*/false, runtime.GetCurrentTime());
+
+        // Second cooldown window: 2m blocked, then another 9m (total 11m from
+        // the second failure) clears it — same ~10m as the first window.
+        runtime.AdvanceCurrentTime(TDuration::Minutes(2));
+        tryNominate(false);
+        runtime.AdvanceCurrentTime(TDuration::Minutes(9));
+        tryNominate(true);
     }
 
     Y_UNIT_TEST(InFlightGCTaskPinsDrainGate) {

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -9,6 +9,7 @@
  *   3. Tier-2 sweep disproves a candidate that still has blobs on disk -> no barrier sent.
  */
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/testlib/actor_helpers.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
@@ -96,6 +97,15 @@ private:
 
 using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
 using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
+using ECutState = NOlap::NBlobOperations::NBlobStorage::ECutState;
+
+// Exposes the protected sweep test hooks to this suite only.
+class TTestableHistoryCutter: public THistoryCutterWrapper {
+public:
+    using THistoryCutterWrapper::GetCutStateForTest;
+    using THistoryCutterWrapper::StartSweepForTest;
+    using THistoryCutterWrapper::THistoryCutterWrapper;
+};
 
 // ---- tests ------------------------------------------------------------------
 
@@ -137,7 +147,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // GetSweepCandidates() is non-empty only after TryNominate; since we have no actor
         // context here, just check IsSweepInFlight() is false and no candidates.
         UNIT_ASSERT(!cutter->IsSweepInFlight());
-        UNIT_ASSERT(cutter->GetSweepCandidates().empty());
+        UNIT_ASSERT(cutter->GetSweepCandidates()->empty());
     }
 
     Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
@@ -220,7 +230,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // Empty boot — all counters zero; entry {ch=2, fromGen=0} is drained.
         cutter->OnBootComplete({});
         UNIT_ASSERT(!cutter->IsSweepInFlight());
-        UNIT_ASSERT(cutter->GetSweepCandidates().empty());
+        UNIT_ASSERT(cutter->GetSweepCandidates()->empty());
     }
 
     Y_UNIT_TEST(DoubleBlobPerPortionDeduplicates) {
@@ -269,6 +279,41 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/10));
         // Non-existent fromGeneration → not found → false.
         UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/99));
+
+        // Entry {5,100} is blocked by {0,100} — unless {0,100} was already cut:
+        // cut entries are transparent for the same-group walk.
+        UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5, /*cutFromGenerations=*/{ 0 }));
+        // A cut entry of a DIFFERENT generation does not unblock it.
+        UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5, /*cutFromGenerations=*/{ 10 }));
+    }
+
+    // Sweep disproval path: disproved candidates return to None (with retry cooldown),
+    // and no barrier is attempted for survivors that fail the final re-check.
+    Y_UNIT_TEST(SweepDisprovalPath) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        // 3 channels; history: {fromGen=0, group=100}, {fromGen=5, group=200}, {fromGen=10, group=300 (active)}.
+        auto info = MakeTabletInfo(/*tabletId=*/777, /*nChannels=*/3, { { 0, 100 }, { 5, 200 }, { 10, 300 } });
+        // Standalone wrapper: expired manager weak_ptr makes IsDrained() false, so the
+        // final re-check can never reach the barrier-send branch in this test.
+        TTestableHistoryCutter cutter(info, /*currentGen=*/20, std::weak_ptr<NOlap::TBlobManager>(), TActorId());
+
+        const TEntryKey keyA{ /*channel=*/2, /*fromGeneration=*/0 };
+        const TEntryKey keyB{ /*channel=*/2, /*fromGeneration=*/5 };
+        cutter.StartSweepForTest({ keyA, keyB });
+        UNIT_ASSERT(cutter.IsSweepInFlight());
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetSweepCandidates()->size(), 2);
+
+        const auto ctx = NActors::TActivationContext::AsActorContext();
+
+        // Batch 1 result: keyA disproved (blob found), cursor exhausted.
+        cutter.OnBatchComplete({ keyA }, /*exhausted=*/true, ctx);
+
+        UNIT_ASSERT(!cutter.IsSweepInFlight());
+        // Disproved entry: back to None, never SentBarrier.
+        UNIT_ASSERT(cutter.GetCutStateForTest(keyA) == ECutState::None);
+        // Survivor keyB failed the final re-check (IsDrained false) → also None, no barrier.
+        UNIT_ASSERT(cutter.GetCutStateForTest(keyB) == ECutState::None);
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -5,8 +5,10 @@
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h>
+#include <ydb/core/tx/columnshard/blobs_action/bs/gc.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h>
 #include <ydb/core/tx/columnshard/blobs_action/common/const.h>
+#include <ydb/core/tx/columnshard/blobs_action/counters/storage.h>
 #include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 
@@ -651,6 +653,66 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(runtime.GrabEdgeEvent<TEvBlobStorage::TEvCollectGarbage>(edgeBs));
         UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::SentBarrier);
         UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 0);
+    }
+
+    Y_UNIT_TEST(InFlightGCTaskPinsDrainGate) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        static constexpr ui64 TabletId = 889;
+        static constexpr ui32 CurrentGen = 5;
+        const TVector<std::pair<ui32, ui32>> history{ { 0, 100 }, { CurrentGen, 200 } };
+        const TEntryKey key{ 2, 0 };
+
+        auto info = MakeTabletInfo(TabletId, 3, history);
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
+        UNIT_ASSERT(cutter.IsDrained(key));
+
+        auto storageCounters = std::make_shared<NOlap::NBlobOperations::TStorageCounters>(NOlap::NBlobOperations::TGlobal::DefaultStorageId);
+        auto gcCounters =
+            std::make_shared<NOlap::NBlobOperations::TRemoveGCCounters>(NOlap::NBlobOperations::TConsumerCounters("GC", *storageCounters));
+        auto task = bm->BuildGCTask(NOlap::NBlobOperations::TGlobal::DefaultStorageId, bm, shared, gcCounters);
+        UNIT_ASSERT_C(task, "the first GC round carries the barrier even with empty queues");
+        UNIT_ASSERT_C(!cutter.IsDrained(key), "a GC task in flight must pin every entry");
+
+        const TGenStep barrier{ CurrentGen, 0 };
+        bm->OnGCStartOnComplete(barrier);
+        bm->OnGCFinishedOnComplete(barrier);
+        UNIT_ASSERT_C(cutter.IsDrained(key), "the pin is released once the task commits");
+    }
+
+    Y_UNIT_TEST(OrphanedDeleteMarkUnderCutEntryIsErasedNotCollected) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        static constexpr ui64 TabletId = 890;
+        static constexpr ui32 CurrentGen = 7;
+        static constexpr ui32 DataChannel = 2;
+        const TVector<std::pair<ui32, ui32>> history{ { 5, 200 } };
+
+        auto info = MakeTabletInfo(TabletId, 3, history);
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+
+        const TLogoBlobID orphan(TabletId, /*gen=*/0, /*step=*/0, DataChannel, BlobSize, /*cookie=*/1);
+        UNIT_ASSERT_VALUES_EQUAL(info->GroupFor(orphan), Max<ui32>());
+        bm->DeleteBlobOnComplete(NOlap::TTabletId(TabletId), NOlap::TUnifiedBlobId(Max<ui32>(), orphan));
+
+        auto storageCounters = std::make_shared<NOlap::NBlobOperations::TStorageCounters>(NOlap::NBlobOperations::TGlobal::DefaultStorageId);
+        auto gcCounters =
+            std::make_shared<NOlap::NBlobOperations::TRemoveGCCounters>(NOlap::NBlobOperations::TConsumerCounters("GC", *storageCounters));
+        auto task = bm->BuildGCTask(NOlap::NBlobOperations::TGlobal::DefaultStorageId, bm, shared, gcCounters);
+        UNIT_ASSERT(task);
+        const TString sentinelPrefix = "g=" + ToString(Max<ui32>()) + ";";
+        for (const auto& [address, lists] : task->GetListsByGroupId()) {
+            UNIT_ASSERT_C(
+                !address.DebugString().StartsWith(sentinelPrefix), "no GC request may target the sentinel group: " + address.DebugString());
+        }
+        bm->OnGCStartOnComplete(TGenStep{ CurrentGen, 0 });
+        bm->OnGCFinishedOnComplete(TGenStep{ CurrentGen, 0 });
+        UNIT_ASSERT_C(bm->HasNoBlobsInRange(DataChannel, 0, 5), "the orphaned mark left the delete queue with the task");
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -125,7 +125,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, TActorId());
+        bm->InitHistoryCutter(bm, nullptr, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         UNIT_ASSERT(cutter);
 
@@ -155,7 +155,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, TActorId());
+        bm->InitHistoryCutter(bm, nullptr, TActorId());
         auto* cutter = bm->GetHistoryCutter();
 
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
@@ -181,7 +181,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, TActorId());
+        bm->InitHistoryCutter(bm, nullptr, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -204,7 +204,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { CurrentGen, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, TActorId());
+        bm->InitHistoryCutter(bm, nullptr, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -223,7 +223,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 3;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 3, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, TActorId());
+        bm->InitHistoryCutter(bm, nullptr, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -239,7 +239,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const ui32 CurrentGen = 5;
         auto info = MakeTabletInfo(TabletId, 3, { { 0, 100 }, { 5, 200 } });
         auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
-        bm->InitHistoryCutter(bm, TActorId());
+        bm->InitHistoryCutter(bm, nullptr, TActorId());
         auto* cutter = bm->GetHistoryCutter();
         NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
 
@@ -296,7 +296,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         auto info = MakeTabletInfo(/*tabletId=*/777, /*nChannels=*/3, { { 0, 100 }, { 5, 200 }, { 10, 300 } });
         // Standalone wrapper: expired manager weak_ptr makes IsDrained() false, so the
         // final re-check can never reach the barrier-send branch in this test.
-        TTestableHistoryCutter cutter(info, /*currentGen=*/20, std::weak_ptr<NOlap::TBlobManager>(), TActorId());
+        TTestableHistoryCutter cutter(info, /*currentGen=*/20, std::weak_ptr<NOlap::TBlobManager>(),
+            std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>(), TActorId());
 
         const TEntryKey keyA{ /*channel=*/2, /*fromGeneration=*/0 };
         const TEntryKey keyB{ /*channel=*/2, /*fromGeneration=*/5 };

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -1,9 +1,13 @@
 // Unit tests for the CutHistory (KIKIMR-26208) two-tier nomination engine.
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/tablet.h>
 #include <ydb/core/testlib/actor_helpers.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/blob_manager.h>
 #include <ydb/core/tx/columnshard/blobs_action/bs/history_cutter.h>
 #include <ydb/core/tx/columnshard/blobs_action/common/const.h>
+#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -102,10 +106,40 @@ static const NColumnShard::THistoryCutterCounters& TestSignals() {
 // Exposes the protected sweep test hooks to this suite only.
 class TTestableHistoryCutter: public THistoryCutterWrapper {
 public:
+    using THistoryCutterWrapper::DecrementCounter;
+    using THistoryCutterWrapper::GetCounterForTest;
     using THistoryCutterWrapper::GetCutStateForTest;
+    using THistoryCutterWrapper::GetDisprovalAttemptsForTest;
+    using THistoryCutterWrapper::IsChannelPoisonedForTest;
     using THistoryCutterWrapper::IsDrained;
     using THistoryCutterWrapper::StartSweepForTest;
     using THistoryCutterWrapper::THistoryCutterWrapper;
+};
+
+// Runs callbacks under a real actor context inside TTestBasicRuntime, so cutter
+// methods that Send/Register (TryNominate, OnBatchComplete) exercise their
+// production paths against edge actors instead of being stubbed out.
+struct TEvRunInActor: public NActors::TEventLocal<TEvRunInActor, EventSpaceBegin(NActors::TEvents::ES_PRIVATE)> {
+    std::function<void(const NActors::TActorContext&)> Fn;
+
+    explicit TEvRunInActor(std::function<void(const NActors::TActorContext&)> fn)
+        : Fn(std::move(fn))
+    {
+    }
+};
+
+class TRunnerActor: public NActors::TActor<TRunnerActor> {
+public:
+    TRunnerActor()
+        : NActors::TActor<TRunnerActor>(&TRunnerActor::StateWork)
+    {
+    }
+
+    STFUNC(StateWork) {
+        if (auto* run = ev->CastAsLocal<TEvRunInActor>()) {
+            run->Fn(ActorContext());
+        }
+    }
 };
 
 // ---- tests ------------------------------------------------------------------
@@ -393,6 +427,270 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         auto cutterOtherChannel = makeCutter(bmOtherChannel, sharedOtherChannel);
         bmOtherChannel->DeleteBlobOnComplete(NOlap::TTabletId(TabletId), MakeUnifiedBlob(MakeBlob(TabletId, OtherChannel, GenInOldRange)));
         UNIT_ASSERT_C(cutterOtherChannel.IsDrained(key), "a blob on another channel must not pin the entry");
+    }
+
+    // Item 5 of the test plan: a counter underflow marks the whole channel poisoned,
+    // and a poisoned channel is excluded from nomination even when its entry passes
+    // every other gate.
+    Y_UNIT_TEST(UnderflowPoisonsChannelAndBlocksNomination) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        static constexpr ui64 TabletId = 1010;
+        static constexpr ui32 DataChannel = 2;
+        static constexpr ui32 OldFromGen = 0;
+        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, 100 }, { 5, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, /*gen=*/5, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, /*currentGen=*/5, bm, shared, TActorId(), TestSignals());
+        const TEntryKey key{ DataChannel, OldFromGen };
+
+        // Positive control: without the poison every nomination gate is open.
+        UNIT_ASSERT(cutter.IsDrained(key));
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(key), 0);
+        UNIT_ASSERT(!cutter.IsChannelPoisonedForTest(DataChannel));
+
+        // Decrement with no matching counter — the underflow branch.
+        cutter.DecrementCounter(key);
+        UNIT_ASSERT(cutter.IsChannelPoisonedForTest(DataChannel));
+
+        // The poisoned channel yields no candidates (the stub context is safe here:
+        // an empty batch means TryNominate returns before any actor-system send).
+        const auto ctx = NActors::TActivationContext::AsActorContext();
+        UNIT_ASSERT(!cutter.TryNominate(ctx));
+        UNIT_ASSERT(guard->GetNominated().empty());
+        UNIT_ASSERT(!cutter.IsSweepInFlight());
+    }
+
+    // Item 9 of the test plan: OnBootComplete must clear every piece of ephemeral
+    // state. Each dirtied field is asserted through its own observer; a leak of any
+    // of them (stale CutState hides an entry, stale DisprovedAt means eternal
+    // backoff, stale poison mutes a channel) would keep this test red.
+    Y_UNIT_TEST(BootCompleteResetsEphemeralState) {
+        TActorSystemStub actorSystemStub;
+        actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+        static constexpr ui64 TabletId = 2020;
+        static constexpr ui32 CurrentGen = 10;
+        auto info = MakeTabletInfo(TabletId, /*nChannels=*/4, { { 0, 100 }, { 5, 200 }, { CurrentGen, 300 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, TActorId(), TestSignals());
+        const auto ctx = NActors::TActivationContext::AsActorContext();
+
+        const TEntryKey keyOld{ /*channel=*/2, /*fromGeneration=*/0 };
+        const TEntryKey keyMid{ /*channel=*/2, /*fromGeneration=*/5 };
+        static constexpr ui32 PoisonChannel = 3;
+
+        // Dirty everything reachable: counters, disproval backoff, poison, and an
+        // in-flight sweep with Verifying state and a portion cursor.
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> oldPortions;
+        oldPortions[1].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 1)));
+        cutter.OnBootComplete(oldPortions);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(keyOld), 1);
+
+        cutter.StartSweepForTest({ keyOld });
+        cutter.OnBatchComplete({ keyOld }, /*exhausted=*/true, ctx);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(keyOld), 1);
+
+        cutter.DecrementCounter(TEntryKey{ PoisonChannel, 0 });
+        UNIT_ASSERT(cutter.IsChannelPoisonedForTest(PoisonChannel));
+
+        cutter.StartSweepForTest({ keyMid });
+        cutter.SetPortionSnapshot({ { NOlap::TInternalPathId::FromRawValue(1), 7 } });
+        UNIT_ASSERT(cutter.IsSweepInFlight());
+        UNIT_ASSERT(cutter.HasPortionSnapshot());
+        UNIT_ASSERT(cutter.GetCutStateForTest(keyMid) == ECutState::Verifying);
+
+        // Reboot with a different portion map: nothing from above may survive.
+        THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> newPortions;
+        newPortions[2].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 7, /*step=*/1, /*cookie=*/2)));
+        cutter.OnBootComplete(newPortions);
+
+        UNIT_ASSERT(!cutter.IsSweepInFlight());
+        UNIT_ASSERT(cutter.GetSweepCandidates()->empty());
+        UNIT_ASSERT(cutter.GetActiveSweepCandidates()->empty());
+        UNIT_ASSERT(!cutter.HasPortionSnapshot());
+        UNIT_ASSERT(cutter.GetCutStateForTest(keyMid) == ECutState::None);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(keyOld), 0);
+        UNIT_ASSERT(!cutter.IsChannelPoisonedForTest(PoisonChannel));
+        // Counters reflect only the new map: gen=7 falls in entry {2,5}, not {2,0}.
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(keyOld), 0);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetCounterForTest(keyMid), 1);
+    }
+
+    // Item 8 of the test plan, formula part: base 5m doubling per attempt, shift
+    // clamped at 12, capped at 6h — no overflow for absurd attempt counts.
+    Y_UNIT_TEST(DisprovedCooldownFormula) {
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(0), TDuration::Minutes(5));
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(1), TDuration::Minutes(10));
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(2), TDuration::Minutes(20));
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(6), TDuration::Minutes(320));
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(7), THistoryCutterWrapper::DisprovedRetryMaxCooldown);
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(12), THistoryCutterWrapper::DisprovedRetryMaxCooldown);
+        UNIT_ASSERT_VALUES_EQUAL(THistoryCutterWrapper::GetDisprovedCooldown(Max<ui32>()), THistoryCutterWrapper::DisprovedRetryMaxCooldown);
+    }
+
+    // Item 6 of the test plan: the full happy path against real actors — nomination
+    // sends the sweep event, a clean exhausted sweep registers the barrier actor,
+    // the barrier is a HARD collect at nextFromGen-1 for the entry's own group, and
+    // an OK result produces TEvCutTabletHistory + TEvCutHistoryBarrierDone(ok).
+    Y_UNIT_TEST(SweepHappyPathSendsHardBarrier) {
+        TTestBasicRuntime runtime;
+        TAppPrepare app;
+        runtime.Initialize(app.Unwrap());
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        static constexpr ui64 TabletId = 3030;
+        static constexpr ui32 DataChannel = 2;
+        static constexpr ui32 OldFromGen = 0;
+        static constexpr ui32 OldGroup = 100;
+        static constexpr ui32 ActiveFromGen = 5;
+        static constexpr ui32 ActiveGroup = 200;
+        static constexpr ui32 CurrentGen = ActiveFromGen;
+
+        const auto edgeTablet = runtime.AllocateEdgeActor();
+        const auto edgeLauncher = runtime.AllocateEdgeActor();
+        const auto edgeBs = runtime.AllocateEdgeActor();
+        runtime.RegisterService(MakeBlobStorageProxyID(OldGroup), edgeBs);
+        const auto runner = runtime.Register(new TRunnerActor());
+        auto runInActor = [&](std::function<void(const NActors::TActorContext&)> fn) {
+            runtime.Send(new IEventHandle(runner, edgeTablet, new TEvRunInActor(std::move(fn))));
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+        };
+
+        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, OldGroup }, { ActiveFromGen, ActiveGroup } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, edgeTablet, TestSignals());
+        cutter.SetLauncherActorId(edgeLauncher);
+        const TEntryKey key{ DataChannel, OldFromGen };
+
+        // Empty queues: the old entry is drained and must be nominated.
+        bool nominated = false;
+        runInActor([&](const NActors::TActorContext& ctx) {
+            nominated = cutter.TryNominate(ctx);
+        });
+        UNIT_ASSERT(nominated);
+        UNIT_ASSERT(runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvStartCutHistorySweep>(edgeTablet));
+        UNIT_ASSERT_VALUES_EQUAL(guard->GetNominated().size(), 1);
+        UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::Verifying);
+
+        // Clean exhausted sweep (empty snapshot, nothing disproved) → barrier send.
+        cutter.SetPortionSnapshot({});
+        runInActor([&](const NActors::TActorContext& ctx) {
+            cutter.OnBatchComplete({}, /*exhausted=*/true, ctx);
+        });
+        UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::SentBarrier);
+
+        auto collect = runtime.GrabEdgeEvent<TEvBlobStorage::TEvCollectGarbage>(edgeBs);
+        UNIT_ASSERT(collect);
+        UNIT_ASSERT(collect->Get()->Hard);
+        UNIT_ASSERT(collect->Get()->Collect);
+        UNIT_ASSERT_VALUES_EQUAL(collect->Get()->TabletId, TabletId);
+        UNIT_ASSERT_VALUES_EQUAL(collect->Get()->Channel, DataChannel);
+        UNIT_ASSERT_VALUES_EQUAL(collect->Get()->CollectGeneration, ActiveFromGen - 1);
+
+        runtime.Send(new IEventHandle(collect->Sender, edgeBs, new TEvBlobStorage::TEvCollectGarbageResult(NKikimrProto::OK, TabletId,
+                                                                   CurrentGen, collect->Get()->PerGenerationCounter, DataChannel)));
+
+        auto cutReq = runtime.GrabEdgeEvent<TEvTablet::TEvCutTabletHistory>(edgeLauncher);
+        UNIT_ASSERT(cutReq);
+        UNIT_ASSERT_VALUES_EQUAL(cutReq->Get()->Record.GetTabletID(), TabletId);
+        UNIT_ASSERT_VALUES_EQUAL(cutReq->Get()->Record.GetChannel(), DataChannel);
+        UNIT_ASSERT_VALUES_EQUAL(cutReq->Get()->Record.GetFromGeneration(), OldFromGen);
+        UNIT_ASSERT_VALUES_EQUAL(cutReq->Get()->Record.GetGroupID(), OldGroup);
+
+        auto done = runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvCutHistoryBarrierDone>(edgeTablet);
+        UNIT_ASSERT(done);
+        UNIT_ASSERT(done->Get()->Ok);
+
+        cutter.OnBarrierResult(key, done->Get()->Ok);
+        UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::Cut);
+        UNIT_ASSERT_VALUES_EQUAL(guard->GetCut().size(), 1);
+    }
+
+    // Item 8 of the test plan, behavior part: each disproving sweep increments
+    // Attempts exactly once, the cooldown blocks renomination for exactly
+    // 5m * 2^attempts of mock time, and a sweep that finally survives to the
+    // barrier erases the backoff record entirely.
+    Y_UNIT_TEST(DisprovalBackoffGatesRenomination) {
+        TTestBasicRuntime runtime;
+        TAppPrepare app;
+        runtime.Initialize(app.Unwrap());
+        auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
+
+        static constexpr ui64 TabletId = 4040;
+        static constexpr ui32 DataChannel = 2;
+        static constexpr ui32 OldFromGen = 0;
+        static constexpr ui32 OldGroup = 100;
+        static constexpr ui32 CurrentGen = 5;
+
+        const auto edgeTablet = runtime.AllocateEdgeActor();
+        const auto edgeBs = runtime.AllocateEdgeActor();
+        runtime.RegisterService(MakeBlobStorageProxyID(OldGroup), edgeBs);
+        const auto runner = runtime.Register(new TRunnerActor());
+        auto runInActor = [&](std::function<void(const NActors::TActorContext&)> fn) {
+            runtime.Send(new IEventHandle(runner, edgeTablet, new TEvRunInActor(std::move(fn))));
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+        };
+
+        auto info = MakeTabletInfo(TabletId, /*nChannels=*/3, { { OldFromGen, OldGroup }, { CurrentGen, 200 } });
+        auto bm = std::make_shared<NOlap::TBlobManager>(info, CurrentGen, NOlap::TTabletId(TabletId));
+        auto shared = std::make_shared<NOlap::NDataSharing::TStorageSharedBlobsManager>(
+            NOlap::NBlobOperations::TGlobal::DefaultStorageId, NOlap::TTabletId(TabletId));
+        TTestableHistoryCutter cutter(info, CurrentGen, bm, shared, edgeTablet, TestSignals());
+        const TEntryKey key{ DataChannel, OldFromGen };
+
+        auto tryNominate = [&](bool expected) {
+            bool result = !expected;
+            runInActor([&](const NActors::TActorContext& ctx) {
+                result = cutter.TryNominate(ctx);
+            });
+            UNIT_ASSERT_VALUES_EQUAL(result, expected);
+        };
+        auto disproveSweep = [&]() {
+            UNIT_ASSERT(runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvStartCutHistorySweep>(edgeTablet));
+            cutter.SetPortionSnapshot({});
+            runInActor([&](const NActors::TActorContext& ctx) {
+                cutter.OnBatchComplete({ key }, /*exhausted=*/true, ctx);
+            });
+        };
+
+        tryNominate(true);
+        disproveSweep();
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 1);
+
+        // After one disproval Attempts=1, so renomination waits cooldown(1)=10m
+        // measured from that disproval: 2m and 6m stay blocked, 11m passes.
+        runtime.AdvanceCurrentTime(TDuration::Minutes(2));
+        tryNominate(false);
+        runtime.AdvanceCurrentTime(TDuration::Minutes(4));
+        tryNominate(false);
+        runtime.AdvanceCurrentTime(TDuration::Minutes(5));
+        tryNominate(true);
+        disproveSweep();
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 2);
+
+        // attempts=2 → 20m window: 12m blocked, 21m clears.
+        runtime.AdvanceCurrentTime(TDuration::Minutes(12));
+        tryNominate(false);
+        runtime.AdvanceCurrentTime(TDuration::Minutes(9));
+        tryNominate(true);
+
+        // This time nothing disproves the entry: the sweep survives to the barrier
+        // and the backoff record is erased before SentBarrier.
+        UNIT_ASSERT(runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvStartCutHistorySweep>(edgeTablet));
+        cutter.SetPortionSnapshot({});
+        runInActor([&](const NActors::TActorContext& ctx) {
+            cutter.OnBatchComplete({}, /*exhausted=*/true, ctx);
+        });
+        UNIT_ASSERT(runtime.GrabEdgeEvent<TEvBlobStorage::TEvCollectGarbage>(edgeBs));
+        UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::SentBarrier);
+        UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 0);
     }
 
 }   // TCutHistoryCutterCounters

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -134,8 +134,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // The entry {ch=2, fromGen=0} should have counter=1 now.
         // Verify indirectly: cutter must NOT nominate it (counter != 0).
         // GetSweepCandidates() is non-empty only after TryNominate; since we have no actor
-        // context here, just check SweepInFlight() is false and no candidates.
-        UNIT_ASSERT(!cutter->SweepInFlight());
+        // context here, just check IsSweepInFlight() is false and no candidates.
+        UNIT_ASSERT(!cutter->IsSweepInFlight());
         UNIT_ASSERT(cutter->GetSweepCandidates().empty());
     }
 
@@ -159,7 +159,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // Now counter=0 and BlobsToKeep/Delete empty → IsDrained true → entry is nominatable.
         // We cannot call TryNominate without actor context, but we can verify GetSweepCandidates
         // is still empty (TryNominate not yet called).
-        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(!cutter->IsSweepInFlight());
     }
 
     Y_UNIT_TEST(ForeignBlobIgnored) {
@@ -182,7 +182,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // If we remove portion 55 nothing should be poisoned.
         cutter->OnPortionRemoved(55);
         // No crash = test passes (no underflow → no poison).
-        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(!cutter->IsSweepInFlight());
     }
 
     Y_UNIT_TEST(ActiveEntryBlobIgnored) {
@@ -200,7 +200,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         portionBlobs[77].push_back(ub);
         cutter->OnBootComplete(portionBlobs);
         // No assertion other than no crash.
-        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(!cutter->IsSweepInFlight());
     }
 
     Y_UNIT_TEST(BootCompleteWithEmptyMap) {
@@ -214,7 +214,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
 
         // Empty boot — all counters zero; entry {ch=2, fromGen=0} is drained.
         cutter->OnBootComplete({});
-        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(!cutter->IsSweepInFlight());
         UNIT_ASSERT(cutter->GetSweepCandidates().empty());
     }
 
@@ -236,7 +236,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         // Remove the portion → counter should go to 0 (was 1, not 2).
         cutter->OnPortionRemoved(88);
         // No poison → removal was clean.
-        UNIT_ASSERT(!cutter->SweepInFlight());
+        UNIT_ASSERT(!cutter->IsSweepInFlight());
     }
 
     Y_UNIT_TEST(SeenGroupsCheck) {

--- a/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
+++ b/ydb/core/tx/columnshard/ut_cut_history/ut_cut_history.cpp
@@ -92,8 +92,7 @@ using TEntryKey = NOlap::NBlobOperations::NBlobStorage::TEntryKey;
 using THistoryCutterWrapper = NOlap::NBlobOperations::NBlobStorage::THistoryCutterWrapper;
 using ECutState = NOlap::NBlobOperations::NBlobStorage::ECutState;
 
-// The suite only needs a live sensor instance to write into; values are asserted
-// through the cutter's own state, not through monitoring.
+// Only a live sensor instance is needed: values are asserted through the cutter's own state.
 static const NColumnShard::THistoryCutterCounters& TestSignals() {
     static const NColumnShard::TBlobsManagerCounters counters("UT_BlobsManager");
     return counters.HistoryCutterCounters;
@@ -117,8 +116,7 @@ struct TCutterEnv {
     std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager> Shared;
 };
 
-// The cutter keeps weak_ptrs to both managers, so they have to outlive it: keep the
-// returned object in the test's own scope, ahead of the cutter.
+// The cutter holds weak_ptrs to both managers, so keep this object in scope ahead of the cutter.
 TCutterEnv MakeCutterEnv(
     const ui64 tabletId, const ui32 gen, const ui32 nChannels = 3, const TVector<std::pair<ui32, ui32>>& history = { { 0, 100 }, { 5, 200 } }) {
     auto info = MakeTabletInfo(tabletId, nChannels, history);
@@ -152,14 +150,7 @@ public:
 };
 
 Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
-    /*
-     * With 3 channels (0, 1, 2) and two history entries per channel:
-     *   History[0]: fromGen=0, group=100
-     *   History[1]: fromGen=5, group=200  <-- active
-     *
-     * Generation=5 => blobs written at gen=0..4 are in history[0], gen>=5 in history[1].
-     * Only data channels (ch >= 2) are tracked.
-     */
+    // Channels 0-2, history {fromGen=0, group=100} and active {fromGen=5, group=200}; only ch >= 2 is tracked.
 
     Y_UNIT_TEST(DecrementToZeroOnPortionRemoved) {
         auto guard = NYDBTest::TControllers::RegisterCSControllerGuard<TCutHistoryController>();
@@ -238,12 +229,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
     }
 
     Y_UNIT_TEST(SeenGroupsCheck) {
-        // History: [{fromGen=0, group=100}, {fromGen=5, group=100}, {fromGen=10, group=200}]
-        //   entry {fromGen=0, group=100}: no earlier entries → passes
-        //   entry {fromGen=5, group=100}: earlier entry {0,100} already has group 100 → blocked
-        //   entry {fromGen=10, group=200}: earlier entries have groups {100,100}; 200 not seen → passes
-        //   entry {fromGen=10, group=200} is the active (last) entry — TryNominate skips it via loop
-        //   bound, but SeenGroupsCheckPasses itself does not exclude it.
+        // History [{0,100}, {5,100}, {10,200}]: {5,100} is blocked by the earlier {0,100}, the others pass.
         using TEntry = TTabletChannelInfo::THistoryEntry;
         std::vector<TEntry> hist;
         auto addEntry = [&](ui32 fromGen, ui32 group) {
@@ -261,21 +247,18 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/10));
         UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/99));
 
-        // Entry {5,100} is blocked by {0,100} — unless {0,100} was already cut:
-        // cut entries are transparent for the same-group walk.
+        // {5,100} is blocked by {0,100} unless that one was cut: cut entries are transparent.
         UNIT_ASSERT(THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5, /*cutFromGenerations=*/{ 0 }));
         UNIT_ASSERT(!THistoryCutterWrapper::SeenGroupsCheckPasses(hist, /*fromGen=*/5, /*cutFromGenerations=*/{ 10 }));
     }
 
-    // Sweep disproval path: disproved candidates return to None (with retry cooldown),
-    // and no barrier is attempted for survivors that fail the final re-check.
+    // Disproved candidates return to None, and survivors failing the final re-check get no barrier.
     Y_UNIT_TEST(SweepDisprovalPath) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
         // 3 channels; history: {fromGen=0, group=100}, {fromGen=5, group=200}, {fromGen=10, group=300 (active)}.
         auto info = MakeTabletInfo(/*tabletId=*/777, /*nChannels=*/3, { { 0, 100 }, { 5, 200 }, { 10, 300 } });
-        // Standalone wrapper: expired manager weak_ptr makes IsDrained() false, so the
-        // final re-check can never reach the barrier-send branch in this test.
+        // An expired manager weak_ptr keeps IsDrained() false, so the re-check never reaches barrier-send.
         TTestableHistoryCutter cutter(info, /*currentGen=*/20, std::weak_ptr<NOlap::TBlobManager>(),
             std::weak_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>(), TActorId(), TestSignals());
 
@@ -295,9 +278,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(cutter.GetCutStateForTest(keyB) == ECutState::None);
     }
 
-    // The drain gate must treat our blobs shared out to other tablets as pinning
-    // the entry: while shared they are in no GC queue, but a hard barrier would
-    // collect them under the borrower.
+    // Shared-out blobs must pin the entry: they are in no GC queue, but a barrier collects them anyway.
     Y_UNIT_TEST(SharedBlobsPinDrainGate) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -317,9 +298,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_C(!cutter.IsDrained(key), "shared-out blob in the old range must pin the entry");
     }
 
-    // The blob-manager arm of the drain gate: an entry whose range still holds queued
-    // blobs must not be nominated. Remove HasNoBlobsInRange() from IsDrained() and this
-    // test must fail.
+    // An entry whose range still holds queued blobs must not be nominated (HasNoBlobsInRange arm).
     Y_UNIT_TEST(QueuedBlobsPinDrainGate) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -335,8 +314,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const TVector<std::pair<ui32, ui32>> history{ { OldFromGen, OldGroup }, { ActiveFromGen, ActiveGroup } };
         const TEntryKey key{ DataChannel, OldFromGen };
 
-        // Both owners must outlive the cutter: it keeps weak_ptrs to them, and IsDrained()
-        // answers false for an expired pointer, which would look exactly like "not drained".
+        // Both owners must outlive the cutter: an expired weak_ptr looks exactly like "not drained".
         auto makeCutter = [&](std::shared_ptr<NOlap::TBlobManager>& bmOut,
                               std::shared_ptr<NOlap::NDataSharing::TStorageSharedBlobsManager>& sharedOut) {
             auto info = MakeTabletInfo(TabletId, ChannelCount, history);
@@ -391,8 +369,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         cutter.DecrementCounter(key);
         UNIT_ASSERT(cutter.IsChannelPoisonedForTest(DataChannel));
 
-        // The poisoned channel yields no candidates (the stub context is safe here:
-        // an empty batch means TryNominate returns before any actor-system send).
+        // The poisoned channel yields no candidates, so TryNominate returns before any actor-system send.
         const auto ctx = NActors::TActivationContext::AsActorContext();
         UNIT_ASSERT(!cutter.TryNominate(ctx));
         UNIT_ASSERT(guard->GetNominated().empty());
@@ -414,8 +391,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         const TEntryKey keyMid{ /*channel=*/2, /*fromGeneration=*/5 };
         static constexpr ui32 PoisonChannel = 3;
 
-        // Dirty everything reachable: counters, disproval backoff, poison, and an
-        // in-flight sweep with Verifying state and a portion cursor.
+        // Dirty everything reachable: counters, backoff, poison, and an in-flight sweep with a cursor.
         THashMap<ui64, std::vector<NOlap::TUnifiedBlobId>> oldPortions;
         oldPortions[1].push_back(MakeUnifiedBlob(MakeBlob(TabletId, 2, 1)));
         cutter.OnBootComplete(oldPortions);
@@ -536,8 +512,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT(cutter.GetCutStateForTest(key) == ECutState::Cut);
         UNIT_ASSERT_VALUES_EQUAL(guard->GetCut().size(), 1);
 
-        // Converged: a cut entry is never nominated again, so Hive gets one request per
-        // entry instead of a nominate/cut loop that would never let the group go.
+        // A cut entry is never nominated again: Hive gets one request per entry, not a nominate/cut loop.
         const auto nominationsAfterCut = guard->GetNominated().size();
         runInActor([&](const NActors::TActorContext& ctx) {
             nominated = cutter.TryNominate(ctx);
@@ -592,8 +567,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         disproveSweep();
         UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 1);
 
-        // After one disproval Attempts=1, so renomination waits cooldown(1)=10m
-        // measured from that disproval: 2m and 6m stay blocked, 11m passes.
+        // Attempts=1 after one disproval, so cooldown(1)=10m: 2m and 6m stay blocked, 11m passes.
         runtime.AdvanceCurrentTime(TDuration::Minutes(2));
         tryNominate(false);
         runtime.AdvanceCurrentTime(TDuration::Minutes(4));
@@ -609,8 +583,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         runtime.AdvanceCurrentTime(TDuration::Minutes(9));
         tryNominate(true);
 
-        // This time nothing disproves the entry: the sweep survives to the barrier
-        // and the backoff record is erased before SentBarrier.
+        // Nothing disproves the entry now: the sweep reaches the barrier and the backoff record is erased.
         UNIT_ASSERT(runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvStartCutHistorySweep>(edgeTablet));
         cutter.SetPortionSnapshot({});
         runInActor([&](const NActors::TActorContext& ctx) {
@@ -621,14 +594,8 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_VALUES_EQUAL(cutter.GetDisprovalAttemptsForTest(key), 0);
     }
 
-    // Open item 4: a failed barrier must enter the disproval cooldown (~10m), not
-    // retry the whole sweep + barrier every nomination cadence against the same
-    // obstacle. Observable contract: TryNominate returns false within the window
-    // and true once it lapses. Repeated barrier failures plateau at the same ~10m
-    // window (they do not escalate the way sweep disprovals do, because the
-    // pre-barrier Attempts erase resets the counter back to 0 before each new
-    // OnBarrierResult raises it to 1 again). Assertions are purely behavioral:
-    // TryNominate return value and TEvCollectGarbage reaching the proxy.
+    // A failed barrier enters the ~10m disproval cooldown instead of retrying every cadence, and repeated
+    // failures plateau there because the pre-barrier erase resets Attempts before each OnBarrierResult.
     Y_UNIT_TEST(BarrierFailureEntersDisprovalCooldown) {
         TTestBasicRuntime runtime;
         TAppPrepare app;
@@ -661,9 +628,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
             });
             UNIT_ASSERT_VALUES_EQUAL(result, expected);
         };
-        // Drives a clean sweep all the way to the barrier message (empty portion
-        // snapshot, no disprovals). The observable outcome is TEvCollectGarbage
-        // going out to the proxy — that is the only assertion inside this lambda.
+        // Drives a clean sweep to the barrier; the only assertion here is TEvCollectGarbage reaching the proxy.
         auto sweepCleanToBarrier = [&]() {
             UNIT_ASSERT(runtime.GrabEdgeEvent<NColumnShard::TEvPrivate::TEvStartCutHistorySweep>(edgeTablet));
             cutter.SetPortionSnapshot({});
@@ -678,8 +643,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         sweepCleanToBarrier();
         cutter.OnBarrierResult(key, /*ok=*/false, runtime.GetCurrentTime());
 
-        // cooldown(1) ≈ 10m from the failure: 2m and 7m are still inside the
-        // window; 11m clears it.
+        // cooldown(1) is about 10m from the failure: 2m and 7m stay inside the window, 11m clears it.
         runtime.AdvanceCurrentTime(TDuration::Minutes(2));
         tryNominate(false);
         runtime.AdvanceCurrentTime(TDuration::Minutes(5));
@@ -687,14 +651,11 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         runtime.AdvanceCurrentTime(TDuration::Minutes(4));
         tryNominate(true);
 
-        // Second sweep → barrier → second failure. The window must stay at ~10m
-        // (not escalate to ~20m), proving that repeated barrier failures plateau
-        // at the same cooldown level.
+        // A second failure must keep the window at ~10m rather than escalating to ~20m.
         sweepCleanToBarrier();
         cutter.OnBarrierResult(key, /*ok=*/false, runtime.GetCurrentTime());
 
-        // Second cooldown window: 2m blocked, then another 9m (total 11m from
-        // the second failure) clears it — same ~10m as the first window.
+        // Second window: 2m blocked, 11m total from the failure clears it — same ~10m as the first.
         runtime.AdvanceCurrentTime(TDuration::Minutes(2));
         tryNominate(false);
         runtime.AdvanceCurrentTime(TDuration::Minutes(9));
@@ -761,8 +722,7 @@ Y_UNIT_TEST_SUITE(TCutHistoryCutterCounters) {
         UNIT_ASSERT_C(bm->HasNoBlobsInRange(DataChannel, 0, 5), "the orphaned mark left the delete queue with the task");
     }
 
-    // A live portion in the entry's range blocks nomination; MoveData's rewrite reaches
-    // the cutter as the portion erase, and that is what opens the gate.
+    // A live portion in the range blocks nomination; the portion erase from MoveData opens the gate.
     Y_UNIT_TEST(LivePortionBlocksNomination) {
         TActorSystemStub actorSystemStub;
         actorSystemStub.AppData.Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();

--- a/ydb/core/tx/columnshard/ut_cut_history/ya.make
+++ b/ydb/core/tx/columnshard/ut_cut_history/ya.make
@@ -4,6 +4,7 @@ SIZE(SMALL)
 
 PEERDIR(
     ydb/core/tx/columnshard/blobs_action/bs
+    ydb/core/tx/columnshard/blobs_action/counters
     ydb/core/tx/columnshard/hooks/abstract
     ydb/core/testlib/default
 )

--- a/ydb/core/tx/columnshard/ut_cut_history/ya.make
+++ b/ydb/core/tx/columnshard/ut_cut_history/ya.make
@@ -1,0 +1,17 @@
+UNITTEST_FOR(ydb/core/tx/columnshard)
+
+SIZE(SMALL)
+
+PEERDIR(
+    ydb/core/tx/columnshard/blobs_action/bs
+    ydb/core/tx/columnshard/hooks/abstract
+    ydb/core/testlib/default
+)
+
+SRCS(
+    ut_cut_history.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/columnshard/ya.make
+++ b/ydb/core/tx/columnshard/ya.make
@@ -17,6 +17,7 @@ SRCS(
     columnshard__tx_abort.cpp
     columnshard__write.cpp
     columnshard__write_index.cpp
+    columnshard_cut_history.cpp
     columnshard_impl.cpp
     columnshard_private_events.cpp
     columnshard_schema.cpp
@@ -106,6 +107,7 @@ RECURSE(
 )
 
 RECURSE_FOR_TESTS(
+    ut_cut_history
     ut_rw
     ut_schema
     backup

--- a/ydb/tests/compatibility/olap/test_cut_history.py
+++ b/ydb/tests/compatibility/olap/test_cut_history.py
@@ -95,7 +95,9 @@ class TestCutHistory(RollingUpgradeAndDowngradeFixture):
             pytest.skip("CutHistory is available starting from 26.4")
 
         yield from self.setup_cluster(
-            extra_feature_flags=["enable_cut_history"],
+            # Both legs are needed for the pool to converge: the platform flag drives the
+            # channel-0/1 cutters, the decommission flag drives ColumnShard's data channels.
+            extra_feature_flags=["enable_cut_history", "enable_columnshard_group_decommission"],
             column_shard_config={
                 "alter_object_enabled": True,
             },

--- a/ydb/tests/compatibility/olap/test_cut_history.py
+++ b/ydb/tests/compatibility/olap/test_cut_history.py
@@ -13,6 +13,70 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 logger = logging.getLogger(__name__)
 
 
+class TestCutHistoryDormant(RollingUpgradeAndDowngradeFixture):
+    """The combination the guarded test cannot reach: NEW code rolled against OLD
+    config. No CutHistory flags are set, so on >= 26.4 nodes the cutter machinery is
+    present but dormant, and the roll proves a mixed-version cluster survives tablet
+    generation churn with the feature merely compiled in. Runs on any version matrix.
+    """
+
+    rows_count = 100
+    restart_rounds = 2
+
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        yield from self.setup_cluster(
+            column_shard_config={
+                "alter_object_enabled": True,
+            },
+        )
+
+    def test_dormant_roll(self):
+        table_name = "olap_cut_history_dormant"
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            session_pool.execute_with_retries(
+                f"""
+                CREATE TABLE `{table_name}` (
+                    ts Timestamp NOT NULL,
+                    id Uint64 NOT NULL,
+                    payload Utf8,
+                    PRIMARY KEY (ts, id)
+                )
+                PARTITION BY HASH(ts, id)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 4)
+                """
+            )
+            values = ",".join(
+                f'(Timestamp("2024-01-01T00:{i // 60 % 60:02d}:{i % 60:02d}.000000Z"), {i}, "p{i}")'
+                for i in range(self.rows_count)
+            )
+            session_pool.execute_with_retries(f"INSERT INTO `{table_name}` (ts, id, payload) VALUES {values};")
+
+        client = kikimr_client_factory("localhost", self.cluster.nodes[1].port)
+
+        def restart_column_shards():
+            response = client.tablet_state(tablet_type=TabletTypes.COLUMNSHARD)
+            for info in response.TabletStateInfo:
+                client.tablet_kill(info.TabletId)
+
+        def assert_readable():
+            with ydb.QuerySessionPool(self.driver) as session_pool:
+                result = session_pool.execute_with_retries(
+                    f"SELECT COUNT(*) AS cnt FROM `{table_name}`;",
+                    retry_settings=ydb.RetrySettings(idempotent=True),
+                )
+                assert result[0].rows[0]["cnt"] == self.rows_count
+
+        # Generation churn first, so channel history exists for the roll to stress.
+        for _ in range(self.restart_rounds):
+            restart_column_shards()
+            assert_readable()
+
+        for _ in self.roll():
+            assert_readable()
+        assert_readable()
+
+
 class TestCutHistory(RollingUpgradeAndDowngradeFixture):
     """Roll the cluster while CutHistory is trimming ColumnShard channel history.
 

--- a/ydb/tests/compatibility/olap/test_cut_history.py
+++ b/ydb/tests/compatibility/olap/test_cut_history.py
@@ -34,10 +34,12 @@ class TestCutHistory(RollingUpgradeAndDowngradeFixture):
             extra_feature_flags=["enable_cut_history"],
             column_shard_config={
                 "cut_history_enabled": True,
-                # ColumnShard is on the deny list by default, which disables the
-                # cutter for exactly the tablets under test.
-                "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
                 "alter_object_enabled": True,
+            },
+            # The deny list is Hive's, not ColumnShard's, and ColumnShard is on it by
+            # default — which would disable the cutter for the tablets under test.
+            hive_config={
+                "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
             },
         )
 

--- a/ydb/tests/compatibility/olap/test_cut_history.py
+++ b/ydb/tests/compatibility/olap/test_cut_history.py
@@ -1,0 +1,153 @@
+import json
+import logging
+import time
+import urllib.request
+
+import pytest
+
+from ydb.tests.library.clients.kikimr_client import kikimr_client_factory
+from ydb.tests.library.common.types import TabletTypes
+from ydb.tests.library.compatibility.fixtures import RollingUpgradeAndDowngradeFixture
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+logger = logging.getLogger(__name__)
+
+
+class TestCutHistory(RollingUpgradeAndDowngradeFixture):
+    """Roll the cluster while CutHistory is trimming ColumnShard channel history.
+
+    History entries only appear on generation changes, so the tablets are restarted
+    to produce them; the cutter then nominates the drained ones on its own one-minute
+    cadence. The roll happens on top of that, and the test checks that data stays
+    readable throughout and that no channel ends up poisoned.
+    """
+
+    rows_count = 200
+    restart_rounds = 3
+
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        if min(self.versions) < (26, 4):
+            pytest.skip("CutHistory is available starting from 26.4")
+
+        yield from self.setup_cluster(
+            extra_feature_flags=["enable_cut_history"],
+            column_shard_config={
+                "cut_history_enabled": True,
+                # ColumnShard is on the deny list by default, which disables the
+                # cutter for exactly the tablets under test.
+                "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
+                "alter_object_enabled": True,
+            },
+        )
+
+    # ---- data ----
+
+    def _create_table(self, table_name):
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            session_pool.execute_with_retries(
+                f"""
+                CREATE TABLE `{table_name}` (
+                    ts Timestamp NOT NULL,
+                    id Uint64 NOT NULL,
+                    payload Utf8,
+                    PRIMARY KEY (ts, id)
+                )
+                PARTITION BY HASH(ts, id)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 4)
+                """
+            )
+
+    def _write_data(self, table_name, offset=0):
+        values = []
+        for i in range(offset, offset + self.rows_count):
+            ts = f"2024-01-01T{i // 3600 % 24:02d}:{i // 60 % 60:02d}:{i % 60:02d}.000000Z"
+            values.append(f'(Timestamp("{ts}"), {i}, "payload_{i}")')
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            session_pool.execute_with_retries(
+                f'INSERT INTO `{table_name}` (ts, id, payload) VALUES {",".join(values)};'
+            )
+
+    def _assert_readable(self, table_name, expected_rows):
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            result = session_pool.execute_with_retries(
+                f"SELECT COUNT(*) AS cnt FROM `{table_name}`;",
+                retry_settings=ydb.RetrySettings(idempotent=True),
+            )
+            assert result[0].rows[0]["cnt"] == expected_rows, (
+                f"`{table_name}` returned {result[0].rows[0]['cnt']} rows, expected {expected_rows}"
+            )
+
+    # ---- tablets and sensors ----
+
+    def _column_shard_ids(self):
+        client = kikimr_client_factory("localhost", self.cluster.nodes[1].port)
+        response = client.tablet_state(tablet_type=TabletTypes.COLUMNSHARD)
+        return [info.TabletId for info in response.TabletStateInfo]
+
+    def _restart_column_shards(self):
+        client = kikimr_client_factory("localhost", self.cluster.nodes[1].port)
+        tablet_ids = self._column_shard_ids()
+        for tablet_id in tablet_ids:
+            client.tablet_kill(tablet_id)
+        logger.info("restarted %s ColumnShard tablet(s)", len(tablet_ids))
+        return len(tablet_ids)
+
+    def _cut_history_sensors(self):
+        """Sum the component=CutHistory sensors over every node, by bare name."""
+        totals = {}
+        for endpoint in self.http_proxy_endpoints:
+            url = f"{endpoint}/counters/counters=tablets/json"
+            try:
+                with urllib.request.urlopen(url, timeout=30) as response:
+                    payload = json.loads(response.read().decode("utf-8", "replace"))
+            except Exception as e:
+                logger.warning("could not read sensors from %s: %s", url, e)
+                continue
+            for item in payload.get("sensors", []):
+                labels = item.get("labels", {})
+                if labels.get("component") != "CutHistory":
+                    continue
+                name = labels.get("sensor", "")
+                for prefix in ("Deriviative/", "Value/"):
+                    if name.startswith(prefix):
+                        name = name[len(prefix):]
+                        break
+                try:
+                    totals[name] = totals.get(name, 0) + int(item.get("value") or 0)
+                except (TypeError, ValueError):
+                    continue
+        return totals
+
+    def test_cut_history_during_roll(self):
+        table_name = "olap_cut_history"
+        self._create_table(table_name)
+        self._write_data(table_name)
+        expected = self.rows_count
+        self._assert_readable(table_name, expected)
+
+        assert self._column_shard_ids(), "no ColumnShard tablets found for the column table"
+
+        # Generation churn first, so there is history to cut once the roll starts.
+        for round_n in range(self.restart_rounds):
+            self._restart_column_shards()
+            self._write_data(table_name, offset=(round_n + 1) * self.rows_count)
+            expected += self.rows_count
+            self._assert_readable(table_name, expected)
+
+        for _ in self.roll():
+            self._assert_readable(table_name, expected)
+            sensors = self._cut_history_sensors()
+            logger.info("cut_history sensors: %s", sensors)
+            # A poisoned channel means the cutter saw a refcount underflow, which is
+            # a real defect rather than an environmental hiccup.
+            assert sensors.get("Channels/Poisoned", 0) == 0, f"cutter poisoned a channel: {sensors}"
+            assert sensors.get("Barriers/Failed/Count", 0) == 0, f"barrier send failed: {sensors}"
+
+        # Give the cutter a nomination cadence to act on the post-roll state, then
+        # confirm it is still healthy and the data survived.
+        time.sleep(90)
+        sensors = self._cut_history_sensors()
+        logger.info("cut_history sensors after settle: %s", sensors)
+        assert sensors.get("Channels/Poisoned", 0) == 0, f"cutter poisoned a channel: {sensors}"
+        self._assert_readable(table_name, expected)

--- a/ydb/tests/compatibility/olap/test_cut_history.py
+++ b/ydb/tests/compatibility/olap/test_cut_history.py
@@ -33,7 +33,6 @@ class TestCutHistory(RollingUpgradeAndDowngradeFixture):
         yield from self.setup_cluster(
             extra_feature_flags=["enable_cut_history"],
             column_shard_config={
-                "cut_history_enabled": True,
                 "alter_object_enabled": True,
             },
             # The deny list is Hive's, not ColumnShard's, and ColumnShard is on it by

--- a/ydb/tests/compatibility/olap/test_cut_history.py
+++ b/ydb/tests/compatibility/olap/test_cut_history.py
@@ -95,14 +95,12 @@ class TestCutHistory(RollingUpgradeAndDowngradeFixture):
             pytest.skip("CutHistory is available starting from 26.4")
 
         yield from self.setup_cluster(
-            # Both legs are needed for the pool to converge: the platform flag drives the
-            # channel-0/1 cutters, the decommission flag drives ColumnShard's data channels.
+            # Both legs are needed: the platform flag drives channels 0/1, the decommission flag the data channels.
             extra_feature_flags=["enable_cut_history", "enable_columnshard_group_decommission"],
             column_shard_config={
                 "alter_object_enabled": True,
             },
-            # The deny list is Hive's, not ColumnShard's, and ColumnShard is on it by
-            # default — which would disable the cutter for the tablets under test.
+            # Hive's deny list carries ColumnShard by default, which would disable the cutter for these tablets.
             hive_config={
                 "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
             },
@@ -206,13 +204,11 @@ class TestCutHistory(RollingUpgradeAndDowngradeFixture):
             self._assert_readable(table_name, expected)
             sensors = self._cut_history_sensors()
             logger.info("cut_history sensors: %s", sensors)
-            # A poisoned channel means the cutter saw a refcount underflow, which is
-            # a real defect rather than an environmental hiccup.
+            # A poisoned channel means a refcount underflow — a real defect, not an environmental hiccup.
             assert sensors.get("Channels/Poisoned", 0) == 0, f"cutter poisoned a channel: {sensors}"
             assert sensors.get("Barriers/Failed/Count", 0) == 0, f"barrier send failed: {sensors}"
 
-        # Give the cutter a nomination cadence to act on the post-roll state, then
-        # confirm it is still healthy and the data survived.
+        # Give the cutter one nomination cadence on the post-roll state, then check health and data.
         time.sleep(90)
         sensors = self._cut_history_sensors()
         logger.info("cut_history sensors after settle: %s", sensors)

--- a/ydb/tests/compatibility/olap/ya.make
+++ b/ydb/tests/compatibility/olap/ya.make
@@ -8,6 +8,7 @@ SPLIT_FACTOR(10)
 
 TEST_SRCS(
     test_bloom_index.py
+    test_cut_history.py
     test_min_max_index.py
     test_rename_table.py
     test_compression.py

--- a/ydb/tests/library/common/types.py
+++ b/ydb/tests/library/common/types.py
@@ -128,6 +128,7 @@ class TabletTypes(Enum):
     FLAT_DATASHARD = _tablet_type(18, 999, service_name='DATASHARD')
     BLOCKSTORE_VOLUME = _tablet_type(25, 999)
     BLOCKSTORE_PARTITION = _tablet_type(26, 999)
+    COLUMNSHARD = _tablet_type(35, 999)
 
     FLAT_TX_COORDINATOR = _tablet_type(13, 0x800001, service_name='TX_COORDINATOR')
     TX_MEDIATOR = _tablet_type(5, 0x810001, service_name='TX_MEDIATOR')

--- a/ydb/tests/stress/olap_workload/__main__.py
+++ b/ydb/tests/stress/olap_workload/__main__.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
     try:
-        with WorkloadRunner(client, args.path, args.duration, args.allow_nullables_in_pk) as runner:
+        with WorkloadRunner(client, args.path, args.duration, args.allow_nullables_in_pk, args.endpoint) as runner:
             runner.run()
     finally:
         client.close()

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -24,7 +24,6 @@ class TestYdbWorkload(StressFixture):
             column_shard_config={
                 "allow_nullable_columns_in_pk": True,
                 "generate_internal_path_id": True,
-                "cut_history_enabled": True,
             },
             # The deny list is Hive's, not ColumnShard's, and ColumnShard is on it by
             # default — which would disable the cutter for the tablets under test.

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -21,6 +21,7 @@ class TestYdbWorkload(StressFixture):
                 "enable_columnshard_bool": True,
                 "enable_cs_dictionary_encoding": True,
                 "enable_cut_history": True,
+                "enable_columnshard_group_decommission": True,
                 "enable_columnshard_interval": True,
                 "enable_columnshard_uuid": True,
                 "enable_columnshard_dy_number": True,

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -29,10 +29,8 @@ class TestYdbWorkload(StressFixture):
                 "allow_nullable_columns_in_pk": True,
                 "generate_internal_path_id": True,
             },
-            # Hive's gate needs both sides: the type must be absent from the deny
-            # list (ColumnShard is on it by default) AND present in the allow list
-            # (which defaults to DataShard only) — with either half missing Hive
-            # refuses the TEvCutTabletHistory this test ultimately waits for.
+            # Hive's gate needs the type off the deny list AND on the allow list;
+            # either half missing and Hive refuses the cut this test waits for.
             hive_config={
                 "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
                 "cut_history_allow_list": "DataShard,ColumnShard",
@@ -74,16 +72,8 @@ class TestYdbWorkload(StressFixture):
         return {}
 
     def _mon_post(self, path):
-        """Returns (error, body): error is None on HTTP success.
-
-        POST, because Hive's mutating monitoring pages (ReassignTablet) reject GET
-        with 400 "Must use POST request". The body is returned for diagnostics —
-        the ReassignTablet page answers 200 with its operations list, so an empty
-        list or an embedded error is only visible there.
-        """
-        # The tablet monitoring proxy takes params from the BODY (not the URL) for
-        # form-urlencoded POSTs — and urllib always stamps that content type when
-        # data is given. So the query must ride in the body or it is invisible.
+        """POST with params in the BODY: the tablet mon proxy ignores the query string
+        for form-urlencoded POSTs, and mutating Hive pages reject GET."""
         base, _, query = path.partition("?")
         errors = []
         for node in self.cluster.nodes.values():
@@ -98,18 +88,12 @@ class TestYdbWorkload(StressFixture):
     def _prepare_cut_history_candidate(self, pool):
         """Make one deterministically cuttable history entry and return the probe path.
 
-        Channel history grows only on a Hive channel (re)assignment
-        (TTxUpdateTabletGroups) — plain tablet restarts never add entries, which is
-        why gating on the workload's restarts alone cannot work. And an entry is
-        nominated only when its generation range holds no blobs. Hence the order
-        here: create an EMPTY column table, force-reassign its data channel (the
-        pre-reassign entry then covers a range with no blobs at all), and only then
-        write rows — the new blobs belong to the active entry, and the writes give
-        the tablet the GC completions on which TryNominate runs.
+        History grows only on a Hive channel reassignment, never on restarts, and an
+        entry is nominated only when its range holds no blobs — hence: empty table,
+        reassign, and only then writes (they feed the GC ticks TryNominate runs on).
         """
         path = f"{self.database}/cut_history_probe"
-        # Compilation can time out while the host digests the workload run's load;
-        # that is environment, not subject matter — retry for up to two minutes.
+        # Compile timeouts under host load are environment, not subject — retry.
         deadline = time.time() + 120
         while True:
             try:
@@ -132,15 +116,6 @@ class TestYdbWorkload(StressFixture):
         tablets = self._mon_json("/viewer/json/tabletinfo?filter=(Type=Hive)")
         hives = [t.get("TabletId") for t in tablets.get("TabletStateInfo", []) if t.get("TabletId")]
         hive_id = hives[0] if hives else 72057594037968897
-        # forcedGroup is REQUIRED here, with the channel's own current group: a manual
-        # reassign (HIVE_REASSIGN_REASON_NO) excludes the current group from selection
-        # (FindFreeAllocationUnit filters newGroup.Id != currentGroup->Id), so on this
-        # single-group cluster an unforced reassign is silently a no-op — the tablet
-        # never restarts and no history entry appears. A forced group bypasses the
-        # selection and is applied verbatim, appending the entry even for the same
-        # group (MaySkipChannelReassign only skips same-group for BALANCE).
-        # Hive's TabletInfo page is the authoritative source for the channel's
-        # current group (whiteboard's ChannelGroupIDs can lag on young tablets).
 
         def channel2_history():
             info = self._mon_json(
@@ -155,14 +130,14 @@ class TestYdbWorkload(StressFixture):
         assert history, f"no channel 2 history in Hive TabletInfo for tablet {shards[0]}"
         force_group = history[-1]["GroupID"]
         history_before = len(history)
-        # wait=0: fire-and-return — the sensor poll below is the real confirmation.
+        # Manual reassign excludes the current group from selection, so only a forced
+        # same-group reassign appends a history entry here.
         err, body = self._mon_post(
             f"/tablets/app?TabletID={hive_id}&page=ReassignTablet"
             f"&tablet={shards[0]}&channel=2&forcedGroup={force_group}&wait=0"
         )
         assert err is None, f"Hive ReassignTablet monitoring call failed: {err}"
-        # The reassignment restarts the tablet; wait until Hive's history actually
-        # grew — the crisp intermediate signal that the entry to cut now exists.
+        # The reassignment restarts the tablet; the entry to cut exists once history grew.
         deadline = time.time() + 60
         while time.time() < deadline and len(channel2_history()) <= history_before:
             time.sleep(3)
@@ -179,12 +154,9 @@ class TestYdbWorkload(StressFixture):
             "--database", self.database,
             "--duration", self.base_duration,
         ])
-        # A run in which the cutter never engaged proves nothing about CutHistory,
-        # so manufacture a guaranteed-cuttable entry and require the full pipeline:
-        # nomination, sweep, hard barrier, TEvCutTabletHistory — i.e. Entries/Cut
-        # must grow, not merely "no errors". The polling window is sized to the
-        # one-minute nomination cadence plus barrier round-trip; the suite is
-        # SIZE(MEDIUM), so the whole run must still fit in ten minutes under asan.
+        # Manufacture a guaranteed-cuttable entry and require the full pipeline:
+        # Entries/Cut must grow, not merely "no errors". Window: one nomination
+        # cadence plus barrier round-trip; SIZE(MEDIUM) budget holds under asan.
         pool = ydb.QuerySessionPool(self.driver)
         try:
             probe = self._prepare_cut_history_candidate(pool)
@@ -192,10 +164,8 @@ class TestYdbWorkload(StressFixture):
             sensors = {}
             row = 0
             while time.time() < deadline:
-                # Each write is a fresh chance for a GC completion, which is the
-                # only place TryNominate is evaluated. The write is a means, not an
-                # assertion target — a compile timeout under host load is not a
-                # verdict on the cutter, so tolerate it and keep polling.
+                # Writes feed GC completions (the only TryNominate trigger); their
+                # own failures are not the subject — tolerate and keep polling.
                 try:
                     pool.execute_with_retries(f"UPSERT INTO `{probe}` (k, v) VALUES ({row}, {row})")
                     row += 1

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+import json
+import time
+import urllib.request
 import os
 import pytest
 import yatest
 from ydb.tests.library.common.types import Erasure
 
 from ydb.tests.library.stress.fixtures import StressFixture
+from ydb.tests.oss.ydb_sdk_import import ydb
 
 
 class TestYdbWorkload(StressFixture):
@@ -25,12 +29,148 @@ class TestYdbWorkload(StressFixture):
                 "allow_nullable_columns_in_pk": True,
                 "generate_internal_path_id": True,
             },
-            # The deny list is Hive's, not ColumnShard's, and ColumnShard is on it by
-            # default — which would disable the cutter for the tablets under test.
+            # Hive's gate needs both sides: the type must be absent from the deny
+            # list (ColumnShard is on it by default) AND present in the allow list
+            # (which defaults to DataShard only) — with either half missing Hive
+            # refuses the TEvCutTabletHistory this test ultimately waits for.
             hive_config={
                 "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
+                "cut_history_allow_list": "DataShard,ColumnShard",
             },
         )
+
+    def _cut_history_sensors(self):
+        totals = {}
+        for node in self.cluster.nodes.values():
+            url = f"http://localhost:{node.mon_port}/counters/counters=tablets/json"
+            try:
+                with urllib.request.urlopen(url, timeout=30) as response:
+                    payload = json.loads(response.read().decode("utf-8", "replace"))
+            except Exception:
+                continue
+            for item in payload.get("sensors", []):
+                labels = item.get("labels", {})
+                if labels.get("component") != "CutHistory":
+                    continue
+                name = labels.get("sensor", "")
+                for prefix in ("Deriviative/", "Value/"):
+                    if name.startswith(prefix):
+                        name = name[len(prefix):]
+                        break
+                try:
+                    totals[name] = totals.get(name, 0) + int(item.get("value") or 0)
+                except (TypeError, ValueError):
+                    continue
+        return totals
+
+    def _mon_json(self, path):
+        for node in self.cluster.nodes.values():
+            url = f"http://localhost:{node.mon_port}{path}"
+            try:
+                with urllib.request.urlopen(url, timeout=30) as response:
+                    return json.loads(response.read().decode("utf-8", "replace"))
+            except Exception:
+                continue
+        return {}
+
+    def _mon_post(self, path):
+        """Returns (error, body): error is None on HTTP success.
+
+        POST, because Hive's mutating monitoring pages (ReassignTablet) reject GET
+        with 400 "Must use POST request". The body is returned for diagnostics —
+        the ReassignTablet page answers 200 with its operations list, so an empty
+        list or an embedded error is only visible there.
+        """
+        # The tablet monitoring proxy takes params from the BODY (not the URL) for
+        # form-urlencoded POSTs — and urllib always stamps that content type when
+        # data is given. So the query must ride in the body or it is invisible.
+        base, _, query = path.partition("?")
+        errors = []
+        for node in self.cluster.nodes.values():
+            url = f"http://localhost:{node.mon_port}{base}"
+            try:
+                with urllib.request.urlopen(url, data=query.encode(), timeout=60) as response:
+                    return None, response.read().decode("utf-8", "replace")
+            except Exception as e:
+                errors.append(f"{url}: {e}")
+        return "; ".join(errors) or "no cluster nodes", ""
+
+    def _prepare_cut_history_candidate(self, pool):
+        """Make one deterministically cuttable history entry and return the probe path.
+
+        Channel history grows only on a Hive channel (re)assignment
+        (TTxUpdateTabletGroups) — plain tablet restarts never add entries, which is
+        why gating on the workload's restarts alone cannot work. And an entry is
+        nominated only when its generation range holds no blobs. Hence the order
+        here: create an EMPTY column table, force-reassign its data channel (the
+        pre-reassign entry then covers a range with no blobs at all), and only then
+        write rows — the new blobs belong to the active entry, and the writes give
+        the tablet the GC completions on which TryNominate runs.
+        """
+        path = f"{self.database}/cut_history_probe"
+        # Compilation can time out while the host digests the workload run's load;
+        # that is environment, not subject matter — retry for up to two minutes.
+        deadline = time.time() + 120
+        while True:
+            try:
+                pool.execute_with_retries(
+                    f"CREATE TABLE `{path}` (k Uint64 NOT NULL, v Uint64, PRIMARY KEY(k)) "
+                    "WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 1)"
+                )
+                break
+            except ydb.issues.Error:
+                if time.time() >= deadline:
+                    raise
+                time.sleep(5)
+        described = self._mon_json(f"/viewer/json/describe?path={path}")
+        shards = ((((described.get("PathDescription") or {}).get("ColumnTableDescription") or {})
+                   .get("Sharding") or {}).get("ColumnShards") or [])
+        assert shards, f"no ColumnShards behind {path}: {described}"
+        # Tenant databases expose their Hive via describe (ProcessingParams.Hive);
+        # the root domain used here does not, so resolve the Hive tablet directly
+        # and keep the well-known root Hive id as the fallback.
+        tablets = self._mon_json("/viewer/json/tabletinfo?filter=(Type=Hive)")
+        hives = [t.get("TabletId") for t in tablets.get("TabletStateInfo", []) if t.get("TabletId")]
+        hive_id = hives[0] if hives else 72057594037968897
+        # forcedGroup is REQUIRED here, with the channel's own current group: a manual
+        # reassign (HIVE_REASSIGN_REASON_NO) excludes the current group from selection
+        # (FindFreeAllocationUnit filters newGroup.Id != currentGroup->Id), so on this
+        # single-group cluster an unforced reassign is silently a no-op — the tablet
+        # never restarts and no history entry appears. A forced group bypasses the
+        # selection and is applied verbatim, appending the entry even for the same
+        # group (MaySkipChannelReassign only skips same-group for BALANCE).
+        # Hive's TabletInfo page is the authoritative source for the channel's
+        # current group (whiteboard's ChannelGroupIDs can lag on young tablets).
+
+        def channel2_history():
+            info = self._mon_json(
+                f"/tablets/app?TabletID={hive_id}&page=TabletInfo&tablet={shards[0]}")
+            channels = ((info.get("TabletStorageInfo") or {}).get("Channels") or [])
+            for ch in channels:
+                if ch.get("Channel") == 2:
+                    return ch.get("History") or []
+            return []
+
+        history = channel2_history()
+        assert history, f"no channel 2 history in Hive TabletInfo for tablet {shards[0]}"
+        force_group = history[-1]["GroupID"]
+        history_before = len(history)
+        # wait=0: fire-and-return — the sensor poll below is the real confirmation.
+        err, body = self._mon_post(
+            f"/tablets/app?TabletID={hive_id}&page=ReassignTablet"
+            f"&tablet={shards[0]}&channel=2&forcedGroup={force_group}&wait=0"
+        )
+        assert err is None, f"Hive ReassignTablet monitoring call failed: {err}"
+        # The reassignment restarts the tablet; wait until Hive's history actually
+        # grew — the crisp intermediate signal that the entry to cut now exists.
+        deadline = time.time() + 60
+        while time.time() < deadline and len(channel2_history()) <= history_before:
+            time.sleep(3)
+        assert len(channel2_history()) > history_before, (
+            f"forced reassign did not grow channel 2 history; "
+            f"POST response: {body[:2000]}; history now: {channel2_history()}"
+        )
+        return path
 
     def test(self):
         yatest.common.execute([
@@ -39,3 +179,39 @@ class TestYdbWorkload(StressFixture):
             "--database", self.database,
             "--duration", self.base_duration,
         ])
+        # A run in which the cutter never engaged proves nothing about CutHistory,
+        # so manufacture a guaranteed-cuttable entry and require the full pipeline:
+        # nomination, sweep, hard barrier, TEvCutTabletHistory — i.e. Entries/Cut
+        # must grow, not merely "no errors". The polling window is sized to the
+        # one-minute nomination cadence plus barrier round-trip; the suite is
+        # SIZE(MEDIUM), so the whole run must still fit in ten minutes under asan.
+        pool = ydb.QuerySessionPool(self.driver)
+        try:
+            probe = self._prepare_cut_history_candidate(pool)
+            deadline = time.time() + 150
+            sensors = {}
+            row = 0
+            while time.time() < deadline:
+                # Each write is a fresh chance for a GC completion, which is the
+                # only place TryNominate is evaluated. The write is a means, not an
+                # assertion target — a compile timeout under host load is not a
+                # verdict on the cutter, so tolerate it and keep polling.
+                try:
+                    pool.execute_with_retries(f"UPSERT INTO `{probe}` (k, v) VALUES ({row}, {row})")
+                    row += 1
+                except ydb.issues.Error:
+                    pass
+                sensors = self._cut_history_sensors()
+                if sensors.get("Entries/Cut/Count", 0) > 0:
+                    break
+                time.sleep(5)
+        finally:
+            pool.stop()
+        assert sensors.get("Nominations/Count", 0) > 0, (
+            f"CutHistory never nominated the probe entry: {sensors}"
+        )
+        assert sensors.get("Entries/Cut/Count", 0) > 0, (
+            f"CutHistory nominated but never cut the probe entry: {sensors}"
+        )
+        assert sensors.get("Channels/Poisoned", 0) == 0, f"cutter poisoned a channel: {sensors}"
+        assert sensors.get("Barriers/Failed/Count", 0) == 0, f"barrier send failed: {sensors}"

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -16,15 +16,21 @@ class TestYdbWorkload(StressFixture):
                 "enable_move_column_table": True,
                 "enable_columnshard_bool": True,
                 "enable_cs_dictionary_encoding": True,
+                "enable_cut_history": True,
                 "enable_columnshard_interval": True,
                 "enable_columnshard_uuid": True,
                 "enable_columnshard_dy_number": True,
             },
             column_shard_config={
                 "allow_nullable_columns_in_pk": True,
-                "generate_internal_path_id": True
-
-            }
+                "generate_internal_path_id": True,
+                "cut_history_enabled": True,
+            },
+            # The deny list is Hive's, not ColumnShard's, and ColumnShard is on it by
+            # default — which would disable the cutter for the tablets under test.
+            hive_config={
+                "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
+            },
         )
 
     def test(self):

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -30,8 +30,7 @@ class TestYdbWorkload(StressFixture):
                 "allow_nullable_columns_in_pk": True,
                 "generate_internal_path_id": True,
             },
-            # Hive's gate needs the type off the deny list AND on the allow list;
-            # either half missing and Hive refuses the cut this test waits for.
+            # Hive's gate needs the type off the deny list and on the allow list, or it refuses the cut.
             hive_config={
                 "cut_history_deny_list": "KeyValue,PersQueue,BlobDepot",
                 "cut_history_allow_list": "DataShard,ColumnShard",
@@ -111,9 +110,7 @@ class TestYdbWorkload(StressFixture):
         shards = ((((described.get("PathDescription") or {}).get("ColumnTableDescription") or {})
                    .get("Sharding") or {}).get("ColumnShards") or [])
         assert shards, f"no ColumnShards behind {path}: {described}"
-        # Tenant databases expose their Hive via describe (ProcessingParams.Hive);
-        # the root domain used here does not, so resolve the Hive tablet directly
-        # and keep the well-known root Hive id as the fallback.
+        # The root domain does not expose its Hive via describe, so resolve it directly with a well-known fallback.
         tablets = self._mon_json("/viewer/json/tabletinfo?filter=(Type=Hive)")
         hives = [t.get("TabletId") for t in tablets.get("TabletStateInfo", []) if t.get("TabletId")]
         hive_id = hives[0] if hives else 72057594037968897
@@ -131,8 +128,7 @@ class TestYdbWorkload(StressFixture):
         assert history, f"no channel 2 history in Hive TabletInfo for tablet {shards[0]}"
         force_group = history[-1]["GroupID"]
         history_before = len(history)
-        # Manual reassign excludes the current group from selection, so only a forced
-        # same-group reassign appends a history entry here.
+        # Manual reassign excludes the current group, so only a forced same-group reassign appends an entry.
         err, body = self._mon_post(
             f"/tablets/app?TabletID={hive_id}&page=ReassignTablet"
             f"&tablet={shards[0]}&channel=2&forcedGroup={force_group}&wait=0"
@@ -155,9 +151,7 @@ class TestYdbWorkload(StressFixture):
             "--database", self.database,
             "--duration", self.base_duration,
         ])
-        # Manufacture a guaranteed-cuttable entry and require the full pipeline:
-        # Entries/Cut must grow, not merely "no errors". Window: one nomination
-        # cadence plus barrier round-trip; SIZE(MEDIUM) budget holds under asan.
+        # Require the full pipeline: Entries/Cut must grow within one nomination cadence plus a barrier round-trip.
         pool = ydb.QuerySessionPool(self.driver)
         try:
             probe = self._prepare_cut_history_candidate(pool)
@@ -165,8 +159,7 @@ class TestYdbWorkload(StressFixture):
             sensors = {}
             row = 0
             while time.time() < deadline:
-                # Writes feed GC completions (the only TryNominate trigger); their
-                # own failures are not the subject — tolerate and keep polling.
+                # Writes feed GC completions, the only TryNominate trigger; their own failures are not the subject.
                 try:
                     pool.execute_with_retries(f"UPSERT INTO `{probe}` (k, v) VALUES ({row}, {row})")
                     row += 1

--- a/ydb/tests/stress/olap_workload/workload/__init__.py
+++ b/ydb/tests/stress/olap_workload/workload/__init__.py
@@ -8,11 +8,13 @@ from ydb.tests.stress.olap_workload.workload.type.insert_delete import WorkloadI
 from ydb.tests.stress.olap_workload.workload.type.transactions import WorkloadTransactions
 from ydb.tests.stress.olap_workload.workload.type.rename_tables import WorkloadRenameTables
 from ydb.tests.stress.olap_workload.workload.type.encodings import WorkloadEncodings
+from ydb.tests.stress.olap_workload.workload.type.cut_history import WorkloadCutHistory
 
 
 class WorkloadRunner:
-    def __init__(self, client, path, duration, allow_nullables_in_pk):
+    def __init__(self, client, path, duration, allow_nullables_in_pk, endpoint=None):
         self.client = client
+        self.endpoint = endpoint
         self.name = path
         self.tables_prefix = "/".join([self.client.database, self.name])
         self.duration = duration
@@ -40,6 +42,10 @@ class WorkloadRunner:
             WorkloadRenameTables(self.client, self.name, stop, 10),
             WorkloadEncodings(self.client, self.name, stop),
         ]
+        # Tablet restarts go through the message-bus client, so this one is only
+        # enabled when the caller supplied an endpoint.
+        if self.endpoint:
+            workloads.append(WorkloadCutHistory(self.client, self.name, stop, self.endpoint))
         for w in workloads:
             w.start()
         started_at = started_at = time.time()

--- a/ydb/tests/stress/olap_workload/workload/__init__.py
+++ b/ydb/tests/stress/olap_workload/workload/__init__.py
@@ -42,8 +42,7 @@ class WorkloadRunner:
             WorkloadRenameTables(self.client, self.name, stop, 10),
             WorkloadEncodings(self.client, self.name, stop),
         ]
-        # Tablet restarts go through the message-bus client, so this one is only
-        # enabled when the caller supplied an endpoint.
+        # Tablet restarts go through the message-bus client, so this needs a caller-supplied endpoint.
         if self.endpoint:
             workloads.append(WorkloadCutHistory(self.client, self.name, stop, self.endpoint))
         for w in workloads:

--- a/ydb/tests/stress/olap_workload/workload/type/cut_history.py
+++ b/ydb/tests/stress/olap_workload/workload/type/cut_history.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import logging
+import time
+
+from ydb.tests.library.clients.kikimr_client import kikimr_client_factory
+from ydb.tests.library.common.types import TabletTypes
+from ydb.tests.stress.common.common import WorkloadBase
+
+logger = logging.getLogger(__name__)
+
+
+class WorkloadCutHistory(WorkloadBase):
+    """Restart ColumnShard tablets so their channel history grows and can be cut.
+
+    CutHistory only has work to do once a tablet's channel history has more than one
+    entry, and entries appear on generation changes. Restarting the tablets is the
+    cheapest way to produce them from a client; the cutter then nominates and cuts
+    the drained ones on its own one-minute cadence.
+    """
+
+    def __init__(self, client, prefix, stop, endpoint, period=30):
+        super().__init__(client, prefix, "cut_history", stop)
+        # kikimr_client_factory speaks plaintext message bus, so grpcs:// cannot work
+        # here: reject it instead of stripping the scheme and failing to connect.
+        scheme, sep, address = endpoint.rpartition("://")
+        if sep and scheme != "grpc":
+            raise ValueError(f"cut_history needs a grpc:// endpoint, got {endpoint}")
+        host, _, port = address.partition(":")
+        self.kikimr_client = kikimr_client_factory(host, port or "2135")
+        self.period = period
+        self.restarts = 0
+        self.errors = 0
+
+    def get_stat(self):
+        return f"Restarts: {self.restarts}, Errors: {self.errors}"
+
+    def _column_shard_ids(self):
+        response = self.kikimr_client.tablet_state(tablet_type=TabletTypes.COLUMNSHARD)
+        return [info.TabletId for info in response.TabletStateInfo]
+
+    def _loop(self):
+        while not self.is_stop_requested():
+            try:
+                tablet_ids = self._column_shard_ids()
+                if not tablet_ids:
+                    # The other workloads may not have created a column table yet.
+                    time.sleep(self.period)
+                    continue
+                for tablet_id in tablet_ids:
+                    if self.is_stop_requested():
+                        return
+                    self.kikimr_client.tablet_kill(tablet_id)
+                    self.restarts += 1
+                logger.info("cut_history: restarted %s ColumnShard tablet(s)", len(tablet_ids))
+            except Exception as e:
+                self.errors += 1
+                logger.warning("cut_history: restart round failed: %s", e)
+            # Wait longer than the cutter's nomination cadence so a sweep can finish
+            # between rounds instead of every entry being reopened by a new generation.
+            waited = 0
+            while waited < self.period and not self.is_stop_requested():
+                time.sleep(1)
+                waited += 1
+
+    def get_workload_thread_funcs(self):
+        return [self._loop]

--- a/ydb/tests/stress/olap_workload/workload/type/cut_history.py
+++ b/ydb/tests/stress/olap_workload/workload/type/cut_history.py
@@ -10,12 +10,14 @@ logger = logging.getLogger(__name__)
 
 
 class WorkloadCutHistory(WorkloadBase):
-    """Restart ColumnShard tablets so their channel history grows and can be cut.
+    """Restart ColumnShard tablets while the cutter runs.
 
-    CutHistory only has work to do once a tablet's channel history has more than one
-    entry, and entries appear on generation changes. Restarting the tablets is the
-    cheapest way to produce them from a client; the cutter then nominates and cuts
-    the drained ones on its own one-minute cadence.
+    Restarts do NOT grow channel history (entries are appended only on a Hive
+    channel reassignment, TTxUpdateTabletGroups) — what this workload exercises is
+    the cutter's restart-safety: every OnBootComplete rebuild, re-nomination and
+    in-flight sweep abort happens under generation churn. The positive make-an-
+    entry-and-cut-it check lives in the test driver, which can reach Hive's
+    monitoring to force a reassignment; a client-side workload cannot.
     """
 
     def __init__(self, client, prefix, stop, endpoint, period=30):

--- a/ydb/tests/stress/olap_workload/workload/type/cut_history.py
+++ b/ydb/tests/stress/olap_workload/workload/type/cut_history.py
@@ -22,8 +22,7 @@ class WorkloadCutHistory(WorkloadBase):
 
     def __init__(self, client, prefix, stop, endpoint, period=30):
         super().__init__(client, prefix, "cut_history", stop)
-        # kikimr_client_factory speaks plaintext message bus, so grpcs:// cannot work
-        # here: reject it instead of stripping the scheme and failing to connect.
+        # kikimr_client_factory speaks plaintext message bus, so reject grpcs:// instead of failing to connect.
         scheme, sep, address = endpoint.rpartition("://")
         if sep and scheme != "grpc":
             raise ValueError(f"cut_history needs a grpc:// endpoint, got {endpoint}")
@@ -57,8 +56,7 @@ class WorkloadCutHistory(WorkloadBase):
             except Exception as e:
                 self.errors += 1
                 logger.warning("cut_history: restart round failed: %s", e)
-            # Wait longer than the cutter's nomination cadence so a sweep can finish
-            # between rounds instead of every entry being reopened by a new generation.
+            # Wait past the nomination cadence so a sweep finishes instead of every entry being reopened.
             waited = 0
             while waited < self.period and not self.is_stop_requested():
                 time.sleep(1)

--- a/ydb/tests/stress/olap_workload/workload/type/ya.make
+++ b/ydb/tests/stress/olap_workload/workload/type/ya.make
@@ -6,9 +6,11 @@ PY_SRCS(
     transactions.py
     rename_tables.py
     encodings.py
+    cut_history.py
 )
 
 PEERDIR(
+    ydb/tests/library
     ydb/tests/stress/common
 )
 


### PR DESCRIPTION
## KIKIMR-26790: history cutting for ColumnShard (group decommission, part 2)

Sibling PR (part 1, MoveData): https://github.com/ydb-platform/ydb/pull/50179

> [!IMPORTANT]
> **Blocked by https://github.com/ydb-platform/ydb/pull/51588 and
> https://github.com/ydb-platform/ydb/pull/51684 — do not merge this before both.**
>
> Cutting history is unsafe until two defects in the generic executor GC path are fixed:
>
> - **#51588** — `ApplyDelta` does not feed `HistoryCutter::SeenBlob` from `delta.Deleted`, so a
>   blob with a pending DoNotKeep mark fails to pin its history entry and the entry can be cut
>   out from under the flag.
> - **#51684** — `SendCollectGarbage` can address a collect to the `Max<ui32>()` sentinel group
>   for a generation below the first surviving history entry.
>
> Either one turns a cut into a boot loop: a GC request to an unresolvable group fails at BS, the
> tablet takes `TEvPoison` and reboots into the same state. Both are reachable today without this
> feature — KeyValue and BlobDepot already send `TEvCutTabletHistory` — which is why they are
> fixed separately rather than behind `enable_cut_history`.

Hive releases a storage group only when no tablet's channel history references it. For every
data-channel history entry under which no persisted blob remains, ColumnShard sends a hard
`TEvCollectGarbage` barrier for `(channel, group)` and then `TEvTablet::TEvCutTabletHistory`, so
Hive can erase the entry and finish the decommission.

Channels 0 and 1 hold the tablet log and the local database and stay with the executor's own
cutter, which cannot see blobs the tablet writes past it. A tablet declares such channels through
the new `NFlatExecutorSetup::ITablet::HasExternallyWrittenBlobs` hook instead of the executor
testing tablet types.



