### PR TITLE
Fix flaky secondary index followers compatibility stats check

### DIFF
--- a/ydb/tests/compatibility/common/test_followers.py
+++ b/ydb/tests/compatibility/common/test_followers.py
@@ -193,26 +193,25 @@ class TestSecondaryIndexFollowers(RollingUpgradeAndDowngradeFixture):
         with ydb.QuerySessionPool(self.driver) as session_pool:
             session_pool.retry_operation_sync(operation)
 
-    def check_statistics(self, enable_followers):
-        queries = [
-            f"""
-                SELECT *
-                FROM `/Root/.sys/partition_stats`
-                WHERE
-                    (RowReads != 0 OR RangeReads != 0)
-                    AND Path = '/Root/{self.TABLE_NAME}/{self.INDEX_NAME}/indexImplTable'
-            """
-        ]
+    def check_statistics(self):
+        index_impl_path = f"/Root/{self.TABLE_NAME}/{self.INDEX_NAME}/indexImplTable"
+        query = f"""
+            SELECT *
+            FROM `/Root/.sys/partition_stats`
+            WHERE
+                (RowReads != 0 OR RangeReads != 0)
+                AND Path = '{index_impl_path}'
+        """
 
         with ydb.QuerySessionPool(self.driver) as session_pool:
-            for _ in range(self.ATTEMPT_COUNT):
-                for query in queries:
-                    result_sets = session_pool.execute_with_retries(query)
-                    result_row_count = len(result_sets[0].rows)
-                    if result_row_count > 0:
-                        return
+            for attempt in range(self.ATTEMPT_COUNT):
+                if attempt > 0:
+                    self.read_data()
+                result_sets = session_pool.execute_with_retries(query)
+                if len(result_sets[0].rows) > 0:
+                    return
                 time.sleep(self.ATTEMPT_INTERVAL)
-            assert False, f"Expected reads but there is timeout waiting for read stats from '/Root/{self.TABLE_NAME}/{self.INDEX_NAME}/indexImplTable'"
+            assert False, f"Expected reads but timed out waiting for read stats from '{index_impl_path}'"
 
     @pytest.mark.parametrize("enable_followers", [True, False])
     def test_secondary_index_followers(self, enable_followers):
@@ -221,4 +220,4 @@ class TestSecondaryIndexFollowers(RollingUpgradeAndDowngradeFixture):
         for _ in self.roll():
             self.write_data()
             self.read_data()
-            self.check_statistics(enable_followers)
+            self.check_statistics()


### PR DESCRIPTION
* Simplified the stats polling logic to use a single query instead of a list of queries.
* Re-runs read_data() on subsequent polling attempts to repopulate read counters before re-checking partition stats.

Fixes #49805