### PR TITLE
[PQ] Freeze Topic API and PQv1 schema behavior in unit tests

### DIFF
--- a/ydb/services/persqueue_v1/actors/schema/pqv1/describe_topic_sdk_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/describe_topic_sdk_ut.cpp
@@ -1,0 +1,98 @@
+#include "pqv1_sdk_test_utils.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/size_literals.h>
+
+namespace NKikimr::NGRpcProxy::V1::NPQv1::NTests {
+
+using namespace NYdb;
+using namespace NYdb::NPersQueue;
+
+Y_UNIT_TEST_SUITE(DescribeTopic_PQv1SDK) {
+
+Y_UNIT_TEST(DescribeMissingTopic) {
+    TPqv1SdkTestSetup setup("DescribeMissingTopic");
+
+    auto& client = setup.GetPersQueueClient();
+    const auto describe = DescribeTopicViaSdk(client, "/Root/no_such_topic");
+    UNIT_ASSERT_C(!describe.IsSuccess(), describe.GetIssues().ToOneLineString());
+    UNIT_ASSERT_VALUES_EQUAL(describe.GetStatus(), EStatus::SCHEME_ERROR);
+}
+
+Y_UNIT_TEST(DescribeCreatedTopicSettings) {
+    TPqv1SdkTestSetup setup("DescribeCreatedTopicSettings");
+
+    auto& client = setup.GetPersQueueClient();
+    const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-describe");
+
+    TCreateTopicSettings settings;
+    settings
+        .PartitionsCount(3)
+        .RetentionPeriod(TDuration::Hours(6))
+        .MaxPartitionWriteSpeed(123456)
+        .MaxPartitionWriteBurst(234567)
+        .SupportedCodecs({ECodec::RAW, ECodec::GZIP})
+        .AllowUnauthenticatedRead(true)
+        .AbcId(42)
+        .AbcSlug("slug")
+        .ReadRules({
+            TReadRuleSettings{}
+                .ConsumerName(DEFAULT_STREAMING_CONSUMER)
+                .Important(true)
+                .StartingMessageTimestamp(TInstant::MilliSeconds(1000))
+                .Version(7)
+                .SupportedCodecs({ECodec::RAW, ECodec::GZIP, ECodec::ZSTD}),
+        });
+
+    const auto createStatus = CreateTopicViaSdk(client, path, settings);
+    UNIT_ASSERT_C(createStatus.IsSuccess(), "CreateTopic: " << createStatus.GetIssues().ToOneLineString());
+
+    const auto describe = DescribeTopicViaSdk(client, path);
+    UNIT_ASSERT_C(describe.IsSuccess(), "DescribeTopic: " << describe.GetIssues().ToOneLineString());
+
+    const auto& topicSettings = describe.TopicSettings();
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.PartitionsCount(), 3u);
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.RetentionPeriod(), TDuration::Hours(6));
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.MaxPartitionWriteSpeed(), 123456u);
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.MaxPartitionWriteBurst(), 234567u);
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.SupportedCodecs().size(), 2u);
+    UNIT_ASSERT_EQUAL(topicSettings.SupportedCodecs().at(0), ECodec::RAW);
+    UNIT_ASSERT_EQUAL(topicSettings.SupportedCodecs().at(1), ECodec::GZIP);
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.AllowUnauthenticatedRead(), true);
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.AllowUnauthenticatedWrite(), false);
+    UNIT_ASSERT(topicSettings.AbcId().has_value());
+    UNIT_ASSERT_VALUES_EQUAL(*topicSettings.AbcId(), 42u);
+    UNIT_ASSERT(topicSettings.AbcSlug().has_value());
+    UNIT_ASSERT_VALUES_EQUAL(*topicSettings.AbcSlug(), "slug");
+
+    UNIT_ASSERT_VALUES_EQUAL(topicSettings.ReadRules().size(), 1u);
+    const auto& rule = topicSettings.ReadRules().at(0);
+    UNIT_ASSERT_VALUES_EQUAL(rule.ConsumerName(), DEFAULT_STREAMING_CONSUMER);
+    UNIT_ASSERT_VALUES_EQUAL(rule.Important(), true);
+    UNIT_ASSERT_VALUES_EQUAL(rule.StartingMessageTimestamp(), TInstant::MilliSeconds(1000));
+    UNIT_ASSERT_VALUES_EQUAL(rule.Version(), 7u);
+    UNIT_ASSERT_VALUES_EQUAL(rule.SupportedCodecs().size(), 3u);
+    UNIT_ASSERT_EQUAL(rule.SupportedCodecs().at(0), ECodec::RAW);
+    UNIT_ASSERT_EQUAL(rule.SupportedCodecs().at(1), ECodec::GZIP);
+    UNIT_ASSERT_EQUAL(rule.SupportedCodecs().at(2), ECodec::ZSTD);
+    UNIT_ASSERT(!rule.SharedConsumer().has_value());
+}
+
+Y_UNIT_TEST(DescribeUnauthenticatedAttributesAbsentWhenFalse) {
+    TPqv1SdkTestSetup setup("DescribeUnauthAttr");
+
+    auto& client = setup.GetPersQueueClient();
+    const std::string path = TPqv1SdkTestSetup::MakeTopicPath("topic-auth-attr");
+
+    const auto createStatus = CreateTopicViaSdk(client, path);
+    UNIT_ASSERT_C(createStatus.IsSuccess(), "CreateTopic: " << createStatus.GetIssues().ToOneLineString());
+
+    const auto describe = DescribeTopicViaSdk(client, path);
+    UNIT_ASSERT_C(describe.IsSuccess(), "DescribeTopic: " << describe.GetIssues().ToOneLineString());
+    UNIT_ASSERT_VALUES_EQUAL(describe.TopicSettings().AllowUnauthenticatedRead(), false);
+    UNIT_ASSERT_VALUES_EQUAL(describe.TopicSettings().AllowUnauthenticatedWrite(), false);
+}
+
+} // Y_UNIT_TEST_SUITE(DescribeTopic_PQv1SDK)
+
+} // namespace NKikimr::NGRpcProxy::V1::NPQv1::NTests

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/schema_ops_ut.cpp
@@ -1,6 +1,8 @@
 #include "actors.h"
 
+#include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/describer/describer.h>
+#include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/testlib/grpc_request/grpc_request.h>
 #include <ydb/public/api/protos/ydb_persqueue_v1.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
@@ -8,6 +10,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/generic/size_literals.h>
+#include <util/generic/vector.h>
 
 namespace NKikimr::NGRpcProxy::V1::NPQv1 {
 
@@ -53,6 +56,13 @@ Ydb::PersQueue::V1::CreateTopicRequest MakeCreateTopicRequest(const TString& pat
     return request;
 }
 
+Ydb::PersQueue::V1::AlterTopicRequest MakeAlterTopicRequest(const TString& path, ui32 partitions = 1) {
+    Ydb::PersQueue::V1::AlterTopicRequest request;
+    request.set_path(path);
+    *request.mutable_settings() = MakeCreateTopicRequest(path, partitions).settings();
+    return request;
+}
+
 Ydb::PersQueue::V1::TopicSettings::ReadRule MakeStreamingReadRule(const TString& consumerName, i32 version = 1) {
     Ydb::PersQueue::V1::TopicSettings::ReadRule rule;
     rule.set_consumer_name(consumerName);
@@ -93,10 +103,46 @@ void ExecuteDDL(TTopicSdkTestSetup& setup, const TString& query) {
     driver.Stop(true);
 }
 
-void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path) {
+void MkDir(TTopicSdkTestSetup& setup, const TString& parent, const TString& name) {
+    setup.GetServer().AnnoyingClient->MkDir(parent, name);
+}
+
+void AssertDescribeAliases(
+    NActors::TTestActorRuntime& runtime,
+    const TVector<TString>& names,
+    const TString& expectedRealPath,
+    const TString& database = "/Root")
+{
+    for (const auto& name : names) {
+        auto edge = runtime.AllocateEdgeActor();
+        runtime.Register(NPQ::NDescriber::CreateDescriberActor(edge, database, {name}));
+        auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL_C(response->Topics.size(), 1u, name);
+        const auto it = response->Topics.find(name);
+        UNIT_ASSERT_C(it != response->Topics.end(), name);
+        UNIT_ASSERT_VALUES_EQUAL_C(it->second.Status, NPQ::NDescriber::EStatus::SUCCESS, name);
+        UNIT_ASSERT_VALUES_EQUAL_C(it->second.RealPath, expectedRealPath, name);
+    }
+}
+
+void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path, const TString& database = "/Root") {
     auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
-        runtime, MakeCreateTopicRequest(path), CreateCreateTopicActor, path);
+        runtime, MakeCreateTopicRequest(path), CreateCreateTopicActor, path, database);
     AssertStatus(result, Ydb::StatusIds::SUCCESS);
+}
+
+NKikimrPQ::TPQTabletConfig DescribeTabletConfig(
+    NActors::TTestActorRuntime& runtime,
+    const TString& path,
+    const TString& database = "/Root")
+{
+    auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(NPQ::NDescriber::CreateDescriberActor(edge, database, {path}));
+    auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+    UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
+    const auto& topic = response->Topics.begin()->second;
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    return topic.Info->Description.GetPQTabletConfig();
 }
 
 } // namespace
@@ -361,6 +407,274 @@ Y_UNIT_TEST(ByteBurstDefaultsToWriteSpeed) {
     const auto& partConfig = response->Topics.begin()->second.Info->Description.GetPQTabletConfig().GetPartitionConfig();
     UNIT_ASSERT_VALUES_EQUAL(partConfig.GetWriteSpeedInBytesPerSecond(), 123456u);
     UNIT_ASSERT_VALUES_EQUAL(partConfig.GetBurstSize(), 123456u);
+}
+
+Y_UNIT_TEST(CreateExistingTopicSucceeds) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_dup";
+    CreateTopic(runtime, path);
+
+    // gRPC CreateTopic uses IfNotExists=true, so a second create is SUCCESS.
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, MakeCreateTopicRequest(path), CreateCreateTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+}
+
+Y_UNIT_TEST(ZeroPartitionsRejected) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+
+    auto request = MakeCreateTopicRequest("/Root/topic_zero_parts", /*partitions=*/0);
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Partitions count must be positive");
+}
+
+Y_UNIT_TEST(UnknownFormatRejected) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+
+    auto request = MakeCreateTopicRequest("/Root/topic_bad_format");
+    request.mutable_settings()->set_supported_format(Ydb::PersQueue::V1::TopicSettings::FORMAT_UNSPECIFIED);
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Unknown format version");
+}
+
+Y_UNIT_TEST(UnknownCodecRejected) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+
+    auto request = MakeCreateTopicRequest("/Root/topic_bad_codec");
+    request.mutable_settings()->add_supported_codecs(Ydb::PersQueue::V1::CODEC_UNSPECIFIED);
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Unknown codec");
+}
+
+Y_UNIT_TEST(ImportantConsumerAndCodecsStored) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_important_codecs";
+
+    auto request = MakeCreateTopicRequest(path);
+    request.mutable_settings()->add_supported_codecs(Ydb::PersQueue::V1::CODEC_RAW);
+    request.mutable_settings()->add_supported_codecs(Ydb::PersQueue::V1::CODEC_ZSTD);
+    *request.mutable_settings()->add_read_rules() = MakeStreamingReadRule("important_c");
+    request.mutable_settings()->mutable_read_rules(0)->set_important(true);
+    // Consumer codecs must include every topic codec.
+    request.mutable_settings()->mutable_read_rules(0)->add_supported_codecs(Ydb::PersQueue::V1::CODEC_RAW);
+    request.mutable_settings()->mutable_read_rules(0)->add_supported_codecs(Ydb::PersQueue::V1::CODEC_ZSTD);
+    request.mutable_settings()->mutable_read_rules(0)->add_supported_codecs(Ydb::PersQueue::V1::CODEC_GZIP);
+
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+
+    const auto config = DescribeTabletConfig(runtime, path);
+    const auto& codecs = config.GetCodecs().GetIds();
+    UNIT_ASSERT_VALUES_EQUAL(codecs.size(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(codecs.Get(0), 0); // RAW = 1 on wire, stored as 0
+    UNIT_ASSERT_VALUES_EQUAL(codecs.Get(1), 3); // ZSTD = 4 on wire, stored as 3
+
+    const auto* consumer = NPQ::GetConsumer(config, "important_c");
+    UNIT_ASSERT(consumer);
+    UNIT_ASSERT(consumer->GetImportant());
+    UNIT_ASSERT_VALUES_EQUAL(consumer->GetCodec().IdsSize(), 3u);
+    UNIT_ASSERT_VALUES_EQUAL(consumer->GetCodec().GetIds(0), 0); // RAW
+    UNIT_ASSERT_VALUES_EQUAL(consumer->GetCodec().GetIds(1), 3); // ZSTD
+    UNIT_ASSERT_VALUES_EQUAL(consumer->GetCodec().GetIds(2), 1); // GZIP
+}
+
+Y_UNIT_TEST(ConsumerCodecsMustCoverTopicCodecs) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+
+    auto request = MakeCreateTopicRequest("/Root/topic_codec_mismatch");
+    request.mutable_settings()->add_supported_codecs(Ydb::PersQueue::V1::CODEC_RAW);
+    request.mutable_settings()->add_supported_codecs(Ydb::PersQueue::V1::CODEC_ZSTD);
+    *request.mutable_settings()->add_read_rules() = MakeStreamingReadRule("c1");
+    request.mutable_settings()->mutable_read_rules(0)->add_supported_codecs(Ydb::PersQueue::V1::CODEC_GZIP);
+
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "got unsupported codec");
+}
+
+Y_UNIT_TEST(ReadQuotaStored) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_read_quota";
+
+    auto request = MakeCreateTopicRequest(path);
+    request.mutable_settings()->set_partition_total_read_speed_bytes_per_second(1111);
+    request.mutable_settings()->set_partition_total_read_speed_messages_per_second(2222);
+    request.mutable_settings()->set_partition_read_without_consumer_speed_bytes_per_second(3333);
+    request.mutable_settings()->set_partition_read_without_consumer_speed_messages_per_second(4444);
+    auto* rule = request.mutable_settings()->add_read_rules();
+    *rule = MakeStreamingReadRule("quota_c");
+    rule->set_read_speed_bytes_per_second(5555);
+    rule->set_read_speed_messages_per_second(6666);
+
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+
+    const auto config = DescribeTabletConfig(runtime, path);
+    const auto& partConfig = config.GetPartitionConfig();
+    UNIT_ASSERT_VALUES_EQUAL(partConfig.GetReadSpeedInBytesPerSecond(), 1111u);
+    UNIT_ASSERT_VALUES_EQUAL(partConfig.GetReadSpeedInMessagesPerSecond(), 2222u);
+
+    const auto* withoutConsumer = NPQ::GetReadQuota(config, NPQ::CLIENTID_WITHOUT_CONSUMER);
+    UNIT_ASSERT(withoutConsumer);
+    UNIT_ASSERT_VALUES_EQUAL(withoutConsumer->GetSpeedInBytesPerSecond(), 3333u);
+    UNIT_ASSERT_VALUES_EQUAL(withoutConsumer->GetSpeedInMessagesPerSecond(), 4444u);
+
+    const auto* consumerQuota = NPQ::GetReadQuota(config, "quota_c");
+    UNIT_ASSERT(consumerQuota);
+    UNIT_ASSERT_VALUES_EQUAL(consumerQuota->GetSpeedInBytesPerSecond(), 5555u);
+    UNIT_ASSERT_VALUES_EQUAL(consumerQuota->GetSpeedInMessagesPerSecond(), 6666u);
+}
+
+Y_UNIT_TEST(AlterSuccessAndMissing) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter";
+    CreateTopic(runtime, path);
+
+    {
+        auto request = MakeAlterTopicRequest(path);
+        request.mutable_settings()->set_retention_period_ms(TDuration::Hours(2).MilliSeconds());
+        auto result = DoActorRequest<Ydb::PersQueue::V1::AlterTopicRequest, Ydb::PersQueue::V1::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(
+            DescribeTabletConfig(runtime, path).GetPartitionConfig().GetLifetimeSeconds(),
+            TDuration::Hours(2).Seconds());
+    }
+
+    {
+        auto request = MakeAlterTopicRequest("/Root/missing_topic");
+        auto result = DoActorRequest<Ydb::PersQueue::V1::AlterTopicRequest, Ydb::PersQueue::V1::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, request.path());
+        AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR);
+    }
+}
+
+Y_UNIT_TEST(AlterCannotChangeConsumerType) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().FeatureFlags.SetEnableTopicMessageLevelParallelism(true);
+    const TString path = "/Root/topic_type_change";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::PersQueue::V1::AddReadRuleRequest request;
+        request.set_path(path);
+        *request.mutable_read_rule() = MakeStreamingReadRule("c1");
+        auto result = DoActorRequest<Ydb::PersQueue::V1::AddReadRuleRequest, Ydb::PersQueue::V1::AddReadRuleResponse>(
+            runtime, request, CreateAddConsumerActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    }
+
+    auto request = MakeAlterTopicRequest(path);
+    *request.mutable_settings()->add_read_rules() = MakeSharedReadRule("c1");
+    auto result = DoActorRequest<Ydb::PersQueue::V1::AlterTopicRequest, Ydb::PersQueue::V1::AlterTopicResponse>(
+        runtime, request, CreateAlterTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Cannot alter consumer type");
+}
+
+Y_UNIT_TEST(NegativeReadSpeedRejected) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+
+    auto request = MakeCreateTopicRequest("/Root/topic_neg_read");
+    request.mutable_settings()->set_partition_total_read_speed_bytes_per_second(-1);
+    auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "partition_total_read_speed_bytes_per_second");
+}
+
+Y_UNIT_TEST(FccTopicNameFormatsCreateAndDescribeAliases) {
+    auto setup = CreateSetup("PQv1NameFormatsFcc");
+    auto& runtime = setup->GetRuntime();
+
+    MkDir(*setup, "/Root", "fcclegacy");
+    MkDir(*setup, "/Root", "fccmodern");
+    MkDir(*setup, "/Root", "fccshort");
+
+    CreateTopic(runtime, "rt3.dc1--fcclegacy--topic");
+    AssertDescribeAliases(
+        runtime,
+        {
+            "rt3.dc1--fcclegacy--topic",
+            "fcclegacy--topic",
+            "fcclegacy/topic",
+            "/Root/fcclegacy/topic",
+        },
+        "/Root/fcclegacy/topic");
+
+    CreateTopic(runtime, "fccmodern/topic");
+    AssertDescribeAliases(
+        runtime,
+        {
+            "rt3.dc1--fccmodern--topic",
+            "fccmodern--topic",
+            "fccmodern/topic",
+            "/Root/fccmodern/topic",
+        },
+        "/Root/fccmodern/topic");
+
+    CreateTopic(runtime, "fccshort--topic");
+    AssertDescribeAliases(
+        runtime,
+        {
+            "rt3.dc1--fccshort--topic",
+            "fccshort--topic",
+            "fccshort/topic",
+            "/Root/fccshort/topic",
+        },
+        "/Root/fccshort/topic");
+}
+
+Y_UNIT_TEST(FederationTopicNameFormats) {
+    auto setup = CreateSetup("PQv1NameFormatsFed");
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+
+    {
+        auto request = MakeCreateTopicRequest("fedshort--topic");
+        auto result = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+            runtime, request, CreateCreateTopicActor, request.path());
+        AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "expected legacy-style name");
+    }
+
+    CreateTopic(runtime, "rt3.dc1--fedleaf--topic");
+    AssertDescribeAliases(
+        runtime,
+        {"/Root/rt3.dc1--fedleaf--topic"},
+        "/Root/rt3.dc1--fedleaf--topic");
+
+    runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbCommunal");
+    MkDir(*setup, "/Root", "LbCommunal");
+    MkDir(*setup, "/Root/LbCommunal", "account");
+
+    auto modern = MakeCreateTopicRequest("/Root/LbCommunal/account/fedtopic");
+    modern.mutable_settings()->mutable_attributes()->insert({"_federation_account", "account"});
+    auto modernResult = DoActorRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        runtime, modern, CreateCreateTopicActor, modern.path(), "/Root/LbCommunal/account");
+    AssertStatus(modernResult, Ydb::StatusIds::SUCCESS);
+
+    AssertDescribeAliases(
+        runtime,
+        {
+            "rt3.dc1--account--fedtopic",
+            "account--fedtopic",
+            "account/fedtopic",
+            "/Root/LbCommunal/account/fedtopic",
+        },
+        "/Root/LbCommunal/account/fedtopic");
 }
 
 } // Y_UNIT_TEST_SUITE(SchemaOps_PQv1)

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/ut/ya.make
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     alter_topic_sdk_ut.cpp
     create_topic_ut.cpp
     create_topic_sdk_ut.cpp
+    describe_topic_sdk_ut.cpp
     pqv1_sdk_test_utils.cpp
     schema_ops_ut.cpp
 )

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -1506,7 +1506,8 @@ Y_UNIT_TEST(AlterCdcAllowsRetentionAndWriteLimits) {
         AssertStatus(result, Ydb::StatusIds::SUCCESS);
     }
 
-    const auto& partConfig = DescribeTabletConfig(runtime, path).GetPartitionConfig();
+    const auto config = DescribeTabletConfig(runtime, path);
+    const auto& partConfig = config.GetPartitionConfig();
     UNIT_ASSERT_VALUES_EQUAL(partConfig.GetStorageLimitBytes(), 100_MB);
     UNIT_ASSERT_VALUES_EQUAL(partConfig.GetWriteSpeedInBytesPerSecond(), 9000u);
     UNIT_ASSERT_VALUES_EQUAL(partConfig.GetBurstSize(), 100500u);

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -2,10 +2,14 @@
 
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/public/constants.h>
+#include <ydb/core/persqueue/public/describer/describer.h>
+#include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/testlib/grpc_request/grpc_request.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 #include <ydb/services/persqueue_v1/actors/events.h>
@@ -13,6 +17,9 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/async.h>
 
+#include <util/generic/hash_set.h>
+#include <util/generic/size_literals.h>
+#include <util/generic/vector.h>
 #include <util/thread/pool.h>
 
 #include <memory>
@@ -168,10 +175,75 @@ Ydb::Topic::CreateTopicRequest MakeCreateTopicRequest(const TString& path, ui32 
     return request;
 }
 
-void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path, ui32 partitions = 1) {
+void CreateTopic(
+    NActors::TTestActorRuntime& runtime,
+    const TString& path,
+    ui32 partitions = 1,
+    const TString& database = "/Root")
+{
     auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
-        runtime, MakeCreateTopicRequest(path, partitions), CreateCreateTopicActor, path);
+        runtime, MakeCreateTopicRequest(path, partitions), CreateCreateTopicActor, path, database);
     AssertStatus(result, Ydb::StatusIds::SUCCESS);
+}
+
+Ydb::Topic::DescribeTopicResult DescribeTopic(
+    NActors::TTestActorRuntime& runtime,
+    const TString& path)
+{
+    Ydb::Topic::DescribeTopicRequest request;
+    request.set_path(path);
+    auto result = DoActorRequest<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+        runtime, request, CreateDescribeTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    return GetResult<Ydb::Topic::DescribeTopicResult>(result);
+}
+
+NKikimrPQ::TPQTabletConfig DescribeTabletConfig(
+    NActors::TTestActorRuntime& runtime,
+    const TString& path,
+    const TString& database = "/Root")
+{
+    auto edge = runtime.AllocateEdgeActor();
+    runtime.Register(NPQ::NDescriber::CreateDescriberActor(edge, database, {path}));
+    auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+    UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
+    const auto& topic = response->Topics.begin()->second;
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+    return topic.Info->Description.GetPQTabletConfig();
+}
+
+void ExecuteDDL(TTopicSdkTestSetup& setup, const TString& query) {
+    NYdb::TDriver driver(setup.MakeDriverConfig());
+    NYdb::NQuery::TQueryClient client(driver);
+    auto session = client.GetSession().GetValueSync().GetSession();
+    auto res = session.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+    UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+    driver.Stop(true);
+}
+
+void MkDir(TTopicSdkTestSetup& setup, const TString& parent, const TString& name) {
+    setup.GetServer().AnnoyingClient->MkDir(parent, name);
+}
+
+void AssertDescribeAliases(
+    NActors::TTestActorRuntime& runtime,
+    const TVector<TString>& names,
+    const TString& expectedRealPath,
+    const TString& database = "/Root")
+{
+    for (const auto& name : names) {
+        auto edge = runtime.AllocateEdgeActor();
+        runtime.Register(NPQ::NDescriber::CreateDescriberActor(edge, database, {name}));
+        auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL_C(response->Topics.size(), 1u, name);
+        const auto it = response->Topics.find(name);
+        UNIT_ASSERT_C(it != response->Topics.end(), name);
+        UNIT_ASSERT_VALUES_EQUAL_C(it->second.Status, NPQ::NDescriber::EStatus::SUCCESS, name);
+        UNIT_ASSERT_VALUES_EQUAL_C(it->second.RealPath, expectedRealPath, name);
+
+        const auto describe = DescribeTopic(runtime, name);
+        UNIT_ASSERT_VALUES_EQUAL_C(describe.partitioning_settings().min_active_partitions(), 1, name);
+    }
 }
 
 THolder<TEvPQProxy::TEvPartitionLocationResponse> DoPartitionsLocationRequest(
@@ -1223,6 +1295,232 @@ Y_UNIT_TEST(AlterTopicSuccessAndMissing) {
     }
 }
 
+Y_UNIT_TEST(CreateTopicDefaultsAndIdempotentCreate) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_create_defaults";
+
+    CreateTopic(runtime, path);
+
+    const auto describe = DescribeTopic(runtime, path);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partitioning_settings().min_active_partitions(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(describe.retention_period().seconds(), TDuration::Days(1).Seconds());
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_speed_bytes_per_second(), NPQ::DEFAULT_PARTITION_SPEED);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_burst_bytes(), NPQ::DEFAULT_PARTITION_SPEED);
+    UNIT_ASSERT_VALUES_EQUAL(
+        describe.partition_write_speed_messages_per_second(),
+        NPQ::DEFAULT_PARTITION_WRITE_SPEED_MESSAGES_PER_SECOND);
+    UNIT_ASSERT_VALUES_EQUAL(
+        describe.partition_write_burst_messages(),
+        NPQ::DEFAULT_PARTITION_WRITE_SPEED_MESSAGES_PER_SECOND);
+    UNIT_ASSERT_VALUES_EQUAL(describe.consumers_size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.consumers(0).name(), "user");
+    UNIT_ASSERT(!describe.content_based_deduplication());
+    UNIT_ASSERT_VALUES_EQUAL(describe.supported_codecs().codecs_size(), 0u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.attributes().at("_partitions_per_tablet"), "1");
+
+    // gRPC CreateTopic uses IfNotExists=true, so a second create is SUCCESS.
+    auto duplicate = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        runtime, MakeCreateTopicRequest(path), CreateCreateTopicActor, path);
+    AssertStatus(duplicate, Ydb::StatusIds::SUCCESS);
+}
+
+Y_UNIT_TEST(CreateTopicWithCodecsWriteSpeedAndRetention) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_create_explicit";
+
+    auto request = MakeCreateTopicRequest(path, /*partitions=*/3);
+    request.mutable_retention_period()->set_seconds(TDuration::Hours(2).Seconds());
+    request.set_partition_write_speed_bytes_per_second(9000);
+    request.set_partition_write_burst_bytes(18000);
+    request.set_partition_write_speed_messages_per_second(111);
+    request.set_partition_write_burst_messages(222);
+    request.set_content_based_deduplication(true);
+    request.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_RAW);
+    request.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_GZIP);
+
+    auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+
+    const auto describe = DescribeTopic(runtime, path);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partitioning_settings().min_active_partitions(), 3);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partitions_size(), 3u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.retention_period().seconds(), TDuration::Hours(2).Seconds());
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_speed_bytes_per_second(), 9000u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_burst_bytes(), 18000u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_speed_messages_per_second(), 111u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_burst_messages(), 222u);
+    UNIT_ASSERT(describe.content_based_deduplication());
+    UNIT_ASSERT_VALUES_EQUAL(describe.supported_codecs().codecs_size(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.supported_codecs().codecs(0), Ydb::Topic::CODEC_RAW);
+    UNIT_ASSERT_VALUES_EQUAL(describe.supported_codecs().codecs(1), Ydb::Topic::CODEC_GZIP);
+}
+
+Y_UNIT_TEST(CreateTopicUnknownCodecRejected) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+
+    auto request = MakeCreateTopicRequest("/Root/topic_bad_codec");
+    request.mutable_supported_codecs()->add_codecs(0);
+    auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Unknown codec");
+}
+
+Y_UNIT_TEST(CreateTopicSharedConsumer) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().FeatureFlags.SetEnableTopicMessageLevelParallelism(true);
+    const TString path = "/Root/topic_shared_consumer";
+
+    auto request = MakeCreateTopicRequest(path);
+    request.mutable_consumers(0)->set_name("shared_c");
+    request.mutable_consumers(0)->mutable_shared_consumer_type()->set_keep_messages_order(true);
+    auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+
+    const auto config = DescribeTabletConfig(runtime, path);
+    const auto* consumer = NPQ::GetConsumer(config, "shared_c");
+    UNIT_ASSERT(consumer);
+    UNIT_ASSERT_VALUES_EQUAL(
+        NKikimrPQ::TPQTabletConfig::EConsumerType_Name(consumer->GetType()),
+        NKikimrPQ::TPQTabletConfig::EConsumerType_Name(NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP));
+    UNIT_ASSERT(consumer->GetKeepMessageOrder());
+}
+
+Y_UNIT_TEST(CreateTopicSharedConsumerDisabledRejected) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().FeatureFlags.SetEnableTopicMessageLevelParallelism(false);
+
+    auto request = MakeCreateTopicRequest("/Root/topic_shared_disabled");
+    request.mutable_consumers(0)->mutable_shared_consumer_type();
+    auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        runtime, request, CreateCreateTopicActor, request.path());
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "shared consumers are disabled");
+}
+
+Y_UNIT_TEST(AlterTopicAddAndDropConsumer) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter_consumers";
+    CreateTopic(runtime, path);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        auto* consumer = request.add_add_consumers();
+        consumer->set_name("extra");
+        consumer->mutable_streaming_consumer_type();
+        auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        const auto describe = DescribeTopic(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(describe.consumers_size(), 2u);
+        THashSet<TString> names;
+        for (const auto& consumer : describe.consumers()) {
+            names.insert(consumer.name());
+        }
+        UNIT_ASSERT(names.contains("user"));
+        UNIT_ASSERT(names.contains("extra"));
+    }
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.add_drop_consumers("extra");
+        auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    }
+
+    {
+        const auto describe = DescribeTopic(runtime, path);
+        UNIT_ASSERT_VALUES_EQUAL(describe.consumers_size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(describe.consumers(0).name(), "user");
+    }
+}
+
+Y_UNIT_TEST(AlterTopicWriteLimits) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/topic_alter_limits";
+    CreateTopic(runtime, path);
+
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path(path);
+    request.set_set_partition_write_speed_bytes_per_second(9000);
+    request.set_set_partition_write_burst_bytes(18000);
+    request.set_set_partition_write_speed_messages_per_second(1234);
+    request.set_set_partition_write_burst_messages(5678);
+    auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+        runtime, request, CreateAlterTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+
+    const auto describe = DescribeTopic(runtime, path);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_speed_bytes_per_second(), 9000u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_burst_bytes(), 18000u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_speed_messages_per_second(), 1234u);
+    UNIT_ASSERT_VALUES_EQUAL(describe.partition_write_burst_messages(), 5678u);
+}
+
+Y_UNIT_TEST(CannotChangeConsumerType) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().FeatureFlags.SetEnableTopicMessageLevelParallelism(true);
+    const TString path = "/Root/topic_type_change";
+    CreateTopic(runtime, path);
+
+    Ydb::Topic::AlterTopicRequest request;
+    request.set_path(path);
+    auto* alter = request.add_alter_consumers();
+    alter->set_name("user");
+    alter->mutable_alter_shared_consumer_type();
+    auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+        runtime, request, CreateAlterTopicActor, path);
+    AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Cannot alter consumer type");
+}
+
+Y_UNIT_TEST(AlterCdcAllowsRetentionAndWriteLimits) {
+    auto setup = CreateSetup();
+    ExecuteDDL(*setup, "CREATE TABLE table_cdc (id Uint64, PRIMARY KEY (id))");
+    ExecuteDDL(*setup, "ALTER TABLE table_cdc ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+
+    auto& runtime = setup->GetRuntime();
+    const TString path = "/Root/table_cdc/feed";
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        request.set_set_retention_storage_mb(100);
+        request.set_set_partition_write_speed_bytes_per_second(9000);
+        request.set_set_partition_write_burst_bytes(100500);
+        auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::SUCCESS);
+    }
+
+    const auto& partConfig = DescribeTabletConfig(runtime, path).GetPartitionConfig();
+    UNIT_ASSERT_VALUES_EQUAL(partConfig.GetStorageLimitBytes(), 100_MB);
+    UNIT_ASSERT_VALUES_EQUAL(partConfig.GetWriteSpeedInBytesPerSecond(), 9000u);
+    UNIT_ASSERT_VALUES_EQUAL(partConfig.GetBurstSize(), 100500u);
+
+    {
+        Ydb::Topic::AlterTopicRequest request;
+        request.set_path(path);
+        (*request.mutable_alter_attributes())["_allowed_codecs"] = "RAW";
+        auto result = DoActorRequest<Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+            runtime, request, CreateAlterTopicActor, path);
+        AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "Full alter of cdc stream is forbidden");
+    }
+}
+
 Y_UNIT_TEST(UnauthenticatedRejectedWhenRequired) {
     auto setup = CreateSetup();
     auto& runtime = setup->GetRuntime();
@@ -1232,6 +1530,81 @@ Y_UNIT_TEST(UnauthenticatedRejectedWhenRequired) {
     auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
         runtime, request, CreateCreateTopicActor, request.path());
     AssertStatus(result, Ydb::StatusIds::UNAUTHORIZED, "Unauthenticated access is forbidden");
+}
+
+Y_UNIT_TEST(FccTopicNameFormatsCreateAndDescribeAliases) {
+    auto setup = CreateSetup("TopicNameFormatsFcc");
+    auto& runtime = setup->GetRuntime();
+
+    MkDir(*setup, "/Root", "fcclegacy");
+    MkDir(*setup, "/Root", "fccmodern");
+    MkDir(*setup, "/Root", "fccshort");
+
+    const TVector<TString> legacyAliases = {
+        "rt3.dc1--fcclegacy--topic",
+        "fcclegacy--topic",
+        "fcclegacy/topic",
+        "/Root/fcclegacy/topic",
+    };
+    CreateTopic(runtime, "rt3.dc1--fcclegacy--topic");
+    AssertDescribeAliases(runtime, legacyAliases, "/Root/fcclegacy/topic");
+
+    const TVector<TString> modernAliases = {
+        "rt3.dc1--fccmodern--topic",
+        "fccmodern--topic",
+        "fccmodern/topic",
+        "/Root/fccmodern/topic",
+    };
+    CreateTopic(runtime, "fccmodern/topic");
+    AssertDescribeAliases(runtime, modernAliases, "/Root/fccmodern/topic");
+
+    const TVector<TString> shortAliases = {
+        "rt3.dc1--fccshort--topic",
+        "fccshort--topic",
+        "fccshort/topic",
+        "/Root/fccshort/topic",
+    };
+    CreateTopic(runtime, "fccshort--topic");
+    AssertDescribeAliases(runtime, shortAliases, "/Root/fccshort/topic");
+}
+
+Y_UNIT_TEST(FederationTopicNameFormats) {
+    auto setup = CreateSetup("TopicNameFormatsFed");
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+
+    {
+        auto request = MakeCreateTopicRequest("fedshort--topic");
+        auto result = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+            runtime, request, CreateCreateTopicActor, request.path());
+        AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "expected legacy-style name");
+    }
+
+    CreateTopic(runtime, "rt3.dc1--fedleaf--topic");
+    AssertDescribeAliases(
+        runtime,
+        {"/Root/rt3.dc1--fedleaf--topic"},
+        "/Root/rt3.dc1--fedleaf--topic");
+
+    runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbCommunal");
+    MkDir(*setup, "/Root", "LbCommunal");
+    MkDir(*setup, "/Root/LbCommunal", "account");
+
+    auto modern = MakeCreateTopicRequest("/Root/LbCommunal/account/fedtopic");
+    (*modern.mutable_attributes())["_federation_account"] = "account";
+    auto modernResult = DoActorRequest<Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        runtime, modern, CreateCreateTopicActor, modern.path(), "/Root/LbCommunal/account");
+    AssertStatus(modernResult, Ydb::StatusIds::SUCCESS);
+
+    AssertDescribeAliases(
+        runtime,
+        {
+            "rt3.dc1--account--fedtopic",
+            "account--fedtopic",
+            "account/fedtopic",
+            "/Root/LbCommunal/account/fedtopic",
+        },
+        "/Root/LbCommunal/account/fedtopic");
 }
 
 } // Y_UNIT_TEST_SUITE(SchemaOps_TopicAPI)

--- a/ydb/services/persqueue_v1/actors/schema/topic/ut/ya.make
+++ b/ydb/services/persqueue_v1/actors/schema/topic/ut/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     ydb/core/testlib/actors
     ydb/core/testlib/grpc_request
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
+    ydb/public/sdk/cpp/src/client/query
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
     library/cpp/testing/unittest
     library/cpp/threading/future


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

None (tests only).

### Description for reviewers <!-- (optional) description for those who read this PR -->

Freeze current Topic API and PQv1 schema ops before the refactor. Tests are split by API.

**Topic API** (`actors/schema/topic/schema_ops_ut.cpp`): create/alter/drop/describe defaults, codecs, retention, write limits, shared consumers, CDC alter (retention/write allowed, full alter forbidden).

**PQv1** (`actors/schema/pqv1/schema_ops_ut.cpp`, `describe_topic_sdk_ut.cpp`): the same surface plus PQv1-only rules (required retention, consumer codecs must cover topic codecs, CDC full alter forbidden).

**Topic names** in both suites:
- FCC: create via legacy (`rt3.dc1--account--topic`), modern (`account/topic`), and short (`account--topic`); describe by all aliases
- Federation: short create in pqRoot is rejected; full legacy creates a pqRoot leaf; modern path with `_federation_account` is described by legacy, short, and modern names

Frozen surprises worth keeping:
- gRPC CreateTopic uses `IfNotExists=true`, so a second create is `SUCCESS`, not `ALREADY_EXISTS`
- If a topic has codecs, each consumer must include every topic codec
- Topic API CDC: retention/write limits are allowed; PQv1 forbids a full CDC alter

## Test plan
- [x] `./ya make --build relwithdebinfo -tA ydb/services/persqueue_v1/actors/schema/topic`
- [x] `./ya make --build relwithdebinfo -tA ydb/services/persqueue_v1/actors/schema/pqv1`
- [x] `./ya make --build relwithdebinfo -tA ydb/services/persqueue_v1/actors/schema/topic -F *TopicNameFormats*`
- [x] `./ya make --build relwithdebinfo -tA ydb/services/persqueue_v1/actors/schema/pqv1 -F *TopicNameFormats*`