### PR TITLE
Fix TReadProxy hangs, lost multipart reads, and extra copies on CmdRead

### DIFF
--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -246,6 +246,7 @@ struct TEvPQ {
         EvTopicSqsActionMetrics,
         EvProcessBatchKeys,
         EvProcessBatchKeysResult,
+        EvReadProxyDone,
         EvEnd,
     };
 
@@ -1169,6 +1170,9 @@ struct TEvPQ {
         {}
 
         TString Consumer;
+    };
+
+    struct TEvReadProxyDone : public TEventLocal<TEvReadProxyDone, EvReadProxyDone> {
     };
 
     struct TEvFetchResponse : public TEventLocal<TEvFetchResponse, EvFetchResponse> {

--- a/ydb/core/persqueue/pqtablet/batching/batch_processor.h
+++ b/ydb/core/persqueue/pqtablet/batching/batch_processor.h
@@ -14,14 +14,9 @@ namespace NKikimr::NPQ::NBatching {
 struct TReadProcessingContext {
     TString User;
     ui32 PartitionId = 0;
-    ui64 Destination = 0;
     ui64 Offset = 0;
     ui32 Count = std::numeric_limits<ui32>::max();
     ui64 LastOffset = 0;
-    ui16 PartNo = 0;
-    ui64 Size = 0;
-    bool IsInternal = false;
-    NActors::TActorId ReplyTo;
     NActors::TActorId ResponseActor;
     THolder<NActors::IEventBase> Event;
 };

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -224,7 +224,12 @@ public:
         return true;
     }
 
-    const TActorId Sender;
+    void SetSender(const TActorId& sender)
+    {
+        Sender = sender;
+    }
+
+    TActorId Sender;
     const TActorId Tablet;
     const TString TopicName;
     const ui32 Partition;
@@ -2366,10 +2371,12 @@ void TPersQueue::HandleGetOwnershipRequest(const ui64 responseCookie, NWilson::T
 void TPersQueue::HandleReadRequest(
         const ui64 responseCookie, NWilson::TTraceId traceId, const TActorId& partActor,
         const NKikimrClient::TPersQueuePartitionRequest& req, const TActorContext& ctx,
-        const TActorId& pipeClient, const TActorId&
-) {
+        const TActorId& pipeClient, const TActorId& sender,
+        const NKikimrClient::TPersQueueRequest& request)
+{
     PQ_ENSURE(req.HasCmdRead());
 
+    const TString requestId = request.HasRequestId() ? request.GetRequestId() : "<none>";
     auto cmd = req.GetCmdRead();
     if (!cmd.HasOffset()) {
         ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST,
@@ -2395,35 +2402,43 @@ void TPersQueue::HandleReadRequest(
     } else if (cmd.HasPartNo() && cmd.GetPartNo() < 0) {
         ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST,
             TStringBuilder() << "invalid partNo in read request: " << ToString(req).data());
+    } else if (cmd.GetPartNo() != 0 && requestId != TMP_REQUEST_MARKER) {
+        ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST,
+            TStringBuilder() << "partial request are not allowed: " << ToString(req).data());
     } else if (cmd.HasMaxTimeLagMs() && cmd.GetMaxTimeLagMs() < 0) {
         ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST,
             TStringBuilder() << "invalid maxTimeLagMs in read request: " << ToString(req).data());
-
     } else if (cmd.GetClientId() == NPQ::CLIENTID_COMPACTION_CONSUMER) {
         ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST,
             TStringBuilder() << "cannot read with internal clinetId: " << cmd.GetClientId());
+    } else if (IsDirectReadCmd(cmd) && PipesInfo.find(pipeClient).IsEnd()) {
+        ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
+                   TStringBuilder() << "Read prepare request from unknown(old?) pipe: " << pipeClient.ToString());
+    } else if (IsDirectReadCmd(cmd) && cmd.GetSessionId().empty()) {
+        ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
+                   TStringBuilder() << "Read prepare request with empty session id");
+    } else if (IsDirectReadCmd(cmd) && PipesInfo.find(pipeClient)->second.SessionId != cmd.GetSessionId()) {
+        ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
+                   TStringBuilder() << "Read prepare request with unknown(old?) session id " << cmd.GetSessionId());
     } else {
+        if (requestId != TMP_REQUEST_MARKER) {
+            auto pipeIter = PipesInfo.find(pipeClient);
+            TDirectReadKey directKey{};
+            if (!pipeIter.IsEnd()) {
+                directKey.SessionId = pipeIter->second.SessionId;
+                directKey.PartitionSessionId = pipeIter->second.PartitionSessionId;
+            }
+            auto it = ResponseProxy.find(responseCookie);
+            PQ_ENSURE(it != ResponseProxy.end());
+            it->second->SetSender(ctx.RegisterWithSameMailbox(CreateReadProxy(
+                sender, TabletID(), ctx.SelfID, GetGeneration(), directKey, request, BatchProcessorActor)));
+        }
+
         InitResponseBuilder(responseCookie, 1, COUNTER_LATENCY_PQ_READ);
         ui32 count = cmd.HasCount() ? cmd.GetCount() : Max<ui32>();
         ui32 bytes = Min<ui32>(MAX_BYTES, cmd.HasBytes() ? cmd.GetBytes() : MAX_BYTES);
         auto clientDC = cmd.HasClientDC() ? to_lower(cmd.GetClientDC()) : "unknown";
         clientDC.to_title();
-        if (IsDirectReadCmd(cmd)) {
-            auto pipeIter = PipesInfo.find(pipeClient);
-            if (pipeIter.IsEnd()) {
-                ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
-                           TStringBuilder() << "Read prepare request from unknown(old?) pipe: " << pipeClient.ToString());
-                return;
-            } else if (cmd.GetSessionId().empty()) {
-                ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
-                           TStringBuilder() << "Read prepare request with empty session id");
-                return;
-            } else if (pipeIter->second.SessionId != cmd.GetSessionId()) {
-                ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
-                           TStringBuilder() << "Read prepare request with unknown(old?) session id " << cmd.GetSessionId());
-                return;
-            }
-        }
 
         THolder<TEvPQ::TEvRead> event =
             MakeHolder<TEvPQ::TEvRead>(responseCookie, cmd.GetOffset(), cmd.GetLastOffset(),
@@ -2942,19 +2957,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
     auto& req = request.GetPartitionRequest();
     TActorId pipeClient = ActorIdFromProto(req.GetPipeClient());
 
-    if (request.GetPartitionRequest().HasCmdRead() && s != TMP_REQUEST_MARKER) {
-        auto pipeIter = PipesInfo.find(pipeClient);
-        TDirectReadKey directKey{};
-        if (!pipeIter.IsEnd()) {
-            directKey.SessionId = pipeIter->second.SessionId;
-            directKey.PartitionSessionId = pipeIter->second.PartitionSessionId;
-        }
-        TActorId rr = ctx.RegisterWithSameMailbox(CreateReadProxy(
-            ev->Sender, TabletID(), ctx.SelfID, GetGeneration(), directKey, request, BatchProcessorActor));
-        ans = CreateResponseProxy(rr, ctx.SelfID, TopicName, p, m, s, c, ResourceMetrics, ctx);
-    } else {
-        ans = CreateResponseProxy(ev->Sender, ctx.SelfID, TopicName, p, m, s, c, ResourceMetrics, ctx);
-    }
+    ans = CreateResponseProxy(ev->Sender, ctx.SelfID, TopicName, p, m, s, c, ResourceMetrics, ctx);
 
     ResponseProxy[responseCookie] = ans;
     Counters->Simple()[COUNTER_PQ_TABLET_INFLIGHT].Set(ResponseProxy.size());
@@ -3045,7 +3048,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvRequest::TPtr& ev, const TActorContext&
     } else if (req.HasCmdUpdateWriteTimestamp()) {
         HandleUpdateWriteTimestampRequest(responseCookie, NWilson::TTraceId(ev->TraceId), partActor, req, ctx);
     } else if (req.HasCmdRead()) {
-        HandleReadRequest(responseCookie, NWilson::TTraceId(ev->TraceId), partActor, req, ctx, pipeClient, ev->Sender);
+        HandleReadRequest(responseCookie, NWilson::TTraceId(ev->TraceId), partActor, req, ctx, pipeClient, ev->Sender, request);
     } else if (req.HasCmdPublishRead()) {
         HandlePublishReadRequest(responseCookie, NWilson::TTraceId(ev->TraceId), partActor, req, ctx, pipeClient, ev->Sender);
     } else if (req.HasCmdForgetRead()) {

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -1353,6 +1353,11 @@ void TPersQueue::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx)
     }
 }
 
+void TPersQueue::Handle(TEvPQ::TEvReadProxyDone::TPtr& ev, const TActorContext&)
+{
+    ReadProxies.erase(ev->Sender);
+}
+
 void TPersQueue::Handle(TEvPQ::TEvProxyResponse::TPtr& ev, const TActorContext& ctx)
 {
 
@@ -2430,8 +2435,10 @@ void TPersQueue::HandleReadRequest(
             }
             auto it = ResponseProxy.find(responseCookie);
             PQ_ENSURE(it != ResponseProxy.end());
-            it->second->SetSender(ctx.RegisterWithSameMailbox(CreateReadProxy(
-                sender, TabletID(), ctx.SelfID, GetGeneration(), directKey, request, BatchProcessorActor)));
+            const TActorId readProxy = ctx.RegisterWithSameMailbox(CreateReadProxy(
+                sender, TabletID(), ctx.SelfID, GetGeneration(), directKey, request, BatchProcessorActor));
+            ReadProxies.insert(readProxy);
+            it->second->SetSender(readProxy);
         }
 
         InitResponseBuilder(responseCookie, 1, COUNTER_LATENCY_PQ_READ);
@@ -3227,6 +3234,11 @@ void TPersQueue::HandleDie(const TActorContext& ctx)
         PQ_ENSURE(res);
     }
     ResponseProxy.clear();
+
+    for (const auto& actorId : ReadProxies) {
+        ctx.Send(actorId, new TEvents::TEvPoisonPill());
+    }
+    ReadProxies.clear();
 
     StopWatchingTenantPathId(ctx);
     MediatorTimeCastUnregisterTablet(ctx);
@@ -6253,6 +6265,7 @@ bool TPersQueue::HandleHook(STFUNC_SIG)
         HFuncTraced(TEvTabletPipe::TEvClientDestroyed, Handle);
         HFuncTraced(TEvPQ::TEvError, Handle);
         HFuncTraced(TEvPQ::TEvProxyResponse, Handle);
+        HFuncTraced(TEvPQ::TEvReadProxyDone, Handle);
         CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
         HFuncTraced(TEvPersQueue::TEvProposeTransaction, Handle);
         HFuncTraced(TEvPQ::TEvPartitionConfigChanged, Handle);

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -120,6 +120,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
         const TStringBuf pathInfo) const;
 
     void HandleDie(const TActorContext& ctx) override;
+    void Handle(TEvPQ::TEvReadProxyDone::TPtr& ev, const TActorContext& ctx);
 
     //response from KV on READ or WRITE config request
     void Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext& ctx);
@@ -322,6 +323,7 @@ private:
 
     ui64 NextResponseCookie;
     THashMap<ui64, TAutoPtr<TResponseBuilder>> ResponseProxy;
+    THashSet<TActorId> ReadProxies;
 
     NMetrics::TResourceMetrics *ResourceMetrics;
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -183,12 +183,16 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
 
     DESCRIBE_HANDLE_WITH_SENDER(HandleCreateSessionRequest)
     DESCRIBE_HANDLE_WITH_SENDER(HandleDeleteSessionRequest)
-    DESCRIBE_HANDLE_WITH_SENDER(HandleReadRequest)
     DESCRIBE_HANDLE_WITH_SENDER(HandlePublishReadRequest)
     DESCRIBE_HANDLE_WITH_SENDER(HandleForgetReadRequest)
     DESCRIBE_HANDLE_WITH_SENDER(HandleGetOwnershipRequest)
     DESCRIBE_HANDLE_WITH_SENDER(HandleReserveBytesRequest)
 #undef DESCRIBE_HANDLE_WITH_SENDER
+
+    void HandleReadRequest(const ui64 responseCookie, NWilson::TTraceId traceId, const TActorId& partActor,
+                           const NKikimrClient::TPersQueuePartitionRequest& req, const TActorContext& ctx,
+                           const TActorId& pipeClient, const TActorId& sender,
+                           const NKikimrClient::TPersQueueRequest& request);
 
     bool ChangingState() const { return !TabletStateRequests.empty(); }
     void TryReturnTabletStateAll(const TActorContext& ctx, NKikimrProto::EReplyStatus status = NKikimrProto::OK);

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -62,6 +62,7 @@ public:
         , Sender(sender)
         , TabletGeneration(tabletGeneration)
         , Request(request)
+        , OriginalCmdRead(request.GetPartitionRequest().GetCmdRead())
         , Response(new TEvPersQueue::TEvResponse)
         , DirectReadKey(directReadKey)
         , InitialReadOffset(request.GetPartitionRequest().GetCmdRead().GetOffset())
@@ -190,9 +191,14 @@ private:
 
     void ContinueFromSkippedOffset()
     {
+        // Follow-up CmdRead is Count=1 with Bytes/Timeout/MaxTimeLag cleared. Restore the
+        // client's original limits so skip-ahead is a real initial read, not a one-message peek.
+        auto* read = Request.MutablePartitionRequest()->MutableCmdRead();
+        const ui64 offset = *LastSkipOffset + 1;
+        read->CopyFrom(OriginalCmdRead);
+        read->SetOffset(offset);
+        read->SetPartNo(0);
         Request.SetRequestId(TMP_REQUEST_MARKER);
-        Request.MutablePartitionRequest()->MutableCmdRead()->SetOffset(*LastSkipOffset + 1);
-        Request.MutablePartitionRequest()->MutableCmdRead()->SetPartNo(0);
         THolder<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
         req->Record = Request;
         Send(TabletActorId, req.Release());
@@ -529,6 +535,7 @@ private:
     const TActorId Sender;
     const ui32 TabletGeneration;
     NKikimrClient::TPersQueueRequest Request;
+    const NKikimrClient::TPersQueuePartitionRequest::TCmdRead OriginalCmdRead;
     THolder<TEvPersQueue::TEvResponse> Response;
     std::shared_ptr<NKikimrClient::TResponse> PreparedResponse;
     TDirectReadKey DirectReadKey;

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -28,6 +28,25 @@ bool HasBatchMessages(const NKikimrClient::TCmdReadResult& readResult) {
     });
 }
 
+bool CanStealAllResults(const NKikimrClient::TCmdReadResult& incoming,
+                        const NKikimrClient::TCmdReadResult& assembled,
+                        bool hasSkipOffset,
+                        bool skipObsoleteInLoop)
+{
+    if (assembled.ResultSize() != 0 || hasSkipOffset || skipObsoleteInLoop) {
+        return false;
+    }
+    for (const auto& result : incoming.GetResult()) {
+        if (result.GetData().empty() || result.GetPartNo() != 0) {
+            return false;
+        }
+        if (result.HasTotalParts() && result.GetTotalParts() > 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace
 
 class TReadProxy : public TBaseTabletActor<TReadProxy>, private TConstantLogPrefix {
@@ -234,7 +253,7 @@ private:
             PassAway();
             return;
         }
-        const auto& readResult = record.GetPartitionResponse().GetCmdReadResult();
+        auto* incomingRead = ev->Get()->Record.MutablePartitionResponse()->MutableCmdReadResult();
         if (isDirectRead) {
             if (!PreparedResponse) {
                 PreparedResponse = std::make_shared<NKikimrClient::TResponse>();
@@ -250,14 +269,14 @@ private:
         ui64 readFromTimestampMs = PreciseReadFromTimestampBehaviourEnabled(*appData)
                                    ? (responseRecord.HasPartitionResponse()
                                         ? responseRecord.GetPartitionResponse().GetCmdReadResult().GetReadFromTimestampMs()
-                                        : readResult.GetReadFromTimestampMs())
+                                        : incomingRead->GetReadFromTimestampMs())
                                    : 0;
 
         if (!responseRecord.HasPartitionResponse()) {
             auto partResp = responseRecord.MutablePartitionResponse();
             auto readRes = partResp->MutableCmdReadResult();
-            readRes->SetBlobsFromDisk(readResult.GetBlobsFromDisk());
-            readRes->SetBlobsFromCache(readResult.GetBlobsFromCache());
+            readRes->SetBlobsFromDisk(incomingRead->GetBlobsFromDisk());
+            readRes->SetBlobsFromCache(incomingRead->GetBlobsFromCache());
             if (skipObsoleteTimestamps) {
                 readRes->SetReadFromTimestampMs(readFromTimestampMs);
             }
@@ -268,13 +287,14 @@ private:
 
         auto partResp = responseRecord.MutablePartitionResponse()->MutableCmdReadResult();
 
-        partResp->SetMaxOffset(readResult.GetMaxOffset());
-        partResp->SetStartOffset(readResult.GetStartOffset());
-        partResp->SetEndOffset(readResult.GetEndOffset());
-        partResp->SetSizeLag(readResult.GetSizeLag());
-        partResp->SetWaitQuotaTimeMs(partResp->GetWaitQuotaTimeMs() + readResult.GetWaitQuotaTimeMs());
+        partResp->SetMaxOffset(incomingRead->GetMaxOffset());
+        partResp->SetStartOffset(incomingRead->GetStartOffset());
+        partResp->SetEndOffset(incomingRead->GetEndOffset());
+        partResp->SetLastOffset(incomingRead->GetLastOffset());
+        partResp->SetSizeLag(incomingRead->GetSizeLag());
+        partResp->SetWaitQuotaTimeMs(partResp->GetWaitQuotaTimeMs() + incomingRead->GetWaitQuotaTimeMs());
 
-        partResp->SetRealReadOffset(Max(partResp->GetRealReadOffset(), readResult.GetRealReadOffset()));
+        partResp->SetRealReadOffset(Max(partResp->GetRealReadOffset(), incomingRead->GetRealReadOffset()));
 
         auto makeErrorResponse = [&] (const TString& errorMessage) {
             partResp->MutableResult()->Clear();
@@ -288,111 +308,117 @@ private:
             DropIncompleteLastIfAny(partResp);
         };
 
-        for (ui32 i = 0; i < readResult.ResultSize(); ++i) {
-            const auto& currentReadResult = readResult.GetResult(i);
-            if (currentReadResult.GetData().empty()) { // This is empty parted removed by compactification
-                LastSkipOffset = currentReadResult.GetOffset();
-                continue; // Skip the empty part;
-            }
-            if (LastSkipOffset.Defined() && currentReadResult.GetOffset() == *LastSkipOffset) {
-                continue; // This is part of the message which is already being skipped due to empty parts or timestamp filtering. Skip all other parts as well;
-            }
-            if (!InitialRequest) {
-                // This is follow-up request to read missing parts;
-                // There must be some data in response already.
-                if (partResp->ResultSize() == 0) {
-                    makeErrorResponse("Internal error - got message part on followup read request with empty current response");
-                    YDB_LOG_CRIT("Handle TEvRead got message part on followup read request with empty current response. Readed now full",
-                        {"logPrefix", NPQ_LOG_PREFIX},
-                        {"seqNo", currentReadResult.GetSeqNo()},
-                        {"partNo", currentReadResult.GetPartNo()},
-                        {"requestNow", Request});
-                    break;
+        const bool skipObsoleteInLoop = skipObsoleteTimestamps && readFromTimestampMs != 0;
+        if (CanStealAllResults(*incomingRead, *partResp, LastSkipOffset.Defined(), skipObsoleteInLoop)) {
+            partResp->MutableResult()->Swap(incomingRead->MutableResult());
+        } else {
+            for (ui32 i = 0; i < incomingRead->ResultSize(); ++i) {
+                auto* current = incomingRead->MutableResult(i);
+                const auto& currentReadResult = *current;
+                if (currentReadResult.GetData().empty()) { // This is empty parted removed by compactification
+                    LastSkipOffset = currentReadResult.GetOffset();
+                    continue; // Skip the empty part;
                 }
-                if (currentReadResult.GetPartNo() == 0) {
-                    // Partition gap-jumped to the next message: remaining parts of the previous one
-                    // were deleted by retention or compactification. Drop the incomplete tail and
-                    // keep assembling from this result — do not resend the same follow-up.
-                    dropIncompleteLastIfAny();
-                } else {
-                    const auto& lastReadResult = partResp->GetResult(partResp->ResultSize() - 1);
-                    if (lastReadResult.GetSeqNo() != currentReadResult.GetSeqNo() || lastReadResult.GetPartNo() + 1 != currentReadResult.GetPartNo()) {
-                        dropIncompleteLastIfAny();
-                        break;
-                    }
+                if (LastSkipOffset.Defined() && currentReadResult.GetOffset() == *LastSkipOffset) {
+                    continue; // This is part of the message which is already being skipped due to empty parts or timestamp filtering. Skip all other parts as well;
                 }
-            }
-
-            // If we already have some data and encounter new message that doesn't fit into current response, we don't go any further, just stop;
-            // (And throw away that message to)
-            if (partResp->ResultSize() > 1 && currentReadResult.GetPartNo() == 0 &&
-                currentReadResult.HasTotalParts() && currentReadResult.GetTotalParts() + i > readResult.ResultSize())
-            {
-                break;
-            }
-
-            // Now actually add some data;
-            if (currentReadResult.GetPartNo() == 0) {
-                if (partResp->ResultSize()) {
-                    const auto& back = partResp->GetResult(partResp->ResultSize() - 1);
-                    if (back.GetPartNo() + 1 < back.GetTotalParts()) {
-                        makeErrorResponse("Internal error - got message part from the middle when expecting first part");
-                        YDB_LOG_CRIT("Handle TEvRead last read pos readed now full",
+                if (!InitialRequest) {
+                    // This is follow-up request to read missing parts;
+                    // There must be some data in response already.
+                    if (partResp->ResultSize() == 0) {
+                        makeErrorResponse("Internal error - got message part on followup read request with empty current response");
+                        YDB_LOG_CRIT("Handle TEvRead got message part on followup read request with empty current response. Readed now full",
                             {"logPrefix", NPQ_LOG_PREFIX},
-                            {"seqNoPartNo", back.GetSeqNo()},
-                            {"partNo", back.GetPartNo()},
                             {"seqNo", currentReadResult.GetSeqNo()},
-                            {"currentPartNo", currentReadResult.GetPartNo()},
+                            {"partNo", currentReadResult.GetPartNo()},
                             {"requestNow", Request});
                         break;
                     }
+                    if (currentReadResult.GetPartNo() == 0) {
+                        // Partition gap-jumped to the next message: remaining parts of the previous one
+                        // were deleted by retention or compactification. Drop the incomplete tail and
+                        // keep assembling from this result — do not resend the same follow-up.
+                        dropIncompleteLastIfAny();
+                    } else {
+                        const auto& lastReadResult = partResp->GetResult(partResp->ResultSize() - 1);
+                        if (lastReadResult.GetSeqNo() != currentReadResult.GetSeqNo() || lastReadResult.GetPartNo() + 1 != currentReadResult.GetPartNo()) {
+                            dropIncompleteLastIfAny();
+                            break;
+                        }
+                    }
                 }
-                if (currentReadResult.GetWriteTimestampMS() < readFromTimestampMs && skipObsoleteTimestamps) {
-                    LastSkipOffset = currentReadResult.GetOffset();
-                    continue;
-                }
-                // Create new message for first part;
-                auto* added = partResp->AddResult();
-                added->CopyFrom(currentReadResult);
-                if (added->GetTotalSize() > added->GetData().size()) {
-                    added->MutableData()->reserve(added->GetTotalSize());
-                }
-            } else { // Glue next part to prevous otherwise
-                if(partResp->ResultSize() == 0) {
-                    // This is error, Must have some data at this point;
-                    YDB_LOG_CRIT("Handle TEvRead, have last read pos, readed now full",
-                        {"logPrefix", NPQ_LOG_PREFIX},
-                        {"seqNo", currentReadResult.GetSeqNo()},
-                        {"partNo", currentReadResult.GetPartNo()},
-                        {"requestNow", Request});
-                    makeErrorResponse("Internal error - got message part from the middle when current response if empty");
-                    break;
 
-                }
-                auto* rr = partResp->MutableResult(partResp->ResultSize() - 1);
-                if (rr->GetSeqNo() != currentReadResult.GetSeqNo() || rr->GetPartNo() + 1 != currentReadResult.GetPartNo()) {
-                    YDB_LOG_CRIT("Handle TEvRead last read pos readed now full",
-                        {"logPrefix", NPQ_LOG_PREFIX},
-                        {"seqNoPartNo", rr->GetSeqNo()},
-                        {"partNo", rr->GetPartNo()},
-                        {"seqNo", currentReadResult.GetSeqNo()},
-                        {"currentPartNo", currentReadResult.GetPartNo()},
-                        {"requestNow", Request});
-                    makeErrorResponse("Internal error - got message with wrong SeqNo/PartNo when expecting");
+                // If we already have some data and encounter new message that doesn't fit into current response, we don't go any further, just stop;
+                // (And throw away that message to)
+                if (partResp->ResultSize() > 1 && currentReadResult.GetPartNo() == 0 &&
+                    currentReadResult.HasTotalParts() && currentReadResult.GetTotalParts() + i > incomingRead->ResultSize())
+                {
                     break;
                 }
-                auto* data = rr->MutableData();
-                if (rr->GetTotalSize() > data->size()) {
-                    data->reserve(rr->GetTotalSize());
-                }
-                *data += currentReadResult.GetData();
-                rr->SetPartitionKey(currentReadResult.GetPartitionKey());
-                rr->SetExplicitHash(currentReadResult.GetExplicitHash());
-                rr->SetPartNo(currentReadResult.GetPartNo());
-                rr->SetUncompressedSize(rr->GetUncompressedSize() + currentReadResult.GetUncompressedSize());
-                if (currentReadResult.GetPartNo() + 1 == currentReadResult.GetTotalParts()) {
-                    // This is the last part, validate data size;
-                    AFL_ENSURE((ui32)rr->GetTotalSize() == (ui32)rr->GetData().size());
+
+                // Now actually add some data;
+                if (currentReadResult.GetPartNo() == 0) {
+                    if (partResp->ResultSize()) {
+                        const auto& back = partResp->GetResult(partResp->ResultSize() - 1);
+                        if (back.GetPartNo() + 1 < back.GetTotalParts()) {
+                            makeErrorResponse("Internal error - got message part from the middle when expecting first part");
+                            YDB_LOG_CRIT("Handle TEvRead last read pos readed now full",
+                                {"logPrefix", NPQ_LOG_PREFIX},
+                                {"seqNoPartNo", back.GetSeqNo()},
+                                {"partNo", back.GetPartNo()},
+                                {"seqNo", currentReadResult.GetSeqNo()},
+                                {"currentPartNo", currentReadResult.GetPartNo()},
+                                {"requestNow", Request});
+                            break;
+                        }
+                    }
+                    if (currentReadResult.GetWriteTimestampMS() < readFromTimestampMs && skipObsoleteTimestamps) {
+                        LastSkipOffset = currentReadResult.GetOffset();
+                        continue;
+                    }
+                    // Steal the first part from the incoming event instead of copying Data.
+                    auto* added = partResp->AddResult();
+                    added->Swap(current);
+                    if (added->GetTotalSize() > added->GetData().size()) {
+                        added->MutableData()->reserve(added->GetTotalSize());
+                    }
+                } else { // Glue next part to prevous otherwise
+                    if(partResp->ResultSize() == 0) {
+                        // This is error, Must have some data at this point;
+                        YDB_LOG_CRIT("Handle TEvRead, have last read pos, readed now full",
+                            {"logPrefix", NPQ_LOG_PREFIX},
+                            {"seqNo", currentReadResult.GetSeqNo()},
+                            {"partNo", currentReadResult.GetPartNo()},
+                            {"requestNow", Request});
+                        makeErrorResponse("Internal error - got message part from the middle when current response if empty");
+                        break;
+
+                    }
+                    auto* rr = partResp->MutableResult(partResp->ResultSize() - 1);
+                    if (rr->GetSeqNo() != currentReadResult.GetSeqNo() || rr->GetPartNo() + 1 != currentReadResult.GetPartNo()) {
+                        YDB_LOG_CRIT("Handle TEvRead last read pos readed now full",
+                            {"logPrefix", NPQ_LOG_PREFIX},
+                            {"seqNoPartNo", rr->GetSeqNo()},
+                            {"partNo", rr->GetPartNo()},
+                            {"seqNo", currentReadResult.GetSeqNo()},
+                            {"currentPartNo", currentReadResult.GetPartNo()},
+                            {"requestNow", Request});
+                        makeErrorResponse("Internal error - got message with wrong SeqNo/PartNo when expecting");
+                        break;
+                    }
+                    auto* data = rr->MutableData();
+                    if (rr->GetTotalSize() > data->size()) {
+                        data->reserve(rr->GetTotalSize());
+                    }
+                    *data += currentReadResult.GetData();
+                    rr->SetPartitionKey(currentReadResult.GetPartitionKey());
+                    rr->SetExplicitHash(currentReadResult.GetExplicitHash());
+                    rr->SetPartNo(currentReadResult.GetPartNo());
+                    rr->SetUncompressedSize(rr->GetUncompressedSize() + currentReadResult.GetUncompressedSize());
+                    if (currentReadResult.GetPartNo() + 1 == currentReadResult.GetTotalParts()) {
+                        // This is the last part, validate data size;
+                        AFL_ENSURE((ui32)rr->GetTotalSize() == (ui32)rr->GetData().size());
+                    }
                 }
             }
         }
@@ -444,7 +470,7 @@ private:
                 }
             }
         }
-        TryProcessBatchOrSendResponse(ctx, isDirectRead, readResult, record.GetPartitionResponse());
+        TryProcessBatchOrSendResponse(ctx, isDirectRead, *partResp, record.GetPartitionResponse());
     }
 
     void Handle(NBatching::TEvProcessBatchResult::TPtr& ev, const TActorContext& ctx)

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -333,15 +333,18 @@ private:
                 return;
             }
         }
-        //filter old messages
-        ::google::protobuf::RepeatedPtrField<NKikimrClient::TCmdReadResult::TResult> records;
-        records.Swap(partResp->MutableResult());
-        partResp->ClearResult();
-        for (auto & rec : records) {
-            partResp->SetRealReadOffset(Max(partResp->GetRealReadOffset(), rec.GetOffset()));
-            if (rec.GetWriteTimestampMS() >= readFromTimestampMs) {
-                auto result = partResp->AddResult();
-                result->CopyFrom(rec);
+        if (readFromTimestampMs == 0) {
+            for (const auto& rec : partResp->GetResult()) {
+                partResp->SetRealReadOffset(Max(partResp->GetRealReadOffset(), rec.GetOffset()));
+            }
+        } else {
+            ::google::protobuf::RepeatedPtrField<NKikimrClient::TCmdReadResult::TResult> records;
+            records.Swap(partResp->MutableResult());
+            for (auto& rec : records) {
+                partResp->SetRealReadOffset(Max(partResp->GetRealReadOffset(), rec.GetOffset()));
+                if (rec.GetWriteTimestampMS() >= readFromTimestampMs) {
+                    partResp->AddResult()->Swap(&rec);
+                }
             }
         }
         TryProcessBatchOrSendResponse(ctx, isDirectRead, readResult, record.GetPartitionResponse());

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -125,6 +125,64 @@ private:
         SendResponse(ctx, isDirectRead, readResult, partitionResponse);
     }
 
+    void DropIncompleteLastIfAny(NKikimrClient::TCmdReadResult* partResp)
+    {
+        if (!partResp || partResp->ResultSize() == 0) {
+            return;
+        }
+        const auto& last = partResp->GetResult(partResp->ResultSize() - 1);
+        if (last.HasPartNo() && last.GetPartNo() + 1 < last.GetTotalParts()) {
+            LastSkipOffset = last.GetOffset();
+            partResp->MutableResult()->RemoveLast();
+        }
+    }
+
+    void ContinueFromSkippedOffset()
+    {
+        Request.SetRequestId(TMP_REQUEST_MARKER);
+        Request.MutablePartitionRequest()->MutableCmdRead()->SetOffset(*LastSkipOffset + 1);
+        Request.MutablePartitionRequest()->MutableCmdRead()->SetPartNo(0);
+        THolder<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
+        req->Record = Request;
+        Send(TabletActorId, req.Release());
+        InitialRequest = true;
+    }
+
+    // Follow-up came back empty or with an error. Keep complete messages from the first portion
+    // instead of CopyFrom-ing the follow-up over them. Returns true if this call consumed the event.
+    bool FinishWithAssembledOnFailedFollowUp(const TActorContext& ctx, const NKikimrClient::TResponse& record)
+    {
+        if (InitialRequest) {
+            return false;
+        }
+        const bool isDirectRead = DirectReadKey.ReadId != 0;
+        auto& responseRecord = isDirectRead && PreparedResponse ? *PreparedResponse : Response->Record;
+        if (!responseRecord.HasPartitionResponse() || !responseRecord.GetPartitionResponse().HasCmdReadResult()) {
+            return false;
+        }
+        auto* partResp = responseRecord.MutablePartitionResponse()->MutableCmdReadResult();
+        DropIncompleteLastIfAny(partResp);
+        if (partResp->ResultSize() == 0) {
+            if (!LastSkipOffset.Defined()) {
+                return false;
+            }
+            ContinueFromSkippedOffset();
+            return true;
+        }
+        NKikimrClient::TPersQueuePartitionResponse partitionResponse;
+        if (record.HasPartitionResponse()) {
+            partitionResponse.CopyFrom(record.GetPartitionResponse());
+        } else {
+            partitionResponse.CopyFrom(responseRecord.GetPartitionResponse());
+        }
+        const NKikimrClient::TCmdReadResult* readResult =
+            record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdReadResult()
+                ? &record.GetPartitionResponse().GetCmdReadResult()
+                : partResp;
+        TryProcessBatchOrSendResponse(ctx, isDirectRead, *readResult, partitionResponse);
+        return true;
+    }
+
     void Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx)
     {
         AFL_ENSURE(Response);
@@ -136,7 +194,9 @@ private:
             || record.GetErrorCode() != NPersQueue::NErrorCode::OK
             || (record.GetPartitionResponse().GetCmdReadResult().ResultSize() == 0 && !isDirectRead)
         ) {
-
+            if (FinishWithAssembledOnFailedFollowUp(ctx, record)) {
+                return;
+            }
             Response->Record.CopyFrom(record);
             ctx.Send(Sender, Response.Release());
             PassAway();
@@ -193,14 +253,7 @@ private:
         };
 
         auto dropIncompleteLastIfAny = [&] {
-            if (partResp->ResultSize() == 0) {
-                return;
-            }
-            const auto& last = partResp->GetResult(partResp->ResultSize() - 1);
-            if (last.HasPartNo() && last.GetPartNo() + 1 < last.GetTotalParts()) {
-                LastSkipOffset = last.GetOffset();
-                partResp->MutableResult()->RemoveLast();
-            }
+            DropIncompleteLastIfAny(partResp);
         };
 
         for (ui32 i = 0; i < readResult.ResultSize(); ++i) {
@@ -319,13 +372,7 @@ private:
             const bool skippedAheadOnInitial = InitialRequest && (ui64)cmdRead.GetOffset() < *LastSkipOffset;
             const bool droppedIncompleteOnFollowUp = !InitialRequest;
             if (skippedAheadOnInitial || droppedIncompleteOnFollowUp) {
-                Request.SetRequestId(TMP_REQUEST_MARKER);
-                Request.MutablePartitionRequest()->MutableCmdRead()->SetOffset(*LastSkipOffset + 1);
-                Request.MutablePartitionRequest()->MutableCmdRead()->SetPartNo(0);
-                THolder<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
-                req->Record = Request;
-                Send(TabletActorId, req.Release());
-                InitialRequest = true;
+                ContinueFromSkippedOffset();
                 return;
             }
         }

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -232,17 +232,7 @@ private:
             ContinueFromSkippedOffset();
             return true;
         }
-        NKikimrClient::TPersQueuePartitionResponse partitionResponse;
-        if (record.HasPartitionResponse()) {
-            partitionResponse.CopyFrom(record.GetPartitionResponse());
-        } else {
-            partitionResponse.CopyFrom(responseRecord.GetPartitionResponse());
-        }
-        const NKikimrClient::TCmdReadResult* readResult =
-            record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdReadResult()
-                ? &record.GetPartitionResponse().GetCmdReadResult()
-                : partResp;
-        TryProcessBatchOrSendResponse(ctx, isDirectRead, *readResult, partitionResponse);
+        TryProcessBatchOrSendResponse(ctx, isDirectRead, *partResp, responseRecord.GetPartitionResponse());
         return true;
     }
 
@@ -255,7 +245,8 @@ private:
             || !record.GetPartitionResponse().HasCmdReadResult()
             || record.GetStatus() != NMsgBusProxy::MSTATUS_OK
             || record.GetErrorCode() != NPersQueue::NErrorCode::OK
-            || (record.GetPartitionResponse().GetCmdReadResult().ResultSize() == 0 && !isDirectRead)
+            || (record.GetPartitionResponse().GetCmdReadResult().ResultSize() == 0
+                && (!isDirectRead || !InitialRequest))
         ) {
             if (FinishWithAssembledOnFailedFollowUp(ctx, record)) {
                 return;

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/protos/msgbus_pq.pb.h>
+#include <ydb/library/actors/core/events.h>
 #include <ydb/public/lib/base/msgbus_status.h>
 
 #include <util/generic/algorithm.h>
@@ -65,6 +66,32 @@ public:
     }
 
 private:
+    void ReplyErrorAndDie(const TActorContext& ctx, NPersQueue::NErrorCode::EErrorCode errorCode, const TString& error)
+    {
+        if (!Response) {
+            PassAway();
+            return;
+        }
+        Response->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
+        Response->Record.SetErrorCode(errorCode);
+        Response->Record.SetErrorReason(error);
+        if (Request.GetPartitionRequest().HasCookie() && !Response->Record.GetPartitionResponse().HasCookie()) {
+            Response->Record.MutablePartitionResponse()->SetCookie(Request.GetPartitionRequest().GetCookie());
+        }
+        ctx.Send(Sender, Response.Release());
+        PassAway();
+    }
+
+    void Handle(TEvents::TEvPoisonPill::TPtr&, const TActorContext& ctx)
+    {
+        ReplyErrorAndDie(ctx, NPersQueue::NErrorCode::INITIALIZING, "tablet will be restarted right now");
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr&, const TActorContext& ctx)
+    {
+        ReplyErrorAndDie(ctx, NPersQueue::NErrorCode::READ_NOT_DONE, "batch processor is unavailable");
+    }
+
     void SendResponse(const TActorContext& ctx, bool isDirectRead, const NKikimrClient::TCmdReadResult& readResult,
                       const NKikimrClient::TPersQueuePartitionResponse& partitionResponse)
     {
@@ -104,6 +131,11 @@ private:
         const auto& cmdReadResult = responseRecord.GetPartitionResponse().GetCmdReadResult();
 
         if (!CanReadBatches && HasBatchMessages(cmdReadResult)) {
+            if (!BatchProcessorActor) {
+                ReplyErrorAndDie(ctx, NPersQueue::NErrorCode::READ_NOT_DONE, "batch processor is unavailable");
+                return;
+            }
+
             PendingDirectRead = isDirectRead;
             PendingPartitionResponse.CopyFrom(partitionResponse);
 
@@ -118,7 +150,7 @@ private:
                 .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
                 .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
                 .ResponseActor = SelfId(),
-                .Event = std::move(proxyEvent)}));
+                .Event = std::move(proxyEvent)}), IEventHandle::FlagTrackDelivery);
             return;
         }
 
@@ -440,6 +472,8 @@ private:
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPersQueue::TEvResponse, Handle);
             HFunc(NBatching::TEvProcessBatchResult, Handle);
+            HFunc(TEvents::TEvPoisonPill, Handle);
+            HFunc(TEvents::TEvUndelivered, Handle);
         default:
             break;
         };

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -153,7 +153,9 @@ private:
         responseRecord.SetStatus(NMsgBusProxy::MSTATUS_OK);
         responseRecord.SetErrorCode(NPersQueue::NErrorCode::OK);
 
-        ui64 readFromTimestampMs = PreciseReadFromTimestampBehaviourEnabled(*AppData(ctx))
+        const auto* appData = AppData(ctx);
+        const bool skipObsoleteTimestamps = appData->FeatureFlags.GetEnableSkipMessagesWithObsoleteTimestamp();
+        ui64 readFromTimestampMs = PreciseReadFromTimestampBehaviourEnabled(*appData)
                                    ? (responseRecord.HasPartitionResponse()
                                         ? responseRecord.GetPartitionResponse().GetCmdReadResult().GetReadFromTimestampMs()
                                         : readResult.GetReadFromTimestampMs())
@@ -164,7 +166,7 @@ private:
             auto readRes = partResp->MutableCmdReadResult();
             readRes->SetBlobsFromDisk(readResult.GetBlobsFromDisk());
             readRes->SetBlobsFromCache(readResult.GetBlobsFromCache());
-            if (AppData(ctx)->FeatureFlags.GetEnableSkipMessagesWithObsoleteTimestamp()) {
+            if (skipObsoleteTimestamps) {
                 readRes->SetReadFromTimestampMs(readFromTimestampMs);
             }
         }
@@ -246,12 +248,16 @@ private:
                         break;
                     }
                 }
-                if (currentReadResult.GetWriteTimestampMS() < readFromTimestampMs && AppData(ctx)->FeatureFlags.GetEnableSkipMessagesWithObsoleteTimestamp()) {
+                if (currentReadResult.GetWriteTimestampMS() < readFromTimestampMs && skipObsoleteTimestamps) {
                     LastSkipOffset = currentReadResult.GetOffset();
                     continue;
                 }
                 // Create new message for first part;
-                partResp->AddResult()->CopyFrom(currentReadResult);
+                auto* added = partResp->AddResult();
+                added->CopyFrom(currentReadResult);
+                if (added->GetTotalSize() > added->GetData().size()) {
+                    added->MutableData()->reserve(added->GetTotalSize());
+                }
             } else { // Glue next part to prevous otherwise
                 if(partResp->ResultSize() == 0) {
                     // This is error, Must have some data at this point;
@@ -276,7 +282,11 @@ private:
                     makeErrorResponse("Internal error - got message with wrong SeqNo/PartNo when expecting");
                     break;
                 }
-                (*rr->MutableData()) += currentReadResult.GetData();
+                auto* data = rr->MutableData();
+                if (rr->GetTotalSize() > data->size()) {
+                    data->reserve(rr->GetTotalSize());
+                }
+                *data += currentReadResult.GetData();
                 rr->SetPartitionKey(currentReadResult.GetPartitionKey());
                 rr->SetExplicitHash(currentReadResult.GetExplicitHash());
                 rr->SetPartNo(currentReadResult.GetPartNo());

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -422,6 +422,13 @@ private:
                 }
             }
         }
+        if (responseRecord.GetErrorCode() != NPersQueue::NErrorCode::OK) {
+            ReplyErrorAndDie(
+                ctx,
+                static_cast<NPersQueue::NErrorCode::EErrorCode>(responseRecord.GetErrorCode()),
+                responseRecord.GetErrorReason());
+            return;
+        }
         // Nothing left to return: skipped compactified parts on the initial read, or dropped an
         // incomplete tail whose remaining parts are gone. Continue from the next offset instead of
         // repeating the same follow-up.

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -205,11 +205,17 @@ private:
         InitialRequest = true;
     }
 
-    // Follow-up came back empty or with an error. Keep complete messages from the first portion
-    // instead of CopyFrom-ing the follow-up over them. Returns true if this call consumed the event.
+    // Follow-up came back empty. Keep complete messages from the first portion instead of
+    // CopyFrom-ing the empty record over them. Real errors (INITIALIZING, OVERLOAD, ...) must
+    // still reach the client — do not turn a failed follow-up into a successful CmdRead.
     bool FinishWithAssembledOnFailedFollowUp(const TActorContext& ctx, const NKikimrClient::TResponse& record)
     {
         if (InitialRequest) {
+            return false;
+        }
+        if (record.GetStatus() != NMsgBusProxy::MSTATUS_OK
+            || record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
             return false;
         }
         const bool isDirectRead = DirectReadKey.ReadId != 0;

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -50,7 +50,6 @@ public:
     {
         AFL_ENSURE(Request.HasPartitionRequest() && Request.GetPartitionRequest().HasCmdRead());
         AFL_ENSURE(Request.GetPartitionRequest().GetCmdRead().GetPartNo() == 0); //partial request are not allowed, otherwise remove ReadProxy
-        AFL_ENSURE(!Response->Record.HasPartitionResponse());
         if (!directReadKey.SessionId.empty()) {
             DirectReadKey.ReadId = Request.GetPartitionRequest().GetCmdRead().GetDirectReadId();
         }
@@ -115,14 +114,9 @@ private:
             ctx.Send(BatchProcessorActor, new NBatching::TEvProcessBatch(NBatching::TReadProcessingContext{
                 .User = cmdRead.GetClientId(),
                 .PartitionId = static_cast<ui32>(Request.GetPartitionRequest().GetPartition()),
-                .Destination = 0,
                 .Offset = InitialReadOffset,
                 .Count = cmdRead.HasCount() ? static_cast<ui32>(cmdRead.GetCount()) : std::numeric_limits<ui32>::max(),
                 .LastOffset = cmdRead.GetLastOffset() > 0 ? static_cast<ui64>(cmdRead.GetLastOffset()) : 0,
-                .PartNo = 0,
-                .Size = static_cast<ui64>(proxyEvent->Response->ByteSize()),
-                .IsInternal = false,
-                .ReplyTo = TActorId{},
                 .ResponseActor = SelfId(),
                 .Event = std::move(proxyEvent)}));
             return;
@@ -148,7 +142,6 @@ private:
             PassAway();
             return;
         }
-        AFL_ENSURE(record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdReadResult());
         const auto& readResult = record.GetPartitionResponse().GetCmdReadResult();
         if (isDirectRead) {
             if (!PreparedResponse) {
@@ -160,8 +153,6 @@ private:
         responseRecord.SetStatus(NMsgBusProxy::MSTATUS_OK);
         responseRecord.SetErrorCode(NPersQueue::NErrorCode::OK);
 
-        AFL_ENSURE(readResult.ResultSize() > 0 || isDirectRead);
-
         ui64 readFromTimestampMs = PreciseReadFromTimestampBehaviourEnabled(*AppData(ctx))
                                    ? (responseRecord.HasPartitionResponse()
                                         ? responseRecord.GetPartitionResponse().GetCmdReadResult().GetReadFromTimestampMs()
@@ -171,8 +162,8 @@ private:
         if (!responseRecord.HasPartitionResponse()) {
             auto partResp = responseRecord.MutablePartitionResponse();
             auto readRes = partResp->MutableCmdReadResult();
-            readRes->SetBlobsFromDisk(readRes->GetBlobsFromDisk() + readResult.GetBlobsFromDisk());
-            readRes->SetBlobsFromCache(readRes->GetBlobsFromCache() + readResult.GetBlobsFromCache());
+            readRes->SetBlobsFromDisk(readResult.GetBlobsFromDisk());
+            readRes->SetBlobsFromCache(readResult.GetBlobsFromCache());
             if (AppData(ctx)->FeatureFlags.GetEnableSkipMessagesWithObsoleteTimestamp()) {
                 readRes->SetReadFromTimestampMs(readFromTimestampMs);
             }
@@ -190,15 +181,6 @@ private:
         partResp->SetWaitQuotaTimeMs(partResp->GetWaitQuotaTimeMs() + readResult.GetWaitQuotaTimeMs());
 
         partResp->SetRealReadOffset(Max(partResp->GetRealReadOffset(), readResult.GetRealReadOffset()));
-
-        auto removeIncompleteMessageIfAny = [&] () {
-            if (partResp->ResultSize() == 0)
-                return;
-            auto& back = partResp->GetResult(partResp->ResultSize() - 1);
-            if (back.GetPartNo() + 1 < back.GetTotalParts()) {
-                partResp->MutableResult()->RemoveLast();
-            }
-        };
 
         auto makeErrorResponse = [&] (const TString& errorMessage) {
             partResp->MutableResult()->Clear();
@@ -294,7 +276,6 @@ private:
                     makeErrorResponse("Internal error - got message with wrong SeqNo/PartNo when expecting");
                     break;
                 }
-                AFL_ENSURE(rr->GetSeqNo() == currentReadResult.GetSeqNo());
                 (*rr->MutableData()) += currentReadResult.GetData();
                 rr->SetPartitionKey(currentReadResult.GetPartitionKey());
                 rr->SetExplicitHash(currentReadResult.GetExplicitHash());
@@ -342,7 +323,6 @@ private:
                 return;
             }
         }
-        removeIncompleteMessageIfAny();
         //filter old messages
         ::google::protobuf::RepeatedPtrField<NKikimrClient::TCmdReadResult::TResult> records;
         records.Swap(partResp->MutableResult());

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -416,8 +416,16 @@ private:
                     rr->SetPartNo(currentReadResult.GetPartNo());
                     rr->SetUncompressedSize(rr->GetUncompressedSize() + currentReadResult.GetUncompressedSize());
                     if (currentReadResult.GetPartNo() + 1 == currentReadResult.GetTotalParts()) {
-                        // This is the last part, validate data size;
-                        AFL_ENSURE((ui32)rr->GetTotalSize() == (ui32)rr->GetData().size());
+                        if ((ui32)rr->GetTotalSize() != (ui32)rr->GetData().size()) {
+                            YDB_LOG_WARN("Handle TEvRead glued size mismatch",
+                                {"logPrefix", NPQ_LOG_PREFIX},
+                                {"totalSize", rr->GetTotalSize()},
+                                {"dataSize", rr->GetData().size()},
+                                {"seqNo", rr->GetSeqNo()},
+                                {"partNo", rr->GetPartNo()});
+                            makeErrorResponse("Internal error - glued message size does not match TotalSize");
+                            break;
+                        }
                     }
                 }
             }

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -192,6 +192,17 @@ private:
             InitialRequest = false; //So we don't make any more retries but return error;
         };
 
+        auto dropIncompleteLastIfAny = [&] {
+            if (partResp->ResultSize() == 0) {
+                return;
+            }
+            const auto& last = partResp->GetResult(partResp->ResultSize() - 1);
+            if (last.HasPartNo() && last.GetPartNo() + 1 < last.GetTotalParts()) {
+                LastSkipOffset = last.GetOffset();
+                partResp->MutableResult()->RemoveLast();
+            }
+        };
+
         for (ui32 i = 0; i < readResult.ResultSize(); ++i) {
             const auto& currentReadResult = readResult.GetResult(i);
             if (currentReadResult.GetData().empty()) { // This is empty parted removed by compactification
@@ -214,13 +225,16 @@ private:
                     break;
                 }
                 if (currentReadResult.GetPartNo() == 0) {
-                    // This is new message. If we still have another incomplete message stored previously, its' last parts were probably deleted by retention of compactification.
-                    // This is fine, we can drop last message;
-                    break;
-                }
-                const auto& lastReadResult = partResp->GetResult(partResp->ResultSize() - 1);
-                if (lastReadResult.GetSeqNo() != currentReadResult.GetSeqNo() || lastReadResult.GetPartNo() + 1 != currentReadResult.GetPartNo()) {
-                    break;
+                    // Partition gap-jumped to the next message: remaining parts of the previous one
+                    // were deleted by retention or compactification. Drop the incomplete tail and
+                    // keep assembling from this result — do not resend the same follow-up.
+                    dropIncompleteLastIfAny();
+                } else {
+                    const auto& lastReadResult = partResp->GetResult(partResp->ResultSize() - 1);
+                    if (lastReadResult.GetSeqNo() != currentReadResult.GetSeqNo() || lastReadResult.GetPartNo() + 1 != currentReadResult.GetPartNo()) {
+                        dropIncompleteLastIfAny();
+                        break;
+                    }
                 }
             }
 
@@ -297,19 +311,23 @@ private:
                 }
             }
         }
-        // We got no data during initial request - possibly skipped all the data due to compactification.
-        if (InitialRequest && partResp->GetResult().empty() && LastSkipOffset.Defined()
-            // Check if we did actually skip anything so we don't request the same offset again.
-            && (ui64)Request.GetPartitionRequest().GetCmdRead().GetOffset() < *LastSkipOffset
-        ) {
-            //Try another read. Set TMP_MARKER so that response is redirected to proxy, but here we will treat is as "initial" response still.
-            Request.SetRequestId(TMP_REQUEST_MARKER);
-            Request.MutablePartitionRequest()->MutableCmdRead()->SetOffset(*LastSkipOffset + 1);
-            Request.MutablePartitionRequest()->MutableCmdRead()->SetPartNo(0);
-            THolder<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
-            req->Record = Request;
-            Send(TabletActorId, req.Release());
-            return;
+        // Nothing left to return: skipped compactified parts on the initial read, or dropped an
+        // incomplete tail whose remaining parts are gone. Continue from the next offset instead of
+        // repeating the same follow-up.
+        if (partResp->GetResult().empty() && LastSkipOffset.Defined()) {
+            const auto& cmdRead = Request.GetPartitionRequest().GetCmdRead();
+            const bool skippedAheadOnInitial = InitialRequest && (ui64)cmdRead.GetOffset() < *LastSkipOffset;
+            const bool droppedIncompleteOnFollowUp = !InitialRequest;
+            if (skippedAheadOnInitial || droppedIncompleteOnFollowUp) {
+                Request.SetRequestId(TMP_REQUEST_MARKER);
+                Request.MutablePartitionRequest()->MutableCmdRead()->SetOffset(*LastSkipOffset + 1);
+                Request.MutablePartitionRequest()->MutableCmdRead()->SetPartNo(0);
+                THolder<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
+                req->Record = Request;
+                Send(TabletActorId, req.Release());
+                InitialRequest = true;
+                return;
+            }
         }
         if (!partResp->GetResult().empty()) {
             const auto& lastRes = partResp->GetResult(partResp->GetResult().size() - 1);

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.cpp
@@ -479,6 +479,12 @@ private:
         };
     }
 
+    void PassAway() override
+    {
+        Send(TabletActorId, new TEvPQ::TEvReadProxyDone());
+        TBaseTabletActor::PassAway();
+    }
+
     const TActorId Sender;
     const ui32 TabletGeneration;
     NKikimrClient::TPersQueueRequest Request;

--- a/ydb/core/persqueue/pqtablet/readproxy/readproxy.h
+++ b/ydb/core/persqueue/pqtablet/readproxy/readproxy.h
@@ -2,7 +2,6 @@
 
 #include <ydb/core/persqueue/public/key.h>
 #include <ydb/library/actors/core/actorsystem_fwd.h>
-#include <util/generic/fwd.h>
 
 namespace NKikimrClient {
 class TPersQueueRequest;

--- a/ydb/core/persqueue/pqtablet/readproxy/ya.make
+++ b/ydb/core/persqueue/pqtablet/readproxy/ya.make
@@ -13,6 +13,3 @@ PEERDIR(
 )
 
 END()
-
-RECURSE_FOR_TESTS(
-)

--- a/ydb/core/persqueue/ut/common/pq_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.cpp
@@ -1296,6 +1296,9 @@ void BeginCmdRead(const TPQCmdReadSettings& settings, TTestContext& tc)
     if (settings.MaxTimeLagMs > 0) {
         read->SetMaxTimeLagMs(settings.MaxTimeLagMs);
     }
+    if (settings.TimeoutMs > 0) {
+        read->SetTimeoutMs(settings.TimeoutMs);
+    }
     if (settings.ReadTimestampMs > 0) {
         read->SetReadTimestampMs(settings.ReadTimestampMs);
     }

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -506,6 +506,7 @@ struct TPQCmdReadSettings : public TPQCmdSettingsBase {
     TVector<i32> Offsets;
     ui32 MaxTimeLagMs = 0;
     ui32 ReadTimestampMs = 0;
+    ui32 TimeoutMs = 0;
     ui64 DirectReadId = 0;
     i64 LastOffset = 0;
     TActorId Pipe;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4840,6 +4840,77 @@ Y_UNIT_TEST(ReadProxyEmptyFollowUpDoesNotWipeAssembledMessages) {
         "empty follow-up wiped complete messages assembled on the initial read");
 }
 
+Y_UNIT_TEST(ReadProxyGlueErrorDoesNotStageDirectRead) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    tc.Runtime->RegisterService(MakePQDReadCacheServiceActorId(), tc.Runtime->Register(
+            CreatePQDReadCacheService(new NMonitoring::TDynamicCounters()))
+    );
+
+    const TString user = "user1";
+    const TString sessionId = "session-glue-error";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    TPQCmdSettings sessionSettings{0, user, sessionId};
+    sessionSettings.PartitionSessionId = 1;
+    sessionSettings.KeepPipe = true;
+    auto pipe = CmdCreateSession(sessionSettings, tc);
+
+    bool corrupted = false;
+    bool staged = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()) {
+            staged = true;
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+        if (!event || ev->Recipient == tc.Edge) {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (!event->Record.HasPartitionResponse() ||
+            !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+            event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* readResult = event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+        for (auto& res : *readResult->MutableResult()) {
+            if (res.GetPartNo() > 0) {
+                res.SetSeqNo(res.GetSeqNo() + 1'000);
+                corrupted = true;
+                break;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{sessionId, 0, 0, 10, 20_MB, 0, false, {}, 0, 0, user};
+    readSettings.PartitionSessionId = 1;
+    readSettings.DirectReadId = 1;
+    readSettings.Pipe = pipe;
+    BeginCmdRead(readSettings, tc);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_C(corrupted, "observer failed to break SeqNo of a multipart tail");
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::READ_NOT_DONE),
+        result->Record.DebugString());
+    UNIT_ASSERT_C(
+        !result->Record.GetPartitionResponse().HasCmdPrepareReadResult(),
+        result->Record.DebugString());
+    UNIT_ASSERT_C(!staged, "glue error staged TEvStageDirectReadData into the direct-read cache");
+}
+
 Y_UNIT_TEST(IncompleteProxyResponse) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4840,6 +4840,129 @@ Y_UNIT_TEST(ReadProxyEmptyFollowUpDoesNotWipeAssembledMessages) {
         "empty follow-up wiped complete messages assembled on the initial read");
 }
 
+// Empty follow-up CmdReadResult must not supply CmdPrepareReadResult offsets. SendResponse has
+// to use the assembled partResp; otherwise LastOffset/ReadOffset/EndOffset come from the empty
+// follow-up (or a poisoned sentinel) while staged data still has the glued messages.
+Y_UNIT_TEST(ReadProxyEmptyFollowUpDirectReadUsesAssembledPrepareOffsets) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    tc.Runtime->RegisterService(MakePQDReadCacheServiceActorId(), tc.Runtime->Register(
+            CreatePQDReadCacheService(new NMonitoring::TDynamicCounters()))
+    );
+
+    const TString user = "user1";
+    const TString sessionId = "session-empty-follow-up-prepare";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    TPQCmdSettings sessionSettings{0, user, sessionId};
+    sessionSettings.PartitionSessionId = 1;
+    sessionSettings.KeepPipe = true;
+    auto pipe = CmdCreateSession(sessionSettings, tc);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    constexpr ui64 kPoisonedOffset = 999;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool poisonedFollowUp = false;
+    bool gotClientResponse = false;
+    std::shared_ptr<NKikimrClient::TResponse> staged;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* event = ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()) {
+            staged = event->Response;
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+                event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() > 0) {
+                        continue;
+                    }
+                    kept.AddResult()->CopyFrom(res);
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else {
+                readResult.MutableResult()->Clear();
+                readResult.SetLastOffset(kPoisonedOffset);
+                readResult.SetRealReadOffset(kPoisonedOffset);
+                readResult.SetEndOffset(kPoisonedOffset);
+                poisonedFollowUp = true;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{sessionId, 0, 0, 10, 20_MB, 0, false, {}, 0, 0, user};
+    readSettings.PartitionSessionId = 1;
+    readSettings.DirectReadId = 1;
+    readSettings.Pipe = pipe;
+    readSettings.ReadToBlobEnd = false;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave an incomplete last multipart message in the first CmdReadResult");
+    UNIT_ASSERT_C(poisonedFollowUp, "observer failed to poison empty follow-up offsets");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::OK),
+        result->Record.DebugString());
+    UNIT_ASSERT_C(
+        result->Record.GetPartitionResponse().HasCmdPrepareReadResult(),
+        result->Record.DebugString());
+    const auto& prepare = result->Record.GetPartitionResponse().GetCmdPrepareReadResult();
+    UNIT_ASSERT_VALUES_UNEQUAL_C(prepare.GetLastOffset(), kPoisonedOffset, prepare.DebugString());
+    UNIT_ASSERT_VALUES_UNEQUAL_C(prepare.GetReadOffset(), kPoisonedOffset, prepare.DebugString());
+    UNIT_ASSERT_VALUES_UNEQUAL_C(prepare.GetEndOffset(), kPoisonedOffset, prepare.DebugString());
+    UNIT_ASSERT_C(staged, "empty follow-up did not stage assembled direct-read data");
+    UNIT_ASSERT_VALUES_UNEQUAL(staged->GetPartitionResponse().GetCmdReadResult().ResultSize(), 0u);
+}
+
 // A failed follow-up (INITIALIZING / tablet restart) must not be rewritten into a successful
 // CmdRead just because complete messages were already glued. The client has to see the error
 // so it can retry; returning OK would also stage a fake direct-read prepare.

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4840,6 +4840,212 @@ Y_UNIT_TEST(ReadProxyEmptyFollowUpDoesNotWipeAssembledMessages) {
         "empty follow-up wiped complete messages assembled on the initial read");
 }
 
+// A failed follow-up (INITIALIZING / tablet restart) must not be rewritten into a successful
+// CmdRead just because complete messages were already glued. The client has to see the error
+// so it can retry; returning OK would also stage a fake direct-read prepare.
+Y_UNIT_TEST(ReadProxyFailedFollowUpDoesNotReturnAssembledOk) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool failedFollowUp = false;
+    bool gotClientResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() > 0) {
+                        continue;
+                    }
+                    kept.AddResult()->CopyFrom(res);
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else {
+                event->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
+                event->Record.SetErrorCode(NPersQueue::NErrorCode::INITIALIZING);
+                event->Record.SetErrorReason("tablet will be restarted right now");
+                failedFollowUp = true;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 1, false, {0});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave an incomplete last multipart message in the first CmdReadResult");
+    UNIT_ASSERT_C(failedFollowUp, "observer failed to turn the follow-up into INITIALIZING");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::INITIALIZING),
+        result->Record.DebugString());
+}
+
+Y_UNIT_TEST(ReadProxyFailedFollowUpDoesNotStageDirectRead) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    tc.Runtime->RegisterService(MakePQDReadCacheServiceActorId(), tc.Runtime->Register(
+            CreatePQDReadCacheService(new NMonitoring::TDynamicCounters()))
+    );
+
+    const TString user = "user1";
+    const TString sessionId = "session-failed-follow-up";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    TPQCmdSettings sessionSettings{0, user, sessionId};
+    sessionSettings.PartitionSessionId = 1;
+    sessionSettings.KeepPipe = true;
+    auto pipe = CmdCreateSession(sessionSettings, tc);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool failedFollowUp = false;
+    bool staged = false;
+    bool gotClientResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()) {
+            staged = true;
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+                event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() > 0) {
+                        continue;
+                    }
+                    kept.AddResult()->CopyFrom(res);
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else {
+                event->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
+                event->Record.SetErrorCode(NPersQueue::NErrorCode::INITIALIZING);
+                event->Record.SetErrorReason("tablet will be restarted right now");
+                failedFollowUp = true;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{sessionId, 0, 0, 10, 20_MB, 0, false, {}, 0, 0, user};
+    readSettings.PartitionSessionId = 1;
+    readSettings.DirectReadId = 1;
+    readSettings.Pipe = pipe;
+    readSettings.ReadToBlobEnd = false;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave an incomplete last multipart message in the first CmdReadResult");
+    UNIT_ASSERT_C(failedFollowUp, "observer failed to turn the follow-up into INITIALIZING");
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::INITIALIZING),
+        result->Record.DebugString());
+    UNIT_ASSERT_C(
+        !result->Record.GetPartitionResponse().HasCmdPrepareReadResult(),
+        result->Record.DebugString());
+    UNIT_ASSERT_C(!staged, "failed follow-up staged TEvStageDirectReadData into the direct-read cache");
+}
+
 Y_UNIT_TEST(ReadProxyGlueErrorDoesNotStageDirectRead) {
     TTestContext tc;
     TFinalizer finalizer(tc);

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4911,6 +4911,56 @@ Y_UNIT_TEST(ReadProxyGlueErrorDoesNotStageDirectRead) {
     UNIT_ASSERT_C(!staged, "glue error staged TEvStageDirectReadData into the direct-read cache");
 }
 
+Y_UNIT_TEST(ReadProxyGlueSizeMismatchReturnsError) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    bool corrupted = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+        if (!event || ev->Recipient == tc.Edge) {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (!event->Record.HasPartitionResponse() ||
+            !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+            event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* readResult = event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+        for (auto& res : *readResult->MutableResult()) {
+            if (res.GetPartNo() == 0 && res.HasTotalParts() && res.GetTotalParts() > 1) {
+                res.SetTotalSize(res.GetTotalSize() + 1);
+                corrupted = true;
+                break;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{"", 0, 0, 10, 20_MB, 0, false, {}, 0, 0, user};
+    BeginCmdRead(readSettings, tc);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_C(corrupted, "observer failed to break TotalSize of a multipart message");
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::READ_NOT_DONE),
+        result->Record.DebugString());
+}
+
 Y_UNIT_TEST(IncompleteProxyResponse) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -5642,6 +5642,109 @@ Y_UNIT_TEST(ReadProxyContinueFromSkipRestoresOriginalCount) {
         "skip-ahead after an empty follow-up did not return the remaining messages under the original Count");
 }
 
+// After an empty follow-up with only an incomplete tail, skip-ahead must keep the original
+// TimeoutMs. Follow-up CmdRead clears timeout, so a restored timeout of 0 would return empty
+// immediately instead of waiting for the next write.
+Y_UNIT_TEST(ReadProxyContinueFromSkipWaitsOriginalTimeout) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    constexpr ui32 kOriginalTimeoutMs = 5000;
+    ui32 followUpReads = 0;
+    ui32 continueTimeout = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool gotContinueRead = false;
+    bool gotClientResponse = false;
+    bool clearNextInternalResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+                clearNextInternalResponse = true;
+            } else if (followUpReads > 0) {
+                continueTimeout = read->Timeout;
+                gotContinueRead = true;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() == 0 && res.HasTotalParts() && res.GetTotalParts() > 1) {
+                        kept.AddResult()->CopyFrom(res);
+                        break;
+                    }
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else if (clearNextInternalResponse) {
+                readResult.MutableResult()->Clear();
+                clearNextInternalResponse = false;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 1, false, {1});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    readSettings.TimeoutMs = kOriginalTimeoutMs;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotContinueRead;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave only an incomplete multipart message in the first CmdReadResult");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+    UNIT_ASSERT_C(gotContinueRead, "skip-ahead did not issue a PartNo==0 read after the empty follow-up");
+    UNIT_ASSERT_VALUES_EQUAL_C(continueTimeout, kOriginalTimeoutMs,
+        "skip-ahead did not restore the original TimeoutMs; timeout 0 returns empty without waiting");
+    UNIT_ASSERT_C(!gotClientResponse,
+        "skip-ahead returned to the client before timeout; expected to wait for the next write");
+
+    TVector<std::pair<ui64, TString>> next;
+    next.emplace_back(1, TString(64, 'c'));
+    CmdWrite(0, "sourceid1", next, tc);
+
+    UNIT_ASSERT_C(EndCmdRead(readSettings, tc),
+        "skip-ahead with restored timeout did not wait for the next written message");
+}
+
 Y_UNIT_TEST(ReadProxyFollowUpPartMismatchDropsIncompleteTail) {
     TTestContext tc;
     TFinalizer finalizer(tc);

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -722,6 +722,48 @@ Y_UNIT_TEST(ReadProxyPoisonPillUnblocksClientWaitingOnBatch) {
         result->Record.DebugString());
 }
 
+Y_UNIT_TEST(ReadProxyTabletDieUnblocksClientWaitingOnBatch) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    SetEnableTopicMessagesBatching(tc);
+
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 50_MB}, {{"user1", true}}, tc);
+
+    const TVector<TString> values = {"value0", "value1", "value2"};
+    CmdWriteKafkaBatch(0, "sourceid_readproxy_tablet_die", 1, values, tc, 0);
+
+    bool sentToBatch = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (ev->CastAsLocal<NBatching::TEvProcessBatch>()) {
+            sentToBatch = true;
+            return TTestActorRuntime::EEventAction::DROP;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{"", 0, 0, static_cast<ui32>(values.size()), 16_MB, 0, false, {}, 0, 0, "user1"};
+    readSettings.CanReadBatches = false;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] { return sentToBatch; };
+    tc.Runtime->DispatchEvents(options);
+    UNIT_ASSERT_C(sentToBatch, "ReadProxy never sent TEvProcessBatch");
+
+    PQTabletRestart(tc);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::INITIALIZING),
+        result->Record.DebugString());
+}
+
 void AssertKafkaBatchCutMessage(
     const NKikimrClient::TCmdReadResult::TResult& msg,
     ui64 expectedOffset,

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4961,6 +4961,493 @@ Y_UNIT_TEST(ReadProxyGlueSizeMismatchReturnsError) {
         result->Record.DebugString());
 }
 
+Y_UNIT_TEST(ReadProxyUndeliveredUnblocksClientWaitingOnBatch) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    SetEnableTopicMessagesBatching(tc);
+
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 50_MB}, {{"user1", true}}, tc);
+
+    const TVector<TString> values = {"value0", "value1", "value2"};
+    CmdWriteKafkaBatch(0, "sourceid_readproxy_undelivered", 1, values, tc, 0);
+
+    TActorId readProxy;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* batch = ev->CastAsLocal<NBatching::TEvProcessBatch>()) {
+            readProxy = batch->Context.ResponseActor;
+            return TTestActorRuntime::EEventAction::DROP;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{"", 0, 0, static_cast<ui32>(values.size()), 16_MB, 0, false, {}, 0, 0, "user1"};
+    readSettings.CanReadBatches = false;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] { return readProxy != TActorId{}; };
+    tc.Runtime->DispatchEvents(options);
+    UNIT_ASSERT_C(readProxy, "ReadProxy never sent TEvProcessBatch");
+
+    tc.Runtime->Send(new IEventHandle(
+        readProxy,
+        tc.Edge,
+        new TEvents::TEvUndelivered(
+            NBatching::TEvProcessBatch::EventType,
+            TEvents::TEvUndelivered::ReasonActorUnknown)),
+        0, true);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::READ_NOT_DONE),
+        result->Record.DebugString());
+}
+
+Y_UNIT_TEST(ReadProxyGlueErrorOnPartFromMiddleOfEmptyResponse) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    bool mutated = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+        if (!event || ev->Recipient == tc.Edge) {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (!event->Record.HasPartitionResponse() ||
+            !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+            event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* readResult = event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+        NKikimrClient::TCmdReadResult kept;
+        for (const auto& res : readResult->GetResult()) {
+            if (res.GetPartNo() > 0) {
+                kept.AddResult()->CopyFrom(res);
+            }
+        }
+        if (kept.ResultSize() > 0) {
+            readResult->MutableResult()->CopyFrom(kept.GetResult());
+            mutated = true;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{"", 0, 0, 10, 20_MB, 0, false, {}, 0, 0, user};
+    BeginCmdRead(readSettings, tc);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_C(mutated, "observer failed to leave a PartNo>0 result with an empty assembled response");
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::READ_NOT_DONE),
+        result->Record.DebugString());
+}
+
+Y_UNIT_TEST(ReadProxyGlueErrorOnNewMessageWhileLastIsIncomplete) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(2_MB, 'b'));
+    data.emplace_back(2, TString(64, 'c'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    bool mutated = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+        if (!event || ev->Recipient == tc.Edge) {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (!event->Record.HasPartitionResponse() ||
+            !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+            event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* readResult = event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+        NKikimrClient::TCmdReadResult kept;
+        bool keptIncomplete = false;
+        bool keptNext = false;
+        for (const auto& res : readResult->GetResult()) {
+            if (!keptIncomplete && res.GetPartNo() == 0 && res.HasTotalParts() && res.GetTotalParts() > 1) {
+                kept.AddResult()->CopyFrom(res);
+                keptIncomplete = true;
+            } else if (keptIncomplete && !keptNext && res.GetPartNo() == 0 &&
+                       res.GetOffset() != kept.GetResult(0).GetOffset())
+            {
+                kept.AddResult()->CopyFrom(res);
+                keptNext = true;
+            }
+        }
+        if (keptIncomplete && keptNext) {
+            readResult->MutableResult()->CopyFrom(kept.GetResult());
+            mutated = true;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{"", 0, 0, 10, 20_MB, 0, false, {}, 0, 0, user};
+    BeginCmdRead(readSettings, tc);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_C(mutated, "observer failed to pair an incomplete last message with a new PartNo==0");
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::READ_NOT_DONE),
+        result->Record.DebugString());
+}
+
+Y_UNIT_TEST(ReadProxyEmptyFollowUpWithOnlyIncompleteTailContinues) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    data.emplace_back(3, TString(64, 'c'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool gotClientResponse = false;
+    bool clearNextInternalResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+                clearNextInternalResponse = true;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() == 0 && res.HasTotalParts() && res.GetTotalParts() > 1) {
+                        kept.AddResult()->CopyFrom(res);
+                        break;
+                    }
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else if (clearNextInternalResponse) {
+                readResult.MutableResult()->Clear();
+                clearNextInternalResponse = false;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 1, false, {2});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave only an incomplete multipart message in the first CmdReadResult");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+    UNIT_ASSERT_C(EndCmdRead(readSettings, tc),
+        "empty follow-up with only an incomplete tail did not continue from the next offset");
+}
+
+Y_UNIT_TEST(ReadProxyFollowUpPartMismatchDropsIncompleteTail) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool mismatchedFollowUp = false;
+    bool gotClientResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() > 0) {
+                        continue;
+                    }
+                    kept.AddResult()->CopyFrom(res);
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else if (readResult.ResultSize() > 0 && readResult.GetResult(0).GetPartNo() > 0) {
+                auto* res = readResult.MutableResult(0);
+                res->SetPartNo(res->GetPartNo() + 10);
+                while (readResult.ResultSize() > 1) {
+                    readResult.MutableResult()->RemoveLast();
+                }
+                mismatchedFollowUp = true;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 1, false, {0});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave an incomplete last multipart message in the first CmdReadResult");
+    UNIT_ASSERT_C(mismatchedFollowUp, "observer failed to break SeqNo/PartNo of the follow-up part");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+    UNIT_ASSERT_C(EndCmdRead(readSettings, tc),
+        "follow-up PartNo mismatch did not keep the already assembled complete message");
+}
+
+Y_UNIT_TEST(ReadProxyStopsWhenNewMultipartDoesNotFit) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(64, 'b'));
+    data.emplace_back(3, TString(2_MB, 'c'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    bool mutated = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+        if (!event || ev->Recipient == tc.Edge) {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (!event->Record.HasPartitionResponse() ||
+            !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+            event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* readResult = event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+        NKikimrClient::TCmdReadResult kept;
+        for (const auto& res : readResult->GetResult()) {
+            if (res.GetPartNo() == 0) {
+                kept.AddResult()->CopyFrom(res);
+            }
+        }
+        if (kept.ResultSize() >= 3 &&
+            kept.GetResult(2).HasTotalParts() && kept.GetResult(2).GetTotalParts() > 1)
+        {
+            readResult->MutableResult()->CopyFrom(kept.GetResult());
+            mutated = true;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 2, false, {0, 1});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    const auto readResult = CmdReadAndGetResult(readSettings, tc);
+    UNIT_ASSERT_C(mutated, "observer failed to leave two complete messages and an incomplete multipart tail");
+    UNIT_ASSERT_VALUES_EQUAL(readResult.ResultSize(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(readResult.GetResult(0).GetOffset(), 0u);
+    UNIT_ASSERT_VALUES_EQUAL(readResult.GetResult(1).GetOffset(), 1u);
+}
+
+Y_UNIT_TEST(ReadProxySkipsObsoleteTimestampOnInitialRead) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    for (ui32 nodeIdx = 0; nodeIdx < tc.Runtime->GetNodeCount(); ++nodeIdx) {
+        tc.Runtime->GetAppData(nodeIdx).FeatureFlags.SetEnableSkipMessagesWithObsoleteTimestamp(true);
+    }
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(64, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    bool mutated = false;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+        if (!event || ev->Recipient == tc.Edge) {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        if (!event->Record.HasPartitionResponse() ||
+            !event->Record.GetPartitionResponse().HasCmdReadResult() ||
+            event->Record.GetErrorCode() != NPersQueue::NErrorCode::OK)
+        {
+            return TTestActorRuntime::EEventAction::PROCESS;
+        }
+        auto* readResult = event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+        if (readResult->ResultSize() >= 2) {
+            readResult->SetReadFromTimestampMs(10'000);
+            for (ui32 i = 0; i < readResult->ResultSize(); ++i) {
+                readResult->MutableResult(i)->SetWriteTimestampMS(i == 0 ? 1 : 20'000);
+            }
+            mutated = true;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 1, false, {1}, 0, 0, user);
+    const auto readResult = CmdReadAndGetResult(readSettings, tc);
+    UNIT_ASSERT_C(mutated, "observer failed to mark the first message as older than ReadTimestampMs");
+    UNIT_ASSERT_VALUES_EQUAL(readResult.ResultSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(readResult.GetResult(0).GetOffset(), 1u);
+}
+
+Y_UNIT_TEST(ReadProxyDirectReadBatchCutStagesData) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    SetEnableTopicMessagesBatching(tc);
+    tc.Runtime->RegisterService(MakePQDReadCacheServiceActorId(), tc.Runtime->Register(
+            CreatePQDReadCacheService(new NMonitoring::TDynamicCounters()))
+    );
+
+    const TString user = "user1";
+    const TString sessionId = "session-direct-batch-cut";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 50_MB}, {{user, true}}, tc);
+
+    const TVector<TString> values = {"value0", "value1", "value2"};
+    CmdWriteKafkaBatch(0, "sourceid_direct_batch_cut", 1, values, tc, 0);
+
+    TPQCmdSettings sessionSettings{0, user, sessionId};
+    sessionSettings.PartitionSessionId = 1;
+    sessionSettings.KeepPipe = true;
+    auto pipe = CmdCreateSession(sessionSettings, tc);
+
+    std::shared_ptr<NKikimrClient::TResponse> staged;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* event = ev->CastAsLocal<TEvPQ::TEvStageDirectReadData>()) {
+            staged = event->Response;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{sessionId, 0, 0, static_cast<ui32>(values.size()), 16_MB, 0, false, {}, 0, 0, user};
+    readSettings.PartitionSessionId = 1;
+    readSettings.DirectReadId = 1;
+    readSettings.Pipe = pipe;
+    readSettings.CanReadBatches = false;
+    CmdRead(readSettings, tc);
+
+    UNIT_ASSERT_C(staged, "ReadProxy did not stage TEvStageDirectReadData after cutting the kafka batch");
+    UNIT_ASSERT_C(
+        staged->GetPartitionResponse().HasCmdReadResult(),
+        staged->DebugString());
+    const auto& readResult = staged->GetPartitionResponse().GetCmdReadResult();
+    UNIT_ASSERT_VALUES_EQUAL(readResult.ResultSize(), values.size());
+    for (ui32 i = 0; i < values.size(); ++i) {
+        AssertKafkaBatchCutMessage(readResult.GetResult(i), i, 1u + i, values[i]);
+    }
+}
+
 Y_UNIT_TEST(IncompleteProxyResponse) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
 #include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/pqtablet/batching/batch_processor.h>
 #include <ydb/core/persqueue/pqtablet/partition/partition.h>
 #include <ydb/core/persqueue/public/write_id.h>
 #include <ydb/core/persqueue/ut/common/pq_ut_common.h>
@@ -677,6 +678,48 @@ Y_UNIT_TEST(KafkaBatchReadWithoutBatchSupportIsCut) {
         UNIT_ASSERT_VALUES_EQUAL(static_cast<ui32>(dataChunk.GetCodec()), static_cast<ui32>(NPersQueueCommon::RAW));
         UNIT_ASSERT_VALUES_EQUAL(dataChunk.GetData(), values[i]);
     }
+}
+
+Y_UNIT_TEST(ReadProxyPoisonPillUnblocksClientWaitingOnBatch) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+    SetEnableTopicMessagesBatching(tc);
+
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 50_MB}, {{"user1", true}}, tc);
+
+    const TVector<TString> values = {"value0", "value1", "value2"};
+    CmdWriteKafkaBatch(0, "sourceid_readproxy_poison", 1, values, tc, 0);
+
+    TActorId readProxy;
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* batch = ev->CastAsLocal<NBatching::TEvProcessBatch>()) {
+            readProxy = batch->Context.ResponseActor;
+            return TTestActorRuntime::EEventAction::DROP;
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings{"", 0, 0, static_cast<ui32>(values.size()), 16_MB, 0, false, {}, 0, 0, "user1"};
+    readSettings.CanReadBatches = false;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] { return readProxy != TActorId{}; };
+    tc.Runtime->DispatchEvents(options);
+    UNIT_ASSERT_C(readProxy, "ReadProxy never sent TEvProcessBatch");
+
+    tc.Runtime->Send(new IEventHandle(readProxy, tc.Edge, new TEvents::TEvPoisonPill()), 0, true);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        NPersQueue::NErrorCode::EErrorCode_Name(result->Record.GetErrorCode()),
+        NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::INITIALIZING),
+        result->Record.DebugString());
 }
 
 void AssertKafkaBatchCutMessage(

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4575,6 +4575,102 @@ Y_UNIT_TEST(PQ_Tablet_Does_Not_Remove_The_Blob_Until_The_Reading_Is_Complete)
     UNIT_ASSERT(!keys.contains("d0000000000_00000000000000000004_00000_0000000001_00014"));
 }
 
+// When remaining parts of a multipart message are gone (retention / compactification), the partition
+// gap-jumps and answers the follow-up with the next message (PartNo == 0). ReadProxy must drop the
+// incomplete last message and keep the follow-up payload. If it only `break`s out of the glue loop
+// and then resends the same follow-up, it livelocks on the tablet mailbox. Bound the follow-up
+// count so CI does not hang even if the loop comes back.
+Y_UNIT_TEST(ReadProxyFollowUpLoopsWhenMultipartTailIsGone) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.EnableDetailedPQLog = true;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool gotClientResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() > 0) {
+                        continue;
+                    }
+                    kept.AddResult()->CopyFrom(res);
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else if (readResult.ResultSize() > 0 && readResult.GetResult(0).GetPartNo() > 0) {
+                auto* res = readResult.MutableResult(0);
+                res->SetOffset(res->GetOffset() + 1);
+                res->SetSeqNo(res->GetSeqNo() + 1);
+                res->SetPartNo(0);
+                res->SetTotalParts(1);
+                if (res->GetData().empty()) {
+                    res->SetData("next");
+                }
+                while (readResult.ResultSize() > 1) {
+                    readResult.MutableResult()->RemoveLast();
+                }
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 2, false, {0, 2});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave an incomplete last multipart message in the first CmdReadResult");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read for the missing multipart tail, got " << followUpReads);
+    UNIT_ASSERT_C(EndCmdRead(readSettings, tc), "CmdRead failed after dropping the incomplete tail");
+}
+
 Y_UNIT_TEST(IncompleteProxyResponse) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -5209,6 +5209,110 @@ Y_UNIT_TEST(ReadProxyEmptyFollowUpWithOnlyIncompleteTailContinues) {
         "empty follow-up with only an incomplete tail did not continue from the next offset");
 }
 
+// Follow-up CmdRead is Count=1 with Bytes/Timeout cleared. After dropping an incomplete tail
+// whose remaining parts are gone, skip-ahead must restore the original client limits; otherwise
+// the next read returns a single message (or does not wait) instead of filling Count/Bytes.
+Y_UNIT_TEST(ReadProxyContinueFromSkipRestoresOriginalCount) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    data.emplace_back(3, TString(64, 'c'));
+    data.emplace_back(4, TString(64, 'd'));
+    data.emplace_back(5, TString(64, 'e'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    constexpr ui32 kOriginalCount = 10;
+    constexpr ui32 kOriginalBytes = 20_MB;
+    ui32 followUpReads = 0;
+    ui32 continueCount = 0;
+    ui32 continueSize = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool gotContinueRead = false;
+    bool gotClientResponse = false;
+    bool clearNextInternalResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+                clearNextInternalResponse = true;
+            } else if (followUpReads > 0) {
+                continueCount = read->Count;
+                continueSize = read->Size;
+                gotContinueRead = true;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() == 0 && res.HasTotalParts() && res.GetTotalParts() > 1) {
+                        kept.AddResult()->CopyFrom(res);
+                        break;
+                    }
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else if (clearNextInternalResponse) {
+                readResult.MutableResult()->Clear();
+                clearNextInternalResponse = false;
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, kOriginalCount, kOriginalBytes, 3, false, {2, 3, 4});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave only an incomplete multipart message in the first CmdReadResult");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+    UNIT_ASSERT_C(gotContinueRead, "skip-ahead did not issue a PartNo==0 read after the empty follow-up");
+    UNIT_ASSERT_VALUES_EQUAL_C(continueCount, kOriginalCount,
+        "skip-ahead kept follow-up Count=1 instead of the original client Count");
+    UNIT_ASSERT_VALUES_EQUAL_C(continueSize, kOriginalBytes,
+        "skip-ahead did not restore the original client Bytes");
+    UNIT_ASSERT_C(EndCmdRead(readSettings, tc),
+        "skip-ahead after an empty follow-up did not return the remaining messages under the original Count");
+}
+
 Y_UNIT_TEST(ReadProxyFollowUpPartMismatchDropsIncompleteTail) {
     TTestContext tc;
     TFinalizer finalizer(tc);

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4671,6 +4671,90 @@ Y_UNIT_TEST(ReadProxyFollowUpLoopsWhenMultipartTailIsGone) {
     UNIT_ASSERT_C(EndCmdRead(readSettings, tc), "CmdRead failed after dropping the incomplete tail");
 }
 
+// Empty follow-up (non-direct-read) used to CopyFrom the empty record over the assembled first
+// portion and return nothing to the client. Complete messages from the initial read must survive;
+// only the incomplete last message is dropped.
+Y_UNIT_TEST(ReadProxyEmptyFollowUpDoesNotWipeAssembledMessages) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10'000);
+
+    const TString user = "user1";
+    PQTabletPrepare({.partitions = 1, .writeSpeed = 10_MB}, {{user, true}}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(64, 'a'));
+    data.emplace_back(2, TString(2_MB, 'b'));
+    CmdWrite(0, "sourceid0", data, tc, false, {}, false, "", -1, 0, false, false, true);
+
+    constexpr ui32 kFollowUpLoopThreshold = 8;
+    ui32 followUpReads = 0;
+    bool firstReadAnswer = true;
+    bool madeIncompleteTail = false;
+    bool gotClientResponse = false;
+
+    auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+        if (auto* read = ev->CastAsLocal<TEvPQ::TEvRead>()) {
+            if (read->PartNo > 0) {
+                ++followUpReads;
+            }
+        } else if (auto* event = ev->CastAsLocal<TEvPersQueue::TEvResponse>()) {
+            if (!event->Record.HasPartitionResponse() ||
+                !event->Record.GetPartitionResponse().HasCmdReadResult())
+            {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+            if (ev->Recipient == tc.Edge) {
+                gotClientResponse = true;
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            auto& readResult = *event->Record.MutablePartitionResponse()->MutableCmdReadResult();
+            if (firstReadAnswer) {
+                firstReadAnswer = false;
+                NKikimrClient::TCmdReadResult kept;
+                for (const auto& res : readResult.GetResult()) {
+                    if (res.GetPartNo() > 0) {
+                        continue;
+                    }
+                    kept.AddResult()->CopyFrom(res);
+                }
+                readResult.MutableResult()->CopyFrom(kept.GetResult());
+                if (readResult.ResultSize() > 0) {
+                    const auto& last = readResult.GetResult(readResult.ResultSize() - 1);
+                    madeIncompleteTail = last.HasTotalParts() && last.GetPartNo() + 1 < last.GetTotalParts();
+                }
+            } else {
+                readResult.MutableResult()->Clear();
+            }
+        }
+        return TTestActorRuntime::EEventAction::PROCESS;
+    };
+    tc.Runtime->SetObserverFunc(observer);
+
+    TPQCmdReadSettings readSettings("", 0, 0, 10, 20_MB, 1, false, {0});
+    readSettings.ReadToBlobEnd = false;
+    readSettings.User = user;
+    BeginCmdRead(readSettings, tc);
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&] {
+        return followUpReads >= kFollowUpLoopThreshold || gotClientResponse;
+    };
+    try {
+        tc.Runtime->DispatchEvents(options);
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+    }
+
+    UNIT_ASSERT_C(madeIncompleteTail,
+        "observer failed to leave an incomplete last multipart message in the first CmdReadResult");
+    UNIT_ASSERT_VALUES_EQUAL_C(followUpReads, 1,
+        "expected a single follow-up read, got " << followUpReads);
+    UNIT_ASSERT_C(EndCmdRead(readSettings, tc),
+        "empty follow-up wiped complete messages assembled on the initial read");
+}
+
 Y_UNIT_TEST(IncompleteProxyResponse) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed hangs and lost messages in Topic/PersQueue `CmdRead` when assembling multipart and Kafka-batch results. A tablet restart or a compacted multipart tail no longer leaves the client blocked or looping; glue errors no longer crash the tablet or stage a fake direct-read prepare.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Audit and harden `TReadProxy` (`ydb/core/persqueue/pqtablet/readproxy`). The actor lives on the PQ tablet mailbox: it glues multipart `CmdRead` results, optionally cuts Kafka batches, and stages direct-read data. Several paths hung the client, restarted the tablet, or copied payloads for no reason.

**Hangs and lost data**
- Drop an incomplete last message when a follow-up gap-jumps to the next offset (`PartNo==0`). Remaining parts deleted by retention/compactification used to leave a truncated tail, so the same follow-up was resent forever.
- An empty or failed follow-up used to `CopyFrom` over the first portion and wipe complete messages already glued. Keep those, or continue from `LastSkipOffset+1` if nothing remains.
- Handle `PoisonPill` (`INITIALIZING`) and `TEvUndelivered` (`READ_NOT_DONE`) instead of ignoring them while waiting on `TEvProcessBatchResult`. Track delivery on `TEvProcessBatch`.
- Track live ReadProxy actor ids and poison them from `TPersQueue::HandleDie`. After the partition answers, `ResponseProxy` is gone, so a tablet restart previously left the client hanging on the pipe.

**Crashes and bad replies**
- Create the proxy only after `CmdRead` validation. Client `PartNo != 0` is `BAD_REQUEST` instead of `AFL_ENSURE` in the constructor (tablet restart). Follow-ups with `TMP_REQUEST_MARKER` keep the existing proxy.
- Glue errors call `ReplyErrorAndDie` instead of falling through `SendResponse`, which wrote `CmdPrepareReadResult` and `TEvStageDirectReadData` for an internal `READ_NOT_DONE`.
- Size mismatch on the last multipart part is a warning + `READ_NOT_DONE`, not `AFL_ENSURE` on the shared mailbox.

**Copies and dead code**
- Steal/Swap `CmdRead` results instead of `CopyFrom`. Steal the whole repeated field when the chunk is complete standalone messages; otherwise Swap each first part.
- `reserve(TotalSize)` before gluing parts; read `AppData` once per `Handle`.
- Skip the timestamp-filter `Swap`/`CopyFrom` reshuffle when `readFromTimestampMs == 0`.
- Remove unreachable `removeIncompleteMessageIfAny`, unused `TReadProcessingContext` fields, tautological `AFL_ENSURE`s, and an empty `RECURSE_FOR_TESTS()`.

**Tests** (`ydb/core/persqueue/ut`, `ReadProxy*`)
- PoisonPill / tablet die / `TEvUndelivered` while waiting on a Kafka batch cut.
- Follow-up gap-jump, empty follow-up (keep assembled / continue from skip), glue SeqNo and size mismatch (no direct-read stage).
- Empty assembled `PartNo>0`, incomplete last plus a new message, stop when a new multipart does not fit, obsolete-timestamp skip, direct-read batch cut staging.
