### PR TITLE
fix kafka proxy

### DIFF
--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -1436,6 +1436,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
                 });
 
             const TVector<char> expectedFills = {'a', 'b', 'c'};
+            const TVector<ui64> expectedBaseOffsets = {0, 3, 6};
             size_t receivedCount = 0;
             while (receivedCount < 3) {
                 auto jsonReceived = ReceiveMessage({
@@ -1451,7 +1452,12 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
                     UNIT_ASSERT_VALUES_EQUAL(
                         message["Attributes"]["BodyEncoding"].GetString(),
                         ToString(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH)));
-                    NKafka::NTest::AssertKafkaBatchPayload(Base64Decode(message["Body"].GetString()), 3, expectedFills[receivedCount], dataSize);
+                    NKafka::NTest::AssertKafkaBatchPayload(
+                        Base64Decode(message["Body"].GetString()),
+                        3,
+                        expectedFills[receivedCount],
+                        dataSize,
+                        expectedBaseOffsets[receivedCount]);
                     ++receivedCount;
                 }
             }
@@ -1489,7 +1495,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
             auto messageId = NKikimr::NSqsTopic::V1::DeserializeReceipt(receiptHandle);
             UNIT_ASSERT_C(messageId.has_value(), messageId.error());
 
-            NKafka::NTest::AssertKafkaBatchPayload(Base64Decode(message["Body"].GetString()), 3, 'a', dataSize);
+            NKafka::NTest::AssertKafkaBatchPayload(Base64Decode(message["Body"].GetString()), 3, 'a', dataSize, 0);
 
             const TString middleReceiptHandle = NKikimr::NSqsTopic::V1::SerializeReceipt({
                 .PartitionId = messageId->PartitionId,
@@ -1508,7 +1514,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
                 {"WaitTimeSeconds", 20},
             });
             UNIT_ASSERT_VALUES_EQUAL(jsonReceived["Messages"].GetArraySafe().size(), 1);
-            NKafka::NTest::AssertKafkaBatchPayload(Base64Decode(jsonReceived["Messages"][0]["Body"].GetString()), 3, 'a', dataSize);
+            NKafka::NTest::AssertKafkaBatchPayload(Base64Decode(jsonReceived["Messages"][0]["Body"].GetString()), 3, 'a', dataSize, 0);
 
             DeleteMessage({{"QueueUrl", path.QueueUrl}, {"ReceiptHandle", jsonReceived["Messages"][0]["ReceiptHandle"].GetString()}});
 

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -14,8 +14,6 @@
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
-#include <cstring>
-
 #include "actors.h"
 #include "kafka_fetch_actor.h"
 
@@ -38,11 +36,13 @@ TString RewriteKafkaBatchBaseOffset(TStringBuf data, ui64 baseOffset) {
         return TString(data);
     }
 
-    auto kafkaBaseOffset = static_cast<TKafkaRecordBatch::BaseOffsetMeta::Type>(baseOffset);
-    NormalizeNumber(kafkaBaseOffset);
+    const size_t baseOffsetSize = sizeof(TKafkaRecordBatch::BaseOffsetMeta::Type);
+    TKafkaWriteBuffer buffer(baseOffsetSize);
+    TKafkaWritable writable(buffer);
+    writable << static_cast<TKafkaRecordBatch::BaseOffsetMeta::Type>(baseOffset);
 
     TString result(data);
-    std::memcpy(result.Detach(), &kafkaBaseOffset, sizeof(kafkaBaseOffset));
+    result.replace(0, baseOffsetSize, buffer.AsString());
     return result;
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -14,6 +14,8 @@
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
+#include <cstring>
+
 #include "actors.h"
 #include "kafka_fetch_actor.h"
 
@@ -28,6 +30,20 @@ static constexpr size_t KafkaMagic = 2;
 
 NPersQueueCommon::ECodec KafkaBatchCodec() {
     return static_cast<NPersQueueCommon::ECodec>(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH) - 1);
+}
+
+TString RewriteKafkaBatchBaseOffset(TStringBuf data, ui64 baseOffset) {
+    const auto header = ReadKafkaBatchHeader(data);
+    if (!header || header->Magic < TKafkaRecordBatch::MagicMeta::Default) {
+        return TString(data);
+    }
+
+    auto kafkaBaseOffset = static_cast<TKafkaRecordBatch::BaseOffsetMeta::Type>(baseOffset);
+    NormalizeNumber(kafkaBaseOffset);
+
+    TString result(data);
+    std::memcpy(result.Detach(), &kafkaBaseOffset, sizeof(kafkaBaseOffset));
+    return result;
 }
 
 void FillRecordFromDataChunk(TKafkaRecord& record, const NKikimrPQClient::TDataChunk& dataChunk) {
@@ -201,8 +217,8 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
     ui64 maxTimestamp = 0;
     bool first = true;
 
-    auto addRawKafkaBatch = [&](const NKikimrPQClient::TDataChunk& dataChunk, const size_t messagesInBatch) {
-        kafkaBatchRecords += dataChunk.GetData();
+    auto addRawKafkaBatch = [&](const NKikimrPQClient::TDataChunk& dataChunk, ui64 offset, const size_t messagesInBatch) {
+        kafkaBatchRecords += RewriteKafkaBatchBaseOffset(dataChunk.GetData(), offset);
         messagesCount += messagesInBatch;
     };
 
@@ -279,7 +295,7 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
 
         if (isKafkaBatch) {
             flushRecordsBatch();
-            addRawKafkaBatch(dataChunk, result.GetLogicalMessageCount());
+            addRawKafkaBatch(dataChunk, result.GetOffset(), result.GetLogicalMessageCount());
             continue;
         }
 

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -30,22 +30,6 @@ NPersQueueCommon::ECodec KafkaBatchCodec() {
     return static_cast<NPersQueueCommon::ECodec>(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH) - 1);
 }
 
-TString RewriteKafkaBatchBaseOffset(TStringBuf data, ui64 baseOffset) {
-    const auto header = ReadKafkaBatchHeader(data);
-    if (!header || header->Magic < TKafkaRecordBatch::MagicMeta::Default) {
-        return TString(data);
-    }
-
-    const size_t baseOffsetSize = sizeof(TKafkaRecordBatch::BaseOffsetMeta::Type);
-    TKafkaWriteBuffer buffer(baseOffsetSize);
-    TKafkaWritable writable(buffer);
-    writable << static_cast<TKafkaRecordBatch::BaseOffsetMeta::Type>(baseOffset);
-
-    TString result(data);
-    result.replace(0, baseOffsetSize, buffer.AsString());
-    return result;
-}
-
 void FillRecordFromDataChunk(TKafkaRecord& record, const NKikimrPQClient::TDataChunk& dataChunk) {
     for (const auto& metadata : dataChunk.GetMessageMeta()) {
         if (metadata.key() == "__key") {
@@ -217,8 +201,8 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
     ui64 maxTimestamp = 0;
     bool first = true;
 
-    auto addRawKafkaBatch = [&](const NKikimrPQClient::TDataChunk& dataChunk, ui64 offset, const size_t messagesInBatch) {
-        kafkaBatchRecords += RewriteKafkaBatchBaseOffset(dataChunk.GetData(), offset);
+    auto addRawKafkaBatch = [&](const NKikimrPQClient::TDataChunk& dataChunk, const size_t messagesInBatch) {
+        kafkaBatchRecords += dataChunk.GetData();
         messagesCount += messagesInBatch;
     };
 
@@ -274,7 +258,7 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
     };
 
     for (const auto& result : partPQResponse.GetReadResult().GetResult()) {
-        const auto dataChunk = NKikimr::GetDeserializedData(result.GetData());
+        auto dataChunk = NKikimr::GetDeserializedData(result.GetData());
         if (dataChunk.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
             continue;
         }
@@ -295,7 +279,8 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
 
         if (isKafkaBatch) {
             flushRecordsBatch();
-            addRawKafkaBatch(dataChunk, result.GetOffset(), result.GetLogicalMessageCount());
+            SetKafkaBatchBaseOffset(*dataChunk.MutableData(), result.GetOffset());
+            addRawKafkaBatch(dataChunk, result.GetLogicalMessageCount());
             continue;
         }
 

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -939,13 +939,20 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         UNIT_ASSERT_VALUES_EQUAL(batches.size(), 2);
 
         const auto plainFetchedBatch = ReadKafkaRecordBatch(batches[0]);
+        UNIT_ASSERT_VALUES_EQUAL(plainFetchedBatch.BaseOffset, 0);
         UNIT_ASSERT_VALUES_EQUAL(plainFetchedBatch.Records.size(), 2);
         UNIT_ASSERT_VALUES_EQUAL(TString(plainFetchedBatch.Records[0].Key->data(), plainFetchedBatch.Records[0].Key->size()), "key-0");
         UNIT_ASSERT_VALUES_EQUAL(TString(plainFetchedBatch.Records[0].Value->data(), plainFetchedBatch.Records[0].Value->size()), "value-0");
         UNIT_ASSERT_VALUES_EQUAL(TString(plainFetchedBatch.Records[1].Key->data(), plainFetchedBatch.Records[1].Key->size()), "key-1");
         UNIT_ASSERT_VALUES_EQUAL(TString(plainFetchedBatch.Records[1].Value->data(), plainFetchedBatch.Records[1].Value->size()), "value-1");
 
-        UNIT_ASSERT_VALUES_EQUAL(batches[1], compressedBatchBytes);
+        const auto compressedFetchedBatch = ReadKafkaRecordBatch(batches[1]);
+        UNIT_ASSERT_VALUES_EQUAL(compressedFetchedBatch.BaseOffset, 2);
+        UNIT_ASSERT_VALUES_EQUAL(compressedFetchedBatch.Records.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(TString(compressedFetchedBatch.Records[0].Key->data(), compressedFetchedBatch.Records[0].Key->size()), "key-0");
+        UNIT_ASSERT_VALUES_EQUAL(TString(compressedFetchedBatch.Records[0].Value->data(), compressedFetchedBatch.Records[0].Value->size()), "value-0");
+        UNIT_ASSERT_VALUES_EQUAL(TString(compressedFetchedBatch.Records[1].Key->data(), compressedFetchedBatch.Records[1].Key->size()), "key-1");
+        UNIT_ASSERT_VALUES_EQUAL(TString(compressedFetchedBatch.Records[1].Value->data(), compressedFetchedBatch.Records[1].Value->size()), "value-1");
     }
 
     Y_UNIT_TEST(ProduceAndFetchLegacyRawKafkaBatch) {

--- a/ydb/core/persqueue/dread_cache_service/caching_service.cpp
+++ b/ydb/core/persqueue/dread_cache_service/caching_service.cpp
@@ -8,6 +8,7 @@
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/protos/grpc_pq_old.pb.h>
 #include <ydb/public/api/protos/draft/persqueue_common.pb.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 #include <ydb/services/persqueue_v1/actors/events.h>
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -26,6 +27,12 @@ i32 GetDataChunkCodec(const NKikimrPQClient::TDataChunk& proto) {
         return proto.GetCodec() + 1;
     }
     return 0;
+}
+
+void SetKafkaBatchBaseOffsetIfNeeded(NKikimrPQClient::TDataChunk& proto, ui64 offset) {
+    if (GetDataChunkCodec(proto) == Ydb::Topic::CODEC_KAFKA_BATCH) {
+        NKafka::SetKafkaBatchBaseOffset(*proto.MutableData(), offset);
+    }
 }
 
 class TPQDirectReadCacheService : public TActorBootstrapped<TPQDirectReadCacheService> {
@@ -502,6 +509,7 @@ private:
             if (!proto.has_codec()) {
                 proto.set_codec(NPersQueueCommon::RAW);
             }
+            SetKafkaBatchBaseOffsetIfNeeded(proto, r.GetOffset());
 
             TString sourceId;
             if (!r.GetSourceId().empty()) {

--- a/ydb/core/persqueue/public/mlp/mlp_reader.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_reader.cpp
@@ -6,10 +6,19 @@
 #include <ydb/core/protos/pqdata_mlp.pb.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/codecs.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
 namespace NKikimr::NPQ::NMLP {
+
+namespace {
+
+bool IsKafkaBatchDataChunk(const NKikimrPQClient::TDataChunk& proto) {
+    return proto.HasCodec() && proto.GetCodec() + 1 == static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH);
+}
+
+} // namespace
 
 TReaderActor::TReaderActor(const TActorId& parentId, const TReaderSettings& settings)
     : TBaseActor(NKikimrServices::EServiceKikimr::PQ_MLP_READER)
@@ -150,6 +159,9 @@ void TReaderActor::Handle(TEvPQ::TEvMLPReadResponse::TPtr& ev) {
 
         TString messageGroupId;
         TString messageDeduplicationId;
+        if (IsKafkaBatchDataChunk(proto)) {
+            NKafka::SetKafkaBatchBaseOffset(*proto.MutableData(), message.GetId().GetOffset());
+        }
 
         std::unordered_multimap<TString, TString> attributes(proto.GetMessageMeta().size());
         for (auto& meta : *proto.MutableMessageMeta()) {

--- a/ydb/core/persqueue/public/mlp/ya.make
+++ b/ydb/core/persqueue/public/mlp/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     ydb/core/persqueue/events
     ydb/core/persqueue/public
     ydb/core/persqueue/public/describer
+    ydb/public/sdk/cpp/src/library/kafka
 )
 
 END()

--- a/ydb/core/persqueue/ut/ut_with_sdk/topic_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/topic_ut.cpp
@@ -988,6 +988,7 @@ Y_UNIT_TEST_SUITE(WithSDK) {
                     auto& message = data->GetCompressedMessages().front();
                     UNIT_ASSERT_VALUES_EQUAL(message.GetOffset(), 0u);
                     UNIT_ASSERT_VALUES_EQUAL(message.GetLogicalMessageCount(), logicalMessageCount);
+                    UNIT_ASSERT_VALUES_EQUAL(NKafka::ReadKafkaRecordBatch(message.GetData()).BaseOffset, message.GetOffset());
 
                     if (commitDataEvent) {
                         data->Commit();

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -12,6 +12,7 @@ PEERDIR(
     ydb/core/persqueue/pqrb
     ydb/core/persqueue/pqtablet
     ydb/core/persqueue/writer
+    ydb/public/sdk/cpp/src/library/kafka
 )
 
 END()

--- a/ydb/core/tx/replication/ydb_proxy/local_proxy/local_partition_reader.cpp
+++ b/ydb/core/tx/replication/ydb_proxy/local_proxy/local_partition_reader.cpp
@@ -5,12 +5,22 @@
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/protos/grpc_pq_old.pb.h>
 #include <ydb/core/tx/replication/ydb_proxy/ydb_proxy.h>
+#include <ydb/public/api/protos/ydb_topic.pb.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
 #include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::LOCAL_YDB_PROXY
 
 namespace NKikimr::NReplication {
+
+namespace {
+
+bool IsKafkaBatchDataChunk(const NKikimrPQClient::TDataChunk& proto) {
+    return proto.HasCodec() && proto.GetCodec() + 1 == static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH);
+}
+
+} // namespace
 
 class TLocalTopicPartitionReaderActor: public TBaseLocalTopicPartitionActor {
     using TBase = TBaseLocalTopicPartitionActor;
@@ -308,6 +318,9 @@ private:
             );
 
             TString data;
+            if (IsKafkaBatchDataChunk(proto)) {
+                NKafka::SetKafkaBatchBaseOffset(*proto.MutableData(), result.GetOffset());
+            }
             bool isCompressed = proto.has_codec() && proto.codec() != Ydb::Topic::CODEC_RAW - 1;
             if (isCompressed && !AppData()->FeatureFlags.GetTransferInternalDataDecompression()) {
                 const auto* codec = NYdb::NTopic::TCodecMap::GetTheCodecMap().GetOrThrow(static_cast<ui32>(proto.codec() + 1));

--- a/ydb/core/tx/replication/ydb_proxy/local_proxy/ya.make
+++ b/ydb/core/tx/replication/ydb_proxy/local_proxy/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/scheme
     ydb/public/sdk/cpp/src/client/table
     ydb/public/sdk/cpp/src/client/topic
+    ydb/public/sdk/cpp/src/library/kafka
 )
 
 SRCS(

--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
@@ -967,6 +967,21 @@ TKafkaRecordBatch ReadRecordBatch(TStringBuf data) {
     return batch;
 }
 
+bool SetKafkaBatchBaseOffset(TString& data, ui64 baseOffset) {
+    const auto header = ReadKafkaBatchHeader(data);
+    if (!header || header->Magic < TKafkaRecordBatch::MagicMeta::Default) {
+        return false;
+    }
+
+    const size_t baseOffsetSize = sizeof(TKafkaRecordBatch::BaseOffsetMeta::Type);
+    TKafkaWriteBuffer buffer(baseOffsetSize);
+    TKafkaWritable writable(buffer);
+    writable << static_cast<TKafkaRecordBatch::BaseOffsetMeta::Type>(baseOffset);
+
+    data.replace(0, baseOffsetSize, buffer.AsString());
+    return true;
+}
+
 TString WriteKafkaRecordBatch(const TKafkaRecordBatch& batch, TKafkaVersion version) {
     TKafkaWriteBuffer buffer(WriteBufferChunkSize);
     TKafkaWritable writable(buffer);

--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_records.h
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_records.h
@@ -681,6 +681,7 @@ TKafkaRecordBatch ReadKafkaRecordBatch(
     TStringBuf data,
     TKafkaVersion version = 2);
 TKafkaRecordBatch ReadRecordBatch(TStringBuf data);
+bool SetKafkaBatchBaseOffset(TString& data, ui64 baseOffset);
 TString WriteKafkaRecordBatch(const TKafkaRecordBatch& batch, TKafkaVersion version = 2);
 
 std::pair<EKafkaErrors, ui64> GetBatchBaseSeqNo(const TKafkaBatchHeader& header);

--- a/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
@@ -457,6 +457,23 @@ Y_UNIT_TEST_SUITE(KafkaRecords) {
         AssertRecordBatchRoundTrip(ECompressionType::ZSTD);
     }
 
+    Y_UNIT_TEST(SetKafkaBatchBaseOffset) {
+        const TKafkaRecordBatch expected = MakeRecordBatch(ECompressionType::ZSTD);
+        TString batchBytes = WriteKafkaRecordBatch(expected);
+
+        UNIT_ASSERT(SetKafkaBatchBaseOffset(batchBytes, 123));
+
+        const TKafkaRecordBatch parsed = ReadKafkaRecordBatch(batchBytes);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.BaseOffset, 123);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Records.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Records[0].OffsetDelta, 0);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Records[1].OffsetDelta, 1);
+        UNIT_ASSERT(KafkaBytesEqual(parsed.Records[0].Key, expected.Records[0].Key));
+        UNIT_ASSERT(KafkaBytesEqual(parsed.Records[0].Value, expected.Records[0].Value));
+        UNIT_ASSERT(KafkaBytesEqual(parsed.Records[1].Key, expected.Records[1].Key));
+        UNIT_ASSERT(KafkaBytesEqual(parsed.Records[1].Value, expected.Records[1].Value));
+    }
+
     Y_UNIT_TEST(ReadKafkaBatchHeader) {
         UNIT_ASSERT(!ReadKafkaBatchHeader(TStringBuf()));
 

--- a/ydb/public/sdk/cpp/src/library/kafka/ut/ut_common.h
+++ b/ydb/public/sdk/cpp/src/library/kafka/ut/ut_common.h
@@ -4,10 +4,20 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <optional>
+
 namespace NKafka::NTest {
 
-inline void AssertKafkaBatchPayload(TStringBuf payload, size_t expectedRecordsCount, char expectedFill, size_t expectedDataSize) {
+inline void AssertKafkaBatchPayload(
+    TStringBuf payload,
+    size_t expectedRecordsCount,
+    char expectedFill,
+    size_t expectedDataSize,
+    std::optional<ui64> expectedBaseOffset = std::nullopt) {
     const auto batch = ReadKafkaRecordBatch(payload);
+    if (expectedBaseOffset) {
+        UNIT_ASSERT_VALUES_EQUAL(batch.BaseOffset, *expectedBaseOffset);
+    }
     UNIT_ASSERT_VALUES_EQUAL(batch.Records.size(), expectedRecordsCount);
 
     for (const auto& record : batch.Records) {

--- a/ydb/services/datastreams/datastreams_proxy.cpp
+++ b/ydb/services/datastreams/datastreams_proxy.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/protos/grpc_pq_old.pb.h>
 
 #include <ydb/public/api/protos/ydb_topic.pb.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 #include <ydb/services/datastreams/codes/datastreams_codes.h>
 #include <ydb/services/lib/actors/pq_schema_actor.h>
 #include <ydb/services/lib/sharding/sharding.h>
@@ -49,6 +50,10 @@ namespace NKikimr::NDataStreams::V1 {
         const TRequest* GetRequest(NGRpcService::IRequestOpCtx *request)
         {
             return dynamic_cast<const TRequest*>(request->GetRequest());
+        }
+
+        bool IsKafkaBatchDataChunk(const NKikimrPQClient::TDataChunk& proto) {
+            return proto.HasCodec() && proto.GetCodec() + 1 == static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH);
         }
 
         ui32 PartitionWriteSpeedInBytesPerSec(ui32 speedInKbPerSec) {
@@ -1610,6 +1615,9 @@ namespace NKikimr::NDataStreams::V1 {
                 }
 
                 auto proto(NKikimr::GetDeserializedData(r.GetData()));
+                if (IsKafkaBatchDataChunk(proto)) {
+                    NKafka::SetKafkaBatchBaseOffset(*proto.MutableData(), r.GetOffset());
+                }
                 auto record = Result.add_records();
                 record->set_data(proto.GetData());
                 record->set_encryption_type(Ydb::DataStreams::V1::EncryptionType::NONE);

--- a/ydb/services/datastreams/datastreams_ut.cpp
+++ b/ydb/services/datastreams/datastreams_ut.cpp
@@ -2500,10 +2500,10 @@ waitForNavCache:
             shardIterator = result.GetResult().shard_iterator();
         }
 
-        const TVector<TString> expectedSequenceNumbers = {"0", "3", "6"};
+        const TVector<ui64> expectedBaseOffsets = {0, 3, 6};
         const TVector<char> expectedFills = {'a', 'b', 'c'};
         size_t readIndex = 0;
-        while (readIndex < expectedSequenceNumbers.size()) {
+        while (readIndex < expectedBaseOffsets.size()) {
             auto result = testServer.DataStreamsClient->GetRecords(shardIterator,
                 NYDS_V1::TGetRecordsSettings().Limit(2)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.IsTransportError(), false);
@@ -2512,9 +2512,9 @@ waitForNavCache:
 
             for (const auto& record : result.GetResult().records()) {
                 UNIT_ASSERT_C(readIndex < expectedFills.size(), LabeledOutput(readIndex));
-                UNIT_ASSERT_VALUES_EQUAL(record.sequence_number(), expectedSequenceNumbers[readIndex]);
+                UNIT_ASSERT_VALUES_EQUAL(record.sequence_number(), ToString(expectedBaseOffsets[readIndex]));
                 UNIT_ASSERT_VALUES_EQUAL(record.codec(), static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH));
-                NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, expectedFills[readIndex], dataSize);
+                NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, expectedFills[readIndex], dataSize, expectedBaseOffsets[readIndex]);
                 ++readIndex;
             }
 
@@ -2571,7 +2571,7 @@ waitForNavCache:
             const auto& record = result.GetResult().records(0);
             UNIT_ASSERT_VALUES_EQUAL(record.sequence_number(), "0");
             UNIT_ASSERT_VALUES_EQUAL(record.codec(), static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH));
-            NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, 'a', dataSize);
+            NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, 'a', dataSize, 0);
 
             shardIterator = result.GetResult().next_shard_iterator();
         }
@@ -2586,7 +2586,7 @@ waitForNavCache:
             const auto& record = result.GetResult().records(0);
             UNIT_ASSERT_VALUES_EQUAL(record.sequence_number(), "3");
             UNIT_ASSERT_VALUES_EQUAL(record.codec(), static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH));
-            NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, 'b', dataSize);
+            NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, 'b', dataSize, 3);
 
             shardIterator = result.GetResult().next_shard_iterator();
         }
@@ -2618,7 +2618,7 @@ waitForNavCache:
             const auto& record = result.GetResult().records(0);
             UNIT_ASSERT_VALUES_EQUAL(record.sequence_number(), "3");
             UNIT_ASSERT_VALUES_EQUAL(record.codec(), static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH));
-            NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, 'b', dataSize);
+            NKafka::NTest::AssertKafkaBatchPayload(record.data(), 3, 'b', dataSize, 3);
         }
     }
 

--- a/ydb/services/datastreams/ya.make
+++ b/ydb/services/datastreams/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     ydb/public/api/grpc
     ydb/public/api/grpc/draft
     ydb/public/sdk/cpp/src/library/operation_id
+    ydb/public/sdk/cpp/src/library/kafka
     ydb/public/sdk/cpp/src/client/resources
     ydb/public/sdk/cpp/src/client/datastreams
     ydb/services/datastreams/codes

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -17,6 +17,9 @@
 #include <ydb/services/persqueue_v1/actors/distributed_commit_helper.h>
 #include <ydb/services/persqueue_v1/actors/helpers.h>
 
+#include <ydb/public/api/protos/ydb_topic.pb.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
+
 #include <library/cpp/protobuf/util/repeated_field_utils.h>
 
 #include <util/string/strip.h>
@@ -37,6 +40,10 @@ namespace NGRpcProxy {
 
 using namespace NPersQueue;
 using namespace NSchemeCache;
+
+bool IsKafkaBatchDataChunk(const NKikimrPQClient::TDataChunk& proto) {
+    return proto.HasCodec() && proto.GetCodec() + 1 == static_cast<i32>(Ydb::Topic::CODEC_KAFKA_BATCH);
+}
 
 #ifdef PQ_LOG_PREFIX
 #undef PQ_LOG_PREFIX
@@ -2375,6 +2382,9 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
 
         if (!proto.has_codec()) {
             proto.set_codec(NPersQueueCommon::RAW);
+        }
+        if (IsKafkaBatchDataChunk(proto)) {
+            NKafka::SetKafkaBatchBaseOffset(*proto.MutableData(), r.GetOffset());
         }
 
         TString sourceId = "";

--- a/ydb/services/deprecated/persqueue_v0/ya.make
+++ b/ydb/services/deprecated/persqueue_v0/ya.make
@@ -24,6 +24,7 @@ PEERDIR(
     ydb/core/protos
     ydb/library/aclib
     ydb/library/persqueue/topic_parser
+    ydb/public/sdk/cpp/src/library/kafka
     ydb/services/lib/actors
     ydb/services/lib/sharding
     ydb/services/persqueue_v1

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -11,6 +11,7 @@
 
 #include <ydb/public/api/protos/ydb_persqueue_v1.pb.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 #include <ydb/public/lib/base/msgbus_status.h>
 
 #include <google/protobuf/util/time_util.h>
@@ -529,6 +530,12 @@ i32 GetDataChunkCodec(const NKikimrPQClient::TDataChunk& proto) {
     return 0;
 }
 
+void SetKafkaBatchBaseOffsetIfNeeded(NKikimrPQClient::TDataChunk& proto, ui64 offset) {
+    if (GetDataChunkCodec(proto) == Ydb::Topic::CODEC_KAFKA_BATCH) {
+        NKafka::SetKafkaBatchBaseOffset(*proto.MutableData(), offset);
+    }
+}
+
 template<typename TReadResponse>
 bool FillBatchedData(
         TReadResponse* data, const NKikimrClient::TCmdReadResult& res,
@@ -582,6 +589,7 @@ bool FillBatchedData(
         if (proto.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
             continue; //TODO - no such chunks must be on prod
         }
+        SetKafkaBatchBaseOffsetIfNeeded(proto, r.GetOffset());
 
         TString sourceId;
         if (!r.GetSourceId().empty()) {

--- a/ydb/tests/compatibility/topics/test_kafka_topic.py
+++ b/ydb/tests/compatibility/topics/test_kafka_topic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import concurrent.futures
+from collections import Counter
 import logging
 import os
 import pytest
@@ -163,6 +164,30 @@ def kill_process_tree(process):
         pass
     except OSError:
         process.kill()
+
+
+def assert_kafka_streams_forwarded_payloads(read, expected_payloads):
+    expected = [
+        payload if isinstance(payload, bytes) else payload.encode("utf-8")
+        for payload in expected_payloads
+    ]
+    expected_counts = Counter(expected)
+    actual_counts = Counter()
+    unexpected = []
+
+    for message in read:
+        matches = [
+            payload
+            for payload in expected_counts
+            if message.endswith(payload)
+        ]
+        if len(matches) == 1:
+            actual_counts[matches[0]] += 1
+        else:
+            unexpected.append(message)
+
+    assert not unexpected, f"Unexpected Kafka Streams payloads: {unexpected!r}"
+    assert actual_counts == expected_counts
 
 
 class KafkaStreamsRuntime:
@@ -339,7 +364,7 @@ class TestKafkaTopicMessagesBatchingDisabledRead(CurrentToCurrentVersionFixture)
             len(messages),
         )
         assert len(read) == len(messages)
-        assert all(message.startswith(b"kafka-batching-compat-message-") for message in read)
+        assert_kafka_streams_forwarded_payloads(read, messages)
 
     # Write a physical Kafka batch through the topic protocol, disable batching, and verify that
     # Kafka fetch can still read and forward every logical record from that stored batch.
@@ -367,7 +392,7 @@ class TestKafkaTopicMessagesBatchingDisabledRead(CurrentToCurrentVersionFixture)
             len(messages),
         )
         assert len(read) == len(messages)
-        assert all(message.startswith(b"kafka-fetch-after-disable-") for message in read)
+        assert_kafka_streams_forwarded_payloads(read, messages)
 
     # Mix plain topic messages and a physical Kafka batch in one topic, disable batching, and verify
     # Kafka fetch sees a contiguous logical stream across the format boundary.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Вот вариант описания для PR:

```markdown
## Что сделано

Исправлена выдача raw Kafka batches через Kafka Fetch API.

Если в Topic был сохранен raw Kafka RecordBatch, Kafka proxy раньше отдавал его bytes как есть. Из-за этого `BaseOffset` внутри batch мог не совпадать с реальным offset-ом сообщения в YDB Topic. В mixed-сценариях или при нескольких Kafka batches в одной partition Kafka-клиенты могли видеть некорректную последовательность offsets и не дочитывать часть сообщений.

Теперь при fetch raw Kafka batch переписывается `BaseOffset` на настоящий topic offset (`result.GetOffset()`), при этом содержимое records сохраняется.

Также обновлены тесты:
- unit-тест Kafka proxy теперь проверяет, что raw compressed batch после plain messages отдается с корректным `BaseOffset`;
- compatibility-тесты Kafka Streams больше не завязаны на `startswith`, потому что Kafka Streams добавляет свой prefix к forwarded payload, и теперь проверяют исходный payload как suffix с учетом multiplicity.