### PR TITLE
[YQ-5514] (-) Forbid dropping resource pool referenced by classifiers

### DIFF
--- a/ydb/services/workload_manager/metadata_subscription/manager.cpp
+++ b/ydb/services/workload_manager/metadata_subscription/manager.cpp
@@ -95,7 +95,7 @@ struct TFeatureFlagExtractor : public NKqp::IFeatureFlagExtractor {
 
 class TClassifiersCheckResult {
 public:
-    // Mutator interface required by NYql::NCommon::ResultFromIssues/ResultFromError used in TActorRequestHandler error paths
+    // Interface required by NYql::NCommon::ResultFromIssues/ResultFromError
     void SetStatus(NYql::EYqlIssueCode status) {
         Status = status;
     }
@@ -121,16 +121,10 @@ private:
     NYql::TIssues Issues;
 };
 
-// Restrict semantics for DROP RESOURCE POOL: reject the drop while some classifier references the pool (YQ-5514)
 TAsyncStatus CheckPoolNotReferencedByClassifiers(const TString& poolId, ui32 nodeId, const TResourcePoolManager::TExternalModificationContext& context) {
     // The default pool is recreated on demand, so a dangling classifier reference to it is not possible
     if (poolId == NResourcePool::DEFAULT_POOL_ID || !NMetadata::NProvider::TServiceOperator::IsEnabled()) {
         return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Success());
-    }
-
-    auto* actorSystem = context.GetActorSystem();
-    if (!actorSystem) {
-        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(NYql::TIssuesIds::KIKIMR_INTERNAL_ERROR, "Internal error. Object operation needs an actor system. Please contact internal support"));
     }
 
     using TRequest = NMetadata::NProvider::TEvAskSnapshot;
@@ -138,7 +132,7 @@ TAsyncStatus CheckPoolNotReferencedByClassifiers(const TString& poolId, ui32 nod
     auto event = std::make_unique<TRequest>(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>());
 
     auto promise = NThreading::NewPromise<TClassifiersCheckResult>();
-    actorSystem->Register(new NKqp::TActorRequestHandler<TRequest, TResponse, TClassifiersCheckResult>(
+    context.GetActorSystem()->Register(new NKqp::TActorRequestHandler<TRequest, TResponse, TClassifiersCheckResult>(
         NMetadata::NProvider::MakeServiceId(nodeId), event.release(), promise,
         [databaseId = context.GetDatabaseId(), poolId](NThreading::TPromise<TClassifiersCheckResult> promise, TResponse&& response) {
             TVector<TString> referencingClassifiers;

--- a/ydb/services/workload_manager/metadata_subscription/manager.cpp
+++ b/ydb/services/workload_manager/metadata_subscription/manager.cpp
@@ -10,6 +10,11 @@
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/resource_pools/resource_pool_settings.h>
 #include <ydb/core/kqp/gateway/utils/metadata_helpers.h>
+#include <ydb/services/metadata/service.h>
+#include <ydb/services/workload_manager/metadata_subscription/resource_pool_classifier/fetcher.h>
+
+#include <util/generic/algorithm.h>
+#include <util/string/join.h>
 
 
 namespace NKikimr::NWorkloadManager {
@@ -86,6 +91,75 @@ struct TFeatureFlagExtractor : public NKqp::IFeatureFlagExtractor {
         }
     }
     return TYqlConclusionStatus::Success();
+}
+
+class TClassifiersCheckResult {
+public:
+    void SetStatus(NYql::EYqlIssueCode status) {
+        Status = status;
+    }
+
+    void AddIssue(NYql::TIssue issue) {
+        Issues.AddIssue(std::move(issue));
+    }
+
+    void AddIssues(NYql::TIssues issues) {
+        Issues.AddIssues(std::move(issues));
+    }
+
+public:
+    NYql::EYqlIssueCode Status = NYql::TIssuesIds::SUCCESS;
+    NYql::TIssues Issues;
+};
+
+// Restrict semantics for DROP RESOURCE POOL: reject the drop while some classifier references the pool (YQ-5514)
+TAsyncStatus CheckPoolNotReferencedByClassifiers(const TString& poolId, ui32 nodeId, const TResourcePoolManager::TExternalModificationContext& context) {
+    // The default pool is recreated on demand, so a dangling classifier reference to it is not possible
+    if (poolId == NResourcePool::DEFAULT_POOL_ID || !NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Success());
+    }
+
+    auto* actorSystem = context.GetActorSystem();
+    if (!actorSystem) {
+        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(NYql::TIssuesIds::KIKIMR_INTERNAL_ERROR, "Internal error. Object operation needs an actor system. Please contact internal support"));
+    }
+
+    using TRequest = NMetadata::NProvider::TEvAskSnapshot;
+    using TResponse = NMetadata::NProvider::TEvRefreshSubscriberData;
+    auto event = std::make_unique<TRequest>(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>());
+
+    auto promise = NThreading::NewPromise<TClassifiersCheckResult>();
+    actorSystem->Register(new NKqp::TActorRequestHandler<TRequest, TResponse, TClassifiersCheckResult>(
+        NMetadata::NProvider::MakeServiceId(nodeId), event.release(), promise,
+        [databaseId = context.GetDatabaseId(), poolId](NThreading::TPromise<TClassifiersCheckResult> promise, TResponse&& response) {
+            TVector<TString> referencingClassifiers;
+            const auto& configs = response.GetSnapshotAs<TResourcePoolClassifierSnapshot>()->GetResourcePoolClassifierConfigs();
+            if (const auto it = configs.find(databaseId); it != configs.end()) {
+                for (const auto& [name, config] : it->second.ByName) {
+                    if (config.GetClassifierSettings().ResourcePool == poolId) {
+                        referencingClassifiers.push_back(name);
+                    }
+                }
+            }
+
+            TClassifiersCheckResult result;
+            if (!referencingClassifiers.empty()) {
+                Sort(referencingClassifiers);
+                result.SetStatus(NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED);
+                result.AddIssue(NYql::TIssue(TStringBuilder() << "Cannot drop resource pool " << poolId
+                    << ", it is referenced by resource pool classifiers: " << JoinSeq(", ", referencingClassifiers)));
+            }
+            promise.SetValue(std::move(result));
+        }
+    ));
+
+    return promise.GetFuture().Apply([](const NThreading::TFuture<TClassifiersCheckResult>& f) {
+        const auto& result = f.GetValue();
+        if (result.Status == NYql::TIssuesIds::SUCCESS) {
+            return TYqlConclusionStatus::Success();
+        }
+        return TYqlConclusionStatus::Fail(result.Status, result.Issues.ToString());
+    });
 }
 
 [[nodiscard]] TYqlConclusionStatus ErrorFromActivityType(TResourcePoolManager::EActivityType activityType) {
@@ -228,6 +302,10 @@ TAsyncStatus TResourcePoolManager::ExecuteSchemeRequest(const NKikimrSchemeOp::T
     if (operationCase != NKqpProto::TKqpSchemeOperation::kDropResourcePool) {
         validationFuture = NKqp::ChainFeatures(validationFuture, [context, nodeId] {
             return CheckFeatureFlag(nodeId, MakeIntrusive<TFeatureFlagExtractor>(), context);
+        });
+    } else {
+        validationFuture = NKqp::ChainFeatures(validationFuture, [poolId = schemeTx.GetDrop().GetName(), nodeId, context] {
+            return CheckPoolNotReferencedByClassifiers(poolId, nodeId, context);
         });
     }
     return NKqp::ChainFeatures(validationFuture, [schemeTx, context] {

--- a/ydb/services/workload_manager/metadata_subscription/manager.cpp
+++ b/ydb/services/workload_manager/metadata_subscription/manager.cpp
@@ -9,7 +9,6 @@
 #include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/resource_pools/resource_pool_settings.h>
-#include <ydb/core/kqp/gateway/utils/metadata_helpers.h>
 #include <ydb/services/metadata/service.h>
 #include <ydb/services/workload_manager/metadata_subscription/resource_pool_classifier/fetcher.h>
 
@@ -136,7 +135,8 @@ TAsyncStatus CheckPoolNotReferencedByClassifiers(const TString& poolId, ui32 nod
         NMetadata::NProvider::MakeServiceId(nodeId), event.release(), promise,
         [databaseId = context.GetDatabaseId(), poolId](NThreading::TPromise<TClassifiersCheckResult> promise, TResponse&& response) {
             TVector<TString> referencingClassifiers;
-            const auto& configs = response.GetSnapshotAs<TResourcePoolClassifierSnapshot>()->GetResourcePoolClassifierConfigs();
+            const auto snapshot = response.GetValidatedSnapshotAs<TResourcePoolClassifierSnapshot>();
+            const auto& configs = snapshot->GetResourcePoolClassifierConfigs();
             if (const auto it = configs.find(databaseId); it != configs.end()) {
                 for (const auto& [name, config] : it->second.ByName) {
                     if (config.GetClassifierSettings().ResourcePool == poolId) {

--- a/ydb/services/workload_manager/metadata_subscription/manager.cpp
+++ b/ydb/services/workload_manager/metadata_subscription/manager.cpp
@@ -95,6 +95,7 @@ struct TFeatureFlagExtractor : public NKqp::IFeatureFlagExtractor {
 
 class TClassifiersCheckResult {
 public:
+    // Mutator interface required by NYql::NCommon::ResultFromIssues/ResultFromError used in TActorRequestHandler error paths
     void SetStatus(NYql::EYqlIssueCode status) {
         Status = status;
     }
@@ -107,7 +108,15 @@ public:
         Issues.AddIssues(std::move(issues));
     }
 
-public:
+    // ResultFromError leaves Status untouched, so non-empty issues mean failure even with SUCCESS status
+    TYqlConclusionStatus ToConclusion() const {
+        if (Status == NYql::TIssuesIds::SUCCESS && Issues.Empty()) {
+            return TYqlConclusionStatus::Success();
+        }
+        return TYqlConclusionStatus::Fail(Status != NYql::TIssuesIds::SUCCESS ? Status : NYql::TIssuesIds::DEFAULT_ERROR, Issues.ToString());
+    }
+
+private:
     NYql::EYqlIssueCode Status = NYql::TIssuesIds::SUCCESS;
     NYql::TIssues Issues;
 };
@@ -154,11 +163,7 @@ TAsyncStatus CheckPoolNotReferencedByClassifiers(const TString& poolId, ui32 nod
     ));
 
     return promise.GetFuture().Apply([](const NThreading::TFuture<TClassifiersCheckResult>& f) {
-        const auto& result = f.GetValue();
-        if (result.Status == NYql::TIssuesIds::SUCCESS) {
-            return TYqlConclusionStatus::Success();
-        }
-        return TYqlConclusionStatus::Fail(result.Status, result.Issues.ToString());
+        return f.GetValue().ToConclusion();
     });
 }
 
@@ -299,13 +304,13 @@ TAsyncStatus TResourcePoolManager::ExecutePrepared(const NKqpProto::TKqpSchemeOp
 
 TAsyncStatus TResourcePoolManager::ExecuteSchemeRequest(const NKikimrSchemeOp::TModifyScheme& schemeTx, const TExternalModificationContext& context, ui32 nodeId, NKqpProto::TKqpSchemeOperation::OperationCase operationCase) const {
     TAsyncStatus validationFuture = NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Success());
-    if (operationCase != NKqpProto::TKqpSchemeOperation::kDropResourcePool) {
-        validationFuture = NKqp::ChainFeatures(validationFuture, [context, nodeId] {
-            return CheckFeatureFlag(nodeId, MakeIntrusive<TFeatureFlagExtractor>(), context);
-        });
-    } else {
+    if (operationCase == NKqpProto::TKqpSchemeOperation::kDropResourcePool) {
         validationFuture = NKqp::ChainFeatures(validationFuture, [poolId = schemeTx.GetDrop().GetName(), nodeId, context] {
             return CheckPoolNotReferencedByClassifiers(poolId, nodeId, context);
+        });
+    } else {
+        validationFuture = NKqp::ChainFeatures(validationFuture, [context, nodeId] {
+            return CheckFeatureFlag(nodeId, MakeIntrusive<TFeatureFlagExtractor>(), context);
         });
     }
     return NKqp::ChainFeatures(validationFuture, [schemeTx, context] {

--- a/ydb/services/workload_manager/metadata_subscription/ya.make
+++ b/ydb/services/workload_manager/metadata_subscription/ya.make
@@ -11,8 +11,10 @@ PEERDIR(
     ydb/core/protos
     ydb/core/resource_pools
 
+    ydb/services/metadata
     ydb/services/metadata/abstract
     ydb/services/metadata/manager
+    ydb/services/workload_manager/metadata_subscription/resource_pool_classifier
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/services/workload_manager/ut/workload_service_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_ut.cpp
@@ -1,5 +1,7 @@
 #include <ydb/core/base/appdata_fwd.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
 
 #include <ydb/services/workload_manager/ut/common/workload_service_ut_common.h>
 
@@ -1178,9 +1180,20 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
 
         auto settings = TQueryRunnerSettings().PoolId("").UserSID("test@user");
         const TString& poolId = "my_pool";
-        CreateSampleResourcePoolClassifier(ydb, settings, poolId);
+        const TString& classifierId = CreateSampleResourcePoolClassifier(ydb, settings, poolId);
 
         WaitForFail(ydb, settings, poolId);
+
+        // Pool is referenced by the classifier, so drop must be rejected
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            DROP RESOURCE POOL )" << poolId << R"(;
+        )", NYdb::EStatus::PRECONDITION_FAILED, TStringBuilder() << "referenced by resource pool classifiers: " << classifierId);
+
+        WaitForFail(ydb, settings, poolId);
+
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            DROP RESOURCE POOL CLASSIFIER )" << classifierId << R"(;
+        )");
 
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             DROP RESOURCE POOL )" << poolId << R"(;
@@ -1282,6 +1295,29 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
         return count;
     }
 
+    // Helper: drop a pool through tx proxy directly, bypassing the DDL check that forbids
+    // dropping a pool referenced by classifiers — simulates a pool dropped before YQ-5514.
+    void DropResourcePoolBypassingClassifierCheck(TIntrusivePtr<IYdbSetup> ydb, const TString& poolId) {
+        auto request = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
+        request->Record.SetDatabaseName(CanonizePath(ydb->GetSettings().DomainName_));
+        auto& schemeTx = *request->Record.MutableTransaction()->MutableModifyScheme();
+        schemeTx.SetWorkingDir(JoinPath({CanonizePath(ydb->GetSettings().DomainName_), ".metadata/workload_manager/pools/"}));
+        schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpDropResourcePool);
+        schemeTx.MutableDrop()->SetName(poolId);
+
+        auto* runtime = ydb->GetRuntime();
+        const auto edgeActor = runtime->AllocateEdgeActor();
+        runtime->Send(new IEventHandle(MakeTxProxyID(), edgeActor, request.release()));
+        runtime->GrabEdgeEvent<TEvTxUserProxy::TEvProposeTransactionStatus>(edgeActor, FUTURE_WAIT_TIMEOUT);
+
+        IYdbSetup::WaitFor(FUTURE_WAIT_TIMEOUT, "pool drop", [ydb, poolId](TString& errorString) {
+            auto kind = ydb->Navigate(TStringBuilder() << ".metadata/workload_manager/pools/" << poolId)->ResultSet.at(0).Kind;
+
+            errorString = TStringBuilder() << "kind = " << kind;
+            return kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown;
+        });
+    }
+
     Y_UNIT_TEST(TestClassifierPointingToNonExistentPool) {
         auto ydb = TYdbSetupSettings().Create();
 
@@ -1350,8 +1386,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
 
         UNIT_ASSERT_VALUES_EQUAL(CountClassifiers(ydb, classifierId), 1u);
 
-        // Drop the pool the classifier references
-        ydb->ExecuteSchemeQuery(TStringBuilder() << "DROP RESOURCE POOL " << poolId << ";");
+        DropResourcePoolBypassingClassifierCheck(ydb, poolId);
 
         // DROP of the classifier must succeed even though the pool is gone:
         // pool existence validation is skipped for Drop operations
@@ -1397,8 +1432,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
 
         UNIT_ASSERT_VALUES_EQUAL(CountClassifiers(ydb, classifierId), 1u);
 
-        // Drop the pool that the classifier references
-        ydb->ExecuteSchemeQuery(TStringBuilder() << "DROP RESOURCE POOL " << poolId << ";");
+        DropResourcePoolBypassingClassifierCheck(ydb, poolId);
 
         // Altering a non-pool attribute (RANK) must still fail because the
         // preparation actor validates all referenced pools for any ALTER operation.

--- a/ydb/services/workload_manager/ut/workload_service_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_ut.cpp
@@ -1184,7 +1184,6 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
 
         WaitForFail(ydb, settings, poolId);
 
-        // Pool is referenced by the classifier, so drop must be rejected
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             DROP RESOURCE POOL )" << poolId << R"(;
         )", NYdb::EStatus::PRECONDITION_FAILED, TStringBuilder() << "referenced by resource pool classifiers: " << classifierId);
@@ -1295,8 +1294,8 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
         return count;
     }
 
-    // Helper: drop a pool through tx proxy directly, bypassing the DDL check that forbids
-    // dropping a pool referenced by classifiers — simulates a pool dropped before YQ-5514.
+    // Drops through tx proxy directly, bypassing the DDL check that forbids dropping a referenced
+    // pool — reproduces the dangling state left by clusters from before YQ-5514.
     void DropResourcePoolBypassingClassifierCheck(TIntrusivePtr<IYdbSetup> ydb, const TString& poolId) {
         auto request = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
         request->Record.SetDatabaseName(CanonizePath(ydb->GetSettings().DomainName_));


### PR DESCRIPTION
Fixes YQ-5514: dropping a resource pool that resource pool classifiers still reference left the classifiers pointing at a deleted pool.

### Solution (restrict semantics)
`DROP RESOURCE POOL` is now rejected with `PRECONDITION_FAILED` while any classifier in the database references the pool:

```
Cannot drop resource pool <pool>, it is referenced by resource pool classifiers: <names>
```

- The check is placed in `TResourcePoolManager::ExecuteSchemeRequest`, so it covers both the immediate and the prepared (deferred DDL) drop paths.
- It requests a fresh classifier snapshot from the metadata provider via `TEvAskSnapshot` — the accessor replies only with a snapshot at least as fresh as the ask, so there is no race with a just-created classifier. No new actor: reuses the generic `NKqp::TActorRequestHandler`, which also fails the check on undelivery instead of hanging.
- The check is skipped for the `default` pool (recreated on demand, a dangling reference to it is not possible) and when the metadata provider is disabled (classifiers cannot exist then).

### Tests
- `ResourcePoolClassifiersDdl::TestDropResourcePool` reworked: it used to codify the buggy behavior (drop succeeded with a live classifier); now it asserts the drop is rejected and succeeds only after the classifier is dropped.
- `TestDropClassifierWhenPoolIsDeleted` / `TestAlterClassifierNonPoolAttributeWhenPoolDeleted` need the dangling state (still possible on clusters from before this fix), so they now set it up via a helper that proposes `ESchemeOpDropResourcePool` through tx proxy directly, bypassing the DDL check.
- Full `ydb/services/workload_manager/ut`: 260/260 pass; `ydb/core/kqp/provider/ut` ResourcePool tests: 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
