### PR TITLE
[26-2-1-ent] Backport KQP index/stream-lookup optimizer chain (#35402, #35853, #35952)

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -80,24 +80,26 @@ public:
         AddHandler(1, &TCoTake::Match, HNDL(RewriteTakeOverIndexRead));
         AddHandler(1, &TDqReadWrapBase::Match, HNDL(DqReadWrapByProvider));
 
-        AddHandler(2, &TKqlReadTableIndex::Match, HNDL(RewriteIndexRead));
-        AddHandler(2, &TKqlStreamLookupIndex::Match, HNDL(RewriteStreamLookupIndex));
-        AddHandler(2, &TKqlReadTableIndexRanges::Match, HNDL(RewriteIndexRead));
-        AddHandler(2, &TDqReadWrap::Match, HNDL(ExtractMembersOverDqReadWrapMultiUsage));
-        AddHandler(2, &TDqReadWrapBase::Match, HNDL(UnorderedOverDqReadWrapMultiUsage));
+        AddHandler(2, &TCoFlatMap::Match, HNDL(RewriteFlatMapOverIndexRead));
 
-        AddHandler(3, &TKqlLookupTableBase::Match, HNDL(RewriteLookupTable));
+        AddHandler(3, &TKqlReadTableIndex::Match, HNDL(RewriteIndexRead));
+        AddHandler(3, &TKqlStreamLookupIndex::Match, HNDL(RewriteStreamLookupIndex));
+        AddHandler(3, &TKqlReadTableIndexRanges::Match, HNDL(RewriteIndexRead));
+        AddHandler(3, &TDqReadWrap::Match, HNDL(ExtractMembersOverDqReadWrapMultiUsage));
+        AddHandler(3, &TDqReadWrapBase::Match, HNDL(UnorderedOverDqReadWrapMultiUsage));
 
-        AddHandler(4, &TKqlReadTableFullTextIndex::Match, HNDL(ApplyExtractMembersToReadTable<true>));
-        AddHandler(4, &TKqlReadTableBase::Match, HNDL(ApplyExtractMembersToReadTable<true>));
-        AddHandler(4, &TKqlReadTableRangesBase::Match, HNDL(ApplyExtractMembersToReadTable<true>));
-        AddHandler(4, &TKqpReadOlapTableRangesBase::Match, HNDL(ApplyExtractMembersToReadOlapTable<true>));
-        AddHandler(4, &TKqlLookupTableBase::Match, HNDL(ApplyExtractMembersToReadTable<true>));
-        AddHandler(5, TOptimizeTransformerBase::Any(), HNDL(InspectErroneousIndexAccess));
+        AddHandler(4, &TKqlLookupTableBase::Match, HNDL(RewriteLookupTable));
+
+        AddHandler(5, &TKqlReadTableFullTextIndex::Match, HNDL(ApplyExtractMembersToReadTable<true>));
+        AddHandler(5, &TKqlReadTableBase::Match, HNDL(ApplyExtractMembersToReadTable<true>));
+        AddHandler(5, &TKqlReadTableRangesBase::Match, HNDL(ApplyExtractMembersToReadTable<true>));
+        AddHandler(5, &TKqpReadOlapTableRangesBase::Match, HNDL(ApplyExtractMembersToReadOlapTable<true>));
+        AddHandler(5, &TKqlLookupTableBase::Match, HNDL(ApplyExtractMembersToReadTable<true>));
+        AddHandler(6, TOptimizeTransformerBase::Any(), HNDL(InspectErroneousIndexAccess));
 
 #undef HNDL
 
-        SetGlobal(4u);
+        SetGlobal(5u);
     }
 
 public:
@@ -286,6 +288,12 @@ protected:
     TMaybeNode<TExprBase> RewriteTopSortOverIndexRead(TExprBase node, TExprContext& ctx, const TGetParents& getParents) {
         TExprBase output = KqpRewriteTopSortOverIndexRead(node, ctx, KqpCtx, *getParents());
         DumpAppliedRule("RewriteTopSortOverIndexRead", node.Ptr(), output.Ptr(), ctx);
+        return output;
+    }
+
+    TMaybeNode<TExprBase> RewriteFlatMapOverIndexRead(TExprBase node, TExprContext& ctx, const TGetParents& getParents) {
+        TExprBase output = KqpRewriteFlatMapOverIndexRead(node, ctx, KqpCtx, *getParents());
+        DumpAppliedRule("RewriteFlatMapOverIndexRead", node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -1119,10 +1119,9 @@ bool CanPushFlatMap(const TCoFlatMapBase& flatMap, const TKikimrTableDescription
     }
 
     for (auto & lambdaColumn : lambdaSubset) {
-        auto columnIndex = tableDesc.GetKeyColumnIndex(lambdaColumn);
-        if (!columnIndex) {
+        auto columnType = tableDesc.GetColumnType(lambdaColumn);
+        if (!columnType)
             return false;
-        }
     }
 
     extraColumns.insert(extraColumns.end(), lambdaSubset.begin(), lambdaSubset.end());
@@ -2036,8 +2035,47 @@ TExprBase KqpRewriteTopSortOverIndexRead(const TExprBase& node, TExprContext& ct
         .Done();
 }
 
+TExprBase KqpRewriteFlatMapOverIndexRead(const TExprBase& node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
+    const TParentsMap& parentsMap)
+{
+    if (!node.Maybe<TCoFlatMap>()) {
+        return node;
+    }
+
+    auto flatMap = node.Cast<TCoFlatMap>();
+
+    auto read = TReadMatch::MatchIndexedRead(flatMap.Input(), kqpCtx);
+    if (!read) {
+        return node;
+    }
+
+    const auto& tableDesc = GetTableData(*kqpCtx.Tables, kqpCtx.Cluster, read.Table().Path());
+    const auto indexName = read.Index().Value();
+    auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(indexName);
+    if (indexDesc->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+        // TODO(mbkkt) some warning?
+        return node;
+    }
+    const auto& implTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, implTable->Name);
+
+    TVector<TString> extraColumns;
+    if (!CanPushFlatMap(flatMap, implTableDesc, parentsMap, extraColumns))
+        return node;
+
+    auto filter = [&](const TExprBase& in) mutable {
+        return Build<TCoFlatMap>(ctx, node.Pos())
+            .Input(in)
+            .Lambda(ctx.DeepCopyLambda(flatMap.Lambda().Ref()))
+            .Done();
+    };
+
+    return DoRewriteIndexRead(read, ctx, tableDesc, implTable, extraColumns, filter);
+}
+
+
 TExprBase KqpRewriteTakeOverIndexRead(const TExprBase& node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
-                                    const TParentsMap& parentsMap) {
+                                    const TParentsMap& parentsMap)
+{
     if (!node.Maybe<TCoTake>()) {
         return node;
     }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -1104,9 +1104,9 @@ TExprBase KqpRewriteStreamLookupIndex(const TExprBase& node, TExprContext& ctx, 
 }
 
 /// Can push flat map node to read from table using only columns available in table description
-bool CanPushFlatMap(const TCoFlatMapBase& flatMap, const TKikimrTableDescription& tableDesc, const TParentsMap& parentsMap, TVector<TString> & extraColumns) {
+bool CanPushFlatMap(const TCoFlatMapBase& flatMap, const TKikimrTableDescription& tableDesc, const TParentsMap& parentsMap, TVector<TString> & extraColumns, bool& residual) {
     auto flatMapLambda = flatMap.Lambda();
-    if (!IsFilterFlatMap(flatMapLambda)) {
+    if (!flatMapLambda.Body().Maybe<TCoOptionalIf>() && !flatMapLambda.Body().Maybe<TCoListIf>()) {
         return false;
     }
 
@@ -1122,6 +1122,20 @@ bool CanPushFlatMap(const TCoFlatMapBase& flatMap, const TKikimrTableDescription
         auto columnType = tableDesc.GetColumnType(lambdaColumn);
         if (!columnType)
             return false;
+    }
+
+    if (flatMapLambdaConditional.Value().Raw() != flatMapLambda.Args().Arg(0).Raw()) {
+        // doesn't support residial values
+        if (!residual) {
+            return false;
+        }
+
+        if (flatMapLambda.Body().Maybe<TCoListIf>()) {
+            return false;
+        }
+
+    } else {
+        residual = false;
     }
 
     extraColumns.insert(extraColumns.end(), lambdaSubset.begin(), lambdaSubset.end());
@@ -1988,7 +2002,8 @@ TExprBase KqpRewriteTopSortOverIndexRead(const TExprBase& node, TExprContext& ct
 
     TVector<TString> extraColumns;
 
-    if (maybeFlatMap && !CanPushFlatMap(maybeFlatMap.Cast(), implTableDesc, parentsMap, extraColumns))
+    bool hasResidual = false;
+    if (maybeFlatMap && !CanPushFlatMap(maybeFlatMap.Cast(), implTableDesc, parentsMap, extraColumns, hasResidual))
         return node;
 
     if (!CanPushTopSort(topBase, implTableDesc, &extraColumns)) {
@@ -2059,17 +2074,51 @@ TExprBase KqpRewriteFlatMapOverIndexRead(const TExprBase& node, TExprContext& ct
     const auto& implTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, implTable->Name);
 
     TVector<TString> extraColumns;
-    if (!CanPushFlatMap(flatMap, implTableDesc, parentsMap, extraColumns))
+    bool hasResidual = true;
+    if (!CanPushFlatMap(flatMap, implTableDesc, parentsMap, extraColumns, hasResidual))
         return node;
 
     auto filter = [&](const TExprBase& in) mutable {
-        return Build<TCoFlatMap>(ctx, node.Pos())
-            .Input(in)
-            .Lambda(ctx.DeepCopyLambda(flatMap.Lambda().Ref()))
-            .Done();
+        if (!hasResidual) {
+            return Build<TCoFlatMap>(ctx, node.Pos())
+                .Input(in)
+                .Lambda(ctx.DeepCopyLambda(flatMap.Lambda().Ref()))
+                .Done();
+        } else {
+            TNodeOnNodeOwnedMap replaces;
+            YQL_ENSURE(flatMap.Lambda().Body().Maybe<TCoConditionalValueBase>());
+            replaces.emplace(flatMap.Lambda().Body().Maybe<TCoConditionalValueBase>().Value().Raw(), flatMap.Lambda().Args().Arg(0).Ptr());
+
+            auto newLambdaBody = TCoLambda{ctx.NewLambda(
+                flatMap.Lambda().Pos(),
+                std::move(flatMap.Lambda().Args().Ptr()),
+                ctx.ReplaceNodes(TExprNode::TListType{flatMap.Lambda().Body().Ptr()}, replaces))};
+
+            return Build<TCoFlatMap>(ctx, node.Pos())
+                .Input(in)
+                .Lambda(NewLambdaFrom(ctx, flatMap.Lambda().Pos(), replaces, flatMap.Lambda().Args().Ref(), newLambdaBody.Body()))
+                .Done();
+        }
     };
 
-    return DoRewriteIndexRead(read, ctx, tableDesc, implTable, extraColumns, filter);
+    if (!hasResidual) {
+        return DoRewriteIndexRead(read, ctx, tableDesc, implTable, extraColumns, filter);
+    } else {
+        auto newRead = DoRewriteIndexRead(read, ctx, tableDesc, implTable, extraColumns, filter);
+        TNodeOnNodeOwnedMap replaces;
+        YQL_ENSURE(flatMap.Lambda().Body().Maybe<TCoConditionalValueBase>());
+        replaces.emplace(flatMap.Lambda().Body().Raw(), flatMap.Lambda().Body().Cast<TCoConditionalValueBase>().Value().Ptr());
+
+        auto newLambdaBody = TCoLambda{ctx.NewLambda(
+            flatMap.Lambda().Pos(),
+            std::move(flatMap.Lambda().Args().Ptr()),
+            ctx.ReplaceNodes(TExprNode::TListType{flatMap.Lambda().Body().Ptr()}, replaces))};
+
+        return Build<TCoMap>(ctx, node.Pos())
+            .Input(newRead)
+            .Lambda(NewLambdaFrom(ctx, flatMap.Lambda().Pos(), replaces, flatMap.Lambda().Args().Ref(), newLambdaBody.Body()))
+            .Done();
+    }
 }
 
 
@@ -2099,7 +2148,8 @@ TExprBase KqpRewriteTakeOverIndexRead(const TExprBase& node, TExprContext& ctx, 
     const auto& implTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, implTable->Name);
 
     TVector<TString> extraColumns;
-    if (maybeFlatMap && !CanPushFlatMap(maybeFlatMap.Cast(), implTableDesc, parentsMap, extraColumns))
+    bool hasResidual = true && maybeFlatMap;
+    if (maybeFlatMap && !CanPushFlatMap(maybeFlatMap.Cast(), implTableDesc, parentsMap, extraColumns, hasResidual))
         return node;
 
     auto filter = [&](const TExprBase& in) mutable {
@@ -2107,17 +2157,53 @@ TExprBase KqpRewriteTakeOverIndexRead(const TExprBase& node, TExprContext& ctx, 
 
         if (maybeFlatMap)
         {
-            takeChild = Build<TCoFlatMap>(ctx, node.Pos())
-                .Input(in)
-                .Lambda(ctx.DeepCopyLambda(maybeFlatMap.Lambda().Ref()))
-                .Done();
+            auto flatMap = maybeFlatMap.Cast();
+            if (!hasResidual) {
+                takeChild = Build<TCoFlatMap>(ctx, node.Pos())
+                    .Input(in)
+                    .Lambda(ctx.DeepCopyLambda(flatMap.Lambda().Ref()))
+                    .Done();
+            } else {
+                TNodeOnNodeOwnedMap replaces;
+                YQL_ENSURE(flatMap.Lambda().Body().Maybe<TCoConditionalValueBase>());
+                replaces.emplace(flatMap.Lambda().Body().Maybe<TCoConditionalValueBase>().Value().Raw(), flatMap.Lambda().Args().Arg(0).Ptr());
+
+                auto newLambdaBody = TCoLambda{ctx.NewLambda(
+                    flatMap.Lambda().Pos(),
+                    std::move(flatMap.Lambda().Args().Ptr()),
+                    ctx.ReplaceNodes(TExprNode::TListType{flatMap.Lambda().Body().Ptr()}, replaces))};
+
+                takeChild = Build<TCoFlatMap>(ctx, node.Pos())
+                    .Input(in)
+                    .Lambda(NewLambdaFrom(ctx, flatMap.Lambda().Pos(), replaces, flatMap.Lambda().Args().Ref(), newLambdaBody.Body()))
+                    .Done();
+            }
         }
 
         // Change input for TCoTake. New input is result of TKqlReadTable.
         return TExprBase(ctx.ChangeChild(*node.Ptr(), 0, takeChild.Ptr()));
     };
 
-    return DoRewriteIndexRead(readTableIndex, ctx, tableDesc, implTable, extraColumns, filter);
+    if (!hasResidual) {
+        return DoRewriteIndexRead(readTableIndex, ctx, tableDesc, implTable, extraColumns, filter);
+    } else {
+        auto flatMap = maybeFlatMap.Cast();
+        auto newRead = DoRewriteIndexRead(readTableIndex, ctx, tableDesc, implTable, extraColumns, filter);
+        TNodeOnNodeOwnedMap replaces;
+        YQL_ENSURE(flatMap.Lambda().Body().Maybe<TCoConditionalValueBase>());
+        replaces.emplace(flatMap.Lambda().Body().Raw(), flatMap.Lambda().Body().Cast<TCoConditionalValueBase>().Value().Ptr());
+
+        auto newLambdaBody = TCoLambda{ctx.NewLambda(
+            flatMap.Lambda().Pos(),
+            std::move(flatMap.Lambda().Args().Ptr()),
+            ctx.ReplaceNodes(TExprNode::TListType{flatMap.Lambda().Body().Ptr()}, replaces))};
+
+        return Build<TCoMap>(ctx, node.Pos())
+            .Input(newRead)
+            .Lambda(NewLambdaFrom(ctx, flatMap.Lambda().Pos(), replaces, flatMap.Lambda().Args().Ref(), newLambdaBody.Body()))
+            .Done();
+
+    }
 }
 
 } // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_ranges_predext.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_ranges_predext.cpp
@@ -245,22 +245,12 @@ struct TIndexComparisonKey {
 
 };
 
-TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
+TMaybe<std::pair<TExprBase, TExprNode::TPtr>> BuildNewRead(TCoFlatMapBase flatmap, TExprBase maybeReadTableNode,  TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
     TTypeAnnotationContext& typesCtx, const NYql::TParentsMap& parentsMap)
 {
-    if (!node.Maybe<TCoFlatMapBase>()) {
-        return node;
-    }
-
-    auto flatmap = node.Cast<TCoFlatMapBase>();
-
-    if (!IsPredicateFlatMap(flatmap.Lambda().Body().Ref())) {
-        return node;
-    }
-
-    auto readMatch = MatchRead<TKqlReadTableRangesBase>(flatmap.Input());
+    auto readMatch = MatchRead<TKqlReadTableRangesBase>(maybeReadTableNode);
     if (!readMatch) {
-        return node;
+        return {};
     }
 
     static const std::set<TStringBuf> supportedReads {
@@ -269,11 +259,11 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
     };
 
     if (!supportedReads.contains(readMatch->Read.Cast<TKqlReadTableRangesBase>().CallableName())) {
-        return node;
+        return {};
     }
 
     if (readMatch->FlatMap) {
-        return node;
+        return {};
     }
 
     auto read = readMatch->Read.Cast<TKqlReadTableRangesBase>();
@@ -285,11 +275,11 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
     auto predicateExtractSetting = kqpCtx.Config->GetOptPredicateExtract();
 
     if (predicateExtractSetting == EOptionalFlag::Disabled) {
-        return node;
+        return {};
     }
 
     if (!read.Ranges().Maybe<TCoVoid>()) {
-        return node;
+        return {};
     }
 
     TMaybeNode<TCoAtom> indexName;
@@ -435,7 +425,7 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
     TExprNode::TPtr ranges = buildResult.ComputeNode;
 
     if (!ranges) {
-        return node;
+        return {};
     }
 
     TExprNode::TPtr prefixPointsExpr;
@@ -488,21 +478,21 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
                 if (indexName) {
                     TKqpStreamLookupSettings settings;
                     settings.Strategy = EStreamLookupStrategyType::LookupRows;
-                    result = Build<TKqlStreamLookupIndex>(ctx, node.Pos())
+                    result = Build<TKqlStreamLookupIndex>(ctx, flatmap.Pos())
                         .Table(read.Table())
                         .Columns(read.Columns())
                         .LookupKeys(keys)
                         .Index(indexName.Cast())
-                        .Settings(settings.BuildNode(ctx, node.Pos()))
+                        .Settings(settings.BuildNode(ctx, flatmap.Pos()))
                         .Done();
                 } else {
                     TKqpStreamLookupSettings settings;
                     settings.Strategy = EStreamLookupStrategyType::LookupRows;
-                    result = Build<TKqlStreamLookupTable>(ctx, node.Pos())
+                    result = Build<TKqlStreamLookupTable>(ctx, flatmap.Pos())
                         .Table(read.Table())
                         .Columns(read.Columns())
                         .LookupKeys(keys)
-                        .Settings(settings.BuildNode(ctx, node.Pos()))
+                        .Settings(settings.BuildNode(ctx, flatmap.Pos()))
                         .Done();
                 }
             };
@@ -514,14 +504,14 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
             if (ispoint && tableDesc.Metadata->Kind != EKikimrTableKind::SysView) {
                 TVector<TExprBase> structMembers;
                 for (size_t i = 0; i < tableDesc.Metadata->KeyColumnNames.size(); ++i) {
-                    auto member = Build<TCoNameValueTuple>(ctx, node.Pos())
+                    auto member = Build<TCoNameValueTuple>(ctx, flatmap.Pos())
                         .Name().Build(tableDesc.Metadata->KeyColumnNames[i])
                         .Value(buildResult.LiteralRange->Left.Columns[i])
                         .Done();
 
                     structMembers.push_back(member);
                 }
-                TExprBase keys = Build<TCoAsList>(ctx, node.Pos())
+                TExprBase keys = Build<TCoAsList>(ctx, flatmap.Pos())
                     .Add<TCoAsStruct>()
                         .Add(structMembers)
                         .Build()
@@ -614,17 +604,70 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
                 .Done();
         }
     }
-
     *input = readMatch->BuildProcessNodes(*input, ctx);
+    return std::make_pair(*input, residualLambda);
+}
+
+
+TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
+    TTypeAnnotationContext& typesCtx, const NYql::TParentsMap& parentsMap)
+{
+    if (!node.Maybe<TCoFlatMapBase>()) {
+        return node;
+    }
+
+    auto flatmap = node.Cast<TCoFlatMapBase>();
+
+    if (!IsPredicateFlatMap(flatmap.Lambda().Body().Ref())) {
+        return node;
+    }
+
+    if (flatmap.Input().Maybe<TCoExtend>()) {
+        auto extend = flatmap.Input().Cast<TCoExtend>();
+
+        if (!IsSingleConsumer(extend, parentsMap)) {
+            return node;
+        }
+
+        TVector<TExprBase> individualReads;
+        for(const auto& arg: extend) {
+            auto result = BuildNewRead(flatmap, arg, ctx, kqpCtx, typesCtx, parentsMap);
+            if (!result) {
+                result = {arg, flatmap.Lambda().Ptr()};
+            }
+
+            if (node.Maybe<TCoFlatMap>()) {
+                individualReads.push_back(Build<TCoFlatMap>(ctx, node.Pos())
+                    .Input(result->first)
+                    .Lambda(result->second)
+                    .Done());
+            } else {
+                individualReads.push_back(Build<TCoOrderedFlatMap>(ctx, node.Pos())
+                    .Input(result->first)
+                    .Lambda(result->second)
+                    .Done());
+            }
+        }
+
+        return Build<TCoExtend>(ctx, node.Pos())
+            .Add(individualReads)
+            .Done();
+    }
+
+    auto result = BuildNewRead(flatmap, flatmap.Input(), ctx, kqpCtx, typesCtx, parentsMap);
+    if (!result) {
+        return node;
+    }
+
     if (node.Maybe<TCoFlatMap>()) {
         return Build<TCoFlatMap>(ctx, node.Pos())
-            .Input(*input)
-            .Lambda(residualLambda)
+            .Input(result->first)
+            .Lambda(result->second)
             .Done();
     } else {
         return Build<TCoOrderedFlatMap>(ctx, node.Pos())
-            .Input(*input)
-            .Lambda(residualLambda)
+            .Input(result->first)
+            .Lambda(result->second)
             .Done();
     }
 }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_rules.h
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_rules.h
@@ -57,6 +57,9 @@ NYql::NNodes::TExprBase KqpRewriteTopSortOverFlatMap(const NYql::NNodes::TExprBa
 NYql::NNodes::TExprBase KqpRewriteTakeOverIndexRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext&,
     const TKqpOptimizeContext& kqpCtx, const NYql::TParentsMap& parentsMap);
 
+NYql::NNodes::TExprBase KqpRewriteFlatMapOverIndexRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext&,
+    const TKqpOptimizeContext& kqpCtx, const NYql::TParentsMap& parentsMap);
+
 NYql::NNodes::TExprBase KqpDeleteOverLookup(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx,
     const TKqpOptimizeContext &kqpCtx, const NYql::TParentsMap& parentsMap);
 

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_multishard_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_multishard_ut.cpp
@@ -2545,6 +2545,12 @@ Y_UNIT_TEST_SUITE(KqpMultishardIndex) {
             LIMIT 2;
         )");
 
+        {
+            auto explainResult = session.ExplainDataQuery(query).GetValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+            Cerr << "CheckPushTopSort AST: " << explainResult.GetAst() << Endl;
+        }
+
         NYdb::NTable::TExecDataQuerySettings execSettings;
         execSettings.CollectQueryStats(ECollectQueryStatsMode::Basic);
         auto result = session.ExecuteDataQuery(
@@ -2552,6 +2558,8 @@ Y_UNIT_TEST_SUITE(KqpMultishardIndex) {
                 TTxControl::BeginTx().CommitTx(),
                 execSettings)
             .ExtractValueSync();
+
+        
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         AssertTableStats(result, "/Root/MultiShardIndexedWithDataColumn", {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -6944,6 +6944,413 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
         }
     }
 
+    Y_UNIT_TEST(SimpleViewAutoSelectIndex) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/orders` (
+                id Uint32,
+                name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        auto upsertResult = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/orders` (id, name) VALUES
+                (1u, "Alice"),
+                (2u, "Bob"),
+                (3u, "Alice"),
+                (4u, "Charlie");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult.IsSuccess(), upsertResult.GetIssues().ToString());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE VIEW `/Root/simple_view` WITH (security_invoker = TRUE) AS
+                SELECT * FROM `/Root/orders`;
+        )").GetValueSync());
+
+        {
+            auto explainResult = session.ExplainDataQuery(R"(
+                SELECT * FROM `/Root/simple_view` WHERE name = 'Alice';
+            )").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+            Cerr << "Plan: " << explainResult.GetPlan() << Endl;
+
+            NJson::TJsonValue plan;
+            NJson::ReadJsonTree(explainResult.GetPlan(), &plan, true);
+            auto indexAccess = CountPlanNodesByKv(plan, "Table", "orders/idx_name/indexImplTable");
+            UNIT_ASSERT_VALUES_EQUAL_C(indexAccess, 1,
+                "Expected auto-select index through simple view, plan: " << explainResult.GetPlan());
+        }
+
+        {
+            auto result = session.ExecuteDataQuery(R"(
+                SELECT id, name FROM `/Root/simple_view` WHERE name = 'Alice' ORDER BY id;
+            )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([[[1u];["Alice"]];[[3u];["Alice"]]])",
+                FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(UnionAllViewAutoSelectIndex) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/orders1` (
+                id Uint32,
+                name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/orders2` (
+                id Uint32,
+                name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        auto upsertResult1 = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/orders1` (id, name) VALUES
+                (1u, "Alice"),
+                (2u, "Bob");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult1.IsSuccess(), upsertResult1.GetIssues().ToString());
+
+        auto upsertResult2 = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/orders2` (id, name) VALUES
+                (3u, "Alice"),
+                (4u, "Charlie");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult2.IsSuccess(), upsertResult2.GetIssues().ToString());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE VIEW `/Root/all_orders` WITH (security_invoker = TRUE) AS
+                SELECT * FROM `/Root/orders1`
+                UNION ALL
+                SELECT * FROM `/Root/orders2`;
+        )").GetValueSync());
+
+        {
+            auto explainResult = session.ExplainDataQuery(R"(
+                SELECT * FROM `/Root/all_orders` WHERE name = 'Alice';
+            )").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+            Cerr << "Plan: " << explainResult.GetPlan() << Endl;
+
+            NJson::TJsonValue plan;
+            NJson::ReadJsonTree(explainResult.GetPlan(), &plan, true);
+
+            auto indexAccess1 = CountPlanNodesByKv(plan, "Table", "orders1/idx_name/indexImplTable");
+            UNIT_ASSERT_VALUES_EQUAL_C(indexAccess1, 1,
+                "Expected auto-select index for orders1 through union view, plan: " << explainResult.GetPlan());
+
+            auto indexAccess2 = CountPlanNodesByKv(plan, "Table", "orders2/idx_name/indexImplTable");
+            UNIT_ASSERT_VALUES_EQUAL_C(indexAccess2, 1,
+                "Expected auto-select index for orders2 through union view, plan: " << explainResult.GetPlan());
+        }
+
+        {
+            auto result = session.ExecuteDataQuery(R"(
+                SELECT id, name FROM `/Root/all_orders` WHERE name = 'Alice' ORDER BY id;
+            )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([[[1u];["Alice"]];[[3u];["Alice"]]])",
+                FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(UnionAllViewPartialAutoSelectIndex) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/orders_indexed` (
+                id Uint32,
+                name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/orders_no_index` (
+                id Uint32,
+                name Utf8,
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        auto upsertResult1 = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/orders_indexed` (id, name) VALUES
+                (1u, "Alice"),
+                (2u, "Bob");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult1.IsSuccess(), upsertResult1.GetIssues().ToString());
+
+        auto upsertResult2 = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/orders_no_index` (id, name) VALUES
+                (3u, "Alice"),
+                (4u, "Charlie");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult2.IsSuccess(), upsertResult2.GetIssues().ToString());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE VIEW `/Root/mixed_orders` WITH (security_invoker = TRUE) AS
+                SELECT * FROM `/Root/orders_indexed`
+                UNION ALL
+                SELECT * FROM `/Root/orders_no_index`;
+        )").GetValueSync());
+
+        {
+            auto explainResult = session.ExplainDataQuery(R"(
+                SELECT * FROM `/Root/mixed_orders` WHERE name = 'Alice';
+            )").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+            Cerr << "Plan: " << explainResult.GetPlan() << Endl;
+
+            NJson::TJsonValue plan;
+            NJson::ReadJsonTree(explainResult.GetPlan(), &plan, true);
+
+            auto indexAccess = CountPlanNodesByKv(plan, "Table", "orders_indexed/idx_name/indexImplTable");
+            UNIT_ASSERT_VALUES_EQUAL_C(indexAccess, 1,
+                "Expected auto-select index for orders_indexed, plan: " << explainResult.GetPlan());
+
+            auto fullScan = CountPlanNodesByKv(plan, "Table", "orders_no_index");
+            UNIT_ASSERT_VALUES_EQUAL_C(fullScan, 1,
+                "Expected full scan for orders_no_index (no index available), plan: " << explainResult.GetPlan());
+        }
+
+        {
+            auto result = session.ExecuteDataQuery(R"(
+                SELECT id, name FROM `/Root/mixed_orders` WHERE name = 'Alice' ORDER BY id;
+            )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([[[1u];["Alice"]];[[3u];["Alice"]]])",
+                FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(UnionAllViewMixedPushdown) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/t1` (
+                id Uint32, name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE `/Root/t2` (
+                id Uint32, name Utf8,
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE `/Root/t3` (
+                id Uint32, name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE `/Root/t4` (
+                id Uint32, name Utf8, status Utf8,
+                INDEX idx_status GLOBAL ON (status),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        auto upsert = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/t1` (id, name) VALUES (1u, "Alice"), (2u, "Bob");
+            UPSERT INTO `/Root/t2` (id, name) VALUES (3u, "Alice"), (4u, "Eve");
+            UPSERT INTO `/Root/t3` (id, name) VALUES (5u, "Alice"), (6u, "Charlie");
+            UPSERT INTO `/Root/t4` (id, name, status) VALUES (7u, "Alice", "active"), (8u, "Dan", "inactive");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsert.IsSuccess(), upsert.GetIssues().ToString());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE VIEW `/Root/v_all` WITH (security_invoker = TRUE) AS
+                SELECT id, name FROM `/Root/t1`
+                UNION ALL
+                SELECT id, name FROM `/Root/t2`
+                UNION ALL
+                SELECT id, name FROM `/Root/t3`
+                UNION ALL
+                SELECT id, name FROM `/Root/t4`;
+        )").GetValueSync());
+
+        {
+            auto explainResult = session.ExplainDataQuery(R"(
+                SELECT * FROM `/Root/v_all` WHERE name = 'Alice';
+            )").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+            Cerr << "Plan: " << explainResult.GetPlan() << Endl;
+
+            NJson::TJsonValue plan;
+            NJson::ReadJsonTree(explainResult.GetPlan(), &plan, true);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "t1/idx_name/indexImplTable"), 1,
+                "t1 has idx_name — should use index, plan: " << explainResult.GetPlan());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "t3/idx_name/indexImplTable"), 1,
+                "t3 has idx_name — should use index, plan: " << explainResult.GetPlan());
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "t2"), 1,
+                "t2 has no index on name — should full scan, plan: " << explainResult.GetPlan());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "t4"), 1,
+                "t4 has index on status not name — should full scan, plan: " << explainResult.GetPlan());
+        }
+
+        {
+            auto result = session.ExecuteDataQuery(R"(
+                SELECT id, name FROM `/Root/v_all` WHERE name = 'Alice' ORDER BY id;
+            )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([[[1u];["Alice"]];[[3u];["Alice"]];[[5u];["Alice"]];[[7u];["Alice"]]])",
+                FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(UnionAllMultiConsumerSkipsPushdown) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/o1` (
+                id Uint32, name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE `/Root/o2` (
+                id Uint32, name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        auto upsert = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/o1` (id, name) VALUES (1u, "Alice"), (2u, "Bob");
+            UPSERT INTO `/Root/o2` (id, name) VALUES (3u, "Alice"), (4u, "Charlie");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsert.IsSuccess(), upsert.GetIssues().ToString());
+
+        const TString query = R"(
+            $sub = SELECT id, name FROM `/Root/o1`
+                   UNION ALL
+                   SELECT id, name FROM `/Root/o2`;
+            SELECT id, name FROM (
+                SELECT id, name FROM $sub WHERE name = 'Alice'
+                UNION ALL
+                SELECT id, name FROM $sub WHERE name = 'Bob'
+            ) ORDER BY id;
+        )";
+
+        {
+            auto explainResult = session.ExplainDataQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+            Cerr << "Plan: " << explainResult.GetPlan() << Endl;
+
+            NJson::TJsonValue plan;
+            NJson::ReadJsonTree(explainResult.GetPlan(), &plan, true);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "o1/idx_name/indexImplTable"), 0,
+                "Multi-consumer Extend should skip index pushdown for o1, plan: " << explainResult.GetPlan());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "o2/idx_name/indexImplTable"), 0,
+                "Multi-consumer Extend should skip index pushdown for o2, plan: " << explainResult.GetPlan());
+        }
+
+        {
+            auto result = session.ExecuteDataQuery(query,
+                TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([[[1u];["Alice"]];[[2u];["Bob"]];[[3u];["Alice"]]])",
+                FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(TopSortOverExtendAutoSelectIndex) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/t1` (
+                id Uint32, name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE `/Root/t2` (
+                id Uint32, name Utf8,
+                INDEX idx_name GLOBAL ON (name),
+                PRIMARY KEY (id)
+            );
+        )").GetValueSync());
+
+        auto upsert = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/t1` (id, name) VALUES
+                (1u, "Alice"), (2u, "Bob"), (3u, "Charlie"), (4u, "Dan");
+            UPSERT INTO `/Root/t2` (id, name) VALUES
+                (5u, "Alice"), (6u, "Eve"), (7u, "Bob"), (8u, "Frank");
+        )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(upsert.IsSuccess(), upsert.GetIssues().ToString());
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE VIEW `/Root/v_union` WITH (security_invoker = TRUE) AS
+                SELECT id, name FROM `/Root/t1`
+                UNION ALL
+                SELECT id, name FROM `/Root/t2`;
+        )").GetValueSync());
+
+        {
+            auto explainResult = session.ExplainDataQuery(R"(
+                SELECT id, name FROM `/Root/v_union`
+                ORDER BY name
+                LIMIT 3;
+            )").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+            Cerr << "Plan: " << explainResult.GetPlan() << Endl;
+
+            NJson::TJsonValue plan;
+            NJson::ReadJsonTree(explainResult.GetPlan(), &plan, true);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "t1/idx_name/indexImplTable"), 1,
+                "Expected index auto-select for t1 with TopSort, plan: " << explainResult.GetPlan());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                CountPlanNodesByKv(plan, "Table", "t2/idx_name/indexImplTable"), 1,
+                "Expected index auto-select for t2 with TopSort, plan: " << explainResult.GetPlan());
+
+            auto limitNode = FindPlanNodeByKv(plan, "Node Type", "Limit");
+            UNIT_ASSERT_C(limitNode.IsDefined(),
+                "Expected Limit node in plan for LIMIT pushdown, plan: " << explainResult.GetPlan());
+        }
+
+        {
+            auto result = session.ExecuteDataQuery(R"(
+                SELECT id, name FROM `/Root/v_union`
+                ORDER BY name, id
+                LIMIT 3;
+            )", TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([[[1u];["Alice"]];[[5u];["Alice"]];[[2u];["Bob"]]])",
+                FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
 }
 }
 }

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -6515,6 +6515,435 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
         }
     }
 
+    Y_UNIT_TEST(CoveringIndexFilterBeforeLookupWithLeftJoin) {
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings().SetKqpSettings({setting});
+        TKikimrRunner kikimr(serverSettings);
+
+        auto queryClient = kikimr.GetQueryClient();
+
+        {
+            const TString createMainTableSql(R"(
+                CREATE TABLE `/Root/MainTable` (
+                    id Utf8 NOT NULL,
+                    ts Timestamp,
+                    code Utf8,
+                    val1 Decimal(22, 9),
+                    val2 Decimal(22, 9),
+                    val3 Decimal(22, 9),
+                    fk_id Utf8,
+                    PRIMARY KEY (id),
+                    INDEX idx_ts GLOBAL SYNC ON (ts)
+                    COVER (code, val1)
+                );
+            )");
+            auto result = queryClient.ExecuteQuery(
+                createMainTableSql, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const TString createLookupTableSql(R"(
+                CREATE TABLE `/Root/LookupTable` (
+                    id Utf8 NOT NULL,
+                    payload Utf8,
+                    PRIMARY KEY (id)
+                );
+            )");
+            auto result = queryClient.ExecuteQuery(
+                createLookupTableSql, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const TString upsertMainSql(Q_(R"(
+                UPSERT INTO `/Root/MainTable` (id, ts, code, val1, val2, val3, fk_id) VALUES
+                    ('d1'u, Timestamp('2026-01-26T10:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('100', 22, 9), Decimal('200', 22, 9), 'f1'u),
+                    ('d2'u, Timestamp('2026-01-26T11:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('150', 22, 9), Decimal('250', 22, 9), 'f2'u),
+                    ('d3'u, Timestamp('2026-01-26T12:00:00.000000Z'), 'AAA'u, Decimal('2', 22, 9), Decimal('300', 22, 9), Decimal('400', 22, 9), 'f1'u),
+                    ('d4'u, Timestamp('2026-01-27T08:00:00.000000Z'), 'BBB'u, Decimal('1', 22, 9), Decimal('500', 22, 9), Decimal('600', 22, 9), 'f1'u),
+                    ('d5'u, Timestamp('2025-12-01T00:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('700', 22, 9), Decimal('800', 22, 9), 'f1'u),
+                    ('d6'u, Timestamp('2026-01-26T15:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('900', 22, 9), Decimal('950', 22, 9), NULL);
+            )"));
+            auto result = queryClient.ExecuteQuery(
+                upsertMainSql,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const TString upsertLookupSql(Q_(R"(
+                UPSERT INTO `/Root/LookupTable` (id, payload) VALUES
+                    ('f1'u, 'One'u),
+                    ('f2'u, 'Two'u);
+            )"));
+            auto result = queryClient.ExecuteQuery(
+                upsertLookupSql,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        const TString query(Q_(R"(
+            SELECT t.id, t.code, t.val1, t.val2, t.val3
+            FROM `/Root/MainTable` VIEW idx_ts AS t
+            LEFT JOIN `/Root/LookupTable` AS l ON l.id = t.fk_id
+            WHERE t.ts >= Timestamp('2026-01-26T00:00:00.000000Z')
+              AND t.code = 'AAA'
+              AND t.val1 = Decimal('1', 22, 9)
+            LIMIT 10
+        )"));
+
+        {
+            auto explainSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .ExecMode(NYdb::NQuery::EExecMode::Explain);
+
+            auto explainResult = queryClient.ExecuteQuery(
+                query, NYdb::NQuery::TTxControl::NoTx(), explainSettings).ExtractValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+
+            UNIT_ASSERT(explainResult.GetStats());
+            auto ast = explainResult.GetStats()->GetAst();
+            UNIT_ASSERT(ast);
+            Cerr << "AST: " << *ast << Endl;
+
+            auto plan = explainResult.GetStats()->GetPlan();
+            UNIT_ASSERT(plan);
+            Cerr << "Plan: " << *plan << Endl;
+
+            NJson::TJsonValue planJson;
+            NJson::ReadJsonTree(*plan, &planJson, true);
+
+            auto indexAccess = CountPlanNodesByKv(planJson, "Table", "MainTable/idx_ts/indexImplTable");
+            UNIT_ASSERT_C(indexAccess > 0, "Expected access to index table idx_ts");
+        }
+
+        {
+            auto execSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+            auto result = queryClient.ExecuteQuery(
+                query,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+                execSettings)
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            auto yson = NYdb::FormatResultSetYson(result.GetResultSet(0));
+            Cerr << "Result: " << yson << Endl;
+
+            {
+                TResultSetParser parser(result.GetResultSet(0));
+                TSet<TString> ids;
+                while (parser.TryNextRow()) {
+                    ids.insert(TString(parser.ColumnParser(0).GetUtf8()));
+                }
+                UNIT_ASSERT_VALUES_EQUAL(ids.size(), 3u);
+                UNIT_ASSERT_C(ids.contains("d1"), "Expected id 'd1' in results");
+                UNIT_ASSERT_C(ids.contains("d2"), "Expected id 'd2' in results");
+                UNIT_ASSERT_C(ids.contains("d6"), "Expected id 'd6' in results");
+            }
+
+            auto& stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
+            ui64 mainTableReads = 0;
+            ui64 indexTableReads = 0;
+            for (const auto& phase : stats.query_phases()) {
+                for (const auto& access : phase.table_access()) {
+                    Cerr << "Table: " << access.name()
+                         << " reads: " << access.reads().rows()
+                         << " updates: " << access.updates().rows() << Endl;
+                    if (access.name() == "/Root/MainTable" && access.reads().rows() > 0) {
+                        mainTableReads += access.reads().rows();
+                    }
+                    if (access.name() == "/Root/MainTable/idx_ts/indexImplTable" && access.reads().rows() > 0) {
+                        indexTableReads += access.reads().rows();
+                    }
+                }
+            }
+            UNIT_ASSERT_C(indexTableReads > 0, "Expected reads from the index table");
+            UNIT_ASSERT_C(indexTableReads > mainTableReads,
+                "Index table should read at least as many rows as main table (filter narrows results before lookup). "
+                "Index reads: " << indexTableReads << ", main table reads: " << mainTableReads);
+        }
+    }
+
+    Y_UNIT_TEST(TopSortOnNonCoveredColumnPreservesIndexFilter) {
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings().SetKqpSettings({setting});
+        TKikimrRunner kikimr(serverSettings);
+
+        auto queryClient = kikimr.GetQueryClient();
+
+        {
+            auto result = queryClient.ExecuteQuery(R"(
+                CREATE TABLE `/Root/MainTable` (
+                    id Utf8 NOT NULL,
+                    ts Timestamp,
+                    code Utf8,
+                    val1 Decimal(22, 9),
+                    val2 Decimal(22, 9),
+                    val3 Decimal(22, 9),
+                    fk_id Utf8,
+                    PRIMARY KEY (id),
+                    INDEX idx_ts GLOBAL SYNC ON (ts)
+                    COVER (code, val1)
+                );
+            )", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto result = queryClient.ExecuteQuery(R"(
+                CREATE TABLE `/Root/LookupTable` (
+                    id Utf8 NOT NULL,
+                    payload Utf8,
+                    PRIMARY KEY (id)
+                );
+            )", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto result = queryClient.ExecuteQuery(Q_(R"(
+                UPSERT INTO `/Root/MainTable` (id, ts, code, val1, val2, val3, fk_id) VALUES
+                    ('d1'u, Timestamp('2026-01-26T10:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('100', 22, 9), Decimal('200', 22, 9), 'f1'u),
+                    ('d2'u, Timestamp('2026-01-26T11:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('150', 22, 9), Decimal('250', 22, 9), 'f2'u),
+                    ('d3'u, Timestamp('2026-01-26T12:00:00.000000Z'), 'AAA'u, Decimal('2', 22, 9), Decimal('300', 22, 9), Decimal('400', 22, 9), 'f1'u),
+                    ('d4'u, Timestamp('2026-01-27T08:00:00.000000Z'), 'BBB'u, Decimal('1', 22, 9), Decimal('500', 22, 9), Decimal('600', 22, 9), 'f1'u),
+                    ('d5'u, Timestamp('2025-12-01T00:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('700', 22, 9), Decimal('800', 22, 9), 'f1'u),
+                    ('d6'u, Timestamp('2026-01-26T15:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('900', 22, 9), Decimal('950', 22, 9), NULL);
+            )"),
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto result = queryClient.ExecuteQuery(Q_(R"(
+                UPSERT INTO `/Root/LookupTable` (id, payload) VALUES
+                    ('f1'u, 'One'u),
+                    ('f2'u, 'Two'u);
+            )"),
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        const TString query(Q_(R"(
+            SELECT t.id, t.code, t.val1, t.val2, t.val3
+            FROM `/Root/MainTable` VIEW idx_ts AS t
+            LEFT JOIN `/Root/LookupTable` AS l ON l.id = t.fk_id
+            WHERE t.ts >= Timestamp('2026-01-26T00:00:00.000000Z')
+              AND t.code = 'AAA'
+              AND t.val1 = Decimal('1', 22, 9)
+            ORDER BY t.val2
+            LIMIT 10
+        )"));
+
+        {
+            auto explainSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .ExecMode(NYdb::NQuery::EExecMode::Explain);
+
+            auto explainResult = queryClient.ExecuteQuery(
+                query, NYdb::NQuery::TTxControl::NoTx(), explainSettings).ExtractValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+
+            UNIT_ASSERT(explainResult.GetStats());
+            auto ast = explainResult.GetStats()->GetAst();
+            UNIT_ASSERT(ast);
+            Cerr << "AST: " << *ast << Endl;
+
+            auto plan = explainResult.GetStats()->GetPlan();
+            UNIT_ASSERT(plan);
+            Cerr << "Plan: " << *plan << Endl;
+
+            NJson::TJsonValue planJson;
+            NJson::ReadJsonTree(*plan, &planJson, true);
+
+            auto indexAccess = CountPlanNodesByKv(planJson, "Table", "MainTable/idx_ts/indexImplTable");
+            UNIT_ASSERT_C(indexAccess > 0, "Expected access to index table idx_ts");
+        }
+
+        {
+            auto execSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+            auto result = queryClient.ExecuteQuery(
+                query,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+                execSettings)
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            auto yson = NYdb::FormatResultSetYson(result.GetResultSet(0));
+            Cerr << "Result: " << yson << Endl;
+
+            {
+                TResultSetParser parser(result.GetResultSet(0));
+                TVector<TString> ids;
+                while (parser.TryNextRow()) {
+                    ids.push_back(TString(parser.ColumnParser(0).GetUtf8()));
+                }
+                UNIT_ASSERT_VALUES_EQUAL(ids.size(), 3u);
+                UNIT_ASSERT_VALUES_EQUAL(ids[0], "d1");
+                UNIT_ASSERT_VALUES_EQUAL(ids[1], "d2");
+                UNIT_ASSERT_VALUES_EQUAL(ids[2], "d6");
+            }
+
+            auto& stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
+            ui64 mainTableReads = 0;
+            ui64 indexTableReads = 0;
+            for (const auto& phase : stats.query_phases()) {
+                for (const auto& access : phase.table_access()) {
+                    Cerr << "Table: " << access.name()
+                         << " reads: " << access.reads().rows()
+                         << " updates: " << access.updates().rows() << Endl;
+                    if (access.name() == "/Root/MainTable" && access.reads().rows() > 0) {
+                        mainTableReads += access.reads().rows();
+                    }
+                    if (access.name() == "/Root/MainTable/idx_ts/indexImplTable" && access.reads().rows() > 0) {
+                        indexTableReads += access.reads().rows();
+                    }
+                }
+            }
+            UNIT_ASSERT_C(indexTableReads > 0, "Expected reads from the index table");
+            UNIT_ASSERT_C(indexTableReads > mainTableReads,
+                "Filter on covered columns (code, val1) should be pushed to index before lookup, "
+                "even when ORDER BY is on a non-covered column (val2). "
+                "Index reads: " << indexTableReads << ", main table reads: " << mainTableReads);
+        }
+    }
+
+    Y_UNIT_TEST(TakePushedBeforeLookupOnCoveringIndex) {
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings().SetKqpSettings({setting});
+        TKikimrRunner kikimr(serverSettings);
+
+        auto queryClient = kikimr.GetQueryClient();
+
+        {
+            auto result = queryClient.ExecuteQuery(R"(
+                CREATE TABLE `/Root/MainTable` (
+                    id Utf8 NOT NULL,
+                    ts Timestamp,
+                    code Utf8,
+                    val1 Decimal(22, 9),
+                    val2 Decimal(22, 9),
+                    val3 Decimal(22, 9),
+                    fk_id Utf8,
+                    PRIMARY KEY (id),
+                    INDEX idx_ts GLOBAL SYNC ON (ts)
+                    COVER (code, val1)
+                );
+            )", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto result = queryClient.ExecuteQuery(Q_(R"(
+                UPSERT INTO `/Root/MainTable` (id, ts, code, val1, val2, val3, fk_id) VALUES
+                    ('d1'u, Timestamp('2026-01-26T10:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('100', 22, 9), Decimal('200', 22, 9), 'f1'u),
+                    ('d2'u, Timestamp('2026-01-26T11:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('150', 22, 9), Decimal('250', 22, 9), 'f2'u),
+                    ('d3'u, Timestamp('2026-01-26T12:00:00.000000Z'), 'AAA'u, Decimal('2', 22, 9), Decimal('300', 22, 9), Decimal('400', 22, 9), 'f1'u),
+                    ('d4'u, Timestamp('2026-01-27T08:00:00.000000Z'), 'BBB'u, Decimal('1', 22, 9), Decimal('500', 22, 9), Decimal('600', 22, 9), 'f1'u),
+                    ('d5'u, Timestamp('2025-12-01T00:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('700', 22, 9), Decimal('800', 22, 9), 'f1'u),
+                    ('d6'u, Timestamp('2026-01-26T15:00:00.000000Z'), 'AAA'u, Decimal('1', 22, 9), Decimal('900', 22, 9), Decimal('950', 22, 9), NULL);
+            )"),
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        const TString query(Q_(R"(
+            SELECT id, code, val1, val2 AS other_val, val3
+            FROM `/Root/MainTable` VIEW idx_ts
+            WHERE ts >= Timestamp('2026-01-26T00:00:00.000000Z')
+              AND code = 'AAA'
+              AND val1 = Decimal('1', 22, 9)
+            LIMIT 2
+        )"));
+
+        {
+            auto explainSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .ExecMode(NYdb::NQuery::EExecMode::Explain);
+
+            auto explainResult = queryClient.ExecuteQuery(
+                query, NYdb::NQuery::TTxControl::NoTx(), explainSettings).ExtractValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+
+            UNIT_ASSERT(explainResult.GetStats());
+            auto ast = explainResult.GetStats()->GetAst();
+            UNIT_ASSERT(ast);
+            Cerr << "AST: " << *ast << Endl;
+
+            auto plan = explainResult.GetStats()->GetPlan();
+            UNIT_ASSERT(plan);
+            Cerr << "Plan: " << *plan << Endl;
+
+            NJson::TJsonValue planJson;
+            NJson::ReadJsonTree(*plan, &planJson, true);
+
+            auto indexAccess = CountPlanNodesByKv(planJson, "Table", "MainTable/idx_ts/indexImplTable");
+            UNIT_ASSERT_C(indexAccess > 0, "Expected access to index table idx_ts");
+        }
+
+        {
+            auto execSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+            auto result = queryClient.ExecuteQuery(
+                query,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+                execSettings)
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            auto yson = NYdb::FormatResultSetYson(result.GetResultSet(0));
+            Cerr << "Result: " << yson << Endl;
+
+            auto resultSets = result.GetResultSets();
+            UNIT_ASSERT_VALUES_EQUAL(resultSets.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(resultSets[0].RowsCount(), 2u);
+
+            {
+                TResultSetParser parser(result.GetResultSet(0));
+                TSet<TString> ids;
+                while (parser.TryNextRow()) {
+                    ids.insert(TString(parser.ColumnParser(0).GetUtf8()));
+                }
+                UNIT_ASSERT_VALUES_EQUAL(ids.size(), 2u);
+                UNIT_ASSERT_C(ids.contains("d1"), "Expected id 'd1' in results");
+                UNIT_ASSERT_C(ids.contains("d2"), "Expected id 'd2' in results");
+            }
+
+            auto& stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
+            ui64 mainTableReads = 0;
+            ui64 indexTableReads = 0;
+            for (const auto& phase : stats.query_phases()) {
+                for (const auto& access : phase.table_access()) {
+                    Cerr << "Table: " << access.name()
+                         << " reads: " << access.reads().rows()
+                         << " updates: " << access.updates().rows() << Endl;
+                    if (access.name() == "/Root/MainTable" && access.reads().rows() > 0) {
+                        mainTableReads += access.reads().rows();
+                    }
+                    if (access.name() == "/Root/MainTable/idx_ts/indexImplTable" && access.reads().rows() > 0) {
+                        indexTableReads += access.reads().rows();
+                    }
+                }
+            }
+            UNIT_ASSERT_C(indexTableReads > 0, "Expected reads from the index table");
+            UNIT_ASSERT_C(mainTableReads <= 2,
+                "Take (LIMIT) should be pushed before lookup so at most 2 main table reads. "
+                "Got main table reads: " << mainTableReads << ", index reads: " << indexTableReads);
+            UNIT_ASSERT_C(indexTableReads <= 2,
+                "Take (LIMIT) should be pushed to index side, limiting index reads to at most LIMIT rows. "
+                "Column rename of a non-covered column should not prevent Take pushdown. "
+                "Got index reads: " << indexTableReads << ", main table reads: " << mainTableReads);
+        }
+    }
+
 }
 }
 }

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -5311,6 +5311,15 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
         )"), TTxControl::BeginTx().CommitTx(), execSettings).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
+        {
+            const TString q = Q1_(R"(
+                SELECT Fk, Value FROM `/Root/SecondaryKeys` VIEW Index WHERE Fk = CAST(0 AS UInt32) LIMIT 1;
+            )");
+            auto explainResult = session.ExplainDataQuery(q).GetValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+            Cerr << "IndexFilterPushDown AST (query 1): " << explainResult.GetAst() << Endl;
+        }
+
         result = session.ExecuteDataQuery(Q1_(R"(
             SELECT Fk, Value FROM `/Root/SecondaryKeys` VIEW Index WHERE Fk = CAST(0 AS UInt32) LIMIT 1;
         )"), TTxControl::BeginTx().CommitTx(), execSettings).ExtractValueSync();
@@ -6384,6 +6393,126 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
             }
             return false;
         });
+    }
+
+    Y_UNIT_TEST(CoveringIndexFilterBeforeLookup) {
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings().SetKqpSettings({setting});
+        TKikimrRunner kikimr(serverSettings);
+
+        auto queryClient = kikimr.GetQueryClient();
+
+        {
+            const TString createTableSql(R"(
+                CREATE TABLE `/Root/t_main` (
+                    pk_col Text NOT NULL,
+                    ts_col Timestamp,
+                    state_a Text,
+                    state_b Text,
+                    ref_col_1 Text,
+                    ref_col_2 Text,
+                    data_col Text,
+                    PRIMARY KEY (pk_col),
+                    INDEX ix_ts GLOBAL SYNC ON (ts_col)
+                    COVER (state_a, state_b, ref_col_1, ref_col_2)
+                );
+            )");
+            auto result = queryClient.ExecuteQuery(
+                createTableSql, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const TString upsertSql(Q_(R"(
+                UPSERT INTO `/Root/t_main` (pk_col, ts_col, state_a, state_b, ref_col_1, ref_col_2, data_col) VALUES
+                    ('r1'u, Timestamp('2025-01-01T00:00:00.000000Z'), 'A1'u, 'B1'u, 'x1'u, 'y1'u, 'D1'u),
+                    ('r2'u, Timestamp('2025-01-01T00:00:00.000000Z'), 'A1'u, 'B1'u, 'x2'u, 'y2'u, 'D2'u),
+                    ('r3'u, Timestamp('2025-01-01T00:00:00.000000Z'), 'A1'u, 'B2'u, 'x3'u, 'y3'u, 'D3'u),
+                    ('r4'u, Timestamp('2025-01-02T00:00:00.000000Z'), 'A1'u, 'B1'u, 'x4'u, 'y4'u, 'D4'u),
+                    ('r5'u, Timestamp('2025-01-01T00:00:00.000000Z'), 'A2'u, 'B1'u, 'x5'u, 'y5'u, 'D5'u);
+            )"));
+
+            auto result = queryClient.ExecuteQuery(
+                upsertSql,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        const TString query(Q_(R"(
+            SELECT ts_col, state_a, state_b, data_col
+            FROM `/Root/t_main` VIEW ix_ts
+            WHERE ts_col = Timestamp('2025-01-01T00:00:00.000000Z')
+                AND state_a = 'A1'
+                AND state_b = 'B1';
+        )"));
+
+        {
+            auto explainSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .ExecMode(NYdb::NQuery::EExecMode::Explain);
+
+            auto explainResult = queryClient.ExecuteQuery(
+                query, NYdb::NQuery::TTxControl::NoTx(), explainSettings).ExtractValueSync();
+            UNIT_ASSERT_C(explainResult.IsSuccess(), explainResult.GetIssues().ToString());
+
+            UNIT_ASSERT(explainResult.GetStats());
+            auto ast = explainResult.GetStats()->GetAst();
+            UNIT_ASSERT(ast);
+            Cerr << "AST: " << *ast << Endl;
+
+            auto plan = explainResult.GetStats()->GetPlan();
+            UNIT_ASSERT(plan);
+            Cerr << "Plan: " << *plan << Endl;
+
+            NJson::TJsonValue planJson;
+            NJson::ReadJsonTree(*plan, &planJson, true);
+
+            auto filterCount = CountPlanNodesByKv(planJson, "Node Type", "Filter");
+            UNIT_ASSERT_C(filterCount > 0, "Expected Filter node in the plan (filter on covered columns should be pushed before lookup)");
+
+            auto indexAccess = CountPlanNodesByKv(planJson, "Table", "t_main/ix_ts/indexImplTable");
+            UNIT_ASSERT_C(indexAccess > 0, "Expected access to index table ix_ts");
+        }
+
+        {
+            auto execSettings = NYdb::NQuery::TExecuteQuerySettings()
+                .StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+            auto result = queryClient.ExecuteQuery(
+                query,
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+                execSettings)
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            auto yson = NYdb::FormatResultSetYson(result.GetResultSet(0));
+            Cerr << "Result: " << yson << Endl;
+
+            CompareYson(R"([
+                [[1735689600000000u];["A1"];["B1"];["D1"]];
+                [[1735689600000000u];["A1"];["B1"];["D2"]]
+            ])", yson);
+
+            auto& stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
+            ui64 mainTableReads = 0;
+            ui64 indexTableReads = 0;
+            for (const auto& phase : stats.query_phases()) {
+                for (const auto& access : phase.table_access()) {
+                    if (access.name() == "/Root/t_main" && access.reads().rows() > 0) {
+                        mainTableReads += access.reads().rows();
+                    }
+                    if (access.name() == "/Root/t_main/ix_ts/indexImplTable" && access.reads().rows() > 0) {
+                        indexTableReads += access.reads().rows();
+                    }
+                }
+            }
+            UNIT_ASSERT_C(indexTableReads > mainTableReads,
+                "Index table should read more rows than main table (filter narrows results before lookup). "
+                "Index reads: " << indexTableReads << ", main table reads: " << mainTableReads);
+            UNIT_ASSERT_VALUES_EQUAL_C(mainTableReads, 2,
+                "Filter on covered columns must be applied before lookup to main table. "
+                "Expected 2 main table reads (only matching rows), got " << mainTableReads);
+        }
     }
 
 }


### PR DESCRIPTION
## What this is

Backport of the KQP index/stream-lookup optimizer chain from `main` into the new enterprise branch `stable-26-2-1-ent`.

Cherry-picked from `main`, **in this order** (one sequential chain — each commit builds on code introduced by the previous one):

| # | main PR | main commit | title |
|---|---|---|---|
| 1 | [#35402](https://github.com/ydb-platform/ydb/pull/35402) | `f4a7ecee27a17c43b4ba2317a6d066c61c911ffb` | push pure flat map over stream lookup |
| 2 | [#35853](https://github.com/ydb-platform/ydb/pull/35853) | `a52984f48ec36fd8bb137a74541e2e74f8f54012` | intial lambda split over conditional value |
| 3 | [#35952](https://github.com/ydb-platform/ydb/pull/35952) | `35c364d992efdbdda06df93009166eccb0f29c20` | fix index auto selection with flatmap over extend |

All cherry-picked with `-x`, so every commit keeps its `(cherry picked from commit ...)` reference.

## Why it's needed

These changes are already present in `stable-26-1-1-enterprise`, merged there as:
- [#47531](https://github.com/ydb-platform/ydb/pull/47531) — `[26-1-1-ent] push pure flat map over stream lookup`
- [#47533](https://github.com/ydb-platform/ydb/pull/47533) — `[26-1-1-ent] intial lambda split over conditional value (#35853)`
- [#47535](https://github.com/ydb-platform/ydb/pull/47535) — `[26-1-1-ent] fix index auto selection with flatmap over extend + fix co skip pushdown`

`stable-26-2-1-ent` is branched from `stable-26-2-1`, whose last common point with `main` is `7a9ac0ddfc4eb317e10fff717d5e1d4be65fda36` (2026-02-24). All three `main` PRs landed after that (2026-03-05 … 2026-03-16), so they were not inherited naturally.

## Why these three are one PR

They are a dependency chain, not three independent fixes: applying a middle commit alone either conflicts outright or — worse — applies cleanly while referencing a symbol the previous commit introduces, producing a build failure that no textual check catches. Verified here in practice: only commit 1 conflicted; commits 2 and 3 auto-merged cleanly **because** commit 1 was already applied.

## Conflict resolution — please review

One conflict, in `ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp` (commit 1). It was purely additive-vs-additive: this branch had added the `DoTestOnlineDuplicates` helper plus `OnlineDuplicatesStage1..4` tests at the same spot where the PR adds `CoveringIndexFilterBeforeLookup`. Resolution: **kept both** — this branch's four `OnlineDuplicates*` tests are untouched, and the PR's `CoveringIndexFilterBeforeLookup` was appended after them. Whole-file brace balance verified identical to the base branch.

## Notes

Not built or tested locally; opened as draft so CI can verify.

Draft: reviewers to be assigned once CODEOWNERS for this branch is updated (see #50289).
