### PR TITLE
Fix flaky vector index compatibility test

### DIFF
--- a/ydb/tests/compatibility/indexes/test_vector_index.py
+++ b/ydb/tests/compatibility/indexes/test_vector_index.py
@@ -15,6 +15,11 @@ class TestVectorIndex(RollingUpgradeAndDowngradeFixture):
         self.rows_per_user = 3
         self.index_name = "vector_idx"
         self.vector_dimension = 3
+        # Keep every branch of the two-level tree populated. Older versions
+        # reject DML when resolving a childless branch, while newer versions
+        # skip it, which makes the result depend on the node handling a query
+        # during a rolling upgrade.
+        self.clusters = 2
         # vector type: [ data type, conversion function ]
         self.vector_types = {
             "Uint8": ["Uint8", "Knn::ToBinaryStringUint8"],
@@ -60,7 +65,7 @@ class TestVectorIndex(RollingUpgradeAndDowngradeFixture):
                   vector_type={vector_type},
                   vector_dimension={self.vector_dimension},
                   levels=2,
-                  clusters=10
+                  clusters={self.clusters}
                   {overlap}
             );
         """


### PR DESCRIPTION
### Changelog entry 
Not for changelog

### Description for reviewers 

The test created a two-level vector index with 10 clusters while providing only 3 rows per prefix. This produced childless branches in prefixed indexes.

  During a rolling upgrade, handling such branches differs between versions: older nodes reject DML with InternalError: Child clusters of N are invalid, while newer nodes skip the empty subtree. Consequently, the test result depended on which node handled the query, making it flaky.

  Reduce the cluster count from 10 to 2 so every branch has enough input rows while retaining coverage of:

  - Two-level vector indexes
  - Prefixed and non-prefixed indexes
  - Overlapping clusters
  - All supported vector types and metrics
  - Insert, update, upsert, and delete operations
  - Rolling upgrade and downgrade scenarios


