### PR TITLE
[detailed-metrics] account for metrics level change; lock to prevent torn HIST

### DIFF
--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -42,6 +42,11 @@ const TString APP_CATEGORY = "app";
  */
 using TTabletKey = std::pair<ui64, ui32>;
 
+struct TTabletInfo {
+    TString RelativePath;
+    EDetailedMetricsLevel Level;
+};
+
 /**
  * @return path with any trailing "/" chopped, as a view into path.
  */
@@ -171,8 +176,6 @@ private:
  *       the effective metrics level of the table.
  */
 struct TTableEntry {
-    EDetailedMetricsLevel MetricsLevel = TDetailedMetricsSettings::MetricsLevelUnspecified;
-
     NMonitoring::TDynamicCounterPtr TableGroup;
 
     /**
@@ -238,13 +241,13 @@ public:
         // can no longer reach. Drop it here, BEFORE the group of the new table is created,
         // because dropping the last table of the database removes the database group too
         auto mapIt = TabletToTableMap.find(tablet);
-        if (mapIt != TabletToTableMap.end() && mapIt->second != relativePath) {
-            RemoveTabletFromTable(mapIt->second, tablet);
+        if (mapIt != TabletToTableMap.end()
+            && (mapIt->second.RelativePath != relativePath || mapIt->second.Level != metricsLevel))
+        {
+            RemoveTabletFromTable(mapIt->second.RelativePath, tablet, mapIt->second.Level);
             TabletToTableMap.erase(mapIt);
             mapIt = TabletToTableMap.end();
         }
-
-        ReconcileTable(relativePath, metricsLevel);
 
         if (IsFollowerRole && IsTableLevel(metricsLevel)) {
             return;
@@ -278,10 +281,10 @@ public:
         // stale case), so the steady state — every report but the first of a tablet —
         // writes nothing and copies no string.
         if (mapIt == TabletToTableMap.end()) {
-            TabletToTableMap.emplace(tablet, TString(relativePath));
+            TabletToTableMap.emplace(tablet, TTabletInfo{TString(relativePath), metricsLevel});
         }
 
-        if (IsTableLevel(entry->MetricsLevel)) {
+        if (IsTableLevel(metricsLevel)) {
             auto& bucket = entry->TableBucket;
             if (!bucket) {
                 bucket = MakeHolder<TCountersBucket>(
@@ -323,7 +326,7 @@ public:
         // it MUST run before the reverse map entry it points into is erased below, or the
         // view dangles. RemoveTabletFromTable is documented not to touch the reverse map,
         // so calling it first before this function's own erase is safe.
-        RemoveTabletFromTable(mapIt->second, tablet);
+        RemoveTabletFromTable(mapIt->second.RelativePath, tablet, mapIt->second.Level);
         TabletToTableMap.erase(mapIt);
     }
 
@@ -395,20 +398,6 @@ private:
     }
 
     /**
-     * Switch the stored shape to match the level the caller now reports for this path.
-     */
-    void ReconcileTable(const TStringBuf relativePath, EDetailedMetricsLevel metricsLevel) {
-        auto it = Tables.find(relativePath);
-        if (it == Tables.end()) {
-            return;
-        }
-
-        if (metricsLevel != it->second.MetricsLevel) {
-            DropTableEntry(it);
-        }
-    }
-
-    /**
      * @return The per-table state, or nullptr if the table collects no detailed metrics
      */
     TTableEntry* GetOrCreateTable(EDetailedMetricsLevel metricsLevel, const TStringBuf relativePath) {
@@ -433,13 +422,12 @@ private:
         // TString, once, shared between the map key and the GetSubgroup() call
         const TString newKey(relativePath);
         auto& entry = Tables[newKey];
-        entry.MetricsLevel = metricsLevel;
         entry.TableGroup = GetOrCreateDatabaseGroup()->GetSubgroup(TABLE_LABEL, newKey);
 
         return &entry;
     }
 
-    void RemoveTabletFromTable(const TStringBuf relativePath, const TTabletKey& tablet) {
+    void RemoveTabletFromTable(const TStringBuf relativePath, const TTabletKey& tablet, EDetailedMetricsLevel level) {
         auto it = Tables.find(relativePath);
         if (it == Tables.end()) {
             // The table collects no detailed metrics, or its entry is already gone
@@ -448,7 +436,7 @@ private:
 
         auto& entry = it->second;
 
-        if (IsTableLevel(entry.MetricsLevel)) {
+        if (IsTableLevel(level)) {
             ForgetTableBucketTablet(it->first, entry, tablet);
         } else {
             ForgetLeaf(it->first, entry, tablet);
@@ -457,26 +445,6 @@ private:
         if (entry.IsEmpty()) {
             EraseTableEntry(it);
         }
-    }
-
-    void DropTableEntry(THashMap<TString, TTableEntry>::iterator it) {
-        auto& entry = it->second;
-
-        TVector<TTabletKey> tablets;
-        tablets.reserve(entry.Leaves.size());
-        for (const auto& [tablet, _] : entry.Leaves) {
-            tablets.push_back(tablet);
-        }
-
-        for (const auto& tablet : tablets) {
-            ForgetLeaf(it->first, entry, tablet);
-        }
-
-        DropTableBucket(it->first, entry);
-
-        Y_DEBUG_ABORT_UNLESS(entry.IsEmpty());
-
-        EraseTableEntry(it);
     }
 
     void EraseTableEntry(THashMap<TString, TTableEntry>::iterator it) {
@@ -540,6 +508,10 @@ private:
             {TABLET_ID_LABEL, ToString(tabletId)},
             {FOLLOWER_ID_LABEL, ToString(followerId)},
         });
+
+        if (entry.Leaves.empty()) {
+            entry.PerPartitionGroup.Reset();
+        }
     }
 
 private:
@@ -573,7 +545,7 @@ private:
      * Reverse map from (tabletId, followerId) to the table's relative path, used to
      * satisfy ForgetTablet when the forget event carries no table identity.
      */
-    THashMap<TTabletKey, TString> TabletToTableMap;
+    THashMap<TTabletKey, TTabletInfo> TabletToTableMap;
 
     /**
      * Keyed by the table's relative path (the same value the "table" label of the

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -9,8 +9,6 @@
 #include <util/string/cast.h>
 #include <util/system/mutex.h>
 
-#include <tuple>
-
 namespace NKikimr {
 
 /**
@@ -173,7 +171,7 @@ private:
  *       the effective metrics level of the table.
  */
 struct TTableEntry {
-    TDetailedMetricsTableInfo Info;
+    EDetailedMetricsLevel MetricsLevel = TDetailedMetricsSettings::MetricsLevelUnspecified;
 
     NMonitoring::TDynamicCounterPtr TableGroup;
 
@@ -213,7 +211,8 @@ public:
     {}
 
     void AddCounters(
-        const TDetailedMetricsTableInfo& table,
+        const TString& tablePath,
+        EDetailedMetricsLevel metricsLevel,
         ui64 tabletId,
         ui32 followerId,
         TTabletTypes::EType tabletType,
@@ -232,7 +231,7 @@ public:
         }
 
         const TTabletKey tablet(tabletId, followerId);
-        const TStringBuf relativePath = MakeRelativeTablePath(DatabasePrefix, table.TablePath);
+        const TStringBuf relativePath = MakeRelativeTablePath(DatabasePrefix, tablePath);
 
         // A tablet reports exactly one table, so a tablet, which is re-reported under
         // another one, leaves behind a contribution to the old table, which ForgetTablet
@@ -245,17 +244,13 @@ public:
             mapIt = TabletToTableMap.end();
         }
 
-        // A straggler of a previous table at this path must neither recreate an entry
-        // from its dead identity nor contribute counters to the table that lives here now
-        if (!ReconcileTable(relativePath, table)) {
+        ReconcileTable(relativePath, metricsLevel);
+
+        if (IsFollowerRole && IsTableLevel(metricsLevel)) {
             return;
         }
 
-        if (IsFollowerRole && IsTableLevel(table)) {
-            return;
-        }
-
-        auto* entry = GetOrCreateTable(table, relativePath);
+        auto* entry = GetOrCreateTable(metricsLevel, relativePath);
         if (!entry) {
             return;
         }
@@ -268,7 +263,7 @@ public:
                 false,
                 "tablet %" PRIu64 " of table %s reports type %s but the table expects %s",
                 tabletId,
-                entry->Info.TablePath.c_str(),
+                tablePath.c_str(),
                 TTabletTypes::TypeToStr(tabletType),
                 TTabletTypes::TypeToStr(entry->RegisteredTabletType)
             );
@@ -286,7 +281,7 @@ public:
             TabletToTableMap.emplace(tablet, TString(relativePath));
         }
 
-        if (IsTableLevel(entry->Info)) {
+        if (IsTableLevel(entry->MetricsLevel)) {
             auto& bucket = entry->TableBucket;
             if (!bucket) {
                 bucket = MakeHolder<TCountersBucket>(
@@ -372,12 +367,12 @@ private:
         );
     }
 
-    static bool IsTableLevel(const TDetailedMetricsTableInfo& table) {
-        return table.MetricsLevel == TDetailedMetricsSettings::MetricsLevelTable;
+    static bool IsTableLevel(EDetailedMetricsLevel level) {
+        return level == TDetailedMetricsSettings::MetricsLevelTable;
     }
 
-    static bool IsPartitionLevel(const TDetailedMetricsTableInfo& table) {
-        return table.MetricsLevel == TDetailedMetricsSettings::MetricsLevelPartition;
+    static bool IsPartitionLevel(EDetailedMetricsLevel level) {
+        return level == TDetailedMetricsSettings::MetricsLevelPartition;
     }
 
     NMonitoring::TDynamicCounterPtr GetOrCreateDatabaseGroup() {
@@ -400,63 +395,28 @@ private:
     }
 
     /**
-     * Bring the stored per-table state in line with the identity the reporting tablet
-     * carries.
-     *
-     * @return false if the report is stale — a tablet of a PREVIOUS table at this path
-     *         is still alive and still reporting. Its identity, the level included, says
-     *         nothing about the table that lives at this path now, so the caller must
-     *         drop the report whole rather than let it tear the current state down.
+     * Switch the stored shape to match the level the caller now reports for this path.
      */
-    bool ReconcileTable(const TStringBuf relativePath, const TDetailedMetricsTableInfo& table) {
+    void ReconcileTable(const TStringBuf relativePath, EDetailedMetricsLevel metricsLevel) {
         auto it = Tables.find(relativePath);
         if (it == Tables.end()) {
-            return true;
+            return;
         }
 
-        const TDetailedMetricsTableInfo& stored = it->second.Info;
-
-        // A table recreated at this path restarts SchemaVersion low, so a plain
-        // SchemaVersion comparison would pin Info to the older, already deleted table
-        // forever. A recreated table always gets a newer PathId, so the identity is
-        // ordered by the PathId first, and only then by SchemaVersion within one PathId.
-        //
-        // assumes a path is only ever recreated by the SAME schemeshard,
-        // which hands out strictly increasing LocalPathIds. TPathId orders by
-        // (OwnerId, LocalPathId), so a path served by another schemeshard with a lower
-        // OwnerId would order backwards. Not reachable within one subdomain.
-        const auto incoming = std::tie(table.TableId, table.SchemaVersion);
-        const auto current = std::tie(stored.TableId, stored.SchemaVersion);
-
-        // DropTableEntry below invalidates both it and stored, hence the ordering is
-        // decided here, before anything is torn down, and not consulted afterwards
-        if (incoming < current) {
-            return false;
-        }
-
-        // An ALTER DATABASE TABLES_METRICS_LEVEL bumps NEITHER the PathId nor the
-        // SchemaVersion, so a level change arrives with an identity EQUAL
-        if (table.MetricsLevel != stored.MetricsLevel) {
+        if (metricsLevel != it->second.MetricsLevel) {
             DropTableEntry(it);
-            return true;
         }
-
-        if (incoming > current) {
-            it->second.Info = table;
-        }
-
-        return true;
     }
 
     /**
      * @return The per-table state, or nullptr if the table collects no detailed metrics
      */
-    TTableEntry* GetOrCreateTable(const TDetailedMetricsTableInfo& table, const TStringBuf relativePath) {
-        if (!IsTableLevel(table) && !IsPartitionLevel(table)) {
+    TTableEntry* GetOrCreateTable(EDetailedMetricsLevel metricsLevel, const TStringBuf relativePath) {
+        if (!IsTableLevel(metricsLevel) && !IsPartitionLevel(metricsLevel)) {
             return nullptr;
         }
 
-        if (!table.TableId || !table.TablePath) {
+        if (relativePath.empty()) {
             return nullptr;
         }
 
@@ -473,7 +433,7 @@ private:
         // TString, once, shared between the map key and the GetSubgroup() call
         const TString newKey(relativePath);
         auto& entry = Tables[newKey];
-        entry.Info = table;
+        entry.MetricsLevel = metricsLevel;
         entry.TableGroup = GetOrCreateDatabaseGroup()->GetSubgroup(TABLE_LABEL, newKey);
 
         return &entry;
@@ -488,7 +448,7 @@ private:
 
         auto& entry = it->second;
 
-        if (IsTableLevel(entry.Info)) {
+        if (IsTableLevel(entry.MetricsLevel)) {
             ForgetTableBucketTablet(it->first, entry, tablet);
         } else {
             ForgetLeaf(it->first, entry, tablet);

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -245,7 +245,11 @@ public:
             mapIt = TabletToTableMap.end();
         }
 
-        ReconcileTable(relativePath, table);
+        // A straggler of a previous table at this path must neither recreate an entry
+        // from its dead identity nor contribute counters to the table that lives here now
+        if (!ReconcileTable(relativePath, table)) {
+            return;
+        }
 
         if (IsFollowerRole && IsTableLevel(table)) {
             return;
@@ -395,26 +399,53 @@ private:
         return entry.PerPartitionGroup;
     }
 
-    void ReconcileTable(const TStringBuf relativePath, const TDetailedMetricsTableInfo& table) {
+    /**
+     * Bring the stored per-table state in line with the identity the reporting tablet
+     * carries.
+     *
+     * @return false if the report is stale — a tablet of a PREVIOUS table at this path
+     *         is still alive and still reporting. Its identity, the level included, says
+     *         nothing about the table that lives at this path now, so the caller must
+     *         drop the report whole rather than let it tear the current state down.
+     */
+    bool ReconcileTable(const TStringBuf relativePath, const TDetailedMetricsTableInfo& table) {
         auto it = Tables.find(relativePath);
         if (it == Tables.end()) {
-            return;
+            return true;
         }
 
         const TDetailedMetricsTableInfo& stored = it->second.Info;
-
-        if (table.MetricsLevel != stored.MetricsLevel) {
-            DropTableEntry(it);
-            return;
-        }
 
         // A table recreated at this path restarts SchemaVersion low, so a plain
         // SchemaVersion comparison would pin Info to the older, already deleted table
         // forever. A recreated table always gets a newer PathId, so the identity is
         // ordered by the PathId first, and only then by SchemaVersion within one PathId.
-        if (std::tie(table.TableId, table.SchemaVersion) > std::tie(stored.TableId, stored.SchemaVersion)) {
+        //
+        // assumes a path is only ever recreated by the SAME schemeshard,
+        // which hands out strictly increasing LocalPathIds. TPathId orders by
+        // (OwnerId, LocalPathId), so a path served by another schemeshard with a lower
+        // OwnerId would order backwards. Not reachable within one subdomain.
+        const auto incoming = std::tie(table.TableId, table.SchemaVersion);
+        const auto current = std::tie(stored.TableId, stored.SchemaVersion);
+
+        // DropTableEntry below invalidates both it and stored, hence the ordering is
+        // decided here, before anything is torn down, and not consulted afterwards
+        if (incoming < current) {
+            return false;
+        }
+
+        // An ALTER DATABASE TABLES_METRICS_LEVEL bumps NEITHER the PathId nor the
+        // SchemaVersion, so a level change arrives with an identity EQUAL
+        if (table.MetricsLevel != stored.MetricsLevel) {
+            DropTableEntry(it);
+            return true;
+        }
+
+        if (incoming > current) {
             it->second.Info = table;
         }
+
+        return true;
     }
 
     /**

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -9,17 +9,19 @@
 #include <util/string/cast.h>
 #include <util/system/mutex.h>
 
-namespace NKikimr {
+#include <tuple>
 
-namespace {
+namespace NKikimr {
 
 /**
  * Process-wide as there's only two TCA per node: leader and follower. Finer granularity will not buy anything.
  */
-TMutex& Lock() {
+TMutex& DetailedMetricsLock() {
     static TMutex lock;
     return lock;
 }
+
+namespace {
 
 // Labels of the detailed metrics counter tree
 const TString DATABASE_LABEL = "database";
@@ -219,7 +221,7 @@ public:
         const TTabletCountersBase& appCounters,
         TInstant now
     ) override {
-        TGuard<TMutex> guard(Lock());
+        TGuard<TMutex> guard(DetailedMetricsLock());
 
         CheckSingleRole(followerId);
 
@@ -242,6 +244,8 @@ public:
             TabletToTableMap.erase(mapIt);
             mapIt = TabletToTableMap.end();
         }
+
+        ReconcileTable(relativePath, table);
 
         if (IsFollowerRole && IsTableLevel(table)) {
             return;
@@ -306,7 +310,7 @@ public:
     }
 
     void ForgetTablet(ui64 tabletId, ui32 followerId) override {
-        TGuard<TMutex> guard(Lock());
+        TGuard<TMutex> guard(DetailedMetricsLock());
 
         const TTabletKey tablet(tabletId, followerId);
 
@@ -325,13 +329,15 @@ public:
     }
 
     /**
-     * Deliberately takes no lock: it only recomputes counter VALUES over state private
-     * to this instance
-     *
-     * This stops being safe once something reads these values concurrently with this
-     * recalculation
+     * Republish every aggregate of the tree, taking DetailedMetricsLock() for the whole
+     * walk. See the lock's own comment for what it does and does not cover.
      */
     void RecalculateAllCounters() override {
+        // The guard is here  for the READER of the published counter VALUES
+        // TAggregatedTabletCounters republishes every HIST(x) by clearing and
+        // refilling it one tablet at a time
+        TGuard<TMutex> guard(DetailedMetricsLock());
+
         for (auto& [_, entry] : Tables) {
             if (entry.TableBucket) {
                 entry.TableBucket->RecalcAll();
@@ -389,6 +395,28 @@ private:
         return entry.PerPartitionGroup;
     }
 
+    void ReconcileTable(const TStringBuf relativePath, const TDetailedMetricsTableInfo& table) {
+        auto it = Tables.find(relativePath);
+        if (it == Tables.end()) {
+            return;
+        }
+
+        const TDetailedMetricsTableInfo& stored = it->second.Info;
+
+        if (table.MetricsLevel != stored.MetricsLevel) {
+            DropTableEntry(it);
+            return;
+        }
+
+        // A table recreated at this path restarts SchemaVersion low, so a plain
+        // SchemaVersion comparison would pin Info to the older, already deleted table
+        // forever. A recreated table always gets a newer PathId, so the identity is
+        // ordered by the PathId first, and only then by SchemaVersion within one PathId.
+        if (std::tie(table.TableId, table.SchemaVersion) > std::tie(stored.TableId, stored.SchemaVersion)) {
+            it->second.Info = table;
+        }
+    }
+
     /**
      * @return The per-table state, or nullptr if the table collects no detailed metrics
      */
@@ -409,12 +437,6 @@ private:
 
             return &it->second;
         }
-
-        // NOTE: Reconciling an existing entry on a schema version or a metrics level
-        //       change is implemented in a separate step (the level and rename step of
-        //       the detailed metrics plan). Until then the level of a table is frozen at
-        //       the very first report, which MetricsLevelChangeIsIgnoredUntilReconciliation
-        //       pins, so that the step has to flip an explicit assertion
 
         // A new entry: this is the one place the key is actually materialized into a
         // TString, once, shared between the map key and the GetSubgroup() call
@@ -442,11 +464,35 @@ private:
         }
 
         if (entry.IsEmpty()) {
-            Tables.erase(it);
+            EraseTableEntry(it);
+        }
+    }
 
-            if (Tables.empty()) {
-                DatabaseGroup.Reset();
-            }
+    void DropTableEntry(THashMap<TString, TTableEntry>::iterator it) {
+        auto& entry = it->second;
+
+        TVector<TTabletKey> tablets;
+        tablets.reserve(entry.Leaves.size());
+        for (const auto& [tablet, _] : entry.Leaves) {
+            tablets.push_back(tablet);
+        }
+
+        for (const auto& tablet : tablets) {
+            ForgetLeaf(it->first, entry, tablet);
+        }
+
+        DropTableBucket(it->first, entry);
+
+        Y_DEBUG_ABORT_UNLESS(entry.IsEmpty());
+
+        EraseTableEntry(it);
+    }
+
+    void EraseTableEntry(THashMap<TString, TTableEntry>::iterator it) {
+        Tables.erase(it);
+
+        if (Tables.empty()) {
+            DatabaseGroup.Reset();
         }
     }
 
@@ -460,12 +506,18 @@ private:
 
         bucket->Forget(tablet);
 
-        if (!bucket->IsEmpty()) {
+        if (bucket->IsEmpty()) {
+            DropTableBucket(relativePath, entry);
+        }
+    }
+
+    void DropTableBucket(const TString& relativePath, TTableEntry& entry) {
+        if (!entry.TableBucket) {
             return;
         }
 
         const TTabletTypes::EType tabletType = entry.RegisteredTabletType;
-        bucket.Reset();
+        entry.TableBucket.Reset();
 
         TargetCounterGroup->RemoveSubgroupChain({
             {DATABASE_LABEL, DatabasePath},

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -10,8 +10,18 @@
 #include <util/datetime/base.h>
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
+#include <util/system/mutex.h>
 
 namespace NKikimr {
+
+/**
+ * Guards the VALUES published into the detailed metrics counter tree, so that a reader
+ * never observes an aggregate midway through being republished.
+ *
+ * A reader MUST hold it across its whole traversal. Locking from inside a traversal
+ * deadlocks.
+ */
+TMutex& DetailedMetricsLock();
 
 /**
  * The per-table detailed metrics settings, as stored in the schema.
@@ -47,15 +57,14 @@ struct TDetailedMetricsTableInfo {
  * scoped to the role of its Tablet Counters Aggregator actor:
  *
  *     ydb_detailed_raw                        (private, created by the caller)
- *       role=leader | role=follower           (created by the caller)
- *         |
- *         +-- the target group of this instance
- *             database=<database path>
- *               table=<table path relative to the database>
- *                 Table level:     the collapsed counters of the table
- *                 Partition level: detailed_metrics=per_partition
- *                                    tablet_id=<id>
- *                                      follower_id=<n>
+ *       |
+ *       +-- the target group of BOTH instances
+ *           database=<database path>
+ *             table=<table path relative to the database>
+ *               Table level:     the collapsed counters of the table (leaders only)
+ *               Partition level: detailed_metrics=per_partition
+ *                                  tablet_id=<id>
+ *                                    follower_id=<n>
  *
  * Every group, which holds counters above, holds them as a
  * type=<tablet type>/category=executor|app subtree of low level counter aggregates,

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -80,7 +80,8 @@ public:
      *          series in every bucket, so the caller decides the cardinality
      */
     virtual void AddCounters(
-        const TDetailedMetricsTableInfo& table,
+        const TString& tablePath,
+        EDetailedMetricsLevel metricsLevel,
         ui64 tabletId,
         ui32 followerId,
         TTabletTypes::EType tabletType,

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -27,26 +27,16 @@ const TString DATABASE_PATH = "/Root/db";
 const TString TABLE_PATH = "/Root/db/dir/table";
 const TString RELATIVE_TABLE_PATH = "dir/table";
 
-const TPathId TABLE_ID(72057594046644480ull, 42);
-
-// The same schemeshard owner as TABLE_ID, but a different local id, reporting under
-// the very same TABLE_PATH: models a table dropped and recreated at the same path,
-// or an ESchemeOpMoveTable rename that moves the old table away and a new one is
-// created at the vacated path.
-const TPathId RECREATED_TABLE_ID(72057594046644480ull, 44);
-
 // Another table of the very same database
 const TString OTHER_TABLE_PATH = "/Root/db/dir/other_table";
 const TString OTHER_RELATIVE_TABLE_PATH = "dir/other_table";
 
-const TPathId OTHER_TABLE_ID(72057594046644480ull, 43);
-
-// The very same table after an ESchemeOpMoveTable rename: another path, a fresh
-// PathId and a bumped schema version, reported by the very same tablets
+// The very same table after an ESchemeOpMoveTable rename: another path, reported by
+// the very same tablets. Whatever changes upstream (a fresh PathId, a bumped schema
+// version) is the Tablet Counters Aggregator's concern, not this class's — see the
+// class comment in the header. All this layer ever sees is a different path.
 const TString RENAMED_TABLE_PATH = "/Root/db/dir/renamed_table";
 const TString RENAMED_RELATIVE_TABLE_PATH = "dir/renamed_table";
-
-const TPathId RENAMED_TABLE_ID(72057594046644480ull, 45);
 
 constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
 
@@ -159,23 +149,16 @@ struct TFakeTablet {
         const TNodeDatabaseMetricsAggregatorPtr& aggregator,
         EDetailedMetricsLevel level,
         TInstant now,
-        const TPathId& tableId = TABLE_ID,
         const TString& tablePath = TABLE_PATH,
-        TTabletTypes::EType tabletType = TABLET_TYPE,
-        ui64 schemaVersion = 1
+        TTabletTypes::EType tabletType = TABLET_TYPE
     ) {
-        TDetailedMetricsTableInfo table;
-        table.TableId = tableId;
-        table.TablePath = tablePath;
-        table.SchemaVersion = schemaVersion;
-        table.MetricsLevel = level;
-
         // An empty baseline (the very first report) makes the diff a plain copy
         auto appDiff = AppCounters.MakeDiffForAggr(AppBaseline);
         auto executorDiff = ExecutorCounters.MakeDiffForAggr(ExecutorBaseline);
 
         aggregator->AddCounters(
-            table,
+            tablePath,
+            level,
             TabletId,
             FollowerId,
             tabletType,
@@ -1103,7 +1086,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             trees.Leaders,
             TDetailedMetricsSettings::MetricsLevelPartition,
             now,
-            OTHER_TABLE_ID,
             OTHER_TABLE_PATH
         );
 
@@ -1300,42 +1282,31 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         const TInstant now = TInstant::Seconds(100);
 
         struct TCase {
-            TPathId TableId;
             TString TablePath;
             TString ExpectedLabel;
         };
 
         const TVector<TCase> cases = {
             // Within the database: the database path and the separator are stripped
-            {TPathId(1, 1), "/Root/db1/dir/table", "dir/table"},
-            {TPathId(1, 2), "/Root/db1/table",     "table"},
+            {"/Root/db1/dir/table", "dir/table"},
+            {"/Root/db1/table",     "table"},
 
             // NOT within the database: the path is reported as is, so that the odd
             // looking label is noticed instead of the counters being silently misplaced
-            {TPathId(1, 3), "/Root/db10/table",    "/Root/db10/table"},
-            {TPathId(1, 4), "/Root/other/table",   "/Root/other/table"},
+            {"/Root/db10/table",    "/Root/db10/table"},
+            {"/Root/other/table",   "/Root/other/table"},
         };
 
         ui64 tabletId = 1000;
 
         for (const auto& testCase : cases) {
-            TDetailedMetricsTableInfo table;
-            table.TableId = testCase.TableId;
-            table.TablePath = testCase.TablePath;
-            table.SchemaVersion = 1;
-            table.MetricsLevel = TDetailedMetricsSettings::MetricsLevelTable;
-
             TFakeTablet tablet(tabletId++, 0);
             tablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
-
-            aggregator->AddCounters(
-                table,
-                tablet.TabletId,
-                tablet.FollowerId,
-                TABLET_TYPE,
-                tablet.ExecutorCounters,
-                tablet.AppCounters,
-                now
+            tablet.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelTable,
+                now,
+                testCase.TablePath
             );
         }
 
@@ -1394,7 +1365,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelTable,
                 now,
-                OTHER_TABLE_ID,
                 OTHER_TABLE_PATH
             );
             aggregator->RecalculateAllCounters();
@@ -1443,7 +1413,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelPartition,
                 now,
-                OTHER_TABLE_ID,
                 OTHER_TABLE_PATH
             );
             aggregator->RecalculateAllCounters();
@@ -1476,21 +1445,18 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Verify that two different TPathIds, which report the very same table path, share
+     * Verify that two different tablets, which report the very same table path, share
      * ONE counter group and ONE aggregate rather than fragmenting the tree between them.
      *
-     * @note In production this happens whenever a table is dropped and a new one is
-     *       created at the same path, or when an ESchemeOpMoveTable rename moves the
-     *       old table away and a new table is created at the vacated old path: the
-     *       schemeshard hands out a fresh PathId, but the "table" label of the counter
-     *       tree is keyed by path, not by PathId. Before this fix, the state map was
-     *       keyed by PathId, so the two reports created two TTableEntry-s aliasing one
-     *       GetSubgroup() result: their TAggregatedTabletCounters overwrote each other's
-     *       sums, and forgetting the last tablet of the OLDER entry unconditionally
-     *       removed the shared group, detaching the counters the SURVIVING entry still
-     *       wrote into.
+     * @note This is what keying the per-table state by PATH rather than by any secondary
+     *       identity buys: whatever two tablets disagree about upstream (a table dropped
+     *       and recreated at the same path, an ESchemeOpMoveTable rename, or simply two
+     *       partitions of one live table), if they report the same path, they land in
+     *       the same entry here. Telling a live table's tablets apart from a stale
+     *       table's stragglers is the caller's job (the Tablet Counters Aggregator's
+     *       LatestByPath), not this class's — see the class comment in the header.
      */
-    Y_UNIT_TEST(SamePathUnderDifferentPathIdsSharesOneTable) {
+    Y_UNIT_TEST(TwoTabletsAtTheSamePathShareOneTable) {
         const TInstant now = TInstant::Seconds(100);
 
         // TEST 1: The table level, where both tablets contribute to a shared bucket
@@ -1503,40 +1469,31 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 false /* isFollowerRole */
             );
 
-            TFakeTablet oldTablet(1000, 0);
-            TFakeTablet newTablet(1001, 0);
+            TFakeTablet tabletA(1000, 0);
+            TFakeTablet tabletB(1001, 0);
 
-            oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
-            oldTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, TABLE_ID, TABLE_PATH);
+            tabletA.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+            tabletA.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
 
-            newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
-            newTablet.Report(
-                aggregator,
-                TDetailedMetricsSettings::MetricsLevelTable,
-                now,
-                RECREATED_TABLE_ID,
-                TABLE_PATH
-            );
+            tabletB.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+            tabletB.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
 
             aggregator->RecalculateAllCounters();
 
-            DumpCounters("Table level counters of two PathIds at one path", rootGroup);
+            DumpCounters("Table level counters of two tablets at one path", rootGroup);
 
-            // Exactly one table= group holds the sum of both PathIds' contributions:
-            // under the bug this would read 5 or 7 (whichever entry recalculated last),
-            // never their sum
+            // Exactly one table= group holds the sum of both tablets' contributions
             UNIT_ASSERT(FindTableGroup(rootGroup));
             UNIT_ASSERT_VALUES_EQUAL(
                 GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
                 5 + 7
             );
 
-            // The tablet of the OLDER PathId is forgotten: the group must stay reachable,
-            // because the surviving PathId's entry still owns it
-            aggregator->ForgetTablet(oldTablet.TabletId, oldTablet.FollowerId);
+            // One tablet is forgotten: the group must stay reachable, held up by the survivor
+            aggregator->ForgetTablet(tabletA.TabletId, tabletA.FollowerId);
             aggregator->RecalculateAllCounters();
 
-            DumpCounters("Table level counters after forgetting the older PathId's tablet", rootGroup);
+            DumpCounters("Table level counters after forgetting one tablet", rootGroup);
 
             UNIT_ASSERT(FindTableGroup(rootGroup));
             UNIT_ASSERT_VALUES_EQUAL(
@@ -1555,50 +1512,38 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 false /* isFollowerRole */
             );
 
-            TFakeTablet oldTablet(1000, 0);
-            TFakeTablet newTablet(1001, 0);
+            TFakeTablet tabletA(1000, 0);
+            TFakeTablet tabletB(1001, 0);
 
-            oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
-            oldTablet.Report(
-                aggregator,
-                TDetailedMetricsSettings::MetricsLevelPartition,
-                now,
-                TABLE_ID,
-                TABLE_PATH
-            );
+            tabletA.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+            tabletA.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
 
-            newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
-            newTablet.Report(
-                aggregator,
-                TDetailedMetricsSettings::MetricsLevelPartition,
-                now,
-                RECREATED_TABLE_ID,
-                TABLE_PATH
-            );
+            tabletB.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+            tabletB.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
 
             aggregator->RecalculateAllCounters();
 
-            DumpCounters("Partition level leaves of two PathIds at one path", rootGroup);
+            DumpCounters("Partition level leaves of two tablets at one path", rootGroup);
 
             // Both leaves live under the very same table= group
             UNIT_ASSERT(FindTableGroup(rootGroup));
 
-            auto oldLeaf = FindLeafCounters(rootGroup, oldTablet.TabletId, oldTablet.FollowerId);
-            UNIT_ASSERT(oldLeaf);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(oldLeaf, "SUM(DbUniqueRowsTotal)"), 5);
+            auto leafA = FindLeafCounters(rootGroup, tabletA.TabletId, tabletA.FollowerId);
+            UNIT_ASSERT(leafA);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafA, "SUM(DbUniqueRowsTotal)"), 5);
 
-            auto newLeaf = FindLeafCounters(rootGroup, newTablet.TabletId, newTablet.FollowerId);
-            UNIT_ASSERT(newLeaf);
-            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(newLeaf, "SUM(DbUniqueRowsTotal)"), 7);
+            auto leafB = FindLeafCounters(rootGroup, tabletB.TabletId, tabletB.FollowerId);
+            UNIT_ASSERT(leafB);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafB, "SUM(DbUniqueRowsTotal)"), 7);
 
-            // Forgetting the OLDER PathId's tablet must not detach the surviving leaf
-            aggregator->ForgetTablet(oldTablet.TabletId, oldTablet.FollowerId);
+            // Forgetting one tablet must not detach the surviving leaf
+            aggregator->ForgetTablet(tabletA.TabletId, tabletA.FollowerId);
 
-            DumpCounters("Partition level leaves after forgetting the older PathId's tablet", rootGroup);
+            DumpCounters("Partition level leaves after forgetting one tablet", rootGroup);
 
-            UNIT_ASSERT(!FindLeafCounters(rootGroup, oldTablet.TabletId, oldTablet.FollowerId));
+            UNIT_ASSERT(!FindLeafCounters(rootGroup, tabletA.TabletId, tabletA.FollowerId));
 
-            auto survivingLeaf = FindLeafCounters(rootGroup, newTablet.TabletId, newTablet.FollowerId);
+            auto survivingLeaf = FindLeafCounters(rootGroup, tabletB.TabletId, tabletB.FollowerId);
             UNIT_ASSERT(survivingLeaf);
             UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(survivingLeaf, "SUM(DbUniqueRowsTotal)"), 7);
         }
@@ -1803,8 +1748,9 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
      * Verify that a per-table ALTER, which enables the detailed metrics of a table that
      * collected none, starts emitting the leaves.
      *
-     * @note Unlike the database default change above, this one DOES bump the schema
-     *       version, and it is the level, which decides what is built either way.
+     * @note Whatever an ALTER TABLE bumps upstream (schema version, in production) is
+     *       the Tablet Counters Aggregator's concern, not this class's — see the class
+     *       comment in the header. All this layer ever reacts to is the level.
      */
     Y_UNIT_TEST(SchemaBumpEnablesPartitionLevel) {
         NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -1821,29 +1767,13 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
 
         // The table follows a database default, which collects nothing
-        leader.Report(
-            aggregator,
-            TDetailedMetricsSettings::MetricsLevelUnspecified,
-            now,
-            TABLE_ID,
-            TABLE_PATH,
-            TABLET_TYPE,
-            1 /* schemaVersion */
-        );
+        leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
         aggregator->RecalculateAllCounters();
 
         UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
 
         // ALTER TABLE ... SET (DETAILED_METRICS_LEVEL = PARTITION)
-        leader.Report(
-            aggregator,
-            TDetailedMetricsSettings::MetricsLevelPartition,
-            now,
-            TABLE_ID,
-            TABLE_PATH,
-            TABLET_TYPE,
-            2 /* schemaVersion */
-        );
+        leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
         aggregator->RecalculateAllCounters();
 
         DumpCounters("Counters after the ALTER enabled the partition level", rootGroup);
@@ -1858,14 +1788,15 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Verify that a schema version bump, which does NOT change the effective level,
-     * keeps the counters of the table exactly where they are.
+     * Verify that a report, which does NOT change the effective level, keeps the
+     * counters of the table exactly where they are.
      *
      * @note The level is the only thing, which decides the shape of the entry, so a
-     *       plain ALTER has nothing to reconcile. Rebuilding the table on every schema
-     *       bump instead would restart the accumulated cumulative counters from zero —
-     *       a consumer reads that as a counter reset — and would blank the leaves of
-     *       the partitions, which have not reported since the ALTER.
+     *       plain ALTER (which does not, upstream, change the effective level) has
+     *       nothing to reconcile here. Rebuilding the table on every such report instead
+     *       would restart the accumulated cumulative counters from zero — a consumer
+     *       reads that as a counter reset — and would blank the leaves of the
+     *       partitions, which have not reported since.
      */
     Y_UNIT_TEST(SchemaBumpAtTheSameLevelKeepsTheCounters) {
         NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -1897,21 +1828,13 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             100
         );
 
-        // The ALTER bumps the schema version, and only the first partition has noticed
-        // it so far
+        // The ALTER reaches this class as a report at the very same level, and only the
+        // first partition has noticed it so far
         leader1.AddCumulative(CONSUMED_CPU, 50);
-        leader1.Report(
-            aggregator,
-            TDetailedMetricsSettings::MetricsLevelPartition,
-            now,
-            TABLE_ID,
-            TABLE_PATH,
-            TABLET_TYPE,
-            2 /* schemaVersion */
-        );
+        leader1.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
         aggregator->RecalculateAllCounters();
 
-        DumpCounters("Counters after a schema bump at the very same level", rootGroup);
+        DumpCounters("Counters after a report at the very same level", rootGroup);
 
         // The accumulated counter keeps growing rather than restarting from the delta
         UNIT_ASSERT_VALUES_EQUAL(
@@ -2015,98 +1938,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Verify that a straggler report from a tablet of a table PREVIOUS to the one now
-     * living at this path is dropped whole rather than reconciled: it carries the old
-     * (PathId, SchemaVersion), so nothing about it — its MetricsLevel included — says
-     * anything about the table that lives at this path now.
-     *
-     * @note The scenario from the PR review: a table is dropped and recreated at the
-     *       same path with a new PathId AND a different level. The new table's own
-     *       tablet reports and builds the correct state. A tablet of the OLD table is
-     *       still alive (draining) and keeps sending its own 5s report, which still
-     *       carries the old PathId and the old level. Without the ordering guard in
-     *       front of the level check, that stale report hits the level-mismatch branch,
-     *       DropTableEntry wipes the NEW table's counters, and GetOrCreateTable rebuilds
-     *       the entry from the stale (and now current) Info — the tree flaps between the
-     *       two shapes every 5s until the old tablet is forgotten.
-     */
-    Y_UNIT_TEST(StaleReportOfARecreatedTableDoesNotDropTheNewState) {
-        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
-
-        auto aggregator = CreateNodeDatabaseMetricsAggregator(
-            rootGroup,
-            DATABASE_PATH,
-            false /* isFollowerRole */
-        );
-
-        const TInstant now = TInstant::Seconds(100);
-
-        // TABLE_ID at the partition level: a per_partition leaf
-        TFakeTablet straggler(1000, 0);
-        straggler.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
-        straggler.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now, TABLE_ID, TABLE_PATH);
-        aggregator->RecalculateAllCounters();
-
-        UNIT_ASSERT(FindLeafCounters(rootGroup, straggler.TabletId, straggler.FollowerId));
-
-        // The table is dropped and recreated at the same path: a newer PathId, and the
-        // level moves to TABLE. Its own tablet builds the correct collapse bucket.
-        TFakeTablet newTablet(2000, 0);
-        newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7).AddCumulative(CONSUMED_CPU, 100);
-        newTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, RECREATED_TABLE_ID, TABLE_PATH);
-        aggregator->RecalculateAllCounters();
-
-        DumpCounters("Counters after the recreated table's own tablet reported", rootGroup);
-
-        auto tableCounters = FindTableBucketCounters(rootGroup);
-        UNIT_ASSERT(tableCounters);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "SUM(DbUniqueRowsTotal)"), 7);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "ConsumedCPU"), 100);
-        UNIT_ASSERT(!FindLeafCounters(rootGroup, straggler.TabletId, straggler.FollowerId));
-
-        // The OLD table's tablet is still alive and reports again, carrying the OLD
-        // PathId and the OLD (partition) level — the straggler
-        straggler.SetSimple(DB_UNIQUE_ROWS_TOTAL, 999);
-        straggler.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now, TABLE_ID, TABLE_PATH);
-        aggregator->RecalculateAllCounters();
-
-        DumpCounters("Counters after the straggler of the old table reported", rootGroup);
-
-        // The new table's collapse bucket survives, its VALUES are exactly as they were
-        // — a rebuilt-from-stale entry would have the right shape with zeroed contents,
-        // which a presence-only check would not catch
-        auto tableCountersAfterStraggler = FindTableBucketCounters(rootGroup);
-        UNIT_ASSERT(tableCountersAfterStraggler);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCountersAfterStraggler, "SUM(DbUniqueRowsTotal)"), 7);
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCountersAfterStraggler, "ConsumedCPU"), 100);
-
-        // No per_partition subtree reappeared: the straggler's report was dropped whole,
-        // never reaching GetOrCreateTable
-        auto tableGroup = FindTableGroup(rootGroup);
-        UNIT_ASSERT(tableGroup);
-        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
-
-        // The bucket is still the SAME live object, not a fresh one: a further report of
-        // the new table's own tablet keeps accumulating rather than restarting from zero
-        newTablet.AddCumulative(CONSUMED_CPU, 50);
-        newTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, RECREATED_TABLE_ID, TABLE_PATH);
-        aggregator->RecalculateAllCounters();
-
-        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(FindTableBucketCounters(rootGroup), "ConsumedCPU"), 100 + 50);
-
-        // Forgetting the straggler's tablet finds no leaf and no source ID in the live
-        // bucket: it never contributed to it, so this is a no-op, and the live table's
-        // bucket and its table= group survive
-        aggregator->ForgetTablet(straggler.TabletId, straggler.FollowerId);
-
-        UNIT_ASSERT(FindTableGroup(rootGroup));
-        UNIT_ASSERT_VALUES_EQUAL(
-            GetCounterValue(FindTableBucketCounters(rootGroup), "ConsumedCPU"),
-            100 + 50
-        );
-    }
-
-    /**
      * Verify that a renamed table manifests as drop-old/create-new, with no stale
      * table= group left behind once the last of its tablets has reported the new path.
      *
@@ -2150,10 +1981,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelTable,
                 now,
-                RENAMED_TABLE_ID,
-                RENAMED_TABLE_PATH,
-                TABLET_TYPE,
-                2 /* schemaVersion */
+                RENAMED_TABLE_PATH
             );
             aggregator->RecalculateAllCounters();
 
@@ -2176,10 +2004,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelTable,
                 now,
-                RENAMED_TABLE_ID,
-                RENAMED_TABLE_PATH,
-                TABLET_TYPE,
-                2 /* schemaVersion */
+                RENAMED_TABLE_PATH
             );
             aggregator->RecalculateAllCounters();
 
@@ -2227,10 +2052,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 aggregator,
                 TDetailedMetricsSettings::MetricsLevelPartition,
                 now,
-                RENAMED_TABLE_ID,
-                RENAMED_TABLE_PATH,
-                TABLET_TYPE,
-                2 /* schemaVersion */
+                RENAMED_TABLE_PATH
             );
             aggregator->RecalculateAllCounters();
 
@@ -2277,7 +2099,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             aggregator,
             TDetailedMetricsSettings::MetricsLevelPartition,
             now,
-            TABLE_ID,
             TABLE_PATH,
             TTabletTypes::ColumnShard
         );
@@ -2317,7 +2138,6 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             aggregator,
             TDetailedMetricsSettings::MetricsLevelPartition,
             now,
-            OTHER_TABLE_ID,
             OTHER_TABLE_PATH
         );
 

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -1673,7 +1673,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
      * Verify that a table, which stops collecting detailed metrics, is dropped whole:
      * its groups go, and its reports create nothing afterwards.
      */
-    Y_UNIT_TEST(LevelChangeToDisabledDropsTheTable) {
+    Y_UNIT_TEST(LevelChangeToDisabledDropsTheTableOnceEveryTabletConverges) {
         const TInstant now = TInstant::Seconds(100);
 
         // TEST 1: From the table level, where the collapse bucket has to go
@@ -1731,15 +1731,37 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
 
             UNIT_ASSERT(FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
 
-            // The first partition to notice takes ONLY its own table's leaves with it,
-            // including the leaf of the partition, which has not reported yet
             leader1.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
 
-            DumpCounters("Counters after the partition level table stopped collecting", rootGroup);
+            DumpCounters("Counters while only one partition has stopped collecting", rootGroup);
+
+            // leader1's leaf is gone, but leader2 has not noticed yet, so its own leaf —
+            // and the table= and database= groups it still fills — survive untouched
+            UNIT_ASSERT(!FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(
+                    FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId),
+                    "SUM(DbUniqueRowsTotal)"
+                ),
+                5
+            );
+            UNIT_ASSERT(FindTableGroup(rootGroup));
+            UNIT_ASSERT(rootGroup->FindSubgroup("database", DATABASE_PATH));
+
+            // The last partition converges too: NOW the table goes whole
+            leader2.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
+
+            DumpCounters("Counters after the last partition stopped collecting", rootGroup);
 
             UNIT_ASSERT(!FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
             UNIT_ASSERT(!FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId));
             UNIT_ASSERT(!FindTableGroup(rootGroup));
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+
+            // The reports of a disabled table keep creating nothing at all
+            leader1.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
+            aggregator->RecalculateAllCounters();
+
             UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
         }
     }
@@ -1935,6 +1957,127 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
             42
         );
+    }
+
+    Y_UNIT_TEST(PartialLevelConvergenceKeepsBothShapes) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1).AddCumulative(CONSUMED_CPU, 100);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2).AddCumulative(CONSUMED_CPU, 200);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        }
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT(FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId));
+
+        // Only the first partition converges on the new level
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 3).AddCumulative(CONSUMED_CPU, 50);
+        leader1.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters while only one partition has converged on the table level", rootGroup);
+
+        // The switched partition has no leaf of its own any more, and its value is in
+        // the table bucket instead
+        UNIT_ASSERT(!FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
+            3
+        );
+
+        // The lagging partition keeps its own leaf, and — the whole point of this test
+        // — its cumulative counter is exactly what it was, not reset to 0 by a
+        // table-wide teardown that no longer happens
+        auto laggingLeaf = FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId);
+        UNIT_ASSERT(laggingLeaf);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(laggingLeaf, "ConsumedCPU"), 200);
+
+        // The lagging partition converges too
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 4).AddCumulative(CONSUMED_CPU, 20);
+        leader2.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after both partitions converged on the table level", rootGroup);
+
+        auto tableGroup = FindTableGroup(rootGroup);
+        UNIT_ASSERT(tableGroup);
+        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
+            3 + 4
+        );
+    }
+
+    Y_UNIT_TEST(StaleLevelReportDoesNotResetTheCumulativeCounters) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet flapping(1000, 0);
+        TFakeTablet steady(2000, 0);
+
+        flapping.AddCumulative(CONSUMED_CPU, 10);
+        steady.AddCumulative(CONSUMED_CPU, 100);
+
+        flapping.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        steady.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        aggregator->RecalculateAllCounters();
+
+        // Read once here, but NOT reused after the flap below: were the shared
+        // per_partition subtree ever detached and rebuilt, a pointer captured now
+        // would still dereference the OLD (orphaned) counter object, and the final
+        // assertion would pass on a tree no longer reachable from rootGroup at all
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(rootGroup, steady.TabletId, steady.FollowerId), "ConsumedCPU"),
+            100
+        );
+
+        // The flapping tablet jumps to the table level ...
+        flapping.AddCumulative(CONSUMED_CPU, 1);
+        flapping.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        // ... straight back to the partition one ...
+        flapping.AddCumulative(CONSUMED_CPU, 1);
+        flapping.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+        // ... and to the table level again, all without the steady tablet ever
+        // reporting anything in between
+        flapping.AddCumulative(CONSUMED_CPU, 1);
+        flapping.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after one tablet flapped between levels", rootGroup);
+
+        // The steady tablet's own leaf, and the cumulative counter accumulated in it,
+        // is untouched by any of the flapping neighbour's moves. Re-resolved through
+        // the root rather than reusing the pointer above, so that a leaf, which the
+        // flap silently detached and rebuilt, would show up as a lookup failure here
+        // instead of a stale value read off a group no longer in the tree
+        auto steadyLeaf = FindLeafCounters(rootGroup, steady.TabletId, steady.FollowerId);
+        UNIT_ASSERT(steadyLeaf);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(steadyLeaf, "ConsumedCPU"), 100);
     }
 
     /**

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -2015,6 +2015,98 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
+     * Verify that a straggler report from a tablet of a table PREVIOUS to the one now
+     * living at this path is dropped whole rather than reconciled: it carries the old
+     * (PathId, SchemaVersion), so nothing about it — its MetricsLevel included — says
+     * anything about the table that lives at this path now.
+     *
+     * @note The scenario from the PR review: a table is dropped and recreated at the
+     *       same path with a new PathId AND a different level. The new table's own
+     *       tablet reports and builds the correct state. A tablet of the OLD table is
+     *       still alive (draining) and keeps sending its own 5s report, which still
+     *       carries the old PathId and the old level. Without the ordering guard in
+     *       front of the level check, that stale report hits the level-mismatch branch,
+     *       DropTableEntry wipes the NEW table's counters, and GetOrCreateTable rebuilds
+     *       the entry from the stale (and now current) Info — the tree flaps between the
+     *       two shapes every 5s until the old tablet is forgotten.
+     */
+    Y_UNIT_TEST(StaleReportOfARecreatedTableDoesNotDropTheNewState) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // TABLE_ID at the partition level: a per_partition leaf
+        TFakeTablet straggler(1000, 0);
+        straggler.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        straggler.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now, TABLE_ID, TABLE_PATH);
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT(FindLeafCounters(rootGroup, straggler.TabletId, straggler.FollowerId));
+
+        // The table is dropped and recreated at the same path: a newer PathId, and the
+        // level moves to TABLE. Its own tablet builds the correct collapse bucket.
+        TFakeTablet newTablet(2000, 0);
+        newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7).AddCumulative(CONSUMED_CPU, 100);
+        newTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, RECREATED_TABLE_ID, TABLE_PATH);
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after the recreated table's own tablet reported", rootGroup);
+
+        auto tableCounters = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT(tableCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "SUM(DbUniqueRowsTotal)"), 7);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCounters, "ConsumedCPU"), 100);
+        UNIT_ASSERT(!FindLeafCounters(rootGroup, straggler.TabletId, straggler.FollowerId));
+
+        // The OLD table's tablet is still alive and reports again, carrying the OLD
+        // PathId and the OLD (partition) level — the straggler
+        straggler.SetSimple(DB_UNIQUE_ROWS_TOTAL, 999);
+        straggler.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now, TABLE_ID, TABLE_PATH);
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after the straggler of the old table reported", rootGroup);
+
+        // The new table's collapse bucket survives, its VALUES are exactly as they were
+        // — a rebuilt-from-stale entry would have the right shape with zeroed contents,
+        // which a presence-only check would not catch
+        auto tableCountersAfterStraggler = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT(tableCountersAfterStraggler);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCountersAfterStraggler, "SUM(DbUniqueRowsTotal)"), 7);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(tableCountersAfterStraggler, "ConsumedCPU"), 100);
+
+        // No per_partition subtree reappeared: the straggler's report was dropped whole,
+        // never reaching GetOrCreateTable
+        auto tableGroup = FindTableGroup(rootGroup);
+        UNIT_ASSERT(tableGroup);
+        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+
+        // The bucket is still the SAME live object, not a fresh one: a further report of
+        // the new table's own tablet keeps accumulating rather than restarting from zero
+        newTablet.AddCumulative(CONSUMED_CPU, 50);
+        newTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, RECREATED_TABLE_ID, TABLE_PATH);
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(FindTableBucketCounters(rootGroup), "ConsumedCPU"), 100 + 50);
+
+        // Forgetting the straggler's tablet finds no leaf and no source ID in the live
+        // bucket: it never contributed to it, so this is a no-op, and the live table's
+        // bucket and its table= group survive
+        aggregator->ForgetTablet(straggler.TabletId, straggler.FollowerId);
+
+        UNIT_ASSERT(FindTableGroup(rootGroup));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(rootGroup), "ConsumedCPU"),
+            100 + 50
+        );
+    }
+
+    /**
      * Verify that a renamed table manifests as drop-old/create-new, with no stale
      * table= group left behind once the last of its tablets has reported the new path.
      *

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -5,8 +5,15 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/array_size.h>
+#include <util/generic/ptr.h>
+#include <util/generic/vector.h>
+#include <util/generic/yexception.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
+#include <util/system/mutex.h>
+
+#include <atomic>
+#include <thread>
 
 using namespace NKikimr;
 using namespace NKikimr::NDetailedMetricsTests;
@@ -33,6 +40,13 @@ const TString OTHER_TABLE_PATH = "/Root/db/dir/other_table";
 const TString OTHER_RELATIVE_TABLE_PATH = "dir/other_table";
 
 const TPathId OTHER_TABLE_ID(72057594046644480ull, 43);
+
+// The very same table after an ESchemeOpMoveTable rename: another path, a fresh
+// PathId and a bumped schema version, reported by the very same tablets
+const TString RENAMED_TABLE_PATH = "/Root/db/dir/renamed_table";
+const TString RENAMED_RELATIVE_TABLE_PATH = "dir/renamed_table";
+
+const TPathId RENAMED_TABLE_ID(72057594046644480ull, 45);
 
 constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
 
@@ -147,12 +161,13 @@ struct TFakeTablet {
         TInstant now,
         const TPathId& tableId = TABLE_ID,
         const TString& tablePath = TABLE_PATH,
-        TTabletTypes::EType tabletType = TABLET_TYPE
+        TTabletTypes::EType tabletType = TABLET_TYPE,
+        ui64 schemaVersion = 1
     ) {
         TDetailedMetricsTableInfo table;
         table.TableId = tableId;
         table.TablePath = tablePath;
-        table.SchemaVersion = 1;
+        table.SchemaVersion = schemaVersion;
         table.MetricsLevel = level;
 
         // An empty baseline (the very first report) makes the diff a plain copy
@@ -275,9 +290,9 @@ NMonitoring::TDynamicCounterPtr FindAppTableBucketCounters(
  * @param[in] tabletId The ID of the tablet
  * @param[in] followerId The follower ID of the tablet (0 for the leader)
  *
- * @return The executor counters of the leaf (or nullptr if there is none)
+ * @return The counter group of the leaf itself (or nullptr if there is none)
  */
-NMonitoring::TDynamicCounterPtr FindLeafCounters(
+NMonitoring::TDynamicCounterPtr FindLeafGroup(
     NMonitoring::TDynamicCounterPtr rootGroup,
     ui64 tabletId,
     ui32 followerId,
@@ -298,7 +313,16 @@ NMonitoring::TDynamicCounterPtr FindLeafCounters(
         return nullptr;
     }
 
-    return FindExecutorCountersGroup(tabletGroup->FindSubgroup("follower_id", ToString(followerId)));
+    return tabletGroup->FindSubgroup("follower_id", ToString(followerId));
+}
+
+NMonitoring::TDynamicCounterPtr FindLeafCounters(
+    NMonitoring::TDynamicCounterPtr rootGroup,
+    ui64 tabletId,
+    ui32 followerId,
+    const TString& relativeTablePath = RELATIVE_TABLE_PATH
+) {
+    return FindExecutorCountersGroup(FindLeafGroup(rootGroup, tabletId, followerId, relativeTablePath));
 }
 
 /**
@@ -314,22 +338,7 @@ NMonitoring::TDynamicCounterPtr FindAppLeafCounters(
     ui32 followerId,
     const TString& relativeTablePath = RELATIVE_TABLE_PATH
 ) {
-    auto tableGroup = FindTableGroup(rootGroup, relativeTablePath);
-    if (!tableGroup) {
-        return nullptr;
-    }
-
-    auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
-    if (!perPartitionGroup) {
-        return nullptr;
-    }
-
-    auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
-    if (!tabletGroup) {
-        return nullptr;
-    }
-
-    return FindAppCountersGroup(tabletGroup->FindSubgroup("follower_id", ToString(followerId)));
+    return FindAppCountersGroup(FindLeafGroup(rootGroup, tabletId, followerId, relativeTablePath));
 }
 
 /**
@@ -438,6 +447,88 @@ struct TRoleTrees {
         Leaders->RecalculateAllCounters();
         Followers->RecalculateAllCounters();
     }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A reader thread, which runs the given check over and over under the shared tree lock,
+ * the way the SysView Service actor reads the tree off its own mailbox, until the writer
+ * on the main thread says it is done.
+ *
+ * @param[in] check Returns the description of the very first violation it finds, or an
+ *                   empty string when the tree looks whole
+ *
+ * @note The check does NOT assert on its own. UNIT_ASSERT off the unittest thread does
+ *       not throw: it panics ("assertion failed in non-unittest thread"), which aborts
+ *       the whole test chunk instead of failing this one test. So the failure is handed
+ *       back to the main thread by Join(), which is where the assertion happens.
+ */
+class TLockedReaderThread {
+public:
+    template <typename TCheck>
+    explicit TLockedReaderThread(TCheck check)
+        : Thread([this, check]() {
+              while (!Stopped.load(std::memory_order_acquire)) {
+                  try {
+                      TGuard<TMutex> guard(DetailedMetricsLock());
+                      Failure = check();
+                  } catch (...) {
+                      // Nothing here is expected to throw, but a panic on this thread
+                      // would be even less readable than a reported failure
+                      Failure = CurrentExceptionMessage();
+                  }
+
+                  if (Failure) {
+                      return;
+                  }
+
+                  ++Reads;
+
+                  // TMutex is not fair, and a reader, which relocks the very moment it
+                  // unlocks, can starve the writer for the whole test
+                  std::this_thread::yield();
+              }
+          })
+    {}
+
+    /**
+     * @note Stops the thread as well, so that an assertion, which fails on the writer
+     *       side, does not leave a joinable thread behind and terminate the process
+     *       instead of failing the test.
+     */
+    ~TLockedReaderThread() {
+        Stop();
+    }
+
+    /**
+     * @return The number of the completed reads, asserting that none of them failed
+     */
+    ui64 Join() {
+        Stop();
+
+        UNIT_ASSERT_C(Failure.empty(), Failure);
+
+        return Reads;
+    }
+
+private:
+    void Stop() {
+        Stopped.store(true, std::memory_order_release);
+
+        if (Thread.joinable()) {
+            Thread.join();
+        }
+    }
+
+private:
+    TString Failure;
+    ui64 Reads = 0;
+    std::atomic<bool> Stopped = false;
+
+    // Declared last on purpose: the thread starts as soon as it is constructed, and it
+    // touches every member above
+    std::thread Thread;
 };
 
 } // namespace <anonymous>
@@ -620,6 +711,7 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             // No replicas_only aggregate is synthesized on the node
             UNIT_ASSERT(!tabletGroup->FindSubgroup("follower_id", "replicas_only"));
         }
+
     }
 
     /**
@@ -1513,21 +1605,133 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
     }
 
     /**
-     * Pin the CURRENT behaviour of a metrics level change: the level of a table is frozen
-     * at its very first report, so a changed level does not re-route the counters.
+     * Verify that a metrics level change with NO schema version bump — an
+     * ALTER DATABASE ... TABLES_METRICS_LEVEL, which reaches the node through the
+     * subdomain publish rather than through the schema — re-routes the counters of the
+     * table from the per-partition leaves into the collapse bucket.
      *
-     * @note This is a deliberate deferral, not the target behaviour: reconciling a table
-     *       entry on a schema version or a metrics level change is the scope of the level
-     *       and rename step, which is expected to REPLACE the assertions below with
-     *       the transition ones (drop the leaves on PARTITION -> TABLE, drop the bucket on
-     *       TABLE -> PARTITION, drop the table on -> DISABLED). The test exists so that
-     *       the step has to flip an explicit assertion instead of silently changing
-     *       behaviour, which nothing pins.
+     * @note This is the transition, which watching the schema version alone would miss
+     *       entirely, leaving the table emitting per-partition leaves forever.
      */
-    Y_UNIT_TEST(MetricsLevelChangeIsIgnoredUntilReconciliation) {
+    Y_UNIT_TEST(LevelChangeWithoutSchemaBumpReconciles) {
+        TRoleTrees trees;
+
         const TInstant now = TInstant::Seconds(100);
 
-        // TEST 1: A table, which was first seen at the table level, keeps collapsing
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+        TFakeTablet follower(1000, 1);
+
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 8);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        }
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+        trees.RecalculateAllCounters();
+
+        UNIT_ASSERT(FindLeafCounters(trees.Root, leader1.TabletId, leader1.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(trees.Root, leader2.TabletId, leader2.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(trees.Root, follower.TabletId, follower.FollowerId));
+
+        // The database default drops to the table level: the very same schema version 1,
+        // the very same tablets, only the level of the report changes
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Counters after ALTER DATABASE dropped the level to the table one", trees.Root);
+
+        // Not a single leaf is left, of either role
+        auto tableGroup = FindTableGroup(trees.Root);
+        UNIT_ASSERT(tableGroup);
+        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+
+        // ... and the collapse bucket holds the leaders alone
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
+            1 + 2
+        );
+    }
+
+    /**
+     * Verify the opposite transition: a table, which collapsed into one bucket, starts
+     * emitting a leaf per partition and drops the bucket it no longer fills.
+     *
+     * @note The table level series of a partition level table is produced on the
+     *       processor by summing the leaves across the nodes, so keeping the bucket here
+     *       as well would publish the very same table twice.
+     */
+    Y_UNIT_TEST(LevelChangeToPartitionDropsTheTableBucket) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
+            1 + 2
+        );
+
+        // The level is raised to the partition one
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after the level was raised to the partition one", rootGroup);
+
+        // The bucket took its type= subtree with it, and every partition has a leaf now
+        UNIT_ASSERT(!FindTableBucketCounters(rootGroup));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId),
+                "SUM(DbUniqueRowsTotal)"
+            ),
+            1
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId),
+                "SUM(DbUniqueRowsTotal)"
+            ),
+            2
+        );
+    }
+
+    /**
+     * Verify that a table, which stops collecting detailed metrics, is dropped whole:
+     * its groups go, and its reports create nothing afterwards.
+     */
+    Y_UNIT_TEST(LevelChangeToDisabledDropsTheTable) {
+        const TInstant now = TInstant::Seconds(100);
+
+        // TEST 1: From the table level, where the collapse bucket has to go
         {
             NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
 
@@ -1538,25 +1742,377 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             );
 
             TFakeTablet leader(1000, 0);
-
             leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
-
-            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
-            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
-
             aggregator->RecalculateAllCounters();
 
-            DumpCounters("Counters after the level changed to the partition one", rootGroup);
+            UNIT_ASSERT(FindTableBucketCounters(rootGroup));
+
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelDisabled, now);
+
+            DumpCounters("Counters after the table level table was disabled", rootGroup);
+
+            UNIT_ASSERT(!FindTableGroup(rootGroup));
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+
+            // The reports of a disabled table keep creating nothing at all
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelDisabled, now);
+            aggregator->RecalculateAllCounters();
+
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+        }
+
+        // TEST 2: From the partition level, where the leaves have to go. The level is
+        //         cleared rather than disabled: a table with no override of its own
+        //         follows a database default, which collects nothing
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet leader1(1000, 0);
+            TFakeTablet leader2(2000, 0);
+
+            for (auto* tablet : {&leader1, &leader2}) {
+                tablet->SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+                tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+            }
+            aggregator->RecalculateAllCounters();
+
+            UNIT_ASSERT(FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
+
+            // The first partition to notice takes ONLY its own table's leaves with it,
+            // including the leaf of the partition, which has not reported yet
+            leader1.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
+
+            DumpCounters("Counters after the partition level table stopped collecting", rootGroup);
+
+            UNIT_ASSERT(!FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId));
+            UNIT_ASSERT(!FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId));
+            UNIT_ASSERT(!FindTableGroup(rootGroup));
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+        }
+    }
+
+    /**
+     * Verify that a per-table ALTER, which enables the detailed metrics of a table that
+     * collected none, starts emitting the leaves.
+     *
+     * @note Unlike the database default change above, this one DOES bump the schema
+     *       version, and it is the level, which decides what is built either way.
+     */
+    Y_UNIT_TEST(SchemaBumpEnablesPartitionLevel) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader(1000, 0);
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+
+        // The table follows a database default, which collects nothing
+        leader.Report(
+            aggregator,
+            TDetailedMetricsSettings::MetricsLevelUnspecified,
+            now,
+            TABLE_ID,
+            TABLE_PATH,
+            TABLET_TYPE,
+            1 /* schemaVersion */
+        );
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+
+        // ALTER TABLE ... SET (DETAILED_METRICS_LEVEL = PARTITION)
+        leader.Report(
+            aggregator,
+            TDetailedMetricsSettings::MetricsLevelPartition,
+            now,
+            TABLE_ID,
+            TABLE_PATH,
+            TABLET_TYPE,
+            2 /* schemaVersion */
+        );
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after the ALTER enabled the partition level", rootGroup);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId),
+                "SUM(DbUniqueRowsTotal)"
+            ),
+            5
+        );
+    }
+
+    /**
+     * Verify that a schema version bump, which does NOT change the effective level,
+     * keeps the counters of the table exactly where they are.
+     *
+     * @note The level is the only thing, which decides the shape of the entry, so a
+     *       plain ALTER has nothing to reconcile. Rebuilding the table on every schema
+     *       bump instead would restart the accumulated cumulative counters from zero —
+     *       a consumer reads that as a counter reset — and would blank the leaves of
+     *       the partitions, which have not reported since the ALTER.
+     */
+    Y_UNIT_TEST(SchemaBumpAtTheSameLevelKeepsTheCounters) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+
+        leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1).AddCumulative(CONSUMED_CPU, 100);
+        leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2).AddCumulative(CONSUMED_CPU, 200);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        }
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId),
+                "ConsumedCPU"
+            ),
+            100
+        );
+
+        // The ALTER bumps the schema version, and only the first partition has noticed
+        // it so far
+        leader1.AddCumulative(CONSUMED_CPU, 50);
+        leader1.Report(
+            aggregator,
+            TDetailedMetricsSettings::MetricsLevelPartition,
+            now,
+            TABLE_ID,
+            TABLE_PATH,
+            TABLET_TYPE,
+            2 /* schemaVersion */
+        );
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Counters after a schema bump at the very same level", rootGroup);
+
+        // The accumulated counter keeps growing rather than restarting from the delta
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(rootGroup, leader1.TabletId, leader1.FollowerId),
+                "ConsumedCPU"
+            ),
+            100 + 50
+        );
+
+        // ... and the partition, which has not reported since, keeps its own leaf
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(rootGroup, leader2.TabletId, leader2.FollowerId),
+                "ConsumedCPU"
+            ),
+            200
+        );
+    }
+
+    /**
+     * Verify that the two instances of a node converge on a new level INDEPENDENTLY,
+     * one report each, and that neither of them detaches a shared node the other still
+     * writes under while they disagree.
+     *
+     * @note A level change reaches the instances through their own tablets' reports, so
+     *       there is always a window where the leader instance has already switched and
+     *       the follower one has not. The removals are routed through
+     *       RemoveSubgroupChain, which tests every node it empties within that node's
+     *       own lock, so the walk stops at the shared tablet_id= node for as long as
+     *       either instance still has a leaf there.
+     */
+    Y_UNIT_TEST(LevelChangeConvergesBothInstances) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // The leader of a partition and its follower, on one node, under ONE tablet_id=
+        TFakeTablet leader(1000, 0);
+        TFakeTablet follower(1000, 1);
+
+        leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 42);
+        follower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 99);
+
+        leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+        trees.RecalculateAllCounters();
+
+        UNIT_ASSERT(FindLeafCounters(trees.Root, leader.TabletId, leader.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(trees.Root, follower.TabletId, follower.FollowerId));
+
+        // TEST 1: The leader instance notices the new level first
+        leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Counters while only the leader instance has switched", trees.Root);
+
+        UNIT_ASSERT(!FindLeafCounters(trees.Root, leader.TabletId, leader.FollowerId));
+
+        // The follower's leaf is untouched and still reachable from the SHARED root:
+        // the leader instance removed its own leaf, and the walk stopped at the
+        // tablet_id= node, which the follower instance still occupies
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindLeafCounters(trees.Root, follower.TabletId, follower.FollowerId),
+                "SUM(DbUniqueRowsTotal)"
+            ),
+            99
+        );
+        UNIT_ASSERT(
+            trees.Root
+                ->FindSubgroup("database", DATABASE_PATH)
+                ->FindSubgroup("table", RELATIVE_TABLE_PATH)
+                ->FindSubgroup("detailed_metrics", "per_partition")
+                ->FindSubgroup("tablet_id", ToString(leader.TabletId))
+                ->FindSubgroup("follower_id", ToString(follower.FollowerId))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
+            42
+        );
+
+        // TEST 2: The follower instance converges one report later, and the last leaf
+        //         takes the whole per-partition subtree with it — but not the table=
+        //         node, which the collapse bucket of the other instance still holds
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelTable, now);
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Counters after both instances converged on the table level", trees.Root);
+
+        auto tableGroup = FindTableGroup(trees.Root);
+        UNIT_ASSERT(tableGroup);
+        UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.Root), "SUM(DbUniqueRowsTotal)"),
+            42
+        );
+    }
+
+    /**
+     * Verify that a renamed table manifests as drop-old/create-new, with no stale
+     * table= group left behind once the last of its tablets has reported the new path.
+     *
+     * @note A rename bumps the schema version and hands out a fresh PathId, but the key
+     *       of the whole per-table state is the RELATIVE PATH, so the new path simply
+     *       creates a new entry, and the tablets drain the old one as they move over —
+     *       the very same path a tablet re-reported under another table takes.
+     */
+    Y_UNIT_TEST(TableRenameCreatesTheNewGroupAndDropsTheOld) {
+        const TInstant now = TInstant::Seconds(100);
+
+        // TEST 1: The table level, where the tablets share one collapse bucket
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet leader1(1000, 0);
+            TFakeTablet leader2(2000, 0);
+
+            leader1.SetSimple(DB_UNIQUE_ROWS_TOTAL, 1);
+            leader2.SetSimple(DB_UNIQUE_ROWS_TOTAL, 2);
+
+            for (auto* tablet : {&leader1, &leader2}) {
+                tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+            }
+            aggregator->RecalculateAllCounters();
 
             UNIT_ASSERT_VALUES_EQUAL(
                 GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
-                7
+                1 + 2
             );
-            UNIT_ASSERT(!FindTableGroup(rootGroup)->FindSubgroup("detailed_metrics", "per_partition"));
+
+            // The first partition reports the new path: the old table keeps the second
+            // one for as long as it has not moved over
+            leader1.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelTable,
+                now,
+                RENAMED_TABLE_ID,
+                RENAMED_TABLE_PATH,
+                TABLET_TYPE,
+                2 /* schemaVersion */
+            );
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Counters while only one partition has reported the new path", rootGroup);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(DbUniqueRowsTotal)"),
+                2
+            );
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(
+                    FindTableBucketCounters(rootGroup, RENAMED_RELATIVE_TABLE_PATH),
+                    "SUM(DbUniqueRowsTotal)"
+                ),
+                1
+            );
+
+            // The second one follows, and nothing of the old path is left
+            leader2.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelTable,
+                now,
+                RENAMED_TABLE_ID,
+                RENAMED_TABLE_PATH,
+                TABLET_TYPE,
+                2 /* schemaVersion */
+            );
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Counters after the rename was fully reported", rootGroup);
+
+            UNIT_ASSERT(!FindTableGroup(rootGroup));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(
+                    FindTableBucketCounters(rootGroup, RENAMED_RELATIVE_TABLE_PATH),
+                    "SUM(DbUniqueRowsTotal)"
+                ),
+                1 + 2
+            );
+
+            // The reverse map points at the new path, so forgetting the tablets drops
+            // the group of the renamed table and the database= node above it
+            for (auto* tablet : {&leader1, &leader2}) {
+                aggregator->ForgetTablet(tablet->TabletId, tablet->FollowerId);
+            }
+
+            UNIT_ASSERT(!FindTableGroup(rootGroup, RENAMED_RELATIVE_TABLE_PATH));
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
         }
 
-        // TEST 2: A table, which was first seen at the partition level, keeps its leaves
+        // TEST 2: The partition level, where every tablet owns a leaf of its own
         {
             NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
 
@@ -1567,25 +2123,41 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             );
 
             TFakeTablet leader(1000, 0);
-
             leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+
             leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
-
-            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
-            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
-
             aggregator->RecalculateAllCounters();
 
-            DumpCounters("Counters after the level changed to the table one", rootGroup);
+            UNIT_ASSERT(FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId));
 
-            UNIT_ASSERT_VALUES_EQUAL(
-                GetCounterValue(
-                    FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId),
-                    "SUM(DbUniqueRowsTotal)"
-                ),
-                7
+            leader.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+            leader.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelPartition,
+                now,
+                RENAMED_TABLE_ID,
+                RENAMED_TABLE_PATH,
+                TABLET_TYPE,
+                2 /* schemaVersion */
             );
-            UNIT_ASSERT(!FindExecutorCountersGroup(FindTableGroup(rootGroup)));
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Leaves after the rename", rootGroup);
+
+            UNIT_ASSERT(!FindTableGroup(rootGroup));
+
+            auto renamedLeaf = FindLeafCounters(
+                rootGroup,
+                leader.TabletId,
+                leader.FollowerId,
+                RENAMED_RELATIVE_TABLE_PATH
+            );
+            UNIT_ASSERT(renamedLeaf);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(renamedLeaf, "SUM(DbUniqueRowsTotal)"), 7);
+
+            aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
+
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
         }
     }
 
@@ -1682,5 +2254,202 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
         UNIT_ASSERT(!HasCounter(leafCounters, "NotInTheAllowList"));
         UNIT_ASSERT(!HasCounter(leafCounters, "SUM(NotInTheAllowList)"));
         UNIT_ASSERT(!HasCounter(leafCounters, "MAX(NotInTheAllowList)"));
+    }
+
+    /**
+     * Verify that a reader, which holds the shared tree lock, never observes a partially
+     * rebuilt histogram while the writer recalculates the aggregates.
+     *
+     * @note This is the regression test for the guard in RecalculateAllCounters().
+     *       TAggregatedTabletCounters republishes a HIST(x) aggregate by resetting the
+     *       histogram and refilling it one tablet at a time, so without that guard the
+     *       reader sees a total anywhere between 0 and the number of the partitions. A
+     *       torn histogram is a perfectly valid looking snapshot, which is why this
+     *       asserts the contents rather than the absence of a crash.
+     */
+    Y_UNIT_TEST(ConcurrentReadDuringRecalculationSeesWholeHistogram) {
+        constexpr ui32 PARTITION_COUNT = 8;
+        constexpr ui32 WRITER_ITERATIONS = 2000;
+
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        TInstant now = TInstant::Seconds(100);
+
+        // The set of the partitions never changes, and neither do their simple counters:
+        // everything the reader asserts below is a constant of the whole test
+        TVector<THolder<TFakeTablet>> partitions;
+        ui64 expectedRowsSum = 0;
+        for (ui32 i = 0; i < PARTITION_COUNT; ++i) {
+            auto& partition = partitions.emplace_back(MakeHolder<TFakeTablet>(1000 + i, 0));
+            partition->SetSimple(DB_UNIQUE_ROWS_TOTAL, i + 1);
+            expectedRowsSum += i + 1;
+        }
+
+        // Report once up front, so that the reader finds the whole tree in place from its
+        // very first iteration
+        for (auto& partition : partitions) {
+            partition->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+        aggregator->RecalculateAllCounters();
+
+        auto bucketCounters = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT(bucketCounters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetHistogramTotal(bucketCounters, "HIST(ConsumedCPU)"),
+            PARTITION_COUNT
+        );
+
+        TLockedReaderThread reader([&]() -> TString {
+            // Looked up by hand rather than through GetHistogramTotal()/GetCounterValue(),
+            // which UNIT_ASSERT_C on a missing histogram/counter: an assert off this
+            // thread panics and aborts the whole test chunk instead of just failing this
+            // one check (see TLockedReaderThread's own comment)
+            auto histogram = bucketCounters->FindHistogram("HIST(ConsumedCPU)");
+            if (!histogram) {
+                return "no histogram HIST(ConsumedCPU)";
+            }
+
+            // Every partition contributes exactly one observation, so any other total
+            // means the reader landed inside the reset-then-refill window of a
+            // recalculation
+            auto snapshot = histogram->Snapshot();
+            ui64 observations = 0;
+            for (ui32 i = 0; i < snapshot->Count(); ++i) {
+                observations += snapshot->Value(i);
+            }
+            if (observations != PARTITION_COUNT) {
+                return TStringBuilder() << "a torn HIST(ConsumedCPU): " << observations
+                    << " observations instead of " << PARTITION_COUNT;
+            }
+
+            // The simple counter aggregates are assigned rather than rebuilt, and their
+            // sources never change, so they must not budge either
+            auto rowsSumCounter = bucketCounters->FindNamedCounter("sensor", "SUM(DbUniqueRowsTotal)");
+            if (!rowsSumCounter) {
+                return "no counter SUM(DbUniqueRowsTotal)";
+            }
+
+            const ui64 rowsSum = rowsSumCounter->Val();
+            if (rowsSum != expectedRowsSum) {
+                return TStringBuilder() << "SUM(DbUniqueRowsTotal) is " << rowsSum
+                    << " instead of " << expectedRowsSum;
+            }
+
+            return {};
+        });
+
+        for (ui32 iteration = 0; iteration < WRITER_ITERATIONS; ++iteration) {
+            // The recalculation rebuilds a histogram only for a counter, whose value has
+            // actually changed, so the per second rate of ConsumedCPU has to differ from
+            // the one of the previous iteration, or there would be no window to hit
+            now += TDuration::Seconds(1);
+            const ui64 consumedCpu = 1 + iteration % 3;
+
+            for (auto& partition : partitions) {
+                partition->AddCumulative(CONSUMED_CPU, consumedCpu);
+                partition->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+            }
+
+            aggregator->RecalculateAllCounters();
+        }
+
+        UNIT_ASSERT(reader.Join() > 0);
+    }
+
+    /**
+     * Verify that a reader, which holds the shared tree lock, never observes a half built
+     * leaf while the writer creates and drops the leaves of a partition level table.
+     *
+     * @note A leaf group and the low level counters underneath it are created in two
+     *       steps, and this is what asserts that both steps are inside one critical
+     *       section: a leaf, which the reader can see, always carries its counters.
+     */
+    Y_UNIT_TEST(ConcurrentStructuralChurnKeepsTheTreeConsistent) {
+        constexpr ui32 PARTITION_COUNT = 16;
+        constexpr ui32 WRITER_ITERATIONS = 200;
+
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        TInstant now = TInstant::Seconds(100);
+
+        TVector<THolder<TFakeTablet>> partitions;
+        for (ui32 i = 0; i < PARTITION_COUNT; ++i) {
+            auto& partition = partitions.emplace_back(MakeHolder<TFakeTablet>(1000 + i, 0));
+            partition->SetSimple(DB_UNIQUE_ROWS_TOTAL, i + 1);
+        }
+
+        TLockedReaderThread reader([&]() -> TString {
+            for (ui32 i = 0; i < PARTITION_COUNT; ++i) {
+                const ui64 tabletId = 1000 + i;
+
+                auto leafGroup = FindLeafGroup(rootGroup, tabletId, 0);
+                if (!leafGroup) {
+                    // The writer has not created this leaf yet, or has already dropped it
+                    continue;
+                }
+
+                // A leaf, which exists at all, is fully built: its type=/category=
+                // subtree is there and the low level counters are already published.
+                // Their VALUES are not checked, because a freshly created leaf carries
+                // its aggregates only from the next recalculation on
+                auto leafCounters = FindExecutorCountersGroup(leafGroup);
+                if (!leafCounters || !leafCounters->FindNamedCounter("sensor", "SUM(DbUniqueRowsTotal)")) {
+                    return TStringBuilder() << "a half built leaf: the tablet " << tabletId
+                        << " has no executor counters";
+                }
+
+                auto leafAppCounters = FindAppCountersGroup(leafGroup);
+                if (!leafAppCounters
+                    || !leafAppCounters->FindNamedCounter("sensor", "DataShard/EngineHostRowUpdates"))
+                {
+                    return TStringBuilder() << "a half built leaf: the tablet " << tabletId
+                        << " has no application counters";
+                }
+            }
+
+            return {};
+        });
+
+        for (ui32 iteration = 0; iteration < WRITER_ITERATIONS; ++iteration) {
+            now += TDuration::Seconds(1);
+
+            for (ui32 i = 0; i < PARTITION_COUNT; ++i) {
+                auto& partition = partitions[i];
+                partition->AddCumulative(CONSUMED_CPU, 1 + i);
+                partition->Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+                // Drop the previous leaf right after creating this one, so that the whole
+                // per_partition subtree — and, on the wrap around, the table= and
+                // database= nodes above it — is torn down and rebuilt under the reader
+                const ui32 previous = (i + PARTITION_COUNT - 1) % PARTITION_COUNT;
+                aggregator->ForgetTablet(partitions[previous]->TabletId, 0);
+            }
+
+            aggregator->RecalculateAllCounters();
+
+            // Now and then drop the very last leaf too, so that the emptied table= and
+            // database= nodes above it are reclaimed and rebuilt under the reader
+            if (iteration % 8 == 0) {
+                for (auto& partition : partitions) {
+                    aggregator->ForgetTablet(partition->TabletId, 0);
+                }
+
+                UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+            }
+        }
+
+        UNIT_ASSERT(reader.Join() > 0);
     }
 }

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -30,7 +30,9 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/monlib/dynamic_counters/encode.h>
 
+#include <algorithm>
 #include <optional>
+#include <tuple>
 
 #include <util/generic/xrange.h>
 #include <util/string/vector.h>
@@ -119,6 +121,20 @@ bool IsCollectedMetricsLevel(EDetailedMetricsLevel level) {
     return false;
 }
 
+/**
+ * Order two reports of the SAME table path by which table they identify. A table
+ * recreated at a path restarts SchemaVersion low, so the PathId comes first and the
+ * SchemaVersion only breaks ties within one PathId.
+ *
+ * assumes a path is only ever recreated by the SAME schemeshard, which hands
+ * out strictly increasing LocalPathIds. TPathId orders by (OwnerId, LocalPathId), so a
+ * path served by another schemeshard with a lower OwnerId would order backwards. Not
+ * reachable within one subdomain.
+ */
+bool IsOlderThan(const TDetailedMetricsTableInfo& lhs, const TDetailedMetricsTableInfo& rhs) {
+    return std::tie(lhs.TableId, lhs.SchemaVersion) < std::tie(rhs.TableId, rhs.SchemaVersion);
+}
+
 ::NMonitoring::TDynamicCounterPtr GetDetailedMetricsRawGroup(
     ::NMonitoring::TDynamicCounterPtr countersRoot, const TActorContext& ctx)
 {
@@ -177,12 +193,24 @@ public:
         }
 
         auto& db = itDb->second;
-        db.TabletContributions[msg.TabletID][msg.FollowerId] = TDetailedMetricsTableInfo{
+
+        const TDetailedMetricsTableInfo info{
             .TableId = msg.TableId,
             .TablePath = msg.TablePath,
             .SchemaVersion = msg.SchemaVersion,
             .MetricsLevel = static_cast<EDetailedMetricsLevel>(msg.MetricsLevel),
         };
+
+        db.TabletContributions[msg.TabletID][msg.FollowerId] = info;
+
+        // Promote into the per-path "latest known identity" whenever this report is NOT
+        // OLDER than what is stored — not strictly newer, because ALTER DATABASE
+        // TABLES_METRICS_LEVEL bumps neither TableId nor SchemaVersion and must still
+        // update the level. See TDetailedMetricsForDb::LatestByPath.
+        auto [itLatest, latestInserted] = db.LatestByPath.try_emplace(info.TablePath, info);
+        if (!latestInserted && !IsOlderThan(info, itLatest->second)) {
+            itLatest->second = info;
+        }
 
         // Fires once per tablet every 5s, hence TRACE
         YDB_LOG_TRACE_CTX(ctx, "Remembered the identity of the table reported by the tablet",
@@ -234,7 +262,27 @@ public:
             return;
         }
 
-        if (!IsCollectedMetricsLevel(table->MetricsLevel)) {
+        auto itLatest = db.LatestByPath.find(table->TablePath);
+        Y_DEBUG_ABORT_UNLESS(itLatest != db.LatestByPath.end());
+        if (itLatest == db.LatestByPath.end()) {
+            return;
+        }
+        if (IsOlderThan(*table, itLatest->second)) {
+            if (db.Aggregator) {
+                db.Aggregator->ForgetTablet(tabletId, followerId);
+            }
+
+            YDB_LOG_TRACE_CTX(ctx, "Skipping a stale report of a table recreated at this path",
+                {"tabletId", tabletId},
+                {"followerId", followerId},
+                {"tablePath", table->TablePath},
+                {"schemaVersion", table->SchemaVersion});
+            return;
+        }
+
+        const EDetailedMetricsLevel metricsLevel = table->MetricsLevel;
+
+        if (!IsCollectedMetricsLevel(metricsLevel)) {
             // The table stopped collecting: withdraw what this tablet published before
             // the level dropped
             if (db.Aggregator) {
@@ -244,7 +292,7 @@ public:
             YDB_LOG_TRACE_CTX(ctx, "Skipping the detailed metrics of the table",
                 {"tabletId", tabletId},
                 {"tablePath", table->TablePath},
-                {"metricsLevel", static_cast<ui32>(table->MetricsLevel)});
+                {"metricsLevel", static_cast<ui32>(metricsLevel)});
             return;
         }
 
@@ -257,7 +305,7 @@ public:
             CreateDetailedMetricsAggregator(db, ctx);
         }
 
-        db.Aggregator->AddCounters(*table, tabletId, followerId, tabletType,
+        db.Aggregator->AddCounters(table->TablePath, metricsLevel, tabletId, followerId, tabletType,
             *executorCounters, *appCounters, ctx.Now());
     }
 
@@ -1099,6 +1147,18 @@ private:
         TNodeDatabaseMetricsAggregatorPtr Aggregator;
 
         THashMap<ui64, THashMap<ui32, TDetailedMetricsTableInfo>> TabletContributions;
+
+        /**
+         * The newest identity (by (TableId, SchemaVersion), ties broken towards the
+         * latest report) seen at each table path on this node for this database — the
+         * authoritative answer to "which table lives at this path right now", kept
+         * separately from TabletContributions because a table dropped and recreated at
+         * the same path leaves its old tablets still reporting for a few more rounds,
+         * each carrying its own (by then stale) idea of the identity and level. See
+         * SetTableInfo() (where this is promoted) and ApplyDetailedMetrics() (where a
+         * stale tablet is rejected against it).
+         */
+        THashMap<TString, TDetailedMetricsTableInfo> LatestByPath;
     };
 
     void RequestDatabasePath(TPathId tenantPathId, TDetailedMetricsForDb& db, const TActorContext& ctx) {
@@ -1155,6 +1215,7 @@ private:
         }
 
         db.TabletContributions.clear();
+        db.LatestByPath.clear();
         db.Aggregator = nullptr;
 
         YDB_LOG_INFO_CTX(ctx, "Dropped the detailed metrics aggregator of the database",
@@ -1175,9 +1236,16 @@ private:
             return;
         }
 
-        if (itTablet->second.erase(followerId) == 0) {
+        auto itFollower = itTablet->second.find(followerId);
+        if (itFollower == itTablet->second.end()) {
             return;
         }
+
+        // Captured before erasing: needed below to tell whether this was the LAST
+        // tablet still reporting this path, once it is gone
+        const TString path = itFollower->second.TablePath;
+
+        itTablet->second.erase(itFollower);
 
         if (db.Aggregator) {
             db.Aggregator->ForgetTablet(tabletId, followerId);
@@ -1185,6 +1253,22 @@ private:
 
         if (itTablet->second.empty()) {
             db.TabletContributions.erase(itTablet);
+        }
+
+        // O(tablets), but only on tablet forget which assumed less often than reports
+        // if this is an issue — mirroring of TabletContributions' is the way to fix it
+        const bool stillReported = std::any_of(
+            db.TabletContributions.begin(), db.TabletContributions.end(),
+            [&path](const auto& tabletContribution) {
+                const auto& byFollower = tabletContribution.second;
+                return std::any_of(byFollower.begin(), byFollower.end(),
+                    [&path](const auto& followerContribution) {
+                        return followerContribution.second.TablePath == path;
+                    });
+            });
+
+        if (!stillReported) {
+            db.LatestByPath.erase(path);
         }
     }
 

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -201,15 +201,53 @@ public:
             .MetricsLevel = static_cast<EDetailedMetricsLevel>(msg.MetricsLevel),
         };
 
+        TString previousTablePath;
+        bool hadPreviousContribution = false;
+        if (auto itTablet = db.TabletContributions.find(msg.TabletID); itTablet != db.TabletContributions.end()) {
+            if (auto itFollower = itTablet->second.find(msg.FollowerId); itFollower != itTablet->second.end()) {
+                hadPreviousContribution = true;
+                previousTablePath = itFollower->second.TablePath;
+            }
+        }
+
         db.TabletContributions[msg.TabletID][msg.FollowerId] = info;
 
-        // Promote into the per-path "latest known identity" whenever this report is NOT
-        // OLDER than what is stored — not strictly newer, because ALTER DATABASE
-        // TABLES_METRICS_LEVEL bumps neither TableId nor SchemaVersion and must still
-        // update the level. See TDetailedMetricsForDb::LatestByPath.
+        // Promote into the per-path "latest known identity" only when this report carries a
+        // strictly newer identity (TableId / SchemaVersion). A level-only change (ALTER
+        // DATABASE ... TABLES_METRICS_LEVEL bumps neither) is a per-contribution concern,
+        // handled through TabletContributions. See TDetailedMetricsForDb::LatestByPath.
         auto [itLatest, latestInserted] = db.LatestByPath.try_emplace(info.TablePath, info);
-        if (!latestInserted && !IsOlderThan(info, itLatest->second)) {
+        if (!latestInserted && IsOlderThan(itLatest->second, info)) {
             itLatest->second = info;
+
+            TVector<std::pair<ui64, ui32>> stale;
+            for (const auto& [tabletId, byFollower] : db.TabletContributions) {
+                for (const auto& [followerId, contribution] : byFollower) {
+                    if (contribution.TablePath == info.TablePath && IsOlderThan(contribution, info)) {
+                        stale.emplace_back(tabletId, followerId);
+                    }
+                }
+            }
+
+            for (const auto& [tabletId, followerId] : stale) {
+                if (db.Aggregator) {
+                    db.Aggregator->ForgetTablet(tabletId, followerId);
+                }
+
+                auto itTablet = db.TabletContributions.find(tabletId);
+                itTablet->second.erase(followerId);
+                if (itTablet->second.empty()) {
+                    db.TabletContributions.erase(itTablet);
+                }
+            }
+        }
+
+        if (hadPreviousContribution && previousTablePath != info.TablePath) {
+            if (db.Aggregator) {
+                db.Aggregator->ForgetTablet(msg.TabletID, msg.FollowerId);
+            }
+
+            DropUnreportedPath(db, previousTablePath);
         }
 
         // Fires once per tablet every 5s, hence TRACE
@@ -1149,14 +1187,20 @@ private:
         THashMap<ui64, THashMap<ui32, TDetailedMetricsTableInfo>> TabletContributions;
 
         /**
-         * The newest identity (by (TableId, SchemaVersion), ties broken towards the
-         * latest report) seen at each table path on this node for this database — the
+         * The newest identity (STRICTLY by (TableId, SchemaVersion); a tie changes
+         * nothing here) seen at each table path on this node for this database — the
          * authoritative answer to "which table lives at this path right now", kept
          * separately from TabletContributions because a table dropped and recreated at
          * the same path leaves its old tablets still reporting for a few more rounds,
-         * each carrying its own (by then stale) idea of the identity and level. See
+         * each carrying its own (by then stale) idea of the identity. See
          * SetTableInfo() (where this is promoted) and ApplyDetailedMetrics() (where a
          * stale tablet is rejected against it).
+         *
+         * @note MetricsLevel is NOT part of the ordering: ALTER DATABASE ...
+         *       TABLES_METRICS_LEVEL bumps neither TableId nor SchemaVersion, and a
+         *       level change is a per-CONTRIBUTION concern (TabletContributions,
+         *       read fresh by ApplyDetailedMetrics on every report), not a
+         *       per-path one. This map answers "which table", not "at which level".
          */
         THashMap<TString, TDetailedMetricsTableInfo> LatestByPath;
     };
@@ -1223,6 +1267,31 @@ private:
             {"pathId", pathId.ToString()});
     }
 
+    /**
+     * Erase db.LatestByPath[path] once no tablet contribution at that path is left, so
+     * that a rename or a table drop does not leave a stale "latest identity" wedging
+     * that path for the rest of the database's lifetime.
+     *
+     * O(tablets), but only on a tablet forget or a rename, assumed less often than
+     * reports — if this is an issue, mirroring TabletContributions' shape by path is
+     * the way to fix it.
+     */
+    void DropUnreportedPath(TDetailedMetricsForDb& db, const TString& path) {
+        const bool stillReported = std::any_of(
+            db.TabletContributions.begin(), db.TabletContributions.end(),
+            [&path](const auto& tabletContribution) {
+                const auto& byFollower = tabletContribution.second;
+                return std::any_of(byFollower.begin(), byFollower.end(),
+                    [&path](const auto& followerContribution) {
+                        return followerContribution.second.TablePath == path;
+                    });
+            });
+
+        if (!stillReported) {
+            db.LatestByPath.erase(path);
+        }
+    }
+
     void ForgetTabletDetailedMetrics(ui64 tabletId, ui32 followerId, TPathId tenantPathId) {
         auto itDb = DetailedMetricsByPathId.find(tenantPathId);
         if (itDb == DetailedMetricsByPathId.end()) {
@@ -1241,8 +1310,8 @@ private:
             return;
         }
 
-        // Captured before erasing: needed below to tell whether this was the LAST
-        // tablet still reporting this path, once it is gone
+        // Captured before erasing: DropUnreportedPath needs it once the contribution
+        // itself is gone
         const TString path = itFollower->second.TablePath;
 
         itTablet->second.erase(itFollower);
@@ -1255,21 +1324,7 @@ private:
             db.TabletContributions.erase(itTablet);
         }
 
-        // O(tablets), but only on tablet forget which assumed less often than reports
-        // if this is an issue — mirroring of TabletContributions' is the way to fix it
-        const bool stillReported = std::any_of(
-            db.TabletContributions.begin(), db.TabletContributions.end(),
-            [&path](const auto& tabletContribution) {
-                const auto& byFollower = tabletContribution.second;
-                return std::any_of(byFollower.begin(), byFollower.end(),
-                    [&path](const auto& followerContribution) {
-                        return followerContribution.second.TablePath == path;
-                    });
-            });
-
-        if (!stillReported) {
-            db.LatestByPath.erase(path);
-        }
+        DropUnreportedPath(db, path);
     }
 
     void RemoveDetailedMetricsByPathId(TPathId pathId, const TActorContext& ctx) {

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -1955,6 +1955,78 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
         UNIT_ASSERT(!FindTableBucketCounters(env));
         UNIT_ASSERT(!FindTableGroup(env));
     }
+
+    /**
+     * Verify the eager eviction of the older generation (PR review Part 2): a table
+     * recreated at the SAME path and the SAME level must not have to wait for the old
+     * tablet to report again (and get rejected by `IsOlderThan`) before the bucket
+     * reflects the new generation alone. Without this, the bucket would sum BOTH
+     * generations' tablets — 5 + 7, not 7 — for as long as the old one stays quiet.
+     */
+    Y_UNIT_TEST(RecreatedTableAtTheSameLevelDropsOldContributions) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet oldTablet(1000, 0, LEVEL_TABLE, TABLE_ID, 1 /* schemaVersion */);
+        oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        oldTablet.SendUpdate(env);
+        ReportCounters(env, {&oldTablet});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(env), "SUM", ALLOWED_EXECUTOR_COUNTER), 5u);
+
+        // The table is dropped and recreated at the SAME path and the SAME level: its
+        // own (different) tablet reports and sends its own round of counters, without
+        // the old one ever reporting again
+        TFakeTablet newTablet(2000, 0, LEVEL_TABLE, RECREATED_TABLE_ID, 1 /* schemaVersion */);
+        newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+        newTablet.SendUpdate(env);
+        ReportCounters(env, {&newTablet});
+
+        // The bucket holds the NEW generation alone
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(env), "SUM", ALLOWED_EXECUTOR_COUNTER), 7u);
+    }
+
+    /**
+     * Verify the rename cleanup (PR review Part 3): once a tablet's identity event
+     * moves it to a new path, the OLD path's group is dropped right away, driven by
+     * the identity event alone — not left to leak until the database is torn down,
+     * and not waiting on a counters tick that will never come again at the old path.
+     */
+    Y_UNIT_TEST(RenameDropsTheStaleGroupOfTheOldPath) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        const TString RENAMED_TABLE_PATH = "/Root/db/dir/renamed_table";
+        const TString RENAMED_RELATIVE_TABLE_PATH = "dir/renamed_table";
+
+        TFakeTablet tablet(1000, 0, LEVEL_PARTITION);
+        tablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        tablet.SendUpdate(env);
+        ReportCounters(env, {&tablet});
+
+        UNIT_ASSERT(FindTableGroup(env));
+
+        // The tablet reports a new identity at another path — an ESchemeOpMoveTable
+        // rename, seen from here as the very same tablet now reporting a different
+        // TablePath — and sends no counters at all afterwards
+        env.Runtime.Send(new IEventHandle(env.GetAggregatorId(tablet.FollowerId), env.Edge,
+            new TEvTabletCounters::TEvTabletSetTableInfo(
+                tablet.TabletId, TENANT_PATH_ID, tablet.FollowerId, tablet.TableId,
+                RENAMED_TABLE_PATH, tablet.SchemaVersion, tablet.MetricsLevel)));
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        // The old table= group is gone immediately: the identity event alone drives
+        // the cleanup, no further counters tick is needed
+        UNIT_ASSERT(!FindTableGroup(env));
+
+        // Nothing of the new path exists yet either: an identity event alone builds
+        // no counter group, only a report does. Guarded at every step, the same shape
+        // as FindTableGroup: this tablet was the database's only one, so ForgetLeaf's
+        // pruning may well have taken database= (and even the raw group) with it too
+        auto rawGroup = FindRawGroup(env);
+        auto databaseGroup = rawGroup ? rawGroup->FindSubgroup("database", DATABASE_PATH) : nullptr;
+        UNIT_ASSERT(!databaseGroup || !databaseGroup->FindSubgroup("table", RENAMED_RELATIVE_TABLE_PATH));
+    }
 }
 
 }

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -1082,6 +1082,11 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
     const TPathId TENANT_PATH_ID(1113, 1001);
     const TPathId TABLE_ID(1113, 42);
 
+    // A newer PathId at the very same TABLE_PATH: models a table dropped and recreated
+    // at the same path, reporting under a fresh identity while the old table's tablet
+    // may still be alive and reporting too
+    const TPathId RECREATED_TABLE_ID(1113, 44);
+
     constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
 
     constexpr ui32 LEVEL_TABLE = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable;
@@ -1213,10 +1218,18 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
      * and the counters (TEvTabletAddCounters) are two separate events.
      */
     struct TFakeTablet {
-        TFakeTablet(ui64 tabletId, ui32 followerId, ui32 metricsLevel)
+        TFakeTablet(
+            ui64 tabletId,
+            ui32 followerId,
+            ui32 metricsLevel,
+            TPathId tableId = TABLE_ID,
+            ui64 schemaVersion = 1
+        )
             : TabletId(tabletId)
             , FollowerId(followerId)
             , MetricsLevel(metricsLevel)
+            , TableId(tableId)
+            , SchemaVersion(schemaVersion)
             , CounterEventsInFlight(new TEvTabletCounters::TInFlightCookie)
             , ExecutorCounters(new TTabletCountersBase(
                 Y_ARRAY_SIZE(EXECUTOR_SIMPLE_COUNTER_NAMES),
@@ -1247,8 +1260,8 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
 
             env.Runtime.Send(new IEventHandle(aggregatorId, env.Edge,
                 new TEvTabletCounters::TEvTabletSetTableInfo(
-                    TabletId, TENANT_PATH_ID, FollowerId, TABLE_ID, TABLE_PATH,
-                    1 /* schemaVersion */, MetricsLevel)));
+                    TabletId, TENANT_PATH_ID, FollowerId, TableId, TABLE_PATH,
+                    SchemaVersion, MetricsLevel)));
         }
 
         void SendCounters(TEnv& env) {
@@ -1292,6 +1305,8 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
         const ui64 TabletId;
         const ui32 FollowerId;
         ui32 MetricsLevel;
+        const TPathId TableId;
+        const ui64 SchemaVersion;
 
         TIntrusivePtr<TEvTabletCounters::TInFlightCookie> CounterEventsInFlight;
 
@@ -1778,6 +1793,167 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorDetailedMetrics) {
         UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
         UNIT_ASSERT_VALUES_EQUAL(
             GetCounterValue(FindLeafCounters(env, 1000, 1), "SUM", ALLOWED_EXECUTOR_COUNTER), 2u);
+    }
+
+    /**
+     * Verify that a tablet whose OWN (TableId, SchemaVersion) is older than the newest
+     * one seen at its table's path is a straggler: its report is withdrawn rather than
+     * applied, and the live table's counters are untouched.
+     *
+     * @note The scenario the node aggregator can no longer defend against on its own: a
+     *       table is dropped and recreated at the same path with a newer PathId. The new
+     *       table's own tablet reports and builds the correct state. The OLD table's
+     *       tablet is still alive and keeps sending its own 5s round, still carrying its
+     *       own (by now stale) identity — LatestByPath is what tells the two apart.
+     */
+    Y_UNIT_TEST(StaleTabletReportIsWithdrawnNotApplied) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet oldTablet(1000, 0, LEVEL_PARTITION, TABLE_ID, 1 /* schemaVersion */);
+        oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        oldTablet.SendUpdate(env);
+        ReportCounters(env, {&oldTablet});
+
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 0));
+
+        // The table is dropped and recreated at the same path with a newer PathId: its
+        // own (different) tablet reports and builds the correct state
+        TFakeTablet newTablet(2000, 0, LEVEL_PARTITION, RECREATED_TABLE_ID, 1 /* schemaVersion */);
+        newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+        newTablet.SendUpdate(env);
+        ReportCounters(env, {&newTablet});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 2000, 0), "SUM", ALLOWED_EXECUTOR_COUNTER), 7u);
+
+        // The OLD table's tablet is still alive and reports again, without ever having
+        // learned of the recreation — its own idea of the identity is still the old one
+        oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 999);
+        ReportCounters(env, {&oldTablet});
+
+        // The straggler's report is withdrawn rather than applied: its own leaf is gone ...
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
+
+        // ... and the live table's counters are exactly as they were
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 2000, 0), "SUM", ALLOWED_EXECUTOR_COUNTER), 7u);
+    }
+
+    /**
+     * Verify that LatestByPath is reclaimed once the last tablet reporting a path is
+     * forgotten, rather than leaking and wedging that path forever.
+     *
+     * @note Proven by an identity that would have been rejected as stale had the old
+     *       entry survived (an OLDER SchemaVersion than the forgotten tablet's) —
+     *       publishing normally means nothing was left behind to compare it against.
+     */
+    Y_UNIT_TEST(LatestByPathIsReclaimedOnceTheLastTabletIsForgotten) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet oldTablet(1000, 0, LEVEL_PARTITION, TABLE_ID, 2 /* schemaVersion */);
+        oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        oldTablet.SendUpdate(env);
+        ReportCounters(env, {&oldTablet});
+
+        UNIT_ASSERT(FindLeafCounters(env, 1000, 0));
+
+        oldTablet.SendForget(env);
+        env.Runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!FindTableGroup(env));
+
+        TFakeTablet newTablet(2000, 0, LEVEL_PARTITION, TABLE_ID, 1 /* schemaVersion, OLDER than the forgotten tablet's */);
+        newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+        newTablet.SendUpdate(env);
+        ReportCounters(env, {&newTablet});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 2000, 0), "SUM", ALLOWED_EXECUTOR_COUNTER), 7u);
+    }
+
+    /**
+     * Verify the Hole-A scenario from the PR review: a table recreated at a level that
+     * collects NOTHING at all (Disabled). Two different guards cooperate to reach the
+     * same end state: the recreated table's own tablet is stopped by the
+     * `IsCollectedMetricsLevel` gate on ITS OWN Disabled level (the level is a
+     * per-tablet input — see `ApplyDetailedMetrics`), and only ever withdraws its OWN
+     * (never-published) contribution; the OLD table's straggler is rejected earlier
+     * still, by the identity comparison (`IsOlderThan`), before the level gate is ever
+     * consulted — and it is THAT rejection which finally withdraws the old leaf, since
+     * the recreated table's own report never touches it.
+     */
+    Y_UNIT_TEST(StaleReportAfterRecreationAsDisabledPublishesNothing) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet oldTablet(1000, 0, LEVEL_PARTITION, TABLE_ID, 1 /* schemaVersion */);
+        oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        oldTablet.SendUpdate(env);
+        ReportCounters(env, {&oldTablet});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 0), "SUM", ALLOWED_EXECUTOR_COUNTER), 5u);
+
+        // The table is dropped and recreated at the same path with a newer PathId, and
+        // this time it collects nothing at all: its own (different) tablet reports Disabled
+        TFakeTablet newTablet(2000, 0, LEVEL_DISABLED, RECREATED_TABLE_ID, 1 /* schemaVersion */);
+        newTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+        newTablet.SendUpdate(env);
+        ReportCounters(env, {&newTablet});
+
+        // Nothing of the recreated table is published — the IsCollectedMetricsLevel
+        // gate stops it on its own (Disabled) level
+        UNIT_ASSERT(!FindLeafCounters(env, 2000, 0));
+
+        // The OLD table's tablet is still alive and reports again, without ever having
+        // learned of the recreation — its own idea of the identity is still the old one
+        oldTablet.SetSimple(DB_UNIQUE_ROWS_TOTAL, 999);
+        ReportCounters(env, {&oldTablet});
+
+        // Nothing came back: no leaf for either tablet, no table= group at all
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 0));
+        UNIT_ASSERT(!FindLeafCounters(env, 2000, 0));
+        UNIT_ASSERT(!FindTableGroup(env));
+    }
+
+    /**
+     * Verify the Hole-B scenario from the PR review: a table recreated at Table level,
+     * observed on the FOLLOWER instance. The follower never builds anything for Table
+     * level (`IsFollowerRole && IsTableLevel(...)` returns before `GetOrCreateTable()`),
+     * so the recreated table's own report only ever tears the old PARTITION leaf down —
+     * nothing replaces it. The straggler's later report, rejected by `IsOlderThan`
+     * before the level gate is ever consulted, then has nothing left to resurrect either.
+     */
+    Y_UNIT_TEST(StaleFollowerReportAfterRecreationAsTableLevelPublishesNothing) {
+        TEnv env(true /* detailedMetricsEnabled */);
+
+        TFakeTablet oldFollower(1000, 1, LEVEL_PARTITION, TABLE_ID, 1 /* schemaVersion */);
+        oldFollower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 5);
+        oldFollower.SendUpdate(env);
+        ReportCounters(env, {&oldFollower});
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindLeafCounters(env, 1000, 1), "SUM", ALLOWED_EXECUTOR_COUNTER), 5u);
+
+        // The table is recreated at Table level: its own (different) follower tablet
+        // reports it. The follower instance skips building anything for Table level, but
+        // the old leaf is still torn down as part of the level reconcile.
+        TFakeTablet newFollower(2000, 1, LEVEL_TABLE, RECREATED_TABLE_ID, 1 /* schemaVersion */);
+        newFollower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 7);
+        newFollower.SendUpdate(env);
+        ReportCounters(env, {&newFollower});
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT(!FindTableBucketCounters(env));
+        UNIT_ASSERT(!FindTableGroup(env));
+
+        // The OLD follower tablet is still alive and reports again, still carrying its
+        // own (by now stale) PARTITION identity — the straggler
+        oldFollower.SetSimple(DB_UNIQUE_ROWS_TOTAL, 999);
+        ReportCounters(env, {&oldFollower});
+
+        UNIT_ASSERT(!FindLeafCounters(env, 1000, 1));
+        UNIT_ASSERT(!FindTableBucketCounters(env));
+        UNIT_ASSERT(!FindTableGroup(env));
     }
 }
 


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

Some amount of plumbing in preparation of sending detailed counter values over the wire to SysViewProcessor for aggregation into ydb_detailed later

- added ReconcileTable to run on every AddCounters and account for level change or rename
-  it checks Info ordered by (TableId, SchemaVersion) to prohibit recreated table pinning Info to dead PathId forever
- lock is added to RecalculateAllCounters and exported for later readers so HIST republishing does not lead to scraping half filled histos (they are zeroed and refilled on each tick and HIST is a series of metrics, unlike SUM/MAX/metric itself)