### PR TITLE
Don't show StorageNodes for the whole cluster in `/viewer/database_stats` HTTP-handler

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -5009,6 +5009,30 @@
             "text": "Parameter 'path' or 'tablet_id' is required"
         }
     },
+    "test.TestViewer.test_viewer_database_stats": {
+        "/Root/dedicated_db": {
+            "DatabaseNodes": 1,
+            "Problems": [],
+            "StorageGroups": 1,
+            "StorageNodes": 1
+        },
+        "/Root/serverless_db": {
+            "DatabaseNodes": 1,
+            "Problems": [],
+            "StorageGroups": 1,
+            "StorageNodes": 1
+        },
+        "/Root/shared_db": {
+            "DatabaseNodes": 1,
+            "Problems": [],
+            "StorageGroups": 1,
+            "StorageNodes": 1
+        },
+        "no-database": {
+            "status_code": 400,
+            "text": "Database is required"
+        }
+    },
     "test.TestViewer.test_viewer_describe": {
         "/Root": {
             "LastExistedPrefixDescription": {},

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -690,6 +690,31 @@ class TestViewer(object):
         return result
 
     @classmethod
+    def normalize_result_database_stats(cls, result):
+        if 'status_code' in result:
+            return result
+        return {
+            'DatabaseNodes': result.get('DatabaseNodes'),
+            'StorageGroups': result.get('StorageGroups'),
+            'StorageNodes': result.get('StorageNodes'),
+            'Problems': sorted(result.get('Problems') or []),
+        }
+
+    @classmethod
+    def get_viewer_database_stats_ready(cls, database):
+        tries = 15
+        last = {}
+        while tries > 0:
+            last = cls.get_viewer("/viewer/database_stats", {'database': database})
+            if 'status_code' not in last and last.get('StorageGroups', 0) > 0:
+                return last
+            tries -= 1
+            time.sleep(1)
+        assert last.get('StorageGroups', 0) > 0, \
+            "StorageGroups was not populated in /viewer/database_stats response after 15 retries: %s" % last
+        return last
+
+    @classmethod
     def normalize_result_transfer_describe(cls, result):
         cls.delete_keys_recursively(result, ['stats'])
         return result
@@ -994,6 +1019,19 @@ class TestViewer(object):
     def test_viewer_healthcheck(cls):
         result = cls.get_viewer_db_normalized("/viewer/healthcheck")
         result = cls.normalize_result_healthcheck(result)
+        return result
+
+    @classmethod
+    def test_viewer_database_stats(cls):
+        result = {
+            'no-database': cls.normalize_result_database_stats(
+                cls.call_viewer("/viewer/database_stats"),
+            ),
+        }
+        for name in (cls.dedicated_db, cls.shared_db, cls.serverless_db):
+            result[name] = cls.normalize_result_database_stats(
+                cls.get_viewer_database_stats_ready(name),
+            )
         return result
 
     @classmethod

--- a/ydb/core/viewer/viewer_database_stats.h
+++ b/ydb/core/viewer/viewer_database_stats.h
@@ -286,10 +286,17 @@ public:
         }
         if (VSlotsResponse.IsOk() && !StorageGroups.empty() && StorageNodes.empty()) {
             std::unordered_set<TNodeId> storageNodes;
+            const bool strictDatabaseOnlyRequest = IsStrictDatabaseOnlyRequest();
             for (const auto& vslot : VSlotsResponse->Record.GetEntries()) {
+                if (!strictDatabaseOnlyRequest) {
+                    storageNodes.insert(vslot.GetKey().GetNodeId());
+                    continue;
+                }
                 const NKikimrSysView::TVSlotInfo& info = vslot.GetInfo();
                 auto itGroup = StorageGroups.find(info.GetGroupId());
-                if (itGroup != StorageGroups.end() && itGroup->second.GetInfo().GetGeneration() == info.GetGroupGeneration()) {
+                if (itGroup != StorageGroups.end() &&
+                    itGroup->second.GetInfo().GetGeneration() == info.GetGroupGeneration()
+                ) {
                     storageNodes.insert(vslot.GetKey().GetNodeId());
                 }
             }

--- a/ydb/core/viewer/viewer_database_stats.h
+++ b/ydb/core/viewer/viewer_database_stats.h
@@ -67,9 +67,6 @@ class TJsonDatabaseStats : public TViewerPipeClient {
     NKikimrSysView::TStoragePoolEntry StaticStoragePool;
     std::unordered_map<TStoragePoolId, const NKikimrSysView::TStoragePoolEntry&> StoragePools;
     std::unordered_map<TGroupId, const NKikimrSysView::TGroupEntry&> StorageGroups;
-    // StorageNodesComputed=false is not the same as empty StorageNodes when processing responses,
-    // because storage nodes may be filtered out i.e. by not belonging to the requested database.
-    bool StorageNodesComputed = false;
 
     bool Streaming = false;
     NKikimrViewer::TDatabaseStats Result;
@@ -280,8 +277,7 @@ public:
             }
             Result.SetStorageGroups(StorageGroups.size());
         }
-        if (VSlotsResponse.IsOk() && !StorageGroups.empty() && !StorageNodesComputed) {
-            StorageNodesComputed = true;
+        if (VSlotsResponse.IsOk() && !StorageGroups.empty() && StorageNodes.empty()) {
             std::unordered_set<TNodeId> storageNodes;
             for (const auto& vslot : VSlotsResponse->Record.GetEntries()) {
                 const NKikimrSysView::TVSlotInfo& info = vslot.GetInfo();
@@ -663,7 +659,6 @@ public:
         StoragePools.clear();
         StorageGroups.clear();
         StorageNodes.clear();
-        StorageNodesComputed = false;
         SystemStateResponse.clear();
         NodeStateResponse.clear();
         PDiskStateResponse.clear();

--- a/ydb/core/viewer/viewer_database_stats.h
+++ b/ydb/core/viewer/viewer_database_stats.h
@@ -51,7 +51,6 @@ class TJsonDatabaseStats : public TViewerPipeClient {
     using TPDiskId = std::pair<TNodeId, ui32>; // node id : pdisk id
 
     // Requests
-    TRequestResponse<TEvInterconnect::TEvNodesInfo> NodesInfoResponse;
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvSystemStateResponse>> SystemStateResponse;
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvNodeStateResponse>> NodeStateResponse;
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvPDiskStateResponse>> PDiskStateResponse;
@@ -127,7 +126,6 @@ public:
 
         ConfigureRefreshSettings();
 
-        NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
         PoolsResponse = MakeCachedRequestBSControllerPools();
         GroupsResponse = MakeCachedRequestBSControllerGroups();
         VSlotsResponse = MakeCachedRequestBSControllerVSlots();
@@ -238,18 +236,13 @@ public:
     }
 
     bool IsPrimaryDataReady() {
-        return NodesInfoResponse.IsDone()
-            && PoolsResponse.IsDone()
+        return PoolsResponse.IsDone()
             && GroupsResponse.IsDone()
             && VSlotsResponse.IsDone();
     }
 
     void ProcessResponses() {
         if (!IsPrimaryDataReady()) {
-            return;
-        }
-        if (NodesInfoResponse.IsError()) {
-            NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
             return;
         }
         if (PoolsResponse.IsError()) {
@@ -588,7 +581,6 @@ public:
 
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            hFunc(TEvInterconnect::TEvNodesInfo, Handle);
             hFunc(NSysView::TEvSysView::TEvGetStoragePoolsResponse, Handle);
             hFunc(NSysView::TEvSysView::TEvGetGroupsResponse, Handle);
             hFunc(NSysView::TEvSysView::TEvGetVSlotsResponse, Handle);
@@ -602,13 +594,6 @@ public:
             hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
             default:
                 return TBase::StateWork(ev);
-        }
-    }
-
-    void Handle(TEvInterconnect::TEvNodesInfo::TPtr& ev) {
-        if (NodesInfoResponse.Set(std::move(ev))) {
-            ProcessResponses();
-            RequestDone();
         }
     }
 
@@ -681,7 +666,6 @@ public:
         DatabaseNodes = GetDatabaseNodes();
         Result.SetDatabaseNodes(DatabaseNodes.size());
         RequestDatabaseNodes();
-        NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
         PoolsResponse = MakeCachedRequestBSControllerPools();
         GroupsResponse = MakeCachedRequestBSControllerGroups();
         VSlotsResponse = MakeCachedRequestBSControllerVSlots();

--- a/ydb/core/viewer/viewer_database_stats.h
+++ b/ydb/core/viewer/viewer_database_stats.h
@@ -286,17 +286,10 @@ public:
         }
         if (VSlotsResponse.IsOk() && !StorageGroups.empty() && StorageNodes.empty()) {
             std::unordered_set<TNodeId> storageNodes;
-            const bool strictDatabaseOnlyRequest = IsStrictDatabaseOnlyRequest();
             for (const auto& vslot : VSlotsResponse->Record.GetEntries()) {
-                if (!strictDatabaseOnlyRequest) {
-                    storageNodes.insert(vslot.GetKey().GetNodeId());
-                    continue;
-                }
                 const NKikimrSysView::TVSlotInfo& info = vslot.GetInfo();
                 auto itGroup = StorageGroups.find(info.GetGroupId());
-                if (itGroup != StorageGroups.end() &&
-                    itGroup->second.GetInfo().GetGeneration() == info.GetGroupGeneration()
-                ) {
+                if (itGroup != StorageGroups.end() && itGroup->second.GetInfo().GetGeneration() == info.GetGroupGeneration()) {
                     storageNodes.insert(vslot.GetKey().GetNodeId());
                 }
             }

--- a/ydb/core/viewer/viewer_database_stats.h
+++ b/ydb/core/viewer/viewer_database_stats.h
@@ -287,7 +287,11 @@ public:
         if (VSlotsResponse.IsOk() && !StorageGroups.empty() && StorageNodes.empty()) {
             std::unordered_set<TNodeId> storageNodes;
             for (const auto& vslot : VSlotsResponse->Record.GetEntries()) {
-                storageNodes.insert(vslot.GetKey().GetNodeId());
+                const NKikimrSysView::TVSlotInfo& info = vslot.GetInfo();
+                auto itGroup = StorageGroups.find(info.GetGroupId());
+                if (itGroup != StorageGroups.end() && itGroup->second.GetInfo().GetGeneration() == info.GetGroupGeneration()) {
+                    storageNodes.insert(vslot.GetKey().GetNodeId());
+                }
             }
             StorageNodes.assign(storageNodes.begin(), storageNodes.end());
             Result.SetStorageNodes(StorageNodes.size());

--- a/ydb/core/viewer/viewer_database_stats.h
+++ b/ydb/core/viewer/viewer_database_stats.h
@@ -67,6 +67,9 @@ class TJsonDatabaseStats : public TViewerPipeClient {
     NKikimrSysView::TStoragePoolEntry StaticStoragePool;
     std::unordered_map<TStoragePoolId, const NKikimrSysView::TStoragePoolEntry&> StoragePools;
     std::unordered_map<TGroupId, const NKikimrSysView::TGroupEntry&> StorageGroups;
+    // StorageNodesComputed=false is not the same as empty StorageNodes when processing responses,
+    // because storage nodes may be filtered out i.e. by not belonging to the requested database.
+    bool StorageNodesComputed = false;
 
     bool Streaming = false;
     NKikimrViewer::TDatabaseStats Result;
@@ -277,7 +280,8 @@ public:
             }
             Result.SetStorageGroups(StorageGroups.size());
         }
-        if (VSlotsResponse.IsOk() && !StorageGroups.empty() && StorageNodes.empty()) {
+        if (VSlotsResponse.IsOk() && !StorageGroups.empty() && !StorageNodesComputed) {
+            StorageNodesComputed = true;
             std::unordered_set<TNodeId> storageNodes;
             for (const auto& vslot : VSlotsResponse->Record.GetEntries()) {
                 const NKikimrSysView::TVSlotInfo& info = vslot.GetInfo();
@@ -659,6 +663,7 @@ public:
         StoragePools.clear();
         StorageGroups.clear();
         StorageNodes.clear();
+        StorageNodesComputed = false;
         SystemStateResponse.clear();
         NodeStateResponse.clear();
         PDiskStateResponse.clear();


### PR DESCRIPTION
### Description for reviewers
По сути это багфикс. В ответах хенлера фильтрация по базе уже была (и он сам проверяет, что база передана в query-параметрах) для `DatabaseNodes` & `StorageGroups `, не фильтровались только `StorageNodes` (см. пример реального ответа кластера https://nda.ya.ru/t/9AsomyZa7nVUST).
Сделано:
- Добавлена проверка принадлежности сторадж нод конкретной базе **для всех запросов/пользователей**.
- Удален не использовавшийся запрос `TEvNodesInfo`.
- Добавлен минимальный функциональный тест (были только юнит-тесты).

PS Возможно хендлер `/viewer/database_stats` стоит удалить, т.к. UI его не использует https://nda.ya.ru/t/WOsCgF6d7mspGh, исходя из его не использования не делаю категорию ПРа багфиксом.