### PR TITLE
Implement schema change aggregation/emission

### DIFF
--- a/ydb/core/change_exchange/change_sender.cpp
+++ b/ydb/core/change_exchange/change_sender.cpp
@@ -290,8 +290,23 @@ void TChangeSender::SendPreparedRecords(ui64 partitionId) {
     sender.Ready = false;
     ReadySenders--;
 
-    sender.Pending.reserve(sender.Prepared.size());
-    for (const auto& record : sender.Prepared) {
+    TVector<IChangeRecord::TPtr> toSend;
+    TVector<IChangeRecord::TPtr> rest;
+    bool seenBroadcast = false;
+    for (auto& record : sender.Prepared) {
+        if (seenBroadcast) {
+            rest.push_back(std::move(record));
+            continue;
+        }
+        if (record->IsBroadcast()) {
+            seenBroadcast = true;
+        }
+        toSend.push_back(std::move(record));
+    }
+    sender.Prepared = std::move(rest);
+
+    sender.Pending.reserve(toSend.size());
+    for (const auto& record : toSend) {
         if (!record->IsBroadcast()) {
             sender.Pending.emplace_back(record->GetOrder(), record->GetBody().size());
             MemUsage -= record->GetBody().size();
@@ -301,7 +316,7 @@ void TChangeSender::SendPreparedRecords(ui64 partitionId) {
     }
 
     Y_ABORT_UNLESS(sender.ActorId);
-    ActorOps->Send(sender.ActorId, new TEvChangeExchange::TEvRecords(std::exchange(sender.Prepared, {})));
+    ActorOps->Send(sender.ActorId, new TEvChangeExchange::TEvRecords(std::move(toSend)));
 }
 
 void TChangeSender::OnGone(ui64 partitionId) {

--- a/ydb/core/change_exchange/change_sender.cpp
+++ b/ydb/core/change_exchange/change_sender.cpp
@@ -47,7 +47,7 @@ void TChangeSender::CreateMissingSenders(const TVector<ui64>& partitionIds) {
     }
 
     for (const auto& [partitionId, sender] : Senders) {
-        ReEnqueueRecords(sender);
+        ReEnqueueRecords(partitionId, sender);
         ProcessBroadcasting(&TChangeSender::RemoveBroadcastPartition, partitionId, sender.Broadcasting);
         if (sender.ActorId) {
             ActorOps->Send(sender.ActorId, new TEvents::TEvPoisonPill());
@@ -325,7 +325,7 @@ void TChangeSender::OnGone(ui64 partitionId) {
         return;
     }
 
-    ReEnqueueRecords(it->second);
+    ReEnqueueRecords(partitionId, it->second);
     if (it->second.Ready) {
         --ReadySenders;
     }
@@ -340,16 +340,25 @@ void TChangeSender::OnGone(ui64 partitionId) {
     PathResolver->Resolve();
 }
 
-void TChangeSender::ReEnqueueRecords(const TSender& sender) {
+void TChangeSender::ReEnqueueRecords(ui64 partitionId, const TSender& sender) {
     for (const auto& record : sender.Pending) {
         Enqueued.insert(ReEnqueue(record));
     }
 
+    TVector<ui64> preparedBroadcasts;
     for (const auto& record : sender.Prepared) {
         if (!record->IsBroadcast()) {
             Enqueued.insert(ReEnqueue(record->GetOrder(), record->GetBody().size()));
             MemUsage -= record->GetBody().size();
+        } else {
+            // Broadcasts held back after a barrier split are not in sender.Broadcasting yet,
+            // but the partition was already removed from PendingPartitions when prepared.
+            // Drop them from the broadcast set so completion cannot stall if the sender is gone.
+            preparedBroadcasts.push_back(record->GetOrder());
         }
+    }
+    if (preparedBroadcasts) {
+        ProcessBroadcasting(&TChangeSender::RemoveBroadcastPartition, partitionId, preparedBroadcasts);
     }
 }
 

--- a/ydb/core/change_exchange/change_sender.cpp
+++ b/ydb/core/change_exchange/change_sender.cpp
@@ -290,16 +290,19 @@ void TChangeSender::SendPreparedRecords(ui64 partitionId) {
     sender.Ready = false;
     ReadySenders--;
 
+    // Hold back records after a schema-change broadcast so post-schema data cannot share
+    // a write batch with a delayed-ACK schema change. Heartbeats stay non-blocking:
+    // they ACK immediately and must not introduce an extra OnReady round-trip.
     TVector<IChangeRecord::TPtr> toSend;
     TVector<IChangeRecord::TPtr> rest;
-    bool seenBroadcast = false;
+    bool seenSchemaChangeBarrier = false;
     for (auto& record : sender.Prepared) {
-        if (seenBroadcast) {
+        if (seenSchemaChangeBarrier) {
             rest.push_back(std::move(record));
             continue;
         }
-        if (record->IsBroadcast()) {
-            seenBroadcast = true;
+        if (record->GetKind() == IChangeRecord::EKind::CdcSchemaChange) {
+            seenSchemaChangeBarrier = true;
         }
         toSend.push_back(std::move(record));
     }

--- a/ydb/core/change_exchange/change_sender.h
+++ b/ydb/core/change_exchange/change_sender.h
@@ -122,7 +122,7 @@ class TChangeSender {
     bool RequestRecords();
     void SendRecords();
     void SendPreparedRecords(ui64 partitionId);
-    void ReEnqueueRecords(const TSender& sender);
+    void ReEnqueueRecords(ui64 partitionId, const TSender& sender);
 
     TBroadcast& EnsureBroadcast(IChangeRecord::TPtr record);
     bool AddBroadcastPartition(ui64 order, ui64 partitionId);

--- a/ydb/core/persqueue/common/schema_change.cpp
+++ b/ydb/core/persqueue/common/schema_change.cpp
@@ -1,0 +1,20 @@
+#include "schema_change.h"
+
+#include <ydb/core/protos/pqconfig.pb.h>
+
+namespace NKikimr::NPQ {
+
+TSchemaChangeInfo TSchemaChangeInfo::Parse(const NKikimrPQ::TSchemaChangeInfo& proto) {
+    return TSchemaChangeInfo{
+        .Version = TRowVersion(proto.GetStep(), proto.GetTxId()),
+        .Data = proto.GetData(),
+    };
+}
+
+void TSchemaChangeInfo::Serialize(NKikimrPQ::TSchemaChangeInfo& proto) const {
+    proto.SetStep(Version.Step);
+    proto.SetTxId(Version.TxId);
+    proto.SetData(Data);
+}
+
+}

--- a/ydb/core/persqueue/common/schema_change.h
+++ b/ydb/core/persqueue/common/schema_change.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ydb/core/base/row_version.h>
+
+#include <util/generic/string.h>
+
+namespace NKikimrPQ {
+    class TSchemaChangeInfo;
+}
+
+namespace NKikimr::NPQ {
+
+struct TSchemaChangeInfo {
+    TRowVersion Version;
+    TString Data;
+
+    static TSchemaChangeInfo Parse(const NKikimrPQ::TSchemaChangeInfo& proto);
+    void Serialize(NKikimrPQ::TSchemaChangeInfo& proto) const;
+};
+
+}

--- a/ydb/core/persqueue/common/schema_change.h
+++ b/ydb/core/persqueue/common/schema_change.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/row_version.h>
 
+#include <util/generic/maybe.h>
 #include <util/generic/string.h>
 
 namespace NKikimrPQ {
@@ -17,5 +18,25 @@ struct TSchemaChangeInfo {
     static TSchemaChangeInfo Parse(const NKikimrPQ::TSchemaChangeInfo& proto);
     void Serialize(NKikimrPQ::TSchemaChangeInfo& proto) const;
 };
+
+// True when a deferred schema-change write can be ACKed.
+inline bool IsSchemaChangeVersionReleased(
+    const TRowVersion& version,
+    const TRowVersion& lastEmitted,
+    const TRowVersion& committedFromStorage)
+{
+    return version <= Max(lastEmitted, committedFromStorage);
+}
+
+// Prefer an already-persisted newer LastSchemaChange over a deferred write's version.
+inline TSchemaChangeInfo SelectSchemaChangeForAck(
+    TSchemaChangeInfo proposed,
+    const TMaybe<TSchemaChangeInfo>& existing)
+{
+    if (existing && existing->Version > proposed.Version) {
+        return *existing;
+    }
+    return proposed;
+}
 
 }

--- a/ydb/core/persqueue/common/sourceid_info.h
+++ b/ydb/core/persqueue/common/sourceid_info.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/persqueue/public/partition_key_range/partition_key_range.h>
 #include "heartbeat.h"
+#include "schema_change.h"
 #include <ydb/core/protos/pqconfig.pb.h>
 
 namespace NKikimr::NPQ {
@@ -24,6 +25,7 @@ struct TSourceIdInfo {
     bool TxModified = false;
     TMaybe<TPartitionKeyRange> KeyRange;
     TMaybe<THeartbeat> LastHeartbeat;
+    TMaybe<TSchemaChangeInfo> LastSchemaChange;
     EState State = EState::Registered;
 
 
@@ -34,6 +36,8 @@ struct TSourceIdInfo {
 
     TSourceIdInfo Updated(ui64 seqNo, ui64 offset, TInstant writeTs, TMaybe<i16> producerEpoch = Nothing()) const;
     TSourceIdInfo Updated(ui64 seqNo, ui64 offset, TInstant writeTs, THeartbeat&& heartbeat, TMaybe<i16> producerEpoch = Nothing()) const;
+    TSourceIdInfo Updated(ui64 seqNo, ui64 offset, TInstant writeTs, TSchemaChangeInfo&& schemaChange, TMaybe<i16> producerEpoch = Nothing()) const;
+    TSourceIdInfo Updated(TSchemaChangeInfo&& schemaChange) const;
 
     static EState ConvertState(NKikimrPQ::TMessageGroupInfo::EState value);
     static NKikimrPQ::TMessageGroupInfo::EState ConvertState(EState value);

--- a/ydb/core/persqueue/common/ya.make
+++ b/ydb/core/persqueue/common/ya.make
@@ -4,6 +4,7 @@ SRCS(
     actor.cpp
     common_app.cpp
     heartbeat.cpp
+    schema_change.cpp
     key.cpp
     microseconds_sliding_window.cpp
     partition_id.cpp

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -301,6 +301,8 @@ struct TEvPQ {
             bool IgnoreQuotaDeadline;
             // If specified, Data will contain heartbeat's data
             std::optional<TRowVersion> HeartbeatVersion;
+            // If specified, Data will contain schema change's data
+            std::optional<TRowVersion> SchemaChangeVersion;
 
             // For Kafka deduplication:
             bool EnableKafkaDeduplication = false;

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -945,6 +945,10 @@ void TPartition::DestroyActor(const TActorContext& ctx)
         ReplyError(ctx, w.GetCookie(), errorCode, TStringBuilder() << ss << " (WriteResponses)");
     }
 
+    for (const auto& w : PendingSchemaChangeResponses) {
+        ReplyError(ctx, w.GetCookie(), errorCode, TStringBuilder() << ss << " (PendingSchemaChangeResponses)");
+    }
+
     for (const auto& ri : ReadInfo) {
         ReplyError(ctx, ri.second.Destination, errorCode,
             TStringBuilder() << ss << " (ReadInfo) cookie " << ri.first);

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -384,6 +384,7 @@ TPartition::TPartition(ui64 tabletId, const TPartitionId& partition, const TActo
     , WriteBufferIsFullCounter(nullptr)
     , WriteLagMs(TDuration::Minutes(1), 100)
     , LastEmittedHeartbeat(TRowVersion::Min())
+    , LastEmittedSchemaChange(TRowVersion::Min())
     , SamplingControl(samplingControl)
     , MessageIdDeduplicator(Partition, CreateDefaultTimeProvider(), TDuration::Minutes(5))
 {

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -1175,6 +1175,8 @@ private:
     void ProcessPendingEvents(const TActorContext& ctx);
 
     TRowVersion LastEmittedHeartbeat;
+    TRowVersion LastEmittedSchemaChange;
+    TMessageQueue PendingSchemaChangeResponses;
 
     const NKikimrPQ::TPQTabletConfig::TPartition* GetPartitionConfig(const NKikimrPQ::TPQTabletConfig& config);
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
@@ -176,20 +176,19 @@ void TPartitionSourceManager::TSourceManager::Update(TSchemaChangeInfo&& schemaC
     // GetCommittedSchemaChangeVersion() without waiting for a re-ACK.
     // Keep the same regression guard as SchemaChangeEmitter::Process (prefer writer
     // state when present so a later Update in this batch cannot regress).
-    const auto isNewerThan = [&](const TSourceIdInfo& info) {
-        return !info.LastSchemaChange || schemaChange.Version > info.LastSchemaChange->Version;
-    };
 
     auto copySchemaChange = schemaChange;
     Batch.SchemaChangeEmitter.Process(SourceId, std::move(copySchemaChange));
-    if (InMemory != MemoryStorage().end()) {
-        if (isNewerThan(InMemory->second)) {
-            Batch.SourceIdWriter.RegisterSourceId(SourceId, InMemory->second.Updated(std::move(schemaChange)));
-        }
-    } else if (InWriter != WriteStorage().end()) {
-        if (isNewerThan(InWriter->second)) {
-            Batch.SourceIdWriter.RegisterSourceId(SourceId, InWriter->second.Updated(std::move(schemaChange)));
-        }
+
+    const TSourceIdInfo* info = nullptr;
+    if (InWriter != WriteStorage().end()) {
+        info = &InWriter->second;
+    } else if (InMemory != MemoryStorage().end()) {
+        info = &InMemory->second;
+    }
+
+    if (info && (!info->LastSchemaChange || schemaChange.Version > info->LastSchemaChange->Version)) {
+        Batch.SourceIdWriter.RegisterSourceId(SourceId, info->Updated(std::move(schemaChange)));
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
@@ -171,6 +171,9 @@ void TPartitionSourceManager::TSourceManager::Update(THeartbeat&& heartbeat) {
 }
 
 void TPartitionSourceManager::TSourceManager::Update(TSchemaChangeInfo&& schemaChange) {
+    // Unlike heartbeats (emitter-only until AnswerCurrentWrites), schema changes also
+    // persist LastSchemaChange via SourceIdWriter so crash recovery can advance
+    // GetCommittedSchemaChangeVersion() without waiting for a re-ACK.
     auto copySchemaChange = schemaChange;
     Batch.SchemaChangeEmitter.Process(SourceId, std::move(copySchemaChange));
     if (InMemory != MemoryStorage().end()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
@@ -171,7 +171,8 @@ void TPartitionSourceManager::TSourceManager::Update(THeartbeat&& heartbeat) {
 }
 
 void TPartitionSourceManager::TSourceManager::Update(TSchemaChangeInfo&& schemaChange) {
-    Batch.SchemaChangeEmitter.Process(SourceId, TSchemaChangeInfo(schemaChange));
+    auto copySchemaChange = schemaChange;
+    Batch.SchemaChangeEmitter.Process(SourceId, std::move(copySchemaChange));
     if (InMemory != MemoryStorage().end()) {
         Batch.SourceIdWriter.RegisterSourceId(SourceId, InMemory->second.Updated(std::move(schemaChange)));
     } else if (InWriter != WriteStorage().end()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
@@ -187,6 +187,8 @@ void TPartitionSourceManager::TSourceManager::Update(TSchemaChangeInfo&& schemaC
         info = &InMemory->second;
     }
 
+    // ExecRequest rejects schema changes without an explicit in-memory/writer source.
+    Y_DEBUG_ABORT_UNLESS(info);
     if (info && (!info->LastSchemaChange || schemaChange.Version > info->LastSchemaChange->Version)) {
         Batch.SourceIdWriter.RegisterSourceId(SourceId, info->Updated(std::move(schemaChange)));
     }

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
@@ -63,7 +63,8 @@ TPartitionSourceManager::TModificationBatch::TModificationBatch(TPartitionSource
     : Manager(manager)
     , Node(Manager.GetPartitionNode())
     , SourceIdWriter(format)
-    , HeartbeatEmitter(Manager.Partition.SourceIdStorage) {
+    , HeartbeatEmitter(Manager.Partition.SourceIdStorage)
+    , SchemaChangeEmitter(Manager.Partition.SourceIdStorage) {
 }
 
 TPartitionSourceManager::TModificationBatch::~TModificationBatch() {
@@ -71,6 +72,10 @@ TPartitionSourceManager::TModificationBatch::~TModificationBatch() {
 
 TMaybe<THeartbeat> TPartitionSourceManager::TModificationBatch::CanEmitHeartbeat() const {
     return HeartbeatEmitter.CanEmit();
+}
+
+TMaybe<TSchemaChangeInfo> TPartitionSourceManager::TModificationBatch::CanEmitSchemaChange() const {
+    return SchemaChangeEmitter.CanEmit();
 }
 
 TPartitionSourceManager::TSourceManager TPartitionSourceManager::TModificationBatch::GetSource(const TString& id) {
@@ -163,6 +168,15 @@ void TPartitionSourceManager::TSourceManager::Update(ui64 seqNo, ui64 offset, TI
 
 void TPartitionSourceManager::TSourceManager::Update(THeartbeat&& heartbeat) {
     Batch.HeartbeatEmitter.Process(SourceId, std::move(heartbeat));
+}
+
+void TPartitionSourceManager::TSourceManager::Update(TSchemaChangeInfo&& schemaChange) {
+    Batch.SchemaChangeEmitter.Process(SourceId, TSchemaChangeInfo(schemaChange));
+    if (InMemory != MemoryStorage().end()) {
+        Batch.SourceIdWriter.RegisterSourceId(SourceId, InMemory->second.Updated(std::move(schemaChange)));
+    } else if (InWriter != WriteStorage().end()) {
+        Batch.SourceIdWriter.RegisterSourceId(SourceId, InWriter->second.Updated(std::move(schemaChange)));
+    }
 }
 
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp
@@ -174,12 +174,22 @@ void TPartitionSourceManager::TSourceManager::Update(TSchemaChangeInfo&& schemaC
     // Unlike heartbeats (emitter-only until AnswerCurrentWrites), schema changes also
     // persist LastSchemaChange via SourceIdWriter so crash recovery can advance
     // GetCommittedSchemaChangeVersion() without waiting for a re-ACK.
+    // Keep the same regression guard as SchemaChangeEmitter::Process (prefer writer
+    // state when present so a later Update in this batch cannot regress).
+    const auto isNewerThan = [&](const TSourceIdInfo& info) {
+        return !info.LastSchemaChange || schemaChange.Version > info.LastSchemaChange->Version;
+    };
+
     auto copySchemaChange = schemaChange;
     Batch.SchemaChangeEmitter.Process(SourceId, std::move(copySchemaChange));
     if (InMemory != MemoryStorage().end()) {
-        Batch.SourceIdWriter.RegisterSourceId(SourceId, InMemory->second.Updated(std::move(schemaChange)));
+        if (isNewerThan(InMemory->second)) {
+            Batch.SourceIdWriter.RegisterSourceId(SourceId, InMemory->second.Updated(std::move(schemaChange)));
+        }
     } else if (InWriter != WriteStorage().end()) {
-        Batch.SourceIdWriter.RegisterSourceId(SourceId, InWriter->second.Updated(std::move(schemaChange)));
+        if (isNewerThan(InWriter->second)) {
+            Batch.SourceIdWriter.RegisterSourceId(SourceId, InWriter->second.Updated(std::move(schemaChange)));
+        }
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.h
@@ -51,6 +51,7 @@ public:
 
         void Update(ui64 seqNo, ui64 offset, TInstant timestamp, TMaybe<i16> producerEpoch = Nothing());
         void Update(THeartbeat&& heartbeat);
+        void Update(TSchemaChangeInfo&& schemaChange);
 
     private:
         const TSourceIdMap& MemoryStorage() const;
@@ -76,6 +77,7 @@ public:
         ~TModificationBatch();
 
         TMaybe<THeartbeat> CanEmitHeartbeat() const;
+        TMaybe<TSchemaChangeInfo> CanEmitSchemaChange() const;
         TSourceManager GetSource(const TString& id);
 
         void Cancel();
@@ -97,6 +99,7 @@ public:
         const TPartitionNode* Node;
         TSourceIdWriter SourceIdWriter;
         THeartbeatEmitter HeartbeatEmitter;
+        TSchemaChangeEmitter SchemaChangeEmitter;
     };
 
     explicit TPartitionSourceManager(TPartition& partition);

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -336,8 +336,11 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         ui64 maxOffset = sit != SourceIdStorage.GetInMemorySourceIds().end() ? sit->second.Offset : 0;
 
         if (sit != SourceIdStorage.GetInMemorySourceIds().end() && partNo + 1 == totalParts) {
+            // Change-sender stalls until ReplyWrite, so SeqNo should not advance while deferred.
+            // Still take Max to avoid regressing SeqNo if that invariant ever breaks.
+            const ui64 registerSeqNo = Max(seqNo, sit->second.SeqNo);
             SourceIdStorage.RegisterSourceId(s, sit->second.Updated(
-                seqNo, maxOffset, CurrentTimestamp,
+                registerSeqNo, maxOffset, CurrentTimestamp,
                 TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}, producerEpoch));
         }
 
@@ -345,7 +348,7 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         ReplyWrite(
             ctx, writeResponse.Cookie, s, seqNo, partNo, totalParts,
             replyOffset, CurrentTimestamp, false, maxSeqNo,
-            PartitionQuotaWaitTimeForCurrentBlob, TopicQuotaWaitTimeForCurrentBlob, queueTime, writeTime, pending.Span
+            TDuration::Zero(), TDuration::Zero(), queueTime, writeTime, pending.Span
         );
         it = PendingSchemaChangeResponses.erase(it);
     }
@@ -2054,7 +2057,7 @@ void TPartition::EndAppendHeadWithNewWrites(const TActorContext& ctx)
                 .External = false,
                 .IgnoreQuotaDeadline = true,
                 .HeartbeatVersion = std::nullopt,
-                .SchemaChangeVersion = std::nullopt, // emitted as regular data for consumers
+                .SchemaChangeVersion = std::nullopt, // must be nullopt to avoid re-deferral in AnswerCurrentWrites
             }, std::nullopt};
 
             WriteInflightSize += schemaChange->Data.size();

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -337,12 +337,17 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         ui64 maxOffset = sit != SourceIdStorage.GetInMemorySourceIds().end() ? sit->second.Offset : 0;
 
         if (sit != SourceIdStorage.GetInMemorySourceIds().end() && partNo + 1 == totalParts) {
-            // Change-sender stalls until ReplyWrite, so SeqNo should not advance while deferred.
-            // Still take Max to avoid regressing SeqNo if that invariant ever breaks.
+            // Change-sender stalls until ReplyWrite, so SeqNo/version should not advance while deferred.
+            // Still take Max / keep newer LastSchemaChange if that invariant ever breaks.
             const ui64 registerSeqNo = Max(seqNo, sit->second.SeqNo);
+            TSchemaChangeInfo scInfo{*scVersion, writeResponse.Msg.Data};
+            if (sit->second.LastSchemaChange && sit->second.LastSchemaChange->Version > scInfo.Version) {
+                scInfo = *sit->second.LastSchemaChange;
+            }
+            // Keep the source's last data offset: schema changes do not advance the log.
             SourceIdStorage.RegisterSourceId(s, sit->second.Updated(
                 registerSeqNo, maxOffset, CurrentTimestamp,
-                TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}, producerEpoch));
+                std::move(scInfo), producerEpoch));
         }
 
         ui64 replyOffset = CalculateReplyOffset(false, writeResponse.Msg.EnableKafkaDeduplication, maxOffset, maxOffset, maxSeqNo, seqNo);

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -309,7 +309,6 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         {"responsesSize", Responses.size()});
     const auto now = ctx.Now();
 
-    const auto committedSchemaChange = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
     for (auto it = PendingSchemaChangeResponses.begin(); it != PendingSchemaChangeResponses.end(); ) {
         auto& pending = *it;
         if (!pending.IsWrite()) {
@@ -318,6 +317,8 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         }
         const auto& writeResponse = pending.GetWrite();
         const auto& scVersion = writeResponse.Msg.SchemaChangeVersion;
+        // Recompute each iteration: RegisterSourceId below can advance the committed version.
+        const auto committedSchemaChange = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
         if (!scVersion || *scVersion > committedSchemaChange) {
             ++it;
             continue;

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -402,6 +402,8 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
                 }
             }
 
+            TMaybe<TRowVersion> scCommittedForDecision;
+
             if (!already && partNo + 1 == totalParts) {
                 if (it == SourceIdStorage.GetInMemorySourceIds().end()) {
                     PQ_ENSURE(!writeResponse.Msg.HeartbeatVersion);
@@ -412,8 +414,11 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
                     SourceIdStorage.RegisterSourceId(s, it->second.Updated(
                         seqNo, offset, CurrentTimestamp, THeartbeat{*hbVersion, writeResponse.Msg.Data}, producerEpoch));
                 } else if (const auto& scVersion = writeResponse.Msg.SchemaChangeVersion) {
-                    const auto committed = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
-                    if (*scVersion > committed) {
+                    // Snapshot committed before RegisterSourceId: that call can advance
+                    // GetCommittedSchemaChangeVersion() (e.g. last source to reach quorum),
+                    // which must not flip the SeqNo-bump vs defer decision mid-way.
+                    scCommittedForDecision = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
+                    if (*scVersion > *scCommittedForDecision) {
                         // Persist LastSchemaChange without bumping SeqNo until the write is actually ACKed.
                         SourceIdStorage.RegisterSourceId(s, it->second.Updated(
                             TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}));
@@ -432,7 +437,9 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
 
             const auto& scVersion = writeResponse.Msg.SchemaChangeVersion;
             if (scVersion) {
-                const auto committed = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
+                const auto committed = scCommittedForDecision
+                    ? *scCommittedForDecision
+                    : Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
                 if (*scVersion > committed) {
                     PendingSchemaChangeResponses.emplace_back(std::move(response));
                     Responses.pop_front();

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -349,7 +349,7 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
             ctx, writeResponse.Cookie, s, seqNo, partNo, totalParts,
             replyOffset, CurrentTimestamp, false, maxSeqNo,
             TDuration::Zero(), TDuration::Zero(), queueTime, writeTime, pending.Span
-        );
+        ); // quota tracking is not meaningful for deferred replies
         it = PendingSchemaChangeResponses.erase(it);
     }
 
@@ -436,7 +436,8 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
             }
 
             const auto& scVersion = writeResponse.Msg.SchemaChangeVersion;
-            if (scVersion) {
+            // Duplicates do not need quorum gating; the original write already registered.
+            if (scVersion && !already) {
                 const auto committed = scCommittedForDecision
                     ? *scCommittedForDecision
                     : Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -317,9 +317,10 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         }
         const auto& writeResponse = pending.GetWrite();
         const auto& scVersion = writeResponse.Msg.SchemaChangeVersion;
-        // Recompute each iteration: RegisterSourceId below can advance the committed version.
-        const auto committedSchemaChange = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
-        if (!scVersion || *scVersion > committedSchemaChange) {
+        // Recompute each iteration / after RegisterSourceId: committed may advance mid-scan.
+        if (!scVersion || !IsSchemaChangeVersionReleased(
+                *scVersion, LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion()))
+        {
             ++it;
             continue;
         }
@@ -340,10 +341,9 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
             // Change-sender stalls until ReplyWrite, so SeqNo/version should not advance while deferred.
             // Still take Max / keep newer LastSchemaChange if that invariant ever breaks.
             const ui64 registerSeqNo = Max(seqNo, sit->second.SeqNo);
-            TSchemaChangeInfo scInfo{*scVersion, writeResponse.Msg.Data};
-            if (sit->second.LastSchemaChange && sit->second.LastSchemaChange->Version > scInfo.Version) {
-                scInfo = *sit->second.LastSchemaChange;
-            }
+            auto scInfo = SelectSchemaChangeForAck(
+                TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data},
+                sit->second.LastSchemaChange);
             // Keep the source's last data offset: schema changes do not advance the log.
             SourceIdStorage.RegisterSourceId(s, sit->second.Updated(
                 registerSeqNo, maxOffset, CurrentTimestamp,
@@ -357,6 +357,8 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
             TDuration::Zero(), TDuration::Zero(), queueTime, writeTime, pending.Span
         ); // quota tracking is not meaningful for deferred replies
         it = PendingSchemaChangeResponses.erase(it);
+        // RegisterSourceId may advance committed; re-scan so earlier skipped items can release.
+        it = PendingSchemaChangeResponses.begin();
     }
 
     ui64 offset = BlobEncoder.EndOffset;

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -309,6 +309,47 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
         {"responsesSize", Responses.size()});
     const auto now = ctx.Now();
 
+    const auto committedSchemaChange = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
+    for (auto it = PendingSchemaChangeResponses.begin(); it != PendingSchemaChangeResponses.end(); ) {
+        auto& pending = *it;
+        if (!pending.IsWrite()) {
+            ++it;
+            continue;
+        }
+        const auto& writeResponse = pending.GetWrite();
+        const auto& scVersion = writeResponse.Msg.SchemaChangeVersion;
+        if (!scVersion || *scVersion > committedSchemaChange) {
+            ++it;
+            continue;
+        }
+
+        const TDuration queueTime = pending.QueueTime;
+        const TDuration writeTime = now - pending.WriteTimeBaseline;
+        const TString& s = writeResponse.Msg.SourceId;
+        const ui64 seqNo = writeResponse.Msg.SeqNo;
+        const ui16 partNo = writeResponse.Msg.PartNo;
+        const ui16 totalParts = writeResponse.Msg.TotalParts;
+        const TMaybe<i16>& producerEpoch = writeResponse.Msg.ProducerEpoch;
+
+        auto sit = SourceIdStorage.GetInMemorySourceIds().find(s);
+        ui64 maxSeqNo = sit != SourceIdStorage.GetInMemorySourceIds().end() ? sit->second.SeqNo : 0;
+        ui64 maxOffset = sit != SourceIdStorage.GetInMemorySourceIds().end() ? sit->second.Offset : 0;
+
+        if (sit != SourceIdStorage.GetInMemorySourceIds().end() && partNo + 1 == totalParts) {
+            SourceIdStorage.RegisterSourceId(s, sit->second.Updated(
+                seqNo, maxOffset, CurrentTimestamp,
+                TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}, producerEpoch));
+        }
+
+        ui64 replyOffset = CalculateReplyOffset(false, writeResponse.Msg.EnableKafkaDeduplication, maxOffset, maxOffset, maxSeqNo, seqNo);
+        ReplyWrite(
+            ctx, writeResponse.Cookie, s, seqNo, partNo, totalParts,
+            replyOffset, CurrentTimestamp, false, maxSeqNo,
+            PartitionQuotaWaitTimeForCurrentBlob, TopicQuotaWaitTimeForCurrentBlob, queueTime, writeTime, pending.Span
+        );
+        it = PendingSchemaChangeResponses.erase(it);
+    }
+
     ui64 offset = BlobEncoder.EndOffset;
     while (!Responses.empty()) {
         auto& response = Responses.front();
@@ -361,17 +402,41 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
             if (!already && partNo + 1 == totalParts) {
                 if (it == SourceIdStorage.GetInMemorySourceIds().end()) {
                     PQ_ENSURE(!writeResponse.Msg.HeartbeatVersion);
+                    PQ_ENSURE(!writeResponse.Msg.SchemaChangeVersion);
                     TabletCounters.Cumulative()[COUNTER_PQ_SID_CREATED].Increment(1);
                     SourceIdStorage.RegisterSourceId(s, seqNo, offset, CurrentTimestamp, producerEpoch);
                 } else if (const auto& hbVersion = writeResponse.Msg.HeartbeatVersion) {
                     SourceIdStorage.RegisterSourceId(s, it->second.Updated(
                         seqNo, offset, CurrentTimestamp, THeartbeat{*hbVersion, writeResponse.Msg.Data}, producerEpoch));
+                } else if (const auto& scVersion = writeResponse.Msg.SchemaChangeVersion) {
+                    // Persist LastSchemaChange without bumping SeqNo until the write is actually ACKed.
+                    SourceIdStorage.RegisterSourceId(s, it->second.Updated(
+                        TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}));
                 } else {
                     SourceIdStorage.RegisterSourceId(s, it->second.Updated(
                         seqNo, offset, CurrentTimestamp, producerEpoch));
                 }
 
                 TabletCounters.Cumulative()[COUNTER_PQ_WRITE_OK].Increment(1);
+            }
+
+            const auto& scVersion = writeResponse.Msg.SchemaChangeVersion;
+            if (scVersion) {
+                const auto committed = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
+                if (*scVersion > committed) {
+                    PendingSchemaChangeResponses.emplace_back(std::move(response));
+                    Responses.pop_front();
+                    continue;
+                }
+
+                if (!already && partNo + 1 == totalParts) {
+                    it = SourceIdStorage.GetInMemorySourceIds().find(s);
+                    if (it != SourceIdStorage.GetInMemorySourceIds().end()) {
+                        SourceIdStorage.RegisterSourceId(s, it->second.Updated(
+                            seqNo, offset, CurrentTimestamp,
+                            TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}, producerEpoch));
+                    }
+                }
             }
 
             ui64 replyOffset = CalculateReplyOffset(already, writeResponse.Msg.EnableKafkaDeduplication, maxOffset, offset, maxSeqNo, seqNo);
@@ -395,7 +460,7 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
             if (PartitionWriteQuotaWaitCounter && !writeResponse.Internal) {
                 PartitionWriteQuotaWaitCounter->IncFor(PartitionQuotaWaitTimeForCurrentBlob.MilliSeconds());
             }
-            if (!already && partNo + 1 == totalParts && !writeResponse.Msg.HeartbeatVersion) {
+            if (!already && partNo + 1 == totalParts && !writeResponse.Msg.HeartbeatVersion && !writeResponse.Msg.SchemaChangeVersion) {
                 offset += writeResponse.Msg.LogicalMessageCount;
             }
         } else if (response.IsOwnership()) {
@@ -1397,6 +1462,34 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
         return true;
     }
 
+    if (const auto& scVersion = p.Msg.SchemaChangeVersion) {
+        if (!sourceId.SeqNo()) {
+            CancelOneWriteOnWrite(ctx,
+                                    TStringBuilder() << "Cannot apply schema change on unknown sourceId: " << EscapeC(p.Msg.SourceId),
+                                    p,
+                                    NPersQueue::NErrorCode::BAD_REQUEST);
+            return false;
+        }
+        if (!sourceId.Explicit()) {
+            CancelOneWriteOnWrite(ctx,
+                                    TStringBuilder() << "Cannot apply schema change on implicit sourceId: " << EscapeC(p.Msg.SourceId),
+                                    p,
+                                    NPersQueue::NErrorCode::BAD_REQUEST);
+            return false;
+        }
+
+        YDB_LOG_DEBUG("Topic partition process schema change sourceId version",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"topicName", TopicName()},
+            {"partition", Partition},
+            {"sourceId", EscapeC(p.Msg.SourceId)},
+            {"scVersion", *scVersion});
+
+        sourceId.Update(TSchemaChangeInfo{*scVersion, p.Msg.Data});
+
+        return true;
+    }
+
     if (poffset < curOffset) { //too small offset
         CancelOneWriteOnWrite(ctx,
                                 TStringBuilder() << "write message sourceId: " << EscapeC(p.Msg.SourceId) <<
@@ -1934,6 +2027,41 @@ void TPartition::EndAppendHeadWithNewWrites(const TActorContext& ctx)
             ExecRequest(hbMsg, *Parameters, PersistRequest.Get());
 
             LastEmittedHeartbeat = heartbeat->Version;
+        }
+    }
+
+    if (const auto schemaChange = SourceIdBatch->CanEmitSchemaChange()) {
+        const auto committed = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
+        if (schemaChange->Version > committed) {
+            YDB_LOG_INFO("Topic partition emit schema change",
+                {"logPrefix", NPQ_LOG_PREFIX},
+                {"topicName", TopicName()},
+                {"partition", Partition},
+                {"version", schemaChange->Version});
+
+            auto scMsg = TWriteMsg{Max<ui64>() /* cookie */, Nothing(), TEvPQ::TEvWrite::TMsg{
+                .SourceId = NSourceIdEncoding::EncodeSimple(ToString(TabletId)),
+                .SeqNo = 0, // we don't use SeqNo because we disable deduplication
+                .PartNo = 0,
+                .TotalParts = 1,
+                .TotalSize = static_cast<ui32>(schemaChange->Data.size()),
+                .CreateTimestamp = CurrentTimestamp.MilliSeconds(),
+                .ReceiveTimestamp = CurrentTimestamp.MilliSeconds(),
+                .DisableDeduplication = true,
+                .WriteTimestamp = CurrentTimestamp.MilliSeconds(),
+                .Data = schemaChange->Data,
+                .UncompressedSize = 0,
+                .PartitionKey = {},
+                .ExplicitHashKey = {},
+                .External = false,
+                .IgnoreQuotaDeadline = true,
+                .HeartbeatVersion = std::nullopt,
+            }, std::nullopt};
+
+            WriteInflightSize += schemaChange->Data.size();
+            ExecRequest(scMsg, *Parameters, PersistRequest.Get());
+
+            LastEmittedSchemaChange = schemaChange->Version;
         }
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -409,9 +409,16 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
                     SourceIdStorage.RegisterSourceId(s, it->second.Updated(
                         seqNo, offset, CurrentTimestamp, THeartbeat{*hbVersion, writeResponse.Msg.Data}, producerEpoch));
                 } else if (const auto& scVersion = writeResponse.Msg.SchemaChangeVersion) {
-                    // Persist LastSchemaChange without bumping SeqNo until the write is actually ACKed.
-                    SourceIdStorage.RegisterSourceId(s, it->second.Updated(
-                        TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}));
+                    const auto committed = Max(LastEmittedSchemaChange, SourceIdStorage.GetCommittedSchemaChangeVersion());
+                    if (*scVersion > committed) {
+                        // Persist LastSchemaChange without bumping SeqNo until the write is actually ACKed.
+                        SourceIdStorage.RegisterSourceId(s, it->second.Updated(
+                            TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}));
+                    } else {
+                        SourceIdStorage.RegisterSourceId(s, it->second.Updated(
+                            seqNo, offset, CurrentTimestamp,
+                            TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}, producerEpoch));
+                    }
                 } else {
                     SourceIdStorage.RegisterSourceId(s, it->second.Updated(
                         seqNo, offset, CurrentTimestamp, producerEpoch));
@@ -427,15 +434,6 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
                     PendingSchemaChangeResponses.emplace_back(std::move(response));
                     Responses.pop_front();
                     continue;
-                }
-
-                if (!already && partNo + 1 == totalParts) {
-                    it = SourceIdStorage.GetInMemorySourceIds().find(s);
-                    if (it != SourceIdStorage.GetInMemorySourceIds().end()) {
-                        SourceIdStorage.RegisterSourceId(s, it->second.Updated(
-                            seqNo, offset, CurrentTimestamp,
-                            TSchemaChangeInfo{*scVersion, writeResponse.Msg.Data}, producerEpoch));
-                    }
                 }
             }
 
@@ -2056,6 +2054,7 @@ void TPartition::EndAppendHeadWithNewWrites(const TActorContext& ctx)
                 .External = false,
                 .IgnoreQuotaDeadline = true,
                 .HeartbeatVersion = std::nullopt,
+                .SchemaChangeVersion = std::nullopt, // emitted as regular data for consumers
             }, std::nullopt};
 
             WriteInflightSize += schemaChange->Data.size();

--- a/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
@@ -512,16 +512,10 @@ TRowVersion TSourceIdStorage::GetCommittedSchemaChangeVersion() const {
         return TRowVersion::Min();
     }
 
-    TRowVersion minVersion = TRowVersion::Max();
-    for (const auto& sourceId : ExplicitSourceIds) {
-        auto it = InMemorySourceIds.find(sourceId);
-        if (it == InMemorySourceIds.end() || !it->second.LastSchemaChange) {
-            return TRowVersion::Min();
-        }
-        minVersion = Min(minVersion, it->second.LastSchemaChange->Version);
-    }
-
-    return minVersion;
+    // Each explicit source with a schema change is in exactly one version bucket;
+    // the map is ordered, so the minimum committed version is begin()->first.
+    AFL_ENSURE(!SourceIdsBySchemaChange.empty());
+    return SourceIdsBySchemaChange.begin()->first;
 }
 
 /// TSourceIdWriter

--- a/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
@@ -641,6 +641,8 @@ TMaybe<THeartbeat> THeartbeatEmitter::CanEmit() const {
             if (Heartbeats.contains(sourceId) && Heartbeats.at(sourceId).Version > version) {
                 --rest;
             } else {
+                // Early exit: if any source in this bucket hasn't advanced past `version`,
+                // the bucket is still active (rest > 0 regardless of iteration order).
                 break;
             }
         }
@@ -745,6 +747,8 @@ TMaybe<TSchemaChangeInfo> TSchemaChangeEmitter::CanEmit() const {
             if (SchemaChanges.contains(sourceId) && SchemaChanges.at(sourceId).Version > version) {
                 --rest;
             } else {
+                // Early exit: if any source in this bucket hasn't advanced past `version`,
+                // the bucket is still active (rest > 0 regardless of iteration order).
                 break;
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
@@ -95,8 +95,29 @@ void THeartbeatProcessor::ForgetHeartbeat(const TString& sourceId, const TRowVer
     }
 }
 
-void THeartbeatProcessor::ForgetSourceId(const TString& sourceId) {
+void THeartbeatProcessor::ForgetHeartbeatSourceId(const TString& sourceId) {
     SourceIdsWithHeartbeat.erase(sourceId);
+}
+
+void TSchemaChangeProcessor::ApplySchemaChange(const TString& sourceId, const TRowVersion& version) {
+    SourceIdsWithSchemaChange.insert(sourceId);
+    SourceIdsBySchemaChange[version].insert(sourceId);
+}
+
+void TSchemaChangeProcessor::ForgetSchemaChange(const TString& sourceId, const TRowVersion& version) {
+    auto it = SourceIdsBySchemaChange.find(version);
+    if (it == SourceIdsBySchemaChange.end()) {
+        return;
+    }
+
+    it->second.erase(sourceId);
+    if (it->second.empty()) {
+        SourceIdsBySchemaChange.erase(it);
+    }
+}
+
+void TSchemaChangeProcessor::ForgetSchemaChangeSourceId(const TString& sourceId) {
+    SourceIdsWithSchemaChange.erase(sourceId);
 }
 
 TSourceIdInfo::TSourceIdInfo(ui64 seqNo, ui64 offset, TInstant createTs, TMaybe<i16> producerEpoch)
@@ -154,6 +175,20 @@ TSourceIdInfo TSourceIdInfo::Updated(ui64 seqNo, ui64 offset, TInstant writeTs, 
     return copy;
 }
 
+TSourceIdInfo TSourceIdInfo::Updated(ui64 seqNo, ui64 offset, TInstant writeTs, TSchemaChangeInfo&& schemaChange, TMaybe<i16> producerEpoch) const {
+    auto copy = Updated(seqNo, offset, writeTs, producerEpoch);
+    copy.LastSchemaChange = std::move(schemaChange);
+
+    return copy;
+}
+
+TSourceIdInfo TSourceIdInfo::Updated(TSchemaChangeInfo&& schemaChange) const {
+    auto copy = *this;
+    copy.LastSchemaChange = std::move(schemaChange);
+
+    return copy;
+}
+
 TSourceIdInfo TSourceIdInfo::Parse(const TString& data, TInstant now) {
     AFL_ENSURE(data.size() >= 2 * sizeof(ui64))("description", "Data must contain at least SeqNo & Offset");
     ui32 pos = 0;
@@ -205,6 +240,9 @@ TSourceIdInfo TSourceIdInfo::Parse(const NKikimrPQ::TMessageGroupInfo& proto) {
     if (proto.HasLastHeartbeat()) {
         result.LastHeartbeat = THeartbeat::Parse(proto.GetLastHeartbeat());
     }
+    if (proto.HasLastSchemaChange()) {
+        result.LastSchemaChange = TSchemaChangeInfo::Parse(proto.GetLastSchemaChange());
+    }
 
     return result;
 }
@@ -227,6 +265,9 @@ void TSourceIdInfo::Serialize(NKikimrPQ::TMessageGroupInfo& proto) const {
     }
     if (LastHeartbeat) {
         LastHeartbeat->Serialize(*proto.MutableLastHeartbeat());
+    }
+    if (LastSchemaChange) {
+        LastSchemaChange->Serialize(*proto.MutableLastSchemaChange());
     }
 }
 
@@ -264,9 +305,13 @@ void TSourceIdStorage::DeregisterSourceId(const TString& sourceId) {
         return;
     }
 
-    ForgetSourceId(sourceId);
+    ForgetHeartbeatSourceId(sourceId);
+    ForgetSchemaChangeSourceId(sourceId);
     if (const auto& heartbeat = it->second.LastHeartbeat) {
         ForgetHeartbeat(sourceId, heartbeat->Version);
+    }
+    if (const auto& schemaChange = it->second.LastSchemaChange) {
+        ForgetSchemaChange(sourceId, schemaChange->Version);
     }
 
     if (it->second.Explicit) {
@@ -416,6 +461,16 @@ void TSourceIdStorage::RegisterSourceIdInfo(const TString& sourceId, TSourceIdIn
         ApplyHeartbeat(sourceId, heartbeat->Version);
     }
 
+    if (const auto& schemaChange = sourceIdInfo.LastSchemaChange) {
+        AFL_ENSURE(sourceIdInfo.Explicit);
+
+        if (it != InMemorySourceIds.end() && it->second.LastSchemaChange) {
+            ForgetSchemaChange(sourceId, it->second.LastSchemaChange->Version);
+        }
+
+        ApplySchemaChange(sourceId, schemaChange->Version);
+    }
+
     InMemorySourceIds[sourceId] = std::move(sourceIdInfo);
 }
 
@@ -450,6 +505,23 @@ TInstant TSourceIdStorage::MinAvailableTimestamp(TInstant now) const {
     }
 
     return ds;
+}
+
+TRowVersion TSourceIdStorage::GetCommittedSchemaChangeVersion() const {
+    if (ExplicitSourceIds.empty() || ExplicitSourceIds.size() != SourceIdsWithSchemaChange.size()) {
+        return TRowVersion::Min();
+    }
+
+    TRowVersion minVersion = TRowVersion::Max();
+    for (const auto& sourceId : ExplicitSourceIds) {
+        auto it = InMemorySourceIds.find(sourceId);
+        if (it == InMemorySourceIds.end() || !it->second.LastSchemaChange) {
+            return TRowVersion::Min();
+        }
+        minVersion = Min(minVersion, it->second.LastSchemaChange->Version);
+    }
+
+    return minVersion;
 }
 
 /// TSourceIdWriter
@@ -616,6 +688,110 @@ TMaybe<THeartbeat> THeartbeatEmitter::GetFromDiff(TSourceIdsByHeartbeat::const_i
 
     AFL_ENSURE(Heartbeats.contains(someSourceId));
     return Heartbeats.at(someSourceId);
+}
+
+/// TSchemaChangeEmitter
+TSchemaChangeEmitter::TSchemaChangeEmitter(const TSourceIdStorage& storage)
+    : Storage(storage)
+{
+}
+
+void TSchemaChangeEmitter::Process(const TString& sourceId, TSchemaChangeInfo&& schemaChange) {
+    auto it = Storage.InMemorySourceIds.find(sourceId);
+    if (it != Storage.InMemorySourceIds.end() && it->second.LastSchemaChange) {
+        if (schemaChange.Version <= it->second.LastSchemaChange->Version) {
+            return;
+        }
+    }
+
+    if (!Storage.SourceIdsWithSchemaChange.contains(sourceId)) {
+        NewSourceIdsWithSchemaChange.insert(sourceId);
+    }
+
+    if (SchemaChanges.contains(sourceId)) {
+        ForgetSchemaChange(sourceId, SchemaChanges.at(sourceId).Version);
+    }
+
+    ApplySchemaChange(sourceId, schemaChange.Version);
+    SchemaChanges[sourceId] = std::move(schemaChange);
+}
+
+TMaybe<TSchemaChangeInfo> TSchemaChangeEmitter::CanEmit() const {
+    if (Storage.ExplicitSourceIds.size() != (Storage.SourceIdsWithSchemaChange.size() + NewSourceIdsWithSchemaChange.size())) {
+        // there is no quorum
+        return Nothing();
+    }
+
+    if (SourceIdsBySchemaChange.empty()) {
+        // there is no new schema changes, nothing to emit
+        return Nothing();
+    }
+
+    if (Storage.SourceIdsBySchemaChange.empty()) {
+        // got quorum, memory state
+        return GetFromDiff(SourceIdsBySchemaChange.begin());
+    }
+
+    if (!NewSourceIdsWithSchemaChange.empty()) {
+        // got quorum, mixed state
+        if (Storage.SourceIdsBySchemaChange.begin()->first < SourceIdsBySchemaChange.begin()->first) {
+            return GetFromStorage(Storage.SourceIdsBySchemaChange.begin());
+        } else {
+            return GetFromDiff(SourceIdsBySchemaChange.begin());
+        }
+    }
+
+    TMaybe<TRowVersion> emitVersion;
+
+    for (auto it = Storage.SourceIdsBySchemaChange.begin(), end = Storage.SourceIdsBySchemaChange.end(); it != end; ++it) {
+        const auto& [version, sourceIds] = *it;
+        auto rest = sourceIds.size();
+
+        for (const auto& sourceId : sourceIds) {
+            if (SchemaChanges.contains(sourceId) && SchemaChanges.at(sourceId).Version > version) {
+                --rest;
+            } else {
+                break;
+            }
+        }
+
+        if (rest) {
+            break;
+        }
+
+        if (auto next = std::next(it); next != end && next->first < SourceIdsBySchemaChange.begin()->first) {
+            emitVersion = next->first;
+        } else {
+            emitVersion = SourceIdsBySchemaChange.begin()->first;
+            break;
+        }
+    }
+
+    if (emitVersion) {
+        if (auto it = Storage.SourceIdsBySchemaChange.find(*emitVersion); it != Storage.SourceIdsBySchemaChange.end()) {
+            return GetFromStorage(it);
+        } else {
+            return GetFromDiff(SourceIdsBySchemaChange.begin());
+        }
+    }
+
+    return Nothing();
+}
+
+TMaybe<TSchemaChangeInfo> TSchemaChangeEmitter::GetFromStorage(TSourceIdsBySchemaChange::const_iterator it) const {
+    AFL_ENSURE(!it->second.empty());
+    const auto& someSourceId = *it->second.begin();
+
+    AFL_ENSURE(Storage.InMemorySourceIds.contains(someSourceId));
+    return Storage.InMemorySourceIds.at(someSourceId).LastSchemaChange;
+}
+
+TMaybe<TSchemaChangeInfo> TSchemaChangeEmitter::GetFromDiff(TSourceIdsBySchemaChange::const_iterator it) const {
+    AFL_ENSURE(!it->second.empty());
+    const auto& someSourceId = *it->second.begin();
+
+    AFL_ENSURE(SchemaChanges.contains(someSourceId));
+    return SchemaChanges.at(someSourceId);
 }
 
 }

--- a/ydb/core/persqueue/pqtablet/partition/sourceid.h
+++ b/ydb/core/persqueue/pqtablet/partition/sourceid.h
@@ -23,7 +23,7 @@ protected:
 public:
     void ApplyHeartbeat(const TString& sourceId, const TRowVersion& version);
     void ForgetHeartbeat(const TString& sourceId, const TRowVersion& version);
-    void ForgetSourceId(const TString& sourceId);
+    void ForgetHeartbeatSourceId(const TString& sourceId);
 
 protected:
     THashSet<TString> SourceIdsWithHeartbeat;
@@ -31,10 +31,27 @@ protected:
 
 }; // THeartbeatProcessor
 
-class THeartbeatEmitter;
+class TSchemaChangeProcessor {
+protected:
+    using TSourceIdsBySchemaChange = TMap<TRowVersion, THashSet<TString>>;
 
-class TSourceIdStorage: private THeartbeatProcessor {
+public:
+    void ApplySchemaChange(const TString& sourceId, const TRowVersion& version);
+    void ForgetSchemaChange(const TString& sourceId, const TRowVersion& version);
+    void ForgetSchemaChangeSourceId(const TString& sourceId);
+
+protected:
+    THashSet<TString> SourceIdsWithSchemaChange;
+    TSourceIdsBySchemaChange SourceIdsBySchemaChange;
+
+}; // TSchemaChangeProcessor
+
+class THeartbeatEmitter;
+class TSchemaChangeEmitter;
+
+class TSourceIdStorage: private THeartbeatProcessor, private TSchemaChangeProcessor {
     friend class THeartbeatEmitter;
+    friend class TSchemaChangeEmitter;
 
 public:
     const TSourceIdMap& GetInMemorySourceIds() const {
@@ -61,6 +78,7 @@ public:
     void MarkOwnersForDeletedSourceId(THashMap<TString, TOwnerInfo>& owners);
 
     TInstant MinAvailableTimestamp(TInstant now) const;
+    TRowVersion GetCommittedSchemaChangeVersion() const;
 
 private:
     void LoadRawSourceIdInfo(const TString& key, const TString& data, TInstant now);
@@ -128,6 +146,24 @@ private:
     THashMap<TString, THeartbeat> Heartbeats;
 
 }; // THeartbeatEmitter
+
+class TSchemaChangeEmitter: private TSchemaChangeProcessor {
+public:
+    explicit TSchemaChangeEmitter(const TSourceIdStorage& storage);
+
+    void Process(const TString& sourceId, TSchemaChangeInfo&& schemaChange);
+    TMaybe<TSchemaChangeInfo> CanEmit() const;
+
+private:
+    TMaybe<TSchemaChangeInfo> GetFromStorage(TSourceIdsBySchemaChange::const_iterator it) const;
+    TMaybe<TSchemaChangeInfo> GetFromDiff(TSourceIdsBySchemaChange::const_iterator it) const;
+
+private:
+    const TSourceIdStorage& Storage;
+    THashSet<TString> NewSourceIdsWithSchemaChange;
+    THashMap<TString, TSchemaChangeInfo> SchemaChanges;
+
+}; // TSchemaChangeEmitter
 
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/sourceid.h
+++ b/ydb/core/persqueue/pqtablet/partition/sourceid.h
@@ -49,7 +49,10 @@ protected:
 class THeartbeatEmitter;
 class TSchemaChangeEmitter;
 
-class TSourceIdStorage: private THeartbeatProcessor, private TSchemaChangeProcessor {
+class TSourceIdStorage
+    : private THeartbeatProcessor
+    , private TSchemaChangeProcessor
+{
     friend class THeartbeatEmitter;
     friend class TSchemaChangeEmitter;
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -2084,7 +2084,11 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             errorStr = "no SeqNo";
         } else if (cmd.HasData() && cmd.HasHeartbeat()) {
             errorStr = "Data and Heartbeat are mutually exclusive";
-        } else if (cmd.GetData().empty() && cmd.GetHeartbeat().GetData().empty()) {
+        } else if (cmd.HasData() && cmd.HasSchemaChange()) {
+            errorStr = "Data and SchemaChange are mutually exclusive";
+        } else if (cmd.HasHeartbeat() && cmd.HasSchemaChange()) {
+            errorStr = "Heartbeat and SchemaChange are mutually exclusive";
+        } else if (cmd.GetData().empty() && cmd.GetHeartbeat().GetData().empty() && cmd.GetSchemaChange().GetData().empty()) {
             errorStr = "empty Data";
         } else if ((!cmd.HasSourceId() || cmd.GetSourceId().empty()) && !req.GetIsDirectWrite() && !cmd.GetDisableDeduplication()) {
             errorStr = "empty SourceId";
@@ -2114,6 +2118,8 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             errorStr = "Too big Heartbeat";
         } else if (cmd.HasHeartbeat() && cmd.HasTotalParts() && cmd.GetTotalParts() != 1) {
             errorStr = "Heartbeat must be a single-part message";
+        } else if (cmd.HasSchemaChange() && cmd.HasTotalParts() && cmd.GetTotalParts() != 1) {
+            errorStr = "SchemaChange must be a single-part message";
         } else if (cmd.GetData().size() > pqConfig.GetMaxMessageSizeBytes()) {
             errorStr = TStringBuilder() << "Too big message. Max message size is " << pqConfig.GetMaxMessageSizeBytes()
                 << " bytes, but got " << cmd.GetData().size() << " bytes";
@@ -2162,6 +2168,11 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             heartbeatVersion.emplace(cmd.GetHeartbeat().GetStep(), cmd.GetHeartbeat().GetTxId());
         }
 
+        std::optional<TRowVersion> schemaChangeVersion;
+        if (cmd.HasSchemaChange()) {
+            schemaChangeVersion.emplace(cmd.GetSchemaChange().GetStep(), cmd.GetSchemaChange().GetTxId());
+        }
+
         if (cmd.GetData().size() > mSize) {
             if (cmd.HasPartNo()) {
                 ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST,
@@ -2205,6 +2216,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
                     .External = cmd.GetExternalOperation(),
                     .IgnoreQuotaDeadline = cmd.GetIgnoreQuotaDeadline(),
                     .HeartbeatVersion = heartbeatVersion,
+                    .SchemaChangeVersion = schemaChangeVersion,
                     .EnableKafkaDeduplication = cmd.GetEnableKafkaDeduplication(),
                     .ProducerEpoch = (cmd.HasProducerEpoch() ? TMaybe<i32>(cmd.GetProducerEpoch()) : Nothing()),
                     .MessageDeduplicationId = deduplicationId,
@@ -2229,10 +2241,16 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST, TStringBuilder()
                 << "Too big heartbeat message, must be at most " << mSize << ", but got " << cmd.GetHeartbeat().GetData().size());
             return;
+        } else if (cmd.GetSchemaChange().GetData().size() > mSize) {
+            ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST, TStringBuilder()
+                << "Too big schema change message, must be at most " << mSize << ", but got " << cmd.GetSchemaChange().GetData().size());
+            return;
         } else {
             ui32 totalSize = cmd.GetData().size();
             if (cmd.HasHeartbeat()) {
                 totalSize = cmd.GetHeartbeat().GetData().size();
+            } else if (cmd.HasSchemaChange()) {
+                totalSize = cmd.GetSchemaChange().GetData().size();
             }
             if (cmd.HasTotalSize()) {
                 totalSize = cmd.GetTotalSize();
@@ -2240,7 +2258,9 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
 
             const auto& data = cmd.HasHeartbeat()
                 ? cmd.GetHeartbeat().GetData()
-                : cmd.GetData();
+                : cmd.HasSchemaChange()
+                    ? cmd.GetSchemaChange().GetData()
+                    : cmd.GetData();
 
             msgs.push_back({
                 .SourceId = cmd.GetSourceId(),
@@ -2260,6 +2280,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
                 .External = cmd.GetExternalOperation(),
                 .IgnoreQuotaDeadline = cmd.GetIgnoreQuotaDeadline(),
                 .HeartbeatVersion = heartbeatVersion,
+                .SchemaChangeVersion = schemaChangeVersion,
                 .EnableKafkaDeduplication = cmd.GetEnableKafkaDeduplication(),
                 .ProducerEpoch = (cmd.HasProducerEpoch() ? TMaybe<i32>(cmd.GetProducerEpoch()) : Nothing()),
                 .MessageDeduplicationId = std::move(deduplicationId),

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -61,6 +61,7 @@ static constexpr ui32 CACHE_SIZE = 100_MB;
 static constexpr ui32 MAX_BYTES = 25_MB;
 static constexpr ui32 MAX_SOURCE_ID_LENGTH = 2048;
 static constexpr ui32 MAX_HEARTBEAT_SIZE = 2_KB;
+static constexpr ui32 MAX_SCHEMA_CHANGE_SIZE = 64_KB;
 static constexpr ui32 MAX_TXS = 1000;
 struct TChangeNotification {
     TChangeNotification(const TActorId& actor, const ui64 txId)
@@ -2118,6 +2119,8 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
             errorStr = "Too big Heartbeat";
         } else if (cmd.HasHeartbeat() && cmd.HasTotalParts() && cmd.GetTotalParts() != 1) {
             errorStr = "Heartbeat must be a single-part message";
+        } else if (cmd.HasSchemaChange() && cmd.GetSchemaChange().GetData().size() > MAX_SCHEMA_CHANGE_SIZE) {
+            errorStr = "Too big SchemaChange";
         } else if (cmd.HasSchemaChange() && cmd.HasTotalParts() && cmd.GetTotalParts() != 1) {
             errorStr = "SchemaChange must be a single-part message";
         } else if (cmd.GetData().size() > pqConfig.GetMaxMessageSizeBytes()) {

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -2245,6 +2245,7 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
                 << "Too big heartbeat message, must be at most " << mSize << ", but got " << cmd.GetHeartbeat().GetData().size());
             return;
         } else if (cmd.GetSchemaChange().GetData().size() > mSize) {
+            Y_DEBUG_ABORT("This should never happen");
             ReplyError(ctx, responseCookie, NPersQueue::NErrorCode::BAD_REQUEST, TStringBuilder()
                 << "Too big schema change message, must be at most " << mSize << ", but got " << cmd.GetSchemaChange().GetData().size());
             return;

--- a/ydb/core/persqueue/ut/sourceid_ut.cpp
+++ b/ydb/core/persqueue/ut/sourceid_ut.cpp
@@ -609,16 +609,21 @@ Y_UNIT_TEST_SUITE(TSourceIdTests) {
             UNIT_ASSERT(!emitter.CanEmit().Defined());
         }
 
+        storage.RegisterSourceId(TestSourceId(1), MakeExplicitSourceIdInfoWithSchemaChange(++offset, MakeSchemaChange(3, "v3")));
+        UNIT_ASSERT_VALUES_EQUAL(storage.GetCommittedSchemaChangeVersion(), MakeSchemaChange(1).Version);
+        storage.RegisterSourceId(TestSourceId(2), MakeExplicitSourceIdInfoWithSchemaChange(++offset, MakeSchemaChange(2, "v2")));
+        UNIT_ASSERT_VALUES_EQUAL(storage.GetCommittedSchemaChangeVersion(), MakeSchemaChange(2).Version);
+
         {
             TSchemaChangeEmitter emitter(storage);
-            emitter.Process(TestSourceId(1), MakeSchemaChange(2, "v2"));
+            emitter.Process(TestSourceId(1), MakeSchemaChange(4, "v4"));
             UNIT_ASSERT(!emitter.CanEmit().Defined());
-            emitter.Process(TestSourceId(2), MakeSchemaChange(2, "v2"));
+            emitter.Process(TestSourceId(2), MakeSchemaChange(4, "v4"));
             {
                 const auto schemaChange = emitter.CanEmit();
                 UNIT_ASSERT(schemaChange.Defined());
-                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Version, MakeSchemaChange(2).Version);
-                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Data, "v2");
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Version, MakeSchemaChange(4).Version);
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Data, "v4");
             }
         }
     }

--- a/ydb/core/persqueue/ut/sourceid_ut.cpp
+++ b/ydb/core/persqueue/ut/sourceid_ut.cpp
@@ -651,6 +651,39 @@ Y_UNIT_TEST_SUITE(TSourceIdTests) {
         UNIT_ASSERT_VALUES_EQUAL(it->second.LastSchemaChange->Data, "payload");
     }
 
+    Y_UNIT_TEST(SchemaChangeDeferredAckInvariants) {
+        // Release eligibility mirrors AnswerCurrentWrites deferred-ACK gating.
+        const auto v1 = MakeSchemaChange(1).Version;
+        const auto v2 = MakeSchemaChange(2).Version;
+        UNIT_ASSERT(!IsSchemaChangeVersionReleased(v2, TRowVersion::Min(), v1));
+        UNIT_ASSERT(IsSchemaChangeVersionReleased(v1, TRowVersion::Min(), v1));
+        UNIT_ASSERT(IsSchemaChangeVersionReleased(v1, v2, TRowVersion::Min())); // LastEmitted wins
+        UNIT_ASSERT(IsSchemaChangeVersionReleased(v2, v2, v1));
+
+        // Prefer newer persisted LastSchemaChange when ACK-registering a deferred write.
+        const auto kept = SelectSchemaChangeForAck(MakeSchemaChange(1, "old"), MakeSchemaChange(3, "new"));
+        UNIT_ASSERT_VALUES_EQUAL(kept.Version, MakeSchemaChange(3).Version);
+        UNIT_ASSERT_VALUES_EQUAL(kept.Data, "new");
+        const auto proposed = SelectSchemaChangeForAck(MakeSchemaChange(4, "newer"), MakeSchemaChange(3, "old"));
+        UNIT_ASSERT_VALUES_EQUAL(proposed.Version, MakeSchemaChange(4).Version);
+        UNIT_ASSERT_VALUES_EQUAL(proposed.Data, "newer");
+
+        // SeqNo bump on ACK must not move GetCommittedSchemaChangeVersion (same SC version).
+        TSourceIdStorage storage;
+        storage.RegisterSourceId(TestSourceId(1), MakeExplicitSourceIdInfoWithSchemaChange(10, MakeSchemaChange(5, "v5")));
+        storage.RegisterSourceId(TestSourceId(2), MakeExplicitSourceIdInfoWithSchemaChange(20, MakeSchemaChange(5, "v5")));
+        UNIT_ASSERT_VALUES_EQUAL(storage.GetCommittedSchemaChangeVersion(), MakeSchemaChange(5).Version);
+
+        auto it = storage.GetInMemorySourceIds().find(TestSourceId(1));
+        UNIT_ASSERT_UNEQUAL(it, storage.GetInMemorySourceIds().end());
+        storage.RegisterSourceId(TestSourceId(1), it->second.Updated(
+            /*seqNo=*/42, /*offset=*/10, TInstant::Now(), MakeSchemaChange(5, "v5")));
+        UNIT_ASSERT_VALUES_EQUAL(storage.GetCommittedSchemaChangeVersion(), MakeSchemaChange(5).Version);
+        it = storage.GetInMemorySourceIds().find(TestSourceId(1));
+        UNIT_ASSERT_VALUES_EQUAL(it->second.SeqNo, 42);
+        UNIT_ASSERT_VALUES_EQUAL(it->second.Offset, 10);
+    }
+
 } // TSourceIdTests
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/sourceid_ut.cpp
+++ b/ydb/core/persqueue/ut/sourceid_ut.cpp
@@ -547,6 +547,105 @@ Y_UNIT_TEST_SUITE(TSourceIdTests) {
 
     }
 
+    inline static TSchemaChangeInfo MakeSchemaChange(ui64 step, const TString& data = "schema") {
+        return TSchemaChangeInfo{
+            .Version = TRowVersion(step, 0),
+            .Data = data,
+        };
+    }
+
+    inline static TSourceIdInfo MakeExplicitSourceIdInfoWithSchemaChange(ui64 offset, const TSchemaChangeInfo& schemaChange) {
+        auto info = TSourceIdInfo(0, offset, TInstant::Now());
+        info.Explicit = true;
+        info.LastSchemaChange = schemaChange;
+        return info;
+    }
+
+    Y_UNIT_TEST(SchemaChangeEmitter) {
+        TSourceIdStorage storage;
+        ui64 offset = 0;
+
+        for (ui64 i = 1; i <= 2; ++i) {
+            storage.RegisterSourceId(TestSourceId(i), MakeExplicitSourceIdInfo(++offset));
+        }
+        {
+            TSchemaChangeEmitter emitter(storage);
+            UNIT_ASSERT(!emitter.CanEmit().Defined());
+
+            emitter.Process(TestSourceId(1), MakeSchemaChange(1, "v1"));
+            UNIT_ASSERT(!emitter.CanEmit().Defined());
+
+            emitter.Process(TestSourceId(2), MakeSchemaChange(1, "v1"));
+            {
+                const auto schemaChange = emitter.CanEmit();
+                UNIT_ASSERT(schemaChange.Defined());
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Version, MakeSchemaChange(1).Version);
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Data, "v1");
+            }
+        }
+
+        storage.RegisterSourceId(TestSourceId(1), MakeExplicitSourceIdInfoWithSchemaChange(++offset, MakeSchemaChange(1, "v1")));
+        {
+            TSchemaChangeEmitter emitter(storage);
+            UNIT_ASSERT(!emitter.CanEmit().Defined());
+            UNIT_ASSERT_VALUES_EQUAL(storage.GetCommittedSchemaChangeVersion(), TRowVersion::Min());
+
+            emitter.Process(TestSourceId(2), MakeSchemaChange(1, "v1"));
+            {
+                const auto schemaChange = emitter.CanEmit();
+                UNIT_ASSERT(schemaChange.Defined());
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Version, MakeSchemaChange(1).Version);
+            }
+        }
+
+        storage.RegisterSourceId(TestSourceId(2), MakeExplicitSourceIdInfoWithSchemaChange(++offset, MakeSchemaChange(1, "v1")));
+        UNIT_ASSERT_VALUES_EQUAL(storage.GetCommittedSchemaChangeVersion(), MakeSchemaChange(1).Version);
+        {
+            TSchemaChangeEmitter emitter(storage);
+            UNIT_ASSERT(!emitter.CanEmit().Defined());
+
+            emitter.Process(TestSourceId(1), MakeSchemaChange(1, "v1"));
+            emitter.Process(TestSourceId(2), MakeSchemaChange(1, "v1"));
+            UNIT_ASSERT(!emitter.CanEmit().Defined());
+        }
+
+        {
+            TSchemaChangeEmitter emitter(storage);
+            emitter.Process(TestSourceId(1), MakeSchemaChange(2, "v2"));
+            UNIT_ASSERT(!emitter.CanEmit().Defined());
+            emitter.Process(TestSourceId(2), MakeSchemaChange(2, "v2"));
+            {
+                const auto schemaChange = emitter.CanEmit();
+                UNIT_ASSERT(schemaChange.Defined());
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Version, MakeSchemaChange(2).Version);
+                UNIT_ASSERT_VALUES_EQUAL(schemaChange->Data, "v2");
+            }
+        }
+    }
+
+    Y_UNIT_TEST(SchemaChangeProtoRoundtrip) {
+        const auto sourceId = TestSourceId();
+        auto sourceIdInfo = MakeExplicitSourceIdInfoWithSchemaChange(10, MakeSchemaChange(7, "payload"));
+
+        TKeyPrefix ikey(TKeyPrefix::TypeInfo, TPartitionId(TestPartition), TKeyPrefix::MarkProtoSourceId);
+        TBuffer idata;
+        TSourceIdWriter::FillKeyAndData(ESourceIdFormat::Proto, sourceId, sourceIdInfo, ikey, idata);
+
+        TString key;
+        ikey.AsString(key);
+        TString data;
+        idata.AsString(data);
+
+        TSourceIdStorage storage;
+        storage.LoadSourceIdInfo(key, data, TInstant());
+
+        auto it = storage.GetInMemorySourceIds().find(sourceId);
+        UNIT_ASSERT_UNEQUAL(it, storage.GetInMemorySourceIds().end());
+        UNIT_ASSERT(it->second.LastSchemaChange.Defined());
+        UNIT_ASSERT_VALUES_EQUAL(it->second.LastSchemaChange->Version, TRowVersion(7, 0));
+        UNIT_ASSERT_VALUES_EQUAL(it->second.LastSchemaChange->Data, "payload");
+    }
+
 } // TSourceIdTests
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/protos/msgbus_pq.proto
+++ b/ydb/core/protos/msgbus_pq.proto
@@ -112,6 +112,7 @@ message TPersQueuePartitionRequest {
         optional bool IgnoreQuotaDeadline = 16 [ default = false ];
 
         optional NKikimrPQ.THeartbeat Heartbeat = 17; // mutually exclusive with Data & related fields
+        optional NKikimrPQ.TSchemaChangeInfo SchemaChange = 26; // mutually exclusive with Data & Heartbeat
 
         optional bool EnableKafkaDeduplication = 18 [ default = false ];
         optional int32 ProducerEpoch = 19;  // For idempotent producer in Kafka protocol

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -535,6 +535,12 @@ message THeartbeat {
     optional bytes Data = 3;
 }
 
+message TSchemaChangeInfo {
+    optional uint64 Step = 1;
+    optional uint64 TxId = 2;
+    optional bytes Data = 3;
+}
+
 message TMessageGroupInfo {
     enum EState {
         STATE_UNKNOWN = 0;
@@ -553,6 +559,7 @@ message TMessageGroupInfo {
     optional TPartitionKeyRange KeyRange = 6;
     optional EState State = 7;
     optional THeartbeat LastHeartbeat = 8;
+    optional TSchemaChangeInfo LastSchemaChange = 11;
 
 }
 

--- a/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
+++ b/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
@@ -41,7 +41,11 @@ class TBaseSerializer: public IChangeRecordSerializer {
     void SerializeSchemaChange(TCmdWrite& cmd, const TChangeRecord& record) {
         auto data = MakeDataChunk();
         FillDataChunk(data, record);
-        cmd.SetData(data.SerializeAsString());
+
+        auto& schemaChange = *cmd.MutableSchemaChange();
+        schemaChange.SetStep(record.GetStep());
+        schemaChange.SetTxId(record.GetTxId());
+        schemaChange.SetData(data.SerializeAsString());
     }
 
     void SerializeHeartbeat(TCmdWrite& cmd, const TChangeRecord& record) {

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -4739,7 +4739,9 @@ Y_UNIT_TEST_SUITE(Cdc) {
         UNIT_ASSERT_C(partitionCount >= 1, "CDC stream must have at least one partition");
 
         TVector<TVector<std::pair<TString, TString>>> records(partitionCount);
-        while (true) {
+        for (ui32 iteration = 0; ; ++iteration) {
+            UNIT_ASSERT_C(iteration < 60, "Timed out waiting for schema change records in all partitions");
+
             bool allHaveSchemaChange = true;
             for (ui32 i = 0; i < records.size(); ++i) {
                 records[i] = GetRecords(runtime, edgeActor, "/Root/Table/Stream", i);

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -1133,6 +1133,11 @@ Y_UNIT_TEST_SUITE(Cdc) {
         return streamDesc;
     }
 
+    TCdcStream WithSchemaChanges(TCdcStream streamDesc) {
+        streamDesc.SchemaChanges = true;
+        return streamDesc;
+    }
+
     TString CalcPartitionKey(const TString& data) {
         NJson::TJsonValue json;
         UNIT_ASSERT(NJson::ReadJsonTree(data, &json));
@@ -4663,6 +4668,118 @@ Y_UNIT_TEST_SUITE(Cdc) {
                     "Record with ts " << ts << " after resolved " << resolved);
             }
         }
+    }
+
+    Y_UNIT_TEST(SchemaChanges) {
+        TPortManager portManager;
+        TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
+            .SetUseRealThreads(false)
+            .SetDomainName("Root")
+        );
+
+        auto& runtime = *server->GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+
+        SetupLogging(runtime);
+        InitRoot(server, edgeActor);
+        CreateShardedTable(server, edgeActor, "/Root", "Table", SimpleTable());
+
+        WaitTxNotification(server, edgeActor, AsyncAlterAddStream(server, "/Root", "Table",
+            WithSchemaChanges(Updates(NKikimrSchemeOp::ECdcStreamFormatJson))));
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES (1, 10);
+        )");
+
+        WaitTxNotification(server, edgeActor, AsyncAlterAddExtraColumn(server, "/Root", "Table"));
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value, extra) VALUES (2, 20, 200);
+        )");
+
+        auto records = WaitForContent(server, edgeActor, "/Root/Table/Stream", {
+            R"({"update":{"value":10},"key":[1]})",
+            R"({"tableChanges":"***","ts":"***"})",
+            R"({"update":{"extra":200,"value":20},"key":[2]})",
+        });
+
+        const auto& table = records[1]["tableChanges"][0]["table"];
+        UNIT_ASSERT(table.Has("schemaVersion"));
+        UNIT_ASSERT_VALUES_EQUAL(table["primaryKeyColumnNames"].GetString(), "key");
+        UNIT_ASSERT_VALUES_EQUAL(table["columns"]["key"].GetString(), "Uint32");
+        UNIT_ASSERT_VALUES_EQUAL(table["columns"]["value"].GetString(), "Uint32");
+        UNIT_ASSERT_VALUES_EQUAL(table["columns"]["extra"].GetString(), "Uint32");
+    }
+
+    Y_UNIT_TEST(SchemaChangesMultipleShards) {
+        TPortManager portManager;
+        TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
+            .SetUseRealThreads(false)
+            .SetDomainName("Root")
+        );
+
+        auto& runtime = *server->GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+
+        SetupLogging(runtime);
+        InitRoot(server, edgeActor);
+        CreateShardedTable(server, edgeActor, "/Root", "Table", TShardedTableOptions().Shards(2));
+
+        WaitTxNotification(server, edgeActor, AsyncAlterAddStream(server, "/Root", "Table",
+            WithSchemaChanges(Updates(NKikimrSchemeOp::ECdcStreamFormatJson))));
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES (1, 10), (2, 20);
+        )");
+
+        WaitTxNotification(server, edgeActor, AsyncAlterAddExtraColumn(server, "/Root", "Table"));
+
+        const auto& pqDesc = GetTopicDescription(runtime, edgeActor, "/Root/Table/Stream");
+        const size_t partitionCount = pqDesc.GetPartitions().size();
+        UNIT_ASSERT_C(partitionCount >= 1, "CDC stream must have at least one partition");
+
+        TVector<TVector<std::pair<TString, TString>>> records(partitionCount);
+        while (true) {
+            bool allHaveSchemaChange = true;
+            for (ui32 i = 0; i < records.size(); ++i) {
+                records[i] = GetRecords(runtime, edgeActor, "/Root/Table/Stream", i);
+                const bool hasSchemaChange = AnyOf(records[i], [](const auto& rec) {
+                    return rec.second.Contains("tableChanges");
+                });
+                allHaveSchemaChange = allHaveSchemaChange && hasSchemaChange;
+            }
+            if (allHaveSchemaChange) {
+                break;
+            }
+            SimulateSleep(server, TDuration::Seconds(1));
+        }
+
+        ui32 schemaChangeCount = 0;
+        TString schemaChangeBody;
+        for (const auto& partitionRecords : records) {
+            for (const auto& rec : partitionRecords) {
+                if (rec.second.Contains("tableChanges")) {
+                    ++schemaChangeCount;
+                    if (schemaChangeBody.empty()) {
+                        schemaChangeBody = rec.second;
+                    } else {
+                        AssertJsonsEqual(rec.second, schemaChangeBody);
+                    }
+                }
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(schemaChangeCount, partitionCount);
+        AssertJsonsEqual(schemaChangeBody, R"({"tableChanges":"***","ts":"***"})");
+
+        NJson::TJsonValue json;
+        UNIT_ASSERT(NJson::ReadJsonTree(schemaChangeBody, &json));
+        const auto& table = json["tableChanges"][0]["table"];
+        UNIT_ASSERT(table.Has("schemaVersion"));
+        UNIT_ASSERT_VALUES_EQUAL(table["primaryKeyColumnNames"].GetString(), "key");
+        UNIT_ASSERT_VALUES_EQUAL(table["columns"]["key"].GetString(), "Uint32");
+        UNIT_ASSERT_VALUES_EQUAL(table["columns"]["value"].GetString(), "Uint32");
+        UNIT_ASSERT_VALUES_EQUAL(table["columns"]["extra"].GetString(), "Uint32");
     }
 
 } // Cdc


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

# CDC Schema Change Record Aggregation

## Goal

When a CDC stream is created with `SCHEMA_CHANGES = TRUE`:

1. Each DataShard emits a schema change record on schema change (column add/drop).
2. Each DataShard broadcasts that record to **every** CDC topic partition (PersQueue).
3. When a schema change first arrives at a PQ partition, it **stops processing further records from that DataShard** until schema changes from **all** other DataShards arrive.
4. Once all shards have reported, PQ emits **one aggregated** schema change record to the partition log.

## Current State (sender already existed)

- Emission in [alter_table_unit.cpp](ydb/core/tx/datashard/alter_table_unit.cpp) for column add/drop when stream has `SchemaChanges`.
- Kind `CdcSchemaChange`, `IsBroadcast() == true`.
- Stream flag: public `schema_changes`, internal `TCdcStreamDescription.SchemaChanges`.
- Empty `TSchemaChange` payload proto; body from schema snapshot + `SchemaVersion` (JSON format).

**Missing (this plan):** PQ recognition, quorum aggregation, delayed ACK, persistence, change-sender batch split, tests.

## Design Decisions

- **PQ delayed ACK**, not extra DataShard blocking. Immediate ACK (heartbeat-style) is unsafe: a shard that gets ACK first can send new-schema data before other shards’ schema changes arrive.
- **No extra DataShard blocking** beyond existing `TChangeSender` broadcast — except a **schema-change-only batching split**: do not send records after a schema-change broadcast in the same write batch (otherwise delayed ACK of the whole `TEvWrite` still writes later data in that request). Heartbeats stay non-blocking.
- Heartbeats ACK immediately (no ordering vs data). Schema changes have a strict ordering guarantee: aggregated schema change must appear before any new-schema data.

## Architecture

### Why immediate ACK fails

1. Shard A reaches schema change first, sends to all partitions.
2. If partitions ACK immediately, A’s broadcast completes.
3. A dequeues next record (new-schema data) and sends it.
4. A’s new-schema data can arrive at partition P before shard B’s schema change.
5. Aggregated schema change appears **after** new-schema data — ordering violated.

### Correct flow with delayed ACK

```mermaid
sequenceDiagram
  participant A as Shard A Writer
  participant B as Shard B Writer
  participant P as PQ Partition
  participant Log as Partition Log

  A->>P: SchemaChange(v=Step:TxId, data)
  Note over P: Buffer response. Don't ACK yet.
  Note over A: Writer blocked (waiting for TEvWriteResponse)
  B->>P: Data (old schema)
  P->>Log: Write data normally
  P-->>B: ACK data
  B->>P: SchemaChange(v=Step:TxId, data)
  Note over P: Quorum met! All ExplicitSourceIds reported.
  P->>Log: Emit aggregated schema change
  P-->>A: ACK schema change (delayed response)
  P-->>B: ACK schema change
  Note over A,B: Broadcast completes on all partitions, new data flows
```

### How blocking works (no special DataShard logic needed)

- `TPartitionWriter` sends `TEvWriteRequest` and waits for `TEvWriteResponse`.
- Without response, the writer cannot send more records.
- Broadcast cannot complete → `TChangeSender` will not dequeue next record.
- DataShard is effectively blocked until **all** PQ partitions reach quorum and ACK.

### Change-sender barrier (schema change only)

In [change_sender.cpp](ydb/core/change_exchange/change_sender.cpp) `SendPreparedRecords`:

- Split `Prepared` at the first `CdcSchemaChange` (not at heartbeats).
- Hold back later records for the next `OnReady`.
- `ReEnqueueRecords` must `RemoveBroadcastPartition` for any broadcast still held in `Prepared` when a sender dies (otherwise `Broadcasting` can stall).

## Implementation Plan

### 1. Proto Layer

**[ydb/core/protos/pqconfig.proto](ydb/core/protos/pqconfig.proto)** — add (analogous to `THeartbeat`):

```protobuf
message TSchemaChangeInfo {
    optional uint64 Step = 1;
    optional uint64 TxId = 2;
    optional bytes Data = 3;
}
```

Also `TMessageGroupInfo.LastSchemaChange`.

**[ydb/core/protos/msgbus_pq.proto](ydb/core/protos/msgbus_pq.proto)** — `TCmdWrite.SchemaChange` (mutually exclusive with Data and Heartbeat).

### 2. Serializer (DataShard)

**[change_record_cdc_serializer.cpp](ydb/core/tx/datashard/change_record_cdc_serializer.cpp)** — `SerializeSchemaChange` fills `cmd.MutableSchemaChange()` with Step/TxId/Data (not `cmd.SetData()`).

**Rolling upgrade note:** old PQ rejects new-format messages as empty Data. Upgrade PQ before DataShard (or before enabling `SCHEMA_CHANGES`), same class of issue as heartbeats.

### 3. PQ Tablet Recognition

**[pq_impl.cpp](ydb/core/persqueue/pqtablet/pq_impl.cpp)** / **[internal.h](ydb/core/persqueue/events/internal.h)**:

- Mutual exclusion Data / Heartbeat / SchemaChange.
- Extract `SchemaChangeVersion` into `TEvPQ::TEvWrite::TMsg`.
- Size limit `MAX_SCHEMA_CHANGE_SIZE` (larger than heartbeat; schema JSON can be bigger).

### 4. Schema Change Emitter

**[sourceid.h](ydb/core/persqueue/pqtablet/partition/sourceid.h) / [sourceid.cpp](ydb/core/persqueue/pqtablet/partition/sourceid.cpp)** — `TSchemaChangeEmitter` (mirror `THeartbeatEmitter`):

- `Process(sourceId, TSchemaChangeInfo&&)`
- `CanEmit()` — quorum over `ExplicitSourceIds`
- Persist tracking via `SourceIdsBySchemaChange` / `SourceIdsWithSchemaChange`
- `GetCommittedSchemaChangeVersion()` — min version once all explicit sources have reported (O(1) via map begin after size check)

Helpers in [schema_change.h](ydb/core/persqueue/common/schema_change.h): `IsSchemaChangeVersionReleased`, `SelectSchemaChangeForAck`.

### 5. TModificationBatch Integration

**[partition_sourcemanager](ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.cpp)**:

- `CanEmitSchemaChange()`
- `Update(TSchemaChangeInfo&&)` — emitter **and** `SourceIdWriter` (crash recovery of `LastSchemaChange` without SeqNo bump until ACK)
- Prefer `InWriter` over `InMemory` when persisting so same-batch SeqNo updates are not regressed

### 6. Partition Write Processing — Delayed ACK

**[partition_write.cpp](ydb/core/persqueue/pqtablet/partition/partition_write.cpp)** / **[partition.h](ydb/core/persqueue/pqtablet/partition/partition.h)**:

**Recognize** (like heartbeat): explicit source required; do not write to log; update emitter/writer.

**Defer ACK** via `PendingSchemaChangeResponses` until `version <= Max(LastEmittedSchemaChange, GetCommittedSchemaChangeVersion())`.

**Emit** in `EndAppendHeadWithNewWrites` when `CanEmitSchemaChange()` and version > committed: write as regular Data (tablet SourceId, `DisableDeduplication`, `SchemaChangeVersion = nullopt` to avoid re-deferral).

**On ACK**: bump SeqNo (with Max guard); keep newer `LastSchemaChange` if present; keep source’s last data offset.

**DestroyActor**: drain pending with `ReplyError`.

**Change-sender barrier**: only on `CdcSchemaChange`.

### 7. State Persistence

- `TSourceIdInfo.LastSchemaChange` proto load/save
- After restart, `GetCommittedSchemaChangeVersion()` allows ACK without re-emitting

### 8. Tests

- Unit: `TSourceIdTests` — emitter quorum, proto roundtrip, deferred-ACK invariants
- Integration: `Cdc::SchemaChanges`, `Cdc::SchemaChangesMultipleShards` in [datashard_ut_change_exchange.cpp](ydb/core/tx/datashard/datashard_ut_change_exchange.cpp)
- Ordering: old data → aggregated schema change → new-schema data
- Multi-shard: one aggregated record per topic partition

## Key Files Summary

| Layer | File | Change |
|-------|------|--------|
| Proto | `ydb/core/protos/pqconfig.proto` | `TSchemaChangeInfo`, `LastSchemaChange` |
| Proto | `ydb/core/protos/msgbus_pq.proto` | `TCmdWrite.SchemaChange` |
| Serializer | `ydb/core/tx/datashard/change_record_cdc_serializer.cpp` | `MutableSchemaChange()` |
| Change sender | `ydb/core/change_exchange/change_sender.cpp` | Schema-change barrier + ReEnqueue cleanup |
| PQ tablet | `ydb/core/persqueue/pqtablet/pq_impl.cpp` | Validate / extract |
| PQ events | `ydb/core/persqueue/events/internal.h` | `SchemaChangeVersion` |
| Common | `ydb/core/persqueue/common/schema_change.{h,cpp}` | Info + release helpers |
| Emitter | `ydb/core/persqueue/pqtablet/partition/sourceid.{h,cpp}` | `TSchemaChangeEmitter` |
| Batch | `ydb/core/persqueue/pqtablet/partition/partition_sourcemanager.{h,cpp}` | Integrate emitter + writer |
| Write | `ydb/core/persqueue/pqtablet/partition/partition_write.cpp` | Delayed ACK + emit |
| Partition | `ydb/core/persqueue/pqtablet/partition/partition.h` | `PendingSchemaChangeResponses`, `LastEmittedSchemaChange` |
| Persistence | `ydb/core/persqueue/common/sourceid_info.h` | `LastSchemaChange` |
| Tests | `ydb/core/persqueue/ut/sourceid_ut.cpp`, `datashard_ut_change_exchange.cpp` | Unit + integration |

## Contrast with Heartbeats

| | Heartbeat | Schema change |
|--|-----------|---------------|
| ACK | Immediate | Delayed until emit/committed |
| Ordering vs data | None | Strict: aggregated SC before new-schema data |
| Change-sender barrier | No | Yes (`CdcSchemaChange` only) |
| Quorum | `THeartbeatEmitter` | `TSchemaChangeEmitter` (same structure) |
| Persist | `LastHeartbeat` | `LastSchemaChange` (+ SeqNo deferred until ACK) |
