### PR TITLE
Check DLQ topic permissions on create/alter with MLP MOVE policy

### DIFF
--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -147,6 +147,11 @@ namespace {
 
     }
 
+    bool CreateDlqTopic(NYdb::TDriver& driver, const TString& dlqTopicName = "DeadLetterQueue") {
+        NYdb::NTopic::TCreateTopicSettings settings;
+        return CreateTopic(driver, dlqTopicName, settings);
+    }
+
     TMaybe<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent> GetNextDataMessage(const std::shared_ptr<NYdb::NTopic::IReadSession>& reader, TInstant deadline) {
         while (true) {
             reader->WaitEvent().Wait(deadline);
@@ -2373,6 +2378,9 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         auto consumerName = [](int i) { return std::format("ydb-sqs-consumer-{}", i); };
         auto queueUrlForConsumer = [&](int i) { return std::format("/v1/{}/{}/{}/{}/{}/{}", database.size(), database.c_str(), topicName.size(), topicName.c_str(), consumerName(i).size(), consumerName(i).c_str()); };
         const TDuration retentionPeriod = TDuration::Hours(10);
+        if (params.Dlq) {
+            UNIT_ASSERT(CreateDlqTopic(driver));
+        }
         {
             NYdb::NTopic::TCreateTopicSettings settings;
             settings.RetentionPeriod(retentionPeriod);

--- a/ydb/core/http_proxy/ut/sqs_topic_xml_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_xml_ut.cpp
@@ -116,6 +116,11 @@ namespace {
 
     }
 
+    bool CreateDlqTopic(NYdb::TDriver& driver, const TString& dlqTopicName = "DeadLetterQueue") {
+        NYdb::NTopic::TCreateTopicSettings settings;
+        return CreateTopic(driver, dlqTopicName, settings);
+    }
+
     TMaybe<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent> GetNextDataMessage(const std::shared_ptr<NYdb::NTopic::IReadSession>& reader, TInstant deadline) {
         while (true) {
             reader->WaitEvent().Wait(deadline);
@@ -1082,6 +1087,9 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxyXml) {
         auto consumerName = [](int i) { return std::format("ydb-sqs-consumer-{}", i); };
         auto queueUrlForConsumer = [&](int i) { return std::format("/v1/{}/{}/{}/{}/{}/{}", database.size(), database.c_str(), topicName.size(), topicName.c_str(), consumerName(i).size(), consumerName(i).c_str()); };
         const TDuration retentionPeriod = TDuration::Hours(10);
+        if (params.Dlq) {
+            UNIT_ASSERT(CreateDlqTopic(driver));
+        }
         {
             NYdb::NTopic::TCreateTopicSettings settings;
             settings.RetentionPeriod(retentionPeriod);

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12581,7 +12581,9 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 )
             )
         )");
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::UNAUTHORIZED, result.GetIssues().ToString());
+        // Query service wraps scheme UNAUTHORIZED as GENERIC_ERROR (execution).
+        const auto expected = UseQueryService ? EStatus::GENERIC_ERROR : EStatus::UNAUTHORIZED;
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expected, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
             "Access denied for user@builtin on path /Root/dlq",
             result.GetIssues().ToString());
@@ -12605,7 +12607,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 )
             )
         )");
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+        const auto expected = UseQueryService ? EStatus::GENERIC_ERROR : EStatus::SCHEME_ERROR;
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expected, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
             "does not exist",
             result.GetIssues().ToString());

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12531,6 +12531,84 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "dead_letter_queue is required for shared consumers with dead letter policy 'move'", result.GetIssues().ToString());
         }
+        {
+            const auto query = R"(
+                --!syntax_v1
+                CREATE TOPIC `/Root/topic1` (
+                    CONSUMER cs WITH (type='shared', dead_letter_policy='move', dead_letter_queue='')
+                )
+            )";
+            const auto result = executeQuery(query);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Dead letter queue cannot be empty", result.GetIssues().ToString());
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(CreateTopicSharedConsumerDlqAccessDenied, UseQueryService) {
+        TKikimrRunner kikimr;
+        auto adminQueryClient = kikimr.GetQueryClient();
+        auto adminSession = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        {
+            const auto result = ExecuteGeneric<UseQueryService>(adminQueryClient, adminSession, R"(
+                --!syntax_v1
+                CREATE TOPIC `/Root/dlq`
+            )");
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        kikimr.GetTestClient().GrantConnect("user@builtin");
+        {
+            const auto result = ExecuteGeneric<UseQueryService>(adminQueryClient, adminSession, R"(
+                --!syntax_v1
+                GRANT CREATE QUEUE, DESCRIBE SCHEMA ON `/Root` TO `user@builtin`;
+            )");
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            Sleep(TDuration::MilliSeconds(300));
+        }
+
+        auto userQueryClient = kikimr.GetQueryClient(NQuery::TClientSettings().AuthToken("user@builtin"));
+        auto userSession = kikimr.GetTableClient(NYdb::NTable::TClientSettings().AuthToken("user@builtin"))
+            .CreateSession().GetValueSync().GetSession();
+
+        const auto result = ExecuteGeneric<UseQueryService>(userQueryClient, userSession, R"(
+            --!syntax_v1
+            CREATE TOPIC `/Root/topic` (
+                CONSUMER cs WITH (
+                    type='shared',
+                    dead_letter_policy='move',
+                    dead_letter_queue='/Root/dlq'
+                )
+            )
+        )");
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::UNAUTHORIZED, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
+            "Access denied for user@builtin on path /Root/dlq",
+            result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
+            "AlterSchema or UpdateRow",
+            result.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST_TWIN(CreateTopicSharedConsumerDlqDoesNotExist, UseQueryService) {
+        TKikimrRunner kikimr;
+        auto queryClient = kikimr.GetQueryClient();
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, R"(
+            --!syntax_v1
+            CREATE TOPIC `/Root/topic` (
+                CONSUMER cs WITH (
+                    type='shared',
+                    dead_letter_policy='move',
+                    dead_letter_queue='/Root/missing_dlq'
+                )
+            )
+        )");
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
+            "does not exist",
+            result.GetIssues().ToString());
     }
 
     Y_UNIT_TEST_TWIN(CreateAndAlterTopicMetricsLevel, UseQueryService) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12392,6 +12392,14 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             const auto query = R"(
                 --!syntax_v1
+                CREATE TOPIC `/Root/dead_letter_queue_97`
+            )";
+            const auto result = executeQuery(query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                --!syntax_v1
                 ALTER TOPIC `/Root/topic`
                     ALTER CONSUMER cs SET (default_processing_timeout = Interval('PT31S'), max_processing_attempts = 67, dead_letter_policy = 'move', dead_letter_queue = 'dead_letter_queue_97')
             )";

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -1,6 +1,7 @@
 #include "mlp_consumer.h"
 #include "mlp_storage.h"
 
+#include <ydb/core/base/path.h>
 #include <ydb/core/persqueue/common/key.h>
 #include <ydb/core/persqueue/public/config.h>
 #include <ydb/core/persqueue/public/constants.h>
@@ -1140,12 +1141,11 @@ void TConsumerActor::MoveToDLQIfPossible() {
     }
 
     auto destinationTopic = [&]() -> TString {
-        auto databasePrefix = TStringBuilder() << Database << "/";
-        if (Config.GetDeadLetterQueue().StartsWith("sqs://") || Config.GetDeadLetterQueue().StartsWith(databasePrefix)) {
-            return Config.GetDeadLetterQueue();
-        } else {
-            return databasePrefix << Config.GetDeadLetterQueue();
+        const auto& dlq = Config.GetDeadLetterQueue();
+        if (dlq.empty() || dlq.StartsWith("sqs://")) {
+            return dlq;
         }
+        return NormalizePath(CanonizePath(Database), CanonizePath(dlq));
     };
 
     auto messages = Storage->GetDLQMessages();

--- a/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_consumer_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_consumer_ut.cpp
@@ -120,6 +120,8 @@ Y_UNIT_TEST(AlterConsumer) {
             ::NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name(::NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_DELETE));
     }
 
+    client.CreateTopic("/Root/dlq-queue", NYdb::NTopic::TCreateTopicSettings()).GetValueSync();
+
     client.AlterTopic("/Root/topic1", NYdb::NTopic::TAlterTopicSettings()
             .SetRetentionPeriod(TDuration::Seconds(103))
             .BeginAlterConsumer("mlp-consumer")
@@ -334,6 +336,8 @@ Y_UNIT_TEST(ReloadPQTabletAfterAlterConsumer) {
         auto result = GetChangeResponse(runtime);
         UNIT_ASSERT_VALUES_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
     }
+
+    client.CreateTopic("/Root/dlq-queue", NYdb::NTopic::TCreateTopicSettings()).GetValueSync();
 
     client.AlterTopic("/Root/topic1", NYdb::NTopic::TAlterTopicSettings()
         .SetRetentionPeriod(TDuration::Seconds(103))
@@ -1135,7 +1139,11 @@ Y_UNIT_TEST(DLQ_MoveFailsThenSucceedsAfterDlqCreated) {
     auto driver = TDriver(setup->MakeDriverConfig());
     auto client = TTopicClient(driver);
 
-    // Destination is missing at first — mover fails and WakeUpDLQ returns the message.
+    // Create DLQ first so create/alter ACL checks pass, then drop it so the mover fails.
+    client.CreateTopic("/Root/topic1-dlq", NYdb::NTopic::TCreateTopicSettings()
+            .BeginAddSharedConsumer("mlp-consumer")
+            .EndAddConsumer()).GetValueSync();
+
     client.CreateTopic("/Root/topic1", NYdb::NTopic::TCreateTopicSettings()
             .BeginAddSharedConsumer("mlp-consumer")
                 .BeginDeadLetterPolicy()
@@ -1146,6 +1154,8 @@ Y_UNIT_TEST(DLQ_MoveFailsThenSucceedsAfterDlqCreated) {
                     .MoveAction("/Root/topic1-dlq")
                 .EndDeadLetterPolicy()
             .EndAddConsumer()).GetValueSync();
+
+    client.DropTopic("/Root/topic1-dlq").GetValueSync();
 
     const auto msg = "dlq-retry-me";
     setup->Write("/Root/topic1", msg, 0);

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -8,8 +8,6 @@
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
 
-#include <util/string/join.h>
-
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
 namespace NKikimr::NPQ::NSchema {
@@ -202,27 +200,20 @@ private:
         const auto& oldConfig = TopicInfo.Info
             ? TopicInfo.Info->Description.GetPQTabletConfig()
             : emptyOldConfig;
-        auto dlqPaths = CollectNewDlqTopicPaths(
-            ModifyScheme.GetAlterPersQueueGroup().GetPQTabletConfig(),
-            oldConfig,
-            Database
-        );
-        if (dlqPaths.empty()) {
-            return DoProposeOrReply();
+        if (auto* actor = CreateCheckDlqTopicsActorIfNeeded(
+                SelfId(),
+                Database,
+                ModifyScheme.GetAlterPersQueueGroup().GetPQTabletConfig(),
+                oldConfig,
+                TCheckDlqTopicsSettings{
+                    .UserToken = Settings.UserToken
+                }))
+        {
+            Become(&TAlterTopicOperationActor::CheckDlqState);
+            RegisterWithSameMailbox(actor);
+            return;
         }
-
-        YDB_LOG_DEBUG("DoCheckDlq",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"dlqPaths", JoinRange(", ", dlqPaths.begin(), dlqPaths.end())});
-        Become(&TAlterTopicOperationActor::CheckDlqState);
-        RegisterWithSameMailbox(CreateCheckDlqTopicsActor(
-            SelfId(),
-            Database,
-            std::move(dlqPaths),
-            TCheckDlqTopicsSettings{
-                .UserToken = Settings.UserToken
-            }
-        ));
+        return DoProposeOrReply();
     }
 
     void Handle(TEvCheckDlqTopicsResponse::TPtr& ev) {

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -1,10 +1,14 @@
 #include "alter_topic_operation.h"
 #include "schema_operation.h"
+#include "check_dlq_topics.h"
 
 #include <ydb/core/grpc_services/rpc_calls.h>
 #include <ydb/core/persqueue/common/actor.h>
+#include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
+
+#include <util/string/join.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
@@ -174,17 +178,8 @@ private:
         }
 
         ModifyScheme = modifyScheme;
-
-        if (Settings.PrepareOnly) {
-            return ReplyAndDie(Ydb::StatusIds::SUCCESS, "");
-        } else {
-            RegisterWithSameMailbox(CreateSchemaOperation(
-                SelfId(),
-                TopicInfo.RealPath,
-                std::move(proposal),
-                Settings.Cookie
-            ));
-        }
+        Proposal = std::move(proposal);
+        return DoCheckDlqOrPropose();
     }
 
     void Handle(TEvSchemaOperationResponse::TPtr& ev) {
@@ -199,6 +194,66 @@ private:
             hFunc(TEvSchemaOperationResponse, Handle);
             sFunc(TEvents::TEvPoison, PassAway);
         }
+    }
+
+private:
+    void DoCheckDlqOrPropose() {
+        const NKikimrPQ::TPQTabletConfig emptyOldConfig;
+        const auto& oldConfig = TopicInfo.Info
+            ? TopicInfo.Info->Description.GetPQTabletConfig()
+            : emptyOldConfig;
+        auto dlqPaths = CollectNewDlqTopicPaths(
+            ModifyScheme.GetAlterPersQueueGroup().GetPQTabletConfig(),
+            oldConfig,
+            Database
+        );
+        if (dlqPaths.empty()) {
+            return DoProposeOrReply();
+        }
+
+        YDB_LOG_DEBUG("DoCheckDlq",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"dlqPaths", JoinRange(", ", dlqPaths.begin(), dlqPaths.end())});
+        Become(&TAlterTopicOperationActor::CheckDlqState);
+        RegisterWithSameMailbox(CreateCheckDlqTopicsActor(
+            SelfId(),
+            Database,
+            std::move(dlqPaths),
+            TCheckDlqTopicsSettings{
+                .UserToken = Settings.UserToken
+            }
+        ));
+    }
+
+    void Handle(TEvCheckDlqTopicsResponse::TPtr& ev) {
+        YDB_LOG_DEBUG("Handle TEvCheckDlqTopicsResponse",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"status", ev->Get()->Status},
+            {"errorMessage", ev->Get()->ErrorMessage});
+        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+            return ReplyAndDie(ev->Get()->Status, std::move(ev->Get()->ErrorMessage));
+        }
+        return DoProposeOrReply();
+    }
+
+    STFUNC(CheckDlqState) {
+        switch(ev->GetTypeRewrite()) {
+            hFunc(TEvCheckDlqTopicsResponse, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
+        }
+    }
+
+    void DoProposeOrReply() {
+        if (Settings.PrepareOnly) {
+            return ReplyAndDie(Ydb::StatusIds::SUCCESS, "");
+        }
+        RegisterWithSameMailbox(CreateSchemaOperation(
+            SelfId(),
+            TopicInfo.RealPath,
+            std::move(Proposal),
+            Settings.Cookie
+        ));
+        Become(&TAlterTopicOperationActor::AlterState);
     }
 
 private:
@@ -220,6 +275,7 @@ private:
     const TString Database;
 
     NDescriber::TTopicInfo TopicInfo;
+    std::unique_ptr<TEvTxUserProxy::TEvProposeTransaction> Proposal;
     NKikimrSchemeOp::TModifyScheme ModifyScheme;
     NPQ::NClusterTracker::TClustersList::TConstPtr ClustersList;
 };

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -1,0 +1,219 @@
+#include "check_dlq_topics.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
+#include <ydb/core/persqueue/public/describer/describer.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
+#include <util/string/builder.h>
+#include <util/string/join.h>
+
+#include <optional>
+
+#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_SCHEMA
+
+#define LOG_PREFIX NActors::TlsActivationContext->AsActorContext().SelfID
+
+namespace NKikimr::NPQ::NSchema {
+
+namespace {
+
+constexpr TStringBuf SqsDlqPrefix = "sqs://";
+
+TString GetSchemeDlqTopicPath(const NKikimrPQ::TPQTabletConfig_TConsumer& consumer) {
+    if (consumer.GetType() != NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP) {
+        return {};
+    }
+    if (consumer.GetDeadLetterPolicy() != NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE
+        || !consumer.GetDeadLetterPolicyEnabled())
+    {
+        return {};
+    }
+
+    const auto& dlq = consumer.GetDeadLetterQueue();
+    if (dlq.empty() || dlq.StartsWith(SqsDlqPrefix)) {
+        return {};
+    }
+    return dlq;
+}
+
+TString NormalizeDlqTopicPath(const TString& dlq, const TString& database) {
+    return NormalizePath(CanonizePath(database), CanonizePath(dlq));
+}
+
+bool IsCdcDlqTarget(const NDescriber::TTopicInfo& info) {
+    if (info.CdcStream) {
+        return true;
+    }
+    return info.Self && info.Self->Info.GetPathSubType() == NKikimrSchemeOp::EPathSubTypeStreamImpl;
+}
+
+TString AccessDeniedMessage(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, const TString& path) {
+    const TString sid = userToken ? TString(userToken->GetUserSID()) : TString("anonymous");
+    return TStringBuilder()
+        << "Access denied for " << sid
+        << " on path " << path
+        << " with any of access rights AlterSchema or UpdateRow";
+}
+
+class TCheckDlqTopicsActor : public TActorBootstrapped<TCheckDlqTopicsActor> {
+public:
+    TCheckDlqTopicsActor(
+        const TActorId& parent,
+        const TString& databasePath,
+        absl::flat_hash_set<TString>&& dlqPaths,
+        const TCheckDlqTopicsSettings& settings
+    )
+        : Parent(parent)
+        , DatabasePath(databasePath)
+        , DlqPaths(std::move(dlqPaths))
+        , Settings(settings)
+    {
+    }
+
+    void Bootstrap() {
+        Become(&TCheckDlqTopicsActor::StateWork);
+
+        if (DlqPaths.empty()) {
+            return ReplyAndDie(Ydb::StatusIds::SUCCESS, {});
+        }
+
+        YDB_LOG_DEBUG("Check DLQ topics",
+            {"logPrefix", LOG_PREFIX},
+            {"database", DatabasePath},
+            {"paths", JoinRange(", ", DlqPaths.begin(), DlqPaths.end())});
+
+        Register(NDescriber::CreateDescriberActor(
+            SelfId(),
+            DatabasePath,
+            std::move(DlqPaths),
+            NDescriber::TDescribeSettings{
+                .UserToken = Settings.UserToken,
+                .AccessRights = NDescriber::TAccessRights(
+                    NACLib::EAccessRights::AlterSchema,
+                    NACLib::EAccessRights::UpdateRow
+                ),
+                .ForceSyncVersion = true,
+            }
+        ));
+    }
+
+    void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
+        for (const auto& [path, info] : ev->Get()->Topics) {
+            if (auto error = MapStatus(path, info); error) {
+                YDB_LOG_DEBUG("DLQ check failed",
+                    {"logPrefix", LOG_PREFIX},
+                    {"path", path},
+                    {"status", error->first},
+                    {"errorMessage", error->second});
+                return ReplyAndDie(error->first, std::move(error->second));
+            }
+        }
+        return ReplyAndDie(Ydb::StatusIds::SUCCESS, {});
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NDescriber::TEvDescribeTopicsResponse, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
+        }
+    }
+
+private:
+    using TStatusAndMessage = std::pair<Ydb::StatusIds::StatusCode, TString>;
+
+    std::optional<TStatusAndMessage> MapStatus(const TString& path, const NDescriber::TTopicInfo& info) const {
+        switch (info.Status) {
+            case NDescriber::EStatus::SUCCESS:
+                if (IsCdcDlqTarget(info)) {
+                    return TStatusAndMessage{
+                        Ydb::StatusIds::BAD_REQUEST,
+                        TStringBuilder() << "CDC stream cannot be used as a dead letter queue: " << path
+                    };
+                }
+                return std::nullopt;
+            case NDescriber::EStatus::NOT_TOPIC:
+                return TStatusAndMessage{
+                    Ydb::StatusIds::BAD_REQUEST,
+                    TStringBuilder() << "Dead letter queue path must be a topic, got " << path
+                };
+            case NDescriber::EStatus::NOT_FOUND:
+                return TStatusAndMessage{
+                    Ydb::StatusIds::SCHEME_ERROR,
+                    TStringBuilder() << "Path `" << path << "` does not exist"
+                };
+            case NDescriber::EStatus::UNAUTHORIZED:
+            case NDescriber::EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS:
+                return TStatusAndMessage{
+                    Ydb::StatusIds::UNAUTHORIZED,
+                    AccessDeniedMessage(Settings.UserToken, path)
+                };
+            case NDescriber::EStatus::BAD_REQUEST:
+                return TStatusAndMessage{
+                    Ydb::StatusIds::BAD_REQUEST,
+                    NDescriber::Description(path, info.Status)
+                };
+            case NDescriber::EStatus::UNKNOWN_ERROR:
+                return TStatusAndMessage{
+                    Ydb::StatusIds::INTERNAL_ERROR,
+                    NDescriber::Description(path, info.Status)
+                };
+        }
+        return std::nullopt;
+    }
+
+    void ReplyAndDie(Ydb::StatusIds::StatusCode status, TString&& errorMessage) {
+        Send(Parent, new TEvCheckDlqTopicsResponse(status, std::move(errorMessage)));
+        PassAway();
+    }
+
+private:
+    const TActorId Parent;
+    const TString DatabasePath;
+    absl::flat_hash_set<TString> DlqPaths;
+    const TCheckDlqTopicsSettings Settings;
+};
+
+} // namespace
+
+absl::flat_hash_set<TString> CollectDlqTopicPaths(
+    const NKikimrPQ::TPQTabletConfig& config,
+    const TString& database
+) {
+    absl::flat_hash_set<TString> result;
+    for (const auto& consumer : config.GetConsumers()) {
+        const auto dlq = GetSchemeDlqTopicPath(consumer);
+        if (!dlq.empty()) {
+            result.insert(NormalizeDlqTopicPath(dlq, database));
+        }
+    }
+    return result;
+}
+
+absl::flat_hash_set<TString> CollectNewDlqTopicPaths(
+    const NKikimrPQ::TPQTabletConfig& newConfig,
+    const NKikimrPQ::TPQTabletConfig& oldConfig,
+    const TString& database
+) {
+    auto result = CollectDlqTopicPaths(newConfig, database);
+    for (const auto& path : CollectDlqTopicPaths(oldConfig, database)) {
+        result.erase(path);
+    }
+    return result;
+}
+
+IActor* CreateCheckDlqTopicsActor(
+    const TActorId& parent,
+    const TString& databasePath,
+    absl::flat_hash_set<TString>&& dlqPaths,
+    const TCheckDlqTopicsSettings& settings
+) {
+    return new TCheckDlqTopicsActor(parent, databasePath, std::move(dlqPaths), settings);
+}
+
+} // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -220,12 +220,17 @@ absl::flat_hash_set<TString> CollectNewDlqTopicPaths(
     return result;
 }
 
-IActor* CreateCheckDlqTopicsActor(
+IActor* CreateCheckDlqTopicsActorIfNeeded(
     const TActorId& parent,
     const TString& databasePath,
-    absl::flat_hash_set<TString>&& dlqPaths,
+    const NKikimrPQ::TPQTabletConfig& newConfig,
+    const NKikimrPQ::TPQTabletConfig& oldConfig,
     const TCheckDlqTopicsSettings& settings
 ) {
+    auto dlqPaths = CollectNewDlqTopicPaths(newConfig, oldConfig, databasePath);
+    if (dlqPaths.empty()) {
+        return nullptr;
+    }
     return new TCheckDlqTopicsActor(parent, databasePath, std::move(dlqPaths), settings);
 }
 

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.cpp
@@ -10,9 +10,11 @@
 
 #include <library/cpp/containers/absl/flat_hash_set.h>
 
+#include <util/generic/vector.h>
 #include <util/string/builder.h>
 #include <util/string/join.h>
 
+#include <algorithm>
 #include <optional>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_SCHEMA
@@ -104,7 +106,15 @@ public:
     }
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-        for (const auto& [path, info] : ev->Get()->Topics) {
+        TVector<TString> paths;
+        paths.reserve(ev->Get()->Topics.size());
+        for (const auto& [path, _] : ev->Get()->Topics) {
+            paths.push_back(path);
+        }
+        std::sort(paths.begin(), paths.end());
+
+        for (const auto& path : paths) {
+            const auto& info = ev->Get()->Topics.at(path);
             if (auto error = MapStatus(path, info); error) {
                 YDB_LOG_DEBUG("DLQ check failed",
                     {"logPrefix", LOG_PREFIX},
@@ -164,7 +174,10 @@ private:
                     NDescriber::Description(path, info.Status)
                 };
         }
-        return std::nullopt;
+        return TStatusAndMessage{
+            Ydb::StatusIds::INTERNAL_ERROR,
+            TStringBuilder() << "Unexpected describer status for path " << path
+        };
     }
 
     void ReplyAndDie(Ydb::StatusIds::StatusCode status, TString&& errorMessage) {

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.h
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.h
@@ -54,10 +54,13 @@ absl::flat_hash_set<TString> CollectNewDlqTopicPaths(
     const TString& database
 );
 
-NActors::IActor* CreateCheckDlqTopicsActor(
+// Builds the new-vs-old DLQ path diff. Returns nullptr when there is nothing to check
+// (create: pass empty oldConfig).
+NActors::IActor* CreateCheckDlqTopicsActorIfNeeded(
     const NActors::TActorId& parent,
     const TString& databasePath,
-    absl::flat_hash_set<TString>&& dlqPaths,
+    const NKikimrPQ::TPQTabletConfig& newConfig,
+    const NKikimrPQ::TPQTabletConfig& oldConfig,
     const TCheckDlqTopicsSettings& settings = {}
 );
 

--- a/ydb/core/persqueue/public/schema/check_dlq_topics.h
+++ b/ydb/core/persqueue/public/schema/check_dlq_topics.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "schema.h"
+
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+
+namespace NACLib {
+
+class TUserToken;
+
+} // namespace NACLib
+
+namespace NKikimrPQ {
+
+class TPQTabletConfig;
+
+} // namespace NKikimrPQ
+
+namespace NKikimr::NPQ::NSchema {
+
+struct TEvCheckDlqTopicsResponse
+    : public NActors::TEventLocal<TEvCheckDlqTopicsResponse, EEv::EvCheckDlqTopicsResponse>
+{
+    TEvCheckDlqTopicsResponse(
+        Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,
+        TString&& errorMessage = {}
+    )
+        : Status(status)
+        , ErrorMessage(std::move(errorMessage))
+    {
+    }
+
+    Ydb::StatusIds::StatusCode Status;
+    TString ErrorMessage;
+};
+
+struct TCheckDlqTopicsSettings {
+    TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+};
+
+// MOVE + enabled, skip empty and sqs:// paths. Paths are normalized against database.
+absl::flat_hash_set<TString> CollectDlqTopicPaths(
+    const NKikimrPQ::TPQTabletConfig& config,
+    const TString& database
+);
+
+// DLQ paths present in newConfig but not in oldConfig.
+absl::flat_hash_set<TString> CollectNewDlqTopicPaths(
+    const NKikimrPQ::TPQTabletConfig& newConfig,
+    const NKikimrPQ::TPQTabletConfig& oldConfig,
+    const TString& database
+);
+
+NActors::IActor* CreateCheckDlqTopicsActor(
+    const NActors::TActorId& parent,
+    const TString& databasePath,
+    absl::flat_hash_set<TString>&& dlqPaths,
+    const TCheckDlqTopicsSettings& settings = {}
+);
+
+} // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/common.h
+++ b/ydb/core/persqueue/public/schema/common.h
@@ -133,6 +133,9 @@ TResult ProcessConsumerType(
         }
 
         if (deadLetterPolicy.has_move_action()) {
+            if (deadLetterPolicy.move_action().dead_letter_queue().empty()) {
+                return {Ydb::StatusIds::BAD_REQUEST, "Dead letter queue cannot be empty"};
+            }
             consumer->SetDeadLetterPolicy(::NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
             consumer->SetDeadLetterQueue(deadLetterPolicy.move_action().dead_letter_queue());
         } else if (deadLetterPolicy.has_delete_action()) {

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -1,6 +1,7 @@
 #include "create_topic_operation.h"
 #include "schema_operation.h"
 #include "schema_propose.h"
+#include "check_dlq_topics.h"
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/grpc_services/rpc_calls.h>
@@ -9,6 +10,8 @@
 #include <ydb/core/persqueue/public/nameresolver/nameresolver.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
+
+#include <util/string/join.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
@@ -121,17 +124,9 @@ private:
         }
 
         ModifyScheme = modifyScheme;
-
-        if (Settings.PrepareOnly) {
-            return ReplyAndDie(Ydb::StatusIds::SUCCESS, "");
-        } else {
-            RegisterWithSameMailbox(CreateSchemaOperation(
-                SelfId(),
-                path,
-                std::move(proposal),
-                Settings.Cookie
-            ));
-        }
+        TopicPath = path;
+        Proposal = std::move(proposal);
+        return DoCheckDlqOrPropose();
     }
 
     void Handle(TEvSchemaOperationResponse::TPtr& ev) {
@@ -146,6 +141,61 @@ private:
             hFunc(TEvSchemaOperationResponse, Handle);
             sFunc(TEvents::TEvPoison, PassAway);
         }
+    }
+
+private:
+    void DoCheckDlqOrPropose() {
+        auto dlqPaths = CollectDlqTopicPaths(
+            ModifyScheme.GetCreatePersQueueGroup().GetPQTabletConfig(),
+            CanonizePath(Settings.Database)
+        );
+        if (dlqPaths.empty()) {
+            return DoProposeOrReply();
+        }
+
+        YDB_LOG_DEBUG("DoCheckDlq",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"dlqPaths", JoinRange(", ", dlqPaths.begin(), dlqPaths.end())});
+        Become(&TCreateTopicOperationActor::CheckDlqState);
+        RegisterWithSameMailbox(CreateCheckDlqTopicsActor(
+            SelfId(),
+            CanonizePath(Settings.Database),
+            std::move(dlqPaths),
+            TCheckDlqTopicsSettings{
+                .UserToken = Settings.UserToken
+            }
+        ));
+    }
+
+    void Handle(TEvCheckDlqTopicsResponse::TPtr& ev) {
+        YDB_LOG_DEBUG("Handle TEvCheckDlqTopicsResponse",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"status", ev->Get()->Status},
+            {"errorMessage", ev->Get()->ErrorMessage});
+        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+            return ReplyAndDie(ev->Get()->Status, std::move(ev->Get()->ErrorMessage));
+        }
+        return DoProposeOrReply();
+    }
+
+    STFUNC(CheckDlqState) {
+        switch(ev->GetTypeRewrite()) {
+            hFunc(TEvCheckDlqTopicsResponse, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
+        }
+    }
+
+    void DoProposeOrReply() {
+        if (Settings.PrepareOnly) {
+            return ReplyAndDie(Ydb::StatusIds::SUCCESS, "");
+        }
+        RegisterWithSameMailbox(CreateSchemaOperation(
+            SelfId(),
+            TopicPath,
+            std::move(Proposal),
+            Settings.Cookie
+        ));
+        Become(&TCreateTopicOperationActor::CreateState);
     }
 
 private:
@@ -169,6 +219,8 @@ private:
     const TActorId ParentId;
     const TCreateTopicOperationSettings Settings;
 
+    TString TopicPath;
+    std::unique_ptr<TEvTxUserProxy::TEvProposeTransaction> Proposal;
     NKikimrSchemeOp::TModifyScheme ModifyScheme;
     NPQ::NClusterTracker::TClustersList::TConstPtr ClustersList;
 };

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -8,10 +8,9 @@
 #include <ydb/core/persqueue/common/actor.h>
 #include <ydb/core/persqueue/public/cluster_tracker/cluster_tracker.h>
 #include <ydb/core/persqueue/public/nameresolver/nameresolver.h>
+#include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
-
-#include <util/string/join.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
@@ -145,26 +144,21 @@ private:
 
 private:
     void DoCheckDlqOrPropose() {
-        auto dlqPaths = CollectDlqTopicPaths(
-            ModifyScheme.GetCreatePersQueueGroup().GetPQTabletConfig(),
-            CanonizePath(Settings.Database)
-        );
-        if (dlqPaths.empty()) {
-            return DoProposeOrReply();
+        const NKikimrPQ::TPQTabletConfig emptyOldConfig;
+        if (auto* actor = CreateCheckDlqTopicsActorIfNeeded(
+                SelfId(),
+                CanonizePath(Settings.Database),
+                ModifyScheme.GetCreatePersQueueGroup().GetPQTabletConfig(),
+                emptyOldConfig,
+                TCheckDlqTopicsSettings{
+                    .UserToken = Settings.UserToken
+                }))
+        {
+            Become(&TCreateTopicOperationActor::CheckDlqState);
+            RegisterWithSameMailbox(actor);
+            return;
         }
-
-        YDB_LOG_DEBUG("DoCheckDlq",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"dlqPaths", JoinRange(", ", dlqPaths.begin(), dlqPaths.end())});
-        Become(&TCreateTopicOperationActor::CheckDlqState);
-        RegisterWithSameMailbox(CreateCheckDlqTopicsActor(
-            SelfId(),
-            CanonizePath(Settings.Database),
-            std::move(dlqPaths),
-            TCheckDlqTopicsSettings{
-                .UserToken = Settings.UserToken
-            }
-        ));
+        return DoProposeOrReply();
     }
 
     void Handle(TEvCheckDlqTopicsResponse::TPtr& ev) {

--- a/ydb/core/persqueue/public/schema/create_topic_ut.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_ut.cpp
@@ -59,6 +59,9 @@ Y_UNIT_TEST(CreateSharedConsumer) {
     auto setup = CreateSetup("CoreCreateShared");
     auto& runtime = setup->GetRuntime();
     const TString path = "/Root/topic_shared";
+    const TString dlqPath = "/Root/dlq";
+
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(dlqPath)), Ydb::StatusIds::SUCCESS);
 
     auto request = MakeCreateTopicRequest(path);
     request.clear_consumers();

--- a/ydb/core/persqueue/public/schema/create_topic_ut.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_ut.cpp
@@ -88,6 +88,22 @@ Y_UNIT_TEST(CreateSharedConsumer) {
     UNIT_ASSERT_VALUES_EQUAL(c->GetDeadLetterQueue(), "dlq");
 }
 
+Y_UNIT_TEST(CreateSharedConsumerEmptyDlqRejected) {
+    auto setup = CreateSetup("CoreCreateSharedEmptyDlq");
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_shared_empty_dlq";
+
+    auto request = MakeCreateTopicRequest(path);
+    request.clear_consumers();
+    auto* consumer = request.add_consumers();
+    consumer->set_name("shared_c1");
+    auto* type = consumer->mutable_shared_consumer_type();
+    type->mutable_dead_letter_policy()->set_enabled(true);
+    type->mutable_dead_letter_policy()->mutable_move_action();
+
+    AssertStatus(DoCreate(runtime, request), Ydb::StatusIds::BAD_REQUEST, "Dead letter queue cannot be empty");
+}
+
 Y_UNIT_TEST(SharedConsumersDisabledRejected) {
     auto setup = CreateSetup("CoreSharedDisabled");
     auto& runtime = setup->GetRuntime();

--- a/ydb/core/persqueue/public/schema/schema.h
+++ b/ydb/core/persqueue/public/schema/schema.h
@@ -20,6 +20,7 @@ enum EEv : ui32 {
     EvSchemaOperationResponse,
     EvSchemaResponse,
     EvDescribeOperationResponse,
+    EvCheckDlqTopicsResponse,
     EvEnd
 };
 

--- a/ydb/core/persqueue/public/schema/ut/check_dlq_topics_ut.cpp
+++ b/ydb/core/persqueue/public/schema/ut/check_dlq_topics_ut.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/persqueue/public/describer/describer.h>
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/actor.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 
@@ -44,17 +45,23 @@ TIntrusiveConstPtr<NACLib::TUserToken> MakeUserToken(const TString& userSid) {
 
 THolder<TEvCheckDlqTopicsResponse> CheckDlq(
     NActors::TTestActorRuntime& runtime,
-    absl::flat_hash_set<TString> paths,
+    const NKikimrPQ::TPQTabletConfig& newConfig,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr,
-    const TString& databasePath = "/Root")
+    const TString& databasePath = "/Root",
+    const NKikimrPQ::TPQTabletConfig& oldConfig = {})
 {
     auto edge = runtime.AllocateEdgeActor();
-    auto actorId = runtime.Register(CreateCheckDlqTopicsActor(
+    auto* actor = CreateCheckDlqTopicsActorIfNeeded(
         edge,
         databasePath,
-        std::move(paths),
+        newConfig,
+        oldConfig,
         TCheckDlqTopicsSettings{.UserToken = std::move(userToken)}
-    ));
+    );
+    if (!actor) {
+        return MakeHolder<TEvCheckDlqTopicsResponse>(Ydb::StatusIds::SUCCESS);
+    }
+    auto actorId = runtime.Register(actor);
     runtime.EnableScheduleForActor(actorId);
     return runtime.GrabEdgeEvent<TEvCheckDlqTopicsResponse>(TDuration::Seconds(10));
 }
@@ -176,11 +183,24 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsHelpers) {
         UNIT_ASSERT(paths.contains("/Root/dlq"));
     }
 
+    Y_UNIT_TEST(FactoryReturnsNullWhenNoNewDlq) {
+        const NActors::TActorId parent;
+        const NKikimrPQ::TPQTabletConfig empty;
+        const auto config = MakeConfigWithDlq("c1", "dlq1");
+
+        UNIT_ASSERT(!CreateCheckDlqTopicsActorIfNeeded(parent, "/Root", empty, empty, {}));
+        UNIT_ASSERT(!CreateCheckDlqTopicsActorIfNeeded(parent, "/Root", config, config, {}));
+
+        NActors::IActor* actor = CreateCheckDlqTopicsActorIfNeeded(parent, "/Root", config, empty, {});
+        UNIT_ASSERT(actor);
+        delete actor;
+    }
+
 }
 
 Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
 
-    Y_UNIT_TEST(EmptyPathSetSucceedsImmediately) {
+    Y_UNIT_TEST(EmptyConfigSucceedsWithoutActor) {
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableLogs(*setup);
 
@@ -192,7 +212,10 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         EnableLogs(*setup);
         ExecuteDDL(*setup, "CREATE TOPIC topic1");
 
-        AssertStatus(CheckDlq(setup->GetRuntime(), {"/Root/topic1"}), Ydb::StatusIds::SUCCESS);
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/topic1")),
+            Ydb::StatusIds::SUCCESS
+        );
     }
 
     Y_UNIT_TEST(MissingTopicIsSchemeError) {
@@ -200,7 +223,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         EnableLogs(*setup);
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/missing"}),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/missing")),
             Ydb::StatusIds::SCHEME_ERROR,
             "does not exist"
         );
@@ -212,7 +235,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/table1"}),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/table1")),
             Ydb::StatusIds::BAD_REQUEST,
             "must be a topic"
         );
@@ -225,7 +248,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/table1/feed"}),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/table1/feed")),
             Ydb::StatusIds::BAD_REQUEST,
             "CDC stream cannot be used as a dead letter queue"
         );
@@ -238,7 +261,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/table1/feed/streamImpl"}),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/table1/feed/streamImpl")),
             Ydb::StatusIds::BAD_REQUEST,
             "CDC stream cannot be used as a dead letter queue"
         );
@@ -256,7 +279,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ModifyTopicAcl(*setup, "topic1", acl);
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/topic1"), MakeUserToken(userSid)),
             Ydb::StatusIds::SUCCESS
         );
     }
@@ -273,7 +296,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ModifyTopicAcl(*setup, "topic1", acl);
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/topic1"), MakeUserToken(userSid)),
             Ydb::StatusIds::SUCCESS
         );
     }
@@ -289,7 +312,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ModifyTopicAcl(*setup, "topic1", acl);
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/topic1"), MakeUserToken(userSid)),
             Ydb::StatusIds::UNAUTHORIZED,
             "AlterSchema or UpdateRow"
         );
@@ -307,7 +330,7 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ModifyTopicAcl(*setup, "topic1", acl);
 
         AssertStatus(
-            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            CheckDlq(setup->GetRuntime(), MakeConfigWithDlq("c1", "/Root/topic1"), MakeUserToken(userSid)),
             Ydb::StatusIds::UNAUTHORIZED,
             "AlterSchema or UpdateRow"
         );
@@ -319,7 +342,15 @@ Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
         ExecuteDDL(*setup, "CREATE TOPIC topic1");
         ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
 
-        auto result = CheckDlq(setup->GetRuntime(), {"/Root/topic1", "/Root/table1"});
+        auto config = MakeConfigWithDlq("c1", "/Root/topic1");
+        auto* c2 = config.AddConsumers();
+        c2->SetName("c2");
+        c2->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c2->SetDeadLetterPolicyEnabled(true);
+        c2->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c2->SetDeadLetterQueue("/Root/table1");
+
+        auto result = CheckDlq(setup->GetRuntime(), config);
         UNIT_ASSERT(result);
         UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
         UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "must be a topic");

--- a/ydb/core/persqueue/public/schema/ut/check_dlq_topics_ut.cpp
+++ b/ydb/core/persqueue/public/schema/ut/check_dlq_topics_ut.cpp
@@ -1,0 +1,330 @@
+#include "check_dlq_topics.h"
+
+#include <ydb/core/persqueue/public/describer/describer.h>
+#include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
+#include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NPQ::NSchema {
+
+using namespace NYdb::NTopic::NTests;
+using namespace NYdb;
+using namespace NYdb::NQuery;
+
+namespace {
+
+void EnableLogs(TTopicSdkTestSetup& setup) {
+    setup.GetServer().EnableLogs(
+        {NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER, NKikimrServices::PQ_SCHEMA},
+        NActors::NLog::PRI_DEBUG
+    );
+}
+
+void ExecuteDDL(TTopicSdkTestSetup& setup, const TString& query) {
+    TDriver driver(setup.MakeDriverConfig());
+    TQueryClient client(driver);
+    auto session = client.GetSession().GetValueSync().GetSession();
+    auto res = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+    UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+    driver.Stop(true);
+}
+
+void ModifyTopicAcl(TTopicSdkTestSetup& setup, const TString& topicName, const NACLib::TDiffACL& acl) {
+    setup.GetServer().AnnoyingClient->ModifyACL("/Root", topicName, acl.SerializeAsString());
+}
+
+TIntrusiveConstPtr<NACLib::TUserToken> MakeUserToken(const TString& userSid) {
+    auto token = MakeIntrusive<NACLib::TUserToken>(userSid, TVector<NACLib::TSID>{});
+    token->SaveSerializationInfo();
+    return token;
+}
+
+THolder<TEvCheckDlqTopicsResponse> CheckDlq(
+    NActors::TTestActorRuntime& runtime,
+    absl::flat_hash_set<TString> paths,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr,
+    const TString& databasePath = "/Root")
+{
+    auto edge = runtime.AllocateEdgeActor();
+    auto actorId = runtime.Register(CreateCheckDlqTopicsActor(
+        edge,
+        databasePath,
+        std::move(paths),
+        TCheckDlqTopicsSettings{.UserToken = std::move(userToken)}
+    ));
+    runtime.EnableScheduleForActor(actorId);
+    return runtime.GrabEdgeEvent<TEvCheckDlqTopicsResponse>(TDuration::Seconds(10));
+}
+
+void AssertStatus(
+    const THolder<TEvCheckDlqTopicsResponse>& result,
+    Ydb::StatusIds::StatusCode expected,
+    const TString& substring = {})
+{
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, expected, result->ErrorMessage);
+    if (!substring.empty()) {
+        UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, substring);
+    }
+}
+
+NKikimrPQ::TPQTabletConfig MakeConfigWithDlq(
+    const TString& consumerName,
+    const TString& dlq,
+    bool enabled = true,
+    NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy policy = NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE)
+{
+    NKikimrPQ::TPQTabletConfig config;
+    auto* consumer = config.AddConsumers();
+    consumer->SetName(consumerName);
+    consumer->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+    consumer->SetDeadLetterPolicyEnabled(enabled);
+    consumer->SetDeadLetterPolicy(policy);
+    consumer->SetDeadLetterQueue(dlq);
+    return config;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TCheckDlqTopicsHelpers) {
+
+    Y_UNIT_TEST(CollectSkipsDisabledSqsEmptyAndStreaming) {
+        NKikimrPQ::TPQTabletConfig config;
+
+        {
+            auto* c = config.AddConsumers();
+            c->SetName("streaming");
+            c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING);
+            c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+            c->SetDeadLetterPolicyEnabled(true);
+            c->SetDeadLetterQueue("dlq-streaming");
+        }
+        {
+            auto* c = config.AddConsumers();
+            c->SetName("disabled");
+            c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+            c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+            c->SetDeadLetterPolicyEnabled(false);
+            c->SetDeadLetterQueue("dlq-disabled");
+        }
+        {
+            auto* c = config.AddConsumers();
+            c->SetName("sqs");
+            c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+            c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+            c->SetDeadLetterPolicyEnabled(true);
+            c->SetDeadLetterQueue("sqs://account/queue");
+        }
+        {
+            auto* c = config.AddConsumers();
+            c->SetName("empty");
+            c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+            c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+            c->SetDeadLetterPolicyEnabled(true);
+            c->SetDeadLetterQueue("");
+        }
+        {
+            auto* c = config.AddConsumers();
+            c->SetName("delete");
+            c->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+            c->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_DELETE);
+            c->SetDeadLetterPolicyEnabled(true);
+            c->SetDeadLetterQueue("dlq-delete");
+        }
+
+        UNIT_ASSERT(CollectDlqTopicPaths(config, "/Root").empty());
+    }
+
+    Y_UNIT_TEST(CollectNormalizesRelativeAndAbsolutePaths) {
+        auto config = MakeConfigWithDlq("c1", "dlq");
+        auto* c2 = config.AddConsumers();
+        c2->SetName("c2");
+        c2->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c2->SetDeadLetterPolicyEnabled(true);
+        c2->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c2->SetDeadLetterQueue("/Root/dlq");
+
+        const auto paths = CollectDlqTopicPaths(config, "/Root");
+        UNIT_ASSERT_VALUES_EQUAL(paths.size(), 1u);
+        UNIT_ASSERT(paths.contains("/Root/dlq"));
+    }
+
+    Y_UNIT_TEST(CollectNewPathsIgnoresUnchangedDlq) {
+        const auto oldConfig = MakeConfigWithDlq("c1", "dlq1");
+        auto newConfig = MakeConfigWithDlq("c1", "dlq1");
+        auto* c2 = newConfig.AddConsumers();
+        c2->SetName("c2");
+        c2->SetType(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP);
+        c2->SetDeadLetterPolicyEnabled(true);
+        c2->SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+        c2->SetDeadLetterQueue("dlq2");
+
+        const auto paths = CollectNewDlqTopicPaths(newConfig, oldConfig, "/Root");
+        UNIT_ASSERT_VALUES_EQUAL(paths.size(), 1u);
+        UNIT_ASSERT(paths.contains("/Root/dlq2"));
+    }
+
+    Y_UNIT_TEST(CollectNewPathsOnEnableExistingQueue) {
+        const auto oldConfig = MakeConfigWithDlq("c1", "dlq", false);
+        const auto newConfig = MakeConfigWithDlq("c1", "dlq", true);
+
+        const auto paths = CollectNewDlqTopicPaths(newConfig, oldConfig, "/Root");
+        UNIT_ASSERT_VALUES_EQUAL(paths.size(), 1u);
+        UNIT_ASSERT(paths.contains("/Root/dlq"));
+    }
+
+}
+
+Y_UNIT_TEST_SUITE(TCheckDlqTopicsActor) {
+
+    Y_UNIT_TEST(EmptyPathSetSucceedsImmediately) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+
+        AssertStatus(CheckDlq(setup->GetRuntime(), {}), Ydb::StatusIds::SUCCESS);
+    }
+
+    Y_UNIT_TEST(ExistingTopicSucceedsWithoutToken) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+
+        AssertStatus(CheckDlq(setup->GetRuntime(), {"/Root/topic1"}), Ydb::StatusIds::SUCCESS);
+    }
+
+    Y_UNIT_TEST(MissingTopicIsSchemeError) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/missing"}),
+            Ydb::StatusIds::SCHEME_ERROR,
+            "does not exist"
+        );
+    }
+
+    Y_UNIT_TEST(TableIsBadRequest) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/table1"}),
+            Ydb::StatusIds::BAD_REQUEST,
+            "must be a topic"
+        );
+    }
+
+    Y_UNIT_TEST(CdcStreamIsBadRequest) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+        ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/table1/feed"}),
+            Ydb::StatusIds::BAD_REQUEST,
+            "CDC stream cannot be used as a dead letter queue"
+        );
+    }
+
+    Y_UNIT_TEST(CdcStreamImplIsBadRequest) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+        ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/table1/feed/streamImpl"}),
+            Ydb::StatusIds::BAD_REQUEST,
+            "CDC stream cannot be used as a dead letter queue"
+        );
+    }
+
+    Y_UNIT_TEST(SucceedsWithOnlyAlterSchema) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+
+        const TString userSid = "user1@builtin";
+        NACLib::TDiffACL acl;
+        acl.SetInterruptInheritance(true);
+        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EAccessRights::AlterSchema, userSid);
+        ModifyTopicAcl(*setup, "topic1", acl);
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            Ydb::StatusIds::SUCCESS
+        );
+    }
+
+    Y_UNIT_TEST(SucceedsWithOnlyUpdateRow) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+
+        const TString userSid = "user1@builtin";
+        NACLib::TDiffACL acl;
+        acl.SetInterruptInheritance(true);
+        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EAccessRights::UpdateRow, userSid);
+        ModifyTopicAcl(*setup, "topic1", acl);
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            Ydb::StatusIds::SUCCESS
+        );
+    }
+
+    Y_UNIT_TEST(FailsWithoutAccess) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+
+        const TString userSid = "user1@builtin";
+        NACLib::TDiffACL acl;
+        acl.SetInterruptInheritance(true);
+        ModifyTopicAcl(*setup, "topic1", acl);
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            Ydb::StatusIds::UNAUTHORIZED,
+            "AlterSchema or UpdateRow"
+        );
+    }
+
+    Y_UNIT_TEST(FailsWithOnlySelectRow) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+
+        const TString userSid = "user1@builtin";
+        NACLib::TDiffACL acl;
+        acl.SetInterruptInheritance(true);
+        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EAccessRights::SelectRow, userSid);
+        ModifyTopicAcl(*setup, "topic1", acl);
+
+        AssertStatus(
+            CheckDlq(setup->GetRuntime(), {"/Root/topic1"}, MakeUserToken(userSid)),
+            Ydb::StatusIds::UNAUTHORIZED,
+            "AlterSchema or UpdateRow"
+        );
+    }
+
+    Y_UNIT_TEST(MixedPathsFailsOnFirstBadTarget) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableLogs(*setup);
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+
+        auto result = CheckDlq(setup->GetRuntime(), {"/Root/topic1", "/Root/table1"});
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+        UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "must be a topic");
+    }
+
+}
+
+} // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/ut/dlq_acl_ut.cpp
+++ b/ydb/core/persqueue/public/schema/ut/dlq_acl_ut.cpp
@@ -577,6 +577,9 @@ Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWhenDlqIsACdcStream) {
     auto& client = *setup->GetServer().AnnoyingClient;
 
     const TString userSid = CreateUser(client, USER_NAME);
+    // CDC streamImpl is a topic; describer checks AlterSchema|UpdateRow before
+    // exposing the type. Grant UpdateRow so the check can return BAD_REQUEST.
+    client.TestGrant("/", "Root", userSid, NACLib::EAccessRights::UpdateRow);
 
     NTests::ExecuteDDL(*setup, TStringBuilder()
         << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
@@ -602,6 +605,7 @@ Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWhenDlqIsACdcStreamImpl) {
     auto& client = *setup->GetServer().AnnoyingClient;
 
     const TString userSid = CreateUser(client, USER_NAME);
+    client.TestGrant("/", "Root", userSid, NACLib::EAccessRights::UpdateRow);
 
     NTests::ExecuteDDL(*setup, TStringBuilder()
         << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
@@ -647,6 +651,7 @@ Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqIsACdcStream) {
     auto& client = *setup->GetServer().AnnoyingClient;
 
     const TString userSid = CreateUser(client, USER_NAME);
+    client.TestGrant("/", "Root", userSid, NACLib::EAccessRights::UpdateRow);
 
     NTests::ExecuteDDL(*setup, TStringBuilder()
         << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
@@ -672,6 +677,7 @@ Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqIsACdcStreamImpl) {
     auto& client = *setup->GetServer().AnnoyingClient;
 
     const TString userSid = CreateUser(client, USER_NAME);
+    client.TestGrant("/", "Root", userSid, NACLib::EAccessRights::UpdateRow);
 
     NTests::ExecuteDDL(*setup, TStringBuilder()
         << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
@@ -688,7 +694,7 @@ Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqIsACdcStreamImpl) {
 }
 
 Y_UNIT_TEST(CreateTopicWithSqsStyleDlqSkipsSchemeCheck) {
-    constexpr const char* USER_NAME = "topicuser-sqs";
+    constexpr const char* USER_NAME = "topicuser15";
     constexpr const char* MAIN_TOPIC = "main-topic-sqs-dlq-test";
 
     auto setup = CreateSetup();

--- a/ydb/core/persqueue/public/schema/ut/dlq_acl_ut.cpp
+++ b/ydb/core/persqueue/public/schema/ut/dlq_acl_ut.cpp
@@ -1,0 +1,705 @@
+#include <ydb/core/persqueue/public/schema/schema.h>
+#include <ydb/core/persqueue/public/schema/schema_ut_helpers.h>
+
+#include <ydb/core/testlib/test_client.h>
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
+
+namespace NKikimr::NPQ::NSchema {
+
+using namespace NYdb::NTopic::NTests;
+using namespace NKikimr::NPersQueueTests;
+using namespace NKikimr::Tests;
+
+namespace {
+
+constexpr const char* USER_PASSWORD = "password";
+constexpr const char* MLP_CONSUMER_NAME = "mlp-consumer";
+
+Ydb::Topic::Consumer MakeConsumerWithDlq(
+    const TString& consumerName,
+    const TString& dlqTopic
+) {
+    Ydb::Topic::Consumer consumer;
+    consumer.set_name(consumerName);
+    auto* shared = consumer.mutable_shared_consumer_type();
+    auto* deadLetterPolicy = shared->mutable_dead_letter_policy();
+    deadLetterPolicy->set_enabled(true);
+    deadLetterPolicy->mutable_condition()->set_max_processing_attempts(5);
+    if (!dlqTopic.empty()) {
+        deadLetterPolicy->mutable_move_action()->set_dead_letter_queue(dlqTopic);
+    }
+    return consumer;
+}
+
+std::shared_ptr<TTopicSdkTestSetup> CreateSetup() {
+    auto setup = std::make_shared<TTopicSdkTestSetup>(
+        "DlqAcl",
+        TTopicSdkTestSetup::MakeServerSettings(),
+        false
+    );
+    setup->GetServer().EnableLogs({
+            NKikimrServices::PQ_SCHEMA,
+            NKikimrServices::PQ_DESCRIBER,
+            NKikimrServices::TX_PROXY_SCHEME_CACHE,
+        },
+        NActors::NLog::PRI_DEBUG
+    );
+    return setup;
+}
+
+Ydb::Topic::CreateTopicRequest MakeCreateTopicRequest(
+    const TString& path,
+    const TString& consumerName = {},
+    const TString& dlqTopic = {}
+) {
+    Ydb::Topic::CreateTopicRequest request;
+    request.set_path(path);
+    request.mutable_retention_period()->set_seconds(TDuration::Hours(24).Seconds());
+
+    auto* partitioning = request.mutable_partitioning_settings();
+    partitioning->set_min_active_partitions(1);
+
+    if (!consumerName.empty()) {
+        *request.add_consumers() = MakeConsumerWithDlq(consumerName, dlqTopic);
+    }
+
+    return request;
+}
+
+THolder<TEvSchemaResponse> DoAlterTopicRequest(
+    NActors::TTestActorRuntime& runtime,
+    const Ydb::Topic::AlterTopicRequest& request,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr
+) {
+    auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(CreateAlterTopicActor(edge, {
+        .Database = "/Root",
+        .Request = request,
+        .UserToken = std::move(userToken),
+        .IfExists = false,
+        .PrepareOnly = false,
+        .Cookie = 0,
+    }));
+
+    return runtime.GrabEdgeEvent<TEvSchemaResponse>(TDuration::Seconds(10));
+}
+
+THolder<TEvSchemaResponse> DoCreateTopicRequest(
+    NActors::TTestActorRuntime& runtime,
+    const Ydb::Topic::CreateTopicRequest& request,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr
+) {
+    auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(CreateCreateTopicActor(edge, {
+        .Database = "/Root",
+        .Request = request,
+        .UserToken = std::move(userToken),
+        .IfNotExists = false,
+        .PrepareOnly = false,
+        .Cookie = 0,
+    }));
+
+    return runtime.GrabEdgeEvent<TEvSchemaResponse>(TDuration::Seconds(10));
+}
+
+TIntrusiveConstPtr<NACLib::TUserToken> MakeUserToken(const TString& userSid) {
+    auto token = MakeIntrusive<NACLib::TUserToken>(userSid, TVector<NACLib::TSID>{});
+    token->SaveSerializationInfo();
+    return token;
+}
+
+TString CreateUser(TFlatMsgBusPQClient& client, const char* userName) {
+    const TString userSid = TString(userName) + "@" BUILTIN_ACL_DOMAIN;
+    client.TestCreateUser("/Root", userName, USER_PASSWORD, "root@builtin");
+    client.TestGrantConnect(userSid);
+    client.TestGrant("/", "Root", userSid, NACLib::EAccessRights::CreateQueue);
+    client.TestGrant("/", "Root", userSid, NACLib::EAccessRights::DescribeSchema);
+    return userSid;
+}
+
+void CreateDLQTopic(const std::shared_ptr<TTopicSdkTestSetup>& setup, const char* dlqTopic) {
+    auto& runtime = setup->GetRuntime();
+    const TString dlqTopicPath = TStringBuilder() << "/Root/" << dlqTopic;
+    auto request = MakeCreateTopicRequest(dlqTopicPath);
+    auto result = DoCreateTopicRequest(runtime, request);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(dlqTopicPath);
+}
+
+THolder<TEvSchemaResponse> CreateTopicWithDLQ(
+    const std::shared_ptr<TTopicSdkTestSetup>& setup,
+    const TString& userSid,
+    const TString& mainTopic,
+    const TString& dlqTopic
+) {
+    auto& runtime = setup->GetRuntime();
+    const auto userToken = MakeUserToken(userSid);
+    const TString mainTopicPath = TStringBuilder() << "/Root/" << mainTopic;
+    auto request = MakeCreateTopicRequest(mainTopicPath, MLP_CONSUMER_NAME, dlqTopic);
+    return DoCreateTopicRequest(runtime, request, userToken);
+}
+
+THolder<TEvSchemaResponse> CreateAndAlterTopicWithDLQ(
+    const std::shared_ptr<TTopicSdkTestSetup>& setup,
+    const TString& userSid,
+    const TString& mainTopic,
+    const TString& dlqTopic
+) {
+    auto& runtime = setup->GetRuntime();
+    const auto userToken = MakeUserToken(userSid);
+    const TString mainTopicPath = TStringBuilder() << "/Root/" << mainTopic;
+
+    {
+        auto request = MakeCreateTopicRequest(mainTopicPath);
+        auto result = DoCreateTopicRequest(runtime, request, userToken);
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+        setup->GetServer().WaitInit(mainTopicPath);
+    }
+
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path(mainTopicPath);
+    *request.add_add_consumers() = MakeConsumerWithDlq(MLP_CONSUMER_NAME, dlqTopic);
+    return DoAlterTopicRequest(runtime, request, userToken);
+}
+
+THolder<TEvSchemaResponse> AlterTopicMlpConsumerDlq(
+    const std::shared_ptr<TTopicSdkTestSetup>& setup,
+    const TString& userSid,
+    const char* mainTopic,
+    const char* newDlqTopic
+) {
+    auto& runtime = setup->GetRuntime();
+    const auto userToken = MakeUserToken(userSid);
+    const TString mainTopicPath = TStringBuilder() << "/Root/" << mainTopic;
+
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path(mainTopicPath);
+    auto* alterConsumer = request.add_alter_consumers();
+    alterConsumer->set_name(MLP_CONSUMER_NAME);
+    alterConsumer->mutable_alter_shared_consumer_type()
+        ->mutable_alter_dead_letter_policy()
+        ->mutable_alter_move_action()
+        ->set_set_dead_letter_queue(newDlqTopic);
+
+    return DoAlterTopicRequest(runtime, request, userToken);
+}
+
+THolder<TEvSchemaResponse> AlterTopicRetention(
+    const std::shared_ptr<TTopicSdkTestSetup>& setup,
+    const TString& userSid,
+    const char* mainTopic
+) {
+    auto& runtime = setup->GetRuntime();
+    const auto userToken = MakeUserToken(userSid);
+    const TString mainTopicPath = TStringBuilder() << "/Root/" << mainTopic;
+
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path(mainTopicPath);
+    request.mutable_set_retention_period()->set_seconds(TDuration::Hours(48).Seconds());
+    return DoAlterTopicRequest(runtime, request, userToken);
+}
+
+void RevokeAllRightsOnTopic(TFlatMsgBusPQClient& client, const TString& topicName, const TString& userSid) {
+    NACLib::TDiffACL diffAcl;
+    diffAcl.SetInterruptInheritance(true);
+    diffAcl.AddAccess(
+        NACLib::EAccessType::Deny,
+        NACLib::EAccessRights::AlterSchema | NACLib::EAccessRights::UpdateRow,
+        userSid
+    );
+    client.TestModifyACL("/Root", topicName, diffAcl.SerializeAsString());
+}
+
+void GrantOnlyOnTopic(
+    TFlatMsgBusPQClient& client,
+    const TString& topicName,
+    const TString& userSid,
+    std::initializer_list<NACLib::EAccessRights> permissions
+) {
+    NACLib::TDiffACL diffAcl;
+    diffAcl.SetInterruptInheritance(true);
+    for (const auto permission : permissions) {
+        diffAcl.AddAccess(NACLib::EAccessType::Allow, permission, userSid);
+    }
+    client.TestModifyACL("/Root", topicName, diffAcl.SerializeAsString());
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(DlqAcl) {
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWithoutDlqTopicAccess) {
+    constexpr const char* USER_NAME = "topicuser";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-acl-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-acl-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    RevokeAllRightsOnTopic(client, DLQ_TOPIC, userSid);
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::UNAUTHORIZED, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerSucceedsWithOnlyAlterSchemaOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser2";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-alterschema-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-alterschema-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {NACLib::EAccessRights::AlterSchema});
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerSucceedsWithOnlyUpdateRowOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser3";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-updaterow-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-updaterow-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {NACLib::EAccessRights::UpdateRow});
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerSucceedsWithAlterSchemaAndUpdateRowOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser4";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-both-rights-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-both-rights-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {
+        NACLib::EAccessRights::AlterSchema,
+        NACLib::EAccessRights::UpdateRow,
+    });
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWhenDlqTopicDoesNotExist) {
+    constexpr const char* USER_NAME = "topicuser6";
+    constexpr const char* DLQ_TOPIC = "nonexistent-dlq-topic";
+    constexpr const char* MAIN_TOPIC = "main-topic-missing-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SCHEME_ERROR, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWithOnlySelectRowOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser5";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-read-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-read-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {NACLib::EAccessRights::SelectRow});
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::UNAUTHORIZED, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWithoutDlqTopicAccess) {
+    constexpr const char* USER_NAME = "topicuser";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-acl-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-acl-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    RevokeAllRightsOnTopic(client, DLQ_TOPIC, userSid);
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::UNAUTHORIZED, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerSucceedsWithOnlyAlterSchemaOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser2";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-alterschema-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-alterschema-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {NACLib::EAccessRights::AlterSchema});
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerSucceedsWithOnlyUpdateRowOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser3";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-updaterow-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-updaterow-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {NACLib::EAccessRights::UpdateRow});
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerSucceedsWithAlterSchemaAndUpdateRowOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser4";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-both-rights-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-both-rights-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {
+        NACLib::EAccessRights::AlterSchema,
+        NACLib::EAccessRights::UpdateRow,
+    });
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+    setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+}
+
+Y_UNIT_TEST(AlterTopicUnrelatedChangeSucceedsAfterDlqAccessRevoked) {
+    constexpr const char* USER_NAME = "topicuser7";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-unrelated-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-unrelated-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {
+        NACLib::EAccessRights::AlterSchema,
+        NACLib::EAccessRights::UpdateRow,
+    });
+
+    {
+        auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+        setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+    }
+
+    RevokeAllRightsOnTopic(client, DLQ_TOPIC, userSid);
+
+    auto result = AlterTopicRetention(setup, userSid, MAIN_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqTopicDoesNotExist) {
+    constexpr const char* USER_NAME = "topicuser6";
+    constexpr const char* DLQ_TOPIC = "nonexistent-dlq-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-missing-dlq-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SCHEME_ERROR, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(AlterTopicMlpConsumerFailsWhenChangingDlqToTopicWithoutAccess) {
+    constexpr const char* USER_NAME = "topicuser8";
+    constexpr const char* DLQ_TOPIC_1 = "dlq-topic-switch-1";
+    constexpr const char* DLQ_TOPIC_2 = "dlq-topic-switch-2";
+    constexpr const char* MAIN_TOPIC = "main-topic-dlq-switch-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC_1);
+    GrantOnlyOnTopic(client, DLQ_TOPIC_1, userSid, {
+        NACLib::EAccessRights::AlterSchema,
+        NACLib::EAccessRights::UpdateRow,
+    });
+
+    CreateDLQTopic(setup, DLQ_TOPIC_2);
+    RevokeAllRightsOnTopic(client, DLQ_TOPIC_2, userSid);
+
+    {
+        auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC_1);
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+        setup->GetServer().WaitInit(TStringBuilder() << "/Root/" << MAIN_TOPIC);
+    }
+
+    auto result = AlterTopicMlpConsumerDlq(setup, userSid, MAIN_TOPIC, DLQ_TOPIC_2);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::UNAUTHORIZED, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWithOnlySelectRowOnDlqTopic) {
+    constexpr const char* USER_NAME = "topicuser5";
+    constexpr const char* DLQ_TOPIC = "dlq-topic-read-alter-test";
+    constexpr const char* MAIN_TOPIC = "main-topic-read-alter-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    CreateDLQTopic(setup, DLQ_TOPIC);
+
+    GrantOnlyOnTopic(client, DLQ_TOPIC, userSid, {NACLib::EAccessRights::SelectRow});
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TOPIC);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::UNAUTHORIZED, result->ErrorMessage);
+    UNIT_ASSERT(!result->ErrorMessage.empty());
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWhenDlqIsATable) {
+    constexpr const char* USER_NAME = "topicuser9";
+    constexpr const char* DLQ_TABLE = "dlqtable";
+    constexpr const char* MAIN_TOPIC = "main-topic-table-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "CREATE TABLE `" << DLQ_TABLE << "` (key Uint64, value String, PRIMARY KEY (key));");
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TABLE);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+    UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "must be a topic");
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWhenDlqIsACdcStream) {
+    constexpr const char* USER_NAME = "topicuser10";
+    constexpr const char* TABLE_NAME = "cdcdlqtable";
+    constexpr const char* FEED_NAME = "feed";
+    constexpr const char* MAIN_TOPIC = "main-topic-cdc-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "ALTER TABLE `" << TABLE_NAME << "` ADD CHANGEFEED `" << FEED_NAME
+        << "` WITH (FORMAT = 'JSON', MODE = 'UPDATES');");
+
+    const TString cdcStreamPath = TStringBuilder() << TABLE_NAME << "/" << FEED_NAME;
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, cdcStreamPath);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+    UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "CDC stream cannot be used as a dead letter queue");
+}
+
+Y_UNIT_TEST(CreateTopicWithMlpConsumerFailsWhenDlqIsACdcStreamImpl) {
+    constexpr const char* USER_NAME = "topicuser11";
+    constexpr const char* TABLE_NAME = "cdcdlqimpltable";
+    constexpr const char* FEED_NAME = "feed";
+    constexpr const char* MAIN_TOPIC = "main-topic-cdc-impl-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "ALTER TABLE `" << TABLE_NAME << "` ADD CHANGEFEED `" << FEED_NAME
+        << "` WITH (FORMAT = 'JSON', MODE = 'UPDATES');");
+
+    const TString cdcImplPath = TStringBuilder() << TABLE_NAME << "/" << FEED_NAME << "/streamImpl";
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, cdcImplPath);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+    UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "CDC stream cannot be used as a dead letter queue");
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqIsATable) {
+    constexpr const char* USER_NAME = "topicuser12";
+    constexpr const char* DLQ_TABLE = "alter-dlqtable";
+    constexpr const char* MAIN_TOPIC = "main-topic-alter-table-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "CREATE TABLE `" << DLQ_TABLE << "` (key Uint64, value String, PRIMARY KEY (key));");
+
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, DLQ_TABLE);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+    UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "must be a topic");
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqIsACdcStream) {
+    constexpr const char* USER_NAME = "topicuser13";
+    constexpr const char* TABLE_NAME = "altercdcdlqtable";
+    constexpr const char* FEED_NAME = "feed";
+    constexpr const char* MAIN_TOPIC = "main-topic-alter-cdc-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "ALTER TABLE `" << TABLE_NAME << "` ADD CHANGEFEED `" << FEED_NAME
+        << "` WITH (FORMAT = 'JSON', MODE = 'UPDATES');");
+
+    const TString cdcStreamPath = TStringBuilder() << TABLE_NAME << "/" << FEED_NAME;
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, cdcStreamPath);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+    UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "CDC stream cannot be used as a dead letter queue");
+}
+
+Y_UNIT_TEST(AlterTopicWithMlpConsumerFailsWhenDlqIsACdcStreamImpl) {
+    constexpr const char* USER_NAME = "topicuser14";
+    constexpr const char* TABLE_NAME = "altercdcdlqimpltable";
+    constexpr const char* FEED_NAME = "feed";
+    constexpr const char* MAIN_TOPIC = "main-topic-alter-cdc-impl-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "CREATE TABLE `" << TABLE_NAME << "` (key Uint64, value String, PRIMARY KEY (key));");
+    NTests::ExecuteDDL(*setup, TStringBuilder()
+        << "ALTER TABLE `" << TABLE_NAME << "` ADD CHANGEFEED `" << FEED_NAME
+        << "` WITH (FORMAT = 'JSON', MODE = 'UPDATES');");
+
+    const TString cdcImplPath = TStringBuilder() << TABLE_NAME << "/" << FEED_NAME << "/streamImpl";
+    auto result = CreateAndAlterTopicWithDLQ(setup, userSid, MAIN_TOPIC, cdcImplPath);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::BAD_REQUEST, result->ErrorMessage);
+    UNIT_ASSERT_STRING_CONTAINS(result->ErrorMessage, "CDC stream cannot be used as a dead letter queue");
+}
+
+Y_UNIT_TEST(CreateTopicWithSqsStyleDlqSkipsSchemeCheck) {
+    constexpr const char* USER_NAME = "topicuser-sqs";
+    constexpr const char* MAIN_TOPIC = "main-topic-sqs-dlq-test";
+
+    auto setup = CreateSetup();
+    auto& client = *setup->GetServer().AnnoyingClient;
+    const TString userSid = CreateUser(client, USER_NAME);
+
+    auto result = CreateTopicWithDLQ(setup, userSid, MAIN_TOPIC, "sqs://account/queue");
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, result->ErrorMessage);
+}
+
+} // Y_UNIT_TEST_SUITE(DlqAcl)
+
+} // namespace NKikimr::NPQ::NSchema

--- a/ydb/core/persqueue/public/schema/ut/ya.make
+++ b/ydb/core/persqueue/public/schema/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     check_dlq_topics_ut.cpp
     create_topic_ut.cpp
     describe_operation_ut.cpp
+    dlq_acl_ut.cpp
     schema_ops_ut.cpp
     validation_ut.cpp
 )
@@ -16,6 +17,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/persqueue/events
     ydb/core/persqueue/public
+    ydb/core/testlib
     ydb/core/testlib/actors
     ydb/core/testlib/grpc_request
     ydb/library/aclib

--- a/ydb/core/persqueue/public/schema/ut/ya.make
+++ b/ydb/core/persqueue/public/schema/ut/ya.make
@@ -5,6 +5,7 @@ SIZE(MEDIUM)
 YQL_LAST_ABI_VERSION()
 
 SRCS(
+    check_dlq_topics_ut.cpp
     create_topic_ut.cpp
     describe_operation_ut.cpp
     schema_ops_ut.cpp
@@ -17,6 +18,7 @@ PEERDIR(
     ydb/core/persqueue/public
     ydb/core/testlib/actors
     ydb/core/testlib/grpc_request
+    ydb/library/aclib
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
     ydb/public/sdk/cpp/src/client/query
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils

--- a/ydb/core/persqueue/public/schema/ya.make
+++ b/ydb/core/persqueue/public/schema/ya.make
@@ -5,6 +5,7 @@ SRCS(
     alter_topic.cpp
     alter_topic_internal.cpp
     alter_topic_operation.cpp
+    check_dlq_topics.cpp
     common.cpp
     create_topic.cpp
     create_topic_internal.cpp
@@ -20,6 +21,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/containers/absl
     ydb/core/persqueue/common
     ydb/core/persqueue/events
     ydb/core/persqueue/public
@@ -28,6 +30,7 @@ PEERDIR(
     ydb/core/persqueue/public/nameresolver
     ydb/core/util
     ydb/core/ydb_convert
+    ydb/library/aclib
 )
 
 END()

--- a/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
@@ -353,6 +353,11 @@ void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSess
     ReadSession->Close(TDuration::MilliSeconds(10));
 }
 
+void CreateEmptyTopic(TTopicClient& client, const TString& topicName) {
+    auto status = client.CreateTopic(topicName, TCreateTopicSettings()).GetValueSync();
+    UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToOneLineString());
+}
+
 Y_UNIT_TEST_SUITE(BasicUsage) {
     Y_UNIT_TEST(CreateTopicWithCustomName) {
         TTopicSdkTestSetup setup{TEST_CASE_NAME, TTopicSdkTestSetup::MakeServerSettings(), false};
@@ -447,6 +452,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         TTopicSdkTestSetup setup{TEST_CASE_NAME, TTopicSdkTestSetup::MakeServerSettings(), false};
 
         TTopicClient client(setup.MakeDriver());
+        CreateEmptyTopic(client, "deadLetterQueue-topic");
 
         TCreateTopicSettings topics;
         topics.BeginAddConsumer()
@@ -603,6 +609,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         TTopicSdkTestSetup setup{TEST_CASE_NAME, TTopicSdkTestSetup::MakeServerSettings(), false};
 
         TTopicClient client(setup.MakeDriver());
+        CreateEmptyTopic(client, "deadLetterQueue-topic");
 
         {
             TCreateTopicSettings topics;
@@ -623,6 +630,8 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
             auto status = client.CreateTopic("topic_name", topics).GetValueSync();
             UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToOneLineString());
         }
+
+        CreateEmptyTopic(client, "deadLetterQueue-topic-new");
 
         {
             TAlterTopicSettings topics;
@@ -661,6 +670,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         TTopicSdkTestSetup setup{TEST_CASE_NAME, TTopicSdkTestSetup::MakeServerSettings(), false};
 
         TTopicClient client(setup.MakeDriver());
+        CreateEmptyTopic(client, "deadLetterQueue-topic");
 
         {
             TCreateTopicSettings topics;
@@ -719,6 +729,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         TTopicSdkTestSetup setup{TEST_CASE_NAME, TTopicSdkTestSetup::MakeServerSettings(), false};
 
         TTopicClient client(setup.MakeDriver());
+        CreateEmptyTopic(client, "deadLetterQueue-topic");
 
         {
             TCreateTopicSettings topics;
@@ -793,6 +804,8 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
             UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToOneLineString());
         }
 
+        CreateEmptyTopic(client, "dlq-topic");
+
         {
             TAlterTopicSettings topics;
             topics.BeginAlterConsumer()
@@ -825,6 +838,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         TTopicSdkTestSetup setup{TEST_CASE_NAME, TTopicSdkTestSetup::MakeServerSettings(), false};
 
         TTopicClient client(setup.MakeDriver());
+        CreateEmptyTopic(client, "dlq-topic");
 
         {
             TCreateTopicSettings topics;
@@ -845,6 +859,8 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
             auto status = client.CreateTopic("topic_name", topics).GetValueSync();
             UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToOneLineString());
         }
+
+        CreateEmptyTopic(client, "dlq-topic-new");
 
         {
             TAlterTopicSettings topics;

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/alter_topic_sdk_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/alter_topic_sdk_ut.cpp
@@ -70,6 +70,11 @@ Y_UNIT_TEST(AddSharedConsumer) {
     auto& client = setup.GetPersQueueClient();
     const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-alter-shared");
 
+    {
+        const auto dlqStatus = CreateDlqTopicViaSdk(client);
+        UNIT_ASSERT_C(dlqStatus.IsSuccess(), "CreateDlqTopic: " << dlqStatus.GetIssues().ToOneLineString());
+    }
+
     const auto createStatus = CreateTopicViaSdk(client, path);
     UNIT_ASSERT_C(createStatus.IsSuccess(), "CreateTopic: " << createStatus.GetIssues().ToOneLineString());
 
@@ -160,6 +165,11 @@ Y_UNIT_TEST(CannotChangeConsumerType_SharedToStreaming) {
     auto& client = setup.GetPersQueueClient();
     const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-alter-change-type-shared-to-streaming");
 
+    {
+        const auto dlqStatus = CreateDlqTopicViaSdk(client);
+        UNIT_ASSERT_C(dlqStatus.IsSuccess(), "CreateDlqTopic: " << dlqStatus.GetIssues().ToOneLineString());
+    }
+
     TCreateTopicSettings createSettings;
     createSettings.ReadRules({MakeSharedConsumerReadRuleSettings()});
 
@@ -188,6 +198,11 @@ Y_UNIT_TEST(AlterSharedConsumer) {
 
     auto& client = setup.GetPersQueueClient();
     const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-alter-keep-shared");
+
+    {
+        const auto dlqStatus = CreateDlqTopicViaSdk(client);
+        UNIT_ASSERT_C(dlqStatus.IsSuccess(), "CreateDlqTopic: " << dlqStatus.GetIssues().ToOneLineString());
+    }
 
     TCreateTopicSettings createSettings;
     createSettings.ReadRules({MakeSharedConsumerReadRuleSettings()});

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_sdk_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_sdk_ut.cpp
@@ -94,6 +94,11 @@ Y_UNIT_TEST(CreateTopicWithSharedConsumer) {
     auto& client = setup.GetPersQueueClient();
     const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-shared");
 
+    {
+        const auto dlqStatus = CreateDlqTopicViaSdk(client);
+        UNIT_ASSERT_C(dlqStatus.IsSuccess(), "CreateDlqTopic: " << dlqStatus.GetIssues().ToOneLineString());
+    }
+
     TCreateTopicSettings settings;
     settings.ReadRules({MakeSharedConsumerReadRuleSettings()});
 
@@ -146,6 +151,11 @@ Y_UNIT_TEST(DescribeTopicReturnsSharedConsumerSettings) {
 
     auto& client = setup.GetPersQueueClient();
     const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-describe-shared");
+
+    {
+        const auto dlqStatus = CreateDlqTopicViaSdk(client);
+        UNIT_ASSERT_C(dlqStatus.IsSuccess(), "CreateDlqTopic: " << dlqStatus.GetIssues().ToOneLineString());
+    }
 
     TCreateTopicSettings settings;
     settings.ReadRules({MakeSharedConsumerReadRuleSettings()});
@@ -271,6 +281,11 @@ Y_UNIT_TEST(DescribeTopicPreservesDeadLetterActionMove) {
 
     auto& client = setup.GetPersQueueClient();
     const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-dlp-move");
+
+    {
+        const auto dlqStatus = CreateDlqTopicViaSdk(client);
+        UNIT_ASSERT_C(dlqStatus.IsSuccess(), "CreateDlqTopic: " << dlqStatus.GetIssues().ToOneLineString());
+    }
 
     TCreateTopicSettings settings;
     settings.ReadRules({

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_ut.cpp
@@ -49,7 +49,29 @@ std::shared_ptr<TResultHolder<TResponse>> DoRequest(NActors::TTestActorRuntime& 
     return result;
 }
 
-    
+void CreateDlqTopic(
+    NActors::TTestActorRuntime& runtime,
+    const TString& dlqTopicPath,
+    const TString& database = "/Root/test_db"
+) {
+    Ydb::PersQueue::V1::CreateTopicRequest request;
+    request.set_path(dlqTopicPath);
+
+    auto& settings = *request.mutable_settings();
+    settings.set_partitions_count(1);
+    settings.set_supported_format(Ydb::PersQueue::V1::TopicSettings::FORMAT_BASE);
+    settings.set_retention_period_ms(TDuration::Days(1).MilliSeconds());
+    settings.mutable_attributes()->insert({"_federation_account", "account1"});
+
+    auto result = DoRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime,
+        request,
+        dlqTopicPath,
+        database
+    );
+    UNIT_ASSERT(result->ResultStatus);
+    UNIT_ASSERT_VALUES_EQUAL_C(*result->ResultStatus, Ydb::StatusIds::SUCCESS, result->Issues.ToString());
+}
 
 using namespace NYdb;
 using namespace NYdb::NQuery;
@@ -61,6 +83,7 @@ Y_UNIT_TEST(SharedConsumer) {
     auto& runtime = setup->GetRuntime();
     runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
 
+    CreateDlqTopic(runtime, "/Root/test_db/test_dead_letter_queue");
 
     Ydb::PersQueue::V1::CreateTopicRequest request;
     request.set_path("/Root/test_db/topic1");

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/pqv1_sdk_test_utils.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/pqv1_sdk_test_utils.cpp
@@ -104,6 +104,13 @@ TStatus CreateTopicViaSdk(
     return client.CreateTopic(path, settings).GetValueSync();
 }
 
+TStatus CreateDlqTopicViaSdk(
+    TPersQueueClient& client,
+    const std::string& dlqTopicName)
+{
+    return CreateTopicViaSdk(client, TPqv1SdkTestSetup::MakeTopicPath(dlqTopicName));
+}
+
 TDescribeTopicResult DescribeTopicViaSdk(
     TPersQueueClient& client,
     const std::string& path)

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/pqv1_sdk_test_utils.h
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/pqv1_sdk_test_utils.h
@@ -43,6 +43,10 @@ NYdb::TStatus CreateTopicViaSdk(
     const std::string& path,
     const NYdb::NPersQueue::TCreateTopicSettings& settings = {});
 
+NYdb::TStatus CreateDlqTopicViaSdk(
+    NYdb::NPersQueue::TPersQueueClient& client,
+    const std::string& dlqTopicName = DEFAULT_DEAD_LETTER_QUEUE);
+
 NYdb::NPersQueue::TDescribeTopicResult DescribeTopicViaSdk(
     NYdb::NPersQueue::TPersQueueClient& client,
     const std::string& path);

--- a/ydb/services/persqueue_v1/topic_yql_ut.cpp
+++ b/ydb/services/persqueue_v1/topic_yql_ut.cpp
@@ -5,6 +5,12 @@ namespace NKikimr::NPersQueueTests {
 
 namespace {
     const static TString DEFAULT_TOPIC_NAME = "rt3.dc1--topic1";
+    const static TString DLQ_TOPIC_PATH = "/Root/PQ/rt3.dc1--dead_letter_queue_97";
+
+    void CreateDlqTopic(NPersQueue::TTestServer& server) {
+        server.AnnoyingClient->RunYqlSchemeQuery(TStringBuilder()
+            << "CREATE TOPIC `" << DLQ_TOPIC_PATH << "`;");
+    }
 }
 
 Y_UNIT_TEST_SUITE(TTopicYqlTest) {
@@ -252,6 +258,8 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
 
         NPersQueue::TTestServer server(settings);
 
+        CreateDlqTopic(server);
+
         {
             const char *query = R"(
                 CREATE TOPIC `/Root/PQ/rt3.dc1--topic_with_shared_consumer`
@@ -263,7 +271,7 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
                         , receive_message_delay = Interval('PT7S')
                         , max_processing_attempts = 67
                         , dead_letter_policy = 'move'
-                        , dead_letter_queue = 'dead_letter_queue_97'
+                        , dead_letter_queue = '/Root/PQ/rt3.dc1--dead_letter_queue_97'
                     ))
             )";
 
@@ -287,7 +295,7 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
             UNIT_ASSERT_VALUES_EQUAL(c.GetMaxProcessingAttempts(), 67);
             UNIT_ASSERT_VALUES_EQUAL(::NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name(c.GetDeadLetterPolicy()),
                 ::NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name( ::NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE));
-            UNIT_ASSERT_VALUES_EQUAL(c.GetDeadLetterQueue(), "dead_letter_queue_97");
+            UNIT_ASSERT_VALUES_EQUAL(c.GetDeadLetterQueue(), DLQ_TOPIC_PATH);
         }
     }
 
@@ -330,6 +338,8 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
             UNIT_ASSERT_VALUES_EQUAL(c.GetDeadLetterQueue(), "");
         }
 
+        CreateDlqTopic(server);
+
         {
             const char *query = R"(
                 ALTER TOPIC `/Root/PQ/rt3.dc1--topic_with_shared_consumer`
@@ -339,7 +349,7 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
                         , receive_message_delay = Interval('PT7S')
                         , max_processing_attempts = 67
                         , dead_letter_policy = 'move'
-                        , dead_letter_queue = 'dead_letter_queue_97'
+                        , dead_letter_queue = '/Root/PQ/rt3.dc1--dead_letter_queue_97'
                     )
             )";
 
@@ -363,7 +373,7 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
             UNIT_ASSERT_VALUES_EQUAL(c.GetMaxProcessingAttempts(), 67);
             UNIT_ASSERT_VALUES_EQUAL(::NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name(c.GetDeadLetterPolicy()),
                 ::NKikimrPQ::TPQTabletConfig::EDeadLetterPolicy_Name( ::NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE));
-            UNIT_ASSERT_VALUES_EQUAL(c.GetDeadLetterQueue(), "dead_letter_queue_97");
+            UNIT_ASSERT_VALUES_EQUAL(c.GetDeadLetterQueue(), DLQ_TOPIC_PATH);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Check write or alter permissions on a Dead Letter Queue topic when creating or altering a topic with an MLP consumer that uses MOVE DLQ.

### Description for reviewers <!-- (optional) description for those who read this PR -->

При create/alter топика с MLP-консьюмером и DLQ (`MOVE`) проверяем, что у пользователя есть право **писать** (`UpdateRow`) **или альтерить** (`AlterSchema`) целевой DLQ-топик.

Rework of #44388: проверка в выделенном акторе схемы, без изменений в `core/tx` / `schemereq`.

#### Зачем

Раньше можно было указать чужой или недоступный DLQ. Сообщения туда уходили бы от имени системы, минуя права пользователя.

#### Как работает

- После сборки `ModifyScheme` create/alter вызывают `CreateCheckDlqTopicsActorIfNeeded(parent, database, newConfig, oldConfig)`. Для create `oldConfig` пустой.
- Фабрика сама считает diff DLQ-путей (новые или вновь включённые относительно старого конфига) и либо возвращает `nullptr`, либо создаёт актор. Сбор списка и решение «надо ли проверять» живут только там, не в create/alter.
- Актор описывает пути через существующий describer (`ForceSyncVersion`, права `AlterSchema` **или** `UpdateRow`). Ошибки отдаются в отсортированном порядке путей.
- Путь должен существовать и быть топиком: таблица / CDC / `streamImpl` → `BAD_REQUEST`, нет пути → `SCHEME_ERROR`, нет прав → `UNAUTHORIZED`, неизвестный статус describer → `INTERNAL_ERROR`.
- Unrelated alter не требует прав на уже настроенную очередь: проверяются только пути из diff.
- Не проверяются: не-MLP, не-MOVE, disabled, пустой путь, `sqs://…`.
- Пустой MOVE `dead_letter_queue` отклоняется на валидации (`BAD_REQUEST`).
- `mlp_consumer` нормализует DLQ-путь так же, как схема (`NormalizePath` / `CanonizePath`).
- PrepareOnly (YQL) тоже проходит проверку до возврата `ModifyScheme`.

Покрывает Topic API, PQv1, YQL, SQS, Kafka — все они идут через create/alter schema actors.

#### Tests

- актор, helpers и фабрика: `ydb/core/persqueue/public/schema/ut/check_dlq_topics_ut.cpp`
- create/alter ACL: `ydb/core/persqueue/public/schema/ut/dlq_acl_ut.cpp`
- связанные SDK / YQL / SQS / PQv1 / MLP consumer tests: существующие сценарии с MOVE теперь создают DLQ-топик заранее
