### PR TITLE
Remove leftover TEvPersQueue::TEvUpdateConfig

### DIFF
--- a/ydb/core/client/server/msgbus_server_pq_metarequest_ut.cpp
+++ b/ydb/core/client/server/msgbus_server_pq_metarequest_ut.cpp
@@ -11,6 +11,8 @@
 #include <ydb/core/testlib/fake_scheme_shard.h>
 #include <ydb/core/testlib/mock_pq_metacache.h>
 #include <ydb/core/testlib/tablet_helpers.h>
+#include <ydb/core/tx/tx_processing.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -165,17 +167,18 @@ protected:
         return id;
     }
 
-    THolder<TEvPersQueue::TEvUpdateConfig> MakeUpdatePQRequest(const TString& topic, const TVector<size_t>& partitions) {
+    THolder<TEvPersQueue::TEvProposeTransactionBuilder> MakeUpdatePQRequest(const TString& topic, const TVector<size_t>& partitions) {
         static int version = 0;
         ++version;
 
-        auto request = MakeHolder<TEvPersQueue::TEvUpdateConfigBuilder>();
-        for (size_t i : partitions) {
-            request->Record.MutableTabletConfig()->AddPartitionIds(i);
-        }
-        request->Record.MutableTabletConfig()->SetCacheSize(10*1024*1024);
+        auto request = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
         request->Record.SetTxId(12345);
-        auto tabletConfig = request->Record.MutableTabletConfig();
+        ActorIdToProto(EdgeActorId, request->Record.MutableSourceActor());
+        auto* tabletConfig = request->Record.MutableConfig()->MutableTabletConfig();
+        for (size_t i : partitions) {
+            tabletConfig->AddPartitionIds(i);
+        }
+        tabletConfig->SetCacheSize(10*1024*1024);
         tabletConfig->SetTopicName(topic);
         tabletConfig->SetVersion(version);
         auto config = tabletConfig->MutablePartitionConfig();
@@ -206,15 +209,32 @@ protected:
 
         TAutoPtr<IEventHandle> handle;
         {
-            THolder<TEvPersQueue::TEvUpdateConfig> request = MakeUpdatePQRequest(topic, partitions);
+            THolder<TEvPersQueue::TEvProposeTransactionBuilder> request = MakeUpdatePQRequest(topic, partitions);
             Runtime->SendToPipe(tabletId, EdgeActorId, request.Release(), 0, GetPipeConfigWithRetries());
-            TEvPersQueue::TEvUpdateConfigResponse* result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvUpdateConfigResponse>(handle);
+            auto* prepared = Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(handle);
+            UNIT_ASSERT(prepared);
+            UNIT_ASSERT_C(prepared->Record.HasStatus() &&
+                          prepared->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::PREPARED,
+                          "rec: " << prepared->Record);
+            UNIT_ASSERT_C(prepared->Record.HasTxId() && prepared->Record.GetTxId() == 12345, "rec: " << prepared->Record);
+            UNIT_ASSERT_C(prepared->Record.HasOrigin() && prepared->Record.GetOrigin() == tabletId, "rec: " << prepared->Record);
 
-            UNIT_ASSERT(result);
-            auto& rec = result->Record;
-            UNIT_ASSERT_C(rec.HasStatus() && rec.GetStatus() == NKikimrPQ::OK, "rec: " << rec);
-            UNIT_ASSERT_C(rec.HasTxId() && rec.GetTxId() == 12345, "rec: " << rec);
-            UNIT_ASSERT_C(rec.HasOrigin() && result->GetOrigin() == tabletId, "rec: " << rec);
+            auto plan = MakeHolder<TEvTxProcessing::TEvPlanStep>();
+            plan->Record.SetStep(1);
+            auto* tx = plan->Record.AddTransactions();
+            tx->SetTxId(12345);
+            ActorIdToProto(EdgeActorId, tx->MutableAckTo());
+            Runtime->SendToPipe(tabletId, EdgeActorId, plan.Release(), 0, GetPipeConfigWithRetries());
+
+            UNIT_ASSERT(Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(handle));
+            UNIT_ASSERT(Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(handle));
+            auto* complete = Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(handle);
+            UNIT_ASSERT(complete);
+            UNIT_ASSERT_C(complete->Record.HasStatus() &&
+                          complete->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::COMPLETE,
+                          "rec: " << complete->Record);
+            UNIT_ASSERT_C(complete->Record.HasTxId() && complete->Record.GetTxId() == 12345, "rec: " << complete->Record);
+            UNIT_ASSERT_C(complete->Record.HasOrigin() && complete->Record.GetOrigin() == tabletId, "rec: " << complete->Record);
         }
 
         {

--- a/ydb/core/persqueue/events/global.h
+++ b/ydb/core/persqueue/events/global.h
@@ -19,7 +19,7 @@
 namespace NKikimr::TEvPersQueue {
     enum EEv {
         EvRequest = InternalEventSpaceBegin(NPQ::NEvents::EServices::GLOBAL),
-        EvUpdateConfig, //change config for all partitions and count of partitions
+        EvUpdateConfig, // reserved: TEvUpdateConfig removed
         EvUpdateConfigResponse,
         EvOffsets, //get offsets from all partitions in order 0..n-1 - it's for scheemeshard to change (TabletId,PartId) to Partition
         EvOffsetsResponse,
@@ -87,15 +87,6 @@ namespace NKikimr::TEvPersQueue {
     struct TEvResponse: public TEventPB<TEvResponse,
             NKikimrClient::TResponse, EvResponse> {
         TEvResponse() {}
-    };
-
-    struct TEvUpdateConfig: public TEventPreSerializedPB<TEvUpdateConfig,
-            NKikimrPQ::TUpdateConfig, EvUpdateConfig> {
-            TEvUpdateConfig() {}
-    };
-
-    struct TEvUpdateConfigBuilder: public TEvUpdateConfig {
-        using TBase::Record;
     };
 
     struct TEvUpdateBalancerConfig: public TEventPB<TEvUpdateBalancerConfig,

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -372,40 +372,6 @@ void TPersQueue::ReplyError(const TActorContext& ctx, const ui64 responseCookie,
     );
 }
 
-void TPersQueue::ApplyNewConfigAndReply(const TActorContext& ctx)
-{
-    EnsurePartitionsAreNotDeleted(NewConfig);
-
-    // in order to answer only after all parts are ready to work
-    PQ_ENSURE(ConfigInited && AllOriginalPartitionsInited());
-
-    ApplyNewConfig(NewConfig, ctx);
-    ClearNewConfig();
-
-    for (auto& p : Partitions) { //change config for already created partitions
-        if (p.first.IsSupportivePartition()) {
-            continue;
-        }
-
-        ctx.Send(p.second.Actor, new TEvPQ::TEvChangePartitionConfig(TopicConverter, Config));
-    }
-    ChangePartitionConfigInflight += Partitions.size();
-
-    for (const auto& partition : Config.GetPartitions()) {
-        const TPartitionId partitionId(partition.GetPartitionId());
-        if (Partitions.find(partitionId) == Partitions.end()) {
-            CreateOriginalPartition(Config,
-                                    partition,
-                                    TopicConverter,
-                                    partitionId,
-                                    true,
-                                    ctx);
-        }
-    }
-
-    TrySendUpdateConfigResponses(ctx);
-}
-
 void TPersQueue::ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
                                 const TActorContext& ctx)
 {
@@ -447,43 +413,6 @@ void TPersQueue::ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
     }
 
     InitializeMeteringSink(ctx);
-}
-
-void TPersQueue::EndWriteConfig(const NKikimrClient::TResponse& resp, const TActorContext& ctx)
-{
-    if (resp.GetStatus() != NMsgBusProxy::MSTATUS_OK ||
-        resp.WriteResultSize() < 1) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Config write error",
-            {"logPrefix", LogPrefix()},
-            {"error", resp.DebugString()},
-            {"selfId", ctx.SelfID});
-        ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
-        return;
-    }
-    for (const auto& res : resp.GetWriteResult()) {
-        if (res.GetStatus() != NKikimrProto::OK) {
-            YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Config write error",
-                {"logPrefix", LogPrefix()},
-                {"error", resp.DebugString()},
-                {"selfId", ctx.SelfID});
-                ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
-            return;
-        }
-    }
-
-    if (resp.WriteResultSize() > 1) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Restarting - have some registering of message groups",
-            {"logPrefix", LogPrefix()});
-            ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
-        return;
-    }
-
-    PQ_ENSURE(resp.WriteResultSize() >= 1);
-    PQ_ENSURE(resp.GetWriteResult(0).GetStatus() == NKikimrProto::OK);
-    if (ConfigInited && AllOriginalPartitionsInited()) //all partitions are working well - can apply new config
-        ApplyNewConfigAndReply(ctx);
-    else
-        NewConfigShouldBeApplied = true; //when config will be inited with old value new config will be applied
 }
 
 void TPersQueue::HandleConfigReadResponse(NKikimrClient::TResponse&& resp, const TActorContext& ctx)
@@ -929,12 +858,6 @@ void TPersQueue::EndReadConfig(const TActorContext& ctx)
 
     InitializeMeteringSink(ctx);
 
-    PQ_ENSURE(!NewConfigShouldBeApplied);
-    for (auto& req : UpdateConfigRequests) {
-        ProcessUpdateConfigRequest(req.first, req.second, ctx);
-    }
-    UpdateConfigRequests.clear();
-
     for (auto& req : HasDataRequests) {
         const TPartitionId partitionId(req->Record.GetPartition());
         auto it = Partitions.find(partitionId);
@@ -1102,9 +1025,6 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
     auto& resp = ev->Get()->Record;
 
     switch (resp.GetCookie()) {
-    case WRITE_CONFIG_COOKIE:
-        EndWriteConfig(resp, ctx);
-        break;
     case READ_CONFIG_COOKIE:
         // read is only for config - is signal to create interal actors
         HandleConfigReadResponse(std::move(resp), ctx);
@@ -1316,10 +1236,6 @@ void TPersQueue::Handle(TEvPQ::TEvInitComplete::TPtr& ev, const TActorContext& c
         OnInitComplete(ctx);
     }
 
-    if (NewConfigShouldBeApplied && allInitialized) {
-        ApplyNewConfigAndReply(ctx);
-    }
-
     if (!partitionId.IsSupportivePartition()) {
         ProcessCheckPartitionStatusRequests(partitionId);
         ProcessCheckMessageDeduplicationRequests(partitionId);
@@ -1371,53 +1287,6 @@ void TPersQueue::FinishResponse(THashMap<ui64, TAutoPtr<TResponseBuilder>>::iter
 }
 
 
-void TPersQueue::Handle(TEvPersQueue::TEvUpdateConfig::TPtr& ev, const TActorContext& ctx)
-{
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPersQueue::TEvUpdateConfig",
-        {"logPrefix", LogPrefix()});
-    if (!ConfigInited) {
-        UpdateConfigRequests.emplace_back(ev->Release(), ev->Sender);
-        return;
-    }
-    ProcessUpdateConfigRequest(ev->Release(), ev->Sender, ctx);
-}
-
-
-void TPersQueue::Handle(TEvPQ::TEvPartitionConfigChanged::TPtr&, const TActorContext& ctx)
-{
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PERSQUEUE, "Handle TEvPQ::TEvPartitionConfigChanged",
-        {"logPrefix", LogPrefix()});
-
-    PQ_ENSURE(ChangePartitionConfigInflight > 0);
-    --ChangePartitionConfigInflight;
-
-    TrySendUpdateConfigResponses(ctx);
-}
-
-void TPersQueue::TrySendUpdateConfigResponses(const TActorContext& ctx)
-{
-    if (ChangePartitionConfigInflight) {
-        return;
-    }
-
-    for (auto& p : ChangeConfigNotification) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Config applied version actor txId config:\n",
-            {"logPrefix", LogPrefix()},
-            {"configVersion", Config.GetVersion()},
-            {"actor", p.Actor},
-            {"txId", p.TxId},
-            {"configDebug", Config.DebugString()});
-
-        THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
-        res->Record.SetStatus(NKikimrPQ::OK);
-        res->Record.SetTxId(p.TxId);
-        res->Record.SetOrigin(TabletID());
-        ctx.Send(p.Actor, res.Release());
-    }
-
-    ChangeConfigNotification.clear();
-}
-
 void TPersQueue::CreateTopicConverter(const NKikimrPQ::TPQTabletConfig& config,
                                       NPersQueue::TConverterFactoryPtr& converterFactory,
                                       NPersQueue::TTopicConverterPtr& topicConverter,
@@ -1451,202 +1320,6 @@ void TPersQueue::UpdateConsumers(NKikimrPQ::TPQTabletConfig& cfg)
             c.SetGeneration(curConfigVersion);
         }
     }
-}
-
-void TPersQueue::ProcessUpdateConfigRequest(TAutoPtr<TEvPersQueue::TEvUpdateConfig> ev, const TActorId& sender, const TActorContext& ctx)
-{
-    const auto& record = ev->GetRecord();
-
-    int oldConfigVersion = Config.HasVersion() ? static_cast<int>(Config.GetVersion()) : -1;
-    int newConfigVersion = NewConfig.HasVersion() ? static_cast<int>(NewConfig.GetVersion()) : oldConfigVersion;
-
-    PQ_ENSURE(newConfigVersion >= oldConfigVersion);
-
-    NKikimrPQ::TPQTabletConfig cfg = record.GetTabletConfig();
-
-    PQ_ENSURE(cfg.HasVersion());
-    const int curConfigVersion = cfg.GetVersion();
-
-    if (curConfigVersion == oldConfigVersion) { //already applied
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Config already applied version actor txId config",
-            {"logPrefix", LogPrefix()},
-            {"configVersion", Config.GetVersion()},
-            {"sender", sender},
-            {"txId", record.GetTxId()},
-            {"config", cfg.DebugString()});
-
-        THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
-        res->Record.SetStatus(NKikimrPQ::OK);
-        res->Record.SetTxId(record.GetTxId());
-        res->Record.SetOrigin(TabletID());
-        ctx.Send(sender, res.Release());
-        return;
-    }
-    if (curConfigVersion < newConfigVersion) { //Version must increase
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Config has too small version actual actor txId config:\n",
-            {"logPrefix", LogPrefix()},
-            {"curConfigVersion", curConfigVersion},
-            {"newConfigVersion", newConfigVersion},
-            {"sender", sender},
-            {"txId", record.GetTxId()},
-            {"config", cfg.DebugString()});
-
-        THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
-        res->Record.SetStatus(NKikimrPQ::ERROR_BAD_VERSION);
-        res->Record.SetTxId(record.GetTxId());
-        res->Record.SetOrigin(TabletID());
-        ctx.Send(sender, res.Release());
-        return;
-    }
-    if (curConfigVersion == newConfigVersion) { //nothing to change, will be answered on cfg write from prev step
-        YDB_LOG_INFO_COMP(NKikimrServices::PERSQUEUE, "Config update version is already in progress actor txId config:\n",
-            {"logPrefix", LogPrefix()},
-            {"newConfigVersion", newConfigVersion},
-            {"sender", sender},
-            {"txId", record.GetTxId()},
-            {"config", cfg.DebugString()});
-        ChangeConfigNotification.insert(TChangeNotification(sender, record.GetTxId()));
-        return;
-    }
-
-    if (curConfigVersion > newConfigVersion && NewConfig.HasVersion()) { //already in progress with older version
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Config version is too big, applying right now version actor txId config:\n",
-            {"logPrefix", LogPrefix()},
-            {"curConfigVersion", curConfigVersion},
-            {"newConfigVersion", newConfigVersion},
-            {"sender", sender},
-            {"txId", record.GetTxId()},
-            {"config", cfg.DebugString()});
-
-        THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
-        res->Record.SetStatus(NKikimrPQ::ERROR_UPDATE_IN_PROGRESS);
-        res->Record.SetTxId(record.GetTxId());
-        res->Record.SetOrigin(TabletID());
-        ctx.Send(sender, res.Release());
-        return;
-    }
-
-    const auto& bootstrapCfg = record.GetBootstrapConfig();
-
-    if (bootstrapCfg.ExplicitMessageGroupsSize() && !AppData(ctx)->PQConfig.GetEnableProtoSourceIdInfo()) {
-        YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Cannot apply explicit message groups unless proto source id enabled actor txId",
-            {"logPrefix", LogPrefix()},
-            {"sender", sender},
-            {"txId", record.GetTxId()});
-
-        THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
-        res->Record.SetStatus(NKikimrPQ::ERROR);
-        res->Record.SetTxId(record.GetTxId());
-        res->Record.SetOrigin(TabletID());
-        ctx.Send(sender, res.Release());
-        return;
-    }
-
-    for (const auto& mg : bootstrapCfg.GetExplicitMessageGroups()) {
-        TString error;
-
-        if (!mg.HasId() || mg.GetId().empty()) {
-            error = "Empty Id";
-        } else if (mg.GetId().size() > MAX_SOURCE_ID_LENGTH) {
-            error = "Too long Id";
-        } else if (mg.HasKeyRange() && !cfg.PartitionKeySchemaSize()) {
-            error = "Missing KeySchema";
-        }
-
-        if (error) {
-            YDB_LOG_ERROR_COMP(NKikimrServices::PERSQUEUE, "Cannot apply explicit message actor txId",
-                {"logPrefix", LogPrefix()},
-                {"group", error},
-                {"sender", sender},
-                {"txId", record.GetTxId()});
-
-            THolder<TEvPersQueue::TEvUpdateConfigResponse> res{new TEvPersQueue::TEvUpdateConfigResponse};
-            res->Record.SetStatus(NKikimrPQ::ERROR);
-            res->Record.SetTxId(record.GetTxId());
-            res->Record.SetOrigin(TabletID());
-            ctx.Send(sender, res.Release());
-            return;
-        }
-    }
-
-    ChangeConfigNotification.insert(TChangeNotification(sender, record.GetTxId()));
-
-    if (!cfg.HasPartitionConfig())
-        cfg.MutablePartitionConfig()->CopyFrom(Config.GetPartitionConfig());
-    if (!cfg.HasCacheSize() && Config.HasCacheSize()) //if not set and it is alter - preserve old cache size
-        cfg.SetCacheSize(Config.GetCacheSize());
-
-    Migrate(cfg);
-
-    UpdateConsumers(cfg);
-
-    YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Config update version (current received from actor txId config:\n",
-        {"logPrefix", LogPrefix()},
-        {"configVersion", cfg.GetVersion()},
-        {"currentConfigVersion", Config.GetVersion()},
-        {"sender", sender},
-        {"txId", record.GetTxId()},
-        {"config", cfg.DebugString()});
-
-    TString str;
-    PQ_ENSURE(CheckPersQueueConfig(cfg, true, &str))("error", str);
-
-    BeginWriteConfig(cfg, bootstrapCfg, ctx);
-
-    NewConfig = std::move(cfg);
-}
-
-void TPersQueue::BeginWriteConfig(const NKikimrPQ::TPQTabletConfig& cfg,
-                                  const NKikimrPQ::TBootstrapConfig& bootstrapCfg,
-                                  const TActorContext& ctx)
-{
-    TAutoPtr<TEvKeyValue::TEvRequest> request(new TEvKeyValue::TEvRequest);
-    request->Record.SetCookie(WRITE_CONFIG_COOKIE);
-
-    AddCmdWriteConfig(request.Get(),
-                      cfg,
-                      bootstrapCfg,
-                      NKikimrPQ::TPartitions(),
-                      ctx);
-    PQ_ENSURE((ui64)request->Record.GetCmdWrite().size() == (ui64)bootstrapCfg.GetExplicitMessageGroups().size() * cfg.PartitionsSize() + 1);
-
-    ctx.Send(ctx.SelfID, request.Release());
-}
-
-void TPersQueue::AddCmdWriteConfig(TEvKeyValue::TEvRequest* request,
-                                   const NKikimrPQ::TPQTabletConfig& cfg,
-                                   const NKikimrPQ::TBootstrapConfig& bootstrapCfg,
-                                   const NKikimrPQ::TPartitions& partitionsData,
-                                   const TActorContext& ctx)
-{
-    PQ_ENSURE(request);
-
-    TString str;
-    PQ_ENSURE(cfg.SerializeToString(&str));
-
-    auto write = request->Record.AddCmdWrite();
-    write->SetKey(KeyConfig());
-    write->SetValue(str);
-    write->SetTactic(AppData(ctx)->PQConfig.GetTactic());
-    write->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
-
-    auto graph = MakePartitionGraph(cfg);
-    for (const auto& partition : cfg.GetPartitions()) {
-        auto explicitMessageGroups = CreateExplicitMessageGroups(bootstrapCfg, partitionsData, graph, partition.GetPartitionId());
-
-        TSourceIdWriter sourceIdWriter(ESourceIdFormat::Proto);
-        for (const auto& [id, mg] : *explicitMessageGroups) {
-            sourceIdWriter.RegisterSourceId(id, mg.SeqNo, 0, ctx.Now(), std::move(mg.KeyRange), false);
-        }
-
-        sourceIdWriter.FillRequest(request, TPartitionId(partition.GetPartitionId()));
-    }
-}
-
-void TPersQueue::ClearNewConfig()
-{
-    NewConfigShouldBeApplied = false;
-    NewConfig.Clear();
 }
 
 void TPersQueue::Handle(TEvPersQueue::TEvDropTablet::TPtr& ev, const TActorContext& ctx)
@@ -3244,7 +2917,6 @@ TPersQueue::TPersQueue(const TActorId& tablet, TTabletStorageInfo *info)
     , ConfigInited(false)
     , PartitionsInited(0)
     , OriginalPartitionsCount(0)
-    , NewConfigShouldBeApplied(false)
     , TabletState(NKikimrPQ::ENormal)
     , NextResponseCookie(0)
     , ResourceMetrics(nullptr)
@@ -4516,6 +4188,36 @@ void TPersQueue::AddCmdDeleteTx(NKikimrClient::TKeyValueRequest& request,
     range->SetIncludeFrom(true);
     range->SetTo(GetTxKey(txId + 1));
     range->SetIncludeTo(false);
+}
+
+void TPersQueue::AddCmdWriteConfig(TEvKeyValue::TEvRequest* request,
+                                   const NKikimrPQ::TPQTabletConfig& cfg,
+                                   const NKikimrPQ::TBootstrapConfig& bootstrapCfg,
+                                   const NKikimrPQ::TPartitions& partitionsData,
+                                   const TActorContext& ctx)
+{
+    PQ_ENSURE(request);
+
+    TString str;
+    PQ_ENSURE(cfg.SerializeToString(&str));
+
+    auto write = request->Record.AddCmdWrite();
+    write->SetKey(KeyConfig());
+    write->SetValue(str);
+    write->SetTactic(AppData(ctx)->PQConfig.GetTactic());
+    write->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
+
+    auto graph = MakePartitionGraph(cfg);
+    for (const auto& partition : cfg.GetPartitions()) {
+        auto explicitMessageGroups = CreateExplicitMessageGroups(bootstrapCfg, partitionsData, graph, partition.GetPartitionId());
+
+        TSourceIdWriter sourceIdWriter(ESourceIdFormat::Proto);
+        for (const auto& [id, mg] : *explicitMessageGroups) {
+            sourceIdWriter.RegisterSourceId(id, mg.SeqNo, 0, ctx.Now(), std::move(mg.KeyRange), false);
+        }
+
+        sourceIdWriter.FillRequest(request, TPartitionId(partition.GetPartitionId()));
+    }
 }
 
 void TPersQueue::ProcessConfigTx(const TActorContext& ctx,
@@ -6230,7 +5932,6 @@ bool TPersQueue::HandleHook(STFUNC_SIG)
         HFuncTraced(TEvInterconnect::TEvNodeInfo, Handle);
         HFuncTraced(TEvPersQueue::TEvRequest, Handle);
         HFuncTraced(TEvPersQueue::TEvPartitionUpdateReadMetrics, Handle);
-        HFuncTraced(TEvPersQueue::TEvUpdateConfig, Handle);
         HFuncTraced(TEvPersQueue::TEvOffsets, Handle);
         HFuncTraced(TEvPersQueue::TEvHasDataInfo, Handle);
         HFuncTraced(TEvPersQueue::TEvStatus, Handle);
@@ -6252,7 +5953,6 @@ bool TPersQueue::HandleHook(STFUNC_SIG)
         HFuncTraced(TEvPQ::TEvProxyResponse, Handle);
         CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
         HFuncTraced(TEvPersQueue::TEvProposeTransaction, Handle);
-        HFuncTraced(TEvPQ::TEvPartitionConfigChanged, Handle);
         HFuncTraced(TEvTxProcessing::TEvPlanStep, Handle);
         HFuncTraced(TEvTxProcessing::TEvReadSet, Handle);
         HFuncTraced(TEvTxProcessing::TEvReadSetAck, Handle);

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -83,11 +83,6 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     void Handle(TEvPQ::TEvTabletCacheCounters::TPtr& ev, const TActorContext&);
     void SetCacheCounters(TEvPQ::TEvTabletCacheCounters::TCacheCounters& cacheCounters);
 
-    //client requests
-    // remove TEvPersQueue::TEvUpdateConfig at 26-3 release
-    void Handle(TEvPersQueue::TEvUpdateConfig::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvPQ::TEvPartitionConfigChanged::TPtr& ev, const TActorContext& ctx);
-    void ProcessUpdateConfigRequest(TAutoPtr<TEvPersQueue::TEvUpdateConfig> ev, const TActorId& sender, const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvOffsets::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvStatus::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvDropTablet::TPtr& ev, const TActorContext& ctx);
@@ -125,7 +120,6 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     void Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext& ctx);
     void HandleConfigReadResponse(NKikimrClient::TResponse&& resp, const TActorContext& ctx);
     void HandleTransactionsReadResponse(NKikimrClient::TResponse&& resp, const TActorContext& ctx);
-    void ApplyNewConfigAndReply(const TActorContext& ctx);
     void ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
                         const TActorContext& ctx);
     void HandleStateWriteResponse(const NKikimrClient::TResponse& resp, const TActorContext& ctx);
@@ -156,7 +150,6 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
         const NKikimrClient::TPersQueuePartitionRequest::TCmdWrite& cmd,
         TEvPQ::TEvWrite::TMsg& msg) const;
 
-    void TrySendUpdateConfigResponses(const TActorContext& ctx);
     static void CreateTopicConverter(const NKikimrPQ::TPQTabletConfig& config,
                                      NPersQueue::TConverterFactoryPtr& converterFactory,
                                      NPersQueue::TTopicConverterPtr& topicConverter,
@@ -256,11 +249,6 @@ private:
     TActorId BatchProcessorActor;
     TActorId ReadBalancerActorId;
 
-    TSet<TChangeNotification> ChangeConfigNotification;
-    NKikimrPQ::TPQTabletConfig NewConfig;
-    bool NewConfigShouldBeApplied;
-    size_t ChangePartitionConfigInflight = 0;
-
     TString TopicName;
     TString TopicPath;
     NPersQueue::TConverterFactoryPtr TopicConverterFactory;
@@ -282,7 +270,6 @@ private:
     THashMap<TString, TTabletLabeledCountersBase> LabeledCounters;
 
     TVector<TAutoPtr<TEvPersQueue::TEvHasDataInfo>> HasDataRequests;
-    TVector<std::pair<TAutoPtr<TEvPersQueue::TEvUpdateConfig>, TActorId> > UpdateConfigRequests;
 
     using TMLPRequest = std::variant<
         TEvPQ::TEvMLPReadRequest::TPtr,
@@ -466,18 +453,11 @@ private:
                                  const TActorContext& ctx);
     void EnsurePartitionsAreNotDeleted(const NKikimrPQ::TPQTabletConfig& config) const;
 
-    void BeginWriteConfig(const NKikimrPQ::TPQTabletConfig& cfg,
-                          const NKikimrPQ::TBootstrapConfig& bootstrapCfg,
-                          const TActorContext& ctx);
-    void EndWriteConfig(const NKikimrClient::TResponse& resp,
-                        const TActorContext& ctx);
     void AddCmdWriteConfig(TEvKeyValue::TEvRequest* request,
                            const NKikimrPQ::TPQTabletConfig& cfg,
                            const NKikimrPQ::TBootstrapConfig& bootstrapCfg,
                            const NKikimrPQ::TPartitions& partitionsData,
                            const TActorContext& ctx);
-
-    void ClearNewConfig();
 
     void SendToPipe(ui64 tabletId,
                     TDistributedTransaction& tx,

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -33,7 +33,7 @@ struct TTransaction;
 
 class TPersQueue : public NKeyValue::TKeyValueFlat {
     enum ECookie : ui64 {
-        WRITE_CONFIG_COOKIE = 2,
+        WRITE_CONFIG_COOKIE = 2, // reserved: former TEvUpdateConfig persist cookie
         READ_CONFIG_COOKIE  = 3,
         WRITE_STATE_COOKIE  = 4,
         WRITE_TX_COOKIE = 5,

--- a/ydb/core/persqueue/ut/common/pq_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.cpp
@@ -9,6 +9,8 @@
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/tx/tx_processing.h>
+#include <ydb/library/actors/core/actorid.h>
 #include <ydb/public/lib/base/msgbus.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -27,11 +29,55 @@ void FillPQConfig(NKikimrPQ::TPQConfig& pqConfig, const TString& dbRoot, bool is
     pqConfig.MutableQuotingConfig()->SetEnableQuoting(false);
 }
 
+void SendPQTabletConfig(
+    TTestActorRuntime& runtime,
+    ui64 tabletId,
+    const TActorId& edge,
+    const NKikimrPQ::TPQTabletConfig& tabletConfig,
+    ui64 txId,
+    ui64 planStep)
+{
+    auto request = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
+    request->Record.SetTxId(txId);
+    ActorIdToProto(edge, request->Record.MutableSourceActor());
+    *request->Record.MutableConfig()->MutableTabletConfig() = tabletConfig;
+
+    runtime.SendToPipe(tabletId, edge, request.Release(), 0, GetPipeConfigWithRetries());
+
+    TAutoPtr<IEventHandle> handle;
+    auto* prepared = runtime.GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(handle);
+    UNIT_ASSERT(prepared);
+    UNIT_ASSERT(prepared->Record.HasStatus());
+    UNIT_ASSERT_EQUAL(prepared->Record.GetStatus(), NKikimrPQ::TEvProposeTransactionResult::PREPARED);
+    UNIT_ASSERT(prepared->Record.HasTxId() && prepared->Record.GetTxId() == txId);
+    UNIT_ASSERT(prepared->Record.HasOrigin() && prepared->Record.GetOrigin() == tabletId);
+
+    auto plan = MakeHolder<TEvTxProcessing::TEvPlanStep>();
+    plan->Record.SetStep(planStep);
+    auto* tx = plan->Record.AddTransactions();
+    tx->SetTxId(txId);
+    ActorIdToProto(edge, tx->MutableAckTo());
+    runtime.SendToPipe(tabletId, edge, plan.Release(), 0, GetPipeConfigWithRetries());
+
+    auto* ack = runtime.GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(handle);
+    UNIT_ASSERT(ack);
+    auto* accepted = runtime.GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(handle);
+    UNIT_ASSERT(accepted);
+    auto* complete = runtime.GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(handle);
+    UNIT_ASSERT(complete);
+    UNIT_ASSERT(complete->Record.HasStatus());
+    UNIT_ASSERT_EQUAL(complete->Record.GetStatus(), NKikimrPQ::TEvProposeTransactionResult::COMPLETE);
+    UNIT_ASSERT(complete->Record.HasTxId() && complete->Record.GetTxId() == txId);
+    UNIT_ASSERT(complete->Record.HasOrigin() && complete->Record.GetOrigin() == tabletId);
+}
+
 void PQTabletPrepare(const TTabletPreparationParameters& parameters,
                     const TConstArrayRef<TConsumerPreparationParameters> users,
                      TTestActorRuntime& runtime,
                      ui64 tabletId,
-                     TActorId edge) {
+                     TActorId edge,
+                     ui64 txId,
+                     ui64 planStep) {
     TAutoPtr<IEventHandle> handle;
     static int version = 0;
     if (parameters.specVersion) {
@@ -39,106 +85,96 @@ void PQTabletPrepare(const TTabletPreparationParameters& parameters,
     } else {
         ++version;
     }
+
+    NKikimrPQ::TPQTabletConfig tabletConfig;
+    for (ui32 i = 0; i < parameters.partitions; ++i) {
+        tabletConfig.AddPartitionIds(i);
+    }
+    tabletConfig.SetCacheSize(10_MB);
+    if (runtime.GetAppData().PQConfig.GetTopicsAreFirstClassCitizen()) {
+        tabletConfig.SetTopicName("topic");
+        tabletConfig.SetTopicPath(runtime.GetAppData().PQConfig.GetDatabase() + "/topic");
+        tabletConfig.SetYcCloudId(parameters.cloudId);
+        tabletConfig.SetYcFolderId(parameters.folderId);
+        tabletConfig.SetYdbDatabaseId(parameters.databaseId);
+        tabletConfig.SetYdbDatabasePath(parameters.databasePath);
+        tabletConfig.SetFederationAccount(parameters.account);
+    } else {
+        tabletConfig.SetTopicName("rt3.dc1--asdfgs--topic");
+        tabletConfig.SetTopicPath("/Root/PQ/rt3.dc1--asdfgs--topic");
+    }
+    tabletConfig.SetTopic("topic");
+    tabletConfig.SetVersion(version);
+    tabletConfig.SetLocalDC(parameters.localDC);
+    if (parameters.AddDefaultConsumer) {
+        auto* consumer = tabletConfig.AddConsumers();
+        consumer->SetName("user");
+        consumer->SetReadFromTimestampsMs(parameters.readFromTimestampsMs);
+    }
+    tabletConfig.SetMeteringMode(parameters.meteringMode);
+    auto partitionConfig = tabletConfig.MutablePartitionConfig();
+    if (parameters.writeSpeed > 0) {
+        partitionConfig->SetWriteSpeedInBytesPerSecond(parameters.writeSpeed);
+        partitionConfig->SetBurstSize(parameters.writeSpeed);
+    }
+    if (parameters.readSpeed > 0) {
+        partitionConfig->SetReadSpeedInBytesPerSecond(parameters.readSpeed);
+        partitionConfig->SetReadBurstBytes(parameters.readSpeed);
+    }
+    if (parameters.readSpeedInMessages > 0) {
+        partitionConfig->SetReadSpeedInMessagesPerSecond(parameters.readSpeedInMessages);
+        partitionConfig->SetReadBurstMessages(parameters.readSpeedInMessages);
+    }
+
+    partitionConfig->SetMaxCountInPartition(parameters.maxCountInPartition);
+    partitionConfig->SetMaxSizeInPartition(parameters.maxSizeInPartition);
+    if (parameters.storageLimitBytes > 0) {
+        partitionConfig->SetStorageLimitBytes(parameters.storageLimitBytes);
+    } else {
+        partitionConfig->SetLifetimeSeconds(parameters.deleteTime);
+    }
+    partitionConfig->SetSourceIdLifetimeSeconds(TDuration::Hours(1).Seconds());
+    if (parameters.sidMaxCount > 0)
+        partitionConfig->SetSourceIdMaxCounts(parameters.sidMaxCount);
+    partitionConfig->SetMaxWriteInflightSize(90'000'000);
+    partitionConfig->SetLowWatermark(parameters.lowWatermark);
+
+    if (parameters.enableCompactificationByKey) {
+        tabletConfig.SetEnableCompactification(true);
+    }
+
+    if (parameters.metricsLevel) {
+        tabletConfig.SetMetricsLevel(static_cast<decltype(tabletConfig.GetMetricsLevel())>(*parameters.metricsLevel));
+    }
+
+    if (parameters.monitoringProjectId) {
+        tabletConfig.SetMonitoringProjectId(*parameters.monitoringProjectId);
+    }
+
+    for (const auto& u : users) {
+        auto* consumer = tabletConfig.AddConsumers();
+        consumer->SetName(u.Name);
+        consumer->SetImportant(u.Important);
+        if (u.MonitoringProjectId.has_value()) {
+            consumer->SetMonitoringProjectId(*u.MonitoringProjectId);
+        }
+        if (u.MetricsLevel.has_value()) {
+            consumer->SetMetricsLevel(*u.MetricsLevel);
+        }
+        if (u.ReadSpeedInBytesPerSecond.has_value() || u.ReadSpeedInMessagesPerSecond.has_value()) {
+            auto* readQuota = NPQ::GetOrAddReadQuota(tabletConfig, u.Name);
+            readQuota->SetSpeedInBytesPerSecond(u.ReadSpeedInBytesPerSecond.value_or(0));
+            readQuota->SetBurstSize(u.ReadSpeedInBytesPerSecond.value_or(0));
+
+            readQuota->SetSpeedInMessagesPerSecond(u.ReadSpeedInMessagesPerSecond.value_or(0));
+            readQuota->SetBurstSizeInMessages(u.ReadSpeedInMessagesPerSecond.value_or(0));
+        }
+    }
+
     for (i32 retriesLeft = 2; retriesLeft > 0; --retriesLeft) {
         try {
             runtime.ResetScheduledCount();
-
-            auto request = MakeHolder<TEvPersQueue::TEvUpdateConfigBuilder>();
-            for (ui32 i = 0; i < parameters.partitions; ++i) {
-                request->Record.MutableTabletConfig()->AddPartitionIds(i);
-            }
-            request->Record.MutableTabletConfig()->SetCacheSize(10_MB);
-            request->Record.SetTxId(12345);
-            auto* tabletConfig = request->Record.MutableTabletConfig();
-            if (runtime.GetAppData().PQConfig.GetTopicsAreFirstClassCitizen()) {
-                tabletConfig->SetTopicName("topic");
-                tabletConfig->SetTopicPath(runtime.GetAppData().PQConfig.GetDatabase() + "/topic");
-                tabletConfig->SetYcCloudId(parameters.cloudId);
-                tabletConfig->SetYcFolderId(parameters.folderId);
-                tabletConfig->SetYdbDatabaseId(parameters.databaseId);
-                tabletConfig->SetYdbDatabasePath(parameters.databasePath);
-                tabletConfig->SetFederationAccount(parameters.account);
-            } else {
-                tabletConfig->SetTopicName("rt3.dc1--asdfgs--topic");
-                tabletConfig->SetTopicPath("/Root/PQ/rt3.dc1--asdfgs--topic");
-            }
-            tabletConfig->SetTopic("topic");
-            tabletConfig->SetVersion(version);
-            tabletConfig->SetLocalDC(parameters.localDC);
-            if (parameters.AddDefaultConsumer) {
-                auto* consumer = tabletConfig->AddConsumers();
-                consumer->SetName("user");
-                consumer->SetReadFromTimestampsMs(parameters.readFromTimestampsMs);
-            }
-            tabletConfig->SetMeteringMode(parameters.meteringMode);
-            auto partitionConfig = tabletConfig->MutablePartitionConfig();
-            if (parameters.writeSpeed > 0) {
-                partitionConfig->SetWriteSpeedInBytesPerSecond(parameters.writeSpeed);
-                partitionConfig->SetBurstSize(parameters.writeSpeed);
-            }
-            if (parameters.readSpeed > 0) {
-                partitionConfig->SetReadSpeedInBytesPerSecond(parameters.readSpeed);
-                partitionConfig->SetReadBurstBytes(parameters.readSpeed);
-            }
-            if (parameters.readSpeedInMessages > 0) {
-                partitionConfig->SetReadSpeedInMessagesPerSecond(parameters.readSpeedInMessages);
-                partitionConfig->SetReadBurstMessages(parameters.readSpeedInMessages);
-            }
-
-            partitionConfig->SetMaxCountInPartition(parameters.maxCountInPartition);
-            partitionConfig->SetMaxSizeInPartition(parameters.maxSizeInPartition);
-            if (parameters.storageLimitBytes > 0) {
-                partitionConfig->SetStorageLimitBytes(parameters.storageLimitBytes);
-            } else {
-                partitionConfig->SetLifetimeSeconds(parameters.deleteTime);
-            }
-            partitionConfig->SetSourceIdLifetimeSeconds(TDuration::Hours(1).Seconds());
-            if (parameters.sidMaxCount > 0)
-                partitionConfig->SetSourceIdMaxCounts(parameters.sidMaxCount);
-            partitionConfig->SetMaxWriteInflightSize(90'000'000);
-            partitionConfig->SetLowWatermark(parameters.lowWatermark);
-
-            if (parameters.enableCompactificationByKey) {
-                tabletConfig->SetEnableCompactification(true);
-            }
-
-            if (parameters.metricsLevel) {
-                tabletConfig->SetMetricsLevel(static_cast<decltype(tabletConfig->GetMetricsLevel())>(*parameters.metricsLevel));
-            }
-
-            if (parameters.monitoringProjectId) {
-                tabletConfig->SetMonitoringProjectId(*parameters.monitoringProjectId);
-            }
-
-            for (const auto& u : users) {
-                auto* consumer = tabletConfig->AddConsumers();
-                consumer->SetName(u.Name);
-                consumer->SetImportant(u.Important);
-                if (u.MonitoringProjectId.has_value()) {
-                    consumer->SetMonitoringProjectId(*u.MonitoringProjectId);
-                }
-                if (u.MetricsLevel.has_value()) {
-                    consumer->SetMetricsLevel(*u.MetricsLevel);
-                }
-                if (u.ReadSpeedInBytesPerSecond.has_value() || u.ReadSpeedInMessagesPerSecond.has_value()) {
-                    auto* readQuota = NPQ::GetOrAddReadQuota(*tabletConfig, u.Name);
-                    readQuota->SetSpeedInBytesPerSecond(u.ReadSpeedInBytesPerSecond.value_or(0));
-                    readQuota->SetBurstSize(u.ReadSpeedInBytesPerSecond.value_or(0));
-
-                    readQuota->SetSpeedInMessagesPerSecond(u.ReadSpeedInMessagesPerSecond.value_or(0));
-                    readQuota->SetBurstSizeInMessages(u.ReadSpeedInMessagesPerSecond.value_or(0));
-                }
-            }
-
-            runtime.SendToPipe(tabletId, edge, request.Release(), 0, GetPipeConfigWithRetries());
-            TEvPersQueue::TEvUpdateConfigResponse* result =
-                runtime.GrabEdgeEvent<TEvPersQueue::TEvUpdateConfigResponse>(handle);
-
-            UNIT_ASSERT(result);
-            auto& rec = result->Record;
-            UNIT_ASSERT(rec.HasStatus() && rec.GetStatus() == NKikimrPQ::OK);
-            UNIT_ASSERT(rec.HasTxId() && rec.GetTxId() == 12345);
-            UNIT_ASSERT(rec.HasOrigin() && result->GetOrigin() == tabletId);
+            SendPQTabletConfig(runtime, tabletId, edge, tabletConfig, txId, planStep);
             retriesLeft = 0;
         } catch (NActors::TSchedulingLimitReachedException) {
             UNIT_ASSERT(retriesLeft >= 1);
@@ -176,7 +212,8 @@ void PQTabletPrepare(const TTabletPreparationParameters& parameters,
             .Important = important,
         });
     }
-    PQTabletPrepare(parameters, users, *context.Runtime, context.TabletId, context.Edge);
+    PQTabletPrepare(parameters, users, *context.Runtime, context.TabletId, context.Edge,
+                    context.NextPqConfigTxId++, context.NextPqConfigPlanStep++);
 }
 
 

--- a/ydb/core/persqueue/ut/common/pq_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.cpp
@@ -71,21 +71,12 @@ void SendPQTabletConfig(
     UNIT_ASSERT(complete->Record.HasOrigin() && complete->Record.GetOrigin() == tabletId);
 }
 
-void PQTabletPrepare(const TTabletPreparationParameters& parameters,
-                    const TConstArrayRef<TConsumerPreparationParameters> users,
-                     TTestActorRuntime& runtime,
-                     ui64 tabletId,
-                     TActorId edge,
-                     ui64 txId,
-                     ui64 planStep) {
-    TAutoPtr<IEventHandle> handle;
-    static int version = 0;
-    if (parameters.specVersion) {
-        version = parameters.specVersion;
-    } else {
-        ++version;
-    }
-
+NKikimrPQ::TPQTabletConfig MakePQTabletConfig(
+    const TTabletPreparationParameters& parameters,
+    TConstArrayRef<TConsumerPreparationParameters> users,
+    TTestActorRuntime& runtime,
+    ui32 version)
+{
     NKikimrPQ::TPQTabletConfig tabletConfig;
     for (ui32 i = 0; i < parameters.partitions; ++i) {
         tabletConfig.AddPartitionIds(i);
@@ -170,6 +161,26 @@ void PQTabletPrepare(const TTabletPreparationParameters& parameters,
             readQuota->SetBurstSizeInMessages(u.ReadSpeedInMessagesPerSecond.value_or(0));
         }
     }
+
+    return tabletConfig;
+}
+
+void PQTabletPrepare(const TTabletPreparationParameters& parameters,
+                    const TConstArrayRef<TConsumerPreparationParameters> users,
+                     TTestActorRuntime& runtime,
+                     ui64 tabletId,
+                     TActorId edge,
+                     ui64 txId,
+                     ui64 planStep) {
+    TAutoPtr<IEventHandle> handle;
+    static int version = 0;
+    if (parameters.specVersion) {
+        version = parameters.specVersion;
+    } else {
+        ++version;
+    }
+
+    NKikimrPQ::TPQTabletConfig tabletConfig = MakePQTabletConfig(parameters, users, runtime, version);
 
     for (i32 retriesLeft = 2; retriesLeft > 0; --retriesLeft) {
         try {

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -91,6 +91,8 @@ struct TTestContext {
     THashMap<ui32, ui32> MsgSeqNoMap;
     THashMap<ui32, TString> OwnerCookieMap;
     bool EnableDetailedPQLog = ENABLE_DETAILED_PQ_LOG;
+    ui64 NextPqConfigTxId = 12345;
+    ui64 NextPqConfigPlanStep = 1;
 
     TTestContext() {
         TabletId = MakeTabletID(false, 1);
@@ -281,12 +283,22 @@ struct TConsumerPreparationParameters {
     std::optional<ui64> ReadSpeedInMessagesPerSecond;
 };
 
+void SendPQTabletConfig(
+    TTestActorRuntime& runtime,
+    ui64 tabletId,
+    const TActorId& edge,
+    const NKikimrPQ::TPQTabletConfig& tabletConfig,
+    ui64 txId,
+    ui64 planStep);
+
 void PQTabletPrepare(
     const TTabletPreparationParameters& parameters,
     const TConstArrayRef<TConsumerPreparationParameters> users,
     TTestActorRuntime& runtime,
     ui64 tabletId,
-    TActorId edge);
+    TActorId edge,
+    ui64 txId = 12345,
+    ui64 planStep = 1);
 
 
 struct TBalancerParams {

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -283,6 +283,12 @@ struct TConsumerPreparationParameters {
     std::optional<ui64> ReadSpeedInMessagesPerSecond;
 };
 
+NKikimrPQ::TPQTabletConfig MakePQTabletConfig(
+    const TTabletPreparationParameters& parameters,
+    TConstArrayRef<TConsumerPreparationParameters> users,
+    TTestActorRuntime& runtime,
+    ui32 version);
+
 void SendPQTabletConfig(
     TTestActorRuntime& runtime,
     ui64 tabletId,

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4237,8 +4237,6 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
         TAutoPtr<IEventHandle> handle;
         TEvPersQueue::TEvResponse* readResult = nullptr;
         THolder<TEvPersQueue::TEvRequest> readRequest;
-        TEvPersQueue::TEvUpdateConfigResponse* consumerDeleteResult = nullptr;
-        THolder<TEvPersQueue::TEvUpdateConfig> consumerDeleteRequest;
 
         // Read request
         {
@@ -4253,17 +4251,16 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
             read->SetTimeoutMs(5000);
         }
 
-        // Consumer delete request
+        NKikimrPQ::TPQTabletConfig consumerDeleteConfig;
         {
-            consumerDeleteRequest.Reset(new TEvPersQueue::TEvUpdateConfig());
-            consumerDeleteRequest->MutableRecord()->SetTxId(42);
-            auto& cfg = *consumerDeleteRequest->MutableRecord()->MutableTabletConfig();
-            cfg.SetVersion(pqConfigVersion++);
-            cfg.AddPartitionIds(0);
-            cfg.AddPartitions()->SetPartitionId(0);
-            cfg.SetLocalDC(true);
-            cfg.SetTopic("topic");
-            auto& cons = *cfg.AddConsumers();
+            consumerDeleteConfig.SetVersion(pqConfigVersion++);
+            consumerDeleteConfig.AddPartitionIds(0);
+            consumerDeleteConfig.AddPartitions()->SetPartitionId(0);
+            consumerDeleteConfig.SetLocalDC(true);
+            consumerDeleteConfig.SetTopic("topic");
+            consumerDeleteConfig.SetTopicName("rt3.dc1--asdfgs--topic");
+            consumerDeleteConfig.SetTopicPath("/Root/PQ/rt3.dc1--asdfgs--topic");
+            auto& cons = *consumerDeleteConfig.AddConsumers();
             cons.SetName("user2");
             cons.SetImportant(true);
         }
@@ -4280,13 +4277,8 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
         });
 
         // Delete consumer while read request is still in progress
-        tc.Runtime->SendToPipe(tc.TabletId, edge, consumerDeleteRequest.Release(), 0, GetPipeConfigWithRetries());
-        consumerDeleteResult = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvUpdateConfigResponse>(handle);
-        {
-            //Cerr << "Got consumer delete response: " << consumerDeleteResult->Record << Endl;
-            UNIT_ASSERT(consumerDeleteResult->Record.HasStatus());
-            UNIT_ASSERT_VALUES_EQUAL((int)consumerDeleteResult->Record.GetStatus(), (int)NKikimrPQ::EStatus::OK);
-        }
+        SendPQTabletConfig(*tc.Runtime, tc.TabletId, edge, consumerDeleteConfig,
+                           tc.NextPqConfigTxId++, tc.NextPqConfigPlanStep++);
 
         // Resend intercepted blob responses and wait for read result
         captureBlobResponsesObserver.Remove();

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4227,8 +4227,13 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
 
         static ui32 pqConfigVersion = 1'000;
 
-        PQTabletPrepare({.maxCountInPartition=100, .deleteTime=TDuration::Days(2).Seconds(), .partitions=1, .specVersion=pqConfigVersion++},
-                        {{"user1", true}, {"user2", true}}, tc);
+        TTabletPreparationParameters prepareParams{
+            .maxCountInPartition=100,
+            .deleteTime=TDuration::Days(2).Seconds(),
+            .partitions=1,
+            .specVersion=pqConfigVersion++,
+        };
+        PQTabletPrepare(prepareParams, {{"user1", true}, {"user2", true}}, tc);
         CmdWrite(0, "sourceid1", data, tc, false, {}, true);
 
         // Reset tablet cache
@@ -4251,19 +4256,12 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
             read->SetTimeoutMs(5000);
         }
 
-        NKikimrPQ::TPQTabletConfig consumerDeleteConfig;
-        {
-            consumerDeleteConfig.SetVersion(pqConfigVersion++);
-            consumerDeleteConfig.AddPartitionIds(0);
-            consumerDeleteConfig.AddPartitions()->SetPartitionId(0);
-            consumerDeleteConfig.SetLocalDC(true);
-            consumerDeleteConfig.SetTopic("topic");
-            consumerDeleteConfig.SetTopicName("rt3.dc1--asdfgs--topic");
-            consumerDeleteConfig.SetTopicPath("/Root/PQ/rt3.dc1--asdfgs--topic");
-            auto& cons = *consumerDeleteConfig.AddConsumers();
-            cons.SetName("user2");
-            cons.SetImportant(true);
-        }
+        TVector<TConsumerPreparationParameters> remainingConsumers{{
+            .Name = "user2",
+            .Important = true,
+        }};
+        auto consumerDeleteConfig = MakePQTabletConfig(
+            prepareParams, remainingConsumers, *tc.Runtime, pqConfigVersion++);
 
         TActorId edge = tc.Runtime->AllocateEdgeActor();
 

--- a/ydb/core/persqueue/ut/resources/counters_pqproxy.html
+++ b/ydb/core/persqueue/ut/resources/counters_pqproxy.html
@@ -3,18 +3,18 @@ subsystem=SLI:
 
     Account=asdfgs:
         sensor=WriteBigLatency: 0
-        sensor=WritesTotal: 5
+        sensor=WritesTotal: 7
 
     Account=total:
         sensor=WriteBigLatency: 0
-        sensor=WritesTotal: 5
+        sensor=WritesTotal: 7
 
     sensor=Write:
 
         Account=asdfgs:
             Duration=10000ms: 0
             Duration=1000ms: 0
-            Duration=100ms: 3
+            Duration=100ms: 5
             Duration=1500ms: 0
             Duration=2000ms: 0
             Duration=200ms: 1
@@ -27,7 +27,7 @@ subsystem=SLI:
         Account=total:
             Duration=10000ms: 0
             Duration=1000ms: 0
-            Duration=100ms: 3
+            Duration=100ms: 5
             Duration=1500ms: 0
             Duration=2000ms: 0
             Duration=200ms: 1

--- a/ydb/core/persqueue/ut/resources/counters_pqproxy_firstclass.html
+++ b/ydb/core/persqueue/ut/resources/counters_pqproxy_firstclass.html
@@ -3,18 +3,18 @@ subsystem=SLI:
 
     Account=federationAccount:
         name=WriteBigLatency: 0
-        name=WritesTotal: 5
+        name=WritesTotal: 7
 
     Account=total:
         name=WriteBigLatency: 0
-        name=WritesTotal: 5
+        name=WritesTotal: 7
 
     sensor=Write:
 
         Account=federationAccount:
             Duration=10000ms: 0
             Duration=1000ms: 0
-            Duration=100ms: 3
+            Duration=100ms: 5
             Duration=1500ms: 0
             Duration=2000ms: 0
             Duration=200ms: 1
@@ -27,7 +27,7 @@ subsystem=SLI:
         Account=total:
             Duration=10000ms: 0
             Duration=1000ms: 0
-            Duration=100ms: 3
+            Duration=100ms: 5
             Duration=1500ms: 0
             Duration=2000ms: 0
             Duration=200ms: 1

--- a/ydb/core/protos/pqevents_global.proto
+++ b/ydb/core/protos/pqevents_global.proto
@@ -9,12 +9,6 @@ package NKikimrPQ;
 option java_package = "ru.yandex.persqueue.events.global.proto";
 
 
-message TUpdateConfig {
-    optional uint64 TxId = 1;
-    optional TPQTabletConfig TabletConfig = 2;
-    optional TBootstrapConfig BootstrapConfig = 3; // passed only upon creation
-}
-
 message TUpdateBalancerConfig { //for schemeshard use only
     optional uint64 TxId = 1;
     optional uint64 PathId = 2;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
@@ -155,50 +155,16 @@ void MakePQTabletConfig(const TOperationContext& context,
 }
 
 class TBootstrapConfigWrapper: public NKikimrPQ::TBootstrapConfig {
-    struct TSerializedProposeTransaction {
-        TString Value;
-
-        static TSerializedProposeTransaction Serialize(const NKikimrPQ::TBootstrapConfig& value) {
-            NKikimrPQ::TEvProposeTransaction record;
-            record.MutableConfig()->MutableBootstrapConfig()->CopyFrom(value);
-            return {record.SerializeAsString()};
-        }
-    };
-
-    struct TSerializedUpdateConfig {
-        TString Value;
-
-        static TSerializedUpdateConfig Serialize(const NKikimrPQ::TBootstrapConfig& value) {
-            NKikimrPQ::TUpdateConfig record;
-            record.MutableBootstrapConfig()->CopyFrom(value);
-            return {record.SerializeAsString()};
-        }
-    };
-
-    mutable std::optional<std::variant<
-        TSerializedProposeTransaction,
-        TSerializedUpdateConfig
-    >> PreSerialized;
-
-    template <typename T>
-    const TString& Get() const {
-        if (!PreSerialized) {
-            PreSerialized.emplace(T::Serialize(*this));
-        }
-
-        const auto* value = std::get_if<T>(&PreSerialized.value());
-        Y_ABORT_UNLESS(value);
-
-        return value->Value;
-    }
+    mutable std::optional<TString> PreSerializedProposeTransaction;
 
 public:
     const TString& GetPreSerializedProposeTransaction() const {
-        return Get<TSerializedProposeTransaction>();
-    }
-
-    const TString& GetPreSerializedUpdateConfig() const {
-        return Get<TSerializedUpdateConfig>();
+        if (!PreSerializedProposeTransaction) {
+            NKikimrPQ::TEvProposeTransaction record;
+            record.MutableConfig()->MutableBootstrapConfig()->CopyFrom(*this);
+            PreSerializedProposeTransaction = record.SerializeAsString();
+        }
+        return *PreSerializedProposeTransaction;
     }
 };
 
@@ -696,19 +662,8 @@ bool TPropose::ProgressState(TOperationContext& context)
     Y_ABORT_UNLESS(txState);
     Y_ABORT_UNLESS(txState->TxType == TTxState::TxCreatePQGroup || txState->TxType == TTxState::TxAlterPQGroup);
 
-    //
-    // If the program works according to the new scheme, then we must add PQ tablets to the list for
-    // the Coordinator. At this stage, we cannot rely on the value of
-    // the EnablePQConfigTransactionsAtSchemeShard flag. Because the operation could have started on one tablet
-    // and moved to another by that time.
-    //
-    // Therefore, here we check the value of the minStep field, which is filled in in
-    // the TEvProposeTransactionResult handler
-    //
     TSet<TTabletId> shardSet;
-    if (ui64(txState->MinStep) > 0) {
-        PrepareShards(*txState, shardSet, context);
-    }
+    PrepareShards(*txState, shardSet, context);
     context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, txState->MinStep, shardSet);
 
     return false;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

After `EnablePQConfigTransactionsAtSchemeShard` was removed, Create/Alter topic always configures PQ tablets with `TEvProposeTransaction`. The disabled-flag path sent `TEvPersQueue::TEvUpdateConfig` instead; that request is no longer produced.

This PR deletes the leftover request, the tablet/SchemeShard code that existed only for it, and tests that still prepared tablets with that event.

**Removed**
- SchemeShard serialization of bootstrap config as `TEvUpdateConfig`, and the `MinStep == 0` skip that left PQ tablets off the coordinator.
- PQ tablet handler for `TEvUpdateConfig`, the pre-init request queue, and the write/reply pipeline used only by that event (`ApplyNewConfigAndReply`, `BeginWriteConfig` / `EndWriteConfig`, `TrySendUpdateConfigResponses`, `Handle(TEvPartitionConfigChanged)`).
- Tests that sent `TEvUpdateConfig` / `TEvUpdateConfigBuilder` (`PQTabletPrepare`, `TestReadAndDeleteConsumer`, msgbus PQ metarequest).
- Event class `TEvPersQueue::TEvUpdateConfig` and proto `NKikimrPQ::TUpdateConfig`.

**Kept**
- SchemeShard → PQRB: `TEvUpdateBalancerConfig`.
- PQRB → SchemeShard: `TEvUpdateConfigResponse` (same event name, different request).
- Config via `TEvProposeTransaction` (Config body) + `TEvPlanStep`.
- `ApplyNewConfig` and `AddCmdWriteConfig` on the tablet (transaction path).
- Partition-local `TEvChangePartitionConfig` / `TEvPartitionConfigChanged`.
- Enum slot `EvUpdateConfig`, so later event ids stay stable.

Partition actors are unchanged.

## Test plan
- [x] `ydb/core/persqueue/ut` — `UpdateConfig_*`, `TestReadAndDeleteConsumer`, `TestWrite`
- [x] `ydb/core/tx/schemeshard/ut_pq_reboots`
- [x] `ydb/core/client/server/ut` — `*PersQueue*`
- [x] `ydb/core/persqueue/pqrb/ut`
