### PR TITLE
[NBS-7486] Generate dirty map data for persisting

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.cpp
@@ -6,7 +6,7 @@ namespace NYdb::NBS::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TBlockRangeField::Add(TBlockRange64 range)
+bool TBlockRangeField::Add(TBlockRange64 range)
 {
     // Non-overlapping ranges sorted by End are also sorted by Start, so we
     // can iterate forward and stop early.
@@ -22,6 +22,8 @@ void TBlockRangeField::Add(TBlockRange64 range)
 
     ui64 mergedStart = range.Start;
     ui64 mergedEnd = range.End;
+    size_t erasedCount = 0;
+    TBlockRange64 firstErased = range;
 
     while (it != Intervals.end()) {
         // For non-overlapping ranges sorted by End (= sorted by Start), we can
@@ -32,24 +34,33 @@ void TBlockRangeField::Add(TBlockRange64 range)
             break;
         }
 
+        if (erasedCount == 0) {
+            firstErased = *it;
+        }
         mergedStart = Min(mergedStart, it->Start);
         mergedEnd = Max(mergedEnd, it->End);
         it = Intervals.erase(it);
+        ++erasedCount;
     }
 
-    Intervals.insert(TBlockRange64::MakeClosedInterval(mergedStart, mergedEnd));
+    const TBlockRange64 merged =
+        TBlockRange64::MakeClosedInterval(mergedStart, mergedEnd);
+    Intervals.insert(merged);
+
+    return erasedCount != 1 || merged != firstErased;
 }
 
-void TBlockRangeField::Remove(TBlockRange64 range)
+bool TBlockRangeField::Remove(TBlockRange64 range)
 {
     if (Intervals.empty()) {
-        return;
+        return false;
     }
 
     // Find first interval with End >= range.Start (could overlap with range).
     auto it = Intervals.lower_bound(
         TBlockRange64::MakeClosedInterval(0, range.Start));
 
+    bool changed = false;
     while (it != Intervals.end()) {
         // Since Start is monotonically increasing (non-overlapping + sorted by
         // End), stop once Start is past range.End.
@@ -59,6 +70,7 @@ void TBlockRangeField::Remove(TBlockRange64 range)
 
         const TBlockRange64 existing = *it;
         it = Intervals.erase(it);
+        changed = true;
 
         // Keep the left tail if the existing interval starts before
         // range.Start.
@@ -75,11 +87,14 @@ void TBlockRangeField::Remove(TBlockRange64 range)
             break;
         }
     }
+    return changed;
 }
 
-void TBlockRangeField::Clear()
+bool TBlockRangeField::Clear()
 {
+    const bool changed = !Intervals.empty();
     Intervals.clear();
+    return changed;
 }
 
 bool TBlockRangeField::Overlaps(TBlockRange64 other) const
@@ -111,6 +126,20 @@ void TBlockRangeField::Enumerate(TEnumerateFunc func) const
 bool TBlockRangeField::Empty() const
 {
     return Intervals.empty();
+}
+
+size_t TBlockRangeField::GetBlockCount() const
+{
+    size_t total = 0;
+    for (const auto& range: Intervals) {
+        total += range.Size();
+    }
+    return total;
+}
+
+size_t TBlockRangeField::GetSegmentCount() const
+{
+    return Intervals.size();
 }
 
 TString TBlockRangeField::Print() const

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h
@@ -21,15 +21,20 @@ public:
     using TEnumerateFunc =
         std::function<EEnumerateContinuation(TBlockRange64 item)>;
 
-    void Add(TBlockRange64 range);
-    void Remove(TBlockRange64 range);
-    void Clear();
+    // Returns true if the intervals have actually changed.
+    bool Add(TBlockRange64 range);
+    // Returns true if the intervals have actually changed.
+    bool Remove(TBlockRange64 range);
+    // Returns true if the intervals have actually changed.
+    bool Clear();
 
     [[nodiscard]] bool Overlaps(TBlockRange64 other) const;
 
     void Enumerate(TEnumerateFunc func) const;
 
     [[nodiscard]] bool Empty() const;
+    [[nodiscard]] size_t GetBlockCount() const;
+    [[nodiscard]] size_t GetSegmentCount() const;
     [[nodiscard]] TString Print() const;
 
 private:

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field_ut.cpp
@@ -39,7 +39,7 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddSingleRange)
     {
         TBlockRangeField f;
-        f.Add(R(10, 20));
+        UNIT_ASSERT(f.Add(R(10, 20)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(10, 20), v[0]);
@@ -48,8 +48,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddTwoNonAdjacentRanges)
     {
         TBlockRangeField f;
-        f.Add(R(0, 5));
-        f.Add(R(10, 15));
+        UNIT_ASSERT(f.Add(R(0, 5)));
+        UNIT_ASSERT(f.Add(R(10, 15)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(2u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 5), v[0]);
@@ -59,8 +59,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddAdjacentRangesMerged)
     {
         TBlockRangeField f;
-        f.Add(R(0, 5));
-        f.Add(R(6, 10));
+        UNIT_ASSERT(f.Add(R(0, 5)));
+        UNIT_ASSERT(f.Add(R(6, 10)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 10), v[0]);
@@ -69,8 +69,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddOverlappingRangesMerged)
     {
         TBlockRangeField f;
-        f.Add(R(0, 10));
-        f.Add(R(5, 15));
+        UNIT_ASSERT(f.Add(R(0, 10)));
+        UNIT_ASSERT(f.Add(R(5, 15)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 15), v[0]);
@@ -79,8 +79,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddCoveredByExistingIsNoop)
     {
         TBlockRangeField f;
-        f.Add(R(0, 100));
-        f.Add(R(10, 20));
+        UNIT_ASSERT(f.Add(R(0, 100)));
+        UNIT_ASSERT(!f.Add(R(10, 20)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 100), v[0]);
@@ -89,11 +89,11 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddCoversMultipleRanges)
     {
         TBlockRangeField f;
-        f.Add(R(0, 5));
-        f.Add(R(10, 15));
-        f.Add(R(20, 25));
+        UNIT_ASSERT(f.Add(R(0, 5)));
+        UNIT_ASSERT(f.Add(R(10, 15)));
+        UNIT_ASSERT(f.Add(R(20, 25)));
         // New range covers all three and the gaps between them.
-        f.Add(R(0, 25));
+        UNIT_ASSERT(f.Add(R(0, 25)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 25), v[0]);
@@ -102,10 +102,10 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddMergesOnBothSides)
     {
         TBlockRangeField f;
-        f.Add(R(0, 5));
-        f.Add(R(10, 15));
+        UNIT_ASSERT(f.Add(R(0, 5)));
+        UNIT_ASSERT(f.Add(R(10, 15)));
         // Bridge the gap.
-        f.Add(R(5, 10));
+        UNIT_ASSERT(f.Add(R(5, 10)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 15), v[0]);
@@ -114,8 +114,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddSameRangeTwice)
     {
         TBlockRangeField f;
-        f.Add(R(3, 7));
-        f.Add(R(3, 7));
+        UNIT_ASSERT(f.Add(R(3, 7)));
+        UNIT_ASSERT(!f.Add(R(3, 7)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(3, 7), v[0]);
@@ -127,23 +127,23 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(RemoveFromEmpty)
     {
         TBlockRangeField f;
-        f.Remove(R(0, 10));   // must not crash
+        UNIT_ASSERT(!f.Remove(R(0, 10)));   // must not crash, returns false
         UNIT_ASSERT(Collect(f).empty());
     }
 
     Y_UNIT_TEST(RemoveExact)
     {
         TBlockRangeField f;
-        f.Add(R(0, 10));
-        f.Remove(R(0, 10));
+        UNIT_ASSERT(f.Add(R(0, 10)));
+        UNIT_ASSERT(f.Remove(R(0, 10)));
         UNIT_ASSERT(Collect(f).empty());
     }
 
     Y_UNIT_TEST(RemoveFromMiddle)
     {
         TBlockRangeField f;
-        f.Add(R(0, 20));
-        f.Remove(R(5, 10));
+        UNIT_ASSERT(f.Add(R(0, 20)));
+        UNIT_ASSERT(f.Remove(R(5, 10)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(2u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 4), v[0]);
@@ -153,8 +153,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(RemoveLeftPart)
     {
         TBlockRangeField f;
-        f.Add(R(0, 20));
-        f.Remove(R(0, 9));
+        UNIT_ASSERT(f.Add(R(0, 20)));
+        UNIT_ASSERT(f.Remove(R(0, 9)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(10, 20), v[0]);
@@ -163,8 +163,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(RemoveRightPart)
     {
         TBlockRangeField f;
-        f.Add(R(0, 20));
-        f.Remove(R(10, 20));
+        UNIT_ASSERT(f.Add(R(0, 20)));
+        UNIT_ASSERT(f.Remove(R(10, 20)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 9), v[0]);
@@ -173,8 +173,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(RemoveNonOverlapping)
     {
         TBlockRangeField f;
-        f.Add(R(10, 20));
-        f.Remove(R(30, 40));   // no overlap, no change
+        UNIT_ASSERT(f.Add(R(10, 20)));
+        UNIT_ASSERT(!f.Remove(R(30, 40)));   // no overlap, no change
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(10, 20), v[0]);
@@ -183,10 +183,10 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(RemoveSeveralRanges)
     {
         TBlockRangeField f;
-        f.Add(R(0, 5));
-        f.Add(R(10, 15));
-        f.Add(R(20, 25));
-        f.Remove(R(3, 22));
+        UNIT_ASSERT(f.Add(R(0, 5)));
+        UNIT_ASSERT(f.Add(R(10, 15)));
+        UNIT_ASSERT(f.Add(R(20, 25)));
+        UNIT_ASSERT(f.Remove(R(3, 22)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(2u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 2), v[0]);
@@ -255,13 +255,46 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     }
 
     // -------------------------------------------------------------------------
+    // Return value – false cases
+
+    Y_UNIT_TEST(AddReturnsFalseWhenFullyCovered)
+    {
+        TBlockRangeField f;
+        UNIT_ASSERT(f.Add(R(0, 100)));
+        // Fully covered by existing interval – no change.
+        UNIT_ASSERT(!f.Add(R(10, 20)));
+        UNIT_ASSERT(!f.Add(R(0, 100)));
+        UNIT_ASSERT(!f.Add(R(50, 50)));
+    }
+
+    Y_UNIT_TEST(RemoveReturnsFalseWhenEmpty)
+    {
+        TBlockRangeField f;
+        UNIT_ASSERT(!f.Remove(R(0, 100)));
+    }
+
+    Y_UNIT_TEST(RemoveReturnsFalseWhenNoOverlap)
+    {
+        TBlockRangeField f;
+        UNIT_ASSERT(f.Add(R(10, 20)));
+        // Strictly before.
+        UNIT_ASSERT(!f.Remove(R(0, 9)));
+        // Strictly after.
+        UNIT_ASSERT(!f.Remove(R(21, 30)));
+        // Contents unchanged.
+        auto v = Collect(f);
+        UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
+        UNIT_ASSERT_VALUES_EQUAL(R(10, 20), v[0]);
+    }
+
+    // -------------------------------------------------------------------------
     // Edge / boundary cases
 
     Y_UNIT_TEST(AddStartingAtZero)
     {
         TBlockRangeField f;
-        f.Add(R(0, 0));
-        f.Add(R(1, 5));
+        UNIT_ASSERT(f.Add(R(0, 0)));
+        UNIT_ASSERT(f.Add(R(1, 5)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 5), v[0]);
@@ -270,8 +303,8 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(RemoveSingleBlock)
     {
         TBlockRangeField f;
-        f.Add(R(0, 4));
-        f.Remove(R(2, 2));
+        UNIT_ASSERT(f.Add(R(0, 4)));
+        UNIT_ASSERT(f.Remove(R(2, 2)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(2u, v.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 1), v[0]);
@@ -281,10 +314,10 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(ManyFragmentsAfterRemoves)
     {
         TBlockRangeField f;
-        f.Add(R(0, 99));
+        UNIT_ASSERT(f.Add(R(0, 99)));
         // Remove every even block to create 50 gaps.
         for (ui64 i = 0; i < 100; i += 2) {
-            f.Remove(R(i, i));
+            UNIT_ASSERT(f.Remove(R(i, i)));
         }
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(50u, v.size());
@@ -297,13 +330,13 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(AddRestoresAfterRemoves)
     {
         TBlockRangeField f;
-        f.Add(R(0, 99));
+        UNIT_ASSERT(f.Add(R(0, 99)));
         for (ui64 i = 0; i < 100; i += 2) {
-            f.Remove(R(i, i));
+            UNIT_ASSERT(f.Remove(R(i, i)));
         }
         // Adding back should merge everything.
         for (ui64 i = 0; i < 100; i += 2) {
-            f.Add(R(i, i));
+            UNIT_ASSERT(f.Add(R(i, i)));
         }
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(1u, v.size());
@@ -313,9 +346,9 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
     Y_UNIT_TEST(EnumerateOrderedByStart)
     {
         TBlockRangeField f;
-        f.Add(R(50, 60));
-        f.Add(R(10, 20));
-        f.Add(R(30, 40));
+        UNIT_ASSERT(f.Add(R(50, 60)));
+        UNIT_ASSERT(f.Add(R(10, 20)));
+        UNIT_ASSERT(f.Add(R(30, 40)));
         auto v = Collect(f);
         UNIT_ASSERT_VALUES_EQUAL(3u, v.size());
         UNIT_ASSERT(v[0].Start < v[1].Start);
@@ -343,6 +376,81 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
         UNIT_ASSERT_VALUES_EQUAL(2u, seen.size());
         UNIT_ASSERT_VALUES_EQUAL(R(0, 5), seen[0]);
         UNIT_ASSERT_VALUES_EQUAL(R(10, 15), seen[1]);
+    }
+
+    // -------------------------------------------------------------------------
+    // GetBlockCount / GetSegmentCount
+
+    Y_UNIT_TEST(CountersOnEmpty)
+    {
+        TBlockRangeField f;
+        UNIT_ASSERT_VALUES_EQUAL(0u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(0u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersAfterSingleAdd)
+    {
+        TBlockRangeField f;
+        f.Add(R(10, 20));   // 11 blocks, 1 segment
+        UNIT_ASSERT_VALUES_EQUAL(11u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(1u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersAfterTwoDisjointAdds)
+    {
+        TBlockRangeField f;
+        f.Add(R(0, 4));     // 5 blocks
+        f.Add(R(10, 14));   // 5 blocks → total 10, 2 segments
+        UNIT_ASSERT_VALUES_EQUAL(10u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(2u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersAfterMerge)
+    {
+        TBlockRangeField f;
+        f.Add(R(0, 4));
+        f.Add(R(5, 9));   // adjacent – merges into [0,9], 10 blocks, 1 segment
+        UNIT_ASSERT_VALUES_EQUAL(10u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(1u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersAfterRemove)
+    {
+        TBlockRangeField f;
+        f.Add(R(0, 19));     // 20 blocks, 1 segment
+        f.Remove(R(5, 9));   // removes 5 blocks from the middle → 2 segments
+        UNIT_ASSERT_VALUES_EQUAL(15u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(2u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersAfterClear)
+    {
+        TBlockRangeField f;
+        f.Add(R(0, 9));
+        f.Add(R(20, 29));
+        f.Clear();
+        UNIT_ASSERT_VALUES_EQUAL(0u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(0u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersSingleBlock)
+    {
+        TBlockRangeField f;
+        f.Add(R(42, 42));
+        UNIT_ASSERT_VALUES_EQUAL(1u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(1u, f.GetSegmentCount());
+    }
+
+    Y_UNIT_TEST(CountersManyFragments)
+    {
+        TBlockRangeField f;
+        f.Add(R(0, 99));
+        // Remove every even block → 50 single-block segments.
+        for (ui64 i = 0; i < 100; i += 2) {
+            f.Remove(R(i, i));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(50u, f.GetBlockCount());
+        UNIT_ASSERT_VALUES_EQUAL(50u, f.GetSegmentCount());
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.cpp
@@ -5,13 +5,70 @@
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
+namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
 
-void TDDiskState::Init(ui64 totalBlockCount, ui64 operationalBlockCount)
+constexpr ui64 Mask = 0xffff;
+constexpr ui64 Offset = 16;
+
+////////////////////////////////////////////////////////////////////////////////
+void SaveField(
+    const TBlockRangeField& field,
+    PartitionDirect::NProto::TBlockField* proto)
 {
+    field.Enumerate(
+        [&](TBlockRange64 item)
+        {
+            Y_ABORT_UNLESS((item.Start & Mask) == item.Start);
+            Y_ABORT_UNLESS((item.Size() & Mask) == item.Size());
+
+            const ui32 startAndLength =
+                ((item.Start & Mask) << Offset) | (item.Size() & Mask);
+            proto->AddStartAndLength(startAndLength);
+            return TBlockRangeField::EEnumerateContinuation::Continue;
+        });
+
+    // TODO save as bitmap when segment count exceed N
+}
+
+void LoadField(
+    const PartitionDirect::NProto::TBlockField& proto,
+    TBlockRangeField* field)
+{
+    for (const ui32 startAndLength: proto.GetStartAndLength()) {
+        const ui64 start = startAndLength >> Offset;
+        const ui64 size = startAndLength & Mask;
+        Y_ABORT_UNLESS(size > 0);
+        field->Add(TBlockRange64::WithLength(start, size));
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDDiskState::Init(
+    IBehindAheadMonitor* behindAheadMonitor,
+    ui64 totalBlockCount,
+    ui64 operationalBlockCount)
+{
+    BehindAheadMonitor = behindAheadMonitor;
     TotalBlockCount = totalBlockCount;
     OperationalBlockCount = operationalBlockCount;
     UpdateState(true);
+}
+
+void TDDiskState::Save(PartitionDirect::NProto::TDDiskState* proto) const
+{
+    SaveField(AheadField, proto->MutableAhead());
+    SaveField(BehindField, proto->MutableBehind());
+}
+
+void TDDiskState::Load(const PartitionDirect::NProto::TDDiskState& proto)
+{
+    LoadField(proto.GetAhead(), &AheadField);
+    LoadField(proto.GetBehind(), &BehindField);
 }
 
 void TDDiskState::SwitchOffline()
@@ -51,7 +108,7 @@ void TDDiskState::OnRangeFlushed(TBlockRange64 range, EFlushCompletion flush)
     // possible to receive successful flush confirmation on a lagging replica.
     // We will ignore such ranges for safety.
     if (Lagging && flush == EFlushCompletion::Missed) {
-        BehindField.Add(range);
+        AddBehind(range);
     }
 
     // The replica is not lagging and data has been written. Adding the range to
@@ -77,13 +134,20 @@ bool TDDiskState::CanReadFromDDisk(TBlockRange64 range) const
         return true;
     }
 
+    // Don't allow reading from "green" blocks for now.
     // if (AheadField.Contains(range))
     //    return true;
+
     if (BehindField.Overlaps(range)) {
         return false;
     }
 
     return range.End < OperationalBlockCount;
+}
+
+bool TDDiskState::HasBehindOverlapping(TBlockRange64 range) const
+{
+    return BehindField.Overlaps(range);
 }
 
 std::optional<TBlockRange64> TDDiskState::GetFreshRange() const
@@ -115,8 +179,11 @@ std::optional<TBlockRange64> TDDiskState::GetFreshRange() const
 
 void TDDiskState::RangeSynced(TBlockRange64 range)
 {
-    BehindField.Remove(range);
-    AheadField.Remove(range);
+    const bool behindChanged = BehindField.Remove(range);
+    const bool aheadChanged = AheadField.Remove(range);
+    if (behindChanged || aheadChanged) {
+        BehindAheadMonitor->OnBehindAheadChanged();
+    }
 
     const ui64 newWatermark = range.End + 1;
     if (OperationalBlockCount < newWatermark &&
@@ -156,6 +223,20 @@ TString TDDiskState::DebugPrintBehind() const
     return BehindField.Print();
 }
 
+TString TDDiskState::DebugPrintAheadBehindBrief() const
+{
+    if (AheadField.Empty() && BehindField.Empty()) {
+        return {};
+    }
+
+    TStringBuilder result;
+    result << "a" << AheadField.GetSegmentCount() << "/"
+           << AheadField.GetBlockCount() << ";";
+    result << "b" << BehindField.GetSegmentCount() << "/"
+           << BehindField.GetBlockCount() << ";";
+    return result;
+}
+
 bool TDDiskState::IsFresh() const
 {
     return OperationalBlockCount != TotalBlockCount || !BehindField.Empty();
@@ -174,10 +255,22 @@ void TDDiskState::AddAhead(TBlockRange64 range)
 {
     Y_ABORT_UNLESS(!Lagging);
 
-    BehindField.Remove(range);
-    AheadField.Add(range);
+    const bool behindChanged = BehindField.Remove(range);
+    const bool aheadChanged = AheadField.Add(range);
+    if (behindChanged || aheadChanged) {
+        BehindAheadMonitor->OnBehindAheadChanged();
+    }
+
     if (OperationalBlockCount) {
         AheadField.Remove(TBlockRange64::WithLength(0, OperationalBlockCount));
+    }
+}
+
+void TDDiskState::AddBehind(TBlockRange64 range)
+{
+    const bool behindChanged = BehindField.Add(range);
+    if (behindChanged) {
+        BehindAheadMonitor->OnBehindAheadChanged();
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 
 #include <util/generic/string.h>
 
@@ -9,6 +10,15 @@
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+// Allows to receive notifications about changes in data that need to be
+// persisted in the partition local database.
+struct IBehindAheadMonitor
+{
+    virtual ~IBehindAheadMonitor() = default;
+
+    virtual void OnBehindAheadChanged() = 0;
+};
 
 class TDDiskState
 {
@@ -36,7 +46,15 @@ public:
 
     // Enables the use of DDisk. If the operational blocks count less then total
     // block count, then the DDisk is only partially filled (fresh).
-    void Init(ui64 totalBlockCount, ui64 operationalBlockCount);
+    void Init(
+        IBehindAheadMonitor* behindAheadMonitor,
+        ui64 totalBlockCount,
+        ui64 operationalBlockCount);
+
+    // Save ahead and behind maps to proto.
+    void Save(PartitionDirect::NProto::TDDiskState* proto) const;
+    // Load ahead and behind maps from proto.
+    void Load(const PartitionDirect::NProto::TDDiskState& proto);
 
     // Completely disables DDisk usage.
     void SwitchOffline();
@@ -57,6 +75,7 @@ public:
 
     [[nodiscard]] EState GetState() const;
     [[nodiscard]] bool CanReadFromDDisk(TBlockRange64 range) const;
+    [[nodiscard]] bool HasBehindOverlapping(TBlockRange64 range) const;
 
     [[nodiscard]] std::optional<TBlockRange64> GetFreshRange() const;
     void RangeSynced(TBlockRange64 range);
@@ -65,11 +84,15 @@ public:
     [[nodiscard]] TString DebugPrint() const;
     [[nodiscard]] TString DebugPrintAhead() const;
     [[nodiscard]] TString DebugPrintBehind() const;
+    [[nodiscard]] TString DebugPrintAheadBehindBrief() const;
 
 private:
     [[nodiscard]] bool IsFresh() const;
     void UpdateState(bool force);
     void AddAhead(TBlockRange64 range);
+    void AddBehind(TBlockRange64 range);
+
+    IBehindAheadMonitor* BehindAheadMonitor = nullptr;
 
     EState State = EState::Disabled;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state_ut.cpp
@@ -6,6 +6,20 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace {
+struct TTestBlockFieldMonitor: public IBehindAheadMonitor
+{
+    void OnBehindAheadChanged() override
+    {
+        ++BehindAheadGeneration;
+    }
+
+    ui64 BehindAheadGeneration = 0;
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
 Y_UNIT_TEST_SUITE(TDDiskStateTest)
 {
     // A range missed while the DDisk was lagging is recorded in the Behind
@@ -14,9 +28,13 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
     // BehindField.Remove step): the range is now up-to-date, not outdated.
     Y_UNIT_TEST(ShouldMoveRangeFromBehindToAheadOnLateFlush)
     {
+        TTestBlockFieldMonitor testBlockFieldMonitor;
         TDDiskState ddisk;
         // Fresh DDisk (operational 5 < total 100) => tracking enabled.
-        ddisk.Init(/*totalBlockCount=*/100, /*operationalBlockCount=*/5);
+        ddisk.Init(
+            &testBlockFieldMonitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/5);
         UNIT_ASSERT_VALUES_EQUAL(true, ddisk.IsTrackingEnabled());
 
         // While lagging, a missed flush marks the range as outdated (Behind).
@@ -35,6 +53,159 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
             TDDiskState::EFlushCompletion::Completed);
         UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintBehind());
         UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintAhead());
+    }
+
+    // Save() encodes Ahead/Behind ranges as (start<<16)|size entries; Load()
+    // must restore exactly the same ranges.  An empty DDisk produces an empty
+    // proto and loads back to empty.
+    Y_UNIT_TEST(ShouldSaveAndLoadAheadAndBehind)
+    {
+        TTestBlockFieldMonitor monitor;
+        TDDiskState source;
+        source.Init(
+            &monitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/5);
+
+        // Populate Behind via a missed flush while lagging.
+        source.StartLagging();
+        source.OnRangeFlushed(
+            TBlockRange64::WithLength(10, 10),
+            TDDiskState::EFlushCompletion::Missed);   // Behind = [10..19]
+
+        // Populate Ahead via a successful flush after stopping lagging.
+        source.StopLagging();
+        source.OnRangeFlushed(
+            TBlockRange64::WithLength(30, 5),
+            TDDiskState::EFlushCompletion::Completed);   // Ahead = [30..34]
+
+        // --- Save ---
+        PartitionDirect::NProto::TDDiskState proto;
+        source.Save(&proto);
+
+        // --- Load into a fresh DDisk ---
+        TTestBlockFieldMonitor monitor2;
+        TDDiskState target;
+        target.Init(
+            &monitor2,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/5);
+        target.Load(proto);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            source.DebugPrintBehind(),
+            target.DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL(
+            source.DebugPrintAhead(),
+            target.DebugPrintAhead());
+
+        // --- Empty DDisk round-trip ---
+        TTestBlockFieldMonitor monitor3;
+        TDDiskState empty;
+        empty.Init(
+            &monitor3,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/100);
+
+        PartitionDirect::NProto::TDDiskState emptyProto;
+        empty.Save(&emptyProto);
+        UNIT_ASSERT_VALUES_EQUAL(0, emptyProto.GetAhead().StartAndLengthSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            emptyProto.GetBehind().StartAndLengthSize());
+
+        TTestBlockFieldMonitor monitor4;
+        TDDiskState loaded;
+        loaded.Init(
+            &monitor4,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/100);
+        loaded.Load(emptyProto);
+        UNIT_ASSERT_VALUES_EQUAL("", loaded.DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL("", loaded.DebugPrintAhead());
+    }
+
+    // HasBehindOverlapping: false when empty, true when the query overlaps
+    // Behind, false when the query is disjoint from Behind.
+    Y_UNIT_TEST(HasBehindOverlapping)
+    {
+        TTestBlockFieldMonitor monitor;
+        TDDiskState ddisk;
+        ddisk.Init(
+            &monitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/5);
+
+        // Empty Behind – always false.
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            ddisk.HasBehindOverlapping(TBlockRange64::WithLength(0, 20)));
+
+        // Populate Behind = [10..19].
+        ddisk.StartLagging();
+        ddisk.OnRangeFlushed(
+            TBlockRange64::WithLength(10, 10),
+            TDDiskState::EFlushCompletion::Missed);
+
+        // Ranges that DO overlap.
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            ddisk.HasBehindOverlapping(
+                TBlockRange64::WithLength(12, 5)));   // fully inside
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            ddisk.HasBehindOverlapping(
+                TBlockRange64::WithLength(5, 10)));   // overlaps left edge
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            ddisk.HasBehindOverlapping(
+                TBlockRange64::WithLength(15, 10)));   // overlaps right edge
+
+        // Ranges that do NOT overlap.
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            ddisk.HasBehindOverlapping(
+                TBlockRange64::WithLength(0, 10)));   // before Behind
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            ddisk.HasBehindOverlapping(
+                TBlockRange64::WithLength(20, 5)));   // after Behind
+    }
+
+    // IBehindAheadMonitor is notified on Behind/Ahead changes and NOT notified
+    // when the field does not actually change (already covered or empty sync).
+    Y_UNIT_TEST(MonitorNotifications)
+    {
+        TTestBlockFieldMonitor monitor;
+        TDDiskState ddisk;
+        ddisk.Init(
+            &monitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/5);
+
+        UNIT_ASSERT_VALUES_EQUAL(0u, monitor.BehindAheadGeneration);
+
+        // First missed flush → Behind changes → monitor called.
+        ddisk.StartLagging();
+        ddisk.OnRangeFlushed(
+            TBlockRange64::WithLength(10, 10),
+            TDDiskState::EFlushCompletion::Missed);
+        UNIT_ASSERT_VALUES_EQUAL(1u, monitor.BehindAheadGeneration);
+
+        // Identical range already covered → no change → monitor NOT called.
+        ddisk.OnRangeFlushed(
+            TBlockRange64::WithLength(10, 10),
+            TDDiskState::EFlushCompletion::Missed);
+        UNIT_ASSERT_VALUES_EQUAL(1u, monitor.BehindAheadGeneration);
+
+        // RangeSynced removes the range from Behind → monitor called.
+        ddisk.RangeSynced(TBlockRange64::WithLength(10, 10));
+        UNIT_ASSERT_VALUES_EQUAL(2u, monitor.BehindAheadGeneration);
+        UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintBehind());
+
+        // Syncing an empty field → no change → monitor NOT called.
+        ddisk.RangeSynced(TBlockRange64::WithLength(0, 10));
+        UNIT_ASSERT_VALUES_EQUAL(2u, monitor.BehindAheadGeneration);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -71,6 +71,7 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
     for (auto indx: added) {
         const auto watermark = vChunkConfig.GetWatermark(indx);
         DDiskStates[indx].Init(
+            this,
             BlockCount,
             watermark ? *watermark / BlockSize : BlockCount);
     }
@@ -264,6 +265,11 @@ TEraseHints TBlocksDirtyMap::MakeEraseHint(size_t batchSize)
         Y_ABORT_UNLESS(item);
 
         auto& val = item->Value;
+
+        if (!CheckEraseAbility(item->Range, val)) {
+            ReadyToErase.insert(lsn);
+            continue;
+        }
 
         for (THostIndex host: val.GetEraseNeeded()) {
             val.RequestErase(host);
@@ -714,6 +720,11 @@ void TBlocksDirtyMap::DataFromPBufferReleased(
     }
 }
 
+void TBlocksDirtyMap::OnBehindAheadChanged()
+{
+    ++BehindAheadGeneration;
+}
+
 bool TBlocksDirtyMap::NeedFlush() const
 {
     return !ReadyToFlush.empty();
@@ -722,6 +733,35 @@ bool TBlocksDirtyMap::NeedFlush() const
 bool TBlocksDirtyMap::NeedErase() const
 {
     return !ReadyToErase.empty() || !ReadyToEraseBelated.empty();
+}
+
+bool TBlocksDirtyMap::NeedPersist() const
+{
+    return BehindAheadGeneration > PersistedGeneration;
+}
+
+PartitionDirect::NProto::TDirtyMapState
+TBlocksDirtyMap::GetStateForPersist() const
+{
+    PartitionDirect::NProto::TDirtyMapState result;
+    result.SetStateGeneration(GetCurrentGeneration());
+    for (const auto& ddiskState: DDiskStates) {
+        ddiskState.Save(result.AddDDiskStates());
+    }
+    return result;
+}
+
+void TBlocksDirtyMap::StatePersisted(ui32 persistGeneration)
+{
+    Y_ABORT_UNLESS(persistGeneration > PersistedGeneration);
+    Y_ABORT_UNLESS(persistGeneration <= BehindAheadGeneration);
+
+    PersistedGeneration = persistGeneration;
+}
+
+ui64 TBlocksDirtyMap::GetCurrentGeneration() const
+{
+    return BehindAheadGeneration;
 }
 
 TString TBlocksDirtyMap::DebugPrintPBuffers()
@@ -830,6 +870,20 @@ TString TBlocksDirtyMap::DebugPrintBehind() const
             continue;
         }
         result << "  " << PrintHostIndex(h) << ": " << behind << "\n";
+    }
+    return result;
+}
+
+TString TBlocksDirtyMap::DebugPrintAheadBehindBrief() const
+{
+    TStringBuilder result;
+    result << "gen:" << GetCurrentGeneration() << "/" << PersistedGeneration
+           << " ";
+    for (THostIndex h = 0; h < GetHostCount(); ++h) {
+        auto brief = DDiskStates[h].DebugPrintAheadBehindBrief();
+        if (brief) {
+            result << PrintHostIndex(h) << ":" << brief;
+        }
     }
     return result;
 }
@@ -967,6 +1021,36 @@ void TBlocksDirtyMap::InflightFlushFinished(TBlockRange64 range)
 
             return TInflightDDiskSyncMap::EEnumerateContinuation::Continue;
         });
+}
+
+bool TBlocksDirtyMap::CheckEraseAbility(
+    TBlockRange64 range,
+    TInflightInfo& inflightInfo)
+{
+    if (BehindAheadGeneration == 0) {
+        return true;
+    }
+
+    if (inflightInfo.GetPersistGeneration() < PersistedGeneration) {
+        return true;
+    }
+
+    bool eraseBlocked = AnyOf(
+        DDiskStates,
+        [&](const TDDiskState& ddiskState)
+        {
+            return ddiskState.IsTrackingEnabled() &&
+                   ddiskState.HasBehindOverlapping(range);
+        });
+
+    if (!eraseBlocked) {
+        return true;
+    }
+
+    if (!inflightInfo.GetPersistGeneration()) {
+        inflightInfo.SetPersistGeneration(BehindAheadGeneration);
+    }
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -5,9 +5,9 @@
 #include "inflight_info.h"
 #include "range_locker.h"
 
-#include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 
 #include <library/cpp/threading/future/core/future.h>
 
@@ -15,8 +15,6 @@
 #include <util/generic/hash_set.h>
 #include <util/generic/set.h>
 #include <util/generic/vector.h>
-
-#include <span>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
@@ -51,6 +49,7 @@ struct TPBufferCounters
 class TBlocksDirtyMap
     : public ILockableRanges
     , public IReadyQueue
+    , public IBehindAheadMonitor
     , public TDisableCopyMove
     , public std::enable_shared_from_this<TBlocksDirtyMap>
 {
@@ -147,8 +146,18 @@ public:
         EPBufferCounter counter,
         size_t byteCount) override;
 
+    // IBehindAheadMonitor implementation
+    void OnBehindAheadChanged() override;
+
     [[nodiscard]] bool NeedFlush() const;
     [[nodiscard]] bool NeedErase() const;
+
+    // Persist
+    [[nodiscard]] bool NeedPersist() const;
+    [[nodiscard]] PartitionDirect::NProto::TDirtyMapState
+    GetStateForPersist() const;
+    void StatePersisted(ui32 persistGeneration);
+    [[nodiscard]] ui64 GetCurrentGeneration() const;
 
     // Debug purposes
     [[nodiscard]] TString DebugPrintPBuffers();
@@ -160,6 +169,7 @@ public:
     [[nodiscard]] TString DebugPrintReadyToErase() const;
     [[nodiscard]] TString DebugPrintAhead() const;
     [[nodiscard]] TString DebugPrintBehind() const;
+    [[nodiscard]] TString DebugPrintAheadBehindBrief() const;
     [[nodiscard]] TString DebugPrintInflightSync();
 
 private:
@@ -202,6 +212,10 @@ private:
     [[nodiscard]] bool HasInflightFlush(THostIndex host, TBlockRange64 range);
     void InflightFlushFinished(TBlockRange64 range);
 
+    [[nodiscard]] bool CheckEraseAbility(
+        TBlockRange64 range,
+        TInflightInfo& inflightInfo);
+
     const ui32 BlockSize;
     const ui64 BlockCount;
 
@@ -236,6 +250,10 @@ private:
 
     // DDisks freshness state.
     TVector<TDDiskState> DDiskStates;
+    // Changed when DDiskState changed his behind or ahead map.
+    ui32 BehindAheadGeneration = 0;
+    // Last persisted DDisks states generation.
+    ui32 PersistedGeneration = 0;
 
     // PBuffers space usage counters.
     TVector<TPBufferCounters> PBufferCounters;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -50,6 +50,13 @@ THostMask MakeHostMask(bool b0, bool b1, bool b2, bool b3, bool b4)
     return mask;
 }
 
+void FlushAll(const TFlushHints& flushHint, TBlocksDirtyMap& dirtyMap)
+{
+    for (const auto& [route, hint]: flushHint.GetAllHints()) {
+        dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -609,18 +616,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto flushHint = dirtyMap->MakeFlushHint(2);
         UNIT_ASSERT(!flushHint.Empty());
         UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
-        dirtyMap->FlushFinished(
-            THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123, 124},
-            {});
-        dirtyMap->FlushFinished(
-            THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
-            {123, 124},
-            {});
-        dirtyMap->FlushFinished(
-            THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123, 124},
-            {});
+        FlushAll(flushHint, *dirtyMap);
         UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
 
         // Erasing lsn 123 from only a sub-quorum of hosts keeps it inflight, so
@@ -689,9 +685,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT(!flushHint.Empty());
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT(!eraseHints.Empty());
@@ -726,9 +720,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT(!flushHint.Empty());
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT(!eraseHints.Empty());
@@ -791,11 +783,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H2->H2:123[10..19];"
             "H3->H3:123[10..19];",
             flushHint.DebugPrint());
-
-        // Finish flushes
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
@@ -854,9 +842,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Finish flushes to every DDisk.
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // FlushCompleted recorded the flushed range in the Fresh DDisk's Ahead
         // field. Only the Fresh host H3 tracks; the Operational hosts do not.
@@ -908,11 +894,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H2->H2:123[10..19];"
             "H3->H3:123[10..19];",
             flushHint.DebugPrint());
-
-        // Finish flushes
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
@@ -971,11 +953,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H3->H3:123[10..19];"
             "H4->H4:123[10..19];",
             flushHint.DebugPrint());
-
-        // Finish flushes
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
@@ -1029,11 +1007,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H1->H3:123[10..19];"
             "H2->H2:123[10..19];",
             flushHint.DebugPrint());
-
-        // Finish flushes
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
@@ -1118,9 +1092,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
-        for (const auto& [route, flush]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, {MakeLsnVector(flush.Segments)}, {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Lock pbuffer
         dirtyMap->LockPBuffer(123);
@@ -1315,19 +1287,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H1->H1:123[0..99];"
             "H2->H2:123[0..99];",
             flushHint.DebugPrint());
-
-        dirtyMap->FlushFinished(
-            THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123},
-            {});
-        dirtyMap->FlushFinished(
-            THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
-            {123},
-            {});
-        dirtyMap->FlushFinished(
-            THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123},
-            {});
+        FlushAll(flushHint, *dirtyMap);
 
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1923,9 +1883,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Flush all hosts.
         auto flushHint = dirtyMap->MakeFlushHint(1);
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Disable host 0 before erase.
         vchunkConfig.DisableHost(0);
@@ -2076,9 +2034,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H1->H1:123[10..19];"
             "H2->H2:123[10..19];",
             flushHint.DebugPrint());
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         // Get erase hints and finish erase on hosts 0 and 2 only.
         auto eraseHints = dirtyMap->MakeEraseHint(1);
@@ -2168,9 +2124,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
-        for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap->FlushFinished(route, MakeLsnVector(hint.Segments), {});
-        }
+        FlushAll(flushHint, *dirtyMap);
 
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_EQUAL(false, eraseHints.Empty());
@@ -2485,6 +2439,63 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H3+{Disabled,0};"
             "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
+    }
+
+    // Exercises the full persist lifecycle:
+    //   - NeedPersist() starts false and generation is 0.
+    //   - After a flush that populates a fresh DDisk's Ahead field,
+    //     NeedPersist() becomes true and generation advances.
+    //   - GetStateForPersist() captures the generation and correct DDisk count.
+    //   - StatePersisted() resets NeedPersist() to false.
+    //   - Only Behind data (not Ahead) can block MakeEraseHint().
+    Y_UNIT_TEST(PersistLifecycleAndEraseNotBlockedByAheadData)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+
+        // H3 is fresh; writes above watermark populate its Ahead field.
+        vchunkConfig.PromoteHost(3);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 5);
+
+        auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        // Initially no changes.
+        UNIT_ASSERT_VALUES_EQUAL(false, dirtyMap->NeedPersist());
+        UNIT_ASSERT_VALUES_EQUAL(0u, dirtyMap->GetCurrentGeneration());
+
+        const THostMask requested = MakeHostMask(true, true, true, true, false);
+        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap->WriteFinished(
+            100,
+            TBlockRange64::WithLength(10, 10),
+            requested,
+            requested);
+
+        // Flush all DDIsks; H3's Ahead field changes → generation increments.
+        auto flushHint = dirtyMap->MakeFlushHint(1);
+        UNIT_ASSERT_EQUAL(false, flushHint.Empty());
+        FlushAll(flushHint, *dirtyMap);
+
+        UNIT_ASSERT_VALUES_EQUAL(true, dirtyMap->NeedPersist());
+        UNIT_ASSERT(dirtyMap->GetCurrentGeneration() > 0);
+
+        // GetStateForPersist captures current generation.
+        // Saves one entry per host slot (DirectBlockGroupHostCount = 5).
+        const ui32 gen = static_cast<ui32>(dirtyMap->GetCurrentGeneration());
+        auto state = dirtyMap->GetStateForPersist();
+        UNIT_ASSERT_VALUES_EQUAL(gen, state.GetStateGeneration());
+        UNIT_ASSERT_VALUES_EQUAL(5, state.DDiskStatesSize());
+
+        // StatePersisted() resets the persist flag.
+        dirtyMap->StatePersisted(gen);
+        UNIT_ASSERT_VALUES_EQUAL(false, dirtyMap->NeedPersist());
+
+        // Only Behind blocks erase; Ahead does not.
+        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintBehind());
+        auto eraseHints = dirtyMap->MakeEraseHint(1);
+        UNIT_ASSERT_EQUAL(false, eraseHints.Empty());
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -59,6 +59,7 @@ TInflightInfo::TInflightInfo(TInflightInfo&& other) noexcept
     , StartAt(other.StartAt)
     , PBuffersLockCount(other.PBuffersLockCount)
     , QuorumReadyPromise(std::move(other.QuorumReadyPromise))
+    , PersistGeneration(other.PersistGeneration)
     , DesiredDDisks(other.DesiredDDisks)
     , Disabled(other.Disabled)
     , WriteRequested(other.WriteRequested)
@@ -363,13 +364,25 @@ void TInflightInfo::UnlockPBuffer()
     }
 }
 
+void TInflightInfo::SetPersistGeneration(ui32 persistGeneration)
+{
+    Y_ABORT_UNLESS(PersistGeneration == 0);
+
+    PersistGeneration = persistGeneration;
+}
+
+ui64 TInflightInfo::GetPersistGeneration() const
+{
+    return PersistGeneration;
+}
+
 TString TInflightInfo::DebugPrint(TInstant now) const
 {
     TStringBuilder result;
     result << " " << FormatDuration(now - StartAt) << ", " << ToString(State)
            << ", size:" << ByteCount << ", locks:" << PBuffersLockCount
-           << ", dd:" << DesiredDDisks.Print() << ", d:" << Disabled.Print()
-           << ", wr:" << WriteRequested.Print()
+           << ", pgen:" << PersistGeneration << ", dd:" << DesiredDDisks.Print()
+           << ", d:" << Disabled.Print() << ", wr:" << WriteRequested.Print()
            << ", wc:" << WriteConfirmed.Print()
            << ", fr:" << FlushRequested.Print()
            << ", fc:" << FlushConfirmed.Print()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -178,6 +178,12 @@ public:
     // Removes the lock that prohibits erasing the PBuffer.
     void UnlockPBuffer();
 
+    // The generation of the DirtyMap persisted state. If a generation has been
+    // assigned, it means that erasing can only be started after saving of data
+    // from that or higher generation in the partition local database.
+    void SetPersistGeneration(ui32 persistGeneration);
+    ui64 GetPersistGeneration() const;
+
     TString DebugPrint(TInstant now) const;
 
 private:
@@ -204,6 +210,7 @@ private:
     TInstant StartAt;
     size_t PBuffersLockCount = 0;
     NThreading::TPromise<void> QuorumReadyPromise;
+    ui32 PersistGeneration = 0;
 
     THostMask DesiredDDisks;
     THostMask Disabled;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -1213,6 +1213,23 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
 
         EraseAll(inflightInfo);
     }
+
+    Y_UNIT_TEST(SetAndGetPersistGeneration)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeDDisks(),
+            THostMask::MakeEmpty(),
+            123,
+            4096);
+
+        UNIT_ASSERT_VALUES_EQUAL(0u, inflightInfo.GetPersistGeneration());
+        inflightInfo.SetPersistGeneration(42);
+        UNIT_ASSERT_VALUES_EQUAL(42u, inflightInfo.GetPersistGeneration());
+        TInflightInfo moved(std::move(inflightInfo));
+        UNIT_ASSERT_VALUES_EQUAL(42u, moved.GetPersistGeneration());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ya.make
@@ -15,6 +15,7 @@ SRCS(
 PEERDIR(
     ydb/core/nbs/cloud/blockstore/libs/common
     ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model
+    ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos
 
     library/cpp/threading/future
 )

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.proto
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package NYdb.NBS.PartitionDirect.NProto;
+
+message TBlockField {
+    repeated fixed32 StartAndLength = 1;
+    optional bytes BitMask = 2;
+}
+
+message TDDiskState {
+    TBlockField Ahead = 1;
+    TBlockField Behind = 2;
+}
+
+message TDirtyMapState {
+    uint32 StateGeneration = 1;
+    repeated TDDiskState DDiskStates = 2;
+}

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/ya.make
@@ -3,6 +3,7 @@ PROTO_LIBRARY()
 EXCLUDE_TAGS(GO_PROTO)
 
 SRCS(
+    dirty_map.proto
     partition_direct.proto
 )
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -330,8 +330,10 @@ TString TVChunk::DebugPrintDirtyMap()
     sb << "CloneQueue: " << BlocksDirtyMap->DebugPrintReadyToClone() << "\n";
     sb << "FlushQueue: " << BlocksDirtyMap->DebugPrintReadyToFlush() << "\n";
     sb << "EraseQueue: " << BlocksDirtyMap->DebugPrintReadyToErase() << "\n";
+    sb << "AheadBehind:" << BlocksDirtyMap->DebugPrintAheadBehindBrief()
+       << "\n";
     sb << "Ahead:\n" << BlocksDirtyMap->DebugPrintAhead();
-    sb << "Behind:\n" << BlocksDirtyMap->DebugPrintBehind();
+    sb << "Behind\n" << BlocksDirtyMap->DebugPrintBehind();
     sb << "DDiskSyncs: " << BlocksDirtyMap->DebugPrintInflightSync() << "\n";
     return sb;
 }
@@ -402,6 +404,7 @@ void TVChunk::OnBelatedWriteBlocksResponse(
     BlocksDirtyMap->UpdateBelatedEraseQueue(completedWrites, bundle->GetLsn());
 
     DoErase(false, TBlocksDirtyMap::EEraseType::Belated);
+    DoPersistDirtyMap();
     ScheduleCleaningUp();
 }
 
@@ -420,6 +423,7 @@ void TVChunk::UpdateDirtyMap(const TDBGRestoreResponse& response)
 
     DoFlush(false);
     DoErase(false, TBlocksDirtyMap::EEraseType::Standard);
+    DoPersistDirtyMap();
 }
 
 void TVChunk::DoStart()
@@ -709,6 +713,7 @@ void TVChunk::OnFlushResponse(const TFlushRequestExecutor::TResponse& response)
     UpdatePendingCounters();
 
     DoErase(false, TBlocksDirtyMap::EEraseType::Standard);
+    DoPersistDirtyMap();
     ScheduleCleaningUp();
 }
 
@@ -814,6 +819,42 @@ void TVChunk::OnEraseBelatedResponse(
     ScheduleCleaningUp();
 }
 
+void TVChunk::DoPersistDirtyMap()
+{
+    if (DirtyMapStatePersisting) {
+        return;
+    }
+    if (!BlocksDirtyMap->NeedPersist()) {
+        return;
+    }
+    DirtyMapStatePersisting = true;
+
+    auto state = BlocksDirtyMap->GetStateForPersist();
+    LOG_INFO(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s DoPersistDirtyMap: %s",
+        LogTitle.GetWithTime().c_str(),
+        state.DebugString().c_str());
+
+    DirectBlockGroup->Schedule(
+        TDuration::Seconds(1),
+        [weakSelf = weak_from_this(),
+         stateGeneration = state.GetStateGeneration()]   //
+        ()
+        {
+            if (auto self = weakSelf.lock()) {
+                self->OnDirtyMapPersisted(stateGeneration);
+            }
+        });
+}
+
+void TVChunk::OnDirtyMapPersisted(ui32 stateGeneration)
+{
+    DirtyMapStatePersisting = false;
+    BlocksDirtyMap->StatePersisted(stateGeneration);
+}
+
 void TVChunk::ScheduleCleaningUp()
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
@@ -868,6 +909,7 @@ void TVChunk::CleaningUp()
 
     DoFlush(true);
     DoErase(true, TBlocksDirtyMap::EEraseType::Standard);
+    DoPersistDirtyMap();
 }
 
 void TVChunk::UpdatePendingCounters()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -127,6 +127,9 @@ private:
     void OnEraseBelatedResponse(
         const TEraseRequestExecutor::TResponse& response);
 
+    void DoPersistDirtyMap();
+    void OnDirtyMapPersisted(ui32 stateGeneration);
+
     void ScheduleCleaningUp();
     void CleaningUp();
 
@@ -168,6 +171,7 @@ private:
     TLogTitle LogTitle;
     TVChunkConfig VChunkConfig;
     TList<TPendingVChunkConfig> PendingVChunkConfigs;
+    bool DirtyMapStatePersisting = false;
     TBlocksDirtyMapPtr BlocksDirtyMap;
     // One-shot signal of the INITIAL DirtyMap assembly at tablet start.
     NThreading::TPromise<void> DirtyMapReady = NThreading::NewPromise();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. Generate dirty map data for persisting
2. Save and load ahead/behind maps
3. Don't erase not LSNs overlapped with not persisted behind blocks

### Description for reviewers <!-- (optional) description for those who read this PR -->
