### PR TITLE
Restrict `node_id` param for strict database users in HTTP requests

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1050,26 +1050,36 @@ bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNode
     }
     // We can't validate the scope of the requested nodes without the database node list,
     // so an unresolved database denies the request.
-    const bool databaseNodesKnown = AreDatabaseNodesKnown();
-    std::unordered_set<TNodeId> databaseNodes;
-    if (databaseNodesKnown) {
-        const auto nodes = GetDatabaseNodes();
-        databaseNodes.insert(nodes.begin(), nodes.end());
+    if (!AreDatabaseNodesKnown()) {
+        YDB_LOG_NOTICE_COMP(
+            NKikimrServices::VIEWER,
+            "Access denied: database node list is unavailable, request cannot be validated",
+            {"logPrefix", GetLogPrefix()},
+            {"user", GetUserSID()},
+            {"database", Database});
+        ReplyAndPassAway(
+            GETHTTPACCESSDENIED(
+                "text/plain",
+                "Database node list is unavailable, request cannot be validated"),
+            "Access denied");
+        return true;
     }
+    std::unordered_set<TNodeId> databaseNodes;
+    const auto nodes = GetDatabaseNodes();
+    databaseNodes.insert(nodes.begin(), nodes.end());
     for (const auto& nodeId : nodeIds) {
         if (!databaseNodes.contains(nodeId)) {
             YDB_LOG_NOTICE_COMP(
                 NKikimrServices::VIEWER,
-                "Access denied: requested node is outside the specified database or cannot be validated",
+                "Access denied: requested node is outside the specified database",
                 {"logPrefix", GetLogPrefix()},
                 {"user", GetUserSID()},
                 {"database", Database},
-                {"outOfDatabaseNode", nodeId},
-                {"databaseNodesKnown", databaseNodesKnown});
+                {"outOfDatabaseNode", nodeId});
             ReplyAndPassAway(
                 GETHTTPACCESSDENIED(
                     "text/plain",
-                    "Some requested nodes are outside the specified database or cannot be validated"),
+                    "Some requested nodes are outside the specified database"),
                 "Access denied");
             return true;
         }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1024,6 +1024,11 @@ bool TViewerPipeClient::IsDatabaseRequest() const {
     return DatabaseBoardInfoResponse || ResourceBoardInfoResponse;
 }
 
+bool TViewerPipeClient::AreDatabaseNodesKnown() const {
+    return (DatabaseBoardInfoResponse && DatabaseBoardInfoResponse->IsOk()) ||
+        (ResourceBoardInfoResponse && ResourceBoardInfoResponse->IsOk());
+}
+
 bool TViewerPipeClient::IsStrictDatabaseOnlyRequest() {
     if (!StrictDatabaseOnlyRequest.has_value()) {
         StrictDatabaseOnlyRequest = IsStrictDatabaseOnlyToken(AppData(), GetRequest().GetUserTokenObject());
@@ -1037,6 +1042,36 @@ TString TViewerPipeClient::GetUserSID() const {
         return {};
     }
     return userToken.GetUserSID();
+}
+
+bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds) {
+    if (nodeIds.empty()) {
+        return false;
+    }
+    // We can't validate the scope of the requested nodes without the database node list, and this
+    // is an access check, so an unresolved database denies the request instead of letting it through.
+    const bool databaseNodesKnown = AreDatabaseNodesKnown();
+    std::unordered_set<TNodeId> databaseNodes;
+    if (databaseNodesKnown) {
+        const auto nodes = GetDatabaseNodes();
+        databaseNodes.insert(nodes.begin(), nodes.end());
+    }
+    for (const auto& nodeId : nodeIds) {
+        if (!databaseNodes.contains(nodeId)) {
+            YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Access denied: requested node is outside the database",
+                {"logPrefix", GetLogPrefix()},
+                {"user", GetUserSID()},
+                {"database", Database},
+                {"outOfDatabaseNode", nodeId},
+                {"databaseNodeCount", databaseNodes.size()},
+                {"databaseNodesKnown", databaseNodesKnown});
+            ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
+                "Access denied");
+            return true;
+        }
+    }
+    return false;
 }
 
 void TViewerPipeClient::InitConfig(const TCgiParameters& params) {

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1058,14 +1058,18 @@ bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNode
     }
     for (const auto& nodeId : nodeIds) {
         if (!databaseNodes.contains(nodeId)) {
-            YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Access denied: requested node is outside the database",
+            YDB_LOG_NOTICE_COMP(
+                NKikimrServices::VIEWER,
+                "Access denied: requested node is outside the specified database or cannot be validated",
                 {"logPrefix", GetLogPrefix()},
                 {"user", GetUserSID()},
                 {"database", Database},
                 {"outOfDatabaseNode", nodeId},
                 {"databaseNodesKnown", databaseNodesKnown});
             ReplyAndPassAway(
-                GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),
+                GETHTTPACCESSDENIED(
+                    "text/plain",
+                    "Some requested nodes are outside the specified database or cannot be validated"),
                 "Access denied");
             return true;
         }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1048,8 +1048,8 @@ bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNode
     if (nodeIds.empty()) {
         return false;
     }
-    // We can't validate the scope of the requested nodes without the database node list, and this
-    // is an access check, so an unresolved database denies the request instead of letting it through.
+    // We can't validate the scope of the requested nodes without the database node list,
+    // so an unresolved database denies the request.
     const bool databaseNodesKnown = AreDatabaseNodesKnown();
     std::unordered_set<TNodeId> databaseNodes;
     if (databaseNodesKnown) {
@@ -1063,7 +1063,6 @@ bool TViewerPipeClient::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNode
                 {"user", GetUserSID()},
                 {"database", Database},
                 {"outOfDatabaseNode", nodeId},
-                {"databaseNodeCount", databaseNodes.size()},
                 {"databaseNodesKnown", databaseNodesKnown});
             ReplyAndPassAway(
                 GETHTTPACCESSDENIED("text/plain", "Some requested nodes are outside the specified database"),

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -17,6 +17,9 @@
 #include <ydb/library/wilson_ids/wilson.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
+#include <span>
+#include <unordered_set>
+
 namespace NKikimr::NViewer {
 
 using namespace NKikimr;
@@ -339,12 +342,19 @@ protected:
     TRequestResponse<TEvStateStorage::TEvBoardInfo> MakeRequestStateStorageEndpointsLookup(const TString& path, ui64 cookie = 0);
     std::vector<TNodeId> GetNodesFromBoardReply(TEvStateStorage::TEvBoardInfo::TPtr& ev);
     std::vector<TNodeId> GetNodesFromBoardReply(const TEvStateStorage::TEvBoardInfo& ev);
+    // Returns real database nodes only when the database (or the shared database for serverless)
+    // endpoints lookup has succeeded, otherwise it returns 0 - a sentinel for the current node.
     std::vector<TNodeId> GetDatabaseNodes();
     bool IsDatabaseRequest() const;
+    bool AreDatabaseNodesKnown() const;
 
     // Such a user is allowed to see the information about its own database only
     bool IsStrictDatabaseOnlyRequest();
     TString GetUserSID() const;
+
+    // Denies the request unless every given node belongs to the requested database. If the database
+    // nodes are unknown, the request is denied too. Returns true if the response has been already sent.
+    bool DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds);
 
     void InitConfig(const TCgiParameters& params);
     void InitConfig(const TRequestSettings& settings);

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -342,8 +342,8 @@ protected:
     TRequestResponse<TEvStateStorage::TEvBoardInfo> MakeRequestStateStorageEndpointsLookup(const TString& path, ui64 cookie = 0);
     std::vector<TNodeId> GetNodesFromBoardReply(TEvStateStorage::TEvBoardInfo::TPtr& ev);
     std::vector<TNodeId> GetNodesFromBoardReply(const TEvStateStorage::TEvBoardInfo& ev);
-    // Returns real database nodes only when the database (or the shared database for serverless)
-    // endpoints lookup has succeeded, otherwise it returns 0 - a sentinel for the current node.
+    // Returns real database nodes only when the database endpoints lookup has succeeded,
+    // otherwise it returns 0 - a sentinel for the current node.
     std::vector<TNodeId> GetDatabaseNodes();
     bool IsDatabaseRequest() const;
     bool AreDatabaseNodesKnown() const;
@@ -353,7 +353,7 @@ protected:
     TString GetUserSID() const;
 
     // Denies the request unless every given node belongs to the requested database. If the database
-    // nodes are unknown, the request is denied too. Returns true if the response has been already sent.
+    // nodes are unknown, the request is denied too. Returns true if "Access Denied" response has been already sent.
     bool DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId> nodeIds);
 
     void InitConfig(const TCgiParameters& params);

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -46,23 +46,16 @@ public:
         return nodeIds;
     }
 
-    // Strict database-only users are allowed to ask the nodes of their database only.
-    // Must be called after NeedToRedirect(), otherwise the database nodes are not resolved yet.
-    // Returns true if the response has been already sent.
-    bool DenyRequestIfNodeIdsAreOutOfDatabase() {
-        if (!TBase::IsStrictDatabaseOnlyRequest()) {
-            return false;
-        }
-        return TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams());
-    }
-
     void Bootstrap() override {
         if (TBase::NeedToRedirect()) {
             return;
         }
-        if (DenyRequestIfNodeIdsAreOutOfDatabase()) {
-            return;
+        if (TBase::IsStrictDatabaseOnlyRequest()) {
+            if (TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams())) {
+                return;
+            }
         }
+
         std::vector<TNodeId> nodeIds = GetNodeIdsFromParams();
         if (!nodeIds.empty()) {
             if (TBase::RequestSettings.FilterNodeIds.empty()) {

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -50,13 +50,13 @@ public:
         if (TBase::NeedToRedirect()) {
             return;
         }
+        std::vector<TNodeId> nodeIds = GetNodeIdsFromParams();
         if (TBase::IsStrictDatabaseOnlyRequest()) {
-            if (TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams())) {
+            if (TBase::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId>(nodeIds.data(), nodeIds.size()))) {
                 return;
             }
         }
 
-        std::vector<TNodeId> nodeIds = GetNodeIdsFromParams();
         if (!nodeIds.empty()) {
             if (TBase::RequestSettings.FilterNodeIds.empty()) {
                 TBase::RequestSettings.FilterNodeIds = nodeIds;

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -36,16 +36,34 @@ public:
         : TBase(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (TBase::NeedToRedirect()) {
-            return;
-        }
+    std::vector<TNodeId> GetNodeIdsFromParams() const {
         std::vector<TNodeId> nodeIds;
         SplitIds(TBase::Params.Get("node_id"), ',', nodeIds);
         std::replace(nodeIds.begin(),
                      nodeIds.end(),
                      (TNodeId)0,
                      TlsActivationContext->ActorSystem()->NodeId);
+        return nodeIds;
+    }
+
+    // Strict database-only users are allowed to ask the nodes of their database only.
+    // Must be called after NeedToRedirect(), otherwise the database nodes are not resolved yet.
+    // Returns true if the response has been already sent.
+    bool DenyRequestIfNodeIdsAreOutOfDatabase() {
+        if (!TBase::IsStrictDatabaseOnlyRequest()) {
+            return false;
+        }
+        return TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams());
+    }
+
+    void Bootstrap() override {
+        if (TBase::NeedToRedirect()) {
+            return;
+        }
+        if (DenyRequestIfNodeIdsAreOutOfDatabase()) {
+            return;
+        }
+        std::vector<TNodeId> nodeIds = GetNodeIdsFromParams();
         if (!nodeIds.empty()) {
             if (TBase::RequestSettings.FilterNodeIds.empty()) {
                 TBase::RequestSettings.FilterNodeIds = nodeIds;
@@ -74,6 +92,15 @@ public:
                 if (TBase::RequestSettings.FilterNodeIds.empty()) {
                     return ReplyAndPassAway();
                 }
+            }
+            if (TBase::RequestSettings.FilterNodeIds.empty() && TBase::IsStrictDatabaseOnlyRequest()) {
+                // If a database has no registered nodes, a strict database-only user gets
+                // 200 with an empty response, not the nodes of the whole cluster.
+                YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Empty response: the database has no nodes to ask",
+                    {"logPrefix", TBase::GetLogPrefix()},
+                    {"user", TBase::GetUserSID()},
+                    {"database", TBase::Database});
+                return ReplyAndPassAway();
             }
         }
         {

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -92,8 +92,8 @@ public:
         // node_id is normally validated by TBase::Bootstrap(), but this handler
         // calls it at the very end. So the check is done up front.
         if (TBase::IsStrictDatabaseOnlyRequest()) {
-             const auto nodeIds = GetNodeIdsFromParams();
-             if (TBase::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId>(nodeIds.data(), nodeIds.size()))) {
+            const auto nodeIds = GetNodeIdsFromParams();
+            if (TBase::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId>(nodeIds.data(), nodeIds.size()))) {
                 return;
             }
         }

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -89,13 +89,12 @@ public:
         if (NeedToRedirect()) {
             return;
         }
-        // node_id is normally validated by TBase::Bootstrap(), but this handler calls it at the very
-        // end: with a "path" param it first asks SchemeShard and reaches TBase::Bootstrap() only from
-        // the describe response handler. Denying the request there would be both too late (SchemeShard
-        // has already been asked) and unsafe (the handler goes on building the whiteboard request
-        // that TBase::Bootstrap() never created). So the check is done up front, for both branches.
-        if (TBase::DenyRequestIfNodeIdsAreOutOfDatabase()) {
-            return;
+        // node_id is normally validated by TBase::Bootstrap(), but this handler
+        // calls it at the very end. So the check is done up front.
+        if (TBase::IsStrictDatabaseOnlyRequest()) {
+            if (TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams())) {
+                return;
+            }
         }
         if (DatabaseNavigateResponse && DatabaseNavigateResponse->IsOk()) {
             TPathId domainRoot;

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -89,6 +89,14 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        // node_id is normally validated by TBase::Bootstrap(), but this handler calls it at the very
+        // end: with a "path" param it first asks SchemeShard and reaches TBase::Bootstrap() only from
+        // the describe response handler. Denying the request there would be both too late (SchemeShard
+        // has already been asked) and unsafe (the handler goes on building the whiteboard request
+        // that TBase::Bootstrap() never created). So the check is done up front, for both branches.
+        if (TBase::DenyRequestIfNodeIdsAreOutOfDatabase()) {
+            return;
+        }
         if (DatabaseNavigateResponse && DatabaseNavigateResponse->IsOk()) {
             TPathId domainRoot;
             if (AppData()) {

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -92,7 +92,8 @@ public:
         // node_id is normally validated by TBase::Bootstrap(), but this handler
         // calls it at the very end. So the check is done up front.
         if (TBase::IsStrictDatabaseOnlyRequest()) {
-            if (TBase::DenyRequestIfNodesAreOutOfDatabase(GetNodeIdsFromParams())) {
+             const auto nodeIds = GetNodeIdsFromParams();
+             if (TBase::DenyRequestIfNodesAreOutOfDatabase(std::span<const TNodeId>(nodeIds.data(), nodeIds.size()))) {
                 return;
             }
         }

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -111,6 +111,28 @@ def get_tenant_path_id(cluster, root_path, database_path, use_tls=False, token=N
     return int(describe_path_self(cluster, root_path, database_path, use_tls, token)['PathId'])
 
 
+def get_nodelist_ids(base_url, database=None, token='root@builtin'):
+    params = {}
+    if database is not None:
+        params['database'] = database
+    response = requests.get(
+        base_url + '/viewer/json/nodelist',
+        params=params,
+        headers={'Authorization': token},
+        verify=False,
+        timeout=5,
+    )
+    response.raise_for_status()
+    return [node['Id'] for node in response.json()]
+
+
+def get_foreign_node_id_for_database(base_url, database, token='root@builtin'):
+    database_nodes = set(get_nodelist_ids(base_url, database=database, token=token))
+    foreign_nodes = set(get_nodelist_ids(base_url, token=token)) - database_nodes
+    assert foreign_nodes, f'no foreign nodes found for database={database}'
+    return min(foreign_nodes)
+
+
 def wait_for_viewer_ready(
     base_url,
     database=DATABASE,

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -8,6 +8,8 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.functional.security.lib.cluster_config import create_ydb_configurator, generate_certificates
 from ydb.tests.functional.security.lib.security_test_helpers import mon_base_url as get_mon_base_url
 from ydb.tests.functional.security.lib.security_test_helpers import grant_describe_schema_provided
+from ydb.tests.functional.security.lib.security_test_helpers import get_foreign_node_id_for_database
+from ydb.tests.functional.security.lib.security_test_helpers import get_nodelist_ids
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
@@ -223,6 +225,18 @@ def tenant_describe_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
         'path_id': get_tenant_path_id(cluster, tenant_database, tenant_database, use_tls=True, token='root@builtin'),
         'schemeshard_id': get_tenant_schemeshard_id(cluster, tenant_database, tenant_database, use_tls=True, token='root@builtin'),
     }
+
+
+@pytest.fixture(scope='module')
+def tenant_nodelist_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_nodelist_ids(base_url, database=tenant_database)
+
+
+@pytest.fixture(scope='module')
+def foreign_node_id(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_foreign_node_id_for_database(base_url, tenant_database)
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -379,3 +379,68 @@ def test_out_of_scope_path_nodes_gives_400(mon_base_url_with_extra_sids_control)
     for ep in ['/viewer/nodes', '/viewer/json/nodes']:
         path = _build_endpoint_path(ep, with_database_cgi=True, extra_params={'path': '/Other'})
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
+
+
+def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_nodelist_ids,
+    foreign_node_id,
+):
+    assert tenant_nodelist_ids, 'tenant database must have at least one node'
+    tenant_node_id = tenant_nodelist_ids[0]
+    endpoints = [
+        '/viewer/sysinfo',
+        '/viewer/tabletinfo',
+    ]
+    for ep in endpoints:
+        foreign_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'node_id': str(foreign_node_id)},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, foreign_path, 'database@builtin', 403)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'node_id': str(tenant_node_id)},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
+
+        # Scope-param validation must not block tokens above strict database level.
+        # Foreign node_id is filtered out by database scope which results with OK (200) empty response, not 4xx.
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(mon_base_url_with_extra_sids_control, foreign_path, token, 200)
+
+
+# /viewer/tabletinfo with the "path" param asks SchemeShard first and builds the whiteboard request
+# only after the describe response, so the node_id scope check has its own code path there.
+def test_viewer_tabletinfo_path_with_node_id_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_nodelist_ids,
+    foreign_node_id,
+):
+    assert tenant_nodelist_ids, 'tenant database must have at least one node'
+    base = mon_base_url_with_extra_sids_control
+    for ep in ['/viewer/tabletinfo', '/viewer/json/tabletinfo']:
+        forbidden_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': tenant_database, 'node_id': str(foreign_node_id)},
+            database=tenant_database,
+        )
+        _assert_status(base, forbidden_path, 'database@builtin', 403)
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(base, forbidden_path, token, 200)
+
+        allowed_path = _build_endpoint_path(
+            ep,
+            with_database_cgi=True,
+            extra_params={'path': tenant_database, 'node_id': str(tenant_nodelist_ids[0])},
+            database=tenant_database,
+        )
+        _assert_status(base, allowed_path, 'database@builtin', 200)

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -414,6 +414,14 @@ def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
         )
         _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
 
+        # Requests with any foreign nodes in the list must be rejected.
+        mixed_list_path = _build_endpoint_path(
+             ep,
+             with_database_cgi=True,
+             extra_params={'node_id': f'{tenant_node_id},{foreign_node_id}'},
+             database=tenant_database,
+         )
+         _assert_status(mon_base_url_with_extra_sids_control, mixed_list_path, 'database@builtin', 403)
 
 # /viewer/tabletinfo may skip the node_id scope check in the base class,
 # so this handler handles the node_id scope check by itself.

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -416,12 +416,13 @@ def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
 
         # Requests with any foreign nodes in the list must be rejected.
         mixed_list_path = _build_endpoint_path(
-             ep,
-             with_database_cgi=True,
-             extra_params={'node_id': f'{tenant_node_id},{foreign_node_id}'},
-             database=tenant_database,
-         )
-         _assert_status(mon_base_url_with_extra_sids_control, mixed_list_path, 'database@builtin', 403)
+            ep,
+            with_database_cgi=True,
+            extra_params={'node_id': f'{tenant_node_id},{foreign_node_id}'},
+            database=tenant_database,
+        )
+        _assert_status(mon_base_url_with_extra_sids_control, mixed_list_path, 'database@builtin', 403)
+
 
 # /viewer/tabletinfo may skip the node_id scope check in the base class,
 # so this handler handles the node_id scope check by itself.

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -400,7 +400,11 @@ def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
             extra_params={'node_id': str(foreign_node_id)},
             database=tenant_database,
         )
+        # Scope-param validation must block strict database level tokens.
         _assert_status(mon_base_url_with_extra_sids_control, foreign_path, 'database@builtin', 403)
+        # Scope-param validation must NOT block tokens above strict database level.
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(mon_base_url_with_extra_sids_control, foreign_path, token, 200)
 
         allowed_path = _build_endpoint_path(
             ep,
@@ -410,14 +414,9 @@ def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
         )
         _assert_status(mon_base_url_with_extra_sids_control, allowed_path, 'database@builtin', 200)
 
-        # Scope-param validation must not block tokens above strict database level.
-        # Foreign node_id is filtered out by database scope which results with OK (200) empty response, not 4xx.
-        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
-            _assert_status(mon_base_url_with_extra_sids_control, foreign_path, token, 200)
 
-
-# /viewer/tabletinfo with the "path" param asks SchemeShard first and builds the whiteboard request
-# only after the describe response, so the node_id scope check has its own code path there.
+# /viewer/tabletinfo may skip the node_id scope check in the base class,
+# so this handler handles the node_id scope check by itself.
 def test_viewer_tabletinfo_path_with_node_id_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,


### PR DESCRIPTION
### Description for reviewers
В базовом классе `TJsonWhiteboardRequest` для группы хендлеров, например `/viewer/sysinfo`, добавлена проверка нод, переданных в query-параметре `node_id` (на самом деле там список может быть через запятую).
Если ноды базы не удаётся зарезолвить, то считаем, что проверить принадлежность нод базе нельзя и запрос запрещаем.

Отдельно проверил, что если зарегистрированных нод реально не будет, то UI не развалится, а просто какие-то данные не покажем.

Так же проверил, что для серверлесс базы нодами базы в `GetDatabaseNodes()` считаются ноды её шаред базы, и новая проверка проходить будет. Видимо когда-то в будущем отдельно будем смотреть на то, что нужно показывать в UI для sls баз и какие данные можно отдавать в ответах АПИ.