### PR TITLE
[detailed-metrics] wire up collection of detailed metrics and publishing it to ydb_detailed_raw group

### DIFF
--- a/ydb/core/tablet/detailed_metrics/detailed_metrics_counter_set.cpp
+++ b/ydb/core/tablet/detailed_metrics/detailed_metrics_counter_set.cpp
@@ -1,0 +1,65 @@
+#include "detailed_metrics_counter_set.h"
+
+#include <ydb/core/protos/counters_detailed_datashard.pb.h>
+#include <ydb/core/tablet/tablet_counters_protobuf.h>
+
+namespace NKikimr {
+
+namespace {
+
+void InsertCounterName(THashSet<TString>& names, TStringBuf sourceName) {
+    names.insert(TString(sourceName));
+
+    for (const TStringBuf prefix : {TStringBuf("SUM("), TStringBuf("MAX(")}) {
+        if (sourceName.StartsWith(prefix) && sourceName.EndsWith(")")) {
+            names.insert(TString(sourceName.SubStr(prefix.size(), sourceName.size() - prefix.size() - 1)));
+        }
+    }
+}
+
+template <class TOpts>
+void CollectCounterNames(const TOpts* opts, TDetailedMetricsCounterNames& names) {
+    for (size_t i = 0; i < opts->Size; ++i) {
+        for (const auto& source : opts->GetSourceCounters(i)) {
+            auto& target = source.GetCategory() == ESourceCounterCategory::SCC_TABLET
+                ? names.AppNames
+                : names.ExecutorNames;
+
+            InsertCounterName(target, source.GetName());
+        }
+    }
+}
+
+const TDetailedMetricsCounterNames* GetDataShardCounterNames() {
+    static const TDetailedMetricsCounterNames names = [] {
+        TDetailedMetricsCounterNames result;
+
+        CollectCounterNames(
+            NAux::GetAppOpts<NDataShard::ESimpleDetailedCounters_descriptor, true /* ParseSourceCounters */>(),
+            result);
+        CollectCounterNames(
+            NAux::GetAppOpts<NDataShard::ECumulativeDetailedCounters_descriptor, true /* ParseSourceCounters */>(),
+            result);
+        CollectCounterNames(
+            NAux::GetAppOpts<NDataShard::EPercentileDetailedCounters_descriptor, true /* ParseSourceCounters */>(),
+            result);
+
+        return result;
+    }();
+
+    return &names;
+}
+
+} // namespace
+
+const TDetailedMetricsCounterNames* GetDetailedMetricsCounterNames(TTabletTypes::EType tabletType) {
+    switch (tabletType) {
+    case TTabletTypes::DataShard:
+        return GetDataShardCounterNames();
+
+    default:
+        return nullptr;
+    }
+}
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/detailed_metrics_counter_set.h
+++ b/ydb/core/tablet/detailed_metrics/detailed_metrics_counter_set.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/core/base/tablet_types.h>
+
+#include <util/generic/hash_set.h>
+#include <util/generic/string.h>
+
+namespace NKikimr {
+
+struct TDetailedMetricsCounterNames {
+    THashSet<TString> ExecutorNames;
+    THashSet<TString> AppNames;
+};
+
+const TDetailedMetricsCounterNames* GetDetailedMetricsCounterNames(TTabletTypes::EType tabletType);
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -13,6 +13,9 @@ namespace NKikimr {
 
 namespace {
 
+/**
+ * Process-wide as there's only two TCA per node: leader and follower. Finer granularity will not buy anything.
+ */
 TMutex& Lock() {
     static TMutex lock;
     return lock;
@@ -321,6 +324,13 @@ public:
         TabletToTableMap.erase(mapIt);
     }
 
+    /**
+     * Deliberately takes no lock: it only recomputes counter VALUES over state private
+     * to this instance
+     *
+     * This stops being safe once something reads these values concurrently with this
+     * recalculation
+     */
     void RecalculateAllCounters() override {
         for (auto& [_, entry] : Tables) {
             if (entry.TableBucket) {

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -1,15 +1,22 @@
 #include "node_database_metrics_aggregator.h"
 
+#include "detailed_metrics_counter_set.h"
+
 #include <ydb/core/tablet/private/aggregated_tablet_counters.h>
 
-#include <util/generic/algorithm.h>
 #include <util/generic/hash.h>
 #include <util/generic/vector.h>
 #include <util/string/cast.h>
+#include <util/system/mutex.h>
 
 namespace NKikimr {
 
 namespace {
+
+TMutex& Lock() {
+    static TMutex lock;
+    return lock;
+}
 
 // Labels of the detailed metrics counter tree
 const TString DATABASE_LABEL = "database";
@@ -74,11 +81,17 @@ TStringBuf MakeRelativeTablePath(const TStringBuf databasePrefix, const TString&
  */
 class TCountersBucket {
 public:
-    TCountersBucket(NMonitoring::TDynamicCounterPtr bucketGroup, TTabletTypes::EType tabletType)
+    TCountersBucket(
+        NMonitoring::TDynamicCounterPtr bucketGroup,
+        TTabletTypes::EType tabletType,
+        const TDetailedMetricsCounterNames& counterNames,
+        NMonitoring::TCountableBase::EVisibility visibility
+    )
         : TabletType(tabletType)
-        , TypeGroup(bucketGroup->GetSubgroup(TYPE_LABEL, TString(TTabletTypes::TypeToStr(tabletType))))
-        , ExecutorCounters(TypeGroup->GetSubgroup(CATEGORY_LABEL, EXECUTOR_CATEGORY))
-        , AppCounters(TypeGroup->GetSubgroup(CATEGORY_LABEL, APP_CATEGORY))
+        , TypeGroup(bucketGroup->GetSubgroup(TYPE_LABEL, TTabletTypes::TypeToStr(tabletType)))
+        , ExecutorCounters(TypeGroup->GetSubgroup(CATEGORY_LABEL, EXECUTOR_CATEGORY), visibility)
+        , AppCounters(TypeGroup->GetSubgroup(CATEGORY_LABEL, APP_CATEGORY), visibility)
+        , CounterNames(&counterNames)
     {}
 
     void Apply(
@@ -94,13 +107,11 @@ public:
             ++NextSourceId;
         }
 
-        // TODO(djant) restrict the counter set
-        // do NOT enable the Partition level in production.
         if (!ExecutorCounters.IsInitialized) {
-            ExecutorCounters.Initialize(&executorCounters);
+            ExecutorCounters.Initialize(&executorCounters, &CounterNames->ExecutorNames);
         }
         if (!AppCounters.IsInitialized) {
-            AppCounters.Initialize(&appCounters);
+            AppCounters.Initialize(&appCounters, &CounterNames->AppNames);
         }
 
         ExecutorCounters.Apply(it->second, &executorCounters, TabletType, now);
@@ -143,6 +154,8 @@ private:
 
     NPrivate::TAggregatedTabletCounters ExecutorCounters;
     NPrivate::TAggregatedTabletCounters AppCounters;
+
+    const TDetailedMetricsCounterNames* CounterNames;
 
     THashMap<TTabletKey, ui64> SourceIds;
     ui64 NextSourceId = 0;
@@ -188,6 +201,7 @@ public:
         bool isFollowerRole
     )
         : TargetCounterGroup(targetCounterGroup)
+        , CounterVisibility(targetCounterGroup->Visibility())
         , DatabasePath(databasePath)
         , DatabasePrefix(ChopTrailingSlash(databasePath))
         , IsFollowerRole(isFollowerRole)
@@ -202,7 +216,15 @@ public:
         const TTabletCountersBase& appCounters,
         TInstant now
     ) override {
+        TGuard<TMutex> guard(Lock());
+
         CheckSingleRole(followerId);
+
+        // The published set is a property of the tablet type: a type without one publishes nothing
+        const TDetailedMetricsCounterNames* counterNames = GetDetailedMetricsCounterNames(tabletType);
+        if (!counterNames) {
+            return;
+        }
 
         const TTabletKey tablet(tabletId, followerId);
         const TStringBuf relativePath = MakeRelativeTablePath(DatabasePrefix, table.TablePath);
@@ -216,6 +238,10 @@ public:
             RemoveTabletFromTable(mapIt->second, tablet);
             TabletToTableMap.erase(mapIt);
             mapIt = TabletToTableMap.end();
+        }
+
+        if (IsFollowerRole && IsTableLevel(table)) {
+            return;
         }
 
         auto* entry = GetOrCreateTable(table, relativePath);
@@ -252,7 +278,12 @@ public:
         if (IsTableLevel(entry->Info)) {
             auto& bucket = entry->TableBucket;
             if (!bucket) {
-                bucket = MakeHolder<TCountersBucket>(entry->TableGroup, tabletType);
+                bucket = MakeHolder<TCountersBucket>(
+                    entry->TableGroup,
+                    tabletType,
+                    *counterNames,
+                    CounterVisibility
+                );
             }
             bucket->Apply(tablet, executorCounters, appCounters, now);
         } else {
@@ -262,7 +293,9 @@ public:
                     GetOrCreatePerPartitionGroup(*entry)
                         ->GetSubgroup(TABLET_ID_LABEL, ToString(tabletId))
                         ->GetSubgroup(FOLLOWER_ID_LABEL, ToString(followerId)),
-                    tabletType
+                    tabletType,
+                    *counterNames,
+                    CounterVisibility
                 );
             }
             leaf->Apply(tablet, executorCounters, appCounters, now);
@@ -270,6 +303,8 @@ public:
     }
 
     void ForgetTablet(ui64 tabletId, ui32 followerId) override {
+        TGuard<TMutex> guard(Lock());
+
         const TTabletKey tablet(tabletId, followerId);
 
         auto mapIt = TabletToTableMap.find(tablet);
@@ -333,19 +368,6 @@ private:
         return DatabaseGroup;
     }
 
-    /**
-     * Remove the database node from the target group. The next table recreates it.
-     */
-    void RemoveDatabaseGroup() {
-        if (!DatabaseGroup) {
-            return;
-        }
-
-        TargetCounterGroup->RemoveSubgroup(DATABASE_LABEL, DatabasePath);
-
-        DatabaseGroup = nullptr;
-    }
-
     NMonitoring::TDynamicCounterPtr GetOrCreatePerPartitionGroup(TTableEntry& entry) {
         if (!entry.PerPartitionGroup) {
             entry.PerPartitionGroup = entry.TableGroup->GetSubgroup(
@@ -373,6 +395,8 @@ private:
         // needs no temporary TString
         auto it = Tables.find(relativePath);
         if (it != Tables.end()) {
+            Y_DEBUG_ABORT_UNLESS(!it->second.IsEmpty());
+
             return &it->second;
         }
 
@@ -392,12 +416,6 @@ private:
         return &entry;
     }
 
-    /**
-     * Drop the contribution of a single tablet to the given table, removing the groups,
-     * which are left empty.
-     *
-     * @note The caller owns the reverse map entry: this function does not touch it.
-     */
     void RemoveTabletFromTable(const TStringBuf relativePath, const TTabletKey& tablet) {
         auto it = Tables.find(relativePath);
         if (it == Tables.end()) {
@@ -408,26 +426,23 @@ private:
         auto& entry = it->second;
 
         if (IsTableLevel(entry.Info)) {
-            ForgetTableBucketTablet(entry, tablet);
+            ForgetTableBucketTablet(it->first, entry, tablet);
         } else {
-            ForgetLeaf(entry, tablet);
+            ForgetLeaf(it->first, entry, tablet);
         }
 
         if (entry.IsEmpty()) {
-            // it->first is the real TString key, so removal builds nothing from the
-            // (possibly borrowed) relativePath parameter
-            DatabaseGroup->RemoveSubgroup(TABLE_LABEL, it->first);
             Tables.erase(it);
-        }
 
-        // The database node is not kept around after its last table is gone: a node
-        // stops hosting a database far more often than the process is restarted
-        if (Tables.empty()) {
-            RemoveDatabaseGroup();
+            if (Tables.empty()) {
+                DatabaseGroup.Reset();
+            }
         }
     }
 
-    void ForgetTableBucketTablet(TTableEntry& entry, const TTabletKey& tablet) {
+    void ForgetTableBucketTablet(
+        const TString& relativePath, TTableEntry& entry, const TTabletKey& tablet)
+    {
         auto& bucket = entry.TableBucket;
         if (!bucket) {
             return;
@@ -435,15 +450,21 @@ private:
 
         bucket->Forget(tablet);
 
-        // The bucket lives directly in the table group, so its own counter groups are
-        // dropped together with the table group by the caller, for which the emptied
-        // entry is now IsEmpty()
-        if (bucket->IsEmpty()) {
-            bucket.Reset();
+        if (!bucket->IsEmpty()) {
+            return;
         }
+
+        const TTabletTypes::EType tabletType = entry.RegisteredTabletType;
+        bucket.Reset();
+
+        TargetCounterGroup->RemoveSubgroupChain({
+            {DATABASE_LABEL, DatabasePath},
+            {TABLE_LABEL, relativePath},
+            {TYPE_LABEL, TTabletTypes::TypeToStr(tabletType)},
+        });
     }
 
-    void ForgetLeaf(TTableEntry& entry, const TTabletKey& tablet) {
+    void ForgetLeaf(const TString& relativePath, TTableEntry& entry, const TTabletKey& tablet) {
         auto it = entry.Leaves.find(tablet);
         if (it == entry.Leaves.end()) {
             return;
@@ -459,30 +480,19 @@ private:
 
         const auto& [tabletId, followerId] = tablet;
 
-        const TString tabletIdValue = ToString(tabletId);
-
-        auto tabletGroup = entry.PerPartitionGroup->FindSubgroup(TABLET_ID_LABEL, tabletIdValue);
-        if (tabletGroup) {
-            tabletGroup->RemoveSubgroup(FOLLOWER_ID_LABEL, ToString(followerId));
-        }
-
-        // The tablet group is removed as soon as its last follower is gone
-        const bool hasOtherFollowers = AnyOf(entry.Leaves, [tabletId = tabletId](const auto& leaf) {
-            return leaf.first.first == tabletId;
+        TargetCounterGroup->RemoveSubgroupChain({
+            {DATABASE_LABEL, DatabasePath},
+            {TABLE_LABEL, relativePath},
+            {DETAILED_METRICS_LABEL, PER_PARTITION_VALUE},
+            {TABLET_ID_LABEL, ToString(tabletId)},
+            {FOLLOWER_ID_LABEL, ToString(followerId)},
         });
-
-        if (!hasOtherFollowers) {
-            entry.PerPartitionGroup->RemoveSubgroup(TABLET_ID_LABEL, tabletIdValue);
-        }
-
-        if (entry.Leaves.empty()) {
-            entry.PerPartitionGroup = nullptr;
-            entry.TableGroup->RemoveSubgroup(DETAILED_METRICS_LABEL, PER_PARTITION_VALUE);
-        }
     }
 
 private:
     NMonitoring::TDynamicCounterPtr TargetCounterGroup;
+
+    const NMonitoring::TCountableBase::EVisibility CounterVisibility;
 
     const TString DatabasePath;
 

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -41,22 +41,28 @@ constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
 // has hundreds of counters, which would make the assertions unreadable without
 // covering anything, which is not covered by these few counters.
 
-constexpr const char* SIMPLE_COUNTER_NAMES[] = {
-    "UniqueRows",
-    "UniqueBytes",
+constexpr const char* EXECUTOR_SIMPLE_COUNTER_NAMES[] = {
+    "DbUniqueRowsTotal",
+    "DbUniqueDataBytes",
+    // Absent from the DataShard allow-list (ydb/core/protos/counters_detailed_datashard.proto),
+    // used to verify Initialize()'s nameFilter is honored (see NameFilterDropsUnlistedCounters)
+    "NotInTheAllowList",
 };
 
-constexpr const char* CUMULATIVE_COUNTER_NAMES[] = {
+constexpr const char* EXECUTOR_CUMULATIVE_COUNTER_NAMES[] = {
     "ConsumedCPU",
 };
 
-constexpr const char* PERCENTILE_COUNTER_NAMES[] = {
+constexpr const char* EXECUTOR_PERCENTILE_COUNTER_NAMES[] = {
     // A histogram aggregate: it is NOT filled by the tablet, it collects
-    // one observation per tablet from the "ConsumedCPU" cumulative counter
+    // one observation per tablet from the "ConsumedCPU" cumulative counter.
+    // It is DataShard's only percentile: there is no ordinary one in the allow-list.
     "HIST(ConsumedCPU)",
+};
 
-    // An ordinary percentile counter, which the tablet fills itself
-    "TxLatency",
+constexpr const char* APP_CUMULATIVE_COUNTER_NAMES[] = {
+    "DataShard/EngineHostRowUpdates",
+    "DataShard/EngineHostRowUpdateBytes",
 };
 
 constexpr TTabletPercentileCounter::TRangeDef PERCENTILE_RANGES[] = {
@@ -66,17 +72,18 @@ constexpr TTabletPercentileCounter::TRangeDef PERCENTILE_RANGES[] = {
 };
 
 enum ESimpleCounter : ui32 {
-    UNIQUE_ROWS = 0,
-    UNIQUE_BYTES = 1,
+    DB_UNIQUE_ROWS_TOTAL = 0,
+    DB_UNIQUE_DATA_BYTES = 1,
+    NOT_IN_ALLOW_LIST = 2,
 };
 
 enum ECumulativeCounter : ui32 {
     CONSUMED_CPU = 0,
 };
 
-enum EPercentileCounter : ui32 {
-    HIST_CONSUMED_CPU = 0,
-    TX_LATENCY = 1,
+enum EAppCumulativeCounter : ui32 {
+    ENGINE_HOST_ROW_UPDATES = 0,
+    ENGINE_HOST_ROW_UPDATE_BYTES = 1,
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -94,32 +101,40 @@ struct TFakeTablet {
     TFakeTablet(ui64 tabletId, ui32 followerId)
         : TabletId(tabletId)
         , FollowerId(followerId)
+        , ExecutorCounters(
+            Y_ARRAY_SIZE(EXECUTOR_SIMPLE_COUNTER_NAMES),
+            Y_ARRAY_SIZE(EXECUTOR_CUMULATIVE_COUNTER_NAMES),
+            Y_ARRAY_SIZE(EXECUTOR_PERCENTILE_COUNTER_NAMES),
+            EXECUTOR_SIMPLE_COUNTER_NAMES,
+            EXECUTOR_CUMULATIVE_COUNTER_NAMES,
+            EXECUTOR_PERCENTILE_COUNTER_NAMES
+        )
         , AppCounters(
-            Y_ARRAY_SIZE(SIMPLE_COUNTER_NAMES),
-            Y_ARRAY_SIZE(CUMULATIVE_COUNTER_NAMES),
-            Y_ARRAY_SIZE(PERCENTILE_COUNTER_NAMES),
-            SIMPLE_COUNTER_NAMES,
-            CUMULATIVE_COUNTER_NAMES,
-            PERCENTILE_COUNTER_NAMES
+            0,
+            Y_ARRAY_SIZE(APP_CUMULATIVE_COUNTER_NAMES),
+            0,
+            nullptr,
+            APP_CUMULATIVE_COUNTER_NAMES,
+            nullptr
         )
     {
-        for (ui32 i = 0; i < Y_ARRAY_SIZE(PERCENTILE_COUNTER_NAMES); ++i) {
-            AppCounters.Percentile()[i].Initialize(PERCENTILE_RANGES, true /* integral */);
+        for (ui32 i = 0; i < Y_ARRAY_SIZE(EXECUTOR_PERCENTILE_COUNTER_NAMES); ++i) {
+            ExecutorCounters.Percentile()[i].Initialize(PERCENTILE_RANGES, true /* integral */);
         }
     }
 
     TFakeTablet& SetSimple(ESimpleCounter counter, ui64 value) {
-        AppCounters.Simple()[counter].Set(value);
+        ExecutorCounters.Simple()[counter].Set(value);
         return *this;
     }
 
     TFakeTablet& AddCumulative(ECumulativeCounter counter, ui64 delta) {
-        AppCounters.Cumulative()[counter] += delta;
+        ExecutorCounters.Cumulative()[counter] += delta;
         return *this;
     }
 
-    TFakeTablet& IncrementPercentile(EPercentileCounter counter, ui64 value) {
-        AppCounters.Percentile()[counter].IncrementFor(value);
+    TFakeTablet& AddAppCumulative(EAppCumulativeCounter counter, ui64 delta) {
+        AppCounters.Cumulative()[counter] += delta;
         return *this;
     }
 
@@ -131,7 +146,8 @@ struct TFakeTablet {
         EDetailedMetricsLevel level,
         TInstant now,
         const TPathId& tableId = TABLE_ID,
-        const TString& tablePath = TABLE_PATH
+        const TString& tablePath = TABLE_PATH,
+        TTabletTypes::EType tabletType = TABLET_TYPE
     ) {
         TDetailedMetricsTableInfo table;
         table.TableId = tableId;
@@ -147,7 +163,7 @@ struct TFakeTablet {
             table,
             TabletId,
             FollowerId,
-            TABLET_TYPE,
+            tabletType,
             *executorDiff,
             *appDiff,
             now
@@ -187,10 +203,14 @@ NMonitoring::TDynamicCounterPtr FindTableGroup(
 
 /**
  * @param[in] bucketGroup The counter group of a table bucket or of a leaf
+ * @param[in] category "executor" or "app"
  *
- * @return The counter group of the application counters (or nullptr if there is none)
+ * @return The counter group of the given category (or nullptr if there is none)
  */
-NMonitoring::TDynamicCounterPtr FindAppCountersGroup(NMonitoring::TDynamicCounterPtr bucketGroup) {
+NMonitoring::TDynamicCounterPtr FindCategoryCountersGroup(
+    NMonitoring::TDynamicCounterPtr bucketGroup,
+    const TString& category
+) {
     if (!bucketGroup) {
         return nullptr;
     }
@@ -200,18 +220,50 @@ NMonitoring::TDynamicCounterPtr FindAppCountersGroup(NMonitoring::TDynamicCounte
         return nullptr;
     }
 
-    return typeGroup->FindSubgroup("category", "app");
+    return typeGroup->FindSubgroup("category", category);
+}
+
+/**
+ * @param[in] bucketGroup The counter group of a table bucket or of a leaf
+ *
+ * @return The counter group of the executor counters (or nullptr if there is none)
+ *
+ * @note The renamed fixture counters (DbUniqueRowsTotal, ConsumedCPU, ...) live here.
+ */
+NMonitoring::TDynamicCounterPtr FindExecutorCountersGroup(NMonitoring::TDynamicCounterPtr bucketGroup) {
+    return FindCategoryCountersGroup(bucketGroup, "executor");
+}
+
+/**
+ * @param[in] bucketGroup The counter group of a table bucket or of a leaf
+ *
+ * @return The counter group of the application counters (or nullptr if there is none)
+ */
+NMonitoring::TDynamicCounterPtr FindAppCountersGroup(NMonitoring::TDynamicCounterPtr bucketGroup) {
+    return FindCategoryCountersGroup(bucketGroup, "app");
+}
+
+/**
+ * @param[in] rootGroup The counter group where the whole tree is created
+ *
+ * @return The executor counters of the table bucket (or nullptr if there is none)
+ *
+ * @note At the table level the collapsed counters live directly in the table group:
+ *       the role is the caller's partition of the tree, not a label within it.
+ */
+NMonitoring::TDynamicCounterPtr FindTableBucketCounters(
+    NMonitoring::TDynamicCounterPtr rootGroup,
+    const TString& relativeTablePath = RELATIVE_TABLE_PATH
+) {
+    return FindExecutorCountersGroup(FindTableGroup(rootGroup, relativeTablePath));
 }
 
 /**
  * @param[in] rootGroup The counter group where the whole tree is created
  *
  * @return The application counters of the table bucket (or nullptr if there is none)
- *
- * @note At the table level the collapsed counters live directly in the table group:
- *       the role is the caller's partition of the tree, not a label within it.
  */
-NMonitoring::TDynamicCounterPtr FindTableBucketCounters(
+NMonitoring::TDynamicCounterPtr FindAppTableBucketCounters(
     NMonitoring::TDynamicCounterPtr rootGroup,
     const TString& relativeTablePath = RELATIVE_TABLE_PATH
 ) {
@@ -223,9 +275,40 @@ NMonitoring::TDynamicCounterPtr FindTableBucketCounters(
  * @param[in] tabletId The ID of the tablet
  * @param[in] followerId The follower ID of the tablet (0 for the leader)
  *
- * @return The application counters of the leaf (or nullptr if there is none)
+ * @return The executor counters of the leaf (or nullptr if there is none)
  */
 NMonitoring::TDynamicCounterPtr FindLeafCounters(
+    NMonitoring::TDynamicCounterPtr rootGroup,
+    ui64 tabletId,
+    ui32 followerId,
+    const TString& relativeTablePath = RELATIVE_TABLE_PATH
+) {
+    auto tableGroup = FindTableGroup(rootGroup, relativeTablePath);
+    if (!tableGroup) {
+        return nullptr;
+    }
+
+    auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
+    if (!perPartitionGroup) {
+        return nullptr;
+    }
+
+    auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
+    if (!tabletGroup) {
+        return nullptr;
+    }
+
+    return FindExecutorCountersGroup(tabletGroup->FindSubgroup("follower_id", ToString(followerId)));
+}
+
+/**
+ * @param[in] rootGroup The counter group where the whole tree is created
+ * @param[in] tabletId The ID of the tablet
+ * @param[in] followerId The follower ID of the tablet (0 for the leader)
+ *
+ * @return The application counters of the leaf (or nullptr if there is none)
+ */
+NMonitoring::TDynamicCounterPtr FindAppLeafCounters(
     NMonitoring::TDynamicCounterPtr rootGroup,
     ui64 tabletId,
     ui32 followerId,
@@ -262,6 +345,18 @@ ui64 GetCounterValue(NMonitoring::TDynamicCounterPtr countersGroup, const TStrin
     UNIT_ASSERT_C(counter, "no counter " << name);
 
     return counter->Val();
+}
+
+/**
+ * @param[in] countersGroup The counter group to check
+ * @param[in] name The name of the counter
+ *
+ * @return Whether a counter of the given name is present in the group
+ */
+bool HasCounter(NMonitoring::TDynamicCounterPtr countersGroup, const TString& name) {
+    UNIT_ASSERT_C(countersGroup, "no counter group to look for the counter " << name);
+
+    return countersGroup->FindNamedCounter("sensor", name) != nullptr;
 }
 
 /**
@@ -320,24 +415,21 @@ void DumpCounters(const TString& title, NMonitoring::TDynamicCounterPtr rootGrou
 }
 
 /**
- * The two role subtrees of the private "ydb_detailed_raw" group, built the way the two
- * Tablet Counters Aggregator actors of a node build them: one aggregator per role,
- * each owning everything below its own role= node, both hanging off one shared root.
+ * The private "ydb_detailed_raw" group with the two aggregators of a node built off it,
+ * the way the two Tablet Counters Aggregator actors do: ONE shared root, no role label,
+ * one aggregator per role writing into the very same tree.
  */
 struct TRoleTrees {
     NMonitoring::TDynamicCounterPtr Root = MakeIntrusive<NMonitoring::TDynamicCounters>();
 
-    NMonitoring::TDynamicCounterPtr LeaderRoot = Root->GetSubgroup("role", "leader");
-    NMonitoring::TDynamicCounterPtr FollowerRoot = Root->GetSubgroup("role", "follower");
-
     TNodeDatabaseMetricsAggregatorPtr Leaders = CreateNodeDatabaseMetricsAggregator(
-        LeaderRoot,
+        Root,
         DATABASE_PATH,
         false /* isFollowerRole */
     );
 
     TNodeDatabaseMetricsAggregatorPtr Followers = CreateNodeDatabaseMetricsAggregator(
-        FollowerRoot,
+        Root,
         DATABASE_PATH,
         true /* isFollowerRole */
     );
@@ -357,8 +449,14 @@ struct TRoleTrees {
  */
 Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     /**
-     * Verify that at the table level all same-node partitions of the table are collapsed
-     * into a single bucket per role tree, and no per-partition counters are created.
+     * Verify that at the table level all same-node LEADER partitions of the table are
+     * collapsed into a single bucket, that the followers contribute nothing to it, and
+     * that no per-partition counters are created.
+     *
+     * @note The bucket belongs to the aggregator of the leaders alone. Both aggregators
+     *       write into one shared tree, and two TAggregatedTabletCounters pointed at one
+     *       counter group assign rather than sum, so a follower side bucket would simply
+     *       overwrite the leader values on every recalculation.
      */
     Y_UNIT_TEST(TableLevelCollapsesPartitions) {
         TRoleTrees trees;
@@ -370,16 +468,21 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         TFakeTablet leader2(2000, 0);
         TFakeTablet leader3(3000, 0);
 
-        leader1.SetSimple(UNIQUE_ROWS, 1).SetSimple(UNIQUE_BYTES, 10).AddCumulative(CONSUMED_CPU, 100);
-        leader2.SetSimple(UNIQUE_ROWS, 2).SetSimple(UNIQUE_BYTES, 20).AddCumulative(CONSUMED_CPU, 200);
-        leader3.SetSimple(UNIQUE_ROWS, 4).SetSimple(UNIQUE_BYTES, 40).AddCumulative(CONSUMED_CPU, 400);
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1).SetSimple(DB_UNIQUE_DATA_BYTES, 10).AddCumulative(CONSUMED_CPU, 100)
+            .AddAppCumulative(ENGINE_HOST_ROW_UPDATES, 1000);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2).SetSimple(DB_UNIQUE_DATA_BYTES, 20).AddCumulative(CONSUMED_CPU, 200)
+            .AddAppCumulative(ENGINE_HOST_ROW_UPDATES, 2000);
+        leader3.SetSimple(DB_UNIQUE_ROWS_TOTAL, 4).SetSimple(DB_UNIQUE_DATA_BYTES, 40).AddCumulative(CONSUMED_CPU, 400)
+            .AddAppCumulative(ENGINE_HOST_ROW_UPDATES, 4000);
 
         // 2 followers of the very same partition: they must NOT collide with each other
         TFakeTablet follower1(1000, 1);
         TFakeTablet follower2(1000, 2);
 
-        follower1.SetSimple(UNIQUE_ROWS, 8).AddCumulative(CONSUMED_CPU, 800);
-        follower2.SetSimple(UNIQUE_ROWS, 16).AddCumulative(CONSUMED_CPU, 1600);
+        follower1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 8).AddCumulative(CONSUMED_CPU, 800)
+            .AddAppCumulative(ENGINE_HOST_ROW_UPDATES, 8000);
+        follower2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 16).AddCumulative(CONSUMED_CPU, 1600)
+            .AddAppCumulative(ENGINE_HOST_ROW_UPDATES, 16000);
 
         for (auto* tablet : {&leader1, &leader2, &leader3}) {
             tablet->Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
@@ -393,28 +496,39 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
         DumpCounters("Table level counters", trees.Root);
 
-        // The bucket of the leader tree holds the 3 leader partitions
-        auto leaderCounters = FindTableBucketCounters(trees.LeaderRoot);
+        // The single bucket holds the 3 leader partitions and nothing else
+        auto leaderCounters = FindTableBucketCounters(trees.Root);
         UNIT_ASSERT(leaderCounters);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(UniqueRows)"), 1 + 2 + 4);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(UniqueRows)"), 4);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(UniqueBytes)"), 10 + 20 + 40);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(UniqueBytes)"), 40);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(DbUniqueRowsTotal)"), 1 + 2 + 4);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(DbUniqueRowsTotal)"), 4);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(DbUniqueDataBytes)"), 10 + 20 + 40);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(DbUniqueDataBytes)"), 40);
         UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200 + 400);
 
-        // The bucket of the follower tree holds the 2 followers
-        auto followerCounters = FindTableBucketCounters(trees.FollowerRoot);
-        UNIT_ASSERT(followerCounters);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "SUM(UniqueRows)"), 8 + 16);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "MAX(UniqueRows)"), 16);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "ConsumedCPU"), 800 + 1600);
+        // The app category counters (category=app, SCC_TABLET) collapse the very same way
+        auto leaderAppCounters = FindAppTableBucketCounters(trees.Root);
+        UNIT_ASSERT(leaderAppCounters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(leaderAppCounters, "DataShard/EngineHostRowUpdates"),
+            1000 + 2000 + 4000
+        );
 
-        // No per-partition counters at the table level, in either tree
-        for (auto roleRoot : {trees.LeaderRoot, trees.FollowerRoot}) {
-            auto tableGroup = FindTableGroup(roleRoot);
-            UNIT_ASSERT(tableGroup);
-            UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
-        }
+        // The regression this whole arrangement exists to prevent: recalculating the
+        // follower side must not touch a single value of the bucket
+        trees.Followers->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(DbUniqueRowsTotal)"), 1 + 2 + 4);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(DbUniqueDataBytes)"), 10 + 20 + 40);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200 + 400);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(leaderAppCounters, "DataShard/EngineHostRowUpdates"),
+            1000 + 2000 + 4000
+        );
+
+        // No per-partition counters at the table level
+        auto tableGroup = FindTableGroup(trees.Root);
+        UNIT_ASSERT(tableGroup);
+        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
     }
 
     /**
@@ -427,8 +541,9 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         const TInstant now = TInstant::Seconds(100);
 
         // 2 partitions of the same table, a leader and 2 followers each. The leader goes
-        // to the leader tree and both followers to the follower one, exactly the way
-        // the two Tablet Counters Aggregator actors of a node are fed.
+        // to the aggregator of the leaders and both followers to the other one, exactly
+        // the way the two Tablet Counters Aggregator actors of a node are fed. All of
+        // them land in ONE shared tree, told apart by follower_id alone.
         const TVector<ui64> tabletIds = {1000, 2000};
         const TVector<ui32> followerIds = {0, 1, 2};
 
@@ -441,7 +556,10 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 expectedValues[std::make_pair(tabletId, followerId)] = value;
 
                 TFakeTablet tablet(tabletId, followerId);
-                tablet.SetSimple(UNIQUE_ROWS, value).AddCumulative(CONSUMED_CPU, value * 100);
+                tablet
+                    .SetSimple(DB_UNIQUE_ROWS_TOTAL, value)
+                    .AddCumulative(CONSUMED_CPU, value * 100)
+                    .AddAppCumulative(ENGINE_HOST_ROW_UPDATES, value * 10);
                 tablet.Report(
                     followerId == 0 ? trees.Leaders : trees.Followers,
                     TDetailedMetricsSettings::MetricsLevelPartition,
@@ -454,39 +572,53 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
         DumpCounters("Partition level counters", trees.Root);
 
-        // Every leaf holds exactly what its tablet has reported, in the tree of its role
+        // Every leaf holds exactly what its tablet has reported, all in the one tree
         for (const auto& [tablet, expectedValue] : expectedValues) {
             const auto& [tabletId, followerId] = tablet;
 
-            auto roleRoot = followerId == 0 ? trees.LeaderRoot : trees.FollowerRoot;
-
-            auto leafCounters = FindLeafCounters(roleRoot, tabletId, followerId);
+            auto leafCounters = FindLeafCounters(trees.Root, tabletId, followerId);
             UNIT_ASSERT_C(leafCounters, "no leaf for " << tabletId << ":" << followerId);
 
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(UniqueRows)"), expectedValue);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "MAX(UniqueRows)"), expectedValue);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(DbUniqueRowsTotal)"), expectedValue);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "MAX(DbUniqueRowsTotal)"), expectedValue);
             UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "ConsumedCPU"), expectedValue * 100);
+
+            auto appLeafCounters = FindAppLeafCounters(trees.Root, tabletId, followerId);
+            UNIT_ASSERT_C(appLeafCounters, "no app leaf for " << tabletId << ":" << followerId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(appLeafCounters, "DataShard/EngineHostRowUpdates"),
+                expectedValue * 10
+            );
         }
 
-        // A leaf of one role never lands in the tree of the other one
-        UNIT_ASSERT(!FindLeafCounters(trees.LeaderRoot, 1000, 1));
-        UNIT_ASSERT(!FindLeafCounters(trees.FollowerRoot, 1000, 0));
+        // The leader and the followers of one partition share a single tablet_id= node,
+        // written by the two different aggregators
+        auto tableGroup = FindTableGroup(trees.Root);
+        UNIT_ASSERT(tableGroup);
 
-        // No table bucket and no on-node rollup at the partition level, in either tree
-        for (auto roleRoot : {trees.LeaderRoot, trees.FollowerRoot}) {
-            auto tableGroup = FindTableGroup(roleRoot);
-            UNIT_ASSERT(tableGroup);
-            UNIT_ASSERT(!FindAppCountersGroup(tableGroup));
+        auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
+        UNIT_ASSERT(perPartitionGroup);
 
-            auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
-            UNIT_ASSERT(perPartitionGroup);
-            UNIT_ASSERT(!FindAppCountersGroup(perPartitionGroup));
+        auto sharedTabletGroup = perPartitionGroup->FindSubgroup("tablet_id", "1000");
+        UNIT_ASSERT(sharedTabletGroup);
+        for (ui32 followerId : followerIds) {
+            UNIT_ASSERT_C(
+                sharedTabletGroup->FindSubgroup("follower_id", ToString(followerId)),
+                "no follower_id=" << followerId << " under the shared tablet_id=1000"
+            );
+        }
 
-            for (ui64 tabletId : tabletIds) {
-                auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
-                UNIT_ASSERT(tabletGroup);
-                UNIT_ASSERT(!FindAppCountersGroup(tabletGroup));
-            }
+        // No table bucket and no on-node rollup at the partition level
+        UNIT_ASSERT(!FindExecutorCountersGroup(tableGroup));
+        UNIT_ASSERT(!FindExecutorCountersGroup(perPartitionGroup));
+
+        for (ui64 tabletId : tabletIds) {
+            auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
+            UNIT_ASSERT(tabletGroup);
+            UNIT_ASSERT(!FindExecutorCountersGroup(tabletGroup));
+
+            // No replicas_only aggregate is synthesized on the node
+            UNIT_ASSERT(!tabletGroup->FindSubgroup("follower_id", "replicas_only"));
         }
     }
 
@@ -560,9 +692,9 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Verify that both kinds of the percentile counters end up in the counter tree:
-     * the ordinary ones, which the tablet fills itself, and the histogram aggregates
-     * named HIST(x), which are filled here from the counter named x.
+     * Verify that the histogram aggregate named HIST(x) ends up in the counter tree,
+     * filled here from the counter named x. DataShard's allow-list has no ordinary
+     * percentile counter, only this synthesized one.
      */
     Y_UNIT_TEST(PercentileCountersAreAggregated) {
         NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -578,17 +710,8 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         TFakeTablet leader1(1000, 0);
         TFakeTablet leader2(2000, 0);
 
-        // 3 transactions on the first partition, 2 on the second one
-        leader1
-            .IncrementPercentile(TX_LATENCY, 5)
-            .IncrementPercentile(TX_LATENCY, 50)
-            .IncrementPercentile(TX_LATENCY, 500)
-            .AddCumulative(CONSUMED_CPU, 100);
-
-        leader2
-            .IncrementPercentile(TX_LATENCY, 5)
-            .IncrementPercentile(TX_LATENCY, 5)
-            .AddCumulative(CONSUMED_CPU, 200);
+        leader1.AddCumulative(CONSUMED_CPU, 100);
+        leader2.AddCumulative(CONSUMED_CPU, 200);
 
         for (auto* tablet : {&leader1, &leader2}) {
             tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
@@ -601,9 +724,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         auto leaderCounters = FindTableBucketCounters(rootGroup);
         UNIT_ASSERT(leaderCounters);
 
-        // The ordinary percentile counter holds the observations of both partitions
-        UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "TxLatency"), 3 + 2);
-
         // The histogram aggregate holds one observation per partition, taken from
         // the "ConsumedCPU" cumulative counter. The tablets do NOT fill it themselves,
         // so an empty histogram here would mean the aggregate is never fed.
@@ -611,13 +731,12 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Verify that forgetting a tablet drops its observations from the percentile
-     * counters of the table bucket, while the accumulated cumulative counters keep
+     * Verify that forgetting a tablet drops its observations from the HIST(x) percentile
+     * aggregate of the table bucket, while the accumulated cumulative counters keep
      * the work the tablet had already done.
      *
-     * @note The two kinds of the percentile counters are dropped by two different
-     *       mechanisms: an ordinary one is subtracted bucket by bucket right away,
-     *       while a HIST(x) aggregate is rebuilt from scratch on the next recalculation.
+     * @note A HIST(x) aggregate is rebuilt from scratch on the next recalculation, rather
+     *       than subtracted bucket by bucket right away.
      */
     Y_UNIT_TEST(ForgetTabletDropsPercentileObservations) {
         NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -633,18 +752,8 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         TFakeTablet leader1(1000, 0);
         TFakeTablet leader2(2000, 0);
 
-        // The observations of the two partitions land in DIFFERENT buckets, so that
-        // a misaligned subtraction is not mistaken for a correct one
-        leader1
-            .IncrementPercentile(TX_LATENCY, 5)
-            .IncrementPercentile(TX_LATENCY, 5)
-            .AddCumulative(CONSUMED_CPU, 100);
-
-        leader2
-            .IncrementPercentile(TX_LATENCY, 500)
-            .IncrementPercentile(TX_LATENCY, 500)
-            .IncrementPercentile(TX_LATENCY, 500)
-            .AddCumulative(CONSUMED_CPU, 200);
+        leader1.AddCumulative(CONSUMED_CPU, 100);
+        leader2.AddCumulative(CONSUMED_CPU, 200);
 
         for (auto* tablet : {&leader1, &leader2}) {
             tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
@@ -655,10 +764,10 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         auto leaderCounters = FindTableBucketCounters(rootGroup);
         UNIT_ASSERT(leaderCounters);
 
-        // The ranges {0, 10, 100} become the 4 buckets <=0, (0;10], (10;100], (100;inf],
-        // so the 2 observations of the first partition land in the second bucket and
-        // the 3 observations of the second one in the last
-        UNIT_ASSERT_VALUES_EQUAL(GetHistogramBuckets(leaderCounters, "TxLatency"), "0,2,0,3");
+        // The very first report of a tablet contributes a 0 observation (there is no
+        // previous report of it to derive a per second rate from), so both partitions'
+        // observations land in the <=0 bucket of the ranges {0, 10, 100}
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramBuckets(leaderCounters, "HIST(ConsumedCPU)"), "2,0,0,0");
         UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "HIST(ConsumedCPU)"), 2);
         UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200);
 
@@ -668,32 +777,30 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
         DumpCounters("Table level counters after forgetting the second partition", rootGroup);
 
-        // Only the observations of the forgotten partition are subtracted, and only
-        // from its own bucket
-        UNIT_ASSERT_VALUES_EQUAL(GetHistogramBuckets(leaderCounters, "TxLatency"), "0,2,0,0");
-
         // The histogram aggregate is rebuilt from the surviving partitions only
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramBuckets(leaderCounters, "HIST(ConsumedCPU)"), "1,0,0,0");
         UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "HIST(ConsumedCPU)"), 1);
 
         // The accumulated cumulative counter is NOT reduced: the CPU the forgotten
         // partition had burnt has still been burnt, and the series must not go backwards
         UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200);
 
-        // The last partition is gone too, so the whole table leaves the tree
+        // The last partition is gone too, so the bucket takes its own type= subtree with
+        // it and the emptied table= and database= nodes above it follow
         aggregator->ForgetTablet(leader1.TabletId, leader1.FollowerId);
 
+        UNIT_ASSERT(!FindTableBucketCounters(rootGroup));
         UNIT_ASSERT(!FindTableGroup(rootGroup));
+        UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
     }
 
     /**
      * Verify that forgetting a tablet of a table level table drops its contribution
      * from the table bucket and removes the counter groups, which become empty.
      *
-     * @note The two role trees are torn down independently. That is the whole reason
-     *       the role is the caller's partition of the tree rather than a label within
-     *       it: an aggregator only ever removes groups it exclusively owns, so emptying
-     *       one role tree can never detach the live counters of the other one from
-     *       the shared root.
+     * @note The table bucket belongs to the aggregator of the leaders alone, so the
+     *       followers of a table level table contribute nothing at all. The table= node
+     *       itself is shared spine and outlives the bucket.
      */
     Y_UNIT_TEST(ForgetTabletAtTableLevel) {
         TRoleTrees trees;
@@ -704,9 +811,9 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         TFakeTablet leader2(2000, 0);
         TFakeTablet follower(1000, 1);
 
-        leader1.SetSimple(UNIQUE_ROWS, 1);
-        leader2.SetSimple(UNIQUE_ROWS, 2);
-        follower.SetSimple(UNIQUE_ROWS, 8);
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 8);
 
         for (auto* tablet : {&leader1, &leader2}) {
             tablet->Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
@@ -715,8 +822,10 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
         trees.RecalculateAllCounters();
 
+        // The follower of a table level table is dropped on the floor: only the leaders
+        // are in the bucket
         UNIT_ASSERT_VALUES_EQUAL(
-            GetCounterValue(FindTableBucketCounters(trees.LeaderRoot), "SUM(UniqueRows)"),
+            GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
             1 + 2
         );
 
@@ -727,133 +836,209 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         DumpCounters("Table level counters after forgetting one leader", trees.Root);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            GetCounterValue(FindTableBucketCounters(trees.LeaderRoot), "SUM(UniqueRows)"),
+            GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
             1
         );
         UNIT_ASSERT_VALUES_EQUAL(
-            GetCounterValue(FindTableBucketCounters(trees.LeaderRoot), "MAX(UniqueRows)"),
+            GetCounterValue(FindTableBucketCounters(trees.Root), "MAX(DbUniqueRowsTotal)"),
             1
         );
 
-        // TEST 2: The table leaves the leader tree as soon as its last leader is gone,
-        //         and the follower tree keeps its own counters, still reachable from
-        //         the shared root
+        // TEST 2: The bucket takes its own type= subtree with it once its last tablet is
+        //         gone, and the table= and database= nodes it emptied go with it. Nothing
+        //         else is under them: the follower of a table level table never built
+        //         anything of its own
         trees.Leaders->ForgetTablet(leader1.TabletId, leader1.FollowerId);
         trees.RecalculateAllCounters();
 
         DumpCounters("Counters after forgetting the last leader", trees.Root);
 
-        UNIT_ASSERT(!FindTableGroup(trees.LeaderRoot));
-        UNIT_ASSERT(!trees.Root->FindSubgroup("role", "leader")->FindSubgroup("database", DATABASE_PATH));
+        UNIT_ASSERT(!FindTableBucketCounters(trees.Root));
+        UNIT_ASSERT(!FindTableGroup(trees.Root));
+        UNIT_ASSERT(!trees.Root->FindSubgroup("database", DATABASE_PATH));
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            GetCounterValue(
-                FindTableBucketCounters(trees.Root->FindSubgroup("role", "follower")),
-                "SUM(UniqueRows)"
-            ),
-            8
-        );
-
-        // TEST 3: The table is removed as soon as its last tablet is gone
+        // TEST 3: Forgetting the follower, which never contributed, is not an error
         trees.Followers->ForgetTablet(follower.TabletId, follower.FollowerId);
-
-        UNIT_ASSERT(!FindTableGroup(trees.FollowerRoot));
 
         // TEST 4: Forgetting an unknown tablet is not an error
         trees.Leaders->ForgetTablet(leader1.TabletId, leader1.FollowerId);
+
+        // TEST 5: A tablet reported after the teardown rebuilds the tree, rather than
+        //         filling the database= node this instance used to hold a pointer to
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 3);
+        leader1.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Counters after the table came back", trees.Root);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
+            3
+        );
     }
 
     /**
-     * Verify that forgetting a tablet of a partition level table removes its leaf
-     * and all the counter groups, which become empty.
+     * Verify that forgetting a tablet of a partition level table removes its own leaf
+     * and ONLY its own leaf.
+     *
+     * @note The tablet_id= node above the leaf is shared: the leader of a partition and
+     *       its followers may run on one node and are reported by the two different
+     *       aggregators. It survives for exactly as long as either of them is still there,
+     *       and is reclaimed together with detailed_metrics=, table= and database= once
+     *       the last leaf below it goes.
      */
     Y_UNIT_TEST(ForgetTabletAtPartitionLevel) {
         TRoleTrees trees;
 
         const TInstant now = TInstant::Seconds(100);
 
-        // Two followers of the same partition plus one of another partition, so that
-        // the tablet group is only removed once its LAST follower is gone
+        // Two followers of the same partition plus one of another partition
         TFakeTablet follower1(1000, 1);
         TFakeTablet follower2(1000, 2);
         TFakeTablet follower3(2000, 1);
 
+        // ... and the leader of the first partition, on this very node, reported by the
+        // OTHER aggregator into the very same tablet_id= node
+        TFakeTablet leader1(1000, 0);
+
         for (auto* tablet : {&follower1, &follower2, &follower3}) {
-            tablet->SetSimple(UNIQUE_ROWS, 1);
+            tablet->SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
             tablet->Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
         }
 
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+        leader1.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
         trees.RecalculateAllCounters();
 
-        auto rootGroup = trees.FollowerRoot;
-
-        auto tableGroup = FindTableGroup(rootGroup);
+        auto tableGroup = FindTableGroup(trees.Root);
         UNIT_ASSERT(tableGroup);
 
         auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
         UNIT_ASSERT(perPartitionGroup);
 
-        // TEST 1: Only the leaf of the forgotten tablet is removed, its sibling survives
+        // TEST 1: Only the leaf of the forgotten tablet is removed, its siblings survive
         trees.Followers->ForgetTablet(follower1.TabletId, follower1.FollowerId);
 
         DumpCounters("Partition level counters after forgetting one follower", trees.Root);
 
-        UNIT_ASSERT(!FindLeafCounters(rootGroup, follower1.TabletId, follower1.FollowerId));
-        UNIT_ASSERT(FindLeafCounters(rootGroup, follower2.TabletId, follower2.FollowerId));
-        UNIT_ASSERT(perPartitionGroup->FindSubgroup("tablet_id", ToString(follower2.TabletId)));
+        UNIT_ASSERT(!FindLeafCounters(trees.Root, follower1.TabletId, follower1.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(trees.Root, follower2.TabletId, follower2.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(trees.Root, leader1.TabletId, leader1.FollowerId));
 
-        // TEST 2: The tablet group is removed as soon as its last follower is gone
+        // TEST 2: Emptying the followers of a partition must NOT take the shared
+        //         tablet_id= node with it — the leader of that partition is still live
+        //         there, reported by the other aggregator
         trees.Followers->ForgetTablet(follower2.TabletId, follower2.FollowerId);
-
-        UNIT_ASSERT(!perPartitionGroup->FindSubgroup("tablet_id", ToString(follower2.TabletId)));
-        UNIT_ASSERT(tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
-
-        // TEST 3: The table is removed as soon as its last tablet is gone
         trees.Followers->ForgetTablet(follower3.TabletId, follower3.FollowerId);
 
-        UNIT_ASSERT(!FindTableGroup(rootGroup));
+        DumpCounters("Counters after forgetting every follower", trees.Root);
+
+        auto sharedTabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(leader1.TabletId));
+        UNIT_ASSERT(sharedTabletGroup);
+
+        auto leaderLeaf = FindLeafCounters(trees.Root, leader1.TabletId, leader1.FollowerId);
+        UNIT_ASSERT(leaderLeaf);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderLeaf, "SUM(DbUniqueRowsTotal)"), 7);
+
+        // ... and it is still reachable from the SHARED root, not merely alive by
+        // reference count
+        UNIT_ASSERT(
+            trees.Root
+                ->FindSubgroup("database", DATABASE_PATH)
+                ->FindSubgroup("table", RELATIVE_TABLE_PATH)
+                ->FindSubgroup("detailed_metrics", "per_partition")
+                ->FindSubgroup("tablet_id", ToString(leader1.TabletId))
+                ->FindSubgroup("follower_id", "0")
+        );
+
+        // TEST 3: The last leaf goes too, and everything it emptied goes with it, all the
+        //         way up to the database= node. Nothing of this database is left on the
+        //         node, so nothing of it is left in the tree either
+        trees.Leaders->ForgetTablet(leader1.TabletId, leader1.FollowerId);
+
+        DumpCounters("Counters after forgetting the last tablet of the database", trees.Root);
+
+        UNIT_ASSERT(!FindLeafCounters(trees.Root, leader1.TabletId, leader1.FollowerId));
+        UNIT_ASSERT(!FindTableGroup(trees.Root));
+        UNIT_ASSERT(!trees.Root->FindSubgroup("database", DATABASE_PATH));
+
+        // TEST 4: The two instances rebuild the tree from scratch afterwards, neither of
+        //         them filling a node it used to hold a pointer to
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        leader1.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+        follower1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 6);
+        follower1.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Counters after the partitions came back", trees.Root);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(trees.Root, leader1.TabletId, leader1.FollowerId),
+                "SUM(DbUniqueRowsTotal)"
+            ),
+            5
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(trees.Root, follower1.TabletId, follower1.FollowerId),
+                "SUM(DbUniqueRowsTotal)"
+            ),
+            6
+        );
     }
 
     /**
-     * Verify that the database counter groups do not pile up empty: the database node
-     * is removed together with the last table of the database and recreated on demand.
+     * Verify that emptying one table of a database reclaims that table's node alone: the
+     * teardown walks upwards only for as long as the nodes it empties come out empty.
      */
-    Y_UNIT_TEST(DatabaseGroupIsRemovedWithTheLastTable) {
-        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
-
-        auto aggregator = CreateNodeDatabaseMetricsAggregator(
-            rootGroup,
-            DATABASE_PATH,
-            false /* isFollowerRole */
-        );
+    Y_UNIT_TEST(ForgetTabletKeepsTheOtherTablesOfTheDatabase) {
+        TRoleTrees trees;
 
         const TInstant now = TInstant::Seconds(100);
 
         TFakeTablet leader(1000, 0);
-        leader.SetSimple(UNIQUE_ROWS, 1);
-        leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        TFakeTablet otherLeader(2000, 0);
 
-        auto databaseGroup = rootGroup->FindSubgroup("database", DATABASE_PATH);
-        UNIT_ASSERT(databaseGroup);
-        UNIT_ASSERT(databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH));
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
 
-        // TEST 1: Nothing of the database is left behind once its last table is gone
-        aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
-
-        DumpCounters("Counters after forgetting the last table", rootGroup);
-
-        UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
-        UNIT_ASSERT(!databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH));
-
-        // TEST 2: The database node is recreated by the next table
-        leader.SetSimple(UNIQUE_ROWS, 2);
-        leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
-        aggregator->RecalculateAllCounters();
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
-            2
+        otherLeader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+        otherLeader.Report(
+            trees.Leaders,
+            TDetailedMetricsSettings::MetricsLevelPartition,
+            now,
+            OTHER_TABLE_ID,
+            OTHER_TABLE_PATH
         );
+
+        trees.RecalculateAllCounters();
+
+        // The only tablet of the first table is gone: that table= node goes with it, and
+        // the walk stops at database=, which the second table still occupies
+        trees.Leaders->ForgetTablet(leader.TabletId, leader.FollowerId);
+
+        DumpCounters("Counters after emptying one table of the database", trees.Root);
+
+        UNIT_ASSERT(!FindTableGroup(trees.Root));
+        UNIT_ASSERT(trees.Root->FindSubgroup("database", DATABASE_PATH));
+
+        auto survivingLeaf = FindLeafCounters(
+            trees.Root,
+            otherLeader.TabletId,
+            otherLeader.FollowerId,
+            OTHER_RELATIVE_TABLE_PATH
+        );
+        UNIT_ASSERT(survivingLeaf);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(survivingLeaf, "SUM(DbUniqueRowsTotal)"), 2);
+
+        // The second table goes too, and now the database= node has nothing left to hold
+        trees.Leaders->ForgetTablet(otherLeader.TabletId, otherLeader.FollowerId);
+
+        UNIT_ASSERT(!trees.Root->FindSubgroup("database", DATABASE_PATH));
     }
 
     /**
@@ -871,7 +1056,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         const TInstant now = TInstant::Seconds(100);
 
         TFakeTablet tablet(1000, 0);
-        tablet.SetSimple(UNIQUE_ROWS, 1);
+        tablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
 
         tablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
         tablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelDisabled, now);
@@ -883,31 +1068,29 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Verify that splitting the counters across two role trees prevents the
-     * double-counting of leader-only metrics at the table level.
+     * Verify that the table level bucket holds the leaders and the leaders alone, so
+     * that the leader-only metrics are neither inflated nor overwritten.
      *
-     * A follower's executor counters are real and equal its leader's (the rows
-     * are physically the same), which is why the corresponding public metric
-     * (table.datashard.row_count) must be leader-only. If the roles were
-     * aggregated into one bucket, the collapsed metric would read the follower's
-     * value twice: once from the leader (100) and once from the follower (100),
-     * yielding 200 against the true 100. This is unrecoverable downstream, because
-     * the raw DataShard counters carry no leader-only marking, and the filter
-     * runs on the processor after aggregation (decision S4).
+     * A follower's executor counters are real and equal its leader's (the rows are
+     * physically the same), which is why the corresponding public metric
+     * (table.datashard.row_count) must be leader-only. The raw DataShard counters carry
+     * no leader-only marking, and the filter runs on the processor after aggregation
+     * (decision S4), so whatever the node collapses into one bucket is what the filter
+     * has to work with.
      *
-     * The role split ensures that the true 100 is preserved in the separate trees
-     * and never summed with itself. A legitimate multi-role metric (one that
-     * counts all copies of the work, not just the leaders) is undamaged: the
-     * consumer adds the two streams and gets the correct total.
+     * Both aggregators of a node write into ONE tree, and the collapsed bucket lives
+     * directly on the shared table= node. A follower side bucket would therefore be the
+     * very same counter group, and TAggregatedTabletCounters ASSIGNS the simple SUM/MAX,
+     * the cumulative MAX and the histograms from its own contributors rather than adding
+     * to what is there. So the two would not sum to a wrong 200 — they would take turns
+     * overwriting each other, and row_count would flap to whatever the last recalculation
+     * saw. Leaving the bucket to the aggregator of the leaders is what removes the
+     * collision, and it agrees with the rule that the high level table.datashard.*
+     * metrics are computed from the leaders alone.
      *
      * @note Two independent mechanisms defend this, and this test pins the second.
-     *       Feeding both roles to ONE instance, which is what a merged bucket would
-     *       mean in production, never reaches the arithmetic at all: CheckSingleRole()
-     *       aborts first. What this test guards is the shape — that the two trees stay
-     *       separate and each reads the truth — so that a change that aliases them onto
-     *       a shared counter group, which the invariant cannot see, still fails here.
-     *
-     * Reference: exchange/review-response-issue1.md (Tree B vs Tree C).
+     *       Feeding both roles to ONE instance never reaches the arithmetic at all:
+     *       CheckSingleRole() aborts first. What this test guards is the shape.
      */
     Y_UNIT_TEST(RoleSplitKeepsLeaderOnlyMetricsUninflated) {
         TRoleTrees trees;
@@ -918,32 +1101,35 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         // The follower's executor counters hold the same value (the rows are the same),
         // and that is precisely why the corresponding public metric is leader-only.
         TFakeTablet leader(1000, 0);
-        leader.SetSimple(UNIQUE_ROWS, 100).AddCumulative(CONSUMED_CPU, 7);
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 100).AddCumulative(CONSUMED_CPU, 7);
 
         TFakeTablet follower(1000, 1);
-        follower.SetSimple(UNIQUE_ROWS, 100).AddCumulative(CONSUMED_CPU, 3);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 100).AddCumulative(CONSUMED_CPU, 3);
 
         leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
         follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelTable, now);
 
         trees.RecalculateAllCounters();
 
-        DumpCounters("Role split and leader-only metrics", trees.Root);
+        DumpCounters("Leader-only metrics at the table level", trees.Root);
 
-        // The leader tree's table bucket reads 100: the true row count
-        auto leaderCounters = FindTableBucketCounters(trees.LeaderRoot);
-        UNIT_ASSERT(leaderCounters);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(UniqueRows)"), 100);
+        // The single table bucket reads 100: the true row count, neither doubled
+        // by the follower nor overwritten by it
+        auto tableCounters = FindTableBucketCounters(trees.Root);
+        UNIT_ASSERT(tableCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "SUM(DbUniqueRowsTotal)"), 100);
 
-        // The follower tree's table bucket also reads 100: separate aggregation
-        auto followerCounters = FindTableBucketCounters(trees.FollowerRoot);
-        UNIT_ASSERT(followerCounters);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "SUM(UniqueRows)"), 100);
+        // The follower contributed nothing at all, not even its cumulative counters:
+        // at the table level its work is simply not collected on the node
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "ConsumedCPU"), 7);
 
-        // Cumulative counters (non-leader-only) are undamaged by the split: they are
-        // legitimately counted in both roles, and the consumer adds them: 7 + 3 = 10
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 7);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "ConsumedCPU"), 3);
+        // Recalculating the follower side leaves every value exactly as it was. This is
+        // the assertion that fails the day a follower side table bucket is reintroduced
+        // onto the shared table= node.
+        trees.Followers->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "SUM(DbUniqueRowsTotal)"), 100);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "ConsumedCPU"), 7);
     }
 
     /**
@@ -970,13 +1156,13 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
         const TInstant now = TInstant::Seconds(100);
 
-        // The leader holds one value, the follower another, so we can verify they
-        // land in their own trees and not in the other's
+        // The leader holds one value, the follower another, so we can verify each lands
+        // in its own follower_id= leaf of the ONE shared tree
         TFakeTablet leader(1000, 0);
-        leader.SetSimple(UNIQUE_ROWS, 42);
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 42);
 
         TFakeTablet follower(1000, 1);
-        follower.SetSimple(UNIQUE_ROWS, 99);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 99);
 
         leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
         follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
@@ -985,19 +1171,24 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
         DumpCounters("Partition level leaves, both roles", trees.Root);
 
-        // The leader's leaf is in the leader tree only, carrying the leader's value
-        auto leaderLeaf = FindLeafCounters(trees.LeaderRoot, 1000, 0);
+        // follower_id=0 is the leader, carrying the leader's value
+        auto leaderLeaf = FindLeafCounters(trees.Root, 1000, 0);
         UNIT_ASSERT(leaderLeaf);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderLeaf, "SUM(UniqueRows)"), 42);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderLeaf, "SUM(DbUniqueRowsTotal)"), 42);
 
-        // The follower's leaf is in the follower tree only, carrying the follower's value
-        auto followerLeaf = FindLeafCounters(trees.FollowerRoot, 1000, 1);
+        // follower_id=1 is the replica, carrying the replica's own value
+        auto followerLeaf = FindLeafCounters(trees.Root, 1000, 1);
         UNIT_ASSERT(followerLeaf);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerLeaf, "SUM(UniqueRows)"), 99);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerLeaf, "SUM(DbUniqueRowsTotal)"), 99);
 
-        // Cross-tree lookup finds nothing: the roles are split at the tree root
-        UNIT_ASSERT(!FindLeafCounters(trees.LeaderRoot, 1000, 1));
-        UNIT_ASSERT(!FindLeafCounters(trees.FollowerRoot, 1000, 0));
+        // The two are separate leaves of ONE tablet_id= node: the label carries the role,
+        // so nothing above the leaf has to
+        auto tabletGroup = FindTableGroup(trees.Root)
+            ->FindSubgroup("detailed_metrics", "per_partition")
+            ->FindSubgroup("tablet_id", "1000");
+        UNIT_ASSERT(tabletGroup);
+        UNIT_ASSERT(tabletGroup->FindSubgroup("follower_id", "0"));
+        UNIT_ASSERT(tabletGroup->FindSubgroup("follower_id", "1"));
     }
 
     /**
@@ -1043,7 +1234,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             table.MetricsLevel = TDetailedMetricsSettings::MetricsLevelTable;
 
             TFakeTablet tablet(tabletId++, 0);
-            tablet.SetSimple(UNIQUE_ROWS, 1);
+            tablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
 
             aggregator->AddCounters(
                 table,
@@ -1096,17 +1287,17 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             TFakeTablet leader(1000, 0);
 
-            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
             aggregator->RecalculateAllCounters();
 
             UNIT_ASSERT_VALUES_EQUAL(
-                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
                 5
             );
 
             // The very same tablet now reports another table of the same database
-            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
             leader.Report(
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelTable,
@@ -1118,21 +1309,23 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             DumpCounters("Counters after the tablet moved to another table", rootGroup);
 
-            // Nothing of the old table is left behind, and the new one holds the counters
-            UNIT_ASSERT(!FindTableGroup(rootGroup));
+            // Nothing of the old table is left behind — its emptied table= node goes with
+            // its counters, and so does the database= node until the new table recreates
+            // it — and the new table holds the counters instead
+            UNIT_ASSERT(!FindTableBucketCounters(rootGroup));
             UNIT_ASSERT_VALUES_EQUAL(
                 GetCounterValue(
                     FindTableBucketCounters(rootGroup, OTHER_RELATIVE_TABLE_PATH),
-                    "SUM(UniqueRows)"
+                    "SUM(DbUniqueRowsTotal)"
                 ),
                 7
             );
 
-            // The reverse map points at the new table, so forgetting the tablet empties
-            // the whole tree rather than the table it no longer belongs to
+            // The reverse map points at the new table, so forgetting the tablet drops
+            // the counters of the NEW table rather than of the one it no longer belongs to
             aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
 
-            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+            UNIT_ASSERT(!FindTableBucketCounters(rootGroup, OTHER_RELATIVE_TABLE_PATH));
         }
 
         // TEST 2: The partition level, where the tablet owns a leaf of its own
@@ -1147,13 +1340,13 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             TFakeTablet leader(1000, 0);
 
-            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
             aggregator->RecalculateAllCounters();
 
             UNIT_ASSERT(FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId));
 
-            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
             leader.Report(
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelPartition,
@@ -1165,7 +1358,9 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             DumpCounters("Leaves after the tablet moved to another table", rootGroup);
 
-            // The old leaf and its whole table are gone, the new leaf holds the counters
+            // The old leaf is gone together with the table= node it emptied, and the new
+            // leaf holds the counters
+            UNIT_ASSERT(!FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId));
             UNIT_ASSERT(!FindTableGroup(rootGroup));
 
             auto leafCounters = FindLeafCounters(
@@ -1175,11 +1370,16 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 OTHER_RELATIVE_TABLE_PATH
             );
             UNIT_ASSERT(leafCounters);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(UniqueRows)"), 7);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(DbUniqueRowsTotal)"), 7);
 
             aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
 
-            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+            UNIT_ASSERT(!FindLeafCounters(
+                rootGroup,
+                leader.TabletId,
+                leader.FollowerId,
+                OTHER_RELATIVE_TABLE_PATH
+            ));
         }
     }
 
@@ -1214,10 +1414,10 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             TFakeTablet oldTablet(1000, 0);
             TFakeTablet newTablet(1001, 0);
 
-            oldTablet.SetSimple(UNIQUE_ROWS, 5);
+            oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
             oldTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, TABLE_ID, TABLE_PATH);
 
-            newTablet.SetSimple(UNIQUE_ROWS, 7);
+            newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
             newTablet.Report(
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelTable,
@@ -1235,7 +1435,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             // never their sum
             UNIT_ASSERT(FindTableGroup(rootGroup));
             UNIT_ASSERT_VALUES_EQUAL(
-                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
                 5 + 7
             );
 
@@ -1248,7 +1448,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             UNIT_ASSERT(FindTableGroup(rootGroup));
             UNIT_ASSERT_VALUES_EQUAL(
-                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
                 7
             );
         }
@@ -1266,7 +1466,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             TFakeTablet oldTablet(1000, 0);
             TFakeTablet newTablet(1001, 0);
 
-            oldTablet.SetSimple(UNIQUE_ROWS, 5);
+            oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
             oldTablet.Report(
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelPartition,
@@ -1275,7 +1475,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 TABLE_PATH
             );
 
-            newTablet.SetSimple(UNIQUE_ROWS, 7);
+            newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
             newTablet.Report(
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelPartition,
@@ -1293,11 +1493,11 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             auto oldLeaf = FindLeafCounters(rootGroup, oldTablet.TabletId, oldTablet.FollowerId);
             UNIT_ASSERT(oldLeaf);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(oldLeaf, "SUM(UniqueRows)"), 5);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(oldLeaf, "SUM(DbUniqueRowsTotal)"), 5);
 
             auto newLeaf = FindLeafCounters(rootGroup, newTablet.TabletId, newTablet.FollowerId);
             UNIT_ASSERT(newLeaf);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(newLeaf, "SUM(UniqueRows)"), 7);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(newLeaf, "SUM(DbUniqueRowsTotal)"), 7);
 
             // Forgetting the OLDER PathId's tablet must not detach the surviving leaf
             aggregator->ForgetTablet(oldTablet.TabletId, oldTablet.FollowerId);
@@ -1308,7 +1508,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             auto survivingLeaf = FindLeafCounters(rootGroup, newTablet.TabletId, newTablet.FollowerId);
             UNIT_ASSERT(survivingLeaf);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(survivingLeaf, "SUM(UniqueRows)"), 7);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(survivingLeaf, "SUM(DbUniqueRowsTotal)"), 7);
         }
     }
 
@@ -1339,10 +1539,10 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             TFakeTablet leader(1000, 0);
 
-            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
 
-            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
 
             aggregator->RecalculateAllCounters();
@@ -1350,7 +1550,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             DumpCounters("Counters after the level changed to the partition one", rootGroup);
 
             UNIT_ASSERT_VALUES_EQUAL(
-                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
                 7
             );
             UNIT_ASSERT(!FindTableGroup(rootGroup)->FindSubgroup("detailed_metrics", "per_partition"));
@@ -1368,10 +1568,10 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             TFakeTablet leader(1000, 0);
 
-            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
 
-            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
 
             aggregator->RecalculateAllCounters();
@@ -1381,11 +1581,106 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             UNIT_ASSERT_VALUES_EQUAL(
                 GetCounterValue(
                     FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId),
-                    "SUM(UniqueRows)"
+                    "SUM(DbUniqueRowsTotal)"
                 ),
                 7
             );
-            UNIT_ASSERT(!FindAppCountersGroup(FindTableGroup(rootGroup)));
+            UNIT_ASSERT(!FindExecutorCountersGroup(FindTableGroup(rootGroup)));
         }
+    }
+
+    /**
+     * Verify that a tablet type with no detailed metrics allow-list publishes nothing.
+     *
+     * @note This is the production path: the aggregator falls back to
+     *       GetDetailedMetricsCounterNames(tabletType), which returns nullptr for
+     *       ColumnShard.
+     */
+    Y_UNIT_TEST(UnsupportedTabletTypePublishesNothing) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet tablet(1000, 0);
+        tablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        tablet.Report(
+            aggregator,
+            TDetailedMetricsSettings::MetricsLevelPartition,
+            now,
+            TABLE_ID,
+            TABLE_PATH,
+            TTabletTypes::ColumnShard
+        );
+
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+    }
+
+    /**
+     * Verify that a counter absent from the DataShard allow-list (NotInTheAllowList,
+     * a simple counter deliberately outside SourceCounters) is published nowhere: not at
+     * the table level bucket, not at the partition level leaf, neither under its raw name
+     * nor under its SUM(...)/MAX(...) aggregates. An allow-listed counter right next to it
+     * is still published, so the absence is the filter's doing, not an empty tree.
+     */
+    Y_UNIT_TEST(NameFilterDropsUnlistedCounters) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // Table level
+        TFakeTablet tableTablet(1000, 0);
+        tableTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5).SetSimple(NOT_IN_ALLOW_LIST, 123);
+        tableTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        // Partition level, a different table so it gets its own leaf
+        TFakeTablet partitionTablet(2000, 0);
+        partitionTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7).SetSimple(NOT_IN_ALLOW_LIST, 456);
+        partitionTablet.Report(
+            aggregator,
+            TDetailedMetricsSettings::MetricsLevelPartition,
+            now,
+            OTHER_TABLE_ID,
+            OTHER_TABLE_PATH
+        );
+
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters with an unlisted counter reported", rootGroup);
+
+        // Table level: the allow-listed neighbour is there, the unlisted counter is not,
+        // neither raw nor as SUM(...)/MAX(...)
+        auto tableCounters = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT(tableCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "SUM(DbUniqueRowsTotal)"), 5);
+        UNIT_ASSERT(!HasCounter(tableCounters, "NotInTheAllowList"));
+        UNIT_ASSERT(!HasCounter(tableCounters, "SUM(NotInTheAllowList)"));
+        UNIT_ASSERT(!HasCounter(tableCounters, "MAX(NotInTheAllowList)"));
+
+        // Partition level: same story for the leaf
+        auto leafCounters = FindLeafCounters(
+            rootGroup,
+            partitionTablet.TabletId,
+            partitionTablet.FollowerId,
+            OTHER_RELATIVE_TABLE_PATH
+        );
+        UNIT_ASSERT(leafCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(DbUniqueRowsTotal)"), 7);
+        UNIT_ASSERT(!HasCounter(leafCounters, "NotInTheAllowList"));
+        UNIT_ASSERT(!HasCounter(leafCounters, "SUM(NotInTheAllowList)"));
+        UNIT_ASSERT(!HasCounter(leafCounters, "MAX(NotInTheAllowList)"));
     }
 }

--- a/ydb/core/tablet/private/aggregated_tablet_counters.cpp
+++ b/ydb/core/tablet/private/aggregated_tablet_counters.cpp
@@ -15,8 +15,12 @@ TAggregatedTabletCounters::TAggregatedTabletCounters(
     , Visibility(visibility)
 {}
 
-void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) {
+void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters, const THashSet<TString>* nameFilter) {
     Y_ABORT_UNLESS(!IsInitialized);
+
+    const auto isPublished = [nameFilter](const char* name) {
+        return name && (!nameFilter || nameFilter->empty() || nameFilter->contains(name));
+    };
 
     if (counters) {
         THashMap<TString, THolder<THistogramCounter>> histogramAggregates;
@@ -25,7 +29,7 @@ void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) 
         FullSizePercentile = counters->Percentile().Size();
         AggregatedHistogramCounters.Reserve(FullSizePercentile);
         for (ui32 i = 0; i < FullSizePercentile; ++i) {
-            if (!counters->PercentileCounterName(i)) {
+            if (!isPublished(counters->PercentileCounterName(i))) {
                 DeprecatedPercentile.insert(i);
                 continue;
             }
@@ -43,7 +47,7 @@ void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) 
         AggregatedSimpleCounters.Reserve(FullSizeSimple);
         for (ui32 i = 0; i < FullSizeSimple; ++i) {
             const char* name = counters->SimpleCounterName(i);
-            if (!name) {
+            if (!isPublished(name)) {
                 DeprecatedSimple.insert(i);
                 continue;
             }
@@ -60,7 +64,7 @@ void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) 
         AggregatedCumulativeCounters.Reserve(FullSizeCumulative);
         for (ui32 i = 0; i < FullSizeCumulative; ++i) {
             const char* name = counters->CumulativeCounterName(i);
-            if (!name) {
+            if (!isPublished(name)) {
                 DeprecatedCumulative.insert(i);
                 continue;
             }
@@ -101,7 +105,7 @@ void TAggregatedTabletCounters::Apply(
     TVector<ui64> simpleValues;
     simpleValues.resize(FullSizeSimple); // more than needed
     for (ui32 i = 0; i < FullSizeSimple; ++i) {
-        if (!counters->SimpleCounterName(i)) {
+        if (DeprecatedSimple.contains(i)) {
             continue;
         }
         const ui32 offset = nextSimpleOffset++;
@@ -115,7 +119,7 @@ void TAggregatedTabletCounters::Apply(
     TVector<ui64> cumulativeValues;
     cumulativeValues.resize(FullSizeCumulative, 0);
     for (ui32 i = 0; i < FullSizeCumulative; ++i) {
-        if (!counters->CumulativeCounterName(i)) {
+        if (DeprecatedCumulative.contains(i)) {
             continue;
         }
         const ui32 offset = nextCumulativeOffset++;
@@ -131,7 +135,7 @@ void TAggregatedTabletCounters::Apply(
     // percentile counters
     ui32 nextPercentileOffset = 0;
     for (ui32 i = 0; i < FullSizePercentile; ++i) {
-        if (!counters->PercentileCounterName(i)) {
+        if (DeprecatedPercentile.contains(i)) {
             continue;
         }
 

--- a/ydb/core/tablet/private/aggregated_tablet_counters.h
+++ b/ydb/core/tablet/private/aggregated_tablet_counters.h
@@ -48,7 +48,7 @@ public:
      * @note The layout of the counter set is a property of the tablet type,
      *       so it is defined once and for all by the very first reporting tablet.
      */
-    void Initialize(const TTabletCountersBase* counters);
+    void Initialize(const TTabletCountersBase* counters, const THashSet<TString>* nameFilter = nullptr);
 
     /**
      * Add the counters of a single tablet to the aggregate.

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -1,7 +1,7 @@
 #include "tablet_counters_aggregator.h"
 #include "tablet_counters_app.h"
 #include "labeled_counters_merger.h"
-#include "labeled_db_counters.h"
+#include "detailed_metrics/node_database_metrics_aggregator.h"
 #include "detailed_metrics/ydb_metrics_mapper.h"
 #include "private/aggregated_counters.h"
 #include "private/aggregated_tablet_counters.h"
@@ -17,6 +17,7 @@
 #include <ydb/core/base/feature_flags.h>
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/counters.h>
+#include <ydb/core/base/path.h>
 #include <ydb/core/sys_view/common/events.h>
 #include <ydb/core/sys_view/service/db_counters.h>
 #include <ydb/core/sys_view/service/sysview_service.h>
@@ -44,6 +45,8 @@
 namespace NKikimr {
 
 const ui32 WAKEUP_TIMEOUT_SECONDS = 4;
+
+constexpr TDuration DATABASE_PATH_RESOLVE_TIMEOUT = TDuration::Seconds(10);
 
 TStringBuf GetHistogramAggregateSimpleName(TStringBuf name) {
     TStringBuf buffer(name);
@@ -94,6 +97,32 @@ public:
     {
         if (!IsFollower) {
             YdbCounters = MakeIntrusive<TYdbTabletCounters>(GetServiceCounters(counters, "ydb"), Counters);
+        }
+    }
+
+    void ResolveDatabasePath(NSchemeCache::TSchemeCacheNavigate* navigate, const TActorContext& ctx) {
+        for (const auto& entry : navigate->ResultSet) {
+            const auto pathId = entry.TableId.PathId;
+
+            auto it = DetailedMetricsByPathId.find(pathId);
+            if (it == DetailedMetricsByPathId.end()) {
+                continue;
+            }
+
+            auto& db = it->second;
+
+            // Let the next round of the counters request the path again
+            db.DatabasePathRequestedAt = TInstant::Zero();
+
+            if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                YDB_LOG_WARN_CTX(ctx, "Failed to resolve the database path of the detailed metrics",
+                    {"pathId", pathId.ToString()},
+                    {"status", static_cast<ui32>(entry.Status)});
+                continue;
+            }
+
+            db.DatabasePath = CanonizePath(entry.Path);
+            CreateDetailedMetricsAggregator(db, ctx);
         }
     }
 
@@ -888,6 +917,56 @@ private:
     }
 
 private:
+    ////////////////////////////////////////////
+    // Detailed metrics
+
+    struct TDetailedMetricsForDb {
+        TString DatabasePath;
+
+        TInstant DatabasePathRequestedAt;
+
+        TNodeDatabaseMetricsAggregatorPtr Aggregator;
+
+        THashMap<ui64, THashMap<ui32, TDetailedMetricsTableInfo>> TabletContributions;
+    };
+
+    void RequestDatabasePath(TPathId tenantPathId, TDetailedMetricsForDb& db, const TActorContext& ctx) {
+        const TInstant now = ctx.Now();
+        if (db.DatabasePathRequestedAt && db.DatabasePathRequestedAt + DATABASE_PATH_RESOLVE_TIMEOUT > now) {
+            return;
+        }
+        db.DatabasePathRequestedAt = now;
+
+        using TNavigate = NSchemeCache::TSchemeCacheNavigate;
+        auto request = MakeHolder<TNavigate>();
+
+        if (const auto& domain = AppData(ctx)->DomainsInfo->Domain) {
+            request->DatabaseName = domain->Name;
+        }
+
+        request->ResultSet.push_back({});
+
+        auto& entry = request->ResultSet.back();
+        entry.TableId.PathId = tenantPathId;
+        entry.Operation = TNavigate::EOp::OpPath;
+        entry.RequestType = TNavigate::TEntry::ERequestType::ByTableId;
+        entry.RedirectRequired = false;
+
+        ctx.Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request));
+    }
+
+    void CreateDetailedMetricsAggregator(TDetailedMetricsForDb& db, const TActorContext& ctx) {
+        db.Aggregator = CreateNodeDatabaseMetricsAggregator(
+            DetailedMetricsGroup,
+            db.DatabasePath,
+            IsFollower
+        );
+
+        YDB_LOG_INFO_CTX(ctx, "Created the detailed metrics aggregator of the database",
+            {"databasePath", db.DatabasePath});
+    }
+
+private:
     ::NMonitoring::TDynamicCounterPtr Counters;
     TTabletCountersForTabletTypePtr AllTypes;
     bool IsFollower = false;
@@ -906,6 +985,10 @@ private:
     TLabeledCountersByDbPath LabeledDbCounters;
     TLabeledCountersByTabletTypeAndGroup LabeledCountersByTabletTypeAndGroup;
     TQuietTabletCounters QuietTabletCounters;
+
+    ::NMonitoring::TDynamicCounterPtr DetailedMetricsGroup;
+
+    THashMap<TPathId, TDetailedMetricsForDb> DetailedMetricsByPathId;
 };
 
 
@@ -949,6 +1032,7 @@ private:
     void HandleWakeup(const TActorContext &ctx);
     void HandleWork(TEvTabletCounters::TEvRemoveDatabase::TPtr& ev);
     void HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev);
+    void HandleWork(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx);
 
     TString RenderSearch(const TStringBuf relPath, const TString& name) const;
 
@@ -1008,6 +1092,12 @@ TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletAddCounte
     Y_UNUSED(ctx);
     TEvTabletCounters::TEvTabletAddCounters* msg = ev->Get();
     TabletMon->Apply(msg->TabletID, msg->TabletType, msg->TenantPathId, msg->ExecutorCounters.Get(), msg->AppCounters.Get(), ctx);
+}
+
+////////////////////////////////////////////
+void
+TTabletCountersAggregatorActor::HandleWork(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev, const TActorContext &ctx) {
+    TabletMon->ResolveDatabasePath(ev->Get()->Request.Get(), ctx);
 }
 
 ////////////////////////////////////////////
@@ -1312,6 +1402,7 @@ STFUNC(TTabletCountersAggregatorActor::StateWork) {
         HFunc(TEvTabletCounters::TEvTabletAddLabeledCounters, HandleWork);
         HFunc(TEvTabletCounters::TEvTabletLabeledCountersRequest, HandleWork);
         HFunc(TEvTabletCounters::TEvTabletLabeledCountersResponse, HandleWork); //from cluster aggregator, for http requests
+        HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleWork);
         hFunc(TEvTabletCounters::TEvRemoveDatabase, HandleWork);
         hFunc(TEvTabletCounters::TEvTabletSetTableInfo, HandleWork);
         HFunc(NMon::TEvHttpInfo, HandleWork);

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -179,7 +179,7 @@ public:
         iterDbLabeled->Apply(tabletId, labeledCounters);
     }
 
-    void ForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId) {
+    void ForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, ui32 followerId) {
         AllTypes->Forget(tabletId);
         // and now erase from every other path
         auto iterTabletType = CountersByTabletType.find(tabletType);
@@ -1043,7 +1043,7 @@ void
 TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletCountersForgetTablet::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ctx);
     TEvTabletCounters::TEvTabletCountersForgetTablet* msg = ev->Get();
-    TabletMon->ForgetTablet(msg->TabletID, msg->TabletType, msg->TenantPathId);
+    TabletMon->ForgetTablet(msg->TabletID, msg->TabletType, msg->TenantPathId, msg->FollowerId);
 }
 
 ////////////////////////////////////////////
@@ -1330,9 +1330,9 @@ CreateTabletCountersAggregator(bool follower) {
     return new TTabletCountersAggregatorActor(follower);
 }
 
-void TabletCountersForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity) {
+void TabletCountersForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity, ui32 followerId) {
     const TActorId countersAggregator = MakeTabletCountersAggregatorID(identity.NodeId(), follower);
-    identity.Send(countersAggregator, new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId, tabletType, tenantPathId));
+    identity.Send(countersAggregator, new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId, tabletType, tenantPathId, followerId));
 }
 
 ///////////////////////////////////////////

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -18,6 +18,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/counters.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/sys_view/common/events.h>
 #include <ydb/core/sys_view/service/db_counters.h>
 #include <ydb/core/sys_view/service/sysview_service.h>
@@ -85,19 +86,165 @@ TActorId MakeTabletCountersAggregatorID(ui32 node, bool follower) {
     }
 }
 
+namespace {
+
+////////////////////////////////////////////
+// Detailed metrics (the private per node counter tree)
+
+const TString DETAILED_METRICS_RAW_GROUP = "ydb_detailed_raw";
+
+// TEvTabletSetTableInfo::MetricsLevel is a plain ui32 (to keep the event free of the
+// schemeshard proto header), carrying the raw values of the schemeshard proto enum;
+// these asserts guard against the two silently drifting apart
+static_assert(static_cast<ui32>(TDetailedMetricsSettings::MetricsLevelUnspecified) ==
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified);
+static_assert(static_cast<ui32>(TDetailedMetricsSettings::MetricsLevelDisabled) ==
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled);
+static_assert(static_cast<ui32>(TDetailedMetricsSettings::MetricsLevelTable) ==
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable);
+static_assert(static_cast<ui32>(TDetailedMetricsSettings::MetricsLevelPartition) ==
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition);
+
+std::optional<EDetailedMetricsLevel> GetDetailedMetricsLevel(ui32 rawLevel) {
+    const auto level = static_cast<EDetailedMetricsLevel>(rawLevel);
+
+    switch (level) {
+        case TDetailedMetricsSettings::MetricsLevelTable:
+        case TDetailedMetricsSettings::MetricsLevelPartition:
+            return level;
+
+        case TDetailedMetricsSettings::MetricsLevelUnspecified:
+        case TDetailedMetricsSettings::MetricsLevelDisabled:
+            return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
+::NMonitoring::TDynamicCounterPtr GetDetailedMetricsRawGroup(
+    ::NMonitoring::TDynamicCounterPtr countersRoot, const TActorContext& ctx)
+{
+    static TMutex lock;
+    TGuard<TMutex> guard(lock);
+
+    auto group = countersRoot->FindSubgroup("counters", DETAILED_METRICS_RAW_GROUP);
+    if (!group) {
+        group = MakeIntrusive<::NMonitoring::TDynamicCounters>(
+            ::NMonitoring::TCountableBase::EVisibility::Private);
+        countersRoot->RegisterSubgroup("counters", DETAILED_METRICS_RAW_GROUP, group);
+
+        YDB_LOG_INFO_CTX(ctx, "Created the private root group of the detailed metrics counter tree");
+    }
+
+    return group;
+}
+
+} // namespace <anonymous>
+
 ////////////////////////////////////////////
 class TTabletMon {
 public:
     //
-    TTabletMon(::NMonitoring::TDynamicCounterPtr counters, bool isFollower, TActorId dbWatcherActorId)
+    TTabletMon(::NMonitoring::TDynamicCounterPtr counters, bool isFollower, TActorId dbWatcherActorId,
+            bool detailedMetricsEnabled, const TActorContext& ctx)
         : Counters(GetServiceCounters(counters, isFollower ? "followers" : "tablets"))
         , AllTypes(MakeIntrusive<TTabletCountersForTabletType>(Counters.Get(), "type", "all"))
         , IsFollower(isFollower)
         , DbWatcherActorId(dbWatcherActorId)
+        , DetailedMetricsEnabled(detailedMetricsEnabled)
     {
         if (!IsFollower) {
             YdbCounters = MakeIntrusive<TYdbTabletCounters>(GetServiceCounters(counters, "ydb"), Counters);
         }
+
+        if (DetailedMetricsEnabled) {
+            DetailedMetricsGroup = GetDetailedMetricsRawGroup(counters, ctx);
+        }
+    }
+
+    void SetTableInfo(const TEvTabletCounters::TEvTabletSetTableInfo& msg, const TActorContext& ctx) {
+        if (!DetailedMetricsEnabled) {
+            return;
+        }
+
+        auto& db = DetailedMetricsByPathId[msg.TenantPathId];
+        db.TabletContributions[msg.TabletID][msg.FollowerId] = TDetailedMetricsTableInfo{
+            .TableId = msg.TableId,
+            .TablePath = msg.TablePath,
+            .SchemaVersion = msg.SchemaVersion,
+            .MetricsLevel = static_cast<EDetailedMetricsLevel>(msg.MetricsLevel),
+        };
+
+        // Fires once per tablet every 5s, hence TRACE
+        YDB_LOG_TRACE_CTX(ctx, "Remembered the identity of the table reported by the tablet",
+            {"tabletId", msg.TabletID},
+            {"followerId", msg.FollowerId},
+            {"tablePath", msg.TablePath},
+            {"schemaVersion", msg.SchemaVersion},
+            {"metricsLevel", msg.MetricsLevel});
+    }
+
+    void ApplyDetailedMetrics(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType,
+        TPathId tenantPathId, const TTabletCountersBase* executorCounters,
+        const TTabletCountersBase* appCounters, const TActorContext& ctx)
+    {
+        if (!DetailedMetricsEnabled) {
+            return;
+        }
+
+        if (!tenantPathId || !executorCounters || !appCounters) {
+            // Logged on every round of the counters of every tablet, hence TRACE
+            YDB_LOG_TRACE_CTX(ctx, "Skipping the detailed metrics of the tablet",
+                {"tabletId", tabletId},
+                {"tenantPathId", tenantPathId.ToString()},
+                {"hasExecutorCounters", executorCounters != nullptr},
+                {"hasAppCounters", appCounters != nullptr});
+            return;
+        }
+
+        auto itDb = DetailedMetricsByPathId.find(tenantPathId);
+        if (itDb == DetailedMetricsByPathId.end()) {
+            // An identity event (TEvTabletSetTableInfo) always creates the database entry
+            // first, so no entry means nothing is known to attribute these counters to yet
+            return;
+        }
+        auto& db = itDb->second;
+
+        auto itTablet = db.TabletContributions.find(tabletId);
+        const TDetailedMetricsTableInfo* table = nullptr;
+        if (itTablet != db.TabletContributions.end()) {
+            auto itFollower = itTablet->second.find(followerId);
+            if (itFollower != itTablet->second.end()) {
+                table = &itFollower->second;
+            }
+        }
+        if (!table) {
+            YDB_LOG_TRACE_CTX(ctx, "Skipping the counters of a tablet with no known table",
+                {"tabletId", tabletId},
+                {"followerId", followerId});
+            return;
+        }
+
+        const auto level = GetDetailedMetricsLevel(static_cast<ui32>(table->MetricsLevel));
+        if (!level) {
+            YDB_LOG_TRACE_CTX(ctx, "Skipping the detailed metrics of the table",
+                {"tabletId", tabletId},
+                {"tablePath", table->TablePath},
+                {"metricsLevel", static_cast<ui32>(table->MetricsLevel)});
+            return;
+        }
+
+        if (!db.Aggregator) {
+            if (!db.DatabasePath) {
+                RequestDatabasePath(tenantPathId, db, ctx);
+                return;
+            }
+
+            CreateDetailedMetricsAggregator(db, ctx);
+        }
+
+        db.Aggregator->AddCounters(*table, tabletId, followerId, tabletType,
+            *executorCounters, *appCounters, ctx.Now());
     }
 
     void ResolveDatabasePath(NSchemeCache::TSchemeCacheNavigate* navigate, const TActorContext& ctx) {
@@ -219,6 +366,7 @@ public:
         if (auto itPath = CountersByPathId.find(tenantPathId); itPath != CountersByPathId.end()) {
             itPath->second->Forget(tabletId, tabletType);
         }
+        ForgetTabletDetailedMetrics(tabletId, followerId, tenantPathId);
 
         for (auto iter = LabeledDbCounters.begin(); iter != LabeledDbCounters.end(); ++iter) {
             iter->second->ForgetTablet(tabletId);
@@ -351,6 +499,12 @@ public:
             counters->RecalcAll();
         }
 
+        for (auto& [_, db] : DetailedMetricsByPathId) {
+            if (db.Aggregator) {
+                db.Aggregator->RecalculateAllCounters();
+            }
+        }
+
         if (YdbCounters) {
             auto hasSchemeshard = (bool)FindCountersByTabletType(
                 TTabletTypes::SchemeShard, CountersByTabletType);
@@ -360,8 +514,9 @@ public:
         }
     }
 
-    void RemoveTabletsByPathId(TPathId pathId) {
+    void RemoveTabletsByPathId(TPathId pathId, const TActorContext& ctx) {
         CountersByPathId.erase(pathId);
+        RemoveDetailedMetricsByPathId(pathId, ctx);
     }
 
     void RemoveTabletsByDbPath(const TString& dbPath) {
@@ -966,6 +1121,61 @@ private:
             {"databasePath", db.DatabasePath});
     }
 
+    void ResetDetailedMetricsAggregator(TPathId pathId, TDetailedMetricsForDb& db, const TActorContext& ctx) {
+        if (!db.Aggregator) {
+            return;
+        }
+
+        for (const auto& [tabletId, byFollower] : db.TabletContributions) {
+            for (const auto& [followerId, _] : byFollower) {
+                db.Aggregator->ForgetTablet(tabletId, followerId);
+            }
+        }
+
+        db.TabletContributions.clear();
+        db.Aggregator = nullptr;
+
+        YDB_LOG_INFO_CTX(ctx, "Dropped the detailed metrics aggregator of the database",
+            {"databasePath", db.DatabasePath},
+            {"pathId", pathId.ToString()});
+    }
+
+    void ForgetTabletDetailedMetrics(ui64 tabletId, ui32 followerId, TPathId tenantPathId) {
+        auto itDb = DetailedMetricsByPathId.find(tenantPathId);
+        if (itDb == DetailedMetricsByPathId.end()) {
+            return;
+        }
+
+        auto& db = itDb->second;
+
+        auto itTablet = db.TabletContributions.find(tabletId);
+        if (itTablet == db.TabletContributions.end()) {
+            return;
+        }
+
+        if (itTablet->second.erase(followerId) == 0) {
+            return;
+        }
+
+        if (db.Aggregator) {
+            db.Aggregator->ForgetTablet(tabletId, followerId);
+        }
+
+        if (itTablet->second.empty()) {
+            db.TabletContributions.erase(itTablet);
+        }
+    }
+
+    void RemoveDetailedMetricsByPathId(TPathId pathId, const TActorContext& ctx) {
+        auto it = DetailedMetricsByPathId.find(pathId);
+        if (it == DetailedMetricsByPathId.end()) {
+            return;
+        }
+
+        ResetDetailedMetricsAggregator(pathId, it->second, ctx);
+        DetailedMetricsByPathId.erase(it);
+    }
+
 private:
     ::NMonitoring::TDynamicCounterPtr Counters;
     TTabletCountersForTabletTypePtr AllTypes;
@@ -985,6 +1195,8 @@ private:
     TLabeledCountersByDbPath LabeledDbCounters;
     TLabeledCountersByTabletTypeAndGroup LabeledCountersByTabletTypeAndGroup;
     TQuietTabletCounters QuietTabletCounters;
+
+    bool DetailedMetricsEnabled = false;
 
     ::NMonitoring::TDynamicCounterPtr DetailedMetricsGroup;
 
@@ -1030,8 +1242,8 @@ private:
     void HandleWork(TEvTabletCounters::TEvTabletLabeledCountersResponse::TPtr &ev, const TActorContext &ctx);//from cluster aggregator
     void HandleWork(NMon::TEvHttpInfo::TPtr& ev, const TActorContext &ctx);
     void HandleWakeup(const TActorContext &ctx);
-    void HandleWork(TEvTabletCounters::TEvRemoveDatabase::TPtr& ev);
-    void HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev);
+    void HandleWork(TEvTabletCounters::TEvRemoveDatabase::TPtr& ev, const TActorContext& ctx);
+    void HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev, const TActorContext& ctx);
     void HandleWork(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx);
 
     TString RenderSearch(const TStringBuf relPath, const TString& name) const;
@@ -1068,7 +1280,8 @@ TTabletCountersAggregatorActor::Bootstrap(const TActorContext &ctx) {
         DbWatcherActorId = ctx.Register(NSysView::CreateDbWatcherActor(callback));
     }
 
-    TabletMon = new TTabletMon(appData->Counters, Follower, DbWatcherActorId);
+    TabletMon = new TTabletMon(appData->Counters, Follower, DbWatcherActorId,
+        appData->FeatureFlags.GetEnableDataShardDetailedMetrics(), ctx);
     auto mon = appData->Mon;
     if (mon) {
         if (!Follower)
@@ -1089,9 +1302,10 @@ TTabletCountersAggregatorActor::Bootstrap(const TActorContext &ctx) {
 ////////////////////////////////////////////
 void
 TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletAddCounters::TPtr &ev, const TActorContext &ctx) {
-    Y_UNUSED(ctx);
     TEvTabletCounters::TEvTabletAddCounters* msg = ev->Get();
     TabletMon->Apply(msg->TabletID, msg->TabletType, msg->TenantPathId, msg->ExecutorCounters.Get(), msg->AppCounters.Get(), ctx);
+    TabletMon->ApplyDetailedMetrics(msg->TabletID, msg->FollowerId, msg->TabletType,
+        msg->TenantPathId, msg->ExecutorCounters.Get(), msg->AppCounters.Get(), ctx);
 }
 
 ////////////////////////////////////////////
@@ -1268,15 +1482,14 @@ TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletLabeledCo
 
 
 ////////////////////////////////////////////
-void TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvRemoveDatabase::TPtr& ev) {
-    TabletMon->RemoveTabletsByPathId(ev->Get()->PathId);
+void TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvRemoveDatabase::TPtr& ev, const TActorContext& ctx) {
+    TabletMon->RemoveTabletsByPathId(ev->Get()->PathId, ctx);
     TabletMon->RemoveTabletsByDbPath(ev->Get()->DbPath);
 }
 
 ////////////////////////////////////////////
-void TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev) {
-    // TODO(djant) join incoming metrics with it later
-    Y_UNUSED(ev);
+void TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev, const TActorContext& ctx) {
+    TabletMon->SetTableInfo(*ev->Get(), ctx);
 }
 
 ////////////////////////////////////////////
@@ -1403,8 +1616,8 @@ STFUNC(TTabletCountersAggregatorActor::StateWork) {
         HFunc(TEvTabletCounters::TEvTabletLabeledCountersRequest, HandleWork);
         HFunc(TEvTabletCounters::TEvTabletLabeledCountersResponse, HandleWork); //from cluster aggregator, for http requests
         HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleWork);
-        hFunc(TEvTabletCounters::TEvRemoveDatabase, HandleWork);
-        hFunc(TEvTabletCounters::TEvTabletSetTableInfo, HandleWork);
+        HFunc(TEvTabletCounters::TEvRemoveDatabase, HandleWork);
+        HFunc(TEvTabletCounters::TEvTabletSetTableInfo, HandleWork);
         HFunc(NMon::TEvHttpInfo, HandleWork);
         CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
 

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -105,20 +105,18 @@ static_assert(static_cast<ui32>(TDetailedMetricsSettings::MetricsLevelTable) ==
 static_assert(static_cast<ui32>(TDetailedMetricsSettings::MetricsLevelPartition) ==
     NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition);
 
-std::optional<EDetailedMetricsLevel> GetDetailedMetricsLevel(ui32 rawLevel) {
-    const auto level = static_cast<EDetailedMetricsLevel>(rawLevel);
-
+bool IsCollectedMetricsLevel(EDetailedMetricsLevel level) {
     switch (level) {
         case TDetailedMetricsSettings::MetricsLevelTable:
         case TDetailedMetricsSettings::MetricsLevelPartition:
-            return level;
+            return true;
 
         case TDetailedMetricsSettings::MetricsLevelUnspecified:
         case TDetailedMetricsSettings::MetricsLevelDisabled:
-            return std::nullopt;
+            return false;
     }
 
-    return std::nullopt;
+    return false;
 }
 
 ::NMonitoring::TDynamicCounterPtr GetDetailedMetricsRawGroup(
@@ -146,11 +144,12 @@ class TTabletMon {
 public:
     //
     TTabletMon(::NMonitoring::TDynamicCounterPtr counters, bool isFollower, TActorId dbWatcherActorId,
-            bool detailedMetricsEnabled, const TActorContext& ctx)
+            bool dbCountersEnabled, bool detailedMetricsEnabled, const TActorContext& ctx)
         : Counters(GetServiceCounters(counters, isFollower ? "followers" : "tablets"))
         , AllTypes(MakeIntrusive<TTabletCountersForTabletType>(Counters.Get(), "type", "all"))
         , IsFollower(isFollower)
         , DbWatcherActorId(dbWatcherActorId)
+        , DbCountersEnabled(dbCountersEnabled)
         , DetailedMetricsEnabled(detailedMetricsEnabled)
     {
         if (!IsFollower) {
@@ -167,7 +166,17 @@ public:
             return;
         }
 
-        auto& db = DetailedMetricsByPathId[msg.TenantPathId];
+        // Register a watch the first time this database is seen, so the detailed
+        // metrics of its tables are reclaimed on database removal even when the
+        // (leader-only) db counters feature is off. TDbWatcherActor dedupes by path
+        // id (sys_view/service/db_counters.cpp), so the "inserted" check here is not
+        // load-bearing for correctness, only for cutting one event every 5s per tablet.
+        auto [itDb, inserted] = DetailedMetricsByPathId.try_emplace(msg.TenantPathId);
+        if (inserted && DbWatcherActorId) {
+            ctx.Send(DbWatcherActorId, new NSysView::TEvSysView::TEvWatchDatabase(msg.TenantPathId));
+        }
+
+        auto& db = itDb->second;
         db.TabletContributions[msg.TabletID][msg.FollowerId] = TDetailedMetricsTableInfo{
             .TableId = msg.TableId,
             .TablePath = msg.TablePath,
@@ -225,8 +234,13 @@ public:
             return;
         }
 
-        const auto level = GetDetailedMetricsLevel(static_cast<ui32>(table->MetricsLevel));
-        if (!level) {
+        if (!IsCollectedMetricsLevel(table->MetricsLevel)) {
+            // The table stopped collecting: withdraw what this tablet published before
+            // the level dropped
+            if (db.Aggregator) {
+                db.Aggregator->ForgetTablet(tabletId, followerId);
+            }
+
             YDB_LOG_TRACE_CTX(ctx, "Skipping the detailed metrics of the table",
                 {"tabletId", tabletId},
                 {"tablePath", table->TablePath},
@@ -284,7 +298,7 @@ public:
             typeCounters->Apply(tabletId, executorCounters, appCounters, tabletType);
         }
         //
-        if (!IsFollower && DbWatcherActorId && tenantPathId) {
+        if (!IsFollower && DbCountersEnabled && tenantPathId) {
             auto dbCounters = GetDbCounters(tenantPathId, ctx);
             if (dbCounters) {
                 auto* limitedAppCounters = GetOrAddLimitedAppCounters(tabletType);
@@ -1015,15 +1029,17 @@ public:
 
     class TTabletsDbWatcherCallback : public NKikimr::NSysView::TDbWatcherCallback {
         TActorSystem* ActorSystem = {};
+        bool Follower = false;
 
     public:
-        explicit TTabletsDbWatcherCallback(TActorSystem* actorSystem)
+        TTabletsDbWatcherCallback(TActorSystem* actorSystem, bool follower)
             : ActorSystem(actorSystem)
+            , Follower(follower)
         {}
 
         void OnDatabaseRemoved(const TString& dbPath, TPathId pathId) override {
             auto evRemove = MakeHolder<TEvTabletCounters::TEvRemoveDatabase>(dbPath, pathId);
-            auto aggregator = MakeTabletCountersAggregatorID(ActorSystem->NodeId, false);
+            auto aggregator = MakeTabletCountersAggregatorID(ActorSystem->NodeId, Follower);
             ActorSystem->Send(aggregator, evRemove.Release());
         }
     };
@@ -1090,6 +1106,12 @@ private:
         if (db.DatabasePathRequestedAt && db.DatabasePathRequestedAt + DATABASE_PATH_RESOLVE_TIMEOUT > now) {
             return;
         }
+
+        if (db.DatabasePathRequestedAt) {
+            YDB_LOG_WARN_CTX(ctx, "Retrying the database path resolve of the detailed metrics: no reply to the previous request",
+                {"pathId", tenantPathId.ToString()});
+        }
+
         db.DatabasePathRequestedAt = now;
 
         using TNavigate = NSchemeCache::TSchemeCacheNavigate;
@@ -1196,6 +1218,7 @@ private:
     TLabeledCountersByTabletTypeAndGroup LabeledCountersByTabletTypeAndGroup;
     TQuietTabletCounters QuietTabletCounters;
 
+    bool DbCountersEnabled = false;
     bool DetailedMetricsEnabled = false;
 
     ::NMonitoring::TDynamicCounterPtr DetailedMetricsGroup;
@@ -1275,13 +1298,20 @@ TTabletCountersAggregatorActor::Bootstrap(const TActorContext &ctx) {
     TAppData* appData = AppData(ctx);
     Y_ABORT_UNLESS(!TabletMon);
 
-    if (AppData(ctx)->FeatureFlags.GetEnableDbCounters() && !Follower) {
-        auto callback = MakeIntrusive<TTabletMon::TTabletsDbWatcherCallback>(ctx.ActorSystem());
+    // GetEnableDbCounters gates the leader-only per-database "tablets" counters (a
+    // SysView feature); the watcher actor itself is also needed by the detailed
+    // metrics of EITHER role, so the two features no longer share DbWatcherActorId as
+    // a single implicit feature gate (see the DbCountersEnabled member of TTabletMon).
+    const bool dbCountersEnabled = appData->FeatureFlags.GetEnableDbCounters() && !Follower;
+    const bool detailedMetricsEnabled = appData->FeatureFlags.GetEnableDataShardDetailedMetrics();
+
+    if (dbCountersEnabled || detailedMetricsEnabled) {
+        auto callback = MakeIntrusive<TTabletMon::TTabletsDbWatcherCallback>(ctx.ActorSystem(), Follower);
         DbWatcherActorId = ctx.Register(NSysView::CreateDbWatcherActor(callback));
     }
 
     TabletMon = new TTabletMon(appData->Counters, Follower, DbWatcherActorId,
-        appData->FeatureFlags.GetEnableDataShardDetailedMetrics(), ctx);
+        dbCountersEnabled, detailedMetricsEnabled, ctx);
     auto mon = appData->Mon;
     if (mon) {
         if (!Follower)

--- a/ydb/core/tablet/tablet_counters_aggregator.h
+++ b/ydb/core/tablet/tablet_counters_aggregator.h
@@ -109,11 +109,14 @@ struct TEvTabletCounters {
         const ui64 TabletID;
         const NKikimrTabletBase::TTabletTypes::EType TabletType;
         const TPathId TenantPathId;
+        const ui32 FollowerId; // 0 = leader, >0 = replica
 
-        TEvTabletCountersForgetTablet(ui64 tabletID, NKikimrTabletBase::TTabletTypes::EType tabletType, TPathId tenantPathId)
+        TEvTabletCountersForgetTablet(ui64 tabletID, NKikimrTabletBase::TTabletTypes::EType tabletType, TPathId tenantPathId,
+            ui32 followerId = 0)
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
+            , FollowerId(followerId)
         {}
     };
 
@@ -153,7 +156,7 @@ struct TTabletLabeledCountersResponseContext {
 };
 
 ////////////////////////////////////////////
-void TabletCountersForgetTablet(ui64 tabletId, NKikimrTabletBase::TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity);
+void TabletCountersForgetTablet(ui64 tabletId, NKikimrTabletBase::TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity, ui32 followerId = 0);
 
 TStringBuf GetHistogramAggregateSimpleName(TStringBuf name);
 bool IsHistogramAggregateSimpleName(TStringBuf name);

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -15,6 +15,7 @@
 #include <ydb/library/actors/core/mon.h>
 
 #include <util/generic/array_size.h>
+#include <util/generic/hash_set.h>
 #include <util/string/cast.h>
 
 namespace NKikimr {
@@ -1085,6 +1086,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
 
     constexpr ui32 LEVEL_TABLE = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable;
     constexpr ui32 LEVEL_PARTITION = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition;
+    constexpr ui32 LEVEL_DISABLED = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled;
 
     // The only tablet type with a detailed metrics counter set is DataShard, and
     // GetDetailedMetricsCounterNames() allow-lists this Executor counter name (it is
@@ -1114,14 +1116,16 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
      */
     class TFakeSchemeCache : public TActor<TFakeSchemeCache> {
     public:
-        explicit TFakeSchemeCache(ui32* requestCounter)
+        TFakeSchemeCache(ui32* requestCounter, THashSet<TPathId>* watchedPathIds)
             : TActor(&TThis::StateWork)
             , RequestCounter(requestCounter)
+            , WatchedPathIds(watchedPathIds)
         {}
 
         STATEFN(StateWork) {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TEvTxProxySchemeCache::TEvNavigateKeySet, Handle);
+                hFunc(TEvTxProxySchemeCache::TEvWatchPathId, Handle);
                 default:
                     break;
             }
@@ -1141,8 +1145,13 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
             Send(ev->Sender, new TEvTxProxySchemeCache::TEvNavigateKeySetResult(navigate));
         }
 
+        void Handle(TEvTxProxySchemeCache::TEvWatchPathId::TPtr& ev) {
+            WatchedPathIds->insert(ev->Get()->PathId);
+        }
+
     private:
         ui32* const RequestCounter;
+        THashSet<TPathId>* const WatchedPathIds;
     };
 
     ////////////////////////////////////////////
@@ -1163,7 +1172,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
 
             Runtime.RegisterService(
                 MakeSchemeCacheID(),
-                Runtime.Register(new TFakeSchemeCache(&NavigateRequests))
+                Runtime.Register(new TFakeSchemeCache(&NavigateRequests, &WatchedPathIds))
             );
 
             LeaderAggregatorId = Runtime.Register(CreateTabletCountersAggregator(false));
@@ -1193,6 +1202,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
         TActorId FollowerAggregatorId;
 
         ui32 NavigateRequests = 0;
+        THashSet<TPathId> WatchedPathIds;
     };
 
     ////////////////////////////////////////////
@@ -1226,6 +1236,10 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
         TFakeTablet& SetSimple(EExecutorSimpleCounter counter, ui64 value) {
             ExecutorCounters->Simple()[counter].Set(value);
             return *this;
+        }
+
+        void SetMetricsLevel(ui32 metricsLevel) {
+            MetricsLevel = metricsLevel;
         }
 
         void SendTableInfo(TEnv& env) {
@@ -1277,7 +1291,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
 
         const ui64 TabletId;
         const ui32 FollowerId;
-        const ui32 MetricsLevel;
+        ui32 MetricsLevel;
 
         TIntrusivePtr<TEvTabletCounters::TInFlightCookie> CounterEventsInFlight;
 
@@ -1604,6 +1618,166 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
         UNIT_ASSERT(!executorCounters->FindNamedCounter("sensor", "SUM(" + UNLISTED_EXECUTOR_COUNTER + ")"));
         UNIT_ASSERT(!executorCounters->FindNamedCounter("sensor", "MAX(" + UNLISTED_EXECUTOR_COUNTER + ")"));
         UNIT_ASSERT(!executorCounters->FindCounter(UNLISTED_EXECUTOR_COUNTER));
+    }
+
+    /**
+     * Verify that when a Table level table's level drops to Disabled, the bucket it
+     * published is withdrawn, not just frozen in place.
+     */
+    Y_UNIT_TEST(TableLevelDisabledDropsTheBucket) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader1(1000, 0, LEVEL_TABLE);
+        TFakeTablet leader2(2000, 0, LEVEL_TABLE);
+
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader1.SendUpdate(env);
+        leader2.SendUpdate(env);
+        ReportCounters(env, {&leader1, &leader2});
+
+        UNIT_ASSERT(FindTableBucketCounters(env));
+
+        leader1.SetMetricsLevel(LEVEL_DISABLED);
+        leader1.SendTableInfo(env);
+        leader2.SetMetricsLevel(LEVEL_DISABLED);
+        leader2.SendTableInfo(env);
+        ReportCounters(env, {&leader1, &leader2});
+
+        UNIT_ASSERT(!FindTableBucketCounters(env));
+        UNIT_ASSERT(!FindRawGroup(env)->FindSubgroup("database", DATABASE_PATH));
+    }
+
+    /**
+     * Same as above for a Partition level table: both leaves must be withdrawn.
+     */
+    Y_UNIT_TEST(PartitionLevelDisabledDropsTheLeaves) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader.SendUpdate(env);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&leader, &follower});
+
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 1));
+
+        leader.SetMetricsLevel(LEVEL_DISABLED);
+        leader.SendTableInfo(env);
+        follower.SetMetricsLevel(LEVEL_DISABLED);
+        follower.SendTableInfo(env);
+        ReportCounters(env, {&leader, &follower});
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+    }
+
+    /**
+     * Verify that disabling one follower's level withdraws only its own leaf, not the
+     * sibling follower's -- the withdraw is per tablet+follower, not per table.
+     */
+    Y_UNIT_TEST(PartitionLevelDisabledDropsOnlyTheDisabledFollower) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet follower1(1000, 1, LEVEL_PARTITION);
+        TFakeTablet follower2(1000, 2, LEVEL_PARTITION);
+
+        follower1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        follower1.SendUpdate(env);
+        follower2.SendUpdate(env);
+        ReportCounters(env, {&follower1, &follower2});
+
+        follower1.SetMetricsLevel(LEVEL_DISABLED);
+        follower1.SendTableInfo(env);
+        ReportCounters(env, {&follower1, &follower2});
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 2), "SUM", ALLOWED_EXECUTOR_COUNTER), 2u);
+    }
+
+    /**
+     * Verify that the follower actor gets its OWN db watcher and registers its own
+     * watch, even though EnableDbCounters (the leader-only db counters feature) is off
+     * in TEnv -- detailed metrics alone must be enough to create the watcher.
+     */
+    Y_UNIT_TEST(FollowerActorWatchesItsDetailedMetricsDatabase) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&follower});
+
+        UNIT_ASSERT(env.WatchedPathIds.contains(TENANT_PATH_ID));
+    }
+
+    /**
+     * Verify that the follower actor's own TEvRemoveDatabase drops its own leaves (and
+     * the leader's TEvRemoveDatabase drops the leader's).
+     */
+    Y_UNIT_TEST(RemoveDatabaseDropsFollowerLeaves) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader.SendUpdate(env);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&leader, &follower});
+
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 1));
+
+        env.Runtime.Send(new IEventHandle(env.LeaderAggregatorId, env.Edge,
+            new TEvTabletCounters::TEvRemoveDatabase(DATABASE_PATH, TENANT_PATH_ID)));
+        env.Runtime.Send(new IEventHandle(env.FollowerAggregatorId, env.Edge,
+            new TEvTabletCounters::TEvRemoveDatabase(DATABASE_PATH, TENANT_PATH_ID)));
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+
+        auto rawGroup = FindRawGroup(env);
+        UNIT_ASSERT(rawGroup);
+        UNIT_ASSERT(!rawGroup->FindSubgroup("database", DATABASE_PATH));
+    }
+
+    /**
+     * Pin that the two actors are independently notified rather than accidentally
+     * coupled: TEvRemoveDatabase sent to the leader alone must not touch the follower.
+     */
+    Y_UNIT_TEST(RemoveDatabaseOnlyReachesItsOwnRole) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader.SendUpdate(env);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&leader, &follower});
+
+        env.Runtime.Send(new IEventHandle(env.LeaderAggregatorId, env.Edge,
+            new TEvTabletCounters::TEvRemoveDatabase(DATABASE_PATH, TENANT_PATH_ID)));
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 1), "SUM", ALLOWED_EXECUTOR_COUNTER), 2u);
     }
 }
 

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -2,14 +2,20 @@
 #include "private/labeled_db_counters.h"
 
 #include <ydb/core/base/counters.h>
+#include <ydb/core/base/path.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 
 #include <library/cpp/monlib/service/monservice.h>
 #include <library/cpp/monlib/service/pages/mon_page.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/library/actors/core/mon.h>
+
+#include <util/generic/array_size.h>
+#include <util/string/cast.h>
 
 namespace NKikimr {
 
@@ -1056,6 +1062,548 @@ Y_UNIT_TEST_SUITE(TEvTabletAddCountersDetailedMetricsFields) {
             7);
 
         UNIT_ASSERT_VALUES_EQUAL(ev.FollowerId, 7u);
+    }
+}
+
+/**
+ * Tests for the detailed metrics, which the two aggregator actors of a node build
+ * within the private "ydb_detailed_raw" counter group.
+ */
+Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
+
+    const TString DETAILED_RAW_GROUP = "ydb_detailed_raw";
+
+    const TString DATABASE_PATH = "/Root/db";
+
+    const TString TABLE_PATH = "/Root/db/dir/table";
+    const TString RELATIVE_TABLE_PATH = "dir/table";
+
+    const TPathId TENANT_PATH_ID(1113, 1001);
+    const TPathId TABLE_ID(1113, 42);
+
+    constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
+
+    constexpr ui32 LEVEL_TABLE = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable;
+    constexpr ui32 LEVEL_PARTITION = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition;
+
+    // The only tablet type with a detailed metrics counter set is DataShard, and
+    // GetDetailedMetricsCounterNames() allow-lists this Executor counter name (it is
+    // the source of the public table.datashard.row_count metric, see
+    // counters_detailed_datashard.proto)
+    const TString ALLOWED_EXECUTOR_COUNTER = "DbUniqueRowsTotal";
+
+    // An Executor simple counter, which is NOT in that allow-list (see
+    // flat_executor_counters.h / counters_detailed_datashard.proto)
+    const TString UNLISTED_EXECUTOR_COUNTER = "LogRedoItems";
+
+    constexpr const char* EXECUTOR_SIMPLE_COUNTER_NAMES[] = {
+        "DbUniqueRowsTotal",
+        "LogRedoItems",
+    };
+
+    enum EExecutorSimpleCounter : ui32 {
+        DB_UNIQUE_ROWS_TOTAL = 0,
+        LOG_REDO_ITEMS = 1,
+    };
+
+    ////////////////////////////////////////////
+
+    /**
+     * A stand-in for the scheme cache: it resolves the path id of the database to
+     * its path and nothing else.
+     */
+    class TFakeSchemeCache : public TActor<TFakeSchemeCache> {
+    public:
+        explicit TFakeSchemeCache(ui32* requestCounter)
+            : TActor(&TThis::StateWork)
+            , RequestCounter(requestCounter)
+        {}
+
+        STATEFN(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvTxProxySchemeCache::TEvNavigateKeySet, Handle);
+                default:
+                    break;
+            }
+        }
+
+    private:
+        void Handle(TEvTxProxySchemeCache::TEvNavigateKeySet::TPtr& ev) {
+            ++*RequestCounter;
+
+            TAutoPtr<NSchemeCache::TSchemeCacheNavigate> navigate = ev->Get()->Request.Release();
+
+            for (auto& entry : navigate->ResultSet) {
+                entry.Status = NSchemeCache::TSchemeCacheNavigate::EStatus::Ok;
+                entry.Path = SplitPath(DATABASE_PATH);
+            }
+
+            Send(ev->Sender, new TEvTxProxySchemeCache::TEvNavigateKeySetResult(navigate));
+        }
+
+    private:
+        ui32* const RequestCounter;
+    };
+
+    ////////////////////////////////////////////
+
+    /**
+     * The two aggregator actors of a single node and a scheme cache, which resolves
+     * the path of the database.
+     */
+    struct TEnv {
+        explicit TEnv(bool detailedMetricsEnabled)
+            : Runtime(1)
+        {
+            TAppPrepare app;
+            app.SetEnableDataShardDetailedMetrics(detailedMetricsEnabled);
+            Runtime.Initialize(app.Unwrap());
+
+            Edge = Runtime.AllocateEdgeActor();
+
+            Runtime.RegisterService(
+                MakeSchemeCacheID(),
+                Runtime.Register(new TFakeSchemeCache(&NavigateRequests))
+            );
+
+            LeaderAggregatorId = Runtime.Register(CreateTabletCountersAggregator(false));
+            FollowerAggregatorId = Runtime.Register(CreateTabletCountersAggregator(true));
+
+            Runtime.EnableScheduleForActor(LeaderAggregatorId);
+            Runtime.EnableScheduleForActor(FollowerAggregatorId);
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 2);
+            Runtime.DispatchEvents(options);
+        }
+
+        TActorId GetAggregatorId(ui32 followerId) const {
+            return followerId == 0 ? LeaderAggregatorId : FollowerAggregatorId;
+        }
+
+        ::NMonitoring::TDynamicCounterPtr GetCountersRoot() {
+            ::NMonitoring::TDynamicCounterPtr counters = Runtime.GetAppData(0).Counters;
+            UNIT_ASSERT(counters);
+            return counters;
+        }
+
+        TTestBasicRuntime Runtime;
+        TActorId Edge;
+        TActorId LeaderAggregatorId;
+        TActorId FollowerAggregatorId;
+
+        ui32 NavigateRequests = 0;
+    };
+
+    ////////////////////////////////////////////
+
+    /**
+     * A single tablet of the table, which reports its low level counters to
+     * the aggregator actor of its role. The table identity (TEvTabletSetTableInfo)
+     * and the counters (TEvTabletAddCounters) are two separate events.
+     */
+    struct TFakeTablet {
+        TFakeTablet(ui64 tabletId, ui32 followerId, ui32 metricsLevel)
+            : TabletId(tabletId)
+            , FollowerId(followerId)
+            , MetricsLevel(metricsLevel)
+            , CounterEventsInFlight(new TEvTabletCounters::TInFlightCookie)
+            , ExecutorCounters(new TTabletCountersBase(
+                Y_ARRAY_SIZE(EXECUTOR_SIMPLE_COUNTER_NAMES),
+                0, // cumulativeCnt
+                0, // percentileCnt
+                EXECUTOR_SIMPLE_COUNTER_NAMES,
+                nullptr,
+                nullptr))
+            , ExecutorCountersBaseline(new TTabletCountersBase)
+            , AppCounters(new TTabletCountersBase)
+            , AppCountersBaseline(new TTabletCountersBase)
+        {
+            ExecutorCounters->RememberCurrentStateAsBaseline(*ExecutorCountersBaseline);
+            AppCounters->RememberCurrentStateAsBaseline(*AppCountersBaseline);
+        }
+
+        TFakeTablet& SetSimple(EExecutorSimpleCounter counter, ui64 value) {
+            ExecutorCounters->Simple()[counter].Set(value);
+            return *this;
+        }
+
+        void SendTableInfo(TEnv& env) {
+            const TActorId aggregatorId = env.GetAggregatorId(FollowerId);
+
+            env.Runtime.Send(new IEventHandle(aggregatorId, env.Edge,
+                new TEvTabletCounters::TEvTabletSetTableInfo(
+                    TabletId, TENANT_PATH_ID, FollowerId, TABLE_ID, TABLE_PATH,
+                    1 /* schemaVersion */, MetricsLevel)));
+        }
+
+        void SendCounters(TEnv& env) {
+            auto executorCounters = ExecutorCounters->MakeDiffForAggr(*ExecutorCountersBaseline);
+            ExecutorCounters->RememberCurrentStateAsBaseline(*ExecutorCountersBaseline);
+
+            auto appCounters = AppCounters->MakeDiffForAggr(*AppCountersBaseline);
+            AppCounters->RememberCurrentStateAsBaseline(*AppCountersBaseline);
+
+            const TActorId aggregatorId = env.GetAggregatorId(FollowerId);
+
+            env.Runtime.Send(new IEventHandle(aggregatorId, env.Edge,
+                new TEvTabletCounters::TEvTabletAddCounters(
+                    CounterEventsInFlight, TabletId, TABLET_TYPE, TENANT_PATH_ID,
+                    executorCounters, appCounters, FollowerId)));
+
+            // force recalc
+            env.Runtime.Send(new IEventHandle(aggregatorId, env.Edge, new TEvents::TEvWakeup()));
+        }
+
+        /**
+         * Send the table identity and one round of the counters, the way a real
+         * tablet does it after boot.
+         */
+        void SendUpdate(TEnv& env) {
+            SendTableInfo(env);
+            SendCounters(env);
+        }
+
+        void SendForget(TEnv& env) {
+            const TActorId aggregatorId = env.GetAggregatorId(FollowerId);
+
+            env.Runtime.Send(new IEventHandle(aggregatorId, env.Edge,
+                new TEvTabletCounters::TEvTabletCountersForgetTablet(
+                    TabletId, TABLET_TYPE, TENANT_PATH_ID, FollowerId)));
+
+            // force recalc
+            env.Runtime.Send(new IEventHandle(aggregatorId, env.Edge, new TEvents::TEvWakeup()));
+        }
+
+        const ui64 TabletId;
+        const ui32 FollowerId;
+        const ui32 MetricsLevel;
+
+        TIntrusivePtr<TEvTabletCounters::TInFlightCookie> CounterEventsInFlight;
+
+        std::unique_ptr<TTabletCountersBase> ExecutorCounters;
+        std::unique_ptr<TTabletCountersBase> ExecutorCountersBaseline;
+
+        std::unique_ptr<TTabletCountersBase> AppCounters;
+        std::unique_ptr<TTabletCountersBase> AppCountersBaseline;
+    };
+
+    /**
+     * Report the counters of the tablets, giving the aggregator actors the round, which
+     * they spend on resolving the path of the database.
+     */
+    void ReportCounters(TEnv& env, const TVector<TFakeTablet*>& tablets) {
+        for (ui32 round = 0; round < 2; ++round) {
+            for (auto* tablet : tablets) {
+                tablet->SendCounters(env);
+            }
+            env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+        }
+    }
+
+    ////////////////////////////////////////////
+
+    ::NMonitoring::TDynamicCounterPtr FindRawGroup(TEnv& env) {
+        return env.GetCountersRoot()->FindSubgroup("counters", DETAILED_RAW_GROUP);
+    }
+
+    /**
+     * @note There is no role= node: both actors of the node build ONE shared tree,
+     *       exactly the shape the specification defines. At the partition level the
+     *       role is carried by follower_id (follower_id=0 IS the leader) and at the
+     *       table level the bucket belongs to the actor of the leaders alone.
+     */
+    ::NMonitoring::TDynamicCounterPtr FindTableGroup(TEnv& env) {
+        auto rawGroup = FindRawGroup(env);
+        if (!rawGroup) {
+            return nullptr;
+        }
+
+        auto databaseGroup = rawGroup->FindSubgroup("database", DATABASE_PATH);
+        if (!databaseGroup) {
+            return nullptr;
+        }
+
+        return databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH);
+    }
+
+    ::NMonitoring::TDynamicCounterPtr FindExecutorCounters(::NMonitoring::TDynamicCounterPtr bucketGroup) {
+        if (!bucketGroup) {
+            return nullptr;
+        }
+
+        auto typeGroup = bucketGroup->FindSubgroup("type", TString(TTabletTypes::TypeToStr(TABLET_TYPE)));
+        if (!typeGroup) {
+            return nullptr;
+        }
+
+        return typeGroup->FindSubgroup("category", "executor");
+    }
+
+    /**
+     * @return The bucket, which collapses ALL the partitions of a TABLE level table
+     *         (this bucket lives directly on the table= node)
+     */
+    ::NMonitoring::TDynamicCounterPtr FindTableBucketCounters(TEnv& env) {
+        return FindExecutorCounters(FindTableGroup(env));
+    }
+
+    /**
+     * @return The leaf of a single tablet of a PARTITION level table
+     */
+    ::NMonitoring::TDynamicCounterPtr FindLeafCounters(TEnv& env, ui64 tabletId, ui32 followerId) {
+        auto tableGroup = FindTableGroup(env);
+        if (!tableGroup) {
+            return nullptr;
+        }
+
+        auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
+        if (!perPartitionGroup) {
+            return nullptr;
+        }
+
+        auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
+        if (!tabletGroup) {
+            return nullptr;
+        }
+
+        return FindExecutorCounters(tabletGroup->FindSubgroup("follower_id", ToString(followerId)));
+    }
+
+    ui64 GetCounterValue(::NMonitoring::TDynamicCounterPtr countersGroup, const TString& aggregate, const TString& name) {
+        UNIT_ASSERT_C(countersGroup, "no counter group for " << aggregate << "(" << name << ")");
+
+        auto counter = countersGroup->FindNamedCounter("sensor", aggregate + "(" + name + ")");
+        UNIT_ASSERT_C(counter, "no counter " << aggregate << "(" << name << ")");
+
+        return counter->Val();
+    }
+
+    ////////////////////////////////////////////
+
+    /**
+     * Verify that nothing at all is created while the feature flag is off.
+     */
+    Y_UNIT_TEST(NoCountersWhenDisabled) {
+        TEnv env(false /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader.SendUpdate(env);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&leader, &follower});
+
+        UNIT_ASSERT(!FindRawGroup(env));
+    }
+
+    /**
+     * Verify that at the partition level both aggregator actors of the node fill their
+     * own leaves of one and the same private counter tree, told apart by follower_id
+     * alone and sharing the tablet_id= node above them.
+     */
+    Y_UNIT_TEST(PartitionLevelLeavesOfBothRoles) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader.SendUpdate(env);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&leader, &follower});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 0), "SUM", ALLOWED_EXECUTOR_COUNTER), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 1), "SUM", ALLOWED_EXECUTOR_COUNTER), 2u);
+
+        // The two leaves hang off ONE shared tablet_id= node, written by the two
+        // different actors, and no invented label appears anywhere
+        auto tabletGroup = FindTableGroup(env)
+            ->FindSubgroup("detailed_metrics", "per_partition")
+            ->FindSubgroup("tablet_id", "1000");
+        UNIT_ASSERT(tabletGroup);
+        UNIT_ASSERT(tabletGroup->FindSubgroup("follower_id", "0"));
+        UNIT_ASSERT(tabletGroup->FindSubgroup("follower_id", "1"));
+
+        UNIT_ASSERT(!FindRawGroup(env)->FindSubgroup("role", "leader"));
+        UNIT_ASSERT(!FindRawGroup(env)->FindSubgroup("role", "follower"));
+    }
+
+    /**
+     * Verify that at the table level the leader partitions of the table are collapsed
+     * into a single bucket and no per-partition group is created.
+     */
+    Y_UNIT_TEST(TableLevelCollapsesPartitions) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader1(1000, 0, LEVEL_TABLE);
+        TFakeTablet leader2(2000, 0, LEVEL_TABLE);
+
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader1.SendUpdate(env);
+        leader2.SendUpdate(env);
+        ReportCounters(env, {&leader1, &leader2});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(env), "SUM", ALLOWED_EXECUTOR_COUNTER), 1u + 2u);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(env), "MAX", ALLOWED_EXECUTOR_COUNTER), 2u);
+
+        auto tableGroup = FindTableGroup(env);
+        UNIT_ASSERT(tableGroup);
+        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+    }
+
+    /**
+     * Verify the ordering guarantee of the identity join: counters, which arrive
+     * before the identity of their table is known, are skipped, not queued.
+     */
+    Y_UNIT_TEST(CountersBeforeTableInfoAreSkipped) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+
+        // Counters arrive first: nothing is published yet
+        ReportCounters(env, {&leader});
+        UNIT_ASSERT(!FindTableGroup(env));
+
+        // The identity arrives, followed by another round of counters
+        leader.SendTableInfo(env);
+        ReportCounters(env, {&leader});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 0), "SUM", ALLOWED_EXECUTOR_COUNTER), 1u);
+    }
+
+    /**
+     * Verify that forgetting a tablet drops its own leaf and ONLY its own leaf while the
+     * other role of the very same tablet is still on the node, and that the shared nodes
+     * above it are reclaimed once that role goes too.
+     *
+     * The leader and its follower share the tablet_id= node and are reported by two
+     * different actors, so a cleanup that reached above the leaf too eagerly would detach
+     * the other actor's live counters for good.
+     */
+    Y_UNIT_TEST(ForgetTabletKeepsTheOtherRole) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        TFakeTablet follower(1000, 1, LEVEL_PARTITION);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        leader.SendUpdate(env);
+        follower.SendUpdate(env);
+        ReportCounters(env, {&leader, &follower});
+
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 1));
+
+        leader.SendForget(env);
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        // The leader's own leaf is gone ...
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
+
+        // ... the shared spine above it stays, because the follower is still there ...
+        UNIT_ASSERT(FindTableGroup(env));
+
+        // ... and the follower's leaf is still reachable from the root
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 1), "SUM", ALLOWED_EXECUTOR_COUNTER), 2u);
+
+        // The follower goes too, so nothing of this tablet is left on the node: the
+        // tablet_id=, detailed_metrics=, table= and database= nodes are all reclaimed,
+        // which is what a rebalanced away tablet must leave behind — nothing
+        follower.SendForget(env);
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT(!FindTableGroup(env));
+
+        // The private root of the node itself stays: it is created once at boot, not
+        // per database
+        auto rawGroup = FindRawGroup(env);
+        UNIT_ASSERT(rawGroup);
+        UNIT_ASSERT(!rawGroup->FindSubgroup("database", DATABASE_PATH));
+    }
+
+    /**
+     * Verify the same for two followers of one tablet, which a node holds while it is
+     * drained or rolled: unlike the leader and its follower, the two are remembered by
+     * ONE actor under one and the same tablet id, so forgetting one of them must not
+     * take the counters of the other with it.
+     */
+    Y_UNIT_TEST(ForgetFollowerKeepsTheOtherFollower) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet follower1(1000, 1, LEVEL_PARTITION);
+        TFakeTablet follower2(1000, 2, LEVEL_PARTITION);
+
+        follower1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        follower2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        follower1.SendUpdate(env);
+        follower2.SendUpdate(env);
+        ReportCounters(env, {&follower1, &follower2});
+
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 2));
+
+        follower1.SendForget(env);
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 2), "SUM", ALLOWED_EXECUTOR_COUNTER), 2u);
+
+        // The one, which is left, keeps reporting into its own leaf
+        follower2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 3);
+        ReportCounters(env, {&follower2});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 2), "SUM", ALLOWED_EXECUTOR_COUNTER), 3u);
+
+        follower2.SendForget(env);
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!FindTableGroup(env));
+    }
+
+    /**
+     * Verify that only the allow-listed counter set of the tablet type is published:
+     * an Executor counter, which is not in counters_detailed_datashard.proto, must
+     * not appear anywhere in the tree.
+     */
+    Y_UNIT_TEST(PublishesOnlyTheDetailedMetricsCounterSet) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet leader(1000, 0, LEVEL_PARTITION);
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader.SetSimple(LOG_REDO_ITEMS, 5);
+
+        leader.SendUpdate(env);
+        ReportCounters(env, {&leader});
+
+        auto executorCounters = FindLeafCounters(env, 1000, 0);
+        UNIT_ASSERT(executorCounters);
+
+        UNIT_ASSERT(executorCounters->FindNamedCounter("sensor", "SUM(" + ALLOWED_EXECUTOR_COUNTER + ")"));
+        UNIT_ASSERT(!executorCounters->FindNamedCounter("sensor", "SUM(" + UNLISTED_EXECUTOR_COUNTER + ")"));
+        UNIT_ASSERT(!executorCounters->FindNamedCounter("sensor", "MAX(" + UNLISTED_EXECUTOR_COUNTER + ")"));
+        UNIT_ASSERT(!executorCounters->FindCounter(UNLISTED_EXECUTOR_COUNTER));
     }
 }
 

--- a/ydb/core/tablet/ya.make
+++ b/ydb/core/tablet/ya.make
@@ -54,6 +54,8 @@ SRCS(
     simple_tablet.h
     tablet_tracing_signals.cpp
     tablet_tracing_signals.h
+    detailed_metrics/detailed_metrics_counter_set.cpp
+    detailed_metrics/detailed_metrics_counter_set.h
     detailed_metrics/metric_value_aggregator.cpp
     detailed_metrics/metric_value_aggregator.h
     detailed_metrics/node_database_metrics_aggregator.cpp

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -252,7 +252,7 @@ void TExecutor::Broken(EBrokenReason reason) {
     if (Owner) {
         ForceSendCounters();
         TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
-            Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
+            Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId(), FollowerId);
         Owner->Detach(OwnerCtx());
     }
 
@@ -867,7 +867,7 @@ void TExecutor::Boot(TEvTablet::TEvBoot::TPtr &ev, const TActorContext &ctx) {
     if (Stats->IsFollower()) {
         ForceSendCounters();
         TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
-            Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
+            Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId(), FollowerId);
     }
 
     if (!Counters) {
@@ -958,7 +958,7 @@ void TExecutor::Restored(TEvTablet::TEvRestored::TPtr &ev, const TActorContext &
 void TExecutor::DetachTablet() {
     ForceSendCounters();
     TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
-        Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
+        Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId(), FollowerId);
     return PassAway();
 }
 


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

- extend TabletCountersForgetTablet to free counter tree from leftovers when Hive moves tablet away
- limit published detailed **aggregated** metrics to SUM and MAX only
- publish all the stuff to ydb_detailed_raw group that's local per node
- **process-wide** mutex guards counters tree shape of TNodeDatabaseMetricsAggregatorImpl with lock in AddCounters and ForgetTablet to avoid interleaving Hive moves (eg when Forget thinks it's the last tablet and removes top entry from counters with table name, but at the same time another tablet of this table arrives and tries to add its counters)