### PR TITLE
fix: support uint64 optional output on darwin

### DIFF
--- a/util/stream/output.cpp
+++ b/util/stream/output.cpp
@@ -297,6 +297,7 @@ DEF_OPTIONAL(TString);
 DEF_OPTIONAL(TStringBuf);
 #if defined(_darwin_) and defined(_arm64_)
 DEF_OPTIONAL(std::int64_t);
+DEF_OPTIONAL(std::uint64_t);
 #endif
 
 #if defined(_android_)

--- a/util/stream/output_ut.cpp
+++ b/util/stream/output_ut.cpp
@@ -1,6 +1,8 @@
 #include "output.h"
 #include <library/cpp/testing/unittest/registar.h>
 #include <complex>
+#include <cstdint>
+#include <optional>
 #include <sstream>
 #include <util/string/builder.h>
 #include <util/generic/vector.h>
@@ -30,5 +32,10 @@ Y_UNIT_TEST_SUITE(TestOutput) {
                 CheckComplexOutHelper(real, imag);
             }
         }
+    }
+
+    Y_UNIT_TEST(TestOptionalUint64) {
+        UNIT_ASSERT_VALUES_EQUAL(TStringBuilder() << std::optional<std::uint64_t>{42}, "42");
+        UNIT_ASSERT_VALUES_EQUAL(TStringBuilder() << std::optional<std::uint64_t>{}, "(NULL)");
     }
 } // Y_UNIT_TEST_SUITE(TestOutput)


### PR DESCRIPTION
## Summary

- instantiate `Out<std::optional<std::uint64_t>>` on Darwin arm64
- cover present and empty `std::optional<std::uint64_t>` values

## Verification

- fail-before: `./ya make --build relwithdebinfo util/stream/ut` failed to link `Out<std::__y1::optional<unsigned long long>>`
- pass-after: `./ya make --build relwithdebinfo util/stream/ut`
- `util/stream/ut/util-stream-ut --print-before-test --show-fails +TestOutput::TestOptionalUint64` (1 passed)
- `util/stream/ut/util-stream-ut --print-before-suite --show-fails` (108 passed)

The standard `-tA` wrapper could not start tests in this public checkout because its resource map does not contain `TEST_TOOL_HOST` resource `13159435523`; the built unit-test binary was therefore executed directly.

Fixes #50178
