### PR TITLE
Make `/viewer/render` HTTP-handler viewer access level

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -306,6 +306,7 @@ public:
                     // `/viewer/render` is used by GraphShard metrics rendering.
                     // It may expose cluster-level metrics, so it's intentionally restricted to Viewer access.
                     // Before changing it back to Database access, ensure that only database-scoped metrics are returned.
+                    {"/viewer/render", {EViewerEndpointAccessType::Viewer}},
 
                     // Database-level endpoints that require explicit database parameter for strict database tokens.
                     {"/storage/groups", {EViewerEndpointAccessType::Database, true}},

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -303,6 +303,10 @@ public:
                     {"/viewer/metainfo", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/browse", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/content", {EViewerEndpointAccessType::Viewer}},
+                    // `/viewer/render` is used for GraphShard which is supposed to show some metrics.
+                    // However, it's possible that this handler can expose some cluster-level metrics.
+                    // To move its scope to database-level, please make sure that cluster-level metrics are not exposed.
+                    {"/viewer/render", {EViewerEndpointAccessType::Viewer}},
 
                     // Database-level endpoints that require explicit database parameter for strict database tokens.
                     {"/storage/groups", {EViewerEndpointAccessType::Database, true}},
@@ -313,7 +317,6 @@ public:
                     {"/query/script/execute", {EViewerEndpointAccessType::Database, true}},
                     {"/query/script/fetch", {EViewerEndpointAccessType::Database, true}},
                     {"/scheme/directory", {EViewerEndpointAccessType::Database, true}},
-                    {"/viewer/render", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/topic_data", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/feature_flags", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/sysinfo", {EViewerEndpointAccessType::Database, true}},

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -303,10 +303,9 @@ public:
                     {"/viewer/metainfo", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/browse", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/content", {EViewerEndpointAccessType::Viewer}},
-                    // `/viewer/render` is used for GraphShard which is supposed to show some metrics.
-                    // However, it's possible that this handler can expose some cluster-level metrics.
-                    // To move its scope to database-level, please make sure that cluster-level metrics are not exposed.
-                    {"/viewer/render", {EViewerEndpointAccessType::Viewer}},
+                    // `/viewer/render` is used by GraphShard metrics rendering.
+                    // It may expose cluster-level metrics, so it's intentionally restricted to Viewer access.
+                    // Before changing it back to Database access, ensure that only database-scoped metrics are returned.
 
                     // Database-level endpoints that require explicit database parameter for strict database tokens.
                     {"/storage/groups", {EViewerEndpointAccessType::Database, true}},

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-no_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-with_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3290,7 +3290,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7176,7 +7176,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-no_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-with_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3290,7 +3290,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7176,7 +7176,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-no_schema_grants_/mon_endpoints_auth-require_counters_authentication-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-no_schema_grants_/mon_endpoints_auth-require_counters_authentication-no_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-with_schema_grants_/mon_endpoints_auth-require_counters_authentication-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-with_schema_grants_/mon_endpoints_auth-require_counters_authentication-with_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3290,7 +3290,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7176,7 +7176,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-no_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-no_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-no_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-with_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-with_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-with_schema_grants.json
@@ -3274,7 +3274,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3282,7 +3282,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -3290,7 +3290,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7160,7 +7160,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7168,7 +7168,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400
@@ -7176,7 +7176,7 @@
       "?database=/Root/Tenant": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 400,
+        "database@builtin": 403,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 400

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -160,9 +160,6 @@ def test_database_scoped_endpoints_access_controls(mon_base_url_with_extra_sids_
         {'path': '/viewer/json/sysinfo', 'method': EndpointMethod.GET},
         {'path': '/viewer/feature_flags', 'method': EndpointMethod.GET},
         {'path': '/viewer/json/feature_flags', 'method': EndpointMethod.GET},
-        # Empty target skips graph request and returns a 1x1 PNG placeholder.
-        {'path': '/viewer/render?target=', 'method': EndpointMethod.POST},
-        {'path': '/viewer/json/render?target=', 'method': EndpointMethod.POST},
     ]
 
     for endpoint in endpoints:


### PR DESCRIPTION
### Description for reviewers
Хендлер `/viewer/render` используется в везде отключенной и не описанной фиче рисования метрик через GraphShard. Она потенциально может репортить метрики уровня кластера. Не стал с ней разбираться, а запретил использование для пользователей уровня database.
Если кто-то захочет включать фичу, надо будет сделать её ревизию, убедиться, что метрики кластера не отдаются для пользователей уровня database и тогда понижать уровень доступа к хендлеру `/viewer/render` обратно.