### PR TITLE
[detailed-metrics] support @private visibility for counters as per spec

### DIFF
--- a/ydb/core/tablet/private/aggregated_counters.cpp
+++ b/ydb/core/tablet/private/aggregated_counters.cpp
@@ -30,8 +30,11 @@ using THistogramVector = TVector<THolder<THistogramCounter>>;
 ** class TAggregatedSimpleCounters
  */
 
-TAggregatedSimpleCounters::TAggregatedSimpleCounters(::NMonitoring::TDynamicCounterPtr counterGroup)
+TAggregatedSimpleCounters::TAggregatedSimpleCounters(
+    ::NMonitoring::TDynamicCounterPtr counterGroup,
+    ::NMonitoring::TCountableBase::EVisibility visibility)
     : CounterGroup(counterGroup)
+    , Visibility(visibility)
 {}
 
 void TAggregatedSimpleCounters::Reserve(size_t hint) {
@@ -50,7 +53,7 @@ void TAggregatedSimpleCounters::AddSimpleCounter(
     TString sumName = Sprintf("SUM(%s)", name);
 
     auto fnAddCounter = [this](const char* name, TCountersVector& container) {
-        auto counter = CounterGroup->GetCounter(name, false);
+        auto counter = CounterGroup->GetCounter(name, false, Visibility);
         container.push_back(counter);
     };
     fnAddCounter(maxName.data(), MaxSimpleCounters);
@@ -190,8 +193,11 @@ bool TAggregatedSimpleCounters::Find(const TString& name, TVector<TTabletCounter
 ** class TAggregatedCumulativeCounters
  */
 
-TAggregatedCumulativeCounters::TAggregatedCumulativeCounters(::NMonitoring::TDynamicCounterPtr counterGroup)
+TAggregatedCumulativeCounters::TAggregatedCumulativeCounters(
+    ::NMonitoring::TDynamicCounterPtr counterGroup,
+    ::NMonitoring::TCountableBase::EVisibility visibility)
     : CounterGroup(counterGroup)
+    , Visibility(visibility)
 {}
 
 void TAggregatedCumulativeCounters::Reserve(size_t hint) {
@@ -208,7 +214,7 @@ void TAggregatedCumulativeCounters::AddCumulativeCounter(
     TString maxName = Sprintf("MAX(%s)", name);
 
     auto fnAddCounter = [this](const char* name, TCountersVector& container) {
-        auto counter = CounterGroup->GetCounter(name, false);
+        auto counter = CounterGroup->GetCounter(name, false, Visibility);
         container.push_back(counter);
     };
     fnAddCounter(maxName.data(), MaxCumulativeCounters);
@@ -331,8 +337,11 @@ bool TAggregatedCumulativeCounters::Find(const TString& name, TVector<TTabletCou
 ** class TAggregatedHistogramCounters
  */
 
-TAggregatedHistogramCounters::TAggregatedHistogramCounters(::NMonitoring::TDynamicCounterPtr counterGroup)
+TAggregatedHistogramCounters::TAggregatedHistogramCounters(
+    ::NMonitoring::TDynamicCounterPtr counterGroup,
+    ::NMonitoring::TCountableBase::EVisibility visibility)
     : CounterGroup(counterGroup)
+    , Visibility(visibility)
 {}
 
 void TAggregatedHistogramCounters::Reserve(size_t hint) {
@@ -365,7 +374,7 @@ void TAggregatedHistogramCounters::AddCounter(
     }
 
     auto histogram = CounterGroup->GetHistogram(
-        name, NMonitoring::ExplicitHistogram(bucketBounds), isDerivative);
+        name, NMonitoring::ExplicitHistogram(bucketBounds), isDerivative, Visibility);
 
     if (histogramAggregate) {
         // either simple or cumulative aggregate will handle this histogram,

--- a/ydb/core/tablet/private/aggregated_counters.h
+++ b/ydb/core/tablet/private/aggregated_counters.h
@@ -36,8 +36,10 @@ struct TTabletCounterValue {
 
 class TAggregatedSimpleCounters {
 public:
-    //
-    TAggregatedSimpleCounters(::NMonitoring::TDynamicCounterPtr counterGroup);
+    TAggregatedSimpleCounters(
+        ::NMonitoring::TDynamicCounterPtr counterGroup,
+        ::NMonitoring::TCountableBase::EVisibility visibility
+            = ::NMonitoring::TCountableBase::EVisibility::Public);
 
     void Reserve(size_t hint);
 
@@ -57,6 +59,7 @@ public:
 
 private:
     ::NMonitoring::TDynamicCounterPtr CounterGroup;
+    ::NMonitoring::TCountableBase::EVisibility Visibility;
 
     TCountersVector MaxSimpleCounters;
     TCountersVector SumSimpleCounters;
@@ -71,8 +74,10 @@ private:
 
 class TAggregatedCumulativeCounters {
 public:
-    //
-    TAggregatedCumulativeCounters(::NMonitoring::TDynamicCounterPtr counterGroup);
+    TAggregatedCumulativeCounters(
+        ::NMonitoring::TDynamicCounterPtr counterGroup,
+        ::NMonitoring::TCountableBase::EVisibility visibility
+            = ::NMonitoring::TCountableBase::EVisibility::Public);
 
     void Reserve(size_t hint);
 
@@ -89,6 +94,7 @@ public:
 
 private:
     ::NMonitoring::TDynamicCounterPtr CounterGroup;
+    ::NMonitoring::TCountableBase::EVisibility Visibility;
 
     TCountersVector MaxCumulativeCounters;
     THistogramVector HistCumulativeCounters;
@@ -102,7 +108,10 @@ private:
 
 class TAggregatedHistogramCounters {
 public:
-    TAggregatedHistogramCounters(::NMonitoring::TDynamicCounterPtr counterGroup);
+    TAggregatedHistogramCounters(
+        ::NMonitoring::TDynamicCounterPtr counterGroup,
+        ::NMonitoring::TCountableBase::EVisibility visibility
+            = ::NMonitoring::TCountableBase::EVisibility::Public);
 
     void Reserve(size_t hint);
 
@@ -131,6 +140,7 @@ private:
 
 private:
     ::NMonitoring::TDynamicCounterPtr CounterGroup;
+    ::NMonitoring::TCountableBase::EVisibility Visibility;
 
     // monitoring counters holders, updated only during recalculation
     TVector<NMonitoring::THistogramPtr> Histograms;

--- a/ydb/core/tablet/private/aggregated_tablet_counters.cpp
+++ b/ydb/core/tablet/private/aggregated_tablet_counters.cpp
@@ -4,12 +4,15 @@
 
 namespace NKikimr::NPrivate {
 
-TAggregatedTabletCounters::TAggregatedTabletCounters(::NMonitoring::TDynamicCounterPtr counterGroup)
+TAggregatedTabletCounters::TAggregatedTabletCounters(
+    ::NMonitoring::TDynamicCounterPtr counterGroup,
+    ::NMonitoring::TCountableBase::EVisibility visibility)
     : IsInitialized(false)
-    , AggregatedSimpleCounters(counterGroup)
-    , AggregatedCumulativeCounters(counterGroup)
-    , AggregatedHistogramCounters(counterGroup)
+    , AggregatedSimpleCounters(counterGroup, visibility)
+    , AggregatedCumulativeCounters(counterGroup, visibility)
+    , AggregatedHistogramCounters(counterGroup, visibility)
     , CounterGroup(counterGroup)
+    , Visibility(visibility)
 {}
 
 void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) {
@@ -67,7 +70,7 @@ void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) 
             } else {
                 AggregatedCumulativeCounters.AddCumulativeCounter(name);
             }
-            auto counter = CounterGroup->GetCounter(name, true);
+            auto counter = CounterGroup->GetCounter(name, true, Visibility);
             CumulativeCounters.push_back(counter);
         }
     }

--- a/ydb/core/tablet/private/aggregated_tablet_counters.h
+++ b/ydb/core/tablet/private/aggregated_tablet_counters.h
@@ -37,7 +37,10 @@ public:
      */
     bool IsInitialized;
 
-    explicit TAggregatedTabletCounters(::NMonitoring::TDynamicCounterPtr counterGroup);
+    explicit TAggregatedTabletCounters(
+        ::NMonitoring::TDynamicCounterPtr counterGroup,
+        ::NMonitoring::TCountableBase::EVisibility visibility
+            = ::NMonitoring::TCountableBase::EVisibility::Public);
 
     /**
      * Create the aggregated counters for the counter set reported by the tablets.
@@ -96,6 +99,7 @@ private:
     THashMap<ui64, TInstant> LastAggregateUpdateTime;
 
     ::NMonitoring::TDynamicCounterPtr CounterGroup;
+    ::NMonitoring::TCountableBase::EVisibility Visibility;
 };
 
 } // namespace NKikimr::NPrivate


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Not for changelog

### Description for reviewers <!-- (optional) description for those who read this PR -->

detailed metrics spec asks for ydb_detailed_raw to be only visible if `@private` visibility is present in the fetch url

this does not affect **group** visibility, as library code does not allow for it
but it does filter out individual counters and if all of them are private — page will be empty