### PR TITLE
Improve test concurrency for muted SetNotNullReboots.SetNotNullOnSing…

### DIFF
--- a/ydb/core/tx/schemeshard/ut_set_column_constraint_reboots/ut_set_column_constraint_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint_reboots/ut_set_column_constraint_reboots.cpp
@@ -9,7 +9,7 @@ using namespace NSchemeShardUT_Private;
 
 Y_UNIT_TEST_SUITE(SetNotNullReboots) {
 
-    Y_UNIT_TEST_WITH_REBOOTS(SetNotNullOnSingleColumn) {
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(SetNotNullOnSingleColumn, 4, 1, false) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
             runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
@@ -48,7 +48,7 @@ Y_UNIT_TEST_SUITE(SetNotNullReboots) {
         });
     }
 
-    Y_UNIT_TEST_WITH_REBOOTS(SetNotNullShouldBeFailed) {
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(SetNotNullShouldBeFailed, 8, 1, false) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
             runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
@@ -107,7 +107,7 @@ Y_UNIT_TEST_SUITE(SetNotNullReboots) {
         });
     }
 
-    Y_UNIT_TEST_WITH_REBOOTS(SetNotNullOnManyColumnsWithManyShards) {
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(SetNotNullOnManyColumnsWithManyShards, 8, 1, false) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
             runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);


### PR DESCRIPTION
…leColumn[TabletReboots]


### Description for reviewers <!-- (optional) description for those who read this PR -->

Improved ydb/core/tx/schemeshard/ut_set_column_constraint_reboots/ut_set_column_constraint_reboots.cpp
Test run shortened from 370s to 52s on build machine (~x5 faster) 