### PR TITLE
PR2.1: V2 B-tree core + write path + skip mechanism + read-path migra…

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -323,4 +323,7 @@ message TFeatureFlags {
     optional bool EnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay = 281 [default = false];
     optional bool EnableFulltextIndexPrefix = 282 [default = false];
     optional bool EnableAccessServiceV2Interface = 283 [default = false, (RequireRestart) = true];
+    optional bool EnableLocalDBBtreeIndexV2 = 284 [default = false];
+    // When EnableLocalDBBtreeIndexV2 is on complete it with V1 shadow index off
+    optional bool EnableLocalDBBtreeIndexV2ShadowV1Write = 285 [default = true];
 }

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -65,7 +65,7 @@ namespace {
                 dataPages += IndexTools::CountMainPages(*part);
                 indexBytes += part->IndexesRawSize;
                 if (useBTree) {
-                    bTreeLevels = Max(bTreeLevels, part->IndexPages.BTreeGroups[0].LevelCount);
+                    bTreeLevels = Max(bTreeLevels, part->IndexPages.BTreeGroups[0].LevelCount());
                 }
             }
             state.counters["DataBytes"] = dataBytes;

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -308,16 +308,9 @@ namespace NFwd {
     public:
         using TGroupId = NPage::TGroupId;
 
-        static TPageLocation GetRootLocation(const NPage::TBtreeIndexMeta& meta,
-            const IPageCollection* indexPageCollection, const IPageCollection* groupPageCollection)
-        {
-            return meta.LevelCount
-                ? indexPageCollection->GetLocation(meta.PageId_)
-                : groupPageCollection->GetLocation(meta.PageId_);
-        }
-
         TBTreeIndexCache(const TPart* part, TIndexPageLocator& indexPageLocator, TGroupId groupId, const TIntrusiveConstPtr<TSlices>& slices, TIntrusiveConstPtr<IPageCollection> groupPageCollection, TIntrusiveConstPtr<IPageCollection> indexPageCollection)
             : Meta(part->IndexPages.GetBTree(groupId))
+            , Part(part)
             , GroupId(groupId)
             , GroupPageCollection(std::move(groupPageCollection))
             , IndexPageCollection(std::move(indexPageCollection))
@@ -331,12 +324,12 @@ namespace NFwd {
                 EndRowId = Max<TRowId>();
             }
 
-            auto rootLoc = GetRootLocation(Meta, IndexPageCollection.Get(), GroupPageCollection.Get());
-            Levels.resize(Meta.LevelCount + 1);
+            auto rootLoc = GetBTreeRootLocation(Meta, IndexPageCollection.Get(), GroupPageCollection.Get());
+            Levels.resize(Meta.LevelCount() + 1);
             Levels[0].Queue.push_back({rootLoc.Offset, rootLoc.Size, Meta.GetDataSize(), rootLoc.Crc32});
             Levels[0].BeginOffset = rootLoc.Offset;
             Levels[0].EndOffset = rootLoc.Offset;
-            if (Meta.LevelCount) {
+            if (Meta.LevelCount()) {
                 IndexPageLocator.Add(rootLoc.Offset, GroupId, 0);
             }
         }
@@ -401,11 +394,10 @@ namespace NFwd {
             Y_ENSURE(it != level.Pages.end() && it->Offset == page.Location.Offset, "Got page that hasn't been requested for load");
 
             if (levelId + 2 < Levels.size()) { // next level is index
-                NPage::TBtreeIndexNode node(page.Data);
+                NPage::TBtreeIndexNode node(page.Data, Meta.HasRootV2());
                 for (auto pos : xrange(node.GetChildrenCount())) {
-                    auto& child = node.GetShortChild(pos);
-                    auto childOffset = IndexPageCollection->GetLocation(child.GetPageId()).Offset;
-                    IndexPageLocator.Add(childOffset, GroupId, levelId + 1);
+                    auto childLoc = node.GetChildLocation(pos, false, Part, GroupId);
+                    IndexPageLocator.Add(childLoc.Offset, GroupId, levelId + 1);
                 }
             }
 
@@ -416,15 +408,10 @@ namespace NFwd {
         }
 
     private:
-        const IPageCollection* PageCollectionForLevel(ui32 levelId) const noexcept {
-            return (&Levels[levelId] == &Levels.back())
-                ? GroupPageCollection.Get()
-                : IndexPageCollection.Get();
-        }
-
         ui32 GetLevel(TPageOffset offset, EPage type) {
             switch (type) {
                 case EPage::BTreeIndex:
+                case EPage::BTreeIndexV2:
                     return IndexPageLocator.GetLevel(offset);
                 case EPage::DataPage:
                     return Levels.size() - 1;
@@ -470,19 +457,21 @@ namespace NFwd {
                 }
 
                 if (levelId + 1 < Levels.size() && page) {
-                    NPage::TBtreeIndexNode node(page.Data);
+                    NPage::TBtreeIndexNode node(page.Data, Meta.HasRootV2());
                     auto& nextLevel = Levels[levelId + 1];
+                    bool isLeaf = (levelId + 1) == Levels.size() - 1;
                     for (auto pos : xrange(node.GetChildrenCount())) {
-                        auto& child = node.GetShortChild(pos);
-                        if (child.GetRowCount() <= BeginRowId) {
+                        if (node.GetChildRowCount(pos) <= BeginRowId) {
                             continue;
                         }
-                        auto childLoc = PageCollectionForLevel(levelId + 1)->GetLocation(child.GetPageId());
+                        auto childLoc = node.GetChildLocation(pos, isLeaf, Part, GroupId);
                         Y_ENSURE(!nextLevel.Queue || nextLevel.Queue.back().Offset < childLoc.Offset);
-                        nextLevel.Queue.push_back({childLoc.Offset, childLoc.Size, child.GetDataSize(), childLoc.Crc32});
-                        nextLevel.BeginOffset = Min(nextLevel.BeginOffset, childLoc.Offset);
-                        nextLevel.EndOffset = Max(nextLevel.EndOffset, childLoc.Offset);
-                        if (child.GetRowCount() >= EndRowId) {
+                        nextLevel.Queue.push_back({childLoc.Offset, childLoc.Size, node.GetChildDataSize(pos), childLoc.Crc32});
+                        if (nextLevel.BeginOffset == TPageOffset::Max()) {
+                            nextLevel.BeginOffset = childLoc.Offset;
+                        }
+                        nextLevel.EndOffset = childLoc.Offset;
+                        if (node.GetChildRowCount(pos) >= EndRowId) {
                             break;
                         }
                     }
@@ -539,7 +528,8 @@ namespace NFwd {
             Y_ENSURE(!level.Queue.empty());
             auto& front = level.Queue.front();
 
-            auto type = &level == &Levels.back() ? EPage::DataPage : EPage::BTreeIndex;
+            auto type = &level == &Levels.back() ? EPage::DataPage
+                : (Meta.HasRootV2() ? EPage::BTreeIndexV2 : EPage::BTreeIndex);
             head->AddToQueue(front.Offset, type, front.PageSize, front.Crc32);
 
             Stat.Fetch += front.PageSize;
@@ -553,6 +543,7 @@ namespace NFwd {
 
     private:
         const NPage::TBtreeIndexMeta& Meta;
+        const TPart* Part;
         const TGroupId GroupId;
         TIntrusiveConstPtr<IPageCollection> GroupPageCollection;
         TIntrusiveConstPtr<IPageCollection> IndexPageCollection;

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -531,20 +531,20 @@ namespace NKikimr::NTable::NPage {
 
         const TShortChildV2& GetShortChildV2(TRecIdx pos) const noexcept
         {
-            Y_DEBUG_ABORT_UNLESS(IsV2Format,"GetShortChildV2 called on v1 node");
+            Y_DEBUG_ABORT_UNLESS(IsV2Format, "GetShortChildV2 called on v1 node");
             return *TDeref<const TShortChildV2>::At(Children, pos * ChildStructSize());
         }
 
         const TChildV2& GetChildV2(TRecIdx pos) const noexcept
         {
-            Y_DEBUG_ABORT_UNLESS(IsV2Format,"GetChildV2 called on v1 node");
+            Y_DEBUG_ABORT_UNLESS(IsV2Format, "GetChildV2 called on v1 node");
             Y_DEBUG_ABORT_UNLESS(!Header->IsShortChildFormat, "GetShortChildV2 should be used instead");
             return *TDeref<const TChildV2>::At(Children, pos * ChildStructSize());
         }
 
         TPageId GetChildV1PageId(TRecIdx pos) const noexcept
         {
-            Y_DEBUG_ABORT_UNLESS(!IsV2Format,"GetChildV1PageId called on v2 node");
+            Y_DEBUG_ABORT_UNLESS(!IsV2Format, "GetChildV1PageId called on v2 node");
             return IsShortChildFormat() ? GetShortChildV1(pos).GetPageId()
                                         : GetChildV1(pos).GetPageId();
         }
@@ -552,7 +552,7 @@ namespace NKikimr::NTable::NPage {
         /// Returns the child's inline TPageLocation (v2 only).
         TPageLocation GetChildV2Location(TRecIdx pos, EPage type) const noexcept
         {
-            Y_DEBUG_ABORT_UNLESS(IsV2Format,"GetChildV2Location called on V1 node");
+            Y_DEBUG_ABORT_UNLESS(IsV2Format, "GetChildV2Location called on V1 node");
             return IsShortChildFormat() ? GetShortChildV2(pos).GetLocation(type)
                                         : GetChildV2(pos).GetLocation(type);
         }

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <variant>
+
 #include <ydb/core/base/defs.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <util/generic/bitmap.h>
@@ -45,6 +47,21 @@ namespace NKikimr::NTable::NPage {
         - TKey[N] - keys data                <-- fixed-size
         - TChild[N+1] - children
     */
+
+    /// Universal page reference — either a V1 page ID or a V2 byte-offset location.
+    struct TPageRef : std::variant<TPageId, TPageLocation> {
+        using TBase = std::variant<TPageId, TPageLocation>;
+        using TBase::variant;
+
+        bool IsValid() const noexcept {
+            return !(std::holds_alternative<TPageLocation>(*this) && !std::get<TPageLocation>(*this));
+        }
+
+        bool operator==(const TPageRef& other) const {
+            return static_cast<const TBase&>(*this) == static_cast<const TBase&>(other);
+        }
+        bool operator!=(const TPageRef& other) const { return !(*this == other); }
+    };
 
     class TBtreeIndexNode {
     public:
@@ -164,6 +181,119 @@ namespace NKikimr::NTable::NPage {
         static_assert(offsetof(TChild, PageId_) == offsetof(TShortChild, PageId_));
         static_assert(offsetof(TChild, RowCount_) == offsetof(TShortChild, RowCount_));
         static_assert(offsetof(TChild, DataSize_) == offsetof(TShortChild, DataSize_));
+
+        struct TShortChildV2 {
+            TPageOffset Offset_; // 8 bytes — byte offset or page index
+            ui64 Size_;          // 8 bytes — page body size
+            ui32 Crc32_;         // 4 bytes
+            TRowId RowCount_;    // 8 bytes  (cumulative)
+            ui64 DataSize_;      // 8 bytes  (cumulative)
+
+            auto operator<=>(const TShortChildV2&) const = default;
+
+            inline TPageOffset GetOffset() const noexcept {
+                return Offset_;
+            }
+
+            inline ui64 GetSize() const noexcept {
+                return Size_;
+            }
+
+            inline ui32 GetCrc32() const noexcept {
+                return Crc32_;
+            }
+
+            inline TRowId GetRowCount() const noexcept {
+                return RowCount_;
+            }
+
+            inline ui64 GetDataSize() const noexcept {
+                return DataSize_;
+            }
+
+            TPageLocation GetLocation(EPage type) const noexcept {
+                return {Offset_, Size_, type, Crc32_};
+            }
+
+            TString ToString() const {
+                return TStringBuilder() << "Offset: " << GetOffset() << " Size: " << GetSize()
+                    << " RowCount: " << GetRowCount() << " DataSize: " << GetDataSize();
+            }
+        } Y_PACKED;
+
+        static_assert(sizeof(TShortChildV2) == 36, "Invalid TBtreeIndexNode TShortChildV2 size");
+
+        struct TChildV2 {
+            TPageOffset Offset_;    // 8 bytes — byte offset or page index
+            ui64 Size_;             // 8 bytes — page body size
+            ui32 Crc32_;            // 4 bytes
+            TRowId RowCount_;       // 8 bytes  (cumulative)
+            ui64 DataSize_;         // 8 bytes  (cumulative)
+            ui64 GroupDataSize_;    // 8 bytes  (cumulative)
+            TRowId ErasedRowCount_; // 8 bytes  (cumulative)
+
+            auto operator<=>(const TChildV2&) const = default;
+
+            inline TPageOffset GetOffset() const noexcept {
+                return Offset_;
+            }
+
+            inline ui64 GetSize() const noexcept {
+                return Size_;
+            }
+
+            inline ui32 GetCrc32() const noexcept {
+                return Crc32_;
+            }
+
+            inline TRowId GetRowCount() const noexcept {
+                return RowCount_;
+            }
+
+            inline ui64 GetDataSize() const noexcept {
+                return DataSize_;
+            }
+
+            inline ui64 GetGroupDataSize() const noexcept {
+                return GroupDataSize_;
+            }
+
+            inline TRowId GetErasedRowCount() const noexcept {
+                return ErasedRowCount_;
+            }
+
+            inline TRowId GetNonErasedRowCount() const noexcept {
+                return RowCount_ - ErasedRowCount_;
+            }
+
+            inline ui64 GetTotalDataSize() const noexcept {
+                return DataSize_ + GroupDataSize_;
+            }
+
+            TPageLocation GetLocation(EPage type) const noexcept {
+                return {Offset_, Size_, type, Crc32_};
+            }
+
+            TString ToString() const {
+                TStringBuilder result;
+                result << "Offset: " << GetOffset() << " Size: " << GetSize()
+                    << " RowCount: " << GetRowCount() << " DataSize: " << GetDataSize();
+                if (GetGroupDataSize()) {
+                    result << " GroupDataSize: " << GetGroupDataSize();
+                }
+                result << " ErasedRowCount: " << GetErasedRowCount();
+                return result;
+            }
+        } Y_PACKED;
+
+        static_assert(sizeof(TChildV2) == 52, "Invalid TBtreeIndexNode TChildV2 size");
+
+        // Common-field offset compatibility between long and short v2 children
+        static_assert(offsetof(TChildV2, Offset_) == offsetof(TShortChildV2, Offset_));
+        static_assert(offsetof(TChildV2, Size_) == offsetof(TShortChildV2, Size_));
+        static_assert(offsetof(TChildV2, Crc32_) == offsetof(TShortChildV2, Crc32_));
+        static_assert(offsetof(TChildV2, RowCount_) == offsetof(TShortChildV2, RowCount_));
+        static_assert(offsetof(TChildV2, DataSize_) == offsetof(TShortChildV2, DataSize_));
 
 #pragma pack(pop)
 
@@ -315,10 +445,11 @@ namespace NKikimr::NTable::NPage {
         // Version = 0 didn't have GroupDataSize field
         static const ui16 FormatVersion = 1;
 
-        TBtreeIndexNode(TSharedData raw)
+        TBtreeIndexNode(TSharedData raw, bool v2Format)
             : Raw(std::move(raw))
+            , IsV2Format(v2Format)
         {
-            const auto data = NPage::TLabelWrapper().Read(Raw, EPage::BTreeIndex);
+            const auto data = NPage::TLabelWrapper().Read(Raw, v2Format ? EPage::BTreeIndexV2 : EPage::BTreeIndex);
 
             Y_ENSURE(data == ECodec::Plain && data.Version == FormatVersion);
 
@@ -335,8 +466,8 @@ namespace NKikimr::NTable::NPage {
             }
             offset += Header->KeysSize;
 
-            Children = TDeref<const TChild>::At(Header, offset);
-            offset += (1 + Header->KeysCount) * (Header->IsShortChildFormat ? sizeof(TShortChild) : sizeof(TChild));
+            Children = TDeref<const char>::At(Header, offset);
+            offset += (1 + Header->KeysCount) * ChildStructSize();
 
             Y_ENSURE(offset == data.Page.size());
         }
@@ -354,6 +485,14 @@ namespace NKikimr::NTable::NPage {
         bool IsFixedFormat() const noexcept
         {
             return Header->FixedKeySize != Header->MaxFixedKeySize;
+        }
+
+        size_t ChildStructSize() const noexcept
+        {
+            if (IsV2Format) {
+                return Header->IsShortChildFormat ? sizeof(TShortChildV2) : sizeof(TChildV2);
+            }
+            return Header->IsShortChildFormat ? sizeof(TShortChild) : sizeof(TChild);
         }
 
         TRecIdx GetKeysCount() const noexcept
@@ -376,26 +515,142 @@ namespace NKikimr::NTable::NPage {
             return GetCells<TCellsIter>(pos, columns);
         }
 
-        const TShortChild* GetShortChildRef(TRecIdx pos) const noexcept
+    private:
+        const TShortChild& GetShortChildV1(TRecIdx pos) const noexcept
         {
-            return TDeref<const TShortChild>::At(Children, 
-                pos * (Header->IsShortChildFormat ? sizeof(TShortChild) : sizeof(TChild)));
+            Y_DEBUG_ABORT_UNLESS(!IsV2Format, "GetShortChildV1 called on v2 node, use GetShortChildV2");
+            return *TDeref<const TShortChild>::At(Children, pos * ChildStructSize());
         }
 
-        const TShortChild& GetShortChild(TRecIdx pos) const noexcept
+        const TChild& GetChildV1(TRecIdx pos) const
         {
-            return *GetShortChildRef(pos);
+            Y_DEBUG_ABORT_UNLESS(!IsV2Format, "GetChildV2/GetShortChildV2 should be used instead");
+            Y_DEBUG_ABORT_UNLESS(!Header->IsShortChildFormat, "GetShortChildV1 should be used instead");
+            return *TDeref<const TChild>::At(Children, pos * ChildStructSize());
         }
 
-        const TChild* GetChildRef(TRecIdx pos) const
+        const TShortChildV2& GetShortChildV2(TRecIdx pos) const noexcept
         {
-            Y_DEBUG_ABORT_UNLESS(!Header->IsShortChildFormat, "GetShortChildRef should be used instead");
-            return TDeref<const TChild>::At(Children, pos * sizeof(TChild));
+            Y_DEBUG_ABORT_UNLESS(IsV2Format,"GetShortChildV2 called on v1 node");
+            return *TDeref<const TShortChildV2>::At(Children, pos * ChildStructSize());
         }
 
-        const TChild& GetChild(TRecIdx pos) const
+        const TChildV2& GetChildV2(TRecIdx pos) const noexcept
         {
-            return *GetChildRef(pos);
+            Y_DEBUG_ABORT_UNLESS(IsV2Format,"GetChildV2 called on v1 node");
+            Y_DEBUG_ABORT_UNLESS(!Header->IsShortChildFormat, "GetShortChildV2 should be used instead");
+            return *TDeref<const TChildV2>::At(Children, pos * ChildStructSize());
+        }
+
+        TPageId GetChildV1PageId(TRecIdx pos) const noexcept
+        {
+            Y_DEBUG_ABORT_UNLESS(!IsV2Format,"GetChildV1PageId called on v2 node");
+            return IsShortChildFormat() ? GetShortChildV1(pos).GetPageId()
+                                        : GetChildV1(pos).GetPageId();
+        }
+
+        /// Returns the child's inline TPageLocation (v2 only).
+        TPageLocation GetChildV2Location(TRecIdx pos, EPage type) const noexcept
+        {
+            Y_DEBUG_ABORT_UNLESS(IsV2Format,"GetChildV2Location called on V1 node");
+            return IsShortChildFormat() ? GetShortChildV2(pos).GetLocation(type)
+                                        : GetChildV2(pos).GetLocation(type);
+        }
+
+    public:
+        /// Returns the child at pos as a version-agnostic TPageRef.
+        /// V2 children carry byte-offset TPageLocation inline.
+        /// V1 children carry TPageId (resolve via ResolvePageLocation/Part->GetPageLocation).
+        TPageRef GetChild(TRecIdx pos, bool isLeafLevel) const noexcept {
+            if (IsV2Format) {
+                auto type = isLeafLevel ? EPage::DataPage : EPage::BTreeIndexV2;
+                return GetChildV2Location(pos, type);
+            }
+            return GetChildV1PageId(pos);
+        }
+
+        TRowId GetChildRowCount(TRecIdx pos) const noexcept
+        {
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos).GetRowCount()
+                                            : GetChildV2(pos).GetRowCount();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos).GetRowCount()
+                                        : GetChildV1(pos).GetRowCount();
+        }
+
+        template<typename TPartType>
+        TPageLocation GetChildLocation(TRecIdx pos, bool isLeafLevel, const TPartType* part, TGroupId groupId) const {
+            auto ref = GetChild(pos, isLeafLevel);
+            if (auto* loc = std::get_if<TPageLocation>(&ref)) {
+                return *loc;
+            }
+            return part->GetPageLocation(std::get<TPageId>(ref), isLeafLevel ? groupId : TGroupId{});
+        }
+
+        TString ChildToString(TRecIdx pos) const {
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos).ToString()
+                                            : GetChildV2(pos).ToString();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos).ToString()
+                                        : GetChildV1(pos).ToString();
+        }
+
+        /// Version-aware data size access for short children.
+        ui64 GetChildDataSize(TRecIdx pos) const noexcept
+        {
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos).GetDataSize()
+                                            : GetChildV2(pos).GetDataSize();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos).GetDataSize()
+                                        : GetChildV1(pos).GetDataSize();
+        }
+
+        /// Version-aware cumulative row count for the child at pos.
+        TRowId GetChildNonErasedRowCount(TRecIdx pos) const noexcept
+        {
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos).GetRowCount()
+                                            : GetChildV2(pos).GetNonErasedRowCount();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos).GetRowCount()
+                                        : GetChildV1(pos).GetNonErasedRowCount();
+        }
+
+        /// Version-aware previous child cumulative data size.
+        ui64 GetPrevChildDataSize(TRecIdx pos) const noexcept
+        {
+            if (pos == 0) return 0;
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos - 1).GetDataSize()
+                                            : GetChildV2(pos - 1).GetDataSize();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos - 1).GetDataSize()
+                                        : GetChildV1(pos - 1).GetDataSize();
+        }
+
+        /// Version-aware previous child non-erased row count.
+        TRowId GetPrevChildNonErasedRowCount(TRecIdx pos) const noexcept
+        {
+            if (pos == 0) return 0;
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos - 1).GetRowCount()
+                                            : GetChildV2(pos - 1).GetNonErasedRowCount();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos - 1).GetRowCount()
+                                        : GetChildV1(pos - 1).GetNonErasedRowCount();
+        }
+
+        ui64 GetChildTotalDataSize(TRecIdx pos) const noexcept
+        {
+            if (IsV2Format) {
+                return IsShortChildFormat() ? GetShortChildV2(pos).GetDataSize()
+                                            : GetChildV2(pos).GetTotalDataSize();
+            }
+            return IsShortChildFormat() ? GetShortChildV1(pos).GetDataSize()
+                                        : GetChildV1(pos).GetTotalDataSize();
         }
 
         static bool Has(TRowId rowId, TRowId beginRowId, TRowId endRowId) noexcept {
@@ -412,19 +667,19 @@ namespace NKikimr::NTable::NPage {
 
             auto range = xrange(0u, childrenCount);
             const auto cmp = [this](TRowId rowId, TPos pos) {
-                return rowId < GetShortChild(pos).GetRowCount();
+                return rowId < GetChildRowCount(pos);
             };
 
             TRecIdx result;
             if (!on) {
                 // Will do a full binary search on full range
-            } else if (GetShortChild(*on).GetRowCount() <= rowId) {
+            } else if (GetChildRowCount(*on) <= rowId) {
                 // Try a short linear search first
                 result = *on;
                 for (int linear = 0; linear < 4; ++linear) {
                     result++;
                     Y_ENSURE(result < childrenCount, "Should always seek some child");
-                    if (GetShortChild(result).GetRowCount() > rowId) {
+                    if (GetChildRowCount(result) > rowId) {
                         return result;
                     }
                 }
@@ -438,7 +693,7 @@ namespace NKikimr::NTable::NPage {
                     if (result == 0) {
                         return 0;
                     }
-                    if (GetShortChild(result - 1).GetRowCount() <= rowId) {
+                    if (GetChildRowCount(result - 1) <= rowId) {
                         return result;
                     }
                     result--;
@@ -547,17 +802,75 @@ namespace NKikimr::NTable::NPage {
         const void* Keys = nullptr;
         const TRecordsEntry* Offsets = nullptr;
         const void* Children = nullptr;
+        bool IsV2Format = false;
     };
 
-    struct TBtreeIndexMeta : public TBtreeIndexNode::TChild {
-        ui32 LevelCount;
-        ui64 IndexSize;
+    struct TBtreeIndexMeta {
+        TPageId RootV1 = Max<TPageId>();
+        TPageLocation RootV2 = {};
+        TRowId RowCount_ = {};
+        ui64 DataSize_ = {};
+        ui64 GroupDataSize_ = {};
+        TRowId ErasedRowCount_ = {};
+        ui32 LevelCountV1 = Max<ui32>();
+        ui32 LevelCountV2 = Max<ui32>();
+        ui64 IndexSize = 0;
 
         auto operator<=>(const TBtreeIndexMeta&) const = default;
 
+        /// Root location for v2 format — root page carries full byte-offset location.
+        static TPageLocation RootV2Location(ui64 offset, ui64 size, ui32 crc32, EPage type) noexcept {
+            return TPageLocation::FromByteOffset(offset, size, type, crc32);
+        }
+
+        /// Returns true when the v1 root (page-id reference) is available.
+        bool HasRootV1() const noexcept
+        {
+            return RootV1 != Max<TPageId>();
+        }
+
+        /// Returns true when the v2 root (byte-offset location) is available.
+        bool HasRootV2() const noexcept
+        {
+            return RootV2 && RootV2.Offset.IsByteOffset();
+        }
+
+        /// Returns true when a V2-specific level count is available (non-sentinel).
+        bool HasLevelCountV2() const noexcept
+        {
+            return LevelCountV2 != Max<ui32>();
+        }
+
+        /// Returns the active tree's level count. V2 takes precedence.
+        ui32 LevelCount() const noexcept
+        {
+            return HasRootV2() ? LevelCountV2 : LevelCountV1;
+        }
+
+        /// Returns the root PageId for v1 format, or Max<TPageId>() when v1 root is not available.
+        TPageId RootV1PageId() const noexcept
+        {
+            return RootV1;
+        }
+
+        inline TRowId GetRowCount() const noexcept { return RowCount_; }
+        inline ui64 GetDataSize() const noexcept { return DataSize_; }
+        inline ui64 GetGroupDataSize() const noexcept { return GroupDataSize_; }
+        inline TRowId GetErasedRowCount() const noexcept { return ErasedRowCount_; }
+        inline TRowId GetNonErasedRowCount() const noexcept { return RowCount_ - ErasedRowCount_; }
+        inline ui64 GetTotalDataSize() const noexcept { return DataSize_ + GroupDataSize_; }
+
         TString ToString() const
         {
-            return TStringBuilder() << TBtreeIndexNode::TChild::ToString() << " LevelCount: " << LevelCount << " IndexSize: " << IndexSize;
+            TStringBuilder result;
+            result << "RootV1: " << RootV1PageId() << " RootV2: " << RootV2
+                << " RowCount: " << GetRowCount() << " DataSize: " << GetDataSize();
+            if (GetGroupDataSize()) {
+                result << " GroupDataSize: " << GetGroupDataSize();
+            }
+            result << " ErasedRowCount: " << GetErasedRowCount()
+                << " LevelCountV1: " << LevelCountV1 << " LevelCountV2: " << LevelCountV2 << " IndexSize: " << IndexSize;
+            return result;
         }
     };
 }

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -14,13 +14,14 @@ namespace NKikimr::NTable::NPage {
         using TChild = TBtreeIndexNode::TChild;
         using TShortChildV2 = TBtreeIndexNode::TShortChildV2;
         using TChildV2 = TBtreeIndexNode::TChildV2;
-        using TChildVariant = std::variant<TChild, TChildV2>;
+        using TChildren = std::variant<TVector<TChild>, TVector<TChildV2>>;
 
     public:
         TBtreeIndexNodeWriter(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId, bool writeV2 = false)
             : Scheme(std::move(scheme))
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
+            , Children(writeV2 ? TChildren(std::in_place_index<1>) : TChildren(std::in_place_index<0>))
             , WriteV2(writeV2)
         {
             if (GroupId.IsMain()) {
@@ -58,19 +59,19 @@ namespace NKikimr::NTable::NPage {
         void AddChild(TChild child) {
             Y_ENSURE(!WriteV2, "Use AddChild(TChildV2) for v2 format");
             Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
-            Children.push_back(std::variant<TChild, TChildV2>(std::in_place_type<TChild>, child));
+            std::get<TVector<TChild>>(Children).push_back(std::move(child));
         }
 
         void AddChild(TChildV2 child) {
             Y_ENSURE(WriteV2, "Use AddChild(TChild) for v1 format");
             Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
-            Children.push_back(std::variant<TChild, TChildV2>(std::in_place_type<TChildV2>, child));
+            std::get<TVector<TChildV2>>(Children).push_back(std::move(child));
         }
 
         void EnsureEmpty() {
             Y_ENSURE(!Keys);
             Y_ENSURE(!KeysSize);
-            Y_ENSURE(!Children);
+            Y_ENSURE(std::visit([](const auto& v) { return v.empty(); }, Children));
             Y_ENSURE(!Ptr);
             Y_ENSURE(!End);
         }
@@ -78,7 +79,7 @@ namespace NKikimr::NTable::NPage {
         void Reset() {
             Keys.clear();
             KeysSize = 0;
-            Children.clear();
+            std::visit([](auto& v) { v.clear(); }, Children);
             Ptr = 0;
             End = 0;
         }
@@ -110,7 +111,7 @@ namespace NKikimr::NTable::NPage {
 
         TSharedData Finish() {
             Y_ENSURE(Keys.size());
-            Y_ENSURE(Children.size() == Keys.size() + 1);
+            Y_ENSURE(std::visit([](const auto& v) { return v.size(); }, Children) == Keys.size() + 1);
 
             size_t pageSize = CalcPageSize();
             TSharedData buf = TSharedData::Uninitialized(pageSize);
@@ -149,10 +150,12 @@ namespace NKikimr::NTable::NPage {
             Keys.clear();
             KeysSize = 0;
 
-            for (auto &child : Children) {
-                std::visit([this](const auto& c) { PlaceChild(c); }, child);
-            }
-            Children.clear();
+            std::visit([this](auto& vec) {
+                for (const auto& c : vec) {
+                    PlaceChild(c);
+                }
+                vec.clear();
+            }, Children);
 
             Y_ENSURE(Ptr == End);
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
@@ -321,7 +324,7 @@ namespace NKikimr::NTable::NPage {
         TVector<TString> Keys;
         size_t KeysSize = 0;
 
-        TVector<TChildVariant> Children;
+        TChildren Children;
         const bool WriteV2;
 
         char* Ptr = 0;

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -331,13 +331,14 @@ namespace NKikimr::NTable::NPage {
         const char* End = 0;
     };
 
+    template <typename TChildT = TBtreeIndexNode::TChild>
     class TBtreeIndexBuilder {
     public:
         using TShortChild = TBtreeIndexNode::TShortChild;
         using TChild = TBtreeIndexNode::TChild;
         using TShortChildV2 = TBtreeIndexNode::TShortChildV2;
         using TChildV2 = TBtreeIndexNode::TChildV2;
-        using TChildVariant = std::variant<TChild, TChildV2>;
+        static constexpr bool WriteV2 = std::is_same_v<TChildT, TChildV2>;
 
     private:
         struct TLevel {
@@ -354,13 +355,13 @@ namespace NKikimr::NTable::NPage {
                 return std::move(key);
             }
 
-            void PushChild(TChildVariant child) {
+            void PushChild(TChildT child) {
                 Children.push_back(std::move(child));
             }
 
-            TChildVariant PopChild() {
+            TChildT PopChild() {
                 Y_ENSURE(Children);
-                TChildVariant result = std::move(Children.front());
+                TChildT result = std::move(Children.front());
                 Children.pop_front();
                 return result;
             }
@@ -380,16 +381,16 @@ namespace NKikimr::NTable::NPage {
         private:
             size_t KeysSize = 0;
             TDeque<TString> Keys;
-            TDeque<TChildVariant> Children;
+            TDeque<TChildT> Children;
         };
 
     public:
         TBtreeIndexBuilder(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId, ui32 nodeTargetSize,
-                           ui32 nodeKeysMin, ui32 nodeKeysMax, bool writeV2 = false)
+                           ui32 nodeKeysMin, ui32 nodeKeysMax)
             : Scheme(std::move(scheme))
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
-            , Writer(Scheme, groupId, writeV2)
+            , Writer(Scheme, groupId, WriteV2)
             , Levels(1)
             , NodeTargetSize(nodeTargetSize)
             , NodeKeysMin(nodeKeysMin)
@@ -418,32 +419,24 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddShortChild(TShortChild child) {
+            static_assert(std::is_same_v<TChildT, TChild>, "V1 short child requires V1 builder");
             AddChild(TChild{child.GetPageId(), child.GetRowCount(), child.GetDataSize(), 0, 0});
         }
 
         void AddShortChild(TShortChildV2 child) {
+            static_assert(std::is_same_v<TChildT, TChildV2>, "V2 short child requires V2 builder");
             AddChild(
                 TChildV2{child.Offset_, child.Size_, child.Crc32_, child.GetRowCount(), child.GetDataSize(), 0, 0});
         }
 
-        void AddChild(TChild child) {
+        void AddChild(TChildT child) {
             // aggregate in order to perform search by row id from any leaf node
             child.RowCount_ = (ChildRowCount += child.GetRowCount());
             child.DataSize_ = (ChildDataSize += child.GetDataSize());
             child.GroupDataSize_ = (ChildGroupDataSize += child.GetGroupDataSize());
             child.ErasedRowCount_ = (ChildErasedRowCount += child.GetErasedRowCount());
 
-            Levels[0].PushChild(child);
-        }
-
-        void AddChild(TChildV2 child) {
-            // aggregate in order to perform search by row id from any leaf node
-            child.RowCount_ = (ChildRowCount += child.GetRowCount());
-            child.DataSize_ = (ChildDataSize += child.GetDataSize());
-            child.GroupDataSize_ = (ChildGroupDataSize += child.GetGroupDataSize());
-            child.ErasedRowCount_ = (ChildErasedRowCount += child.GetErasedRowCount());
-
-            Levels[0].PushChild(child);
+            Levels[0].PushChild(std::move(child));
         }
 
         void Flush(IPageWriter &pager) {
@@ -469,7 +462,7 @@ namespace NKikimr::NTable::NPage {
                     Y_ENSURE(levelIndex + 1 == Levels.size(), "Should be root");
 
                     auto rootChild = Levels[levelIndex].PopChild();
-                    return std::visit([&](const auto& c) { return MakeMeta(c, levelIndex, IndexSize); }, rootChild);
+                    return MakeMeta(rootChild, levelIndex, IndexSize);
                 }
 
                 DoFlush(levelIndex, pager, true);
@@ -537,10 +530,10 @@ namespace NKikimr::NTable::NPage {
                 Levels.emplace_back();
                 Y_ENSURE(Levels.size() < Max<ui32>(), "Levels size is out of bounds");
             }
-            if (auto* v1 = std::get_if<TChild>(&lastChild)) {
-                FillChildLocation(*v1, pageId);
+            if constexpr (WriteV2) {
+                FillChildLocation(lastChild, location);
             } else {
-                FillChildLocation(std::get<TChildV2>(lastChild), location);
+                FillChildLocation(lastChild, pageId);
             }
             Levels[levelIndex + 1].PushChild(std::move(lastChild));
             if (!last) {
@@ -556,12 +549,12 @@ namespace NKikimr::NTable::NPage {
             }
         }
 
-        void AddChildToWriter(const TChildVariant& child) {
-            std::visit([this](const auto& c) { Writer.AddChild(c); }, child);
+        void AddChildToWriter(const TChildT& child) {
+            Writer.AddChild(child);
         }
 
-        void AddChildToWriter(TChildVariant&& child) {
-            std::visit([this](auto&& c) { Writer.AddChild(std::move(c)); }, std::move(child));
+        void AddChildToWriter(TChildT&& child) {
+            Writer.AddChild(std::move(child));
         }
 
         static void FillChildLocation(TChild& child, TPageId pageId) {

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -3,10 +3,9 @@
 #include "flat_page_btree_index.h"
 #include "flat_part_iface.h"
 
-#include <variant>
-
 namespace NKikimr::NTable::NPage {
 
+    template <typename TChildT = TBtreeIndexNode::TChild>
     class TBtreeIndexNodeWriter {
         using THeader = TBtreeIndexNode::THeader;
         using TIsNullBitmap = TBtreeIndexNode::TIsNullBitmap;
@@ -14,15 +13,13 @@ namespace NKikimr::NTable::NPage {
         using TChild = TBtreeIndexNode::TChild;
         using TShortChildV2 = TBtreeIndexNode::TShortChildV2;
         using TChildV2 = TBtreeIndexNode::TChildV2;
-        using TChildren = std::variant<TVector<TChild>, TVector<TChildV2>>;
+        static constexpr bool WriteV2 = std::is_same_v<TChildT, TChildV2>;
 
     public:
-        TBtreeIndexNodeWriter(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId, bool writeV2 = false)
+        TBtreeIndexNodeWriter(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId)
             : Scheme(std::move(scheme))
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
-            , Children(writeV2 ? TChildren(std::in_place_index<1>) : TChildren(std::in_place_index<0>))
-            , WriteV2(writeV2)
         {
             if (GroupId.IsMain()) {
                 // TODO: some main groups without nulls and var-sized cells also may use fixed format
@@ -56,22 +53,15 @@ namespace NKikimr::NTable::NPage {
             Keys.emplace_back(std::move(key));
         }
 
-        void AddChild(TChild child) {
-            Y_ENSURE(!WriteV2, "Use AddChild(TChildV2) for v2 format");
+        void AddChild(TChildT child) {
             Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
-            std::get<TVector<TChild>>(Children).push_back(std::move(child));
-        }
-
-        void AddChild(TChildV2 child) {
-            Y_ENSURE(WriteV2, "Use AddChild(TChild) for v1 format");
-            Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
-            std::get<TVector<TChildV2>>(Children).push_back(std::move(child));
+            Children.push_back(std::move(child));
         }
 
         void EnsureEmpty() {
             Y_ENSURE(!Keys);
             Y_ENSURE(!KeysSize);
-            Y_ENSURE(std::visit([](const auto& v) { return v.empty(); }, Children));
+            Y_ENSURE(!Children);
             Y_ENSURE(!Ptr);
             Y_ENSURE(!End);
         }
@@ -79,7 +69,7 @@ namespace NKikimr::NTable::NPage {
         void Reset() {
             Keys.clear();
             KeysSize = 0;
-            std::visit([](auto& v) { v.clear(); }, Children);
+            Children.clear();
             Ptr = 0;
             End = 0;
         }
@@ -111,7 +101,7 @@ namespace NKikimr::NTable::NPage {
 
         TSharedData Finish() {
             Y_ENSURE(Keys.size());
-            Y_ENSURE(std::visit([](const auto& v) { return v.size(); }, Children) == Keys.size() + 1);
+            Y_ENSURE(Children.size() == Keys.size() + 1);
 
             size_t pageSize = CalcPageSize();
             TSharedData buf = TSharedData::Uninitialized(pageSize);
@@ -150,12 +140,10 @@ namespace NKikimr::NTable::NPage {
             Keys.clear();
             KeysSize = 0;
 
-            std::visit([this](auto& vec) {
-                for (const auto& c : vec) {
-                    PlaceChild(c);
-                }
-                vec.clear();
-            }, Children);
+            for (auto& c : Children) {
+                PlaceChild(c);
+            }
+            Children.clear();
 
             Y_ENSURE(Ptr == End);
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
@@ -324,8 +312,7 @@ namespace NKikimr::NTable::NPage {
         TVector<TString> Keys;
         size_t KeysSize = 0;
 
-        TChildren Children;
-        const bool WriteV2;
+        TVector<TChildT> Children;
 
         char* Ptr = 0;
         const char* End = 0;
@@ -390,7 +377,7 @@ namespace NKikimr::NTable::NPage {
             : Scheme(std::move(scheme))
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
-            , Writer(Scheme, groupId, WriteV2)
+            , Writer(Scheme, groupId)
             , Levels(1)
             , NodeTargetSize(nodeTargetSize)
             , NodeKeysMin(nodeKeysMin)
@@ -599,7 +586,7 @@ namespace NKikimr::NTable::NPage {
     private:
         ui64 IndexSize = 0;
 
-        TBtreeIndexNodeWriter Writer;
+        TBtreeIndexNodeWriter<TChildT> Writer;
         TVector<TLevel> Levels; // from bottom to top
 
         const ui32 NodeTargetSize;

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -3,6 +3,8 @@
 #include "flat_page_btree_index.h"
 #include "flat_part_iface.h"
 
+#include <variant>
+
 namespace NKikimr::NTable::NPage {
 
     class TBtreeIndexNodeWriter {
@@ -10,12 +12,16 @@ namespace NKikimr::NTable::NPage {
         using TIsNullBitmap = TBtreeIndexNode::TIsNullBitmap;
         using TShortChild = TBtreeIndexNode::TShortChild;
         using TChild = TBtreeIndexNode::TChild;
+        using TShortChildV2 = TBtreeIndexNode::TShortChildV2;
+        using TChildV2 = TBtreeIndexNode::TChildV2;
+        using TChildVariant = std::variant<TChild, TChildV2>;
 
     public:
-        TBtreeIndexNodeWriter(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId)
+        TBtreeIndexNodeWriter(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId, bool writeV2 = false)
             : Scheme(std::move(scheme))
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
+            , WriteV2(writeV2)
         {
             if (GroupId.IsMain()) {
                 // TODO: some main groups without nulls and var-sized cells also may use fixed format
@@ -50,8 +56,15 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddChild(TChild child) {
+            Y_ENSURE(!WriteV2, "Use AddChild(TChildV2) for v2 format");
             Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
-            Children.push_back(child);
+            Children.push_back(std::variant<TChild, TChildV2>(std::in_place_type<TChild>, child));
+        }
+
+        void AddChild(TChildV2 child) {
+            Y_ENSURE(WriteV2, "Use AddChild(TChild) for v1 format");
+            Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
+            Children.push_back(std::variant<TChild, TChildV2>(std::in_place_type<TChildV2>, child));
         }
 
         void EnsureEmpty() {
@@ -68,6 +81,13 @@ namespace NKikimr::NTable::NPage {
             Children.clear();
             Ptr = 0;
             End = 0;
+        }
+
+        size_t ChildStructSize() const noexcept {
+            if (WriteV2) {
+                return IsShortChildFormat() ? sizeof(TShortChildV2) : sizeof(TChildV2);
+            }
+            return IsShortChildFormat() ? sizeof(TShortChild) : sizeof(TChild);
         }
 
         TString SerializeKey(TCellsRef cells) {
@@ -97,7 +117,9 @@ namespace NKikimr::NTable::NPage {
             Ptr = buf.mutable_begin();
             End = buf.end();
 
-            WriteUnaligned<TLabel>(Advance(sizeof(TLabel)), TLabel::Encode(EPage::BTreeIndex, TBtreeIndexNode::FormatVersion, pageSize));
+            WriteUnaligned<TLabel>(
+                Advance(sizeof(TLabel)),
+                TLabel::Encode(PageType(), TBtreeIndexNode::FormatVersion, pageSize));
 
             auto &header = Place<THeader>();
             header.KeysCount = Keys.size();
@@ -128,7 +150,7 @@ namespace NKikimr::NTable::NPage {
             KeysSize = 0;
 
             for (auto &child : Children) {
-                PlaceChild(child);
+                std::visit([this](const auto& c) { PlaceChild(c); }, child);
             }
             Children.clear();
 
@@ -145,11 +167,12 @@ namespace NKikimr::NTable::NPage {
         }
 
         size_t CalcPageSize(size_t keysSize, size_t keysCount) const {
+            size_t childSize = ChildStructSize();
             return
                 sizeof(TLabel) + sizeof(THeader) +
                 (IsFixedFormat() ? 0 : sizeof(TRecordsEntry) * keysCount) +
                 keysSize +
-                (IsShortChildFormat() ? sizeof(TShortChild) : sizeof(TChild)) * (keysCount + 1);
+                childSize * (keysCount + 1);
         }
 
         size_t GetKeysCount() const {
@@ -157,10 +180,7 @@ namespace NKikimr::NTable::NPage {
         }
 
         TPgSize CalcKeySizeWithMeta(TCellsRef cells) const noexcept {
-            return 
-                sizeof(TRecordsEntry) + 
-                CalcKeySize(cells) + 
-                (IsShortChildFormat() ? sizeof(TShortChild) : sizeof(TChild));
+            return sizeof(TRecordsEntry) + CalcKeySize(cells) + ChildStructSize();
         }
 
     private:
@@ -257,6 +277,18 @@ namespace NKikimr::NTable::NPage {
             }
         }
 
+        void PlaceChild(const TChildV2& child)
+        {
+            if (IsShortChildFormat()) {
+                Y_DEBUG_ABORT_UNLESS(child.GetGroupDataSize() == 0);
+                Y_DEBUG_ABORT_UNLESS(child.GetErasedRowCount() == 0);
+                Place<TShortChildV2>() =
+                    TShortChildV2{child.Offset_, child.Size_, child.Crc32_, child.GetRowCount(), child.GetDataSize()};
+            } else {
+                Place<TChildV2>() = child;
+            }
+        }
+
         template<typename T>
         T& Place()
         {
@@ -281,13 +313,16 @@ namespace NKikimr::NTable::NPage {
         const TGroupId GroupId;
         const TPartScheme::TGroupInfo& GroupInfo;
 
+        EPage PageType() const noexcept { return WriteV2 ? EPage::BTreeIndexV2 : EPage::BTreeIndex; }
+
     private:
         size_t FixedKeySize;
 
         TVector<TString> Keys;
         size_t KeysSize = 0;
 
-        TVector<TChild> Children;
+        TVector<TChildVariant> Children;
+        const bool WriteV2;
 
         char* Ptr = 0;
         const char* End = 0;
@@ -297,6 +332,9 @@ namespace NKikimr::NTable::NPage {
     public:
         using TShortChild = TBtreeIndexNode::TShortChild;
         using TChild = TBtreeIndexNode::TChild;
+        using TShortChildV2 = TBtreeIndexNode::TShortChildV2;
+        using TChildV2 = TBtreeIndexNode::TChildV2;
+        using TChildVariant = std::variant<TChild, TChildV2>;
 
     private:
         struct TLevel {
@@ -313,13 +351,13 @@ namespace NKikimr::NTable::NPage {
                 return std::move(key);
             }
 
-            void PushChild(TChild child) {
-                Children.push_back(child);
+            void PushChild(TChildVariant child) {
+                Children.push_back(std::move(child));
             }
 
-            TChild PopChild() {
+            TChildVariant PopChild() {
                 Y_ENSURE(Children);
-                TChild result = Children.front();
+                TChildVariant result = std::move(Children.front());
                 Children.pop_front();
                 return result;
             }
@@ -339,16 +377,16 @@ namespace NKikimr::NTable::NPage {
         private:
             size_t KeysSize = 0;
             TDeque<TString> Keys;
-            TDeque<TChild> Children;
+            TDeque<TChildVariant> Children;
         };
 
     public:
-        TBtreeIndexBuilder(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId,
-                ui32 nodeTargetSize, ui32 nodeKeysMin, ui32 nodeKeysMax)
+        TBtreeIndexBuilder(TIntrusiveConstPtr<TPartScheme> scheme, TGroupId groupId, ui32 nodeTargetSize,
+                           ui32 nodeKeysMin, ui32 nodeKeysMax, bool writeV2 = false)
             : Scheme(std::move(scheme))
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
-            , Writer(Scheme, groupId)
+            , Writer(Scheme, groupId, writeV2)
             , Levels(1)
             , NodeTargetSize(nodeTargetSize)
             , NodeKeysMin(nodeKeysMin)
@@ -380,6 +418,11 @@ namespace NKikimr::NTable::NPage {
             AddChild(TChild{child.GetPageId(), child.GetRowCount(), child.GetDataSize(), 0, 0});
         }
 
+        void AddShortChild(TShortChildV2 child) {
+            AddChild(
+                TChildV2{child.Offset_, child.Size_, child.Crc32_, child.GetRowCount(), child.GetDataSize(), 0, 0});
+        }
+
         void AddChild(TChild child) {
             // aggregate in order to perform search by row id from any leaf node
             child.RowCount_ = (ChildRowCount += child.GetRowCount());
@@ -389,7 +432,17 @@ namespace NKikimr::NTable::NPage {
 
             Levels[0].PushChild(child);
         }
-        
+
+        void AddChild(TChildV2 child) {
+            // aggregate in order to perform search by row id from any leaf node
+            child.RowCount_ = (ChildRowCount += child.GetRowCount());
+            child.DataSize_ = (ChildDataSize += child.GetDataSize());
+            child.GroupDataSize_ = (ChildGroupDataSize += child.GetGroupDataSize());
+            child.ErasedRowCount_ = (ChildErasedRowCount += child.GetErasedRowCount());
+
+            Levels[0].PushChild(child);
+        }
+
         void Flush(IPageWriter &pager) {
             for (ui32 levelIndex = 0; levelIndex < Levels.size(); levelIndex++) {
                 bool hasChanges = false;
@@ -411,7 +464,9 @@ namespace NKikimr::NTable::NPage {
                 if (!Levels[levelIndex].GetKeysCount()) {
                     Y_ENSURE(Levels[levelIndex].GetChildrenCount() == 1, "Should be root");
                     Y_ENSURE(levelIndex + 1 == Levels.size(), "Should be root");
-                    return {Levels[levelIndex].PopChild(), levelIndex, IndexSize};
+
+                    auto rootChild = Levels[levelIndex].PopChild();
+                    return std::visit([&](const auto& c) { return MakeMeta(c, levelIndex, IndexSize); }, rootChild);
                 }
 
                 DoFlush(levelIndex, pager, true);
@@ -454,7 +509,7 @@ namespace NKikimr::NTable::NPage {
                 // we may to try splitting them more evenly later
 
                 while (Levels[levelIndex].GetKeysCount()) {
-                    Writer.AddChild(Levels[levelIndex].PopChild());
+                    AddChildToWriter(Levels[levelIndex].PopChild());
                     Writer.AddKey(Levels[levelIndex].PopKey());
                 }
             } else {
@@ -463,23 +518,28 @@ namespace NKikimr::NTable::NPage {
                         Levels[levelIndex].GetKeysCount() > 2 &&
                         Writer.GetKeysCount() < NodeKeysMax &&
                         Writer.CalcPageSize() < NodeTargetSize)) {
-                    Writer.AddChild(Levels[levelIndex].PopChild());
+                    AddChildToWriter(Levels[levelIndex].PopChild());
                     Writer.AddKey(Levels[levelIndex].PopKey());
                 }
             }
             auto lastChild = Levels[levelIndex].PopChild();
-            Writer.AddChild(lastChild);
+            AddChildToWriter(lastChild);
 
             auto page = Writer.Finish();
             IndexSize += page.size();
-            pager.Write(std::move(page), EPage::BTreeIndex, 0);
+            auto location = pager.Write(std::move(page), Writer.PageType(), 0);
+            TPageId pageId = pager.GetLastWrittenPageId(0);
 
             if (levelIndex + 1 == Levels.size()) {
                 Levels.emplace_back();
                 Y_ENSURE(Levels.size() < Max<ui32>(), "Levels size is out of bounds");
             }
-            lastChild.PageId_ = pager.GetWrittenPageId(0);
-            Levels[levelIndex + 1].PushChild(lastChild);
+            if (auto* v1 = std::get_if<TChild>(&lastChild)) {
+                FillChildLocation(*v1, pageId);
+            } else {
+                FillChildLocation(std::get<TChildV2>(lastChild), location);
+            }
+            Levels[levelIndex + 1].PushChild(std::move(lastChild));
             if (!last) {
                 Levels[levelIndex + 1].PushKey(Levels[levelIndex].PopKey());
             }
@@ -491,6 +551,44 @@ namespace NKikimr::NTable::NPage {
             } else {
                 Y_ENSURE(Levels[levelIndex].GetKeysCount(), "Shouldn't leave empty levels");
             }
+        }
+
+        void AddChildToWriter(const TChildVariant& child) {
+            std::visit([this](const auto& c) { Writer.AddChild(c); }, child);
+        }
+
+        void AddChildToWriter(TChildVariant&& child) {
+            std::visit([this](auto&& c) { Writer.AddChild(std::move(c)); }, std::move(child));
+        }
+
+        static void FillChildLocation(TChild& child, TPageId pageId) {
+            child.PageId_ = pageId;
+        }
+
+        static void FillChildLocation(TChildV2& child, const TPageLocation& location) {
+            child.Offset_ = location.Offset;
+            child.Size_ = location.Size;
+            child.Crc32_ = location.Crc32;
+        }
+
+        static TBtreeIndexMeta MakeMeta(const TChild& c, ui32 levelCount, ui64 indexSize) {
+            return {/*V1Root=*/c.GetPageId(), /*V2Root=*/TPageLocation::Max(),
+                    c.GetRowCount(), c.GetDataSize(),
+                    c.GetGroupDataSize(),
+                    c.GetErasedRowCount(),
+                    /*LevelCountV1=*/levelCount,
+                    /*LevelCountV2=*/Max<ui32>(),
+                    /*IndexSize=*/indexSize};
+        }
+
+        static TBtreeIndexMeta MakeMeta(const TChildV2& c, ui32 levelCount, ui64 indexSize) {
+            auto type = levelCount == 0 ? EPage::DataPage : EPage::BTreeIndexV2;
+            return {/*V1Root=*/Max<TPageId>(), /*V2Root=*/c.GetLocation(type),
+                    c.GetRowCount(), c.GetDataSize(), c.GetGroupDataSize(),
+                    c.GetErasedRowCount(),
+                    /*LevelCountV1=*/Max<ui32>(),
+                    /*LevelCountV2=*/levelCount,
+                    /*IndexSize=*/indexSize};
         }
 
         size_t CalcPageSize(const TLevel& level) const {

--- a/ydb/core/tablet_flat/flat_page_conf.h
+++ b/ydb/core/tablet_flat/flat_page_conf.h
@@ -85,6 +85,8 @@ namespace NPage {
         bool Final = true;
         bool CutIndexKeys = true;
         bool WriteBTreeIndex = true;
+        bool WriteBTreeIndexV2 = false;
+        bool BTreeIndexV2KeepV1Shadow = true;   /* write V1 b-tree alongside V2 (revert safety) */
         bool WriteFlatIndex = true;
         ui32 MaxLargeBlob = 8 * 1024 * 1024 - 8; /* Maximum large blob size */
         ui32 LargeEdge = Max<ui32>();   /* External blob edge size      */

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -14,15 +14,14 @@ class TChargeBTreeIndex : public ICharge {
     using TGroupId = NPage::TGroupId;
     using TChild = TBtreeIndexNode::TChild;
     using TShortChild = TBtreeIndexNode::TShortChild;
-
     struct TChildState {
-        TPageId PageId;
+        TPageRef Ref;
         TRowId BeginRowId, EndRowId;
         TRowId PrevItems, Items;
         ui64 PrevBytes, Bytes;
 
-        TChildState(TPageId pageId, TRowId beginRowId, TRowId endRowId, TRowId prevItems, TRowId items, ui64 prevDataSize, ui64 dataSize)
-            : PageId(pageId)
+        TChildState(TPageRef ref, TRowId beginRowId, TRowId endRowId, TRowId prevItems, TRowId items, ui64 prevDataSize, ui64 dataSize)
+            : Ref(std::move(ref))
             , BeginRowId(beginRowId)
             , EndRowId(endRowId)
             , PrevItems(prevItems)
@@ -31,18 +30,22 @@ class TChargeBTreeIndex : public ICharge {
             , Bytes(dataSize)
         {
         }
+
+        static TChildState Invalid(TRowId beginRowId, TRowId endRowId, TRowId prevItems, TRowId items,
+                                   ui64 prevDataSize, ui64 dataSize) {
+            return TChildState(NPage::TPageLocation::Max(), beginRowId, endRowId, prevItems, items, prevDataSize,
+                               dataSize);
+        }
+
+        bool IsValid() const noexcept {
+            return Ref.IsValid();
+        }
     };
 
     struct TNodeState : TChildState, TBtreeIndexNode {
-        TNodeState(TSharedData data, TPageId pageId, TRowId beginRowId, TRowId endRowId, TRowId prevItems, TRowId items, ui64 prevDataSize, ui64 dataSize)
-            : TChildState(pageId, beginRowId, endRowId, prevItems, items, prevDataSize, dataSize)
-            , TBtreeIndexNode(data)
-        {
-        }
-
-        TNodeState(TSharedData data, TChildState child)
-            : TChildState(child)
-            , TBtreeIndexNode(data)
+        TNodeState(TSharedData data, TChildState child, bool v2Format)
+            : TChildState(std::move(child))
+            , TBtreeIndexNode(data, v2Format)
         {
         }
     };
@@ -82,11 +85,11 @@ public:
         }
 
         TVector<TNodeState> level, nextLevel(::Reserve(3));
-        TPageId key1PageId = key1 ? meta.GetPageId() : Max<TPageId>();
-        TPageId key2PageId = key2 ? meta.GetPageId() : Max<TPageId>();
+        TPageRef key1Ref = key1 ? BuildRootChildState(meta).Ref : NPage::TPageLocation::Max();
+        TPageRef key2Ref = key2 ? BuildRootChildState(meta).Ref : NPage::TPageLocation::Max();
         TChildState firstChild = BuildRootChildState(meta);
 
-        const auto iterateLevel = [&](const auto& tryHandleChild) {
+        const auto iterateLevel = [&](const auto& tryHandleChild, bool isLeafLevel, bool isDataBelow) {
             // tryHandleChild may update them, copy for simplicity
             const TRowId levelBeginRowId = beginRowId, levelEndRowId = endRowId;
 
@@ -97,10 +100,8 @@ public:
                 TRecIdx from = 0, to = node.GetChildrenCount();
                 if (node.BeginRowId <= levelBeginRowId) {
                     from = node.Seek(levelBeginRowId);
-                    if (firstChild.PageId != Max<TPageId>()) { // still valid and should be updated
-                        auto& child = node.GetChild(from);
-                        auto prevChild = from ? node.GetChildRef(from - 1) : nullptr;
-                        firstChild = BuildChildState(node, child, prevChild);
+                    if (firstChild.IsValid()) { // still valid and should be updated
+                        firstChild = BuildChildState(node, from, isLeafLevel);
                     }
                 }
                 if (node.EndRowId > levelEndRowId) {
@@ -108,48 +109,45 @@ public:
                 }
 
                 for (TRecIdx pos : xrange(from, to)) {
-                    auto child = node.GetChild(pos);
-                    auto prevChild = pos ? node.GetChildRef(pos - 1) : nullptr;
-                    auto childState = BuildChildState(node, child, prevChild);
+                    auto childState = BuildChildState(node, pos, isLeafLevel);
                     if (LimitExceeded(firstChild.Items, childState.PrevItems, itemsLimit) || LimitExceeded(firstChild.Bytes, childState.PrevBytes, bytesLimit)) {
                         endRowId = Min(endRowId, childState.BeginRowId);
                         return;
                     }
-                    ready &= tryHandleChild(childState);
+                    ready &= tryHandleChild(childState, isDataBelow);
                 }
             }
         };
 
         const auto skipUnloadedRows = [&](const TChildState& child) {
-            if (child.PageId == firstChild.PageId) {
-                firstChild.PageId = Max<TPageId>(); // mark first child unloaded
+            if (child.Ref == firstChild.Ref) {
+                firstChild.Ref = NPage::TPageLocation::Max(); // mark first child unloaded
             }
-            if (child.PageId == key1PageId) {
+            if (child.Ref == key1Ref) {
                 beginRowId = Max(beginRowId, child.EndRowId);
             }
-            if (child.PageId == key2PageId) {
+            if (child.Ref == key2Ref) {
                 endRowId = Min(endRowId, child.BeginRowId);
             }
         };
 
-        const auto tryHandleNode = [&](const TChildState& child) -> bool {
-            if (child.PageId == firstChild.PageId || child.PageId == key1PageId || child.PageId == key2PageId) {
-                if (TryLoadNode(child, nextLevel)) {
+        const auto tryHandleNode = [&](const TChildState& child, bool isDataBelow) -> bool {
+            if (child.Ref == firstChild.Ref || child.Ref == key1Ref || child.Ref == key2Ref) {
+                if (TryLoadNode(child, nextLevel, meta.HasRootV2())) {
                     const auto& node = nextLevel.back();
-                    if (child.PageId == key1PageId) {
+                    if (child.Ref == key1Ref) {
                         TRecIdx pos = node.Seek(ESeek::Lower, key1, Scheme.Groups[0].ColsKeyIdx, &keyDefaults);
-                        auto& key1Child = node.GetChild(pos);
-                        key1PageId = key1Child.GetPageId();
+                        key1Ref = node.GetChild( pos, isDataBelow);
                         if (pos) {
-                            beginRowId = Max(beginRowId, node.GetChild(pos - 1).GetRowCount()); // move beginRowId to the first key >= key1
+                            beginRowId = Max(beginRowId, node.GetChildRowCount(pos - 1)); // move beginRowId to the first key >= key1
                         }
                     }
-                    if (child.PageId == key2PageId) {
+                    if (child.Ref == key2Ref) {
                         TRecIdx pos = node.Seek(ESeek::Lower, key2, Scheme.Groups[0].ColsKeyIdx, &keyDefaults);
-                        auto& key2Child = node.GetChild(pos);
-                        key2PageId = key2Child.GetPageId();
-                        endRowId = Min(endRowId, key2Child.GetRowCount() + 1); // move endRowId - 1 to the first key > key2
-                        if (key2Child.GetRowCount() <= sliceBeginRowId) {
+                        TRowId key2ChildRowCount = node.GetChildRowCount(pos);
+                        key2Ref = node.GetChild( pos, isDataBelow);
+                        endRowId = Min(endRowId, key2ChildRowCount + 1); // move endRowId - 1 to the first key > key2
+                        if (key2ChildRowCount <= sliceBeginRowId) {
                             hasValidRowsRange = false; // key2 is before current slice
                             endRowId = Max(endRowId, sliceBeginRowId + 1); // always load sliceBeginRowId regardless of key2
                         }
@@ -160,7 +158,7 @@ public:
                     return false;
                 }
             } else {
-                return TryLoadNode(child, nextLevel);
+                return TryLoadNode(child, nextLevel, meta.HasRootV2());
             }
         };
 
@@ -169,18 +167,19 @@ public:
         //       the size of each data page in the number of bytes precharged.
         ui64 prechargedBytes = 0;
 
-        const auto tryHandleDataPage = [&](const TChildState& child) -> bool {
+        const auto tryHandleDataPage = [&](const TChildState& child, bool /*isDataBelow*/ = false) -> bool {
             prechargedBytes += child.Bytes - child.PrevBytes;
 
-            if (hasValidRowsRange && (child.PageId == key1PageId || child.PageId == key2PageId)) {
-                const auto page = TryGetDataPage(child.PageId, { });
+            if (hasValidRowsRange && (child.Ref == key1Ref || child.Ref == key2Ref)) {
+                auto location = NTable::ResolvePageLocation(Part, child.Ref, {});
+                const auto page = TryGetDataPage(location, { });
                 if (page) {
                     auto data = NPage::TDataPage(page);
-                    if (child.PageId == key1PageId) {
+                    if (child.Ref == key1Ref) {
                         TRowId key1RowId = data.BaseRow() + data.LookupKey(key1, Scheme.Groups[0], ESeek::Lower, &keyDefaults).Off();
                         beginRowId = Max(beginRowId, key1RowId);
                     }
-                    if (child.PageId == key2PageId) {
+                    if (child.Ref == key2Ref) {
                         TRowId key2RowId = data.BaseRow() + data.LookupKey(key2, Scheme.Groups[0], ESeek::Upper, &keyDefaults).Off();
                         endRowId = Min(endRowId, key2RowId);
                     }
@@ -190,19 +189,21 @@ public:
                     return false;
                 }
             } else {
-                return HasDataPage(child.PageId, { });
+                auto location = NTable::ResolvePageLocation(Part, child.Ref, {});
+                return HasDataPage(location, { });
             }
         };
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            const bool isDataBelow = (height + 1 == meta.LevelCount());
             if (height == 0) {
-                ready &= tryHandleNode(BuildRootChildState(meta));
+                ready &= tryHandleNode(BuildRootChildState(meta), isDataBelow);
             } else {
-                iterateLevel(tryHandleNode);
+                iterateLevel(tryHandleNode, /*isLeafLevel=*/false, isDataBelow);
             }
             level.swap(nextLevel);
             nextLevel.clear();
-            if (firstChild.PageId == Max<TPageId>()) { // first child is unloaded, consider all first's child rows are needed for next levels
+            if (!firstChild.IsValid()) { // first child is unloaded, consider all first's child rows are needed for next levels
                 firstChild.Items = firstChild.PrevItems;
                 firstChild.Bytes = firstChild.PrevBytes;
             }
@@ -212,10 +213,10 @@ public:
         // TODO: remove it later
         overshot &= endRowId == sliceEndRowId;
 
-        if (meta.LevelCount == 0) {
-            ready &= tryHandleDataPage(BuildRootChildState(meta));
+        if (meta.LevelCount() == 0) {
+            ready &= tryHandleDataPage(BuildRootChildState(meta), 0);
         } else {
-            iterateLevel(tryHandleDataPage);
+            iterateLevel(tryHandleDataPage, /*isLeafLevel=*/true, 0);
         }
 
         // NOTE: Column groups are precharged for the same set of rows, but the overall
@@ -255,11 +256,10 @@ public:
 
         // level's nodes is in reverse order
         TVector<TNodeState> level, nextLevel(::Reserve(3));
-        TPageId key1PageId = key1 ? meta.GetPageId() : Max<TPageId>();
-        TPageId key2PageId = key2 ? meta.GetPageId() : Max<TPageId>();
+        TPageRef key1Ref = key1 ? BuildRootChildState(meta).Ref : NPage::TPageLocation::Max();
+        TPageRef key2Ref = key2 ? BuildRootChildState(meta).Ref : NPage::TPageLocation::Max();
         TChildState lastChild = BuildRootChildState(meta);
-
-        const auto iterateLevel = [&](const auto& tryHandleChild) {
+        const auto iterateLevel = [&](const auto& tryHandleChild, bool isLeafLevel, bool isDataBelow) {
             // tryHandleChild may update them, copy for simplicity
             const TRowId levelBeginRowId = beginRowId, levelEndRowId = endRowId;
 
@@ -273,55 +273,50 @@ public:
                 }
                 if (node.EndRowId >= levelEndRowId) {
                     to = node.Seek(levelEndRowId - 1);
-                    if (lastChild.PageId != Max<TPageId>()) { // still valid and should be updated
-                        auto& child = node.GetChild(to);
-                        auto prevChild = to ? node.GetChildRef(to - 1) : nullptr;
-                        lastChild = BuildChildState(node, child, prevChild);
+                    if (lastChild.IsValid()) { // still valid and should be updated
+                        lastChild = BuildChildState(node, to, isLeafLevel);
                     }
                 }
 
                 for (TRecIdx posExt = to + 1; posExt > from; posExt--) {
-                    auto& child = node.GetChild(posExt - 1);
-                    auto prevChild = posExt - 1 ? node.GetChildRef(posExt - 2) : nullptr;
-                    auto childState = BuildChildState(node, child, prevChild);
+                    auto childState = BuildChildState(node, posExt - 1, isLeafLevel);
                     if (LimitExceeded(childState.Items, lastChild.PrevItems, itemsLimit) || LimitExceeded(childState.Bytes, lastChild.PrevBytes, bytesLimit)) {
                         beginRowId = Max(beginRowId, childState.EndRowId);
                         return;
                     }
-                    ready &= tryHandleChild(childState);
+                    ready &= tryHandleChild(childState, isDataBelow);
                 }
             }
         };
 
         const auto skipUnloadedRows = [&](const TChildState& child) {
-            if (child.PageId == lastChild.PageId) {
-                lastChild.PageId = Max<TPageId>(); // mark last child unloaded
+            if (child.Ref == lastChild.Ref) {
+                lastChild.Ref = NPage::TPageLocation::Max(); // mark last child unloaded
             }
-            if (child.PageId == key1PageId) {
+            if (child.Ref == key1Ref) {
                 endRowId = Min(endRowId, child.BeginRowId);
             }
-            if (child.PageId == key2PageId) {
+            if (child.Ref == key2Ref) {
                 beginRowId = Max(beginRowId, child.EndRowId);
             }
         };
 
-        const auto tryHandleNode = [&](const TChildState& child) -> bool {
-            if (child.PageId == lastChild.PageId || child.PageId == key1PageId || child.PageId == key2PageId) {
-                if (TryLoadNode(child, nextLevel)) {
+        const auto tryHandleNode = [&](const TChildState& child, bool isDataBelow) -> bool {
+            if (child.Ref == lastChild.Ref || child.Ref == key1Ref || child.Ref == key2Ref) {
+                if (TryLoadNode(child, nextLevel, meta.HasRootV2())) {
                     const auto& node = nextLevel.back();
-                    if (child.PageId == key1PageId) {
+                    if (child.Ref == key1Ref) {
                         TRecIdx pos = node.SeekReverse(ESeek::Lower, key1, Scheme.Groups[0].ColsKeyIdx, &keyDefaults);
-                        auto& key1Child = node.GetChild(pos);
-                        key1PageId = key1Child.GetPageId();
-                        endRowId = Min(endRowId, key1Child.GetRowCount()); // move endRowId - 1 to the last key <= key1
+                        key1Ref = node.GetChild( pos, isDataBelow);
+                        endRowId = Min(endRowId, node.GetChildRowCount(pos)); // move endRowId - 1 to the last key <= key1
                     }
-                    if (child.PageId == key2PageId) {
+                    if (child.Ref == key2Ref) {
                         TRecIdx pos = node.Seek(ESeek::Lower, key2, Scheme.Groups[0].ColsKeyIdx, &keyDefaults);
-                        key2PageId = node.GetChild(pos).GetPageId();
+                        key2Ref = node.GetChild( pos, isDataBelow);
                         if (pos) {
-                            auto& prevKey2Child = node.GetChild(pos - 1);
-                            beginRowId = Max(beginRowId, prevKey2Child.GetRowCount() - 1); // move beginRowId to the last key < key2
-                            if (prevKey2Child.GetRowCount() >= sliceEndRowId) {
+                            auto prevKey2ChildRowCount = node.GetChildRowCount(pos - 1);
+                            beginRowId = Max(beginRowId, prevKey2ChildRowCount - 1); // move beginRowId to the last key < key2
+                            if (prevKey2ChildRowCount >= sliceEndRowId) {
                                 hasValidRowsRange = false; // key2 is after current slice
                                 beginRowId = Min(beginRowId, sliceEndRowId - 1); // always load endRowId - 1 regardless of keys
                             }
@@ -333,7 +328,7 @@ public:
                     return false;
                 }
             } else {
-                return TryLoadNode(child, nextLevel);
+                return TryLoadNode(child, nextLevel, meta.HasRootV2());
             }
         };
 
@@ -342,14 +337,15 @@ public:
         //       the size of each data page in the number of bytes precharged.
         ui64 prechargedBytes = 0;
 
-        const auto tryHandleDataPage = [&](const TChildState& child) -> bool {
+        const auto tryHandleDataPage = [&](const TChildState& child, bool /*isDataBelow*/ = false) -> bool {
             prechargedBytes += child.Bytes - child.PrevBytes;
 
-            if (hasValidRowsRange && (child.PageId == key1PageId || child.PageId == key2PageId)) {
-                const auto page = TryGetDataPage(child.PageId, { });
+            if (hasValidRowsRange && (child.Ref == key1Ref || child.Ref == key2Ref)) {
+                auto location = NTable::ResolvePageLocation(Part, child.Ref, {});
+                const auto page = TryGetDataPage(location, { });
                 if (page) {
                     auto data = NPage::TDataPage(page);
-                    if (child.PageId == key1PageId) {
+                    if (child.Ref == key1Ref) {
                         auto iter = data.LookupKeyReverse(key1, Scheme.Groups[0], ESeek::Lower, &keyDefaults);
                         if (iter) {
                             TRowId key1RowId = data.BaseRow() + iter.Off();
@@ -358,7 +354,7 @@ public:
                             endRowId = Min(endRowId, child.BeginRowId);
                         }
                     }
-                    if (child.PageId == key2PageId) {
+                    if (child.Ref == key2Ref) {
                         auto iter = data.LookupKeyReverse(key2, Scheme.Groups[0], ESeek::Upper, &keyDefaults);
                         if (iter) {
                             TRowId key2RowId = data.BaseRow() + iter.Off();
@@ -373,19 +369,21 @@ public:
                     return false;
                 }
             } else {
-                return HasDataPage(child.PageId, { });
+                auto location = NTable::ResolvePageLocation(Part, child.Ref, {});
+                return HasDataPage(location, { });
             }
         };
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            const bool isDataBelow = (height + 1 == meta.LevelCount());
             if (height == 0) {
-                ready &= tryHandleNode(BuildRootChildState(meta));
+                ready &= tryHandleNode(BuildRootChildState(meta), isDataBelow);
             } else {
-                iterateLevel(tryHandleNode);
+                iterateLevel(tryHandleNode, /*isLeafLevel=*/false, isDataBelow);
             }
             level.swap(nextLevel);
             nextLevel.clear();
-            if (lastChild.PageId == Max<TPageId>()) { // last child is unloaded, consider all last's child rows are needed for next levels
+            if (!lastChild.IsValid()) { // last child is unloaded, consider all last's child rows are needed for next levels
                 lastChild.PrevItems = lastChild.Items;
                 lastChild.PrevBytes = lastChild.Bytes;
             }
@@ -395,10 +393,10 @@ public:
         // TODO: remove it later
         overshot &= beginRowId == sliceBeginRowId;
 
-        if (meta.LevelCount == 0) {
-            ready &= tryHandleDataPage(BuildRootChildState(meta));
+        if (meta.LevelCount() == 0) {
+            ready &= tryHandleDataPage(BuildRootChildState(meta), 0);
         } else {
-            iterateLevel(tryHandleDataPage);
+            iterateLevel(tryHandleDataPage, /*isLeafLevel=*/true, 0);
         }
 
         // NOTE: Column groups are precharged for the same set of rows, but the overall
@@ -432,9 +430,11 @@ private:
             return ready;
         }
 
+        bool firstChildLoaded = firstChild.IsValid();
+
         if (itemsLimit) {
             // TODO: items limit should be applied on items not rows, but it requires iteration via first and last data pages
-            TRowId limitFromRowId = firstChild.PageId == Max<TPageId>() ? firstChild.BeginRowId : beginRowId;
+            TRowId limitFromRowId = !firstChildLoaded ? firstChild.BeginRowId : beginRowId;
             if (endRowId - limitFromRowId - 1 > itemsLimit) {
                 endRowId = limitFromRowId + itemsLimit + 1;
             }
@@ -443,7 +443,7 @@ private:
             }
         }
 
-        if (IncludeHistory && (!bytesLimit || firstChild.PageId != Max<TPageId>())) {
+        if (IncludeHistory && (!bytesLimit || firstChildLoaded)) {
             ready &= DoHistory(beginRowId, endRowId);
         }
 
@@ -464,9 +464,11 @@ private:
             return ready;
         }
 
+        bool lastChildLoaded = lastChild.IsValid();
+
         if (itemsLimit) {
             // TODO: items limit should be applied on items not rows, but it requires iteration via first and last data pages
-            TRowId limitToRowId = lastChild.PageId == Max<TPageId>() ? lastChild.EndRowId : endRowId;
+            TRowId limitToRowId = !lastChildLoaded ? lastChild.EndRowId : endRowId;
             if (limitToRowId - beginRowId - 1 >= itemsLimit) {
                 beginRowId = limitToRowId - itemsLimit - 1;
             }
@@ -475,7 +477,7 @@ private:
             }
         }
 
-        if (IncludeHistory && (!bytesLimit || lastChild.PageId != Max<TPageId>())) {
+        if (IncludeHistory && (!bytesLimit || lastChildLoaded)) {
             ready &= DoHistory(beginRowId, endRowId);
         }
 
@@ -492,9 +494,9 @@ private:
         const auto& meta = Part->IndexPages.GetBTree(groupId);
 
         TVector<TNodeState> level, nextLevel(::Reserve(3));
-        ui64 firstChildPrevBytes = bytesLimit ? GetPrevBytes(meta, firstChildBeginRowId) : 0;
+        ui64 firstChildPrevBytes = bytesLimit ? GetPrevBytes(meta, groupId, firstChildBeginRowId) : 0;
 
-        const auto iterateLevel = [&](const auto& tryHandleChild) {
+        const auto iterateLevel = [&](const auto& tryHandleChild, bool isLeafLevel, bool isDataBelow) {
             for (const auto &node : level) {
                 TRecIdx from = 0, to = node.GetChildrenCount();
                 if (node.BeginRowId < beginRowId) {
@@ -505,39 +507,39 @@ private:
                 }
 
                 for (TRecIdx pos : xrange(from, to)) {
-                    auto& child = node.GetShortChild(pos);
-                    auto prevChild = pos ? node.GetShortChildRef(pos - 1) : nullptr;
-                    auto childState = BuildChildState(node, child, prevChild);
+                    auto childState = BuildChildState(node, pos, isLeafLevel);
                     if (LimitExceeded(firstChildPrevBytes, childState.PrevBytes, bytesLimit)) {
                         return;
                     }
-                    ready &= tryHandleChild(childState);
+                    ready &= tryHandleChild(childState, isDataBelow);
                 }
             }
         };
 
-        const auto tryHandleNode = [&](const TChildState& child) -> bool {
-            return TryLoadNode(child, nextLevel);
+        const auto tryHandleNode = [&](const TChildState& child, bool /*isDataBelow*/) -> bool {
+            return TryLoadNode(child, nextLevel, meta.HasRootV2());
         };
 
-        const auto tryHandleDataPage = [&](const TChildState& child) -> bool {
-            return HasDataPage(child.PageId, groupId);
+        const auto tryHandleDataPage = [&](const TChildState& child, bool /*isDataBelow*/ = false) -> bool {
+            auto location = NTable::ResolvePageLocation(Part, child.Ref, groupId);
+            return HasDataPage(location, groupId);
         };
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            const bool isDataBelow = (height + 1 == meta.LevelCount());
             if (height == 0) {
-                ready &= tryHandleNode(BuildRootChildState(meta));
+                ready &= tryHandleNode(BuildRootChildState(meta), isDataBelow);
             } else {
-                iterateLevel(tryHandleNode);
+                iterateLevel(tryHandleNode, /*isLeafLevel=*/false, isDataBelow);
             }
             level.swap(nextLevel);
             nextLevel.clear();
         }
 
-        if (meta.LevelCount == 0) {
-            ready &= tryHandleDataPage(BuildRootChildState(meta));
+        if (meta.LevelCount() == 0) {
+            ready &= tryHandleDataPage(BuildRootChildState(meta), 0);
         } else {
-            iterateLevel(tryHandleDataPage);
+            iterateLevel(tryHandleDataPage, /*isLeafLevel=*/true, 0);
         }
 
         return ready;
@@ -549,9 +551,9 @@ private:
 
         // level's nodes is in reverse order
         TVector<TNodeState> level, nextLevel(::Reserve(3));
-        ui64 lastChildBytes = bytesLimit ? GetBytes(meta, lastChildEndRowId - 1) : 0;
+        ui64 lastChildBytes = bytesLimit ? GetBytes(meta, groupId, lastChildEndRowId - 1) : 0;
 
-        const auto iterateLevel = [&](const auto& tryHandleChild) {
+        const auto iterateLevel = [&](const auto& tryHandleChild, bool isLeafLevel, bool isDataBelow) {
             for (const auto &node : level) {
                 TRecIdx from = 0, to = node.GetKeysCount();
                 if (node.BeginRowId < beginRowId) {
@@ -561,39 +563,39 @@ private:
                     to = node.Seek(endRowId - 1);
                 }
                 for (TRecIdx posExt = to + 1; posExt > from; posExt--) {
-                    auto& child = node.GetShortChild(posExt - 1);
-                    auto prevChild = posExt - 1 ? node.GetShortChildRef(posExt - 2) : nullptr;
-                    auto childState = BuildChildState(node, child, prevChild);
+                    auto childState = BuildChildState(node, posExt - 1, isLeafLevel);
                     if (LimitExceeded(childState.Bytes, lastChildBytes, bytesLimit)) {
                         return;
                     }
-                    ready &= tryHandleChild(childState);
+                    ready &= tryHandleChild(childState, isDataBelow);
                 }
             }
         };
 
-        const auto tryHandleNode = [&](const TChildState& child) -> bool {
-            return TryLoadNode(child, nextLevel);
+        const auto tryHandleNode = [&](const TChildState& child, bool /*isDataBelow*/) -> bool {
+            return TryLoadNode(child, nextLevel, meta.HasRootV2());
         };
 
-        const auto tryHandleDataPage = [&](const TChildState& child) -> bool {
-            return HasDataPage(child.PageId, groupId);
+        const auto tryHandleDataPage = [&](const TChildState& child, bool /*isDataBelow*/ = false) -> bool {
+            auto location = NTable::ResolvePageLocation(Part, child.Ref, groupId);
+            return HasDataPage(location, groupId);
         };
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            const bool isDataBelow = (height + 1 == meta.LevelCount());
             if (height == 0) {
-                ready &= tryHandleNode(BuildRootChildState(meta));
+                ready &= tryHandleNode(BuildRootChildState(meta), isDataBelow);
             } else {
-                iterateLevel(tryHandleNode);
+                iterateLevel(tryHandleNode, /*isLeafLevel=*/false, isDataBelow);
             }
             level.swap(nextLevel);
             nextLevel.clear();
         }
 
-        if (meta.LevelCount == 0) {
-            ready &= tryHandleDataPage(BuildRootChildState(meta));
+        if (meta.LevelCount() == 0) {
+            ready &= tryHandleDataPage(BuildRootChildState(meta), 0);
         } else {
-            iterateLevel(tryHandleDataPage);
+            iterateLevel(tryHandleDataPage, /*isLeafLevel=*/true, 0);
         }
 
         return ready;
@@ -633,9 +635,10 @@ private:
         TRowId beginRowId = 0, endRowId = meta.GetRowCount();
 
         TVector<TNodeState> level, nextLevel(::Reserve(3));
-        TPageId key1PageId = meta.GetPageId(), key2PageId = meta.GetPageId();
+        TPageRef key1Ref = BuildRootChildState(meta).Ref;
+        TPageRef key2Ref = BuildRootChildState(meta).Ref;
 
-        const auto iterateLevel = [&](const auto& tryHandleChild) {
+        const auto iterateLevel = [&](const auto& tryHandleChild, bool isLeafLevel, bool isDataBelow) {
             for (const auto &node : level) {
                 TRecIdx from = 0, to = node.GetChildrenCount();
                 if (node.BeginRowId < beginRowId) {
@@ -645,40 +648,37 @@ private:
                     to = node.Seek(endRowId - 1) + 1;
                 }
                 for (TRecIdx pos : xrange(from, to)) {
-                    auto& child = node.GetShortChild(pos);
-                    auto prevChild = pos ? node.GetShortChildRef(pos - 1) : nullptr;
-                    auto childState = BuildChildState(node, child, prevChild);
-                    ready &= tryHandleChild(childState);
+                    auto childState = BuildChildState(node, pos, isLeafLevel);
+                    ready &= tryHandleChild(childState, isDataBelow);
                 }
             }
         };
 
         const auto skipUnloadedRows = [&](const TChildState& child) {
-            if (child.PageId == key1PageId) {
+            if (child.Ref == key1Ref) {
                 beginRowId = Max(beginRowId, child.EndRowId);
             }
-            if (child.PageId == key2PageId) {
+            if (child.Ref == key2Ref) {
                 endRowId = Min(endRowId, child.BeginRowId);
             }
         };
 
-        const auto tryHandleNode = [&](const TChildState& child) -> bool {
-            if (child.PageId == key1PageId || child.PageId == key2PageId) {
-                if (TryLoadNode(child, nextLevel)) {
+        const auto tryHandleNode = [&](const TChildState& child, bool isDataBelow) -> bool {
+            if (child.Ref == key1Ref || child.Ref == key2Ref) {
+                if (TryLoadNode(child, nextLevel, meta.HasRootV2())) {
                     const auto& node = nextLevel.back();
-                    if (child.PageId == key1PageId) {
+                    if (child.Ref == key1Ref) {
                         TRecIdx pos = node.Seek(ESeek::Lower, key1, scheme.ColsKeyIdx, keyDefaults);
-                        auto& key1Child = node.GetShortChild(pos);
-                        key1PageId = key1Child.GetPageId();
+                        key1Ref = node.GetChild( pos, isDataBelow);
                         if (pos) {
-                            beginRowId = Max(beginRowId, node.GetShortChild(pos - 1).GetRowCount()); // move beginRowId to the first key >= key1
+                            beginRowId = Max(beginRowId, node.GetChildRowCount(pos - 1)); // move beginRowId to the first key >= key1
                         }
                     }
-                    if (child.PageId == key2PageId) {
+                    if (child.Ref == key2Ref) {
                         TRecIdx pos = node.Seek(ESeek::Lower, key2, scheme.ColsKeyIdx, keyDefaults);
-                        auto& key2Child = node.GetShortChild(pos);
-                        key2PageId = key2Child.GetPageId();
-                        endRowId = Min(endRowId, key2Child.GetRowCount()); // move endRowId to the first key > key2
+                        TRowId key2ChildRowCount = node.GetChildRowCount(pos);
+                        key2Ref = node.GetChild( pos, isDataBelow);
+                        endRowId = Min(endRowId, key2ChildRowCount); // move endRowId to the first key > key2
                     }
                     return true;
                 } else {
@@ -686,20 +686,21 @@ private:
                     return false;
                 }
             } else {
-                return TryLoadNode(child, nextLevel);
+                return TryLoadNode(child, nextLevel, meta.HasRootV2());
             }
         };
 
-        const auto tryHandleDataPage = [&](const TChildState& child) -> bool {
-            if (Groups && (child.PageId == key1PageId || child.PageId == key2PageId)) {
-                const auto page = TryGetDataPage(child.PageId, groupId);
+        const auto tryHandleDataPage = [&](const TChildState& child, bool /*isDataBelow*/ = false) -> bool {
+            if (Groups && (child.Ref == key1Ref || child.Ref == key2Ref)) {
+                auto location = NTable::ResolvePageLocation(Part, child.Ref, groupId);
+                const auto page = TryGetDataPage(location, groupId);
                 if (page) {
                     auto data = NPage::TDataPage(page);
-                    if (child.PageId == key1PageId) {
+                    if (child.Ref == key1Ref) {
                         TRowId key1RowId = data.BaseRow() + data.LookupKey(key1, scheme, ESeek::Lower, keyDefaults).Off();
                         beginRowId = Max(beginRowId, key1RowId);
                     }
-                    if (child.PageId == key2PageId) {
+                    if (child.Ref == key2Ref) {
                         TRowId key2RowId = data.BaseRow() + data.LookupKey(key2, scheme, ESeek::Upper, keyDefaults).Off();
                         endRowId = Min(endRowId, key2RowId);
                     }
@@ -709,24 +710,26 @@ private:
                     return false;
                 }
             } else {
-                return HasDataPage(child.PageId, groupId);
+                auto location = NTable::ResolvePageLocation(Part, child.Ref, groupId);
+                return HasDataPage(location, groupId);
             }
         };
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            const bool isDataBelow = (height + 1 == meta.LevelCount());
             if (height == 0) {
-                ready &= tryHandleNode(BuildRootChildState(meta));
+                ready &= tryHandleNode(BuildRootChildState(meta), isDataBelow);
             } else {
-                iterateLevel(tryHandleNode);
+                iterateLevel(tryHandleNode, /*isLeafLevel=*/false, isDataBelow);
             }
             level.swap(nextLevel);
             nextLevel.clear();
         }
 
-        if (meta.LevelCount == 0) {
-            ready &= tryHandleDataPage(BuildRootChildState(meta));
+        if (meta.LevelCount() == 0) {
+            ready &= tryHandleDataPage(BuildRootChildState(meta), false);
         } else {
-            iterateLevel(tryHandleDataPage);
+            iterateLevel(tryHandleDataPage, /*isLeafLevel=*/true, false);
         }
 
         ready &= DoHistoricGroups(beginRowId, endRowId); // precharge historic groups using the latest row bounds
@@ -747,60 +750,67 @@ private:
     }
 
 private:
-    ui64 GetPrevBytes(const TBtreeIndexMeta& meta, TRowId rowId) const {
-        TPageId pageId = meta.GetPageId();
+    ui64 GetPrevBytes(const TBtreeIndexMeta& meta, TGroupId groupId, TRowId rowId) const {
+        auto* indexPages = Part->GetPageCollection(0);
+        auto* groupPages = Part->GetPageCollection(groupId.Index);
+        auto location = GetBTreeRootLocation(meta, indexPages, groupPages);
         ui64 result = 0;
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
-            auto page = Env->TryGetPage(Part, Part->GetPageLocation(pageId, {}), {});
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            bool isDataPage = (height + 1 == meta.LevelCount());
+            auto page = Env->TryGetPage(Part, location, {});
             if (!page) {
                 return result;
             }
-            auto node = TBtreeIndexNode(*page);
+            auto node = TBtreeIndexNode(*page, meta.HasRootV2());
             auto pos = node.Seek(rowId);
-            pageId = node.GetShortChild(pos).GetPageId();
+            location = ResolvePageLocation(Part, node.GetChild( pos, isDataPage), isDataPage ? groupId : TGroupId{});
             if (pos) {
-                result = node.GetShortChild(pos - 1).GetDataSize();
+                result = node.GetChildDataSize(pos - 1);
             }
         }
 
         return result;
     }
 
-    ui64 GetBytes(TBtreeIndexMeta meta, TRowId rowId) const {
-        TPageId pageId = meta.GetPageId();
+    ui64 GetBytes(TBtreeIndexMeta meta, TGroupId groupId, TRowId rowId) const {
+        auto* indexPages = Part->GetPageCollection(0);
+        auto* groupPages = Part->GetPageCollection(groupId.Index);
+        auto location = GetBTreeRootLocation(meta, indexPages, groupPages);
         ui64 result = meta.GetDataSize();
 
-        for (ui32 height = 0; height < meta.LevelCount; height++) {
-            auto page = Env->TryGetPage(Part, Part->GetPageLocation(pageId, {}), {});
+        for (ui32 height = 0; height < meta.LevelCount(); height++) {
+            bool isDataPage = (height + 1 == meta.LevelCount());
+            auto page = Env->TryGetPage(Part, location, {});
             if (!page) {
                 return result;
             }
-            auto node = TBtreeIndexNode(*page);
+            auto node = TBtreeIndexNode(*page, meta.HasRootV2());
             auto pos = node.Seek(rowId);
-            pageId = node.GetShortChild(pos).GetPageId();
-            result = node.GetShortChild(pos).GetDataSize();
+            location = ResolvePageLocation(Part, node.GetChild( pos, isDataPage), isDataPage ? groupId : TGroupId{});
+            result = node.GetChildDataSize(pos);
         }
 
         return result;
     }
 
 private:
-    const TSharedData* TryGetDataPage(TPageId pageId, TGroupId groupId) const {
-        return Env->TryGetPage(Part, Part->GetPageLocation(pageId, groupId), groupId);
-    };
-
-    bool HasDataPage(TPageId pageId, TGroupId groupId) const {
-        return bool(Env->TryGetPage(Part, Part->GetPageLocation(pageId, groupId), groupId));
+    const TSharedData* TryGetDataPage(const NPage::TPageLocation& location, TGroupId groupId) const {
+        return Env->TryGetPage(Part, location, groupId);
     }
 
-    bool TryLoadNode(const TChildState& child, TVector<TNodeState>& level) const {
-        auto page = Env->TryGetPage(Part, Part->GetPageLocation(child.PageId, {}), {});
+    bool HasDataPage(const NPage::TPageLocation& location, TGroupId groupId) const {
+        return bool(Env->TryGetPage(Part, location, groupId));
+    }
+
+    bool TryLoadNode(const TChildState& child, TVector<TNodeState>& level, bool v2Format) const {
+        auto location = NTable::ResolvePageLocation(Part, child.Ref, {});
+        auto page = Env->TryGetPage(Part, location, {});
         if (!page) {
             return false;
         }
 
-        level.emplace_back(*page, child);
+        level.emplace_back(*page, child, v2Format);
         return true;
     }
 
@@ -822,24 +832,29 @@ private:
     }
 
     TChildState BuildRootChildState(const TBtreeIndexMeta& meta) const {
-        return TChildState(meta.GetPageId(),
+        if (meta.HasRootV2()) {
+            return TChildState(meta.RootV2,
+                0, meta.GetRowCount(),
+                0, meta.GetNonErasedRowCount(),
+                0, meta.GetDataSize());
+        }
+        return TChildState(meta.RootV1PageId(),
             0, meta.GetRowCount(),
             0, meta.GetNonErasedRowCount(),
             0, meta.GetDataSize());
     }
 
-    TChildState BuildChildState(const TNodeState& parent, TChild child, const TChild* prevChild) const {
-        return TChildState(child.GetPageId(),
-            prevChild ? prevChild->GetRowCount() : parent.BeginRowId, child.GetRowCount(),
-            prevChild ? prevChild->GetNonErasedRowCount() : parent.PrevItems, child.GetNonErasedRowCount(),
-            prevChild ? prevChild->GetDataSize() : parent.PrevBytes, child.GetDataSize());
-    }
-
-    TChildState BuildChildState(const TNodeState& parent, TShortChild child, const TShortChild* prevChild) const {
-        return TChildState(child.GetPageId(),
-            prevChild ? prevChild->GetRowCount() : parent.BeginRowId, child.GetRowCount(),
-            prevChild ? prevChild->GetRowCount() : parent.BeginRowId, child.GetRowCount(),
-            prevChild ? prevChild->GetDataSize() : parent.PrevBytes, child.GetDataSize());
+    // Version-aware child state builder
+    TChildState BuildChildState(const TNodeState& parent, TRecIdx curPos, bool isDataPage) const {
+        auto prevPos = curPos - 1;
+        bool hasPrev = prevPos != Max<TRecIdx>();
+        TRowId beginRowId = hasPrev ? parent.GetChildRowCount(prevPos) : parent.BeginRowId;
+        TRowId endRowId = parent.GetChildRowCount(curPos);
+        TRowId prevItems = hasPrev ? parent.GetChildNonErasedRowCount(prevPos) : parent.PrevItems;
+        TRowId items = parent.GetChildNonErasedRowCount(curPos);
+        ui64 prevBytes = hasPrev ? parent.GetChildDataSize(prevPos) : parent.PrevBytes;
+        ui64 bytes = parent.GetChildDataSize(curPos);
+        return TChildState(parent.GetChild(curPos, isDataPage), beginRowId, endRowId, prevItems, items, prevBytes, bytes);
     }
 
     bool LimitExceeded(ui64 prev, ui64 current, ui64 limit) const {

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -176,8 +176,9 @@ namespace {
     {
         if (part.IndexPages.HasBTree()) {
             auto meta = part.IndexPages.GetBTree({});
-            if (meta.LevelCount) {
-                BTreeIndexNode(part, meta);
+            if (meta.LevelCount()) {
+                auto rootLoc = part.IndexPages.GetRootLocation(&part, {});
+                BTreeIndexNode(part, rootLoc, meta.ToString(), /* level */ 0, /* totalLevels */ meta.LevelCount(), meta.HasRootV2());
             } else {
                 Out
                     << " + BTreeIndex{Empty, "
@@ -297,7 +298,7 @@ namespace {
         Out << "}";
     }
 
-    void TDump::BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level)
+    void TDump::BTreeIndexNode(const TPart &part, NPage::TPageLocation loc, const TString &parent, ui32 level, ui32 totalLevels, bool v2Format)
     {
         TVector<TCell> key(Reserve(part.Scheme->Groups[0].KeyTypes.size()));
 
@@ -306,31 +307,35 @@ namespace {
             intend += " |";
         }
 
-        auto dumpChild = [&] (NPage::TBtreeIndexNode::TChild child) {
-            if (part.GetPageType(child.GetPageId(), {}) == EPage::BTreeIndex) {
-                BTreeIndexNode(part, child, level + 1);
+        bool isLeafLevel = (totalLevels <= 1);
+
+        auto dumpChild = [&](const NPage::TBtreeIndexNode &node, NPage::TRecIdx pos) {
+            auto childRef = node.GetChild(pos, isLeafLevel);
+            auto childLoc = NTable::ResolvePageLocation(&part, childRef, {});
+            if (childLoc.Type == (v2Format ? NPage::EPage::BTreeIndexV2 : NPage::EPage::BTreeIndex)) {
+                BTreeIndexNode(part, childLoc, node.ChildToString(pos), level + 1, totalLevels - 1, v2Format);
             } else {
-                Out << intend << " | " << child.ToString() << Endl;
+                Out << intend << " | " << node.ChildToString(pos) << Endl;
             }
         };
 
-        auto page = Env->TryGetPage(&part, part.GetPageLocation(meta.GetPageId(), {}), {});
+        auto page = Env->TryGetPage(&part, loc, {});
         if (!page) {
             Out << intend << " | -- the rest of the index pages aren't loaded" << Endl;
             return;
         }
 
-        auto node = NPage::TBtreeIndexNode(*page);
+        auto node = NPage::TBtreeIndexNode(*page, v2Format);
 
         auto label = node.Label();
 
         Out
             << intend
-            << " + BTreeIndex{" << meta.ToString() << "}"
+            << " + BTreeIndex{" << parent << "}"
             << " Label{" << (ui16)label.Type << " rev " << label.Format << ", " << label.Size << "b}"
             << Endl;
 
-        dumpChild(node.GetChild(0));
+        dumpChild(node, 0);
 
         for (NPage::TRecIdx i : xrange(node.GetKeysCount())) {
             Out << intend << " | > ";
@@ -344,7 +349,7 @@ namespace {
 
             Key(key, *part.Scheme);
             Out << Endl;
-            dumpChild(node.GetChild(i + 1));
+            dumpChild(node, i + 1);
         }
 
         Out << Endl;

--- a/ydb/core/tablet_flat/flat_part_dump.h
+++ b/ydb/core/tablet_flat/flat_part_dump.h
@@ -25,7 +25,7 @@ namespace NTable {
         void DataPage(const TPart&, NPage::TPageLocation location);
         void TName(ui32 num);
         void Key(TCellsRef cells, const TPartScheme&);
-        void BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level = 0);
+        void BTreeIndexNode(const TPart &part, NPage::TPageLocation loc, const TString &parent, ui32 level, ui32 totalLevels, bool v2Format);
 
         IOutputStream &Out;
         IPages * const Env = nullptr;

--- a/ydb/core/tablet_flat/flat_part_iface.h
+++ b/ydb/core/tablet_flat/flat_part_iface.h
@@ -37,13 +37,13 @@ namespace NTable {
         using TPageId = NPage::TPageId;
 
         virtual ~IPageWriter() = default;
-        virtual TPageOffset Write(TSharedData page, EPage type, ui32 group) = 0;
+        virtual TPageLocation Write(TSharedData page, EPage type, ui32 group) = 0;
         virtual TPageId WriteOuter(TSharedData) = 0;
         virtual void WriteInplace(TPageId page, TArrayRef<const char> body) = 0;
         virtual NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) = 0;
         virtual void Finish(TString overlay) = 0;
 
-        virtual ui32 GetWrittenPageId(ui32 group) const noexcept = 0;
+        virtual ui32 GetLastWrittenPageId(ui32 group) const noexcept = 0;
     };
 
     struct IPages {

--- a/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
@@ -26,7 +26,7 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
         std::optional<TBtreeIndexNode> Node;
         std::optional<TRecIdx> Pos;
 
-        TNodeState(TPageLocation location, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, TCellsIterable endKey)
+        TNodeState(const TPageLocation& location, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, TCellsIterable endKey)
             : Location(location)
             , BeginRowId(beginRowId)
             , EndRowId(endRowId)

--- a/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
@@ -18,7 +18,7 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
     using TBtreeIndexMeta = NPage::TBtreeIndexMeta;
 
     struct TNodeState {
-        TPageId PageId;
+        TPageLocation Location;
         TRowId BeginRowId;
         TRowId EndRowId;
         TCellsIterable BeginKey;
@@ -26,8 +26,8 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
         std::optional<TBtreeIndexNode> Node;
         std::optional<TRecIdx> Pos;
 
-        TNodeState(TPageId pageId, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, TCellsIterable endKey)
-            : PageId(pageId)
+        TNodeState(TPageLocation location, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, TCellsIterable endKey)
+            : Location(location)
             , BeginRowId(beginRowId)
             , EndRowId(endRowId)
             , BeginKey(beginKey)
@@ -115,12 +115,12 @@ public:
         , GroupId(groupId)
         , GroupInfo(Part->Scheme->GetLayout(GroupId))
         , Meta(Part->IndexPages.GetBTree(GroupId))
-        , State(Reserve(Meta.LevelCount + 1))
+        , State(Reserve(Meta.LevelCount() + 1))
     {
         const static TCellsIterable EmptyKey(static_cast<const char*>(nullptr), TColumns());
-        State.emplace_back(Meta.GetPageId(), 0, GetEndRowId(), EmptyKey, EmptyKey);
+        State.emplace_back(Part->IndexPages.GetRootLocation(Part, GroupId), 0, GetEndRowId(), EmptyKey, EmptyKey);
     }
-    
+
     EReady Seek(TRowId rowId) override {
         if (rowId >= GetEndRowId()) {
             return Exhaust();
@@ -180,7 +180,7 @@ public:
     EReady Next() override {
         Y_ENSURE(!IsExhausted());
 
-        if (Meta.LevelCount == 0) {
+        if (Meta.LevelCount() == 0) {
             return Exhaust();
         }
 
@@ -194,7 +194,7 @@ public:
             PushNextState(*State.back().Pos + 1);
         }
 
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount())) {
             if (!TryLoad(State[level])) {
                 // exiting with an intermediate state
                 Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
@@ -211,7 +211,7 @@ public:
     EReady Prev() override {
         Y_ENSURE(!IsExhausted());
 
-        if (Meta.LevelCount == 0) {
+        if (Meta.LevelCount() == 0) {
             return Exhaust();
         }
 
@@ -225,7 +225,7 @@ public:
             PushNextState(*State.back().Pos - 1);
         }
 
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount())) {
             if (!TryLoad(State[level])) {
                 // exiting with an intermediate state
                 Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
@@ -251,7 +251,7 @@ public:
 
     TPageLocation GetLocation() const override {
         Y_ENSURE(IsLeaf());
-        return Part->GetPageLocation(State.back().PageId, GroupId);
+        return State.back().Location;
     }
 
     TRowId GetRowId() const override {
@@ -298,7 +298,7 @@ private:
             State[0].Pos = { };
         }
 
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount())) {
             auto &state = State[level];
             Y_DEBUG_ABORT_UNLESS(seek.BelongsTo(state));
             if (!TryLoad(state)) {
@@ -307,7 +307,7 @@ private:
                 return EReady::Page;
             }
             auto pos = seek.Do(state);
-            
+
             PushNextState(pos);
         }
 
@@ -320,7 +320,7 @@ private:
     bool IsRoot() const noexcept {
         return State.size() == 1;
     }
-    
+
     bool IsExhausted() const noexcept {
         return State[0].Pos == Max<TRecIdx>();
     }
@@ -328,7 +328,7 @@ private:
     bool IsLeaf() const noexcept {
         // Note: it is possible to have 0 levels in B-Tree
         // so we may have exhausted state with leaf (data) node
-        return State.size() == Meta.LevelCount + 1 && !IsExhausted();
+        return State.size() == Meta.LevelCount() + 1 && !IsExhausted();
     }
 
     EReady Exhaust() {
@@ -344,15 +344,14 @@ private:
         Y_ENSURE(pos < current.Node->GetChildrenCount(), "Should point to some child");
         current.Pos.emplace(pos);
 
-        auto& child = current.Node->GetShortChild(pos);
-
-        TPageId pageId = child.GetPageId();
-        TRowId beginRowId = pos ? current.Node->GetShortChild(pos - 1).GetRowCount() : current.BeginRowId;
-        TRowId endRowId = child.GetRowCount();
+        bool isLeafLevel = State.size() == Meta.LevelCount();
+        auto location = current.Node->GetChildLocation(pos, isLeafLevel, Part, GroupId);
+        TRowId beginRowId = pos ? current.Node->GetChildRowCount(pos - 1) : current.BeginRowId;
+        TRowId endRowId = current.Node->GetChildRowCount(pos);
         TCellsIterable beginKey = pos ? current.Node->GetKeyCellsIterable(pos - 1, GroupInfo.ColsKeyIdx) : current.BeginKey;
         TCellsIterable endKey = pos < current.Node->GetKeysCount() ? current.Node->GetKeyCellsIterable(pos, GroupInfo.ColsKeyIdx) : current.EndKey;
-        
-        State.emplace_back(pageId, beginRowId, endRowId, beginKey, endKey);
+
+        State.emplace_back(location, beginRowId, endRowId, beginKey, endKey);
     }
 
     bool TryLoad(TNodeState& state) {
@@ -360,9 +359,9 @@ private:
             return true;
         }
 
-        auto page = Env->TryGetPage(Part, Part->GetPageLocation(state.PageId, {}), {});
+        auto page = Env->TryGetPage(Part, state.Location, {});
         if (page) {
-            state.Node.emplace(*page);
+            state.Node.emplace(*page, Meta.HasRootV2());
             return true;
         }
         return false;

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -82,20 +82,31 @@ void TLoader::StageParseMeta()
             FlatHistoricIndexes.push_back(id);
         }
 
+        auto loadMeta = [](const NProto::TBTreeIndexMeta& proto) -> NPage::TBtreeIndexMeta {
+            ui32 lv1 = proto.HasLevelCount() ? proto.GetLevelCount() : Max<ui32>();
+            ui32 lv2 = proto.HasLevelCountV2() ? proto.GetLevelCountV2() : Max<ui32>();
+            auto v2RootType = (lv2 == 0 ? NPage::EPage::DataPage : NPage::EPage::BTreeIndexV2);
+            auto v1Root = proto.HasRootPageId()
+                ? proto.GetRootPageId()
+                : Max<TPageId>();
+            auto v2Root = proto.HasRootOffset()
+                ? NPage::TBtreeIndexMeta::RootV2Location(proto.GetRootOffset(), proto.GetRootSize(), proto.GetRootCrc32(), v2RootType)
+                : NPage::TPageLocation::Max();
+            Y_ENSURE(v1Root != Max<TPageId>() || v2Root, "TBtreeIndexMeta has neither RootPageId nor RootOffset");
+            Y_ENSURE(v2Root ? lv2 != Max<ui32>() : lv1 != Max<ui32>(), "TBtreeIndexMeta has no valid level count");
+
+            return { v1Root, v2Root, proto.GetRowCount(), proto.GetDataSize(), proto.GetGroupDataSize(),
+                proto.GetErasedRowCount(), lv1, lv2, proto.GetIndexSize() };
+        };
+
         BTreeGroupIndexes.clear();
         BTreeHistoricIndexes.clear();
-        if (layout.HasBTreeIndexesFormatVersion() && layout.GetBTreeIndexesFormatVersion() == NPage::TBtreeIndexNode::FormatVersion) {
+        if (layout.HasBTreeIndexesFormatVersion() &&
+            layout.GetBTreeIndexesFormatVersion() == NPage::TBtreeIndexNode::FormatVersion) {
             for (bool history : {false, true}) {
-                for (const auto &meta : history ? layout.GetBTreeHistoricIndexes() : layout.GetBTreeGroupIndexes()) {
-                    NPage::TBtreeIndexMeta converted{{
-                        meta.GetRootPageId(),
-                        meta.GetRowCount(),
-                        meta.GetDataSize(),
-                        meta.GetGroupDataSize(),
-                        meta.GetErasedRowCount()},
-                        meta.GetLevelCount(),
-                        meta.GetIndexSize()};
-                    (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);
+                for (const auto& meta :
+                     history ? layout.GetBTreeHistoricIndexes() : layout.GetBTreeGroupIndexes()) {
+                    (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(loadMeta(meta));
                 }
             }
         }
@@ -152,7 +163,7 @@ void TLoader::StageParseMeta()
             << " " << PageCollections.size() << "s " << meta.TotalPages() << "pg"
             << ", Scheme " << SchemeId
             << ", FlatIndex " << (FlatGroupIndexes.size() ? FlatGroupIndexes[0] : Max<TPageId>())
-            << ", BTreeIndex " << (BTreeGroupIndexes.size() ? BTreeGroupIndexes[0].GetPageId() : Max<TPageId>())
+            << ", BTreeIndex " << (BTreeGroupIndexes.size() ? BTreeGroupIndexes[0].RootV1PageId() : Max<TPageId>())
             << ", Blobs " << GlobsId << ", Small " << SmallId
             << ", Large " << LargeId << ", ByKey " << ByKeyId
             << ", Garbage " << GarbageStatsId
@@ -170,15 +181,19 @@ TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
             ? nullptr
             : LoaderEnv->TryGetPage(nullptr, PageCollections[0]->PageCollection->GetLocation(pageId), {});
     };
+    auto getMetaPage = [&](const NPage::TBtreeIndexMeta& meta) {
+        return meta.HasRootV2() ? LoaderEnv->TryGetPage(nullptr, meta.RootV2, {})
+                                : getPage(meta.RootV1PageId());
+    };
 
     if (BTreeGroupIndexes) {
         if (preloadIndex) {
             // Note: preload root nodes only because we don't want to have multiple restarts here
             for (const auto& meta : BTreeGroupIndexes) {
-                if (meta.LevelCount) getPage(meta.GetPageId());
+                if (meta.LevelCount()) getMetaPage(meta);
             }
             for (const auto& meta : BTreeHistoricIndexes) {
-                if (meta.LevelCount) getPage(meta.GetPageId());
+                if (meta.LevelCount()) getMetaPage(meta);
             }
         }
     } else if (FlatGroupIndexes) {

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -98,6 +98,12 @@ public:
         return PageCollections[groupId.Index]->PageCollection->GetLocation(pageId);
     }
 
+    const NPageCollection::IPageCollection* GetPageCollection(ui32 room) const override
+    {
+        Y_ENSURE(room < PageCollections.size());
+        return PageCollections[room]->PageCollection.Get();
+    }
+
     ui8 GetGroupChannel(NPage::TGroupId groupId) const override
     {
         Y_ENSURE(groupId.Index < PageCollections.size());
@@ -145,10 +151,18 @@ public:
         Y_ENSURE(room < PageCollections.size());
 
         auto& pageCollection = *PageCollections[room]->PageCollection;
-        auto total = pageCollection.Total();
-
-        TVector<TPageLocation> pages(Reserve(total));
+        auto meta =
+            room < IndexPages.BTreeGroups.size() ? &IndexPages.GetBTree(NTable::NPage::TGroupId(room)) : nullptr;
+        bool skipV1 = meta && meta->HasRootV2();
+        auto total = pageCollection.MetaPages();
+        TVector<TPageLocation> pages(Reserve(skipV1 ? 8 : total));
         for (ui32 i = 0; i < total; ++i) {
+            auto type = pageCollection.Page(i).Type;
+            if (type == ui32(EPage::Skip) ||
+                (skipV1 && (type == ui32(EPage::BTreeIndex) || type == ui32(EPage::BTreeIndexV2) ||
+                               type == ui32(EPage::DataPage)))) {
+                continue;
+            }
             pages.push_back(pageCollection.GetLocation(i));
         }
 

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -41,7 +41,7 @@ namespace NTable {
             , CutIndexKeys(conf.CutIndexKeys)
             , WriteBTreeIndex(conf.WriteBTreeIndex)
             , WriteBTreeIndexV2(conf.WriteBTreeIndexV2)
-            , WriteFlatIndex(!conf.WriteBTreeIndexV2 && (conf.WriteFlatIndex || !conf.WriteBTreeIndex))
+            , WriteFlatIndex(conf.WriteFlatIndex || (!conf.WriteBTreeIndex && !conf.WriteBTreeIndexV2))
             , SmallEdge(conf.SmallEdge)
             , LargeEdge(conf.LargeEdge)
             , MaxLargeBlob(conf.MaxLargeBlob)
@@ -59,6 +59,8 @@ namespace NTable {
             , EraseRowState(tags.size())
             , SchemeData(scheme->Serialize())
         {
+            Y_ENSURE(!(conf.WriteFlatIndex && conf.WriteBTreeIndexV2),
+                     "V2 b-tree index replaces the flat index, can't write both");
             for (ui32 group : xrange(conf.Groups.size())) {
                 Groups.emplace_back(scheme, conf, tags, NPage::TGroupId(group));
                 Histories.emplace_back(scheme, conf, tags, NPage::TGroupId(group, true));

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -19,8 +19,6 @@
 #include <ydb/core/util/intrusive_heap.h>
 #include <util/system/sanitizers.h>
 
-#include <optional>
-
 namespace NKikimr {
 namespace NTable {
 
@@ -213,7 +211,7 @@ namespace NTable {
                 TCellsRef groupKey = groupIdx == 0 ? KeyState.Key : TCellsRef{ };
                 g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, TRowVersion::Min(), TRowVersion::Max(), txId, KeyState.LockMode, KeyState.LockTxId);
                 g.NextIndexSize = WriteFlatIndex ? g.FlatIndex.CalcSize(groupKey) : 0;
-                g.NextBTreeIndexSize = WriteBTreeIndex ? g.BTreeIndex.CalcSize(groupKey) : 0;
+                g.NextBTreeIndexSize = WriteBTreeIndex ? (WriteBTreeIndexV2 ? g.BTreeIndexV2.CalcSize(groupKey) : g.BTreeIndexV1.CalcSize(groupKey)) : 0;
                 overheadBytes += (
                     g.NextDataSize.DataPageSize +
                     g.NextDataSize.SmallSize +
@@ -288,7 +286,7 @@ namespace NTable {
                 TCellsRef groupKey = groupIdx == 0 ? KeyState.Key : TCellsRef{ };
                 g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, minVersion, maxVersion, /* txId */ 0, KeyState.LockMode, KeyState.LockTxId);
                 g.NextIndexSize = WriteFlatIndex ? g.FlatIndex.CalcSize(groupKey) : 0;
-                g.NextBTreeIndexSize = WriteBTreeIndex ? g.BTreeIndex.CalcSize(groupKey) : 0;
+                g.NextBTreeIndexSize = WriteBTreeIndex ? (WriteBTreeIndexV2 ? g.BTreeIndexV2.CalcSize(groupKey) : g.BTreeIndexV1.CalcSize(groupKey)) : 0;
 
                 // FIXME: not each row produces index row so overhead bytes shouldn't add index size
                 overheadBytes += (
@@ -419,7 +417,7 @@ namespace NTable {
                 TCellsRef groupKey = groupIdx == 0 ? syntheticKey : TCellsRef{ };
                 g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, TRowVersion::Min(), maxVersion, /* txId */ 0);
                 g.NextIndexSize = WriteFlatIndex ? g.FlatIndex.CalcSize(groupKey) : 0;
-                g.NextBTreeIndexSize = WriteBTreeIndex ? g.BTreeIndex.CalcSize(groupKey) : 0;
+                g.NextBTreeIndexSize = WriteBTreeIndex ? (WriteBTreeIndexV2 ? g.BTreeIndexV2.CalcSize(groupKey) : g.BTreeIndexV1.CalcSize(groupKey)) : 0;
 
                 // FIXME: not each row produces index row so overhead bytes shouldn't add index size
                 overheadBytes += (
@@ -496,7 +494,7 @@ namespace NTable {
                             indexSize += g.FlatIndex.BytesUsed() + g.FirstKeyIndexSize;
                         }
                         if (WriteBTreeIndex) {
-                            indexSize += g.BTreeIndex.EstimateBytesUsed() + g.FirstKeyBTreeIndexSize;
+                            indexSize += (WriteBTreeIndexV2 ? g.BTreeIndexV2.EstimateBytesUsed() : g.BTreeIndexV1.EstimateBytesUsed()) + g.FirstKeyBTreeIndexSize;
                         }
                         if (g.NextDataSize.Overflow) {
                             // On overflow we would have to start a new data page
@@ -569,9 +567,9 @@ namespace NTable {
                 if (WriteBTreeIndex) {
                     /* When dual-write is active, also finish the V1 shadow */
                     auto finishBTree = [&](TGroupState& g) -> NPage::TBtreeIndexMeta {
-                        auto meta = g.BTreeIndex.Finish(Pager);
-                        if (g.BTreeIndexV1Shadow) {
-                            auto v1ShadowMeta = g.BTreeIndexV1Shadow->Finish(Pager);
+                        auto meta = WriteBTreeIndexV2 ? g.BTreeIndexV2.Finish(Pager) : g.BTreeIndexV1.Finish(Pager);
+                        if (WriteBTreeIndexV2 && g.WriteBTreeIndexV1) {
+                            auto v1ShadowMeta = g.BTreeIndexV1.Finish(Pager);
                             meta.RootV1 = v1ShadowMeta.RootV1PageId();
                             meta.LevelCountV1 = v1ShadowMeta.LevelCountV1;
                             meta.IndexSize += v1ShadowMeta.IndexSize;
@@ -643,17 +641,21 @@ namespace NTable {
                 for (auto& g : Groups) {
                     g.Data.Reset();
                     g.FlatIndex.Reset();
-                    g.BTreeIndex.Reset();
-                    if (g.BTreeIndexV1Shadow) {
-                        g.BTreeIndexV1Shadow->Reset();
+                    if (WriteBTreeIndexV2) {
+                        g.BTreeIndexV2.Reset();
+                    }
+                    if (g.WriteBTreeIndexV1) {
+                        g.BTreeIndexV1.Reset();
                     }
                 }
                 for (auto& g : Histories) {
                     g.Data.Reset();
                     g.FlatIndex.Reset();
-                    g.BTreeIndex.Reset();
-                    if (g.BTreeIndexV1Shadow) {
-                        g.BTreeIndexV1Shadow->Reset();
+                    if (WriteBTreeIndexV2) {
+                        g.BTreeIndexV2.Reset();
+                    }
+                    if (g.WriteBTreeIndexV1) {
+                        g.BTreeIndexV1.Reset();
                     }
                 }
                 FrameL.Reset();
@@ -906,42 +908,44 @@ namespace NTable {
 
                 if (WriteBTreeIndex) {
                     if (dataPage.BaseRow()) {
-                        g.BTreeIndex.AddKey(Key);
-                        if (g.BTreeIndexV1Shadow) {
-                            g.BTreeIndexV1Shadow->AddKey(Key);
+                        if (WriteBTreeIndexV2) {
+                            g.BTreeIndexV2.AddKey(Key);
+                        }
+                        if (g.WriteBTreeIndexV1) {
+                            g.BTreeIndexV1.AddKey(Key);
                         }
                     }
                     if (groupId.IsMain()) {
                         if (WriteBTreeIndexV2) {
-                            g.BTreeIndex.AddChild(NPage::TBtreeIndexNode::TChildV2{
-                                location.Offset, location.Size, location.Crc32, dataPage->Count, raw.size(),
-                                Current.BTreeGroupDataSize, Current.BTreeIndexErasedRowCount});
-                            if (g.BTreeIndexV1Shadow) {
-                                g.BTreeIndexV1Shadow->AddChild({page, dataPage->Count, raw.size(),
-                                          Current.BTreeGroupDataSize, Current.BTreeIndexErasedRowCount});
-                            }
-                        } else {
-                            g.BTreeIndex.AddChild({page, dataPage->Count, raw.size(), Current.BTreeGroupDataSize,
-                                                   Current.BTreeIndexErasedRowCount});
+                            g.BTreeIndexV2.AddChild(
+                                NPage::TBtreeIndexNode::TChildV2{
+                                    location.Offset, location.Size, location.Crc32, dataPage->Count, raw.size(),
+                                    Current.BTreeGroupDataSize, Current.BTreeIndexErasedRowCount});
+                        }
+                        if (g.WriteBTreeIndexV1) {
+                            g.BTreeIndexV1.AddChild(
+                                {page, dataPage->Count, raw.size(), Current.BTreeGroupDataSize,
+                                 Current.BTreeIndexErasedRowCount});
                         }
                         Current.BTreeGroupDataSize = 0;
                         Current.BTreeIndexErasedRowCount = 0;
                     } else {
                         if (WriteBTreeIndexV2) {
-                            g.BTreeIndex.AddShortChild(NPage::TBtreeIndexNode::TShortChildV2{
-                                location.Offset, location.Size, location.Crc32, dataPage->Count, raw.size()});
-                            if (g.BTreeIndexV1Shadow) {
-                                g.BTreeIndexV1Shadow->AddShortChild({page, dataPage->Count, raw.size()});
-                            }
-                        } else {
-                            g.BTreeIndex.AddShortChild({page, dataPage->Count, raw.size()});
+                            g.BTreeIndexV2.AddShortChild(
+                                NPage::TBtreeIndexNode::TShortChildV2{
+                                    location.Offset, location.Size, location.Crc32, dataPage->Count, raw.size()});
+                        }
+                        if (g.WriteBTreeIndexV1) {
+                            g.BTreeIndexV1.AddShortChild({page, dataPage->Count, raw.size()});
                         }
                         // Note: group data size is approximate, includes only finished pages
                         Current.BTreeGroupDataSize += raw.size();
                     }
-                    g.BTreeIndex.Flush(Pager);
-                    if (g.BTreeIndexV1Shadow) {
-                        g.BTreeIndexV1Shadow->Flush(Pager);
+                    if (WriteBTreeIndexV2) {
+                        g.BTreeIndexV2.Flush(Pager);
+                    }
+                    if (g.WriteBTreeIndexV1) {
+                        g.BTreeIndexV1.Flush(Pager);
                     }
                 }
 
@@ -1210,8 +1214,13 @@ namespace NTable {
 
             NPage::TDataPageWriter Data;
             NPage::TFlatIndexWriter FlatIndex;
-            NPage::TBtreeIndexBuilder BTreeIndex;
-            std::optional<NPage::TBtreeIndexBuilder> BTreeIndexV1Shadow;
+
+            using TBtreeIndexBuilderV1 = NPage::TBtreeIndexBuilder<NPage::TBtreeIndexNode::TChild>;
+            using TBtreeIndexBuilderV2 = NPage::TBtreeIndexBuilder<NPage::TBtreeIndexNode::TChildV2>;
+
+            TBtreeIndexBuilderV1 BTreeIndexV1;
+            TBtreeIndexBuilderV2 BTreeIndexV2;
+            const bool WriteBTreeIndexV1; // V1 is written: as primary (V1 mode) or shadow (V2 mode)
 
             NPage::TDataPageWriter::TSizeInfo NextDataSize;
             TPgSize NextIndexSize;
@@ -1227,15 +1236,14 @@ namespace NTable {
                 , Codec(conf.Groups[groupId.Index].Codec)
                 , Data(scheme, conf, tags, groupId)
                 , FlatIndex(scheme, conf, groupId)
-                , BTreeIndex(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize,
-                             conf.Groups[groupId.Index].BTreeIndexNodeKeysMin,
-                             conf.Groups[groupId.Index].BTreeIndexNodeKeysMax, conf.WriteBTreeIndexV2)
+                , BTreeIndexV1(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize,
+                               conf.Groups[groupId.Index].BTreeIndexNodeKeysMin,
+                               conf.Groups[groupId.Index].BTreeIndexNodeKeysMax)
+                , BTreeIndexV2(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize,
+                               conf.Groups[groupId.Index].BTreeIndexNodeKeysMin,
+                               conf.Groups[groupId.Index].BTreeIndexNodeKeysMax)
+                , WriteBTreeIndexV1(!conf.WriteBTreeIndexV2 || conf.BTreeIndexV2KeepV1Shadow)
             {
-                if (conf.BTreeIndexV2KeepV1Shadow && conf.WriteBTreeIndexV2) {
-                    BTreeIndexV1Shadow.emplace(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize,
-                                              conf.Groups[groupId.Index].BTreeIndexNodeKeysMin,
-                                              conf.Groups[groupId.Index].BTreeIndexNodeKeysMax, /*writeV2=*/false);
-                }
             }
         };
 

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -19,6 +19,8 @@
 #include <ydb/core/util/intrusive_heap.h>
 #include <util/system/sanitizers.h>
 
+#include <optional>
+
 namespace NKikimr {
 namespace NTable {
 
@@ -40,7 +42,8 @@ namespace NTable {
             : Final(conf.Final)
             , CutIndexKeys(conf.CutIndexKeys)
             , WriteBTreeIndex(conf.WriteBTreeIndex)
-            , WriteFlatIndex(conf.WriteFlatIndex || !conf.WriteBTreeIndex)
+            , WriteBTreeIndexV2(conf.WriteBTreeIndexV2)
+            , WriteFlatIndex(!conf.WriteBTreeIndexV2 && (conf.WriteFlatIndex || !conf.WriteBTreeIndex))
             , SmallEdge(conf.SmallEdge)
             , LargeEdge(conf.LargeEdge)
             , MaxLargeBlob(conf.MaxLargeBlob)
@@ -564,14 +567,25 @@ namespace NTable {
                 Current.BTreeGroupIndexes.clear();
                 Current.BTreeHistoricIndexes.clear();
                 if (WriteBTreeIndex) {
+                    /* When dual-write is active, also finish the V1 shadow */
+                    auto finishBTree = [&](TGroupState& g) -> NPage::TBtreeIndexMeta {
+                        auto meta = g.BTreeIndex.Finish(Pager);
+                        if (g.BTreeIndexV1Shadow) {
+                            auto v1ShadowMeta = g.BTreeIndexV1Shadow->Finish(Pager);
+                            meta.RootV1 = v1ShadowMeta.RootV1PageId();
+                            meta.LevelCountV1 = v1ShadowMeta.LevelCountV1;
+                            meta.IndexSize += v1ShadowMeta.IndexSize;
+                        }
+                        return meta;
+                    };
                     Current.BTreeGroupIndexes.reserve(Groups.size());
                     for (auto& g : Groups) {
-                        Current.BTreeGroupIndexes.push_back(g.BTreeIndex.Finish(Pager));
+                        Current.BTreeGroupIndexes.push_back(finishBTree(g));
                     }
                     if (Current.HistoryWritten > 0) {
                         Current.BTreeHistoricIndexes.reserve(Histories.size());
                         for (auto& g : Histories) {
-                            Current.BTreeHistoricIndexes.push_back(g.BTreeIndex.Finish(Pager));
+                            Current.BTreeHistoricIndexes.push_back(finishBTree(g));
                         }
                     }
                 }
@@ -630,11 +644,17 @@ namespace NTable {
                     g.Data.Reset();
                     g.FlatIndex.Reset();
                     g.BTreeIndex.Reset();
+                    if (g.BTreeIndexV1Shadow) {
+                        g.BTreeIndexV1Shadow->Reset();
+                    }
                 }
                 for (auto& g : Histories) {
                     g.Data.Reset();
                     g.FlatIndex.Reset();
                     g.BTreeIndex.Reset();
+                    if (g.BTreeIndexV1Shadow) {
+                        g.BTreeIndexV1Shadow->Reset();
+                    }
                 }
                 FrameL.Reset();
                 FrameS.Reset();
@@ -739,8 +759,16 @@ namespace NTable {
                     for (bool history : {false, true}) {
                         for (auto meta : history ? Current.BTreeHistoricIndexes : Current.BTreeGroupIndexes) {
                             auto m = history ? lay->AddBTreeHistoricIndexes() : lay->AddBTreeGroupIndexes();
-                            m->SetRootPageId(meta.GetPageId());
-                            m->SetLevelCount(meta.LevelCount);
+                            if (meta.HasRootV1()) {
+                                m->SetRootPageId(meta.RootV1PageId());
+                                m->SetLevelCount(meta.LevelCountV1);
+                            }
+                            if (meta.HasRootV2()) {
+                                m->SetRootOffset(meta.RootV2.Offset.AsByteOffset());
+                                m->SetRootSize(meta.RootV2.Size);
+                                m->SetRootCrc32(meta.RootV2.Crc32);
+                                m->SetLevelCountV2(meta.LevelCountV2);
+                            }
                             m->SetIndexSize(meta.IndexSize);
                             m->SetDataSize(meta.GetDataSize());
                             m->SetGroupDataSize(meta.GetGroupDataSize());
@@ -785,7 +813,7 @@ namespace NTable {
             return blob;
         }
 
-        TPageOffset WritePage(TSharedData page, EPage type, ui32 group = 0)
+        TPageLocation WritePage(TSharedData page, EPage type, ui32 group = 0)
         {
             NSan::CheckMemIsInitialized(page.data(), page.size());
 
@@ -811,7 +839,7 @@ namespace NTable {
         TPageId WriteGetId(TSharedData page, EPage type, ui32 group = 0)
         {
             WritePage(std::move(page), type, group);
-            return Pager.GetWrittenPageId(group);
+            return Pager.GetLastWrittenPageId(group);
         }
 
         void Save(TSharedData raw, NPage::TGroupId groupId) override
@@ -866,7 +894,8 @@ namespace NTable {
 
                 Current.Coded += raw.size(); /* after encoding */
 
-                auto page = WriteGetId(raw, EPage::DataPage, groupId.Index);
+                auto location = WritePage(raw, EPage::DataPage, groupId.Index);
+                auto page = Pager.GetLastWrittenPageId(groupId.Index);
 
                 if (WriteFlatIndex) {
                     // N.B. non-main groups have no key
@@ -878,17 +907,42 @@ namespace NTable {
                 if (WriteBTreeIndex) {
                     if (dataPage.BaseRow()) {
                         g.BTreeIndex.AddKey(Key);
+                        if (g.BTreeIndexV1Shadow) {
+                            g.BTreeIndexV1Shadow->AddKey(Key);
+                        }
                     }
                     if (groupId.IsMain()) {
-                        g.BTreeIndex.AddChild({page, dataPage->Count, raw.size(), Current.BTreeGroupDataSize, Current.BTreeIndexErasedRowCount});
+                        if (WriteBTreeIndexV2) {
+                            g.BTreeIndex.AddChild(NPage::TBtreeIndexNode::TChildV2{
+                                location.Offset, location.Size, location.Crc32, dataPage->Count, raw.size(),
+                                Current.BTreeGroupDataSize, Current.BTreeIndexErasedRowCount});
+                            if (g.BTreeIndexV1Shadow) {
+                                g.BTreeIndexV1Shadow->AddChild({page, dataPage->Count, raw.size(),
+                                          Current.BTreeGroupDataSize, Current.BTreeIndexErasedRowCount});
+                            }
+                        } else {
+                            g.BTreeIndex.AddChild({page, dataPage->Count, raw.size(), Current.BTreeGroupDataSize,
+                                                   Current.BTreeIndexErasedRowCount});
+                        }
                         Current.BTreeGroupDataSize = 0;
                         Current.BTreeIndexErasedRowCount = 0;
                     } else {
-                        g.BTreeIndex.AddShortChild({page, dataPage->Count, raw.size()});
+                        if (WriteBTreeIndexV2) {
+                            g.BTreeIndex.AddShortChild(NPage::TBtreeIndexNode::TShortChildV2{
+                                location.Offset, location.Size, location.Crc32, dataPage->Count, raw.size()});
+                            if (g.BTreeIndexV1Shadow) {
+                                g.BTreeIndexV1Shadow->AddShortChild({page, dataPage->Count, raw.size()});
+                            }
+                        } else {
+                            g.BTreeIndex.AddShortChild({page, dataPage->Count, raw.size()});
+                        }
                         // Note: group data size is approximate, includes only finished pages
                         Current.BTreeGroupDataSize += raw.size();
                     }
                     g.BTreeIndex.Flush(Pager);
+                    if (g.BTreeIndexV1Shadow) {
+                        g.BTreeIndexV1Shadow->Flush(Pager);
+                    }
                 }
 
                 // N.B. hack to save the last row/key for the main group
@@ -1116,6 +1170,7 @@ namespace NTable {
         const bool Final = false;
         const bool CutIndexKeys;
         const bool WriteBTreeIndex;
+        const bool WriteBTreeIndexV2;
         const bool WriteFlatIndex;
         const ui32 SmallEdge;
         const ui32 LargeEdge;
@@ -1156,6 +1211,7 @@ namespace NTable {
             NPage::TDataPageWriter Data;
             NPage::TFlatIndexWriter FlatIndex;
             NPage::TBtreeIndexBuilder BTreeIndex;
+            std::optional<NPage::TBtreeIndexBuilder> BTreeIndexV1Shadow;
 
             NPage::TDataPageWriter::TSizeInfo NextDataSize;
             TPgSize NextIndexSize;
@@ -1165,13 +1221,22 @@ namespace NTable {
             TPgSize FirstKeyBTreeIndexSize = 0;
             TPgSize LastKeyIndexSize = 0;
 
-            TGroupState(const TIntrusiveConstPtr<TPartScheme>& scheme, const NPage::TConf& conf, TTagsRef tags, NPage::TGroupId groupId)
+            TGroupState(const TIntrusiveConstPtr<TPartScheme>& scheme, const NPage::TConf& conf, TTagsRef tags,
+                        NPage::TGroupId groupId)
                 : ForceCompression(conf.Groups[groupId.Index].ForceCompression)
                 , Codec(conf.Groups[groupId.Index].Codec)
                 , Data(scheme, conf, tags, groupId)
                 , FlatIndex(scheme, conf, groupId)
-                , BTreeIndex(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize, conf.Groups[groupId.Index].BTreeIndexNodeKeysMin, conf.Groups[groupId.Index].BTreeIndexNodeKeysMax)
-            { }
+                , BTreeIndex(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize,
+                             conf.Groups[groupId.Index].BTreeIndexNodeKeysMin,
+                             conf.Groups[groupId.Index].BTreeIndexNodeKeysMax, conf.WriteBTreeIndexV2)
+            {
+                if (conf.BTreeIndexV2KeepV1Shadow && conf.WriteBTreeIndexV2) {
+                    BTreeIndexV1Shadow.emplace(scheme, groupId, conf.Groups[groupId.Index].BTreeIndexNodeTargetSize,
+                                              conf.Groups[groupId.Index].BTreeIndexNodeKeysMin,
+                                              conf.Groups[groupId.Index].BTreeIndexNodeKeysMax, /*writeV2=*/false);
+                }
+            }
         };
 
         TDeque<TGroupState> Groups;

--- a/ydb/core/tablet_flat/flat_sausage_gut.h
+++ b/ydb/core/tablet_flat/flat_sausage_gut.h
@@ -14,6 +14,8 @@ namespace NPageCollection {
 
         virtual const TLogoBlobID& Label() const noexcept = 0;
         virtual ui32 Total() const noexcept = 0;
+        /* Number of structural pages addressable by TPageId */
+        virtual ui32 MetaPages() const noexcept { return Total(); }
         virtual TInfo Page(ui32 page) const = 0;
         virtual TBorder Bounds(ui32 page) const = 0;
         /// Maps a page location to the blob storage range containing it
@@ -24,6 +26,9 @@ namespace NPageCollection {
         virtual bool Verify(const TPageLocation&, TArrayRef<const char>) const = 0;
         virtual size_t BackingSize() const noexcept = 0;
         virtual NTable::NPage::TPageLocation GetLocation(ui32 pageId) const = 0;
+        /// Returns true when the collection carries both BTreeIndex and BTreeIndexV2 pages
+        virtual bool SkipBTreeIndexV1Shadow() const noexcept { return false; }
+        virtual void SetSkipBTreeIndexV1Shadow(bool) const noexcept { }
     };
 
 }

--- a/ydb/core/tablet_flat/flat_sausage_meta.cpp
+++ b/ydb/core/tablet_flat/flat_sausage_meta.cpp
@@ -29,6 +29,10 @@ TMeta::TMeta(TSharedData raw, ui32 group)
         for (auto &one: blobs)
             Steps.push_back(offset += one.BlobSize());
     }
+
+    /* Crc32 stores pages - 1 per skip entry (not the raw count, see TRecord::PushSkip);
+       Total = MetaPages + SkippedPages gives the correct full page count. */
+    SkippedPages_ = (Extra[0].Type == ui32(NTable::NPage::EPage::Skip) ? Extra[0].Crc32 : 0);
 }
 
 TMeta::~TMeta()
@@ -81,6 +85,8 @@ ui64 TMeta::GetPageSize(ui32 pageId) const
 NTable::NPage::TPageLocation TMeta::GetLocation(ui32 pageId) const
 {
     Y_ENSURE(pageId < Header->Pages);
+    Y_ENSURE(Extra[pageId].Type != ui32(NTable::NPage::EPage::Skip),
+        "Cannot get location for skip page entry by pageId");
 
     const ui64 offset = (pageId == 0) ? 0 : Index[pageId - 1].Page;
     const ui64 size = Index[pageId].Page - offset;

--- a/ydb/core/tablet_flat/flat_sausage_meta.h
+++ b/ydb/core/tablet_flat/flat_sausage_meta.h
@@ -41,6 +41,10 @@ namespace NPageCollection {
         ui64 GetPageSize(ui32 pageId) const;
         TStringBuf GetPageInplaceData(ui32 pageId) const;
 
+        /* Number of data/btree pages absorbed into EPage::Skip entries.
+           Recovered from the Crc32 field of each skip entry. */
+        ui32 SkippedPages() const noexcept { return SkippedPages_; };
+
         TBorder Bounds(const NTable::NPage::TPageLocation& location) const;
         TPageLocation GetLocation(ui32 pageId) const;
 
@@ -54,6 +58,7 @@ namespace NPageCollection {
         const TExtra *Extra = nullptr;
         const char *InboundData = nullptr;
         TVector<ui64> Steps;    /* Pages boundaries vector  */
+        ui32 SkippedPages_ = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_sausage_packet.h
+++ b/ydb/core/tablet_flat/flat_sausage_packet.h
@@ -5,6 +5,8 @@
 #include "flat_sausage_gut.h"
 #include "util_fmt_abort.h"
 
+#include <atomic>
+
 namespace NKikimr {
 namespace NPageCollection {
 
@@ -15,6 +17,7 @@ namespace NPageCollection {
         TPageCollection(TLargeGlobId largeGlobId, TSharedData raw)
             : LargeGlobId(largeGlobId)
             , Meta(std::move(raw), LargeGlobId.Group)
+            , SkippedInMeta(Meta.SkippedPages())
         {
             if (!Meta.Raw || LargeGlobId.Bytes != Meta.Raw.size() || LargeGlobId.Group == TLargeGlobId::InvalidGroup) {
                 Y_TABLET_ERROR("Invalid TLargeGlobId of page collection meta blob");
@@ -27,6 +30,14 @@ namespace NPageCollection {
         }
 
         ui32 Total() const noexcept override
+        {
+            return MetaPages() + SkippedInMeta;
+        }
+
+        /* Structural pages addressable by TPageId (enumerated in TMeta).
+           Total() may exceed MetaPages() for shrunk v2 collections. SkippedInMeta
+           carries the number of extra pages beyond MetaPages. */
+        ui32 MetaPages() const noexcept override
         {
             return Meta.TotalPages();
         }
@@ -73,6 +84,16 @@ namespace NPageCollection {
             return Meta.BackingSize();
         }
 
+        bool SkipBTreeIndexV1Shadow() const noexcept override
+        {
+            return SkipBTreeIndexV1Shadow_.load(std::memory_order_relaxed);
+        }
+
+        void SetSkipBTreeIndexV1Shadow(bool v) const noexcept override
+        {
+            SkipBTreeIndexV1Shadow_.store(v, std::memory_order_relaxed);
+        }
+
         template<typename TContainer>
         void SaveAllBlobIdsTo(TContainer &vec) const
         {
@@ -86,12 +107,17 @@ namespace NPageCollection {
 
         const TLargeGlobId LargeGlobId;
         const TMeta Meta;
+        const ui32 SkippedInMeta;
+        // Set before the collection is handed to the shared cache; read afterwards by cache actors
+        mutable std::atomic<bool> SkipBTreeIndexV1Shadow_ = false;
     };
 
     /// Page-index TPageOffset to satisfy forward cache
     class TOuterPageCollection : public TPageCollection {
     public:
-        using TPageCollection::TPageCollection;
+        TOuterPageCollection(TLargeGlobId largeGlobId, TSharedData raw)
+            : TPageCollection(std::move(largeGlobId), std::move(raw))
+        {}
 
         NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override
         {

--- a/ydb/core/tablet_flat/flat_sausage_record.h
+++ b/ydb/core/tablet_flat/flat_sausage_record.h
@@ -47,6 +47,25 @@ namespace NPageCollection {
             return Index.size() - 1;
         }
 
+        ui32 PushSkip(ui64 totalOffset, ui32 type, ui32 pages)
+        {
+            Y_ENSURE(totalOffset >= Offset,
+                "PushSkip: totalOffset " << totalOffset << " less than current Offset " << Offset);
+
+            Index.push_back({ totalOffset, Inbound.size() });
+            /* Crc32 stores the net page contribution beyond the skip entry
+               itself: (pages - 1) when pages > 0, or 0 for old-format entries.
+               Skip entries have no data to checksum, so the field is repurposed.
+               The total with skipped pages is MetaPages + sum(Crc32). */
+            Extra.push_back({ type, pages ? pages - 1 : 0 });
+
+            Offset = totalOffset;
+
+            return Index.size() - 1;
+        }
+
+        ui64 GetOffset() const noexcept { return Offset; }
+
         void PushInplace(ui32 page, TArrayRef<const char> body)
         {
             Y_ENSURE(Index && page == Index.size() - 1);

--- a/ydb/core/tablet_flat/flat_sausage_writer.h
+++ b/ydb/core/tablet_flat/flat_sausage_writer.h
@@ -2,6 +2,7 @@
 
 #include "flat_sausage_record.h"
 #include "flat_sausage_grind.h"
+#include "flat_page_iface.h"
 #include "util_basics.h"
 
 namespace NKikimr {
@@ -9,11 +10,12 @@ namespace NPageCollection {
 
     class TWriter {
     public:
-        TWriter(TCookieAllocator &cookieAllocator, ui8 channel, ui32 maxBlobSize)
+        TWriter(TCookieAllocator &cookieAllocator, ui8 channel, ui32 maxBlobSize, bool v2OnlyMode)
             : MaxBlobSize(maxBlobSize)
             , Channel(channel)
             , CookieAllocator(cookieAllocator)
             , Record(cookieAllocator.GroupBy(channel))
+            , V2OnlyMode(v2OnlyMode)
         {
 
         }
@@ -40,7 +42,28 @@ namespace NPageCollection {
                 }
             }
 
+            // Must match skipType condition in TBlocks::Write
+            bool pageSkipped = V2OnlyMode && (type == ui32(NTable::NPage::EPage::BTreeIndexV2) ||
+                                              type == ui32(NTable::NPage::EPage::DataPage));
+            /* No TEntry/TExtra entry created */
+            if (pageSkipped) {
+                SkippedBytes += body.size();
+                SkippedPages += 1;
+                if (crc32)
+                    *crc32 = Checksum(body);
+                return Max<ui32>();
+            }
+
             return Record.Push(type, body, crc32);
+        }
+
+        void PushSkipEntry()
+        {
+            if (SkippedBytes > 0) {
+                Record.PushSkip(Record.GetOffset() + SkippedBytes, (ui32)NTable::NPage::EPage::Skip, SkippedPages);
+                SkippedBytes = 0;
+                SkippedPages = 0;
+            }
         }
 
         void AddInplace(ui32 page, TArrayRef<const char> body)
@@ -50,6 +73,7 @@ namespace NPageCollection {
 
         TSharedData Finish(bool empty)
         {
+            Y_ENSURE(SkippedBytes == 0, "PushSkipEntry not called before Finish");
             Flush();
 
             TSharedData meta;
@@ -104,6 +128,9 @@ namespace NPageCollection {
         TCookieAllocator &CookieAllocator;
         TVector<TGlob> Blobs;
         NPageCollection::TRecord Record;
+        bool V2OnlyMode = false;
+        ui64 SkippedBytes = 0;
+        ui32 SkippedPages = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
@@ -18,15 +18,15 @@ class TStatsPartGroupBtreeIndexIter : public IStatsPartGroupIter {
     using TBtreeIndexMeta = NPage::TBtreeIndexMeta;
 
     struct TNodeState {
-        TPageId PageId;
+        TPageRef Ref;
         TRowId BeginRowId;
         TRowId EndRowId;
         TCellsIterable BeginKey;
         ui64 BeginDataSize;
         ui64 EndDataSize;
 
-        TNodeState(TPageId pageId, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, ui64 beginDataSize, ui64 endDataSize)
-            : PageId(pageId)
+        TNodeState(TPageRef ref, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, ui64 beginDataSize, ui64 endDataSize)
+            : Ref(std::move(ref))
             , BeginRowId(beginRowId)
             , EndRowId(endRowId)
             , BeginKey(beginKey)
@@ -58,9 +58,12 @@ public:
 
         bool ready = true;
         TVector<TNodeState> nextNodes;
-        Nodes.emplace_back(Meta.GetPageId(), 0, GetEndRowId(), EmptyKey, 0, Meta.GetDataSize());
+        auto rootLoc = GetBTreeRootLocation(Meta,
+            Part->GetPageCollection(0),               // btree index pages always room 0
+            Part->GetPageCollection(GroupId.Index));  // data pages in the group's room
+        Nodes.emplace_back(TPageRef(rootLoc), 0, GetEndRowId(), EmptyKey, 0, Meta.GetDataSize());
 
-        for (ui32 height = 0; height < Meta.LevelCount; height++) {
+        for (ui32 height = 0; height < Meta.LevelCount(); height++) {
             bool hasChanges = false;
             size_t splitPointIndex = 0;
 
@@ -76,24 +79,26 @@ public:
                     continue; // don't go deeper
                 }
 
-                auto page = Env->TryGetPage(Part, Part->GetPageLocation(nodeState.PageId, {}), {});
+                auto location = ResolvePageLocation(Part, nodeState.Ref, {});
+                auto page = Env->TryGetPage(Part, location, {});
                 if (!page) {
                     ready = false;
                     continue; // continue requesting other nodes
                 }
-                TBtreeIndexNode node(*page);
+                TBtreeIndexNode node(*page, Meta.HasRootV2());
+
+                bool isLeafLevel = (height + 1 == Meta.LevelCount());
 
                 for (TRecIdx pos : xrange<TRecIdx>(0, node.GetChildrenCount())) {
-                    auto& child = node.GetShortChild(pos);
+                    TPageRef ref = node.GetChild(pos, isLeafLevel);
 
-                    TPageId pageId = child.GetPageId();
-                    TRowId beginRowId = pos ? node.GetShortChild(pos - 1).GetRowCount() : nodeState.BeginRowId;
-                    TRowId endRowId = child.GetRowCount();
+                    TRowId beginRowId = pos ? node.GetChildRowCount(pos - 1) : nodeState.BeginRowId;
+                    TRowId endRowId = node.GetChildRowCount(pos);
                     TCellsIterable beginKey = pos ? node.GetKeyCellsIterable(pos - 1, GroupInfo.ColsKeyIdx) : nodeState.BeginKey;
-                    ui64 beginDataSize = pos ? node.GetShortChild(pos - 1).GetDataSize() : nodeState.BeginDataSize;
-                    ui64 endDataSize = child.GetDataSize();
+                    ui64 beginDataSize = pos ? node.GetPrevChildDataSize(pos) : nodeState.BeginDataSize;
+                    ui64 endDataSize = node.GetChildDataSize(pos);
 
-                    nextNodes.emplace_back(pageId, beginRowId, endRowId, beginKey, beginDataSize, endDataSize);
+                    nextNodes.emplace_back(std::move(ref), beginRowId, endRowId, beginKey, beginDataSize, endDataSize);
                     hasChanges = true;
                 }
             }
@@ -139,10 +144,6 @@ public:
 
     TRowId GetEndRowId() const override {
         return Meta.GetRowCount();
-    }
-
-    TPageLocation GetLocation() const override {
-        return Part->GetPageLocation(GetCurrentNode().PageId, GroupId);
     }
 
     TRowId GetRowId() const override {

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
@@ -31,7 +31,6 @@ struct IStatsPartGroupIter {
     virtual bool IsValid() const = 0;
 
     virtual TRowId GetEndRowId() const = 0;
-    virtual TPageLocation GetLocation() const = 0;
     virtual TRowId GetRowId() const = 0;
 
     virtual TPos GetKeyCellsCount() const = 0;

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
@@ -9,11 +9,20 @@ namespace NKikimr::NTable {
 namespace {
 
 using TGroupId = NPage::TGroupId;
+using TRecIdx = NPage::TRecIdx;
 using TFrames = NPage::TFrames;
 using TBtreeIndexNode = NPage::TBtreeIndexNode;
+using TBtreeIndexMeta = NPage::TBtreeIndexMeta;
 using TChild = TBtreeIndexNode::TChild;
 using TColumns = TBtreeIndexNode::TColumns;
 using TCells = NPage::TCells;
+
+// Resolve root page location from meta, supporting both V1 and V2 formats.
+NPage::TPageLocation RootLocation(const TPart* part, const TBtreeIndexMeta& meta, TGroupId groupId) {
+    return GetBTreeRootLocation(meta,
+        part->GetPageCollection(0),          // btree index pages are always in room 0
+        part->GetPageCollection(groupId.Index)); // data pages are in the group's room
+}
 
 ui64 GetPrevDataSize(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
     auto& meta = part->IndexPages.GetBTree(groupId);
@@ -25,21 +34,22 @@ ui64 GetPrevDataSize(const TPart* part, TGroupId groupId, TRowId rowId, IPages* 
         return meta.GetDataSize();
     }
 
-    TPageId pageId = meta.GetPageId();
+    auto location = RootLocation(part, meta, groupId);
     ui64 prevDataSize = 0;
 
-    for (ui32 height = 0; height < meta.LevelCount; height++) {
-        auto page = env->TryGetPage(part, part->GetPageLocation(pageId, {}), {});
+    for (ui32 height = 0; height < meta.LevelCount(); height++) {
+        auto page = env->TryGetPage(part, location, {});
         if (!page) {
             ready = false;
             return prevDataSize;
         }
-        auto node = TBtreeIndexNode(*page);
+        auto node = TBtreeIndexNode(*page, meta.HasRootV2());
         auto pos = node.Seek(rowId);
 
-        pageId = node.GetShortChild(pos).GetPageId();
+        bool isLeafLevel = (height + 1 == meta.LevelCount());
+        location = node.GetChildLocation(pos, isLeafLevel, part, groupId);
         if (pos) {
-            prevDataSize = node.GetShortChild(pos - 1).GetDataSize();
+            prevDataSize = node.GetPrevChildDataSize(pos);
         }
     }
 
@@ -60,7 +70,7 @@ ui64 GetPrevHistoricDataSize(const TPart* part, TGroupId groupId, TRowId rowId, 
         return meta.GetDataSize();
     }
 
-    TPageId pageId = meta.GetPageId();
+    auto location = RootLocation(part, meta, groupId);
     ui64 prevDataSize = 0;
     historicRowId = 0;
 
@@ -74,20 +84,20 @@ ui64 GetPrevHistoricDataSize(const TPart* part, TGroupId groupId, TRowId rowId, 
     };
     TCells key1{ key1Cells, 3 };
 
-    for (ui32 height = 0; height < meta.LevelCount; height++) {
-        auto page = env->TryGetPage(part, part->GetPageLocation(pageId, {}), {});
+    for (ui32 height = 0; height < meta.LevelCount(); height++) {
+        auto page = env->TryGetPage(part, location, {});
         if (!page) {
             ready = false;
             return prevDataSize;
         }
-        auto node = TBtreeIndexNode(*page);
+        auto node = TBtreeIndexNode(*page, meta.HasRootV2());
         auto pos = node.Seek(ESeek::Lower, key1, part->Scheme->HistoryGroup.ColsKeyIdx, part->Scheme->HistoryKeys.Get());
 
-        pageId = node.GetShortChild(pos).GetPageId();
+        bool isLeafLevel = (height + 1 == meta.LevelCount());
+        location = node.GetChildLocation(pos, isLeafLevel, part, groupId);
         if (pos) {
-            const auto& prevChild = node.GetShortChild(pos - 1);
-            prevDataSize = prevChild.GetDataSize();
-            historicRowId = prevChild.GetRowCount();
+            prevDataSize = node.GetPrevChildDataSize(pos);
+            historicRowId = node.GetChildRowCount(pos - 1);
         }
     }
 

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
@@ -28,16 +28,17 @@ enum class ENodeState : ui8 {
 class TTableHistogramBuilderBtreeIndex {
     struct TNodeState {
         const TPart* Part;
-        TPageId PageId;
+        TPageRef Ref;
         ui32 Level;
         TRowId BeginRowId, EndRowId;
         ui64 BeginDataSize, EndDataSize;
         TCellsIterable BeginKey, EndKey;
         ENodeState State = ENodeState::Initial;
 
-        TNodeState(const TPart* part, TPageId pageId, ui32 level, TRowId beginRowId, TRowId endRowId, TRowId beginDataSize, TRowId endDataSize, TCellsIterable beginKey, TCellsIterable endKey)
+        TNodeState(const TPart* part, TPageRef ref, ui32 level, TRowId beginRowId, TRowId endRowId,
+                   TRowId beginDataSize, TRowId endDataSize, TCellsIterable beginKey, TCellsIterable endKey)
             : Part(part)
-            , PageId(pageId)
+            , Ref(std::move(ref))
             , Level(level)
             , BeginRowId(beginRowId)
             , EndRowId(endRowId)
@@ -49,9 +50,17 @@ class TTableHistogramBuilderBtreeIndex {
         }
 
         TString ToString(const TKeyCellDefaults &keyDefaults) const {
-            return TStringBuilder() 
+            NPage::TPageOffset offset = std::visit([](const auto& val) -> NPage::TPageOffset {
+                using T = std::decay_t<decltype(val)>;
+                if constexpr (std::is_same_v<T, TPageId>) {
+                    return NPage::TPageOffset::FromPageIndex(val);
+                } else {
+                    return val.Offset;
+                }
+            }, Ref);
+            return TStringBuilder()
                 << "Part: " << Part->Label.ToString()
-                << " PageId: " << PageId
+                << " Offset: " << offset
                 << " Level: " << Level
                 << " BeginRowId: " << BeginRowId
                 << " EndRowId: " << EndRowId
@@ -243,8 +252,11 @@ public:
             if (part.Slices && part.Slices->back().LastKey.GetCells()) {
                 endKey = MakeCellsIterableKey(part.Part.Get(), part.Slices->back().LastKey);
             }
-            LoadedStateNodes.emplace_back(part.Part.Get(), meta.GetPageId(), meta.LevelCount, 0, meta.GetRowCount(), 0, meta.GetTotalDataSize(), beginKey, endKey);
-            ready &= SlicePart(*part.Slices, LoadedStateNodes.back());
+            auto* pageColl = part->GetPageCollection(0);
+            auto rootLoc = GetBTreeRootLocation(meta, pageColl, pageColl);
+            LoadedStateNodes.emplace_back(part.Part.Get(), TPageRef(rootLoc), meta.LevelCount(), 0, meta.GetRowCount(), 0,
+                                          meta.GetTotalDataSize(), beginKey, endKey);
+            if (part.Slices) ready &= SlicePart(*part.Slices, LoadedStateNodes.back());
         }
 
         if (!ready) {
@@ -538,28 +550,35 @@ private:
         histogram.push_back({serializedKey, value});
     }
 
+    static TNodeState BuildChildState(const TNodeState& parent, const TBtreeIndexNode& node, NPage::TRecIdx pos, bool isLeafLevel, TColumns colsKeyData) {
+        return TNodeState(parent.Part, node.GetChild(pos, isLeafLevel), parent.Level - 1,
+            pos ? node.GetChildRowCount(pos - 1) : parent.BeginRowId,
+            node.GetChildRowCount(pos),
+            pos ? node.GetChildTotalDataSize(pos - 1) : parent.BeginDataSize,
+            node.GetChildTotalDataSize(pos),
+            pos ? node.GetKeyCellsIterable(pos - 1, colsKeyData) : parent.BeginKey,
+            pos < node.GetKeysCount() ? node.GetKeyCellsIterable(pos, colsKeyData) : parent.EndKey);
+    }
+
     bool TryLoadNode(const TNodeState& parent, const auto& addNode) {
         Y_ENSURE(parent.Level);
 
-        auto page = Env->TryGetPage(parent.Part, parent.Part->GetPageLocation(parent.PageId, {}), {});
+        auto location = ResolvePageLocation(parent.Part, parent.Ref, {});
+        auto page = Env->TryGetPage(parent.Part, location, {});
         if (!page) {
             return false;
         }
 
-        LoadedBTreeNodes.emplace_back(*page);
+        bool v2Format = parent.Part->IndexPages.GetBTree({}).HasRootV2();
+        LoadedBTreeNodes.emplace_back(*page, v2Format);
         auto &bTreeNode = LoadedBTreeNodes.back();
         auto& groupInfo = parent.Part->Scheme->GetLayout({});
 
+        bool isLeafLevel = (parent.Level == 1);
+
         for (auto pos : xrange(bTreeNode.GetChildrenCount())) {
-            auto& child = bTreeNode.GetChild(pos);
-
-            LoadedStateNodes.emplace_back(parent.Part, child.GetPageId(), parent.Level - 1,
-                pos ? bTreeNode.GetChild(pos - 1).GetRowCount() : parent.BeginRowId, child.GetRowCount(),
-                pos ? bTreeNode.GetChild(pos - 1).GetTotalDataSize() : parent.BeginDataSize, child.GetTotalDataSize(),
-                pos ? bTreeNode.GetKeyCellsIterable(pos - 1, groupInfo.ColsKeyData) : parent.BeginKey,
-                pos < bTreeNode.GetKeysCount() ? bTreeNode.GetKeyCellsIterable(pos, groupInfo.ColsKeyData) : parent.EndKey);
-
-            addNode(LoadedStateNodes.back());
+            auto& child = LoadedStateNodes.emplace_back(BuildChildState(parent, bTreeNode, pos, isLeafLevel, groupInfo.ColsKeyData));
+            addNode(child);
         }
 
         return true;
@@ -580,12 +599,13 @@ private:
     TCellsIterable MakeCellsIterableKey(const TPart* part, TSerializedCellVec serializedKey) {
         // Note: this method is only called for root nodes and don't worth optimizing
         // so let's simply create a new fake b-tree index node with a given key
+        // writeV2=false is fine: key encoding is same in V1/V2, children are dummy
         NPage::TBtreeIndexNodeWriter writer(part->Scheme, {});
         writer.AddChild({1, 1, 1, 0, 0});
         writer.AddKey(serializedKey.GetCells());
         writer.AddChild({2, 2, 2, 0, 0});
         TSharedData serializedNode = writer.Finish();
-        LoadedBTreeNodes.emplace_back(serializedNode);
+        LoadedBTreeNodes.emplace_back(serializedNode, /*v2Format=*/false);
         return LoadedBTreeNodes.back().GetKeyCellsIterable(0, part->Scheme->GetLayout({}).ColsKeyData);
     }
 

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -13,9 +13,28 @@
 #include "flat_page_txidstat.h"
 #include "flat_page_txstatus.h"
 
+#include <type_traits>
+#include <variant>
+
 namespace NKikimr {
 namespace NTable {
     struct IPages;
+
+    /// Resolves the root TPageLocation from btree meta through page collections.
+    /// For v2 roots (byte-offset), returns the inline location directly.
+    /// For v1 roots (page-index), resolves through the appropriate page collection.
+    /// When LevelCount==0 the root IS a data page (use groupPages);
+    /// when LevelCount>0 the root is a btree index page (use indexPages).
+    inline NPage::TPageLocation GetBTreeRootLocation(
+        const NPage::TBtreeIndexMeta& meta,
+        const NPageCollection::IPageCollection* indexPages,
+        const NPageCollection::IPageCollection* groupPages)
+    {
+        if (meta.HasRootV2()) return meta.RootV2;
+        return (meta.LevelCount() == 0 ? *groupPages : *indexPages).GetLocation(meta.RootV1PageId());
+    }
+
+    using TPageRef = NPage::TPageRef;
 
     /**
      * Cold parts are parts that don't have any metadata loaded into memory,
@@ -82,6 +101,18 @@ namespace NTable {
                     Y_ENSURE(groupId.Index < FlatGroups.size());
                     return FlatGroups[groupId.Index];
                 }
+            }
+
+            /// Resolves the root TPageLocation from the btree meta through the part's page collection.
+            /// When LevelCount==0 the root IS a data page (resolved via groupId),
+            /// when LevelCount>0 the root is a btree index page (resolved via index collection 0).
+            using TMetaRef = NPage::TBtreeIndexMeta;
+            using TPages = NPageCollection::IPageCollection;
+            NPage::TPageLocation GetRootLocation(const TPart* part, TGroupId groupId) const {
+                const auto& meta = GetBTree(groupId);
+                return ::NKikimr::NTable::GetBTreeRootLocation(meta,
+                    part->GetPageCollection(0),
+                    part->GetPageCollection(groupId.Index));
             }
         };
 
@@ -170,6 +201,7 @@ namespace NTable {
         virtual ui64 GetPageSize(ELargeObj lob, ui64 ref) const = 0;
         virtual NPage::EPage GetPageType(NPage::TPageId pageId, NPage::TGroupId groupId) const = 0;
         virtual NPage::TPageLocation GetPageLocation(NPage::TPageId pageId, NPage::TGroupId groupId) const = 0;
+        virtual const NPageCollection::IPageCollection* GetPageCollection(ui32 room) const = 0;
         virtual ui8 GetGroupChannel(NPage::TGroupId groupId) const = 0;
         virtual ui8 GetPageChannel(ELargeObj lob, ui64 ref) const = 0;
 
@@ -238,6 +270,18 @@ namespace NTable {
         const TEpoch Epoch;
         const TIntrusiveConstPtr<NPage::TTxStatusPage> TxStatusPage;
     };
+
+    /// Resolve a TPageRef to a concrete TPageLocation through the part's page collections.
+    inline NPage::TPageLocation ResolvePageLocation(const TPart* part, const TPageRef& ref, NPage::TGroupId groupId) {
+        return std::visit([&](const auto& val) -> NPage::TPageLocation {
+            using T = std::decay_t<decltype(val)>;
+            if constexpr (std::is_same_v<T, NPage::TPageId>) {
+                return part->GetPageLocation(val, groupId);
+            } else {
+                return val;
+            }
+        }, ref);
+    }
 
 }
 }

--- a/ydb/core/tablet_flat/flat_writer_blocks.h
+++ b/ydb/core/tablet_flat/flat_writer_blocks.h
@@ -18,6 +18,7 @@ namespace NWriter {
         using EPage = NTable::NPage::EPage;
         using TPageId = NTable::NPage::TPageId;
         using TPageOffset = NTable::NPage::TPageOffset;
+        using TPageLocation = NTable::NPage::TPageLocation;
         using TPageCollection = TPrivatePageCache::TPageCollection;
 
         struct TResult : TMoveOnly {
@@ -26,14 +27,15 @@ namespace NWriter {
             TVector<NPageCollection::TLoadedPage> StickyPages;
         };
 
-        TBlocks(ICone *cone, ui8 channel, ECache cache, ECacheMode cacheMode, ui32 block, bool stickyFlatIndex, bool isOuter = false)
+        TBlocks(ICone *cone, ui8 channel, ECache cache, ECacheMode cacheMode, ui32 block, bool stickyFlatIndex, bool isOuter = false, bool v2Only = false)
             : Cone(cone)
             , Channel(channel)
             , Cache(cache)
             , CacheMode(cacheMode)
             , StickyFlatIndex(stickyFlatIndex)
             , IsOuter(isOuter)
-            , Writer(Cone->CookieRange(1), Channel, block)
+            , V2OnlyMode(v2Only && !isOuter)
+            , Writer(Cone->CookieRange(1), Channel, block, V2OnlyMode)
         {
         }
 
@@ -44,6 +46,8 @@ namespace NWriter {
 
         TResult Finish()
         {
+            Writer.PushSkipEntry();
+
             if (auto meta = Writer.Finish(false /* omit empty page collection */)) {
                 for (auto &glob : Writer.Grab()) {
                     Cone->Put(std::move(glob));
@@ -62,14 +66,20 @@ namespace NWriter {
 
             Offset = 0;
             WrittenPageCount = 0;
+            LastPageId = Max<ui32>();
             return std::exchange(Result, {});
         }
 
-        TPageOffset Write(TSharedData raw, EPage type)
+        TPageLocation Write(TSharedData raw, EPage type)
         {
             ui32 crc32 = 0;
 
-            Writer.AddPage(raw, (ui32)type, &crc32);
+            // Flush skip entry on non-V2 pages
+            bool skipType = V2OnlyMode && (type == EPage::DataPage || type == EPage::BTreeIndexV2);
+            if (!skipType)
+                Writer.PushSkipEntry();
+
+            auto pageId = Writer.AddPage(raw, (ui32)type, &crc32);
 
             for (auto &glob : Writer.Grab()) {
                 Cone->Put(std::move(glob));
@@ -84,21 +94,27 @@ namespace NWriter {
             }
             Offset += raw.size();
             WrittenPageCount++;
+            LastPageId = pageId;
 
             if (NTable::TLoader::NeedIn(type) || Cache == ECache::Ever || StickyFlatIndex && type == EPage::FlatIndex) {
                 Result.StickyPages.emplace_back(location, std::move(raw));
-            } else if (bool(Cache) && type == EPage::DataPage || type == EPage::BTreeIndex || CacheMode == ECacheMode::TryKeepInMemory) {
+            } else if (bool(Cache) && type == EPage::DataPage || type == EPage::BTreeIndex ||
+                       type == EPage::BTreeIndexV2 || CacheMode == ECacheMode::TryKeepInMemory) {
                 // TODO: take into account memory limits for TryKeepInMemory mode
                 // Note: save b-tree index pages to shared cache regardless of a cache mode
                 Result.RegularPages.emplace_back(location, std::move(raw));
             }
 
-            return location.Offset;
+            return location;
         }
 
-        ui32 GetWrittenPageId(ui32 /*group*/) const noexcept
+        ui32 GetLastWrittenPageId(ui32 /*group*/) const noexcept
         {
-            return WrittenPageCount - 1;
+            /* LastPageId captures the most recent AddPage() return value.
+               In v2 mode, for structural pages, it returns the correct compacted index (1-based after skip entry).
+               For DataPage/BTreeIndex it returns Max<ui32>() (no TEntry entry).
+               */
+            return LastPageId;
         }
 
         void WriteInplace(TPageId page, TArrayRef<const char> body)
@@ -119,11 +135,13 @@ namespace NWriter {
         const ECacheMode CacheMode = ECacheMode::Regular;
         const bool StickyFlatIndex;
         const bool IsOuter;
+        const bool V2OnlyMode;
 
         NPageCollection::TWriter Writer;
         TResult Result;
         ui64 Offset = 0;
         ui32 WrittenPageCount = 0;
+        ui32 LastPageId = Max<ui32>();
     };
 }
 }

--- a/ydb/core/tablet_flat/flat_writer_bundle.h
+++ b/ydb/core/tablet_flat/flat_writer_bundle.h
@@ -32,12 +32,14 @@ namespace NWriter {
             const auto none = NTable::NPage::ECache::None;
             const auto regular = NTable::NPage::ECacheMode::Regular;
 
+            bool V2OnlyMode = conf.WriteBTreeIndexV2 && !conf.BTreeIndexV2KeepV1Shadow;
             Blocks.resize(Groups.size() + 1);
             for (size_t group : xrange(Groups.size())) {
-                Blocks[group].Reset(
-                    new TBlocks(this, Groups[group].Channel, Groups[group].Cache, Groups[group].CacheMode, Groups[group].MaxBlobSize, conf.StickyFlatIndex));
+                Blocks[group].Reset(new TBlocks(this, Groups[group].Channel, Groups[group].Cache,
+                                                Groups[group].CacheMode, Groups[group].MaxBlobSize,
+                                                conf.StickyFlatIndex, false, V2OnlyMode));
             }
-            // Outer Blob Collection
+            // Outer Blob Collection is still page-index addressing in V2
             Blocks[Groups.size()].Reset(new TBlocks(this, conf.OuterChannel, none, regular, Groups[0].MaxBlobSize, conf.StickyFlatIndex, true));
 
             Growth = new NTable::TScreen::TCook;
@@ -63,7 +65,7 @@ namespace NWriter {
         }
 
     private:
-        TPageOffset Write(TSharedData page, EPage type, ui32 group) override
+        TPageLocation Write(TSharedData page, EPage type, ui32 group) override
         {
             return Blocks.at(group)->Write(std::move(page), type);
         }
@@ -71,7 +73,7 @@ namespace NWriter {
         TPageId WriteOuter(TSharedData page) override
         {
             Blocks.back()->Write(std::move(page), EPage::Opaque);
-            return Blocks.back()->GetWrittenPageId(Groups.size());
+            return Blocks.back()->GetLastWrittenPageId(Groups.size());
         }
 
         void WriteInplace(TPageId page, TArrayRef<const char> body) override
@@ -79,9 +81,9 @@ namespace NWriter {
             Blocks[0]->WriteInplace(page, body);
         }
 
-        ui32 GetWrittenPageId(ui32 group) const noexcept override
+        ui32 GetLastWrittenPageId(ui32 group) const noexcept override
         {
-            return Blocks[group]->GetWrittenPageId(group);
+            return Blocks[group]->GetLastWrittenPageId(group);
         }
 
         NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) override

--- a/ydb/core/tablet_flat/flat_writer_conf.h
+++ b/ydb/core/tablet_flat/flat_writer_conf.h
@@ -37,6 +37,8 @@ namespace NWriter {
         TVector<TGroup> Groups; /* Per-group page collection settings */
         TVector<TSlot> Slots;   /* Storage slots, referred by rooms */
         bool StickyFlatIndex = true;
+        bool WriteBTreeIndexV2 = false;
+        bool BTreeIndexV2KeepV1Shadow = true;   /* write V1 b-tree alongside V2 (revert safety) */
     };
 
 }

--- a/ydb/core/tablet_flat/protos/flat_table_part.proto
+++ b/ydb/core/tablet_flat/protos/flat_table_part.proto
@@ -31,6 +31,10 @@ message TBTreeIndexMeta {
     optional uint64 RowCount = 5; // Total number of data rows
     optional uint64 ErasedRowCount = 6; // Total number of erased data rows
     optional uint64 GroupDataSize = 7; // Group pages data size (includes history and external blobs)
+    optional uint64 RootOffset = 8; // Direct root page offset (v2 format, byte offset)
+    optional uint64 RootSize = 9;   // Direct root page size (v2 format)
+    optional uint32 RootCrc32 = 10; // Direct root page crc32 (v2 format)
+    optional uint32 LevelCountV2 = 11; // V2 b-tree level count (V2 tree may have more levels than V1)
 }
 
 message TBloomFilterMeta {

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -17,7 +17,7 @@ namespace NTest {
 
     namespace {
         bool IsIndexPage(EPage type) noexcept {
-            return type == EPage::FlatIndex || type == EPage::BTreeIndex;
+            return type == EPage::FlatIndex || type == EPage::BTreeIndex || type == EPage::BTreeIndexV2;
         }
     }
 
@@ -111,7 +111,7 @@ namespace NTest {
         {
             auto pass = ShouldPass((const void*)part,
                 static_cast<ui64>(THash<TPageOffset>()(location.Offset)) ^ (ui64(groupId.Raw()) << 48),
-                location.Type == EPage::FlatIndex || location.Type == EPage::BTreeIndex);
+                location.Type == EPage::FlatIndex || location.Type == EPage::BTreeIndex || location.Type == EPage::BTreeIndexV2);
 
             return pass ? TTestEnv::TryGetPage(part, location, groupId) : nullptr;
         }
@@ -164,58 +164,6 @@ namespace NTest {
         TVector<TSeen> Trace;
         TMap<TSeen, ui64> IndexTraceTtl;
         ui32 Offset = Max<ui32>();
-    };
-
-    class TStorePageCollection : public NPageCollection::IPageCollection {
-        TIntrusiveConstPtr<TStore> Store;
-        ui32 Room;
-    public:
-        TStorePageCollection(TIntrusiveConstPtr<TStore> store, ui32 room)
-            : Store(std::move(store)), Room(room)
-        {}
-
-        const TLogoBlobID& Label() const noexcept override {
-            static TLogoBlobID dummy(0, 0, 0, 0, 0, 0);
-            return dummy;
-        }
-
-        ui32 Total() const noexcept override {
-            return Store->PageCollectionPagesCount(Room);
-        }
-
-        NPageCollection::TInfo Page(ui32 page) const override {
-            return {Store->GetPageSize(Room, page), 0};
-        }
-
-        NPageCollection::TBorder Bounds(ui32 page) const override {
-            ui32 size = Store->GetPageSize(Room, page);
-            return { size, { page, 0 }, { page, size } };
-        }
-
-        NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
-            return Bounds(location.Offset.AsPageIndex());
-        }
-
-        NPageCollection::TGlobId Glob(ui32) const override {
-            Y_TABLET_ERROR("Not implemented");
-        }
-
-        bool Verify(ui32, TArrayRef<const char>) const override {
-            return true;
-        }
-
-        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
-            return data.size() == location.Size;
-        }
-
-        size_t BackingSize() const noexcept override {
-            return Store->PageCollectionBytes(Room);
-        }
-
-        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override {
-            auto* data = Store->GetPage(Room, pageId);
-            return NTable::NPage::TPageLocation::FromPageIndex(pageId, data->size(), NTable::NPage::EPage::Undef, Store->GetPageChecksum(Room, pageId));
-        }
     };
 
     class TForwardEnv : public IPages {

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -25,6 +25,7 @@ namespace NTest {
             : TPart(src, epoch)
             , Store(src.Store)
             , Slices(src.Slices)
+            , PageColls(src.PageColls)
         { }
 
     public:
@@ -34,7 +35,9 @@ namespace NTest {
             , Store(std::move(store))
             , Slices(std::move(slices))
         {
-
+            for (ui32 room : xrange(Store->GetRoomCount())) {
+                PageColls.emplace_back(new TStorePageCollection(Store, room));
+            }
         }
 
         ui64 DataSize() const noexcept override
@@ -66,10 +69,8 @@ namespace NTest {
 
         NPage::TPageLocation GetPageLocation(NPage::TPageId pageId, NPage::TGroupId groupId) const override
         {
-            auto size = Store->GetPageSize(groupId.Index, pageId);
-            auto type = Store->GetPageType(groupId.Index, pageId);
-            auto crc32 = Store->GetPageChecksum(groupId.Index, pageId);
-            return NPage::TPageLocation::FromPageIndex(pageId, size, type, crc32);
+            auto* coll = static_cast<const TStorePageCollection*>(GetPageCollection(groupId.Index));
+            return coll->GetLocation(pageId);
         }
 
         ui8 GetGroupChannel(NPage::TGroupId groupId) const override
@@ -85,6 +86,12 @@ namespace NTest {
             return 0;
         }
 
+        const NPageCollection::IPageCollection* GetPageCollection(ui32 room) const override
+        {
+            Y_ENSURE(room < PageColls.size());
+            return PageColls[room].Get();
+        }
+
         TIntrusiveConstPtr<NTable::TPart> CloneWithEpoch(NTable::TEpoch epoch) const override
         {
             return new TPartStore(*this, epoch);
@@ -92,6 +99,7 @@ namespace NTest {
 
         const TIntrusiveConstPtr<TStore> Store;
         const TIntrusiveConstPtr<TSlices> Slices;
+        mutable TVector<TIntrusiveConstPtr<NPageCollection::IPageCollection>> PageColls;
     };
 
     class TTestEnv: public IPages {
@@ -118,8 +126,15 @@ namespace NTest {
 
         const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
-            auto pageId = location.GetPageIndex();
-            return Get(part, groupId.Index, pageId);
+            return CheckedCast<const TPartStore*>(part)->Store->GetPage(groupId.Index, location.Offset);
+        }
+
+    protected:
+        ui32 ResolvePageId(const TPart *part, const TPageLocation& location, TGroupId groupId) const {
+            if (location.Offset.IsByteOffset()) {
+                return CheckedCast<const TPartStore*>(part)->Store->ResolveByteOffset(groupId.Index, location.Offset.AsByteOffset());
+            }
+            return location.Offset.AsPageIndex();
         }
 
     private:

--- a/ydb/core/tablet_flat/test/libs/table/test_store.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_store.h
@@ -9,6 +9,7 @@
 #include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/generic/xrange.h>
+#include <util/generic/hash.h>
 #include <array>
 
 namespace NKikimr {
@@ -21,6 +22,11 @@ namespace NTest {
         };
 
     public:
+        static bool IsByteOffsetType(NPage::EPage type) noexcept {
+            return type == NPage::EPage::DataPage || type == NPage::EPage::BTreeIndex ||
+                   type == NPage::EPage::BTreeIndexV2;
+        }
+
         using TData = const TSharedData;
 
         struct TEggs {
@@ -66,13 +72,27 @@ namespace NTest {
         const TSharedData* GetPage(ui32 room, NPage::TPageOffset offset) const
         {
             Y_ENSURE(room < PageCollections.size(), "Room is out of bounds");
-            // TStore stores pages indexed by page index.
-            return &PageCollections.at(room).at(offset.AsPageIndex());
+            TPageId pageId;
+            if (offset.IsByteOffset()) {
+                auto it = ByteOffsetToPageId[room].find(offset.AsByteOffset());
+                Y_ENSURE(it != ByteOffsetToPageId[room].end(),
+                    "Byte offset " << offset.AsByteOffset() << " not found in room " << room);
+                pageId = it->second;
+            } else {
+                pageId = offset.AsPageIndex();
+            }
+            Y_ENSURE(pageId < PageCollections.at(room).size(),
+                "GetPage(offset) OOB: room=" << room << " pageId=" << pageId
+                << " size=" << PageCollections.at(room).size());
+            return &PageCollections.at(room).at(pageId);
         }
 
         size_t GetPageSize(ui32 room, ui32 page) const
         {
             Y_ENSURE(room < PageCollections.size(), "Room is out of bounds");
+            Y_ENSURE(page < PageCollections.at(room).size(),
+                "GetPageSize index " << page << " out of range for room " << room
+                << " (size=" << PageCollections.at(room).size() << ")");
 
             return PageCollections.at(room).at(page).size();
         }
@@ -80,6 +100,9 @@ namespace NTest {
         NPage::EPage GetPageType(ui32 room, ui32 page) const
         {
             Y_ENSURE(room < PageCollections.size(), "Room is out of bounds");
+            Y_ENSURE(page < PageTypes.at(room).size(),
+                "GetPageType index " << page << " out of range for room " << room
+                << " (size=" << PageTypes.at(room).size() << ")");
 
             return PageTypes.at(room).at(page);
         }
@@ -87,6 +110,9 @@ namespace NTest {
         ui32 GetPageChecksum(ui32 room, ui32 page) const
         {
             Y_ENSURE(room < PageCrc32.size(), "Room is out of bounds");
+            Y_ENSURE(page < PageCrc32.at(room).size(),
+                "GetPageChecksum index " << page << " out of range for room " << room
+                << " (size=" << PageCrc32.at(room).size() << ")");
 
             return PageCrc32.at(room).at(page);
         }
@@ -236,7 +262,7 @@ namespace NTest {
             return pageId;
         }
 
-        TPageOffset Write(TSharedData page, EPage type, ui32 group)
+        TPageLocation Write(TSharedData page, EPage type, ui32 group)
         {
             Y_ENSURE(group < PageCollections.size() - 1, "Invalid column group");
             Y_ENSURE(!Finished, "This store is already finished");
@@ -246,9 +272,18 @@ namespace NTest {
                 DataBytes[group] += page.size();
             }
             TPageId pageId = PageCollections[group].size();
+            ui64 byteOffset = CumulativeOffset[group]; // byte offset in cumulative stream
+
+            CumulativeOffset[group] += page.size();
+            PageOffset[group].push_back(byteOffset);
+
             PageCollections[group].emplace_back(std::move(page));
             PageTypes[group].push_back(type);
             PageCrc32[group].push_back(crc32);
+
+            if (IsByteOffsetType(type)) {
+                ByteOffsetToPageId[group][byteOffset] = pageId;
+            }
 
             if (group == 0) {
                 switch (type) {
@@ -274,7 +309,12 @@ namespace NTest {
                 }
             }
 
-            return TPageOffset::FromPageIndex(pageId);
+            auto size = PageCollections[group][pageId].size();
+            if (IsByteOffsetType(type)) {
+                return TPageLocation::FromByteOffset(byteOffset, size, type, crc32);
+            } else {
+                return TPageLocation::FromPageIndex(pageId, size, type, crc32);
+            }
         }
 
         void WriteInplace(TPageId page, TArrayRef<const char> body)
@@ -284,7 +324,7 @@ namespace NTest {
             Meta = TSharedData::Copy(body.data(), body.size());
         }
 
-        ui32 GetWrittenPageId(ui32 group) const
+        ui32 GetLastWrittenPageId(ui32 group) const
         {
             return PageCollections[group].size() - 1;
         }
@@ -310,13 +350,36 @@ namespace NTest {
             Finished = true;
         }
 
+        TPageId ResolveByteOffset(ui32 room, ui64 offset) const
+        {
+            auto it = ByteOffsetToPageId[room].find(offset);
+            Y_ENSURE(it != ByteOffsetToPageId[room].end(),
+                "Byte offset " << offset << " not found in room " << room);
+            return it->second;
+        }
+
+        NTable::NPage::TPageLocation GetPageLocation(ui32 room, TPageId pageId) const
+        {
+            auto type = GetPageType(room, pageId);
+            auto size = GetPageSize(room, pageId);
+            auto crc32 = GetPageChecksum(room, pageId);
+            if (IsByteOffsetType(type)) {
+                auto byteOffset = PageOffset.at(room).at(pageId);
+                return NTable::NPage::TPageLocation::FromByteOffset(byteOffset, size, type, crc32);
+            }
+            return NTable::NPage::TPageLocation::FromPageIndex(pageId, size, type, crc32);
+        }
+
         explicit TStore(size_t groups, ui32 globOffset = 0)
             : Groups(groups)
             , GlobOffset(globOffset)
             , PageCollections(groups + 2)
             , PageTypes(groups + 2)
             , PageCrc32(groups + 2)
+            , PageOffset(groups + 2)
             , DataBytes(groups + 2)
+            , CumulativeOffset(groups + 2, 0)
+            , ByteOffsetToPageId(groups + 2)
         { }
 
         ui32 NextGlobOffset() const {
@@ -330,7 +393,10 @@ namespace NTest {
         TVector<TVector<TSharedData>> PageCollections;
         TVector<TVector<EPage>> PageTypes;
         TVector<TVector<ui32>> PageCrc32;
+        TVector<TVector<ui64>> PageOffset;
         TVector<ui64> DataBytes;
+        TVector<ui64> CumulativeOffset;
+        mutable TVector<THashMap<ui64, TPageId>> ByteOffsetToPageId;
 
         /*_ Sometimes will be replaced just with one root TPageId */
 
@@ -342,6 +408,64 @@ namespace NTest {
         TSharedData Meta;
         bool Rooted = false;
         bool Finished = false;
+    };
+
+    class TStorePageCollection : public NPageCollection::IPageCollection {
+        TIntrusiveConstPtr<TStore> Store;
+        ui32 Room;
+    public:
+        TStorePageCollection(TIntrusiveConstPtr<TStore> store, ui32 room)
+            : Store(std::move(store)), Room(room)
+        {}
+
+        const TLogoBlobID& Label() const noexcept override {
+            static TLogoBlobID dummy(0, 0, 0, 0, 0, 0);
+            return dummy;
+        }
+
+        ui32 Total() const noexcept override {
+            return Store->PageCollectionPagesCount(Room);
+        }
+
+        NPageCollection::TInfo Page(ui32 page) const override {
+            return {Store->GetPageSize(Room, page), 0};
+        }
+
+        NPageCollection::TBorder Bounds(ui32 page) const override {
+            ui32 size = Store->GetPageSize(Room, page);
+            return { size, { page, 0 }, { page, size } };
+        }
+
+        NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
+            TPageId pageId;
+            if (location.Offset.IsByteOffset()) {
+                pageId = Store->ResolveByteOffset(Room, location.Offset.AsByteOffset());
+            } else {
+                pageId = location.Offset.AsPageIndex();
+            }
+            ui32 size = Store->GetPageSize(Room, pageId);
+            return { size, { pageId, 0 }, { pageId, size } };
+        }
+
+        NPageCollection::TGlobId Glob(ui32) const override {
+            Y_TABLET_ERROR("Not implemented");
+        }
+
+        bool Verify(ui32, TArrayRef<const char>) const override {
+            return true;
+        }
+
+        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
+            return data.size() == location.Size;
+        }
+
+        size_t BackingSize() const noexcept override {
+            return Store->PageCollectionBytes(Room);
+        }
+
+        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override {
+            return Store->GetPageLocation(Room, pageId);
+        }
     };
 
 }

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -152,18 +152,23 @@ namespace NTest {
                 indexHistoricPages.push_back(pageId);
             }
 
+            auto loadMeta = [](const NProto::TBTreeIndexMeta& proto) -> NPage::TBtreeIndexMeta {
+                ui32 lv1 = proto.HasLevelCount() ? proto.GetLevelCount() : Max<ui32>();
+                ui32 lv2 = proto.HasLevelCountV2() ? proto.GetLevelCountV2() : Max<ui32>();
+                auto rootType = (lv2 == 0 ? NPage::EPage::DataPage : NPage::EPage::BTreeIndexV2);
+                auto v1Root = proto.HasRootPageId()
+                    ? proto.GetRootPageId()
+                    : Max<TPageId>();
+                auto v2Root = proto.HasRootOffset()
+                    ? NPage::TBtreeIndexMeta::RootV2Location(proto.GetRootOffset(), proto.GetRootSize(), proto.GetRootCrc32(), rootType)
+                    : NPage::TPageLocation::Max();
+                return { v1Root, v2Root, proto.GetRowCount(), proto.GetDataSize(), proto.GetGroupDataSize(),
+                    proto.GetErasedRowCount(), lv1, lv2, proto.GetIndexSize() };
+            };
             TVector<NPage::TBtreeIndexMeta> BTreeGroupIndexes, BTreeHistoricIndexes;
             for (bool history : {false, true}) {
                 for (const auto &meta : history ? lay.GetBTreeHistoricIndexes() : lay.GetBTreeGroupIndexes()) {
-                    NPage::TBtreeIndexMeta converted{{
-                        meta.GetRootPageId(),
-                        meta.GetRowCount(),
-                        meta.GetDataSize(),
-                        meta.GetGroupDataSize(),
-                        meta.GetErasedRowCount()}, 
-                        meta.GetLevelCount(), 
-                        meta.GetIndexSize()};
-                    (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);
+                    (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(loadMeta(meta));
                 }
             }
 
@@ -220,7 +225,7 @@ namespace NTest {
             return Back().WriteOuter(blob);
         }
 
-        TPageOffset Write(TSharedData page, EPage type, ui32 group) override
+        TPageLocation Write(TSharedData page, EPage type, ui32 group) override
         {
             return Back().Write(page, type, group);
         }
@@ -230,9 +235,9 @@ namespace NTest {
             Back().WriteInplace(page, body);
         }
 
-        ui32 GetWrittenPageId(ui32 group) const noexcept override
+        ui32 GetLastWrittenPageId(ui32 group) const noexcept override
         {
-            return Store->GetWrittenPageId(group);
+            return Store->GetLastWrittenPageId(group);
         }
 
         NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) override

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -20,7 +20,7 @@ namespace {
     struct TTouchEnv : public NTest::TTestEnv {
         const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
-            auto pageId = location.GetPageIndex();
+            auto pageId = ResolvePageId(part, location, groupId);
             if (Sticky[groupId].contains(pageId)) {
                 Loaded[groupId].insert(pageId);
             }
@@ -79,7 +79,12 @@ namespace {
             // this should be resolved using slices (see ChargeRange)
             if (allowAdditionalFirstLastPartPages) {
                 for (auto additionalLoc : {IndexTools::GetFirstPageLocation(part, groupId), IndexTools::GetLastPageLocation(part, groupId)}) {
-                    auto additionalPageId = additionalLoc.GetPageIndex();
+                    TPageId additionalPageId;
+                    if (additionalLoc.Offset.IsByteOffset()) {
+                        additionalPageId = part.Store->ResolveByteOffset(groupId.Index, additionalLoc.Offset.AsByteOffset());
+                    } else {
+                        additionalPageId = additionalLoc.Offset.AsPageIndex();
+                    }
                     if (bTreeDataPages.contains(additionalPageId)) {
                         flatDataPages.insert(additionalPageId);
                     }
@@ -243,11 +248,11 @@ namespace {
         part.Slices->Describe(Cerr);
         Cerr << Endl;
 
-        UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[0].LevelCount, params.Levels);
+        UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[0].LevelCount(), params.Levels);
         if (params.Groups) {
-            UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[1].LevelCount, params.Levels);
-            UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[2].LevelCount, 2);
-            UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[3].LevelCount, 1);
+            UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[1].LevelCount(), params.Levels);
+            UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[2].LevelCount(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[3].LevelCount(), 1);
         }
 
         return eggs;
@@ -545,7 +550,7 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                         }
 
                         // The B-Tree implementation ignores the limits when the tree has no levels
-                        if ((itemsLimit == 0) || (part.IndexPages.GetBTree({}).LevelCount == 0)) {
+                        if ((itemsLimit == 0) || (part.IndexPages.GetBTree({}).LevelCount() == 0)) {
                             UNIT_ASSERT_VALUES_EQUAL_C(treeChargeResult.ItemsPrecharged, rowId2 - rowId1 + 1, message);
                         } else {
                             // The B-Tree implementation can overcharge items by up to the size
@@ -613,7 +618,7 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
 
                                 // The B-Tree implementation ignores the limits and keys when the tree has no levels,
                                 // except for the case when the history or the groups are turned on
-                                if ((part.IndexPages.GetBTree({}).LevelCount == 0) && (!params.Groups) && (!params.History)) {
+                                if ((part.IndexPages.GetBTree({}).LevelCount() == 0) && (!params.Groups) && (!params.History)) {
                                     UNIT_ASSERT_VALUES_EQUAL_C(
                                         treeChargeResult.ItemsPrecharged,
                                         part.IndexPages.GetBTree({}).GetRowCount(),
@@ -1079,7 +1084,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIteration) {
 
                             // The B-Tree implementation ignores the limits and keys when the tree has no levels,
                             // except for the case when the history or the groups are turned on
-                            if ((part.IndexPages.GetBTree({}).LevelCount == 0) && (!params.Groups) && (!params.History)) {
+                            if ((part.IndexPages.GetBTree({}).LevelCount() == 0) && (!params.Groups) && (!params.History)) {
                                 if (treeChargeResult.ItemsPrecharged != 0) {
                                     UNIT_ASSERT_VALUES_EQUAL_C(
                                         treeChargeResult.ItemsPrecharged,

--- a/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
@@ -1,5 +1,6 @@
 #include "flat_page_btree_index.h"
 #include "flat_page_btree_index_writer.h"
+#include "flat_table_part.h"
 #include "test/libs/table/test_writer.h"
 #include <ydb/core/tablet_flat/test/libs/rows/layout.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -10,6 +11,25 @@ namespace {
     using namespace NTest;
     using TShortChild = TBtreeIndexNode::TShortChild;
     using TChild = TBtreeIndexNode::TChild;
+
+    // Helper: compact v1 TBtreeIndexMeta construction
+    auto Meta(TPageId pageId, TRowId rowCount, ui64 dataSize, ui64 groupDataSize, TRowId erasedRowCount,
+              ui32 levelCount, ui64 indexSize) {
+        return TBtreeIndexMeta{pageId, TPageLocation::Max(),
+                               rowCount,
+                               dataSize,
+                               groupDataSize,
+                               erasedRowCount,
+                               levelCount,
+                               /*LevelCountV2=*/Max<ui32>(),
+                               indexSize};
+    }
+
+    auto Meta(const TChild& child, ui32 levelCount, ui64 indexSize) {
+        return Meta(child.GetPageId(), child.GetRowCount(), child.GetDataSize(), child.GetGroupDataSize(),
+                    child.GetErasedRowCount(), levelCount, indexSize);
+    }
+
 
     TLayoutCook MakeLayout() {
         TLayoutCook lay;
@@ -26,7 +46,7 @@ namespace {
 
     TString MakeKey(std::optional<ui32> c0 = { }, std::optional<std::string> c1 = { }, std::optional<bool> c2 = { }, std::optional<ui64> c3 = { }) {
         TVector<TCell> cells;
-        
+
         if (c0) {
             cells.push_back(TCell::Make(c0.value()));
         } else {
@@ -70,13 +90,13 @@ namespace {
         }
 
         auto dumpChild = [&] (TBtreeIndexNode node, TRecIdx pos) {
-            TChild child;
-            if (node.IsShortChildFormat()) {
-                auto shortChild = node.GetShortChild(pos);
-                child = {shortChild.GetPageId(), shortChild.GetRowCount(), shortChild.GetDataSize(), 0, 0};
-            } else {
-                child = node.GetChild(pos);
-            }
+            auto ref = node.GetChild(pos, /* isDataPage */ false);
+            TChild child{
+                std::holds_alternative<TPageId>(ref) ? std::get<TPageId>(ref) : Max<TPageId>(),
+                node.GetChildRowCount(pos),
+                node.GetChildDataSize(pos),
+                0, 0
+            };
             if (child.GetPageId() < 1000) {
                 Dump(child, groupInfo, store, level + 1);
             } else {
@@ -84,7 +104,7 @@ namespace {
             }
         };
 
-        auto node = TBtreeIndexNode(*store.GetPage(0, meta.GetPageId()));
+        auto node = TBtreeIndexNode(*store.GetPage(0, meta.GetPageId()), /*v2Format=*/false);
 
         auto label = node.Label();
 
@@ -92,7 +112,7 @@ namespace {
             << intend
             << " + BTreeIndex{"
             << meta.ToString() << ", "
-            << (ui16)label.Type << " rev " << label.Format << ", " 
+            << (ui16)label.Type << " rev " << label.Format << ", "
             << label.Size << "b}"
             << Endl;
 
@@ -118,11 +138,18 @@ namespace {
         Cerr << Endl;
     }
 
+    void Dump(NPage::TBtreeIndexMeta meta, const TPartScheme::TGroupInfo& groupInfo, const TStore& store,
+              ui32 level = 0)
+    {
+        Dump(TChild{meta.RootV1PageId(), meta.GetRowCount(), meta.GetDataSize(), meta.GetGroupDataSize(),
+                    meta.GetErasedRowCount()}, groupInfo, store, level);
+    }
+
     void Dump(TSharedData node, const TPartScheme::TGroupInfo& groupInfo) {
         TWriterBundle pager(1, TLogoBlobID());
         auto& writer = static_cast<IPageWriter&>(pager);
         writer.Write(node, EPage::BTreeIndex, 0);
-        TChild page{writer.GetWrittenPageId(0), 0, 0, 0, 0};
+        TChild page{writer.GetLastWrittenPageId(0), 0, 0, 0, 0};
         Dump(page, groupInfo, pager.Back());
     }
 
@@ -132,7 +159,7 @@ namespace {
             TVector<TCell> actualCells;
             auto cells = node.GetKeyCellsIter(i, groupInfo.ColsKeyIdx);
             UNIT_ASSERT_VALUES_EQUAL(cells.Count(), groupInfo.ColsKeyIdx.size());
-            
+
             for (TPos pos : xrange(cells.Count())) {
                 Y_UNUSED(pos);
                 actualCells.push_back(cells.Next());
@@ -145,23 +172,33 @@ namespace {
 
     void CheckKeys(TPageId pageId, const TVector<TString>& keys, const TPartScheme::TGroupInfo& groupInfo, const TStore& store) {
         auto page = store.GetPage(0, pageId);
-        auto node = TBtreeIndexNode(*page);
+        auto node = TBtreeIndexNode(*page, /*v2Format=*/false);
         CheckKeys(node, keys, groupInfo);
     }
 
     void CheckChildren(const NPage::TBtreeIndexNode& node, const TVector<TChild>& children) {
         UNIT_ASSERT_VALUES_EQUAL(node.GetKeysCount() + 1, children.size());
         for (TRecIdx i : xrange(node.GetKeysCount() + 1)) {
-            UNIT_ASSERT_EQUAL(node.GetChild(i), children[i]);
-            TShortChild shortChild{children[i].GetPageId(), children[i].GetRowCount(), children[i].GetDataSize()};
-            UNIT_ASSERT_EQUAL(node.GetShortChild(i), shortChild);
+            auto ref = node.GetChild(i, false);
+            TPageId pageId = std::holds_alternative<TPageId>(ref)
+                ? std::get<TPageId>(ref) : Max<TPageId>();
+            UNIT_ASSERT_EQUAL(pageId, children[i].GetPageId());
+            UNIT_ASSERT_EQUAL(node.GetChildRowCount(i), children[i].GetRowCount());
+            UNIT_ASSERT_EQUAL(node.GetChildDataSize(i), children[i].GetDataSize());
+            UNIT_ASSERT_EQUAL(node.GetChildTotalDataSize(i) - node.GetChildDataSize(i), children[i].GetGroupDataSize());
+            UNIT_ASSERT_EQUAL(node.GetChildRowCount(i) - node.GetChildNonErasedRowCount(i), children[i].GetErasedRowCount());
         }
     }
 
     void CheckShortChildren(const NPage::TBtreeIndexNode& node, const TVector<TShortChild>& children) {
         UNIT_ASSERT_VALUES_EQUAL(node.GetKeysCount() + 1, children.size());
         for (TRecIdx i : xrange(node.GetKeysCount() + 1)) {
-            UNIT_ASSERT_EQUAL(node.GetShortChild(i), children[i]);
+            auto ref = node.GetChild(i, false);
+            TPageId pageId = std::holds_alternative<TPageId>(ref)
+                ? std::get<TPageId>(ref) : Max<TPageId>();
+            UNIT_ASSERT_EQUAL(pageId, children[i].GetPageId());
+            UNIT_ASSERT_EQUAL(node.GetChildRowCount(i), children[i].GetRowCount());
+            UNIT_ASSERT_EQUAL(node.GetChildDataSize(i), children[i].GetDataSize());
         }
     }
 }
@@ -202,7 +239,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
             writer.AddKey(aa.GetCells());
             writer.AddChild(MakeChild(1));
 
-            auto node = TBtreeIndexNode(writer.Finish());
+            auto node = TBtreeIndexNode(writer.Finish(), /*v2Format=*/false);
             TSerializedCellVec bb(b);
             return node.GetKeyCellsIter(0, scheme.GetLayout({}).ColsKeyIdx)
                 .CompareTo(bb.GetCells(), lay.RowScheme()->Keys.Get());
@@ -215,7 +252,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
         UNIT_ASSERT_VALUES_EQUAL(compareTo(MakeKey(100, "a"), MakeKey(100, "b")), -1);
         UNIT_ASSERT_VALUES_EQUAL(compareTo(MakeKey(100, "a"), MakeKey(100, "a")), 0);
         UNIT_ASSERT_VALUES_EQUAL(compareTo(MakeKey(100, "b"), MakeKey(100, "a")), 1);
-        
+
         UNIT_ASSERT_VALUES_EQUAL(compareTo(MakeKey(100), MakeKey(100, "a")), -1);
         UNIT_ASSERT_VALUES_EQUAL(compareTo(MakeKey(100, "a"), MakeKey(100)), 1);
 
@@ -229,7 +266,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
         TLayoutCook lay = MakeLayout();
 
         TBtreeIndexNodeWriter writer(new TPartScheme(lay.RowScheme()->Cols), { });
-        
+
         TVector<TString> keys;
         keys.push_back(MakeKey({ }, { }, true));
         keys.push_back(MakeKey(100, "asdf", true, 10000));
@@ -261,7 +298,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
         auto serialized = writer.Finish();
 
-        auto node = TBtreeIndexNode(serialized);
+        auto node = TBtreeIndexNode(serialized, /*v2Format=*/false);
 
         Dump(serialized, writer.GroupInfo);
         CheckKeys(node, keys, writer.GroupInfo);
@@ -273,7 +310,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
     Y_UNIT_TEST(Group) {
         TLayoutCook lay;
-        
+
         lay
             .Col(0, 0,  NScheme::NTypeIds::Uint32)
             .Col(0, 1,  NScheme::NTypeIds::String)
@@ -305,7 +342,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
         auto serialized = writer.Finish();
 
-        auto node = TBtreeIndexNode(serialized);
+        auto node = TBtreeIndexNode(serialized, /*v2Format=*/false);
 
         Dump(serialized, writer.GroupInfo);
         CheckKeys(node, keys, writer.GroupInfo);
@@ -314,7 +351,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
     Y_UNIT_TEST(History) {
         TLayoutCook lay;
-        
+
         lay
             .Col(0, 0,  NScheme::NTypeIds::Uint32)
             .Col(0, 1,  NScheme::NTypeIds::String)
@@ -349,7 +386,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
         auto serialized = writer.Finish();
 
-        auto node = TBtreeIndexNode(serialized);
+        auto node = TBtreeIndexNode(serialized, /*v2Format=*/false);
 
         Dump(serialized, writer.GroupInfo);
         CheckKeys(node, keys, writer.GroupInfo);
@@ -364,11 +401,11 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
         TLayoutCook lay = MakeLayout();
 
         TBtreeIndexNodeWriter writer(new TPartScheme(lay.RowScheme()->Cols), { });
-        
+
         auto check= [&] (TString key) {
             TVector<TString> keys;
             keys.push_back(key);
-            
+
             TVector<TChild> children;
             for (ui32 i : xrange(keys.size() + 1)) {
                 children.push_back(MakeChild(i));
@@ -384,7 +421,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
             auto serialized = writer.Finish();
 
-            auto node = TBtreeIndexNode(serialized);
+            auto node = TBtreeIndexNode(serialized, /*v2Format=*/false);
 
             Dump(serialized, writer.GroupInfo);
             CheckKeys(node, keys, writer.GroupInfo);
@@ -406,12 +443,12 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
         TLayoutCook lay = MakeLayout();
 
         TBtreeIndexNodeWriter writer(new TPartScheme(lay.RowScheme()->Cols), { });
-        
+
         TVector<TString> keys;
         keys.push_back(MakeKey(100, "asdf", true, 10000));
         keys.push_back(MakeKey(101, "xyz", true, 10000));
         keys.push_back(MakeKey(103, { }, true, 10000));
-        
+
         TVector<TChild> children;
         for (ui32 i : xrange(keys.size() + 1)) {
             children.push_back(MakeChild(i));
@@ -438,7 +475,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
         auto serialized = writer.Finish();
 
-        auto node = TBtreeIndexNode(serialized);
+        auto node = TBtreeIndexNode(serialized, /*v2Format=*/false);
 
         Dump(serialized, writer.GroupInfo);
         CheckKeys(node, keys, writer.GroupInfo);
@@ -449,7 +486,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
         TLayoutCook lay = MakeLayout();
 
         TBtreeIndexNodeWriter writer(new TPartScheme(lay.RowScheme()->Cols), { });
-        
+
         TVector<TString> fullKeys;
         fullKeys.push_back(MakeKey({ }, { }, { }, { }));
         fullKeys.push_back(MakeKey(100, { }, { }, { }));
@@ -467,7 +504,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
             }
             cutKeys.push_back(TSerializedCellVec::Serialize(cells));
         }
-        
+
         TVector<TChild> children;
         for (ui32 i : xrange(fullKeys.size() + 1)) {
             children.push_back(MakeChild(i));
@@ -483,7 +520,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
 
         auto serialized = writer.Finish();
 
-        auto node = TBtreeIndexNode(serialized);
+        auto node = TBtreeIndexNode(serialized, /*v2Format=*/false);
 
         Dump(serialized, writer.GroupInfo);
         CheckKeys(node, fullKeys, writer.GroupInfo);
@@ -508,7 +545,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
         TWriterBundle pager(1, TLogoBlobID());
         auto result = builder.Finish(pager);
 
-        TBtreeIndexMeta expected{child, 0, 0};
+        auto expected = Meta(child, 0, 0);
         UNIT_ASSERT_EQUAL_C(result, expected, "Got " + result.ToString());
     }
 
@@ -517,7 +554,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
         TIntrusivePtr<TPartScheme> scheme = new TPartScheme(lay.RowScheme()->Cols);
 
         TBtreeIndexBuilder builder(scheme, { }, Max<ui32>(), Max<ui32>(), Max<ui32>());
-        
+
         TVector<TString> keys;
         for (ui32 i : xrange(10)) {
             keys.push_back(MakeKey(i, std::string{char('a' + i)}, i % 2, i * 10));
@@ -540,10 +577,10 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
 
         Dump(result, builder.GroupInfo, pager.Back());
 
-        TBtreeIndexMeta expected{{0, 1155, 11055, 22055, 385}, 1, 683};
+        auto expected = Meta(0, 1155, 11055, 22055, 385, 1, 683);
         UNIT_ASSERT_EQUAL_C(result, expected, "Got " + result.ToString());
 
-        CheckKeys(result.GetPageId(), keys, builder.GroupInfo, pager.Back());
+        CheckKeys(result.RootV1PageId(), keys, builder.GroupInfo, pager.Back());
     }
 
     Y_UNIT_TEST(FewNodes) {
@@ -574,8 +611,8 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
         auto result = builder.Finish(pager);
 
         Dump(result, builder.GroupInfo, pager.Back());
-        
-        TBtreeIndexMeta expected{{9, 0, 0, 0, 0}, 3, 1790};
+
+        auto expected = Meta(9, 0, 0, 0, 0, 3, 1790);
         for (auto c : children) {
             expected.RowCount_ += c.GetRowCount();
             expected.DataSize_ += c.GetDataSize();
@@ -636,7 +673,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
         TIntrusivePtr<TPartScheme> scheme = new TPartScheme(lay.RowScheme()->Cols);
 
         TBtreeIndexBuilder builder(scheme, { }, 650, 1, Max<ui32>());
-        
+
         TVector<TString> keys;
         for (ui32 i : xrange(100)) {
             keys.push_back(MakeKey(i, TString(i + 1, 'x')));
@@ -659,8 +696,8 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
         auto result = builder.Finish(pager);
 
         Dump(result, builder.GroupInfo, pager.Back());
-        
-        TBtreeIndexMeta expected{{15, 15150, 106050, 207050, 8080}, 3, 11198};
+
+        auto expected = Meta(15, 15150, 106050, 207050, 8080, 3, 11198);
         UNIT_ASSERT_EQUAL_C(result, expected, "Got " + result.ToString());
     }
 
@@ -685,9 +722,10 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(5)) {
             cook.Add(*TSchemedCookRow(*lay).Col(0u, TString(1024, 'x') + ToString(i)));
         }
@@ -701,7 +739,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 1);
 
-        TBtreeIndexMeta expected{{0 /*Data page*/, 5, 5240, 0, 0}, 0, 0};
+        auto expected = Meta(0, 5, 5240, 0, 0, 0, 0);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -715,9 +753,10 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(10)) {
             cook.Add(*TSchemedCookRow(*lay).Col(0u, TString(1024, 'x') + ToString(i)));
         }
@@ -731,7 +770,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 2);
 
-        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].GetPageId(), 10, 10480, 0, 0}, 1, 1131};
+        auto expected = Meta(part->IndexPages.BTreeGroups[0].RootV1PageId(), 10, 10480, 0, 0, 1, 1131);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -745,11 +784,12 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
         conf.Group(0).BTreeIndexNodeTargetSize = 3 * 1024;
         conf.Group(0).BTreeIndexNodeKeysMin = 3;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(700)) {
             // some index keys will be cut
             cook.Add(*TSchemedCookRow(*lay).Col(i / 9, TString(1024, 'x') + ToString(i % 9)));
@@ -764,7 +804,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 117);
 
-        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].GetPageId(), 700, 733140, 0, 0}, 3, 87172};
+        auto expected = Meta(part->IndexPages.BTreeGroups[0].RootV1PageId(), 700, 733140, 0, 0, 3, 87172);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -778,14 +818,15 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
         conf.Final = false;
         conf.Group(0).PageRows = 33;
         conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 5;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(1000)) {
-            cook.Add(*TSchemedCookRow(*lay).Col(i, ToString(i)), 
+            cook.Add(*TSchemedCookRow(*lay).Col(i, ToString(i)),
                 i % 7 ? ERowOp::Upsert : ERowOp::Erase);
         }
 
@@ -798,7 +839,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 31);
 
-        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].GetPageId(), 1000, 22098, 0, 143}, 2, 1668};
+        auto expected = Meta(part->IndexPages.BTreeGroups[0].RootV1PageId(), 1000, 22098, 0, 143, 2, 1668);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -812,13 +853,14 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
         conf.Group(0).PageRows = 3;
         conf.Group(1).PageRows = 4;
         conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 5;
         conf.Group(1).BTreeIndexNodeKeysMin = conf.Group(1).BTreeIndexNodeKeysMax = 6;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(1000)) {
             cook.Add(*TSchemedCookRow(*lay).Col(i, ToString(i)));
         }
@@ -832,10 +874,10 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 334);
 
-        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].GetPageId(), 1000, 16680, 21890, 0}, 3, 18430};
+        auto expected0 = Meta(part->IndexPages.BTreeGroups[0].RootV1PageId(), 1000, 16680, 21890, 0, 3, 18430);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected0, "Got " + part->IndexPages.BTreeGroups[0].ToString());
 
-        TBtreeIndexMeta expected1{{part->IndexPages.BTreeGroups[1].GetPageId(), 1000, 21890, 0, 0}, 3, 6497};
+        auto expected1 = Meta(part->IndexPages.BTreeGroups[1].RootV1PageId(), 1000, 21890, 0, 0, 3, 6497);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[1], expected1, "Got " + part->IndexPages.BTreeGroups[1].ToString());
     }
 
@@ -850,13 +892,14 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
         conf.Group(0).PageRows = 3;
         conf.Group(1).PageRows = 4;
         conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 5;
         conf.Group(1).BTreeIndexNodeKeysMin = conf.Group(1).BTreeIndexNodeKeysMax = 6;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(1000)) {
             for (ui32 j : xrange(i % 5 + 1)) {
                 cook.Ver({0, 10 - j}).Add(*TSchemedCookRow(*lay).Col(i, TString(i * 2 + j, 'x'), TString(i * 3 + j, 'x')));
@@ -877,16 +920,16 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         ui64 dataSizeHist0 = IndexTools::CountDataSize(*part, TGroupId{0, 1});
         ui64 dataSizeHist1 = IndexTools::CountDataSize(*part, TGroupId{1, 1});
 
-        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].GetPageId(), 1000, dataSize0, dataSize1+dataSizeHist0+dataSizeHist1, 0}, 3, 18430};
+        auto expected0 = Meta(part->IndexPages.BTreeGroups[0].RootV1PageId(), 1000, dataSize0, dataSize1+dataSizeHist0+dataSizeHist1, 0, 3, 18430);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected0, "Got " + part->IndexPages.BTreeGroups[0].ToString());
 
-        TBtreeIndexMeta expected1{{part->IndexPages.BTreeGroups[1].GetPageId(), 1000, dataSize1, 0, 0}, 3, 8284};
+        auto expected1 = Meta(part->IndexPages.BTreeGroups[1].RootV1PageId(), 1000, dataSize1, 0, 0, 3, 8284);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[1], expected1, "Got " + part->IndexPages.BTreeGroups[1].ToString());
 
-        TBtreeIndexMeta expectedHist0{{part->IndexPages.BTreeHistoric[0].GetPageId(), 2000, dataSizeHist0, 0, 0}, 4, 34225};
+        auto expectedHist0 = Meta(part->IndexPages.BTreeHistoric[0].RootV1PageId(), 2000, dataSizeHist0, 0, 0, 4, 34225);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeHistoric[0], expectedHist0, "Got " + part->IndexPages.BTreeHistoric[0].ToString());
 
-        TBtreeIndexMeta expectedHist1{{part->IndexPages.BTreeHistoric[1].GetPageId(), 2000, dataSizeHist1, 0, 0}, 3, 16645};
+        auto expectedHist1 = Meta(part->IndexPages.BTreeHistoric[1].RootV1PageId(), 2000, dataSizeHist1, 0, 0, 3, 16645);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeHistoric[1], expectedHist1, "Got " + part->IndexPages.BTreeHistoric[1].ToString());
     }
 
@@ -901,6 +944,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
 
         NPage::TConf conf{ true, 7 * 1024 };
         conf.WriteBTreeIndex = true;
+        conf.WriteBTreeIndexV2 = false;
         conf.SmallEdge = 133;
         conf.LargeEdge = 333;
         conf.Group(0).PageRows = 3;
@@ -909,7 +953,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         conf.Group(1).BTreeIndexNodeKeysMin = conf.Group(1).BTreeIndexNodeKeysMax = 6;
 
         TPartCook cook(lay, conf);
-        
+
         for (ui32 i : xrange(1000)) {
             for (ui32 j : xrange(i % 5 + 1)) {
                 cook.Ver({0, 10 - j}).Add(*TSchemedCookRow(*lay).Col(i, TString(i * 2 + j, 'x'), TString(i * 3 + j, 'x')));
@@ -931,18 +975,18 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         ui64 dataSizeHist1 = IndexTools::CountDataSize(*part, TGroupId{1, 1});
         ui64 groupDataSize = dataSize1+dataSizeHist0+dataSizeHist1 + 120463 + 7413329;
 
-        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].GetPageId(), 1000, dataSize0, groupDataSize, 0}, 3, 18430};
+        auto expected0 = Meta(part->IndexPages.BTreeGroups[0].RootV1PageId(), 1000, dataSize0, groupDataSize, 0, 3, 18430);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected0, "Got " + part->IndexPages.BTreeGroups[0].ToString());
 
-        TBtreeIndexMeta expected1{{part->IndexPages.BTreeGroups[1].GetPageId(), 1000, dataSize1, 0, 0}, 3, 6497};
+        auto expected1 = Meta(part->IndexPages.BTreeGroups[1].RootV1PageId(), 1000, dataSize1, 0, 0, 3, 6497);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[1], expected1, "Got " + part->IndexPages.BTreeGroups[1].ToString());
 
-        TBtreeIndexMeta expectedHist0{{part->IndexPages.BTreeHistoric[0].GetPageId(), 2000, dataSizeHist0, 0, 0}, 4, 34225};
+        auto expectedHist0 = Meta(part->IndexPages.BTreeHistoric[0].RootV1PageId(), 2000, dataSizeHist0, 0, 0, 4, 34225);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeHistoric[0], expectedHist0, "Got " + part->IndexPages.BTreeHistoric[0].ToString());
 
-        TBtreeIndexMeta expectedHist1{{part->IndexPages.BTreeHistoric[1].GetPageId(), 2000, dataSizeHist1, 0, 0}, 3, 13014};
+        auto expectedHist1 = Meta(part->IndexPages.BTreeHistoric[1].RootV1PageId(), 2000, dataSizeHist1, 0, 0, 3, 13014);
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeHistoric[1], expectedHist1, "Got " + part->IndexPages.BTreeHistoric[1].ToString());
     }
 }
 
-}
+} // namespace NKikimr::NTable::NPage

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -55,7 +55,7 @@ namespace {
 
         const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
-            auto pageId = location.GetPageIndex();
+            auto pageId = ResolvePageId(part, location, groupId);
             Touched[groupId].insert(pageId);
 
             if (!Fail || Sticky.contains({groupId, pageId})) {
@@ -427,10 +427,10 @@ namespace {
             }
 
             for (auto &x : pages.BTreeGroups) {
-                result.insert({mainGroupId, x.GetPageId()});
+                result.insert({mainGroupId, x.RootV1PageId()});
             }
             for (auto &x : pages.BTreeHistoric) {
-                result.insert({mainGroupId, x.GetPageId()});
+                result.insert({mainGroupId, x.RootV1PageId()});
             }
 
             return result;
@@ -452,7 +452,10 @@ namespace {
                         Y_ENSURE(ready != EReady::Page);
                         break;
                     }
-                    absoluteId[absoluteId.size()] = static_cast<ui64>(groupIndex->GetLocation().Offset);
+                    auto location = groupIndex->GetLocation();
+                    absoluteId[absoluteId.size()] = location.Offset.IsByteOffset()
+                        ? Eggs.Lone()->Store->ResolveByteOffset(groupId.Index, location.Offset.AsByteOffset())
+                        : location.Offset.AsPageIndex();
                 }
 
                 TSet<TPageId> actualValue;

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -217,8 +217,7 @@ namespace {
         }
 
         NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override {
-            auto* data = Store->GetPage(Room, pageId);
-            return NTable::NPage::TPageLocation::FromPageIndex(pageId, data->size(), NTable::NPage::EPage::Undef, Store->GetPageChecksum(Room, pageId));
+            return Store->GetPageLocation(Room, pageId);
         }
     };
 
@@ -244,7 +243,8 @@ namespace {
 
         TCacheWrap& Get(TPageId pageId, bool has, bool grow, bool need, NFwd::TStat stat)
         {
-            auto got = Cache->Get(this, TPageOffset::FromPageIndex(pageId), Part->GetPageType(pageId, { }), AheadLo);
+            auto loc = Part->GetPageLocation(pageId, { });
+            auto got = Cache->Get(this, loc.Offset, loc.Type, AheadLo);
 
             if (has != bool(got.Page) || grow != got.Grow || need != got.Need){
                 Log()
@@ -276,7 +276,7 @@ namespace {
             NTest::TTestEnv testEnv;
             size_t i = 0;
             for (auto& loc : std::exchange(Queue, TDeque<TPageLocation>{})) {
-                UNIT_ASSERT_VALUES_EQUAL_C(loc.Offset.AsPageIndex(), pageIds[i++], CurrentStepStr());
+                UNIT_ASSERT_VALUES_EQUAL_C(loc.Offset, Part->GetPageLocation(pageIds[i++], { }).Offset, CurrentStepStr());
                 load.emplace_back(loc, *testEnv.TryGetPage(Part.Get(), loc, { }));
             }
 
@@ -300,7 +300,7 @@ namespace {
             UNIT_ASSERT_VALUES_EQUAL_C(Queue.size(), pageIds.size(), CurrentStepStr());
             for (size_t i = 0; i < Queue.size(); i++) {
                 UNIT_ASSERT_VALUES_EQUAL_C(Queue[i].Offset,
-                    NFwd::TPageOffset::FromPageIndex(pageIds[i]), CurrentStepStr());
+                    Part->GetPageLocation(pageIds[i], { }).Offset, CurrentStepStr());
             }
 
             UNIT_ASSERT_VALUES_EQUAL_C(Cache->Stat, stat, CurrentStepStr());
@@ -313,10 +313,11 @@ namespace {
             TVector<NPageCollection::TLoadedPage> load;
             NTest::TTestEnv testEnv;
             for (auto pageId : pageIds) {
+                NFwd::TPageOffset offset = Part->GetPageLocation(pageId, { }).Offset;
                 TPageLocation location;
                 bool found = false;
                 for (auto it = Queue.begin(); it != Queue.end(); it++) {
-                    if (it->Offset == NFwd::TPageOffset::FromPageIndex(pageId)) {
+                    if (it->Offset == offset) {
                         found = true;
                         location = *it;
                         Queue.erase(it);
@@ -340,14 +341,20 @@ namespace {
 
         TCacheWrap& CheckLocator(TVector<TPageId> pageIds)
         {
-            TVector<TPageId> actual;
-            for (const auto& it : IndexPageLocator.GetMap()) {
-                actual.push_back(it.first.AsPageIndex());
+            TVector<NFwd::TPageOffset> expected;
+            for (auto pageId : pageIds) {
+                expected.push_back(Part->GetPageLocation(pageId, { }).Offset);
             }
 
-            std::sort(pageIds.begin(), pageIds.end());
+            TVector<NFwd::TPageOffset> actual;
+            for (const auto& it : IndexPageLocator.GetMap()) {
+                actual.push_back(it.first);
+            }
 
-            UNIT_ASSERT_VALUES_EQUAL_C(actual, pageIds, CurrentStepStr());
+            std::sort(expected.begin(), expected.end());
+            std::sort(actual.begin(), actual.end());
+
+            UNIT_ASSERT_VALUES_EQUAL_C(actual, expected, CurrentStepStr());
 
             return *this;
         }

--- a/ydb/core/tablet_flat/ut/ut_iterator.cpp
+++ b/ydb/core/tablet_flat/ut/ut_iterator.cpp
@@ -183,7 +183,7 @@ Y_UNIT_TEST_SUITE(TIterator) {
         }
 
         const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override {
-            auto pageId = location.GetPageIndex();
+            auto pageId = ResolvePageId(part, location, groupId);
             if (AutoLoad) {
                 if (Loaded[groupId].insert(pageId).second) {
                     return nullptr;

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -60,7 +60,7 @@ namespace {
     struct TTouchEnv : public NTest::TTestEnv {
         const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
-            auto pageId = location.GetPageIndex();
+            auto pageId = ResolvePageId(part, location, groupId);
             if (PrechargePhase) {
                 Precharged[groupId].insert(pageId);
                 return NTest::TTestEnv::TryGetPage(part, location, groupId);
@@ -191,7 +191,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             UNIT_ASSERT_VALUES_EQUAL(cmp.Compare(*IndexTools::GetFlatLastRecord(*part), TRowTool(*lay).KeyCells(bar)), 0);
         }
         if (part->IndexPages.HasBTree()) {
-            UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.GetBTree({}).LevelCount, 0); // no index keys
+            UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.GetBTree({}).LevelCount(), 0); // no index keys
         }
 
         DumpPart(*(*wrap).Eggs.Lone(), 10);
@@ -451,7 +451,7 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         { /*_  Ensure that B-Tree index has enough layers */
             if (part.IndexPages.BTreeGroups.size()) {
-                UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[0].LevelCount, 3);
+                UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[0].LevelCount(), 3);
             }
         }
 

--- a/ydb/core/tablet_flat/ut/ut_sausage.cpp
+++ b/ydb/core/tablet_flat/ut/ut_sausage.cpp
@@ -33,7 +33,7 @@ namespace {
             return { size, { page, 0 }, { page, size } };
         }
 
-        inline TBorder Bounds(NTable::NPage::TPageLocation location) const noexcept
+        inline TBorder Bounds(const NTable::NPage::TPageLocation& location) const noexcept
         {
             return Bounds(location.Offset.AsPageIndex());
         }
@@ -122,7 +122,7 @@ Y_UNIT_TEST_SUITE(NPageCollection) {
 
         TCookieAllocator cookieAllocator(10, (ui64(20) << 32) | 30, { 0,  999 }, {{ 1, 777 }});
 
-        TWriter writer(cookieAllocator, 1 /* channel */, 8192 * 1024);
+        TWriter writer(cookieAllocator, 1 /* channel */, 8192 * 1024, false /* v2OnlyMode */);
 
         const auto r1 = writer.AddPage(chunk1, 1);
         writer.AddInplace(r1, TStringBuf("chunk 1"));
@@ -647,7 +647,7 @@ Y_UNIT_TEST_SUITE(NPageCollection) {
         struct TByteOffsetStore : public IPages {
             THashMap<TPageOffset, TSharedData> Map;
 
-            void Add(TPageLocation loc, TSharedData data)
+            void Add(const TPageLocation& loc, TSharedData data)
             {
                 Map[loc.Offset] = std::move(data);
             }

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -67,6 +67,14 @@ namespace {
             : Part(std::move(part))
             , Room(room)
         {
+            // Build byte-offset to pageId map
+            for (ui32 i = 0; i < Total(); i++) {
+                auto type = Part->Store->GetPageType(Room, i);
+                if (NTest::TStore::IsByteOffsetType(type)) {
+                    auto loc = Part->Store->GetPageLocation(Room, i);
+                    ByteOffsetToPageId[loc.Offset.AsByteOffset()] = i;
+                }
+            }
         }
 
         const TLogoBlobID& Label() const noexcept override
@@ -92,6 +100,15 @@ namespace {
         }
 
         NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
+            if (location.Offset.IsByteOffset()) {
+                auto it = ByteOffsetToPageId.find(location.Offset.AsByteOffset());
+                if (it == ByteOffsetToPageId.end()) {
+                    return { 0, { Max<ui32>(), 0 }, { Max<ui32>(), 0 } };
+                }
+                ui32 pageId = it->second;
+                ui32 pageSize = Part->Store->GetPageSize(Room, pageId);
+                return { pageSize, { pageId, 0 }, { pageId, pageSize } };
+            }
             return Bounds(location.Offset.AsPageIndex());
         }
 
@@ -116,12 +133,13 @@ namespace {
 
         NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override
         {
-            return NTable::NPage::TPageLocation::FromPageIndex(pageId, Page(pageId).Size, NTable::NPage::EPage::Undef, Part->Store->GetPageChecksum(Room, pageId));
+            return Part->Store->GetPageLocation(Room, pageId);
         }
 
     private:
         TIntrusiveConstPtr<NTest::TPartStore> Part;
         ui32 Room;
+        THashMap<ui64, ui32> ByteOffsetToPageId;
     };
 
     struct TCheckResult {
@@ -169,9 +187,8 @@ namespace {
                 result.Pages += fetch.Pages.size();
 
                 for (auto& location : fetch.Pages) {
-                    auto pageId = location.GetPageIndex();
-                    auto* page = part->Store->GetPage(0, pageId);
-                    UNIT_ASSERT_C(page, "TLoader wants a missing page " << pageId);
+                    auto* page = part->Store->GetPage(0, location.Offset);
+                    UNIT_ASSERT_C(page, "TLoader wants a missing page at offset " << location.Offset);
                     env.Save({ location.Offset, location.Size, NSharedCache::TSharedPageRef::MakePrivate(*page) });
                 }
             } else {

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -18,13 +18,15 @@ namespace {
     struct TTouchEnv : public NTest::TTestEnv {
         const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
-            auto pageId = location.GetPageIndex();
             auto page = NTest::TTestEnv::TryGetPage(part, location, groupId);
 
-            bool newTouch = Touched[{part, groupId}].insert(pageId).second;
+            bool newTouch = Touched[{part, groupId}].insert(location.Offset).second;
 
             if (newTouch) {
-                auto type = part->GetPageType(pageId, groupId);
+                auto type = location.Type;
+                if (type == EPage::Undef && location.Offset.IsPageIndex()) {
+                    type = part->GetPageType(location.Offset.AsPageIndex(), groupId);
+                }
                 if (type == EPage::DataPage) {
                     auto dataPage = NPage::TDataPage(page);
 
@@ -44,7 +46,7 @@ namespace {
                 : page;
         }
 
-        TMap<std::pair<const TPart*, TGroupId>, TSet<TPageId>> Touched;
+        TMap<std::pair<const TPart*, TGroupId>, TSet<TPageOffset>> Touched;
         bool Faulty = true;
         ui64 TouchedBytes = 0, TouchedRows = 0, TouchedIndexBytes = 0, TouchedIndexPages = 0;
     };
@@ -464,7 +466,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             auto index = CreateIndexIter(part.Part.Get(), &env, {});
             Cerr << "  " << part->Label << " " << index->GetEndRowId() << " rows, "
                 << IndexTools::CountMainPages(*part.Part) << " pages, "
-                << (part->IndexPages.HasBTree() ? part->IndexPages.GetBTree({}).LevelCount : -1) << " levels: ";
+                << (part->IndexPages.HasBTree() ? part->IndexPages.GetBTree({}).LevelCount() : -1) << " levels: ";
             for (ui32 sample : xrange(1u, samples + 1)) {
                 TRowId rowId((index->GetEndRowId() - 1) * sample / samples);
                 Y_ENSURE(index->Seek(rowId) == EReady::Data);

--- a/ydb/core/tablet_flat/ut_large/ut_btree_index_large.cpp
+++ b/ydb/core/tablet_flat/ut_large/ut_btree_index_large.cpp
@@ -40,7 +40,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount(), 3);
     }
 
     Y_UNIT_TEST(MiddleKeys1GB) {
@@ -71,7 +71,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount(), 3);
     }
 
     Y_UNIT_TEST(BigKeys1GB) {
@@ -102,7 +102,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 6);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount(), 6);
     }
 
     Y_UNIT_TEST(CutKeys) {
@@ -135,7 +135,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount(), 3);
     }
 
     Y_UNIT_TEST(Group) {
@@ -167,7 +167,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[1].LevelCount, 2);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[1].LevelCount(), 2);
     }
 
     Y_UNIT_TEST(History) {
@@ -199,7 +199,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeHistoric[0].LevelCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeHistoric[0].LevelCount(), 3);
     }
 
 }


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

The V2-ready core: new page format (TChildV2/YShortChildV2, byte-offset child addressing), V2 write path with V1-shadow dual-write, the skip-entry mechanism (PushSkip/SkippedPages/MetaPages/SkipBTreeIndexV1Shadow), and the version-agnostic read-path migration (TPageRef, GetChildLocation, GetBTreeRootLocation, LevelCount()). V1 behavior preserved everywhere.

- Format/meta: flat_page_btree_index.h (TPageRef, TBtreeIndexMeta restructure), flat_table_part.h (GetBTreeRootLocation, ResolvePageLocation, TPart::GetPageCollection), flat_part_index_iter_bree_index.h
- Write path: flat_page_btree_index_writer.h, flat_part_writer.h (dual-write), flat_writer_blocks.h/bundle.h (Write->TPageLocation), flat_page_conf.h, flat_writer_conf.h, feature_flags.proto (284/285), protos/flat_table_part.proto (RootOffset/Size/Crc32/LevelCountV2); IPageWriter Write->TPageLocation + GetWrittenPageId->GetLastWrittenPageId (flat_part_iface.h)
- Skip mechanism: flat_sausage_record.h (PushSkip), flat_sausage_writer.h (V2OnlyMode), flat_sausage_meta.h/.cpp (SkippedPages), flat_sausage_packet.h (MetaPages/Total/SkipBTreeIndexV1Shadow), flat_sausage_gut.h virtuals
- Read-path migration (V1 behavior): flat_part_charge_btree_index.h, flat_stat_table_btree_index.cpp/histogram, flat_stat_part_group_btree_index.h, flat_stat_part_group_iter_iface.h, flat_fwd_cache.h
- Loader/store meta-usage only: flat_part_loader.cpp (loadMeta, RootV1PageId, LevelCount()), flat_part_store.h (GetPageCollection, AllPages V1/V2 filter)
- flat_part_dump.cpp/.h, benchmark/b_part.cpp
- Test-harness adaptation (test lib implements IPageWriter/TPart/TBtreeIndexMeta, must move with the interface migration): test_envs.h, test_writer.h, test_store.h, test_part.h; 1-line GetLastWrittenPageId rename in ut_btree_index_nodes.cpp
