### PR TITLE
Improve ydb-bench topology UI

### DIFF
--- a/ydb/tools/ydb_bench/lib/topology.py
+++ b/ydb/tools/ydb_bench/lib/topology.py
@@ -1,8 +1,10 @@
 import os
+import plistlib
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-
 
 AFFINITY_MODES = (
     "none",
@@ -29,6 +31,7 @@ class CpuTopology:
     physical_cores: tuple = ()
     smt_siblings: tuple = ()
     hierarchy_reasons: tuple = ()
+    chiplet_labels: tuple = ()
     # A non-empty value means the discovered L3 groups cannot safely drive a
     # chiplet-aware placement.  The raw hierarchy remains useful for display,
     # while plan_affinity() rejects only modes which rely on this level.
@@ -93,10 +96,82 @@ def _allowed_cpus():
     return tuple(range(os.cpu_count() or 1))
 
 
+def _device_tree_integer(value):
+    if isinstance(value, int):
+        return value
+    if isinstance(value, bytes) and value:
+        return int.from_bytes(value, byteorder="little")
+    return None
+
+
+def _parse_darwin_topology(data, allowed):
+    try:
+        roots = plistlib.loads(data)
+        entries = roots[0]["IORegistryEntryChildren"]
+    except (IndexError, KeyError, TypeError, ValueError, plistlib.InvalidFileException):
+        return None
+
+    allowed_set = set(allowed)
+    cpus = []
+    for entry in entries:
+        cpu = _device_tree_integer(entry.get("logical-cpu-id"))
+        cluster = _device_tree_integer(entry.get("cluster-id"))
+        cluster_type = entry.get("cluster-type")
+        if isinstance(cluster_type, bytes):
+            cluster_type = cluster_type.rstrip(b"\0").decode("ascii", errors="replace")
+        if cpu in allowed_set and cluster is not None and cluster_type in ("E", "P"):
+            cpus.append((cpu, cluster, cluster_type))
+    if {cpu for cpu, _, _ in cpus} != allowed_set:
+        return None
+
+    groups = {}
+    for cpu, cluster, cluster_type in cpus:
+        groups.setdefault((cluster, cluster_type), []).append(cpu)
+    ordered_groups = sorted(groups.items())
+    type_counts = {kind: sum(1 for (_, current), _ in ordered_groups if current == kind) for kind in ("E", "P")}
+    type_indexes = {"E": 0, "P": 0}
+    labels = []
+    chiplets = []
+    for (_, kind), group_cpus in ordered_groups:
+        type_indexes[kind] += 1
+        name = "Efficiency" if kind == "E" else "Performance"
+        suffix = " {}".format(type_indexes[kind]) if type_counts[kind] > 1 else ""
+        group = tuple(sorted(group_cpus))
+        chiplets.append((0, group))
+        labels.append((group, "{} cluster{}".format(name, suffix)))
+    cores = tuple((cpu,) for cpu in allowed)
+    return CpuTopology(
+        allowed_cpus=allowed,
+        numa_nodes=((0, allowed),),
+        chiplets=tuple(chiplets),
+        physical_cores=cores,
+        smt_siblings=cores,
+        hierarchy_reasons=(("numa", "macOS does not expose NUMA placement; using package 0"),),
+        chiplet_labels=tuple(labels),
+    )
+
+
+def _discover_darwin_topology(allowed):
+    try:
+        result = subprocess.run(
+            ("ioreg", "-a", "-l", "-p", "IODeviceTree", "-r", "-n", "cpus"),
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return _parse_darwin_topology(result.stdout, allowed)
+
+
 def discover_topology(sys_root=Path("/sys/devices/system"), allowed_cpus=None):
     sys_root = Path(sys_root)
     allowed = tuple(sorted(set(_allowed_cpus() if allowed_cpus is None else allowed_cpus)))
     allowed_set = set(allowed)
+
+    if sys.platform == "darwin" and sys_root == Path("/sys/devices/system"):
+        darwin_topology = _discover_darwin_topology(allowed)
+        if darwin_topology is not None:
+            return darwin_topology
 
     reasons = []
     nodes = []
@@ -163,18 +238,14 @@ def discover_topology(sys_root=Path("/sys/devices/system"), allowed_cpus=None):
 
     chiplets = []
     for cpus in sorted(chiplet_sets):
-        node_ids = tuple(
-            node_id for node_id, node_cpus in nodes if set(cpus).issubset(node_cpus)
-        )
+        node_ids = tuple(node_id for node_id, node_cpus in nodes if set(cpus).issubset(node_cpus))
         if len(node_ids) != 1:
             # The chiplet record has a NUMA-node identifier, so assigning this
             # group to the node of its first CPU would fabricate a hierarchy.
             # Keep chiplet-based modes unavailable until this topology is
             # understood; NUMA-only modes do not rely on the L3 grouping.
             chiplet_topology_reasons.append(
-                "L3 cache group {} does not belong to exactly one NUMA node".format(
-                    ", ".join(str(cpu) for cpu in cpus)
-                )
+                "L3 cache group {} does not belong to exactly one NUMA node".format(", ".join(str(cpu) for cpu in cpus))
             )
             continue
         node_id = node_ids[0]
@@ -190,8 +261,11 @@ def discover_topology(sys_root=Path("/sys/devices/system"), allowed_cpus=None):
         topology_root = sys_root / "cpu" / "cpu{}".format(cpu) / "topology"
         package_id = _read_int(topology_root / "physical_package_id")
         core_id = _read_int(topology_root / "core_id")
-        siblings = tuple(candidate for candidate in _read_cpu_list(topology_root / "thread_siblings_list")
-                         if candidate in allowed_set)
+        siblings = tuple(
+            candidate
+            for candidate in _read_cpu_list(topology_root / "thread_siblings_list")
+            if candidate in allowed_set
+        )
         if not siblings or cpu not in siblings:
             incomplete_smt_data = True
             siblings = (cpu,)
@@ -218,7 +292,9 @@ def discover_topology(sys_root=Path("/sys/devices/system"), allowed_cpus=None):
         # conservative and can never merge two distinct physical cores.
         core_groups.setdefault(key if key is not None else ("cpu", cpu), []).append(cpu)
     if incomplete_core_data:
-        reasons.append(("physical_core", "physical_package_id or core_id is unavailable; affected CPUs are singleton cores"))
+        reasons.append(
+            ("physical_core", "physical_package_id or core_id is unavailable; affected CPUs are singleton cores")
+        )
     if incomplete_smt_data:
         reasons.append(("smt", "thread_siblings_list is incomplete; affected CPUs are singleton SMT groups"))
 
@@ -332,9 +408,7 @@ def plan_affinity(mode, topology, required_cpus):
     if policy.get("chiplet") and topology.chiplet_topology_reason:
         return _unsupported(
             mode,
-            "chiplet-based affinity is unavailable: {}".format(
-                topology.chiplet_topology_reason
-            ),
+            "chiplet-based affinity is unavailable: {}".format(topology.chiplet_topology_reason),
         )
     numa_nodes = [cpus for _, cpus in topology.numa_nodes if cpus]
     if policy.get("numa") == "spread" and len(numa_nodes) < 2:
@@ -389,14 +463,8 @@ def plan_background_load(mode, topology, foreground_cpus, foreground_threads):
         groups = tuple((cpu,) for cpu in representatives)
         return BackgroundPlacement(mode=mode, cpus=tuple(representatives), groups=groups, workers=len(groups))
 
-    cpu_to_node = {
-        cpu: node_id for node_id, cpus in topology.numa_nodes for cpu in cpus
-    }
-    cpu_to_chiplet = {
-        cpu: (node_id, index)
-        for index, (node_id, cpus) in enumerate(topology.chiplets)
-        for cpu in cpus
-    }
+    cpu_to_node = {cpu: node_id for node_id, cpus in topology.numa_nodes for cpu in cpus}
+    cpu_to_chiplet = {cpu: (node_id, index) for index, (node_id, cpus) in enumerate(topology.chiplets) for cpu in cpus}
     groups = []
     if mode == "coherence-chiplet":
         by_chiplet = {}
@@ -435,18 +503,20 @@ def plan_background_load(mode, topology, foreground_cpus, foreground_threads):
 
 
 def topology_record(topology):
+    chiplet_labels = dict(topology.chiplet_labels)
     return {
         "version": topology.version,
         "allowed_cpus": list(topology.allowed_cpus),
-        "numa_nodes": [
-            {"id": node_id, "cpus": list(cpus)} for node_id, cpus in topology.numa_nodes
-        ],
+        "numa_nodes": [{"id": node_id, "cpus": list(cpus)} for node_id, cpus in topology.numa_nodes],
         "chiplets": [
-            {"numa_node": node_id, "cpus": list(cpus)} for node_id, cpus in topology.chiplets
+            {
+                "numa_node": node_id,
+                "cpus": list(cpus),
+                **({"label": chiplet_labels[cpus]} if cpus in chiplet_labels else {}),
+            }
+            for node_id, cpus in topology.chiplets
         ],
         "physical_cores": [list(cpus) for cpus in topology.physical_cores],
         "smt_siblings": [list(cpus) for cpus in topology.smt_siblings],
-        "hierarchy_reasons": [
-            {"level": level, "reason": reason} for level, reason in topology.hierarchy_reasons
-        ],
+        "hierarchy_reasons": [{"level": level, "reason": reason} for level, reason in topology.hierarchy_reasons],
     }

--- a/ydb/tools/ydb_bench/lib/topology.py
+++ b/ydb/tools/ydb_bench/lib/topology.py
@@ -112,7 +112,7 @@ def _parse_darwin_topology(data, allowed):
         return None
 
     allowed_set = set(allowed)
-    cpus = []
+    cpus = {}
     for entry in entries:
         cpu = _device_tree_integer(entry.get("logical-cpu-id"))
         cluster = _device_tree_integer(entry.get("cluster-id"))
@@ -120,12 +120,15 @@ def _parse_darwin_topology(data, allowed):
         if isinstance(cluster_type, bytes):
             cluster_type = cluster_type.rstrip(b"\0").decode("ascii", errors="replace")
         if cpu in allowed_set and cluster is not None and cluster_type in ("E", "P"):
-            cpus.append((cpu, cluster, cluster_type))
-    if {cpu for cpu, _, _ in cpus} != allowed_set:
+            placement = (cluster, cluster_type)
+            if cpu in cpus and cpus[cpu] != placement:
+                return None
+            cpus[cpu] = placement
+    if set(cpus) != allowed_set:
         return None
 
     groups = {}
-    for cpu, cluster, cluster_type in cpus:
+    for cpu, (cluster, cluster_type) in cpus.items():
         groups.setdefault((cluster, cluster_type), []).append(cpu)
     ordered_groups = sorted(groups.items())
     type_counts = {kind: sum(1 for (_, current), _ in ordered_groups if current == kind) for kind in ("E", "P")}
@@ -157,8 +160,9 @@ def _discover_darwin_topology(allowed):
             ("ioreg", "-a", "-l", "-p", "IODeviceTree", "-r", "-n", "cpus"),
             check=True,
             capture_output=True,
+            timeout=10,
         )
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return _parse_darwin_topology(result.stdout, allowed)
 

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -79,11 +79,18 @@ _CSS = (
     'monospace;overflow-wrap:anywhere}.topology-map{display:grid;grid-template-columns:repeat(auto-fit,minmax(18rem,1fr));gap'
     ':.8rem}.numa-block{border:1px solid #c9c1ff;border-left:4px solid var(--topology-accent);border-radius:6px;background:#f'
     '8f7ff;padding:.75rem}.numa-header{display:flex;align-items:baseline;justify-content:space-between;gap:.5rem;margin-botto'
-    'm:.5rem}.chiplet-list{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.65rem}.cpu-block{border:1px solid #c9c1ff;border'
-    '-radius:4px;background:#fff;padding:.35rem .45rem;min-width:5.5rem}.cpu-block small{display:block;color:var(--muted);fon'
-    't-size:.75rem}.topology-level{margin-top:1rem}.topology-level summary{cursor:pointer;font-weight:650}.cpu-block-grid{dis'
-    'play:grid;grid-template-columns:repeat(auto-fit,minmax(8rem,1fr));gap:.45rem;margin-top:.65rem}.cpu-block-grid .cpu-bloc'
-    'k{border-color:#d0d5dd}.affinity-mask{min-width:12rem}.affinity-mask code{white-space:normal;overflow-wrap:anywhere}.cha'
+    'm:.5rem}.topology-tree,.topology-tree ul,.affinity-tree,.affinity-tree ul{list-style:none;margin:.45rem 0 0;padding-l'
+    'eft:1.1rem}.topology-tree>li,.affinity-tree>li{padding-left:0}.topology-tree li,.affinity-tree li{position:relative;ma'
+    'rgin:.35rem 0}.topology-tree li:before,.affinity-tree li:before{content:"";position:absolute;left:-.75rem;top:.72rem;wi'
+    'dth:.55rem;border-top:1px solid #b8b0ec}.topology-node{border:1px solid #d9d6f5;border-radius:5px;background:#fff;paddin'
+    'g:.4rem .55rem}.topology-node-header{display:flex;align-items:baseline;justify-content:space-between;gap:.6rem}.core-list'
+    '{display:grid;grid-template-columns:repeat(auto-fit,minmax(10rem,1fr));gap:.4rem}.core-item{border:1px solid #e4e7ec;bo'
+    'rder-radius:4px;padding:.35rem .45rem;background:#fff}.core-item .cpu-ranges,.core-item small{display:block}.core-item sm'
+    'all{color:var(--muted)}.affinity-tree{pa'
+    'dding-left:.25rem}.affinity-node{display:flex;align-items:center;gap:.55rem;flex-wrap:wrap}.affinity-unavailable{color:var'
+    '(--muted)}.availability-badge{font-size:.75rem;font-weight:650;color:var(--bad);b'
+    'ackground:#fff0f0;border:1px solid #fecdca;border-radius:999px;padding:.1rem .4rem}.affinity-reason{font-size:.85rem;co'
+    'lor:var(--bad)}.cha'
     'rt-controls{display:grid;grid-template-columns:repeat(auto-fit,minmax(12rem,1fr));gap:.75rem}.series-picker{max-height:1'
     '5rem;overflow:auto;border:1px solid #d0d5dd;border-radius:5px;padding:.55rem}.series-picker label{display:block;margin:.'
     '25rem 0}.series-cpus{display:block;margin-left:1.35rem;color:var(--muted);font:12px ui-monospace,SFMono-Regular,Menlo,mo'
@@ -669,41 +676,51 @@ _JS = (
     "  }catch(error){app.innerHTML=shell('runs',breadcrumbs([{route:'runs',label:'Runs'},{route:'run/'+enc(id),label:id}])+di"
     'splayError(error))}\n'
     '}\n'
-    "function cpuBlock(label,index,cpus){return '<div class=cpu-block><small>'+esc(label)+' '+(index+1)+'</small><span class="
-    "cpu-ranges>'+esc(cpuRanges(cpus))+'</span></div>'}\n"
+    'function affinityPath(mode){if(mode===\'none\')return [\'No pinning\'];const parts=mode.split(\'-\'),result=[],labels={num'
+    "a:'NUMA',chiplet:'Chiplet',core:'Core'};for(let index=0;index<parts.length;index+=2)result.push(labels[parts[index+1]]+'"
+    ": '+parts[index]);return result}\n"
+    'function affinityTree(items){const root={children:new Map};for(const item of items){let node=root;for(const label of affi'
+    'nityPath(item.mode)){if(!node.children.has(label))node.children.set(label,{children:new Map,item:null});node=node.childr'
+    "en.get(label)}node.item=item}const render=node=>'<ul class=affinity-tree>'+[...node.children.entries()].map(([label,chi"
+    "ld])=>{const item=child.item,unavailable=item&&!item.supported;return '<li><div class=\"affinity-node '+(unavailable?'af"
+    "finity-unavailable':'')+'\"><strong>'+esc(label)+'</strong>'+(item?'<code>'+esc(item.mode)+'</code>':'')+(unavailable?"
+    "'<span class=availability-badge>Unavailable</span><span class=affinity-reason>'+esc(item.reason||'Not supported by thi"
+    "s topology.')+'</span>':'')+'</div>'+(child.ch"
+    "ildren.size?render(child):'')+'</li>'}).join('')+'</ul>';return render(root)}\n"
     'async function renderTopology(){\n'
     '  clearRefresh();\n'
     '  try{\n'
     "    const value=await api('/api/system-topology'),topology=value.topology;\n"
-    '    const chipletsByNode=new Map;\n'
+    '    const chipletsByNode=new Map,coreIndex=new Map,siblingsByCpu=new Map;\n'
     '    for(const chiplet of topology.chiplets)chipletsByNode.set(chiplet.numa_node,[...(chipletsByNode.get(chiplet.numa_nod'
     'e)||[]),chiplet]);\n'
+    '    topology.physical_cores.forEach((cpus,index)=>cpus.forEach(cpu=>coreIndex.set(cpu,{index,cpus})));for(const siblings '
+    'of topology.smt_siblings)for(const cpu of siblings)siblingsByCpu.set(cpu,siblings);\n'
+    '    const coresFor=cpus=>{const allowed=new Set(cpus),seen=new Set,result=[];for(const cpu of cpus){const core=coreIndex.'
+    'get(cpu);if(!core||seen.has(core.index))continue;seen.add(core.index);const visible=core.cpus.filter(item=>allowed.has(it'
+    'em)),siblings=[...new Set(visible.flatMap(item=>siblingsByCpu.get(item)||[item]))].filter(item=>allowed.has(item));resu'
+    'lt.push({...core,cpus:visible,siblings})}return result};\n'
+    "    const coreList=cpus=>'<ul class=core-list>'+coresFor(cpus).map(core=>'<li class=core-item><strong>Core '+core.index"
+    "+'</strong><span class=cpu-ranges>vCPU '+esc(cpuRanges(core.cpus))+'</span><small>'+(core.siblings.length>1?core.si"
+    "blings.length+' SMT threads':'1 hardware thread')+'</small></li>').join('')+'</ul>';\n"
     '    const numaBlocks=topology.numa_nodes.map(node=>{\n'
     '      const chiplets=chipletsByNode.get(node.id)||[];\n'
-    "      return '<article class=numa-block><div class=numa-header><strong>NUMA '+esc(node.id)+'</strong><small class=muted>"
-    "'+node.cpus.length+' CPUs</small></div><div class=cpu-ranges>'+esc(cpuRanges(node.cpus))+'</div>'+(chiplets.length?'<div"
-    " class=chiplet-list>'+chiplets.map((chiplet,index)=>'<div class=cpu-block><small>L3 / chiplet '+(index+1)+'</small><span"
-    " class=cpu-ranges>'+esc(cpuRanges(chiplet.cpus))+'</span></div>').join('')+'</div>':'')+'</article>'\n"
+    "      const children=chiplets.length?chiplets.map((chiplet,index)=>'<li><div class=topology-node><div class=topology-no"
+    "de-header><strong>'+esc(chiplet.label||'L3 / chiplet '+(index+1))+'</strong><span class=cpu-ranges>CPU '+esc(cpuRanges(chiplet.cpus))+'</span></"
+    "div>'+coreList(chiplet.cpus)+'</div></li>').join(''):'<li><div class=topology-node>'+coreList(node.cpus)+'</div></li>';"
+    "return '<article class=numa-block><div class=numa-header><strong>NUMA '+esc(node.id)+'</strong><small class=muted>'+node"
+    ".cpus.length+' CPUs</small></div><div class=cpu-ranges>CPU '+esc(cpuRanges(node.cpus))+'</div><ul class=topology-tree>'"
+    "+children+'</ul></article>'\n"
     "    }).join('');\n"
-    "    const blocks=(label,groups)=>groups.map((cpus,index)=>cpuBlock(label,index,cpus)).join('');\n"
     "    let content='<h1 class=page-title>System topology</h1><p class=muted>Only CPUs allowed by this process cpuset are sh"
     'own. Unsupported modes are never silently substituted.</p><section class="card topology-summary"><div><div class=metric>'
     "'+topology.allowed_cpus.length+' allowed CPUs</div><div class=muted>Compressed CPU ranges</div></div><div class=cpu-rang"
-    "es>'+esc(cpuRanges(topology.allowed_cpus))+'</div></section><section class=card><h2>NUMA and cache layout</h2><div class"
-    "=topology-map>'+numaBlocks+'</div></section><section class=card topology-level><details><summary>Physical cores ('+topol"
-    "ogy.physical_cores.length+')</summary><div class=cpu-block-grid>'+blocks('Core',topology.physical_cores)+'</div></detail"
-    "s></section><section class=card topology-level><details><summary>SMT sibling sets ('+topology.smt_siblings.length+')</su"
-    "mmary><div class=cpu-block-grid>'+blocks('SMT set',topology.smt_siblings)+'</div></details></section><section class=card"
-    "><h2>Affinity availability</h2><table><tr><th>Mode</th><th>Status</th><th>First mask</th><th>Reason</th><th></th></tr>'+"
-    "value.affinity.map(item=>'<tr><td><code>'+esc(item.mode)+'</code></td><td>'+status(item.supported?'passed':'unsupported'"
-    ")+'</td><td class=affinity-mask><code>'+esc(cpuRanges(item.cpus))+'</code></td><td>'+esc(item.reason||'')+'</td><td><but"
-    'ton data-mode="\'+esc(item.mode)+\'">Use in new run</button></td></tr>\').join(\'\')+\'</table></section>\'+(topology.hierarchy'
+    "es>'+esc(cpuRanges(topology.allowed_cpus))+'</div></section><section class=card><h2>NUMA, cache and cores</h2><p cla"
+    "ss=muted>Physical cores include their visible SMT thread count.</p><div class=topology-map>'+numaBlocks+'</div></section"
+    "><section class=card><h2>Affinity availability</h2>'+affinityTree(value.affinity)+'</section>'+(topology.hierarchy"
     "_reasons.length?'<section class=card><h2>Topology notes</h2><ul>'+topology.hierarchy_reasons.map(item=>'<li><strong>'+es"
     "c(item.level)+':</strong> '+esc(item.reason)+'</li>').join('')+'</ul></section>':'');\n"
     "    app.innerHTML=shell('topology',content);\n"
-    "    for(const button of document.querySelectorAll('[data-mode]'))button.onclick=()=>{const mode=button.dataset.mode;edit"
-    "or.yaml='ping-bench:\\n  topology-template:\\n    threads: [1]\\n    duration: 3\\n    repetitions: 1\\n    affinity: ['+mode"
-    "+']\\n';editor.selected=null;saveDraft();setRoute('new')}\n"
     "  }catch(error){app.innerHTML=shell('topology',displayError(error))}\n"
     '}\n'
     'async function renderComparisons(){\n'

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -677,7 +677,7 @@ _JS = (
     'splayError(error))}\n'
     '}\n'
     'function affinityPath(mode){if(mode===\'none\')return [\'No pinning\'];const parts=mode.split(\'-\'),result=[],labels={num'
-    "a:'NUMA',chiplet:'Chiplet',core:'Core'};for(let index=0;index<parts.length;index+=2)result.push(labels[parts[index+1]]+'"
+    "a:'NUMA',chiplet:'Chiplet',core:'Core'};for(let index=0;index<parts.length;index+=2)result.push((labels[parts[index+1]]||parts[index+1])+'"
     ": '+parts[index]);return result}\n"
     'function affinityTree(items){const root={children:new Map};for(const item of items){let node=root;for(const label of affi'
     'nityPath(item.mode)){if(!node.children.has(label))node.children.set(label,{children:new Map,item:null});node=node.childr'

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3,6 +3,7 @@ import inspect
 import io
 import json
 import os
+import plistlib
 import shutil
 import signal
 import socket
@@ -44,6 +45,7 @@ from ydb.tools.ydb_bench.lib.results import ResultStore, SCHEMA_VERSION, load_ma
 from ydb.tools.ydb_bench.lib.runner import run_command
 from ydb.tools.ydb_bench.lib.topology import (
     CpuTopology,
+    _parse_darwin_topology,
     discover_topology,
     parse_cpu_list,
     plan_affinity,
@@ -1214,6 +1216,34 @@ class YdbBenchTest(unittest.TestCase):
     def test_cpu_list_parser(self):
         self.assertEqual(parse_cpu_list("0-3,8,10-11\n"), (0, 1, 2, 3, 8, 10, 11))
 
+    def test_darwin_topology_uses_device_tree_clusters(self):
+        entries = []
+        for cpu, cluster, kind in ((0, 0, "E"), (1, 0, "E"), (2, 1, "P"), (3, 1, "P"), (4, 2, "P")):
+            entries.append(
+                {
+                    "logical-cpu-id": cpu,
+                    "cluster-id": cluster.to_bytes(4, byteorder="little"),
+                    "cluster-type": kind.encode("ascii") + b"\0",
+                }
+            )
+        topology = _parse_darwin_topology(
+            plistlib.dumps([{"IORegistryEntryChildren": entries}]),
+            (0, 1, 2, 3, 4),
+        )
+
+        self.assertEqual(topology.chiplets, ((0, (0, 1)), (0, (2, 3)), (0, (4,))))
+        self.assertEqual(
+            topology.chiplet_labels,
+            (
+                ((0, 1), "Efficiency cluster"),
+                ((2, 3), "Performance cluster 1"),
+                ((4,), "Performance cluster 2"),
+            ),
+        )
+        self.assertEqual(topology.physical_cores, ((0,), (1,), (2,), (3,), (4,)))
+        self.assertEqual(topology.smt_siblings, topology.physical_cores)
+        self.assertEqual(topology_record(topology)["chiplets"][0]["label"], "Efficiency cluster")
+
     def test_topology_discovery_intersects_sysfs_with_allowed_cpus(self):
         sys_root = self.root / "sys" / "devices" / "system"
         for node_id, cpus in ((0, "0-3"), (1, "4-7")):
@@ -1934,6 +1964,18 @@ class WebTest(unittest.TestCase):
             with urllib.request.urlopen(base + "/app.js") as response:
                 script = response.read()
                 self.assertIn(b"System topology", script)
+                self.assertIn(b"NUMA, cache and cores", script)
+                self.assertIn(b"function affinityTree", script)
+                self.assertIn(b"class=affinity-tree", script)
+                self.assertIn(b"SMT threads", script)
+                self.assertIn(b"<span class=cpu-ranges>vCPU ", script)
+                self.assertNotIn(b"(core.index+1)", script)
+                self.assertIn(b"Unavailable", script)
+                self.assertNotIn(b"Use in new run", script)
+                self.assertNotIn(b"data-mode", script)
+                self.assertNotIn(b"<th>First mask</th>", script)
+                self.assertNotIn(b"Physical cores (", script)
+                self.assertNotIn(b"SMT sibling sets (", script)
                 self.assertIn(b"New run", script)
                 self.assertIn(b"<th>Duration</th>", script)
                 self.assertIn(b"<th>Runs</th>", script)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -22,7 +22,7 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from unittest import mock
 
-from ydb.tools.ydb_bench.lib import actors_core, cli, import_results, runner, web
+from ydb.tools.ydb_bench.lib import actors_core, cli, import_results, runner, topology, web
 from ydb.tools.ydb_bench.lib.actors_core import (
     PING_BENCHMARK,
     STAR_PING_BENCHMARK,
@@ -1226,6 +1226,7 @@ class YdbBenchTest(unittest.TestCase):
                     "cluster-type": kind.encode("ascii") + b"\0",
                 }
             )
+        entries.append(entries[0].copy())
         topology = _parse_darwin_topology(
             plistlib.dumps([{"IORegistryEntryChildren": entries}]),
             (0, 1, 2, 3, 4),
@@ -1243,6 +1244,29 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(topology.physical_cores, ((0,), (1,), (2,), (3,), (4,)))
         self.assertEqual(topology.smt_siblings, topology.physical_cores)
         self.assertEqual(topology_record(topology)["chiplets"][0]["label"], "Efficiency cluster")
+
+    def test_darwin_topology_rejects_conflicting_cpu_entries(self):
+        entries = [
+            {"logical-cpu-id": 0, "cluster-id": 0, "cluster-type": b"E\0"},
+            {"logical-cpu-id": 0, "cluster-id": 1, "cluster-type": b"P\0"},
+        ]
+
+        self.assertIsNone(
+            _parse_darwin_topology(
+                plistlib.dumps([{"IORegistryEntryChildren": entries}]),
+                (0,),
+            )
+        )
+
+    def test_darwin_topology_discovery_times_out(self):
+        with mock.patch.object(
+            topology.subprocess,
+            "run",
+            side_effect=topology.subprocess.TimeoutExpired("ioreg", 10),
+        ) as run:
+            self.assertIsNone(topology._discover_darwin_topology((0,)))
+
+        self.assertEqual(run.call_args.kwargs["timeout"], 10)
 
     def test_topology_discovery_intersects_sysfs_with_allowed_cpus(self):
         sys_root = self.root / "sys" / "devices" / "system"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improved ydb-bench topology visualization and added accurate Apple Silicon CPU cluster discovery.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The topology page now presents affinity modes and NUMA/cache/core relationships as compact trees, while macOS topology discovery reads Performance and Efficiency clusters from the Apple Device Tree.
