### PR TITLE
Add @ydb-platform/entbuilders to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-* @ydb-platform/ReleaseApprovers
-/.github @ydb-platform/ci
-/.github/workflows/docs_* @ydb-platform/docs
-/.github/workflows/ydbdoc-* @ydb-platform/docs     
-/CHANGELOG.md @ydb-platform/changelog-reviewers
-/ydb/docs/ @ydb-platform/docs
+* @ydb-platform/ReleaseApprovers @ydb-platform/entbuilders
+/.github @ydb-platform/ci @ydb-platform/entbuilders
+/.github/workflows/docs_* @ydb-platform/docs @ydb-platform/entbuilders
+/.github/workflows/ydbdoc-* @ydb-platform/docs @ydb-platform/entbuilders
+/CHANGELOG.md @ydb-platform/changelog-reviewers @ydb-platform/entbuilders
+/ydb/docs/ @ydb-platform/docs @ydb-platform/entbuilders


### PR DESCRIPTION
## Summary

Grants `@ydb-platform/entbuilders` co-ownership of the sections already covered by CODEOWNERS in this branch, following the same pattern established in other enterprise branches (e.g. `stable-26-1-1-enterprise`, `stable-25-4-1-enterprise`).

## Changes

Added `@ydb-platform/entbuilders` alongside the existing owners on all 6 CODEOWNERS entries:
- `*`
- `/.github`
- `/.github/workflows/docs_*`
- `/.github/workflows/ydbdoc-*`
- `/CHANGELOG.md`
- `/ydb/docs/`

Note: the last two entries (doc-workflow files) don't exist yet in older enterprise branches' CODEOWNERS, so there's no direct precedent for them — included for consistency since they currently fall under `/.github` in this branch's file layout.