### PR TITLE
[26-2-1-ent] Backport: Allow to create invalid VIEW during import (#41265)

### DIFF
--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1576,6 +1576,7 @@ private:
             TKqpTranslationSettingsBuilder settingsBuilder(SessionCtx->Query().Type, Cluster, query.Text, SessionCtx->Config().GetYqlBindingsMode(), GUCSettings);
             settingsBuilder.SetSqlAutoCommit(false)
                 .SetUsePgParser(settings.UsePgParser)
+                .SetValidateViewStatement(!settings.IsInternalCall.GetOrElse(false))
                 .SetFromConfig(SessionCtx->Config());
             auto compileResult = CompileYqlQuery(query, /* isSql */ true, ctx, sqlVersion, settingsBuilder);
 

--- a/ydb/core/kqp/host/kqp_translate.cpp
+++ b/ydb/core/kqp/host/kqp_translate.cpp
@@ -287,6 +287,8 @@ NSQLTranslation::TTranslationSettings TKqpTranslationSettingsBuilder::Build(NYql
     settings.ApplicationName = ApplicationName;
     settings.GUCSettings = GUCSettings;
 
+    settings.ValidateViewStatement = ValidateViewStatement;
+
     return settings;
 }
 

--- a/ydb/core/kqp/host/kqp_translate.h
+++ b/ydb/core/kqp/host/kqp_translate.h
@@ -164,6 +164,11 @@ public:
         return IsAmbiguityError;
     }
 
+    TKqpTranslationSettingsBuilder& SetValidateViewStatement(bool value) {
+        ValidateViewStatement = value;
+        return *this;
+    }
+
 private:
     const NYql::EKikimrQueryType QueryType;
     ui16 KqpYqlSyntaxVersion = 1;
@@ -184,6 +189,7 @@ private:
     NYql::TLangVersion LangVer = NYql::MinLangVersion;
     NYql::EBackportCompatibleFeaturesMode BackportMode = NYql::EBackportCompatibleFeaturesMode::Released;
     bool IsAmbiguityError = false;
+    bool ValidateViewStatement = true;
 };
 
 NYql::EKikimrQueryType ConvertType(NKikimrKqp::EQueryType type);

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -204,6 +204,42 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         UNIT_ASSERT_STRING_CONTAINS(creationResult.GetIssues().ToString(), "Error: Cannot divide type String and String");
     }
 
+    void InvalidRef(const char* createTableQuery, const char* selectTableQuery) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        auto session = kikimr.GetQueryClient().GetSession().ExtractValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(createTableQuery, NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), "Failed to CREATE TABLE: " << result.GetIssues().ToOneLineString());
+        }
+        {
+            auto result = session.ExecuteQuery(std::format("CREATE VIEW `View` WITH (security_invoker = true) AS {}", selectTableQuery),
+                NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), "CREATE VIEW executed successfully");
+        }
+    }
+
+    Y_UNIT_TEST(InvalidTableRef) {
+        InvalidRef(
+            "CREATE TABLE `Table` (key Int32, PRIMARY KEY (key))",
+            "SELECT `key` FROM `MissingTable`"
+        );
+    }
+
+    Y_UNIT_TEST(InvalidColumnRef) {
+        InvalidRef(
+            "CREATE TABLE `Table` (key Int32, PRIMARY KEY (key))",
+            "SELECT `MissingColumn` FROM `Table`"
+        );
+    }
+
+    Y_UNIT_TEST(InvalidIndexRef) {
+        InvalidRef(
+            "CREATE TABLE `Table` (key Int32, value Int32, PRIMARY KEY (key), INDEX `Index` GLOBAL ON (value))",
+            "SELECT `value` FROM `Table` VIEW `MissingIndex`"
+        );
+    }
+
     Y_UNIT_TEST(ParsingSecurityInvoker) {
         TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
         auto session = kikimr.GetQueryClient().GetSession().ExtractValueSync().GetSession();

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -10,6 +10,7 @@
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/tablet/resource_broker.h>
 #include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/testlib/actors/wait_events.h>
 #include <ydb/core/testlib/audit_helpers/audit_helper.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_billing_helpers.h>
@@ -5799,7 +5800,64 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         TestGetImport(runtime, txId, "/MyRoot");
     }
 
-    Y_UNIT_TEST(ViewCreationRetry) {
+    Y_UNIT_TEST(ShouldImportInvalidView) {
+        TTestBasicRuntime runtime;
+        auto options = TTestEnvOptions()
+            .RunFakeConfigDispatcher(true)
+            .SetupKqpProxy(true);
+        TTestEnv env(runtime, options);
+        ui64 txId = 100;
+
+        THashMap<TString, TTestDataWithScheme> bucketContent(2);
+        bucketContent.emplace("/table", GenerateTestData(R"(
+            columns {
+                name: "key"
+                type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+        )"));
+        bucketContent.emplace("/view", GenerateTestData(
+            {
+                EPathTypeView,
+                R"(
+                    -- backup root: "/MyRoot"
+                    CREATE VIEW IF NOT EXISTS `view` WITH security_invoker = TRUE AS SELECT missing FROM `table`;
+                )"
+            }
+        ));
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(bucketContent), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        const ui64 importId = ++txId;
+        TestImport(runtime, importId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: "table"
+                destination_path: "/MyRoot/table"
+              }
+              items {
+                source_prefix: "view"
+                destination_path: "/MyRoot/view"
+              }
+            }
+        )", port));
+
+        env.TestWaitNotification(runtime, importId);
+        TestGetImport(runtime, importId, "/MyRoot");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/view"), {
+            NLs::Finished,
+            NLs::IsView
+        });
+    }
+
+    Y_UNIT_TEST(ShouldNotRetryViewCreation) {
         TTestBasicRuntime runtime;
         auto options = TTestEnvOptions()
             .RunFakeConfigDispatcher(true)
@@ -5837,33 +5895,30 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         UNIT_ASSERT(s3Mock.Start());
 
         ui64 tableCreationTxId = 0;
-        TActorId schemeshardActorId;
-        TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction> tableCreationBlocker(runtime,
-            [&](const TEvSchemeShard::TEvModifySchemeTransaction::TPtr& event) {
-                const auto& record = event->Get()->Record;
-                if (record.GetTransaction(0).GetOperationType() == ESchemeOpCreateIndexedTable) {
-                    tableCreationTxId = record.GetTxId();
-                    schemeshardActorId = event->Recipient;
-                    return true;
-                }
+        ui64 viewCreationTxId = 0;
+        TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction> tableCreationBlocker(runtime, [&](auto& ev) {
+            const auto& record = ev->Get()->Record;
+            switch (record.GetTransaction(0).GetOperationType()) {
+            case ESchemeOpCreateIndexedTable:
+                tableCreationTxId = record.GetTxId();
+                return true;
+            case ESchemeOpCreateView:
+                viewCreationTxId = record.GetTxId();
+                return false;
+            default:
                 return false;
             }
-        );
+        });
 
-        TBlockEvents<TEvPrivate::TEvImportSchemeQueryResult> queryResultBlocker(runtime,
-            [&](const TEvPrivate::TEvImportSchemeQueryResult::TPtr& event) {
-                // The test expects the SchemeShard actor ID to be already initialized when we receive the first query result message.
-                // This expectation is valid because we import items in order of their appearance on the import items list.
-                if (!schemeshardActorId || event->Recipient != schemeshardActorId) {
-                    return false;
-                }
-                UNIT_ASSERT_VALUES_EQUAL(event->Get()->Status, Ydb::StatusIds::SCHEME_ERROR);
-                const auto* error = std::get_if<TString>(&event->Get()->Result);
-                UNIT_ASSERT(error);
-                UNIT_ASSERT_STRING_CONTAINS(*error, "Cannot find table");
-                return true;
+        TWaitForFirstEvent<TEvSchemeShard::TEvModifySchemeTransactionResult> viewCreationAccepter(runtime, [&](auto& ev) {
+            const auto& record = ev->Get()->Record;
+            if (!viewCreationTxId || viewCreationTxId != record.GetTxId()) {
+                return false;
             }
-        );
+
+            UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrScheme::StatusAccepted);
+            return true;
+        });
 
         const ui64 importId = ++txId;
         TestImport(runtime, importId, "/MyRoot", Sprintf(R"(
@@ -5882,21 +5937,25 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         )", port));
 
         runtime.WaitFor("table creation attempt", [&]{ return !tableCreationBlocker.empty(); });
-        runtime.WaitFor("query result", [&]{ return !queryResultBlocker.empty(); });
+        viewCreationAccepter.Wait();
+        env.TestWaitNotification(runtime, viewCreationTxId);
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/view"), {
+            NLs::Finished,
+            NLs::IsView,
+        });
+
         tableCreationBlocker.Unblock().Stop();
-        queryResultBlocker.Unblock().Stop();
         env.TestWaitNotification(runtime, tableCreationTxId);
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/table"), {
+            NLs::Finished,
+            NLs::IsTable,
+        });
 
         env.TestWaitNotification(runtime, importId);
         TestGetImport(runtime, importId, "/MyRoot");
-
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/view"), {
-            NLs::Finished,
-            NLs::IsView
-        });
     }
 
-    Y_UNIT_TEST(MultipleViewCreationRetries) {
+    Y_UNIT_TEST(ShouldImportMultipleViews) {
         TTestBasicRuntime runtime;
         auto options = TTestEnvOptions()
             .RunFakeConfigDispatcher(true)
@@ -5928,40 +5987,13 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         TS3Mock s3Mock(ConvertTestData(bucketContent), TS3Mock::TSettings(port));
         UNIT_ASSERT(s3Mock.Start());
 
-        TActorId schemeshardActorId;
-        TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction> viewCreationBlocker(runtime,
-            [&](const TEvSchemeShard::TEvModifySchemeTransaction::TPtr& event) {
-                const auto& record = event->Get()->Record;
-                if (record.GetTransaction(0).GetOperationType() == ESchemeOpCreateView) {
-                    schemeshardActorId = event->Recipient;
-                    return true;
-                }
-                return false;
-            }
-        );
-
-        int missingDependencyFails = 0;
-        auto missingDependencyObserver = runtime.AddObserver<TEvPrivate::TEvImportSchemeQueryResult>(
-            [&](const TEvPrivate::TEvImportSchemeQueryResult::TPtr& event) {
-                if (!schemeshardActorId
-                    || event->Recipient != schemeshardActorId
-                    || event->Get()->Status != Ydb::StatusIds::SCHEME_ERROR) {
-                    return;
-                }
-                const auto* error = std::get_if<TString>(&event->Get()->Result);
-                if (error && error->Contains("Cannot find table")) {
-                    ++missingDependencyFails;
-                }
-            }
-        );
-
         auto importSettings = TStringBuilder() << std::format(R"(
                 ImportFromS3Settings {{
                     endpoint: "localhost:{}"
                     scheme: HTTP
             )", port
         );
-        for (int i = 0; i < ViewLayers; ++i) {
+        for (int i = ViewLayers - 1; i >= 0; --i) {
             importSettings << std::format(R"(
                     items {{
                         source_prefix: "view{}"
@@ -5974,23 +6006,6 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
         const ui64 importId = ++txId;
         TestImport(runtime, importId, "/MyRoot", importSettings);
-
-        int expectedFails = 0;
-        for (int iteration = 1; iteration <= ViewLayers; ++iteration) {
-            runtime.WaitFor("blocked view creation", [&]{ return !viewCreationBlocker.empty(); });
-
-            expectedFails += ViewLayers - iteration;
-            if (iteration > 1) {
-                runtime.WaitFor("query results", [&]{ return missingDependencyFails >= expectedFails; });
-            } else {
-                // the first iteration might miss some query results due to the initially unset schemeshardActorId
-                missingDependencyFails = expectedFails;
-            }
-
-            viewCreationBlocker.Unblock(1);
-        }
-        UNIT_ASSERT(viewCreationBlocker.empty());
-        viewCreationBlocker.Stop();
 
         env.TestWaitNotification(runtime, importId);
         TestGetImport(runtime, importId, "/MyRoot");

--- a/yql/essentials/sql/settings/translation_settings.h
+++ b/yql/essentials/sql/settings/translation_settings.h
@@ -135,6 +135,8 @@ struct TTranslationSettings {
     bool AlwaysAllowExports = false;
     bool IsReplay = false;
     TVector<TString> ExtraSystemColumnPrefixes;
+
+    bool ValidateViewStatement = true;
 };
 
 struct TParsedSettings {

--- a/yql/essentials/sql/v1/sql_translation.cpp
+++ b/yql/essentials/sql/v1/sql_translation.cpp
@@ -5781,11 +5781,13 @@ bool TSqlTranslation::ParseViewQuery(
 
     // The AST is needed solely for the validation of the CREATE VIEW statement.
     // The final storage format for the query is a plain text, not an AST.
-    const auto viewSelect = BuildViewSelect(query, Ctx_);
-    if (!viewSelect) {
-        return false;
+    if (Ctx_.Settings.ValidateViewStatement) {
+        const auto viewSelect = BuildViewSelect(query, Ctx_);
+        if (!viewSelect) {
+            return false;
+        }
+        features["query_ast"] = {viewSelect, Ctx_};
     }
-    features["query_ast"] = {viewSelect, Ctx_};
 
     return true;
 }


### PR DESCRIPTION
## What this is

Backport of "Allow to create invalid VIEW during import" into the new enterprise branch `stable-26-2-1-ent`.

Origin on `main`: [#41265](https://github.com/ydb-platform/ydb/pull/41265) — commit `e55c625445f270656e786b2ff5d6abb3fcefcfce`.

## Why it's needed

The change is already present in `stable-26-1-1-enterprise`, merged there as [#41733](https://github.com/ydb-platform/ydb/pull/41733) (`26-1-1-e: Allow to create invalid VIEW during import`).

`stable-26-2-1-ent` is branched from `stable-26-2-1`, whose last common point with `main` is `7a9ac0ddfc4eb317e10fff717d5e1d4be65fda36` (2026-02-24). The `main` PR landed 2026-05-28, so it was not inherited naturally.

## Why this cherry-picks the enterprise commit rather than the raw main commit

The `main` commit alone is **not self-contained for a release branch**. On `main`, PR #41265 changes only the `ydb/core/kqp/*` side (5 files); the `yql/essentials` half of the feature — the `TTranslationSettings::ValidateViewStatement` field and the `ParseViewQuery` guard that actually consumes it — arrives on `main` separately through the vendored `yql/essentials` sync.

Cherry-picking only #41265 here compiles into a dangling reference: `kqp_translate.cpp` would assign `settings.ValidateViewStatement` while `TTranslationSettings` on this branch has no such field. Verified directly — the field is absent on `stable-26-2-1-ent` and present on `main`.

So this PR cherry-picks `a48b68dd8eac8d644d53fa81efcd3b9a5c85a841`, the 26-1-1-enterprise commit, which is the same change with both halves included and with the `yql/essentials` part at the path this branch still uses. Note that on `main` that file has since been moved (`yql/essentials/sql/v1/sql_translation.cpp` → `yql/essentials/sql/v1/translation/sql_translation.cpp`); the logic applied here was diffed against `main`'s current version at the new path and is identical.

The resulting diff matches the 26-1-1-enterprise change exactly: 7 files, +145 / −81.

## Conflict resolution — please review

Two conflicts, both genuine divergence rather than mechanical noise:

1. **`yql/essentials/sql/settings/translation_settings.h`** — this branch had added `ExtraSystemColumnPrefixes` at the same position. Resolution: kept both fields.

2. **`ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp`** — this branch had added a test `ShouldImportMultiPartitionTable` exactly where the PR adds `ShouldImportInvalidView`, and the PR additionally renames the following test (`ViewCreationRetry` → `ShouldNotRetryViewCreation`) while rewriting its body. Resolution: kept this branch's `ShouldImportMultiPartitionTable` intact, added the PR's `ShouldImportInvalidView`, and applied the rename plus rewritten body. Verified that `ShouldImportMultiPartitionTable` does not appear as removed in the final diff, and that whole-file brace balance matches the base branch.

Separately, in `kqp_translate.h` / `kqp_host.cpp` the conflict region carried `main`-only context (`SetYqlSelect` / `YqlSelect`) that belongs to a different, un-backported feature and does not exist on this branch. Only the `ValidateViewStatement` additions were taken; `SetYqlSelect` was deliberately **not** pulled in, since `TPrepareSettings` here has no `YqlSelect` member and it would not compile.

## Notes

Not built or tested locally; opened as draft so CI can verify.

Draft: reviewers to be assigned once CODEOWNERS for this branch is updated (see #50289).
