### PR TITLE
[26-2-1-ent] Backport documentation build-warning fixes

### DIFF
--- a/ydb/docs/en/core/yql/reference/types/primitive.md
+++ b/ydb/docs/en/core/yql/reference/types/primitive.md
@@ -1,6 +1,6 @@
 # Primitive data types
 
-<!-- markdownlint-disable blanks-around-fences -->
+<!-- markdownlint-disable blanks-around-fences blanks-around-headings MD055 MD056 -->
 
 The terms "simple", "primitive", and "elementary" data types are used as synonyms.
 ## Numeric types {#numeric}

--- a/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
@@ -75,7 +75,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "not_var{{ ansible_config_file | dirname }}/files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище
@@ -138,7 +138,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "not_var{{ ansible_config_file | dirname }}/files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище
@@ -196,7 +196,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "not_var{{ ansible_config_file | dirname }}/files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище


### PR DESCRIPTION
## What this is

Backport of documentation build-warning fixes into the new enterprise branch `stable-26-2-1-ent`.

Two targeted changes, both matching the **current state of `main`**:

| file | change | origin on main |
|---|---|---|
| `ydb/docs/en/core/yql/reference/types/primitive.md` | extend `markdownlint-disable` with `blanks-around-headings MD055 MD056` | [#41299](https://github.com/ydb-platform/ydb/pull/41299) |
| `ydb/docs/ru/core/.../ansible/initial-deployment/deployment-configuration-v1.md` | prefix the jinja placeholder with `not_var` (3 occurrences) so the linter stops treating it as a link | [#44105](https://github.com/ydb-platform/ydb/pull/44105), then [#44685](https://github.com/ydb-platform/ydb/pull/44685) |

## Why it's needed

The same fixes are already present in `stable-26-1-1-enterprise`, as the text part of [#47617](https://github.com/ydb-platform/ydb/pull/47617) (`Fix warnings in 26-1-1`).

`stable-26-2-1-ent` is branched from `stable-26-2-1`, whose last common point with `main` is `7a9ac0ddfc4eb317e10fff717d5e1d4be65fda36` (2026-02-24). Both upstream fixes landed after that (2026-06-02 and 2026-06-21 / 2026-06-26), so they were not inherited naturally.

## Why this is not a straight cherry-pick

The `main` originals are large "fix all documentation warnings" PRs touching many unrelated files, and the ansible fix evolved in two steps on `main` (#44105 first used HTML entities `&#123;&#123;`, then #44685 replaced that with the `not_var` form). Cherry-picking either commit would drag in unrelated churn or land the intermediate form.

So this PR applies only the two relevant edits, set to `main`'s current content. Both files were diffed against `main` after the change to confirm the affected lines now match exactly.

The image/excalidraw assets that make up the bulk of #47617 on the 26-1-1 line are **not** included — they are already present on this branch through shared docs history (verified).

## Scope note

This is documentation-build hygiene, not enterprise functionality — it is included because it was one of the gaps found when diffing `stable-26-1-1-enterprise` against this line. It is independent of the other backport PRs and can be dropped without affecting them if the docs build here turns out not to need it.

Draft: reviewers to be assigned once CODEOWNERS for this branch is updated (see #50289).
