### PR TITLE
[26-2-1-ent] Backport Kafka mTLS authentication (#33358, #36568, #37382)

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -135,6 +135,9 @@
 
 #include <ydb/core/quoter/quoter_service.h>
 
+#include <ydb/core/raw_socket/sock_ssl.h>
+#include <ydb/core/raw_socket/sock64.h>
+
 #include <ydb/core/scheme/scheme_type_registry.h>
 
 #include <ydb/core/security/ticket_parser.h>
@@ -3167,6 +3170,50 @@ void TKafkaProxyServiceInitializer::InitializeServices(NActors::TActorSystemSetu
         settings.PrivateKeyFile = Config.GetKafkaProxyConfig().GetKey();
         settings.TcpNotDelay = true;
 
+        std::shared_ptr<NKafka::TInet64SecureStreamSocket::TServerMtlsCreds> serverCreds = std::make_shared<NKafka::TInet64SecureStreamSocket::TServerMtlsCreds>();
+
+        auto readFile = [](std::optional<TString> path) {
+            if (path) {
+                try {
+                    return TFileInput(*path).ReadAll();
+                } catch (const std::exception& ex) {
+                    return TString();
+                }
+            }
+            return TString();
+        };
+
+        TString serverCert = readFile(settings.CertificateFile);
+        TString serverPrivateKey = readFile(settings.PrivateKeyFile);
+        TString caCert = readFile(Config.GetKafkaProxyConfig().GetCA());
+
+        {
+            TSslHolder<BIO> bio(BIO_new_mem_buf(serverCert.data(), serverCert.size()));
+            if (bio) {
+                serverCreds->ServerCert = TSslHolder<X509>(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
+            } else {
+                serverCreds->ServerCert = TSslHolder<X509>();
+            }
+        }
+
+        {
+            TSslHolder<BIO> bio(BIO_new_mem_buf(serverPrivateKey.data(), serverPrivateKey.size()));
+            if (bio) {
+                serverCreds->ServerPrivateKey = TSslHolder<EVP_PKEY>(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
+            } else {
+                serverCreds->ServerPrivateKey = TSslHolder<EVP_PKEY>();
+            }
+        }
+
+        {
+            TSslHolder<BIO> bio(BIO_new_mem_buf(caCert.data(), caCert.size()));
+            if (bio) {
+                serverCreds->CACert = TSslHolder<X509>(
+                    PEM_read_bio_X509_AUX(bio.get(), nullptr, nullptr, nullptr));
+            } else {
+                serverCreds->CACert = TSslHolder<X509>();
+            }
+        }
         setup->LocalServices.emplace_back(
             NKafka::MakeKafkaDiscoveryCacheID(),
             TActorSetupCmd(CreateDiscoveryCache(NGRpcService::KafkaEndpointId),
@@ -3186,7 +3233,7 @@ void TKafkaProxyServiceInitializer::InitializeServices(NActors::TActorSystemSetu
 
         setup->LocalServices.emplace_back(
             TActorId(),
-            TActorSetupCmd(NKafka::CreateKafkaListener(MakePollerActorId(), settings, Config.GetKafkaProxyConfig()),
+            TActorSetupCmd(NKafka::CreateKafkaListener(MakePollerActorId(), settings, Config.GetKafkaProxyConfig(), serverCreds),
                            TMailboxType::HTSwap, appData->UserPoolId)
         );
 

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -3186,6 +3186,7 @@ void TKafkaProxyServiceInitializer::InitializeServices(NActors::TActorSystemSetu
         TString serverCert = readFile(settings.CertificateFile);
         TString serverPrivateKey = readFile(settings.PrivateKeyFile);
         TString caCert = readFile(Config.GetKafkaProxyConfig().GetCA());
+        serverCreds->AllowSelfSignedCerts = Config.GetKafkaProxyConfig().GetEnableSelfSignedCerts();
 
         {
             TSslHolder<BIO> bio(BIO_new_mem_buf(serverCert.data(), serverCert.size()));

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.h
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.h
@@ -13,6 +13,7 @@
 #include <ydb/core/tablet_flat/shared_sausagecache.h>
 
 #include <ydb/core/protos/config.pb.h>
+#include <ydb/core/raw_socket/sock_ssl.h>
 
 #include <ydb/public/lib/base/msgbus.h>
 
@@ -630,6 +631,9 @@ public:
 
 class TKafkaProxyServiceInitializer : public IKikimrServicesInitializer {
 public:
+    template<typename T>
+    using TSslHolder = NRawSocket::TSslLayer<TStreamSocket>::TSslHolder<T>;
+
     TKafkaProxyServiceInitializer(const TKikimrRunConfig& runConfig);
 
     void InitializeServices(NActors::TActorSystemSetup* setup, const NKikimr::TAppData* appData) override;

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -354,7 +354,9 @@ void TKafkaSaslAuthActor::SendScramLoginRequest(const NActors::TActorContext& ct
 }
 
 void TKafkaSaslAuthActor::SendMtlsAuthRequest(const NActors::TActorContext&) {
-    Send(NKikimr::MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket(ClientCert));
+    Send(NKikimr::MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket({.Ticket = ClientCert,
+                                                                                                     .Database = DatabasePath,
+                                                                                                     .PeerName = TStringBuilder() << Address}));
     Become(&TKafkaSaslAuthActor::StateTicketResolve);
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -77,11 +77,25 @@ void TKafkaSaslAuthActor::HandleAuthRequest(TEvKafka::TEvAuthRequest::TPtr& ev, 
     }
 }
 
+void TKafkaSaslAuthActor::HandleMtlsAuthRequest(TEvKafka::TEvMtlsAuthRequest::TPtr& ev, const NActors::TActorContext&) {
+    auto& mtlsRequest = *ev->Get();
+    ClientCert = mtlsRequest.ClientCertificate;
+    if (CurrentStateFunc() == &TThis::StateWork) {
+        StartMtlsAuth();
+        SendDescribeRequest();
+        Become(&TKafkaSaslAuthActor::StateResolveDatabase);
+    }
+}
+
 bool TKafkaSaslAuthActor::StartPlainAuth(const NActors::TActorContext& ctx) {
     return TryParseAuthDataTo(ClientAuthData, ctx);
 }
 
 void TKafkaSaslAuthActor::StartScramAuth() {
+    DatabasePath = AppData()->TenantName;
+}
+
+void TKafkaSaslAuthActor::StartMtlsAuth() {
     DatabasePath = AppData()->TenantName;
 }
 
@@ -339,6 +353,11 @@ void TKafkaSaslAuthActor::SendScramLoginRequest(const NActors::TActorContext& ct
     }
 }
 
+void TKafkaSaslAuthActor::SendMtlsAuthRequest(const NActors::TActorContext&) {
+    Send(NKikimr::MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket(ClientCert));
+    Become(&TKafkaSaslAuthActor::StateTicketResolve);
+}
+
 void TKafkaSaslAuthActor::SendDescribeRequest() {
     auto schemeCacheRequest = std::make_unique<NKikimr::NSchemeCache::TSchemeCacheNavigate>();
     NKikimr::NSchemeCache::TSchemeCacheNavigate::TEntry entry;
@@ -435,6 +454,9 @@ void TKafkaSaslAuthActor::HandleNavigate(TEvTxProxySchemeCache::TEvNavigateKeySe
         } else if (Context->SaslMechanism == "SCRAM-SHA-256") {
             // Scram Login/Password authentication
             SendScramLoginRequest(ctx);
+        } else if (Context->SaslMechanism == "MTLS") {
+            // Mtls authentication
+            SendMtlsAuthRequest(ctx);
         }
     }
 }

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.h
@@ -37,6 +37,7 @@ private:
         KAFKA_LOG_T("Received event: " << (*ev.Get()).GetTypeName());
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvKafka::TEvAuthRequest, HandleAuthRequest);
+            HFunc(TEvKafka::TEvMtlsAuthRequest, HandleMtlsAuthRequest);
             CFunc(TEvents::TEvPoison::EventType, Die);
         }
     }
@@ -89,6 +90,7 @@ private:
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const NActors::TActorContext& ctx);
     void HandleFirstLoginResponse(NSasl::TEvSasl::TEvSaslScramFirstServerResponse::TPtr& ev);
     void HandleAuthRequest(TEvKafka::TEvAuthRequest::TPtr& ev, const NActors::TActorContext& ctx);
+    void HandleMtlsAuthRequest(TEvKafka::TEvMtlsAuthRequest::TPtr& ev, const NActors::TActorContext& ctx);
     void HandleLoginResult(const NYql::TIssue& issue, const std::string& reason, const std::string& token,
         const std::string& sanitizedToken, bool isAdmin, const NActors::TActorContext& ctx);
     void HandleLoginResult(NSasl::TEvSasl::TEvSaslPlainLoginResponse::TPtr& ev, const NActors::TActorContext& ctx);
@@ -99,8 +101,10 @@ private:
 
     [[nodiscard]] bool StartPlainAuth(const NActors::TActorContext& ctx);
     void StartScramAuth();
+    void StartMtlsAuth();
     void SendPlainLoginRequest(const NActors::TActorContext& ctx);
     void SendScramLoginRequest(const NActors::TActorContext& ctx);
+    void SendMtlsAuthRequest(const NActors::TActorContext& ctx);
     void SendTicketParserRequest();
     void SendDescribeRequest();
     [[nodiscard]] bool TryParseAuthDataTo(TKafkaSaslAuthActor::TAuthData& authData, const NActors::TActorContext& ctx);
@@ -126,6 +130,7 @@ private:
     TString Ticket;
     TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> TicketParserEntries;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    TString ClientCert;
     TString FolderId;
     TString ServiceAccountId;
     TString DatabaseId;

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -1,5 +1,6 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/ticket_parser.h>
 #include <ydb/core/raw_socket/sock_config.h>
 #include <ydb/core/util/address_classifier.h>
 #include <ydb/core/kafka_proxy/kafka_transactions_coordinator.h>
@@ -67,6 +68,7 @@ public:
     bool CloseConnection = false;
 
     bool RetryingWriteToSocket = false;
+    TEvPollerReady::TPtr PollerEventSaved = nullptr;
 
     NAddressClassifier::TLabeledAddressClassifier::TConstPtr DatacenterClassifier;
 
@@ -82,14 +84,21 @@ public:
     size_t InflightSize;
 
     TActorId ProduceActorId;
-    TActorId SaslAuthActorId;
+    TActorId AuthActorId;
+
+    enum MtlsAuthStages { NO_CERT_YET, PROCESSING_CERT, AUTH_SUCCESSFUL, AUTH_FAILED };
+    MtlsAuthStages MtlsAuthStage;
+    std::shared_ptr<TInet64SecureStreamSocket::TServerMtlsCreds> ServerCreds;
+
+    enum SslHandshakeErrors {ERROR_NONE = 1, ERROR_WANT_READ = -1, ERROR_WANT_WRITE = -2};
 
     TContext::TPtr Context;
 
     TKafkaConnection(const TActorId& listenerActorId,
                      TIntrusivePtr<TSocketDescriptor> socket,
                      TNetworkConfig::TSocketAddressType address,
-                     const NKikimrConfig::TKafkaProxyConfig& config)
+                     const NKikimrConfig::TKafkaProxyConfig& config,
+                     std::shared_ptr<NKafka::TInet64SecureStreamSocket::TServerMtlsCreds> serverCreds)
         : ListenerActorId(listenerActorId)
         , Socket(std::move(socket))
         , Address(address)
@@ -97,6 +106,7 @@ public:
         , Step(SIZE_READ)
         , Demand(NoDemand)
         , InflightSize(0)
+        , ServerCreds(serverCreds)
         , Context(std::make_shared<TContext>(config))
     {
         SetNonBlock();
@@ -112,6 +122,8 @@ public:
             Context->ResourceDatabasePath = NKikimr::AppData()->TenantName;
         }
 
+        MtlsAuthStage = NO_CERT_YET;
+
         Become(&TKafkaConnection::StateAccepting);
         Schedule(InactivityTimeout, InactivityEvent = new TEvPollerReady(nullptr, false, false));
         KAFKA_LOG_I("incoming connection opened " << Address);
@@ -124,8 +136,8 @@ public:
         if (ProduceActorId) {
             Send(ProduceActorId, new TEvents::TEvPoison());
         }
-        if (SaslAuthActorId) {
-            Send(SaslAuthActorId, new TEvents::TEvPoison());
+        if (AuthActorId) {
+            Send(AuthActorId, new TEvents::TEvPoison());
         }
         if (Context->ReadSession.ProxyActorId) {
             Send(Context->ReadSession.ProxyActorId, new TEvents::TEvPoison());
@@ -284,14 +296,14 @@ protected:
     }
 
     void EnsureKafkaSaslAuthActor() {
-        if (!SaslAuthActorId) {
-            SaslAuthActorId = RegisterWithSameMailbox(CreateKafkaSaslAuthActor(Context, Address));
+        if (!AuthActorId) {
+            AuthActorId = RegisterWithSameMailbox(CreateKafkaSaslAuthActor(Context, Address));
         }
     }
 
     void HandleMessage(const TRequestHeaderData* header, const TMessagePtr<TSaslAuthenticateRequestData>& message) {
         EnsureKafkaSaslAuthActor();
-        Send(SaslAuthActorId, new TEvKafka::TEvAuthRequest(header->CorrelationId, message));
+        Send(AuthActorId, new TEvKafka::TEvAuthRequest(header->CorrelationId, message));
     }
 
     void HandleMessage(const TRequestHeaderData* header, const TMessagePtr<TSaslHandshakeRequestData>& message) {
@@ -542,8 +554,25 @@ protected:
 
         auto authStep = event->AuthStep;
         if (authStep == EAuthSteps::FAILED) {
+            if (IsSslActive && NKikimr::AppData()->KafkaProxyConfig.GetMtlsEnable()) {
+                MtlsAuthStage = AUTH_FAILED;
+            }
             KAFKA_LOG_ERROR(event->Error);
             Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
+            CloseConnection = true;
+            return;
+        }
+
+        if (Context->SaslMechanism != "MTLS" && IsSslActive && NKikimr::AppData()->KafkaProxyConfig.GetMtlsEnable()) {
+            auto kafkaError = EKafkaErrors::SASL_AUTHENTICATION_FAILED;
+            auto responseToClient = std::make_shared<TSaslAuthenticateResponseData>();
+            responseToClient->ErrorCode = kafkaError;
+            TString errorMessage = TStringBuilder() << Context->SaslMechanism << " authentication mechanism is disabled, because mTLS flag is on. Turn of mTLS in configuration to use this mechanism.";
+            responseToClient->ErrorMessage = errorMessage;
+            KAFKA_LOG_D(errorMessage);
+
+            std::shared_ptr<TEvKafka::TEvResponse> errorResponse = std::make_shared<TEvKafka::TEvResponse>(event->ClientResponse->CorrelationId, responseToClient, kafkaError);
+            Reply(event->ClientResponse->CorrelationId, errorResponse->Response, kafkaError, ctx);
             CloseConnection = true;
             return;
         }
@@ -560,13 +589,31 @@ protected:
         Context->ResourceDatabasePath = event->ResourceDatabasePath ? NKikimr::CanonizePath(event->ResourceDatabasePath) : Context->DatabasePath;
 
         KAFKA_LOG_D("Authentication successful. SID=" << Context->UserToken->GetUserSID());
-        Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
+        if (Context->SaslMechanism != "MTLS") {
+            Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
+        } else {
+            MtlsAuthStage = AUTH_SUCCESSFUL;
+            HandleConnected(PollerEventSaved, ctx);
+        }
     }
 
     void Handle(TEvKafka::TEvHandshakeResult::TPtr ev, const TActorContext& ctx) {
         auto event = ev->Get();
-        Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
 
+        if (IsSslActive && NKikimr::AppData()->KafkaProxyConfig.GetMtlsEnable()) {
+            EKafkaErrors kafkaError = EKafkaErrors::SASL_AUTHENTICATION_FAILED;
+            auto responseToClient = std::make_shared<TSaslHandshakeResponseData>();
+            responseToClient->ErrorCode = kafkaError;
+
+            auto errorResponse = std::make_shared<TEvKafka::TEvResponse>(event->ClientResponse->CorrelationId, responseToClient, kafkaError);
+            TString errorMessage = TStringBuilder() << event->SaslMechanism << " authentication mechanism is disabled, because mTLS flag is on. Turn of mTLS in configuration to use this mechanism.";
+            KAFKA_LOG_D(errorMessage);
+            Reply(event->ClientResponse->CorrelationId, errorResponse->Response, kafkaError, ctx);
+            CloseConnection = true;
+            return;
+        }
+
+        Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
         auto authStep = event->AuthStep;
         if (authStep == EAuthSteps::FAILED) {
             KAFKA_LOG_ERROR(event->Error);
@@ -676,7 +723,7 @@ protected:
 
     bool UpgradeToSecure() {
         if (IsSslRequired && !IsSslActive) {
-            int res = Socket->TryUpgradeToSecure();
+            int res = Socket->TryUpgradeToSecure(NKikimrServices::KAFKA_PROXY, ServerCreds);
             if (res < 0) {
                 KAFKA_LOG_ERROR("connection closed - error in UpgradeToSecure: " << strerror(-res));
                 PassAway();
@@ -828,6 +875,11 @@ protected:
 
                         Step = SIZE_READ;
 
+                        if (IsSslActive && NKikimr::AppData()->KafkaProxyConfig.GetMtlsEnable() && MtlsAuthStage != MtlsAuthStages::AUTH_SUCCESSFUL) {
+                            KAFKA_LOG_D("Mtls authentication was not successful.");
+                            return false;
+                        }
+
                         if (!ProcessRequest(ctx)) {
                             return false;
                         }
@@ -844,10 +896,39 @@ protected:
                 EApiKey::SASL_AUTHENTICATE == apiKey);
     }
 
-
     void HandleConnected(TEvPollerReady::TPtr event, const TActorContext& ctx) {
         if (event->Get()->Read) {
             if (!CloseConnection) {
+                if (IsSslActive && NKikimr::AppData()->KafkaProxyConfig.GetMtlsEnable() && MtlsAuthStage == NO_CERT_YET) {
+                    int sslHandshakeResult = Socket->GetSslHandshakeResult();
+                    if (sslHandshakeResult != SslHandshakeErrors::ERROR_WANT_READ &&
+                        sslHandshakeResult != SslHandshakeErrors::ERROR_WANT_WRITE &&
+                        sslHandshakeResult != SslHandshakeErrors::ERROR_NONE) {
+                        KAFKA_LOG_D("Error in ssl handshake, ssl ErrorCode=" << sslHandshakeResult);
+                        PassAway();
+                        return;
+                    }
+                    if (sslHandshakeResult == SslHandshakeErrors::ERROR_NONE) {
+                        TSslHelpers::TSslHolder<X509> cert = Socket->GetSslClientCert();
+                        if (!cert) {
+                            KAFKA_LOG_ERROR("No cert was received from client during ssl handshake for mTLS authentication.");
+                            PassAway();
+                            return;
+                        }
+
+                        TString clientCert = Socket->GetStringClientCert(cert.get());
+                        MtlsAuthStage = PROCESSING_CERT;
+                        PollerEventSaved = event;
+
+                        EnsureKafkaSaslAuthActor();
+                        Context->AuthenticationStep = EAuthSteps::WAIT_AUTH;
+                        Context->SaslMechanism = "MTLS";
+                        Context->RequireAuthentication = true;
+                        Send(AuthActorId, new TEvKafka::TEvMtlsAuthRequest(clientCert));
+                        return;
+                    }
+
+                }
                 if (!DoRead(ctx)) {
                     return;
                 }
@@ -874,7 +955,7 @@ protected:
                 KAFKA_LOG_ERROR("connection closed - error in FlushOutput: " << strerror(-res) << ". Buffer queue size: " << BufferedWriter.GetBuffersDeque().size());
                 PassAway();
                 return;
-            } else if (res > 0 && BufferedWriter.Empty()) { // we successfuly retryed sending the reqsponse
+            } else if (res > 0 && BufferedWriter.Empty()) { // we successfuly retried sending the response
                 RetryingWriteToSocket = false;
                 auto& request = PendingRequestsQueue.front();
                 auto& header = request->Header;
@@ -924,8 +1005,9 @@ protected:
 NActors::IActor* CreateKafkaConnection(const TActorId& listenerActorId,
                                        TIntrusivePtr<TSocketDescriptor> socket,
                                        TNetworkConfig::TSocketAddressType address,
-                                       const NKikimrConfig::TKafkaProxyConfig& config) {
-    return new TKafkaConnection(listenerActorId, std::move(socket), std::move(address), config);
+                                       const NKikimrConfig::TKafkaProxyConfig& config,
+                                       std::shared_ptr<NKafka::TInet64SecureStreamSocket::TServerMtlsCreds> serverCreds) {
+    return new TKafkaConnection(listenerActorId, std::move(socket), std::move(address), config, serverCreds);
 }
 
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -90,7 +90,7 @@ public:
     MtlsAuthStages MtlsAuthStage;
     std::shared_ptr<TInet64SecureStreamSocket::TServerMtlsCreds> ServerCreds;
 
-    enum SslHandshakeErrors {ERROR_NONE = 1, ERROR_WANT_READ = -1, ERROR_WANT_WRITE = -2};
+    enum SslHandshakeErrors {ERROR_NONE = 0, ERROR_WANT_READ = 1, ERROR_WANT_WRITE = 2};
 
     TContext::TPtr Context;
 

--- a/ydb/core/kafka_proxy/kafka_connection.h
+++ b/ydb/core/kafka_proxy/kafka_connection.h
@@ -12,6 +12,7 @@ using namespace NKikimr::NRawSocket;
 NActors::IActor* CreateKafkaConnection(const TActorId& listenerActorId,
                                        TIntrusivePtr<TSocketDescriptor> socket,
                                        TNetworkConfig::TSocketAddressType address,
-                                       const NKikimrConfig::TKafkaProxyConfig& config);
+                                       const NKikimrConfig::TKafkaProxyConfig& config,
+                                       std::shared_ptr<NKafka::TInet64SecureStreamSocket::TServerMtlsCreds> serverCreds);
 
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/kafka_events.h
+++ b/ydb/core/kafka_proxy/kafka_events.h
@@ -46,6 +46,7 @@ struct TEvKafka {
         EvFetchRequest,
         EvFetchActorStateRequest,
         EvFetchActorStateResponse,
+        EvMtlsAuthRequest,
         EvResponse = EvRequest + 256,
         EvInternalEvents = EvResponse + 256,
         EvEnd
@@ -152,7 +153,7 @@ struct TEvKafka {
         const TMessagePtr<TSaslAuthenticateRequestData> Request;
     };
 
-    struct TEvMtlsAuthRequest : public TEventLocal<TEvMtlsAuthRequest, EvRequest> {
+    struct TEvMtlsAuthRequest : public TEventLocal<TEvMtlsAuthRequest, EvMtlsAuthRequest> {
         TEvMtlsAuthRequest(const TString& clientCertificate)
             : ClientCertificate(clientCertificate)
         {

--- a/ydb/core/kafka_proxy/kafka_events.h
+++ b/ydb/core/kafka_proxy/kafka_events.h
@@ -152,6 +152,15 @@ struct TEvKafka {
         const TMessagePtr<TSaslAuthenticateRequestData> Request;
     };
 
+    struct TEvMtlsAuthRequest : public TEventLocal<TEvMtlsAuthRequest, EvRequest> {
+        TEvMtlsAuthRequest(const TString& clientCertificate)
+            : ClientCertificate(clientCertificate)
+        {
+        }
+
+        const TString ClientCertificate;
+    };
+
     struct TEvAuthResult : public TEventLocal<TEvAuthResult, EvAuthResult> {
 
         TEvAuthResult(EAuthSteps authStep, std::shared_ptr<TEvKafka::TEvResponse> clientResponse, TString error = "")

--- a/ydb/core/kafka_proxy/kafka_listener.h
+++ b/ydb/core/kafka_proxy/kafka_listener.h
@@ -8,12 +8,13 @@ namespace NKafka {
 using namespace NKikimr::NRawSocket;
 
 inline NActors::IActor* CreateKafkaListener(
-        const NActors::TActorId& poller, const TListenerSettings& settings, const NKikimrConfig::TKafkaProxyConfig& config
+        const NActors::TActorId& poller, const TListenerSettings& settings, const NKikimrConfig::TKafkaProxyConfig& config,
+        std::shared_ptr<NKafka::TInet64SecureStreamSocket::TServerMtlsCreds> serverCreds = nullptr
 ) {
     return CreateSocketListener(
         poller, settings,
         [=](const TActorId& listenerActorId, TIntrusivePtr<TSocketDescriptor> socket, TNetworkConfig::TSocketAddressType address) {
-            return CreateKafkaConnection(listenerActorId, socket, address, config);
+            return CreateKafkaConnection(listenerActorId, socket, address, config, serverCreds);
         },
         NKikimrServices::EServiceKikimr::KAFKA_PROXY, EErrorAction::Abort);
 }

--- a/ydb/core/pgproxy/pg_connection.cpp
+++ b/ydb/core/pgproxy/pg_connection.cpp
@@ -896,7 +896,7 @@ protected:
     }
 
     bool UpgradeToSecure() {
-        int res = Socket->TryUpgradeToSecure();
+        int res = Socket->TryUpgradeToSecure(NKikimrServices::PGYDB);
         if (res < 0) {
             BLOG_ERROR("connection closed - error in UpgradeToSecure: " << strerror(-res));
             PassAway();

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2971,6 +2971,7 @@ message TKafkaProxyConfig {
     optional string Cert = 8 [(Ydb.sensitive) = true];
     optional string Key = 9 [(Ydb.sensitive) = true];
     optional string CA = 17 [(Ydb.sensitive) = true];
+    optional bool EnableSelfSignedCerts = 19 [default = false];
     optional bool MtlsEnable = 18 [default = false];
 
     optional uint64 MaxMessageSize = 4 [default = 16777216];

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2970,6 +2970,8 @@ message TKafkaProxyConfig {
     optional string SslCertificate = 3 [(Ydb.sensitive) = true];
     optional string Cert = 8 [(Ydb.sensitive) = true];
     optional string Key = 9 [(Ydb.sensitive) = true];
+    optional string CA = 17 [(Ydb.sensitive) = true];
+    optional bool MtlsEnable = 18 [default = false];
 
     optional uint64 MaxMessageSize = 4 [default = 16777216];
     optional uint64 MaxInflightSize = 5 [default = 16777216];

--- a/ydb/core/raw_socket/sock64.h
+++ b/ydb/core/raw_socket/sock64.h
@@ -2,7 +2,10 @@
 
 #include <optional>
 #include <util/network/sock.h>
+#include <util/stream/file.h>
+#include <ydb/core/protos/config.pb.h>
 #include <ydb/library/actors/interconnect/poller/poller_actor.h>
+#include <ydb/core/base/appdata.h>
 #include "sock_settings.h"
 #include "sock_ssl.h"
 
@@ -140,27 +143,118 @@ protected:
 };
 
 class TInet64SecureStreamSocket : public TInet64StreamSocket, TSslLayer<TStreamSocket> {
+public:
+    struct TServerMtlsCreds {
+        TSslHolder<X509> ServerCert;
+        TSslHolder<EVP_PKEY> ServerPrivateKey;
+        TSslHolder<X509> CACert;
+    };
+
+    TInet64SecureStreamSocket(const TSocketSettings& socketSettings = {})
+        : TInet64StreamSocket(socketSettings)
+    {}
+
+    TInet64SecureStreamSocket(TInet64StreamSocket&& socket, NKikimrServices::EServiceKikimr service,
+                const std::optional<std::shared_ptr<TServerMtlsCreds>>& serverCreds = std::nullopt)
+        : TInet64StreamSocket(std::move(socket))
+    {
+        Service = service;
+        if (serverCreds.has_value()) {
+            ServerCreds = *serverCreds;
+            UseMtlsAuth = true;
+        }
+    }
+
+private:
     template<typename T>
     using TSslHolder = TSslLayer<TStreamSocket>::TSslHolder<T>;
 
     TSslHolder<BIO> Bio;
     TSslHolder<SSL> Ssl;
+    std::shared_ptr<TServerMtlsCreds> ServerCreds;
+    bool UseMtlsAuth = false;
+    NKikimrServices::EServiceKikimr Service;
 
 public:
-    TInet64SecureStreamSocket(const TSocketSettings& socketSettings = {})
-        : TInet64StreamSocket(socketSettings)
-    {}
-
-    TInet64SecureStreamSocket(TInet64StreamSocket&& socket)
-        : TInet64StreamSocket(std::move(socket))
-    {}
-
-    void InitServerSsl(SSL_CTX* ctx) {
+    bool InitServerSsl(SSL_CTX* ctx) {
         Bio.reset(BIO_new(TSslLayer<TStreamSocket>::IoMethod()));
         BIO_set_data(Bio.get(), static_cast<TStreamSocket*>(this));
         BIO_set_nbio(Bio.get(), 1);
+
+        if (UseMtlsAuth) {
+            if (!ServerCreds || !ServerCreds->ServerCert || !ServerCreds->ServerPrivateKey || !ServerCreds->CACert) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Not enough data in MTLS configuration.");
+                return false;
+            }
+            SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,&TInet64SecureStreamSocket::Verify);
+
+            int retServerCert = SSL_CTX_use_certificate(ctx, ServerCreds->ServerCert.get());
+            if (retServerCert != 1) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't add server certificate to ssl context, it might be incorrect.");
+                return false;
+            }
+
+            if (!ServerCreds->ServerPrivateKey) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't parse server private key, it might be incorrect.");
+                return false;
+            }
+            int retPrivateKey = SSL_CTX_use_PrivateKey(ctx, ServerCreds->ServerPrivateKey.get());
+            if (retPrivateKey != 1) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't add server private key to ssl context, it might be incorrect.");
+                return false;
+            }
+
+            X509_STORE* store = SSL_CTX_get_cert_store(ctx);
+            if (!store) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't get cert store from SSL context.");
+
+                return false;
+            }
+
+            if (X509_STORE_add_cert(store, ServerCreds->CACert.get()) != 1) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't load CA file. Check its correctness.");
+                return false;
+            }
+
+            SSL_CTX_set_verify_depth(ctx, 9);
+            if (SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256") != 1) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't load cipher list");
+                return false;
+            }
+
+            const char *session_context = "YdbMtlsContext";
+            if (SSL_CTX_set_session_id_context(ctx, (const unsigned char *)session_context, strlen(session_context)) != 1) {
+                LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't add ssl session id to ssl context.");
+                return false;
+            }
+        } else {
+            SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+        }
+
         Ssl = TSslHelpers::ConstructSsl(ctx, Bio.get());
-        SSL_set_accept_state(Ssl.get());
+        if (Ssl) {
+            SSL_set_accept_state(Ssl.get());
+            return true;
+        }
+        return false;
+    }
+
+    TSslHolder<X509> GetServerCert(const TString& certificate) {
+        TSslHolder<BIO> bio(BIO_new_mem_buf(certificate.data(), certificate.size()));
+        if (bio) {
+            TSslHolder<X509> cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
+            return cert;
+        }
+        return TSslHolder<X509>();
+    }
+
+     TSslHolder<EVP_PKEY> GetServerPrivateKey(const TString& privateKey) {
+        TSslHolder<BIO> bio(BIO_new_mem_buf(privateKey.data(), privateKey.size()));
+        if (bio) {
+            TSslHolder<EVP_PKEY> pkey(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
+            return pkey;
+        }
+        return TSslHolder<EVP_PKEY>();
     }
 
     int ProcessResult(int res) {
@@ -182,10 +276,51 @@ public:
 
     int SecureAccept(SSL_CTX* ctx) {
         if (!Ssl) {
-            InitServerSsl(ctx);
+            if (!InitServerSsl(ctx)) {
+                return -EIO;
+            }
         }
         int res = SSL_accept(Ssl.get());
         return ProcessResult(res);
+    }
+
+    static TString ConvertX509ToPEMString(X509* cert) {
+        TSslHolder<BIO> bio = TSslHolder<BIO>(BIO_new(BIO_s_mem()));
+        if (bio && PEM_write_bio_X509(bio.get(), cert)) {
+            char* buffer = NULL;
+            long length = BIO_get_mem_data(bio.get(), &buffer);
+            return TString(buffer, length);
+        }
+        return TString();
+    }
+
+    static int Verify(int preverify, X509_STORE_CTX *ctx) {
+        X509* current = X509_STORE_CTX_get_current_cert(ctx);
+        if (!preverify) {
+            int err = X509_STORE_CTX_get_error(ctx);
+            char buffer[1024];
+            X509_NAME_oneline(X509_get_subject_name(current), buffer, sizeof(buffer));
+            if (err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) {
+                // Allow self-signed certificates
+                preverify = 1;
+            }
+        }
+        return preverify;
+    }
+
+    int GetSslHandshakeResult() {
+        if (!Ssl) {
+            return -1;
+        }
+        int ret = SSL_do_handshake(Ssl.get());
+        return ret;
+    }
+
+    TSslHolder<X509> GetSslClientCert() {
+        if (!Ssl) {
+            return nullptr;
+        }
+        return TSslHolder<X509>(SSL_get_peer_certificate(Ssl.get()));
     }
 
     ssize_t Send(const void* msg, size_t len, int flags = 0) override {

--- a/ydb/core/raw_socket/sock64.h
+++ b/ydb/core/raw_socket/sock64.h
@@ -313,7 +313,7 @@ public:
             return -1;
         }
         int ret = SSL_do_handshake(Ssl.get());
-        return ret;
+        return SSL_get_error(Ssl.get(), ret);
     }
 
     TSslHolder<X509> GetSslClientCert() {

--- a/ydb/core/raw_socket/sock64.h
+++ b/ydb/core/raw_socket/sock64.h
@@ -148,6 +148,7 @@ public:
         TSslHolder<X509> ServerCert;
         TSslHolder<EVP_PKEY> ServerPrivateKey;
         TSslHolder<X509> CACert;
+        bool AllowSelfSignedCerts = false;
     };
 
     TInet64SecureStreamSocket(const TSocketSettings& socketSettings = {})
@@ -186,9 +187,12 @@ public:
                 LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Not enough data in MTLS configuration.");
                 return false;
             }
-            SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,&TInet64SecureStreamSocket::Verify);
-
-            int retServerCert = SSL_CTX_use_certificate(ctx, ServerCreds->ServerCert.get());
+            if (ServerCreds->AllowSelfSignedCerts) {
+                SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,&TInet64SecureStreamSocket::VerifyAllowSelfSignedCerts);
+            } else {
+                SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+            }
+            i32 retServerCert = SSL_CTX_use_certificate(ctx, ServerCreds->ServerCert.get());
             if (retServerCert != 1) {
                 LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't add server certificate to ssl context, it might be incorrect.");
                 return false;
@@ -198,7 +202,7 @@ public:
                 LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't parse server private key, it might be incorrect.");
                 return false;
             }
-            int retPrivateKey = SSL_CTX_use_PrivateKey(ctx, ServerCreds->ServerPrivateKey.get());
+            i32 retPrivateKey = SSL_CTX_use_PrivateKey(ctx, ServerCreds->ServerPrivateKey.get());
             if (retPrivateKey != 1) {
                 LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't add server private key to ssl context, it might be incorrect.");
                 return false;
@@ -207,7 +211,6 @@ public:
             X509_STORE* store = SSL_CTX_get_cert_store(ctx);
             if (!store) {
                 LOG_ERROR_S(*NActors::TlsActivationContext, Service, "Couldn't get cert store from SSL context.");
-
                 return false;
             }
 
@@ -239,23 +242,6 @@ public:
         return false;
     }
 
-    TSslHolder<X509> GetServerCert(const TString& certificate) {
-        TSslHolder<BIO> bio(BIO_new_mem_buf(certificate.data(), certificate.size()));
-        if (bio) {
-            TSslHolder<X509> cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
-            return cert;
-        }
-        return TSslHolder<X509>();
-    }
-
-     TSslHolder<EVP_PKEY> GetServerPrivateKey(const TString& privateKey) {
-        TSslHolder<BIO> bio(BIO_new_mem_buf(privateKey.data(), privateKey.size()));
-        if (bio) {
-            TSslHolder<EVP_PKEY> pkey(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
-            return pkey;
-        }
-        return TSslHolder<EVP_PKEY>();
-    }
 
     int ProcessResult(int res) {
         if (res <= 0) {
@@ -294,12 +280,9 @@ public:
         return TString();
     }
 
-    static int Verify(int preverify, X509_STORE_CTX *ctx) {
-        X509* current = X509_STORE_CTX_get_current_cert(ctx);
+    static int VerifyAllowSelfSignedCerts(int preverify, X509_STORE_CTX *ctx) {
         if (!preverify) {
             int err = X509_STORE_CTX_get_error(ctx);
-            char buffer[1024];
-            X509_NAME_oneline(X509_get_subject_name(current), buffer, sizeof(buffer));
             if (err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) {
                 // Allow self-signed certificates
                 preverify = 1;

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -15,6 +15,7 @@ class TSocketDescriptor : public NActors::TSharedDescriptor, public TNetworkConf
     std::unique_ptr<TNetworkConfig::TSocketType> Socket;
     std::shared_ptr<TEndpointInfo> Endpoint;
     TSpinLock Lock;
+    TSslHelpers::TSslHolder<X509> SecureConnectionClientCert;
 
 public:
     TSocketDescriptor(TSocketType&& s, std::shared_ptr<TEndpointInfo> endpoint)
@@ -54,17 +55,19 @@ public:
         Socket->RequestPoller(pollerToken);
     }
 
-    int UpgradeToSecure() {
-        std::unique_ptr<TNetworkConfig::TSecureSocketType> socket = std::make_unique<TNetworkConfig::TSecureSocketType>(std::move(*Socket));
+    int UpgradeToSecure(NKikimrServices::EServiceKikimr service,
+                        const std::optional<std::shared_ptr<TInet64SecureStreamSocket::TServerMtlsCreds>>& serverCreds = std::nullopt) {
+        std::unique_ptr<TNetworkConfig::TSecureSocketType> socket = std::make_unique<TNetworkConfig::TSecureSocketType>(std::move(*Socket), service, serverCreds);
         int res = socket->SecureAccept(Endpoint->SecureContext.get());
         TGuard lock(Lock);
         Socket.reset(socket.release());
         return res;
     }
 
-    int TryUpgradeToSecure() {
+    int TryUpgradeToSecure(NKikimrServices::EServiceKikimr service,
+                          const std::optional<std::shared_ptr<TInet64SecureStreamSocket::TServerMtlsCreds>>& serverCreds = std::nullopt) {
         for (;;) {
-            int res = UpgradeToSecure();
+            int res = UpgradeToSecure(service, serverCreds);
             if (res >= 0) {
                 return 0;
             } else if (-res == EINTR) {
@@ -85,6 +88,21 @@ public:
     SOCKET GetRawSocket() const {
         TGuard lock(Lock);
         return *Socket;
+    }
+
+    TSslHelpers::TSslHolder<X509> GetSslClientCert() {
+        auto *socket = dynamic_cast<TNetworkConfig::TSecureSocketType*>(Socket.get());
+        return socket->GetSslClientCert();
+    }
+
+    int GetSslHandshakeResult() {
+        auto *socket = dynamic_cast<TNetworkConfig::TSecureSocketType*>(Socket.get());
+        return socket->GetSslHandshakeResult();
+    }
+
+    TString GetStringClientCert(X509* cert) {
+        auto *socket = dynamic_cast<TNetworkConfig::TSecureSocketType*>(Socket.get());
+        return socket->ConvertX509ToPEMString(cert);
     }
 
     int GetDescriptor() override {
@@ -190,7 +208,7 @@ private:
 
     ssize_t Send(const char* data, size_t length) {
         ssize_t res = Socket->Send(data, length);
-        
+
         return res;
     }
 
@@ -203,4 +221,3 @@ private:
 };
 
 } // namespace NKikimr::NRawSocket
-

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -92,16 +92,19 @@ public:
 
     TSslHelpers::TSslHolder<X509> GetSslClientCert() {
         auto *socket = dynamic_cast<TNetworkConfig::TSecureSocketType*>(Socket.get());
+        Y_VERIFY(socket);
         return socket->GetSslClientCert();
     }
 
     int GetSslHandshakeResult() {
         auto *socket = dynamic_cast<TNetworkConfig::TSecureSocketType*>(Socket.get());
+        Y_VERIFY(socket);
         return socket->GetSslHandshakeResult();
     }
 
     TString GetStringClientCert(X509* cert) {
         auto *socket = dynamic_cast<TNetworkConfig::TSecureSocketType*>(Socket.get());
+        Y_VERIFY(socket);
         return socket->ConvertX509ToPEMString(cert);
     }
 


### PR DESCRIPTION
## What this is

Backport of the Kafka mTLS authentication feature from `main` into the new enterprise branch `stable-26-2-1-ent`.

Cherry-picked from `main`, **in this order** (the three commits are one sequential chain — each builds on the previous one):

| # | main PR | main commit | title |
|---|---|---|---|
| 1 | [#33358](https://github.com/ydb-platform/ydb/pull/33358) | `13e08c5f736e8ee6e1693f06114cbde22175704e` | Kafka add mtls auth attempt |
| 2 | [#36568](https://github.com/ydb-platform/ydb/pull/36568) | `c3abe5902d11c7683bcd5bb80aca7bcf009ea027` | Mtls fixes |
| 3 | [#37382](https://github.com/ydb-platform/ydb/pull/37382) | `f4f08d733cde5de97a64ecde73e874d41254edeb` | Mtls kafka api fixes2 |

All cherry-picked with `-x`, so every commit keeps its `(cherry picked from commit ...)` reference.

## Why it's needed

These changes are already present in `stable-26-1-1-enterprise`, merged there as [#38756](https://github.com/ydb-platform/ydb/pull/38756) (`Add mtls kafka api stable 26 1 1 enterprise`).

`stable-26-2-1-ent` is branched from `stable-26-2-1`, whose last common point with `main` is `7a9ac0ddfc4eb317e10fff717d5e1d4be65fda36` (2026-02-24). All three `main` PRs landed after that (2026-03-19 … 2026-04-16), so nothing was inherited naturally and an explicit backport is required for enterprise feature parity with the 26-1-1 line.

## Conflict resolution — please review carefully

Only the **first** commit conflicted; once it was in place, #36568 and #37382 applied cleanly. That is why the chain must stay in this order and must not be split into separate PRs.

The single conflict was in `ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp`, and it is a genuine divergence, not a mechanical one:

- At the time of #33358, `main` had `void StartPlainAuth(...)`.
- `stable-26-2-1` has since evolved to `[[nodiscard]] bool StartPlainAuth(...)`, with the caller written as `if (!StartPlainAuth(ctx)) { ... }`.

Taking the `main` side wholesale would have **reverted** that later refactoring and broken the caller. Resolution applied: added the new `HandleMtlsAuthRequest` handler from the PR, and **kept this branch's `bool` signature and body** unchanged. The matching header (`kafka_sasl_auth_actor.h`) auto-merged consistently — `[[nodiscard]] bool StartPlainAuth` is preserved alongside the new `HandleMtlsAuthRequest` / `StartMtlsAuth` / `ClientCert` declarations.

## Notes

- New `TKafkaProxyConfig` proto fields (`CA` = 17, `MtlsEnable` = 18, `EnableSelfSignedCerts` = 19) do not collide — this branch previously used field numbers only up to 16.
- Not built or tested locally; opened as draft so CI can verify.

Draft: reviewers to be assigned once CODEOWNERS for this branch is updated (see #50289).
