### PR TITLE
[NBS-7486] Persist dirty map state

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -306,6 +306,16 @@ size_t TBaseFixture::ReplyUpdateRequests()
     return requests.size();
 }
 
+size_t TBaseFixture::ReplyUpdateDirtyMapStateRequests()
+{
+    auto requests =
+        std::move(PartitionDirectService->UpdateDirtyMapStateRequests);
+    for (auto& r: requests) {
+        r.Promise.SetValue();
+    }
+    return requests.size();
+}
+
 template <typename T>
 void TBaseFixture::SetResult(
     TVector<NThreading::TPromise<T>>& promises,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -101,6 +101,7 @@ struct TBaseFixture: public NUnitTest::TBaseFixture
     bool WaitEraseRequests(size_t count, TDuration timeout);
 
     size_t ReplyUpdateRequests();
+    size_t ReplyUpdateDirtyMapStateRequests();
 
     static auto& AccessBlocksDirtyMap(TVChunk& vchunk)
     {
@@ -115,6 +116,17 @@ struct TBaseFixture: public NUnitTest::TBaseFixture
     static bool IsDirtyMapReady(TVChunk& vchunk)
     {
         return vchunk.DirtyMapReady.HasValue();
+    }
+
+    static bool IsDirtyMapStatePersisting(TVChunk& vchunk)
+    {
+        return vchunk.DirtyMapStatePersisting;
+    }
+
+    // Must be invoked on the vchunk's executor thread.
+    static void InvokePersistDirtyMap(TVChunk& vchunk)
+    {
+        vchunk.DoPersistDirtyMap();
     }
 
     static auto& AccessDirtyMapReadyPromise(TVChunk& vchunk)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.cpp
@@ -1,5 +1,7 @@
 #include "ddisk_state.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+
 #include <util/string/builder.h>
 #include <util/string/cast.h>
 
@@ -13,9 +15,7 @@ constexpr ui64 Mask = 0xffff;
 constexpr ui64 Offset = 16;
 
 ////////////////////////////////////////////////////////////////////////////////
-void SaveField(
-    const TBlockRangeField& field,
-    PartitionDirect::NProto::TBlockField* proto)
+void SaveField(const TBlockRangeField& field, TBlockFieldProto* proto)
 {
     field.Enumerate(
         [&](TBlockRange64 item)
@@ -32,9 +32,7 @@ void SaveField(
     // TODO save as bitmap when segment count exceed N
 }
 
-void LoadField(
-    const PartitionDirect::NProto::TBlockField& proto,
-    TBlockRangeField* field)
+void LoadField(const TBlockFieldProto& proto, TBlockRangeField* field)
 {
     for (const ui32 startAndLength: proto.GetStartAndLength()) {
         const ui64 start = startAndLength >> Offset;
@@ -59,13 +57,13 @@ void TDDiskState::Init(
     UpdateState(true);
 }
 
-void TDDiskState::Save(PartitionDirect::NProto::TDDiskState* proto) const
+void TDDiskState::Save(TDDiskStateProto* proto) const
 {
     SaveField(AheadField, proto->MutableAhead());
     SaveField(BehindField, proto->MutableBehind());
 }
 
-void TDDiskState::Load(const PartitionDirect::NProto::TDDiskState& proto)
+void TDDiskState::Load(const TDDiskStateProto& proto)
 {
     LoadField(proto.GetAhead(), &AheadField);
     LoadField(proto.GetBehind(), &BehindField);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
 #include <util/generic/string.h>
 
@@ -52,9 +52,9 @@ public:
         ui64 operationalBlockCount);
 
     // Save ahead and behind maps to proto.
-    void Save(PartitionDirect::NProto::TDDiskState* proto) const;
+    void Save(TDDiskStateProto* proto) const;
     // Load ahead and behind maps from proto.
-    void Load(const PartitionDirect::NProto::TDDiskState& proto);
+    void Load(const TDDiskStateProto& proto);
 
     // Completely disables DDisk usage.
     void SwitchOffline();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state_ut.cpp
@@ -1,5 +1,7 @@
 #include "ddisk_state.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
@@ -80,7 +82,7 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
             TDDiskState::EFlushCompletion::Completed);   // Ahead = [30..34]
 
         // --- Save ---
-        PartitionDirect::NProto::TDDiskState proto;
+        TDDiskStateProto proto;
         source.Save(&proto);
 
         // --- Load into a fresh DDisk ---
@@ -107,7 +109,7 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
             /*totalBlockCount=*/100,
             /*operationalBlockCount=*/100);
 
-        PartitionDirect::NProto::TDDiskState emptyProto;
+        TDDiskStateProto emptyProto;
         empty.Save(&emptyProto);
         UNIT_ASSERT_VALUES_EQUAL(0, emptyProto.GetAhead().StartAndLengthSize());
         UNIT_ASSERT_VALUES_EQUAL(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
@@ -740,10 +741,9 @@ bool TBlocksDirtyMap::NeedPersist() const
     return BehindAheadGeneration > PersistedGeneration;
 }
 
-PartitionDirect::NProto::TDirtyMapState
-TBlocksDirtyMap::GetStateForPersist() const
+TDirtyMapStateProto TBlocksDirtyMap::GetStateForPersist() const
 {
-    PartitionDirect::NProto::TDirtyMapState result;
+    TDirtyMapStateProto result;
     result.SetStateGeneration(GetCurrentGeneration());
     for (const auto& ddiskState: DDiskStates) {
         ddiskState.Save(result.AddDDiskStates());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -7,7 +7,7 @@
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
 #include <library/cpp/threading/future/core/future.h>
 
@@ -154,8 +154,7 @@ public:
 
     // Persist
     [[nodiscard]] bool NeedPersist() const;
-    [[nodiscard]] PartitionDirect::NProto::TDirtyMapState
-    GetStateForPersist() const;
+    [[nodiscard]] TDirtyMapStateProto GetStateForPersist() const;
     void StatePersisted(ui32 persistGeneration);
     [[nodiscard]] ui64 GetCurrentGeneration() const;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -405,6 +405,19 @@ NThreading::TFuture<void> TFastPathService::UpdateVChunkConfig(
     return result;
 }
 
+NThreading::TFuture<void> TFastPathService::UpdateDirtyMapState(
+    ui32 vChunkIndex,
+    TDirtyMapStateProto state)
+{
+    auto event =
+        std::make_unique<TEvPartitionDirectPrivate::TEvUpdateDirtyMapState>(
+            vChunkIndex,
+            std::move(state));
+    auto result = event->UpdateCompleted.GetFuture();
+    ActorSystem->Send(PartitionActorId, event.release());
+    return result;
+}
+
 void TFastPathService::QueryAddHost(
     size_t directBlockGroupId,
     size_t newHostIndex)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -123,6 +123,10 @@ public:
     NThreading::TFuture<void> UpdateVChunkConfig(
         const TVChunkConfig& cfg) override;
 
+    NThreading::TFuture<void> UpdateDirtyMapState(
+        ui32 vChunkIndex,
+        TDirtyMapStateProto state) override;
+
     void QueryAddHost(size_t directBlockGroupId, size_t newHostIndex) override;
 
     ui64 GenerateLsn() override;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.cpp
@@ -179,6 +179,42 @@ void TPartitionDatabase::StoreVChunkConfig(const TVChunkConfig& cfg)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool TPartitionDatabase::ReadAllDirtyMapStates(
+    TMap<ui32, TDirtyMapStateProto>& out)
+{
+    using TTable = TPartitionSchema::DirtyMapStates;
+
+    auto it =
+        Table<TTable>().Range().Select<TTable::VChunkIndex, TTable::State>();
+
+    if (!it.IsReady()) {
+        return false;
+    }
+
+    while (it.IsValid()) {
+        if (it.HaveValue<TTable::State>()) {
+            out[it.GetValue<TTable::VChunkIndex>()] =
+                it.GetValue<TTable::State>();
+        }
+        it.Next();
+    }
+
+    return true;
+}
+
+void TPartitionDatabase::StoreDirtyMapState(
+    ui32 vChunkIndex,
+    const TDirtyMapStateProto& state)
+{
+    using TTable = TPartitionSchema::DirtyMapStates;
+
+    Table<TTable>()
+        .Key(vChunkIndex)
+        .Update(NKikimr::NIceDb::TUpdate<TTable::State>(state));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 bool TPartitionDatabase::ReadAddHostInProgress(
     TMaybe<TAddHostInProgress>& addHostInProgress)
 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.pb.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
 #include <ydb/core/protos/blockstore_config.pb.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
+
+#include <util/generic/map.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
@@ -47,6 +51,9 @@ public:
         const TDirectBlockGroupsConnections& directBlockGroupsConnections);
 
     void StoreVChunkConfig(const TVChunkConfig& cfg);
+
+    bool ReadAllDirtyMapStates(TMap<ui32, TDirtyMapStateProto>& out);
+    void StoreDirtyMapState(ui32 vChunkIndex, const TDirtyMapStateProto& state);
 
     bool ReadAddHostInProgress(TMaybe<TAddHostInProgress>& addHostInProgress);
     void StoreAddHostInProgress(const TAddHostInProgress& addHostInProgress);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
@@ -53,6 +53,27 @@ TDirectBlockGroupsConnections MakeSampleDirectBlockGroupsConnections()
     return msg;
 }
 
+TDirtyMapStateProto MakeSampleDirtyMapState(ui32 stateGeneration)
+{
+    TDirtyMapStateProto state;
+    state.SetStateGeneration(stateGeneration);
+
+    auto* ddiskState = state.AddDDiskStates();
+    auto* ahead = ddiskState->MutableAhead();
+    ahead->AddStartAndLength(10);
+    ahead->AddStartAndLength(5);
+    auto* behind = ddiskState->MutableBehind();
+    behind->AddStartAndLength(100);
+    behind->AddStartAndLength(20);
+
+    auto* secondDDiskState = state.AddDDiskStates();
+    auto* secondAhead = secondDDiskState->MutableAhead();
+    secondAhead->AddStartAndLength(200);
+    secondAhead->AddStartAndLength(50);
+
+    return state;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -360,6 +381,130 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                 UNIT_ASSERT_VALUES_EQUAL(
                     connectionsWritten.SerializeAsString(),
                     connections->SerializeAsString());
+            });
+    }
+
+    Y_UNIT_TEST(ShouldReturnEmptyDirtyMapStatesWhenAbsent)
+    {
+        TTestExecutor executor;
+
+        executor.WriteTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                partitionDb.InitSchema();
+            });
+
+        executor.ReadTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                TMap<ui32, TDirtyMapStateProto> loaded;
+                UNIT_ASSERT(partitionDb.ReadAllDirtyMapStates(loaded));
+                UNIT_ASSERT(loaded.empty());
+            });
+    }
+
+    Y_UNIT_TEST(ShouldStoreAndReadDirtyMapState)
+    {
+        TTestExecutor executor;
+        const auto written = MakeSampleDirtyMapState(7);
+
+        executor.WriteTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                partitionDb.InitSchema();
+                partitionDb.StoreDirtyMapState(42, written);
+            });
+
+        executor.ReadTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                TMap<ui32, TDirtyMapStateProto> loaded;
+                UNIT_ASSERT(partitionDb.ReadAllDirtyMapStates(loaded));
+                UNIT_ASSERT_VALUES_EQUAL(1u, loaded.size());
+                UNIT_ASSERT(loaded.contains(42));
+
+                const auto& state = loaded.at(42);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    written.SerializeAsString(),
+                    state.SerializeAsString());
+                UNIT_ASSERT_VALUES_EQUAL(7u, state.GetStateGeneration());
+                UNIT_ASSERT_VALUES_EQUAL(2, state.DDiskStatesSize());
+            });
+    }
+
+    Y_UNIT_TEST(ShouldStoreDirtyMapStatePerVChunkIndependently)
+    {
+        TTestExecutor executor;
+        const auto first = MakeSampleDirtyMapState(1);
+        const auto second = MakeSampleDirtyMapState(2);
+
+        executor.WriteTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                partitionDb.InitSchema();
+                partitionDb.StoreDirtyMapState(0, first);
+                partitionDb.StoreDirtyMapState(1, second);
+            });
+
+        executor.ReadTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                TMap<ui32, TDirtyMapStateProto> loaded;
+                UNIT_ASSERT(partitionDb.ReadAllDirtyMapStates(loaded));
+                UNIT_ASSERT_VALUES_EQUAL(2u, loaded.size());
+
+                UNIT_ASSERT(loaded.contains(0));
+                UNIT_ASSERT_VALUES_EQUAL(1u, loaded.at(0).GetStateGeneration());
+
+                UNIT_ASSERT(loaded.contains(1));
+                UNIT_ASSERT_VALUES_EQUAL(2u, loaded.at(1).GetStateGeneration());
+
+                // A vchunk that was never written must be absent from the map.
+                UNIT_ASSERT(!loaded.contains(2));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldOverwriteDirtyMapStateOnRepeatedStore)
+    {
+        TTestExecutor executor;
+
+        executor.WriteTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                partitionDb.InitSchema();
+                partitionDb.StoreDirtyMapState(5, MakeSampleDirtyMapState(1));
+            });
+
+        const auto updated = MakeSampleDirtyMapState(99);
+
+        executor.WriteTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                partitionDb.StoreDirtyMapState(5, updated);
+            });
+
+        executor.ReadTx(
+            [&](NKikimr::NTable::TDatabase& db)
+            {
+                TPartitionDatabase partitionDb(db);
+                TMap<ui32, TDirtyMapStateProto> loaded;
+                UNIT_ASSERT(partitionDb.ReadAllDirtyMapStates(loaded));
+                UNIT_ASSERT_VALUES_EQUAL(1u, loaded.size());
+                UNIT_ASSERT(loaded.contains(5));
+
+                const auto& state = loaded.at(5);
+                UNIT_ASSERT_VALUES_EQUAL(99u, state.GetStateGeneration());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    updated.SerializeAsString(),
+                    state.SerializeAsString());
             });
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_schema.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_schema.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/core/tablet_schema.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.pb.h>
 
 #include <ydb/core/protos/blockstore_config.pb.h>
@@ -72,7 +73,24 @@ struct TPartitionSchema: public NKikimr::NIceDb::Schema
         using TColumns = TableColumns<VChunkIndex, Config>;
     };
 
-    using TTables = SchemaTables<TabletInfo, VChunkConfigs>;
+    // Persisted dirty map state, keyed by vchunk index. Only vchunks whose
+    // dirty map was explicitly updated have a row here.
+    struct DirtyMapStates: public TTableSchema<3>
+    {
+        struct VChunkIndex: public Column<1, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
+
+        struct State: public Column<2, NKikimr::NScheme::NTypeIds::String>
+        {
+            using Type = ::NYdb::NBS::PartitionDirect::NProto::TDirtyMapState;
+        };
+
+        using TKey = TableKey<VChunkIndex>;
+        using TColumns = TableColumns<VChunkIndex, State>;
+    };
+
+    using TTables = SchemaTables<TabletInfo, VChunkConfigs, DirtyMapStates>;
 
     using TSettings =
         SchemaSettings<ExecutorLogBatching<true>, ExecutorLogFlushPeriod<0>>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -2,7 +2,9 @@
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.pb.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
 #include <ydb/core/protos/blobstorage_ddisk.pb.h>
 #include <ydb/core/protos/blockstore_config.pb.h>
@@ -25,6 +27,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
     xxx(StoreVolumeConfig, __VA_ARGS__)             \
     xxx(StorePartitionIds, __VA_ARGS__)             \
     xxx(UpdateVChunkConfig, __VA_ARGS__)            \
+    xxx(UpdateDirtyMapState, __VA_ARGS__)           \
     xxx(StartAddHost, __VA_ARGS__)                  \
     xxx(AddHostToDBG, __VA_ARGS__)                  \
     xxx(Monitoring, __VA_ARGS__)
@@ -126,6 +129,30 @@ struct TTxPartition
             TVChunkConfig vChunkConfig,
             NThreading::TPromise<void> updateCompleted)
             : VChunkConfig(std::move(vChunkConfig))
+            , UpdateCompleted(std::move(updateCompleted))
+        {}
+
+        void Clear()
+        {
+            // nothing to do
+        }
+    };
+
+    //
+    // TUpdateDirtyMapState
+    //
+    struct TUpdateDirtyMapState
+    {
+        const ui32 VChunkIndex;
+        const TDirtyMapStateProto State;
+        NThreading::TPromise<void> UpdateCompleted;
+
+        TUpdateDirtyMapState(
+            ui32 vChunkIndex,
+            TDirtyMapStateProto state,
+            NThreading::TPromise<void> updateCompleted)
+            : VChunkIndex(vChunkIndex)
+            , State(std::move(state))
             , UpdateCompleted(std::move(updateCompleted))
         {}
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
@@ -1,0 +1,47 @@
+#include "partition_direct_actor.h"
+
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TPartitionActor::PrepareUpdateDirtyMapState(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxPartition::TUpdateDirtyMapState& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TPartitionActor::ExecuteUpdateDirtyMapState(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxPartition::TUpdateDirtyMapState& args)
+{
+    Y_UNUSED(ctx);
+
+    TPartitionDatabase db(tx.DB);
+    db.StoreDirtyMapState(args.VChunkIndex, args.State);
+}
+
+void TPartitionActor::CompleteUpdateDirtyMapState(
+    const TActorContext& ctx,
+    TTxPartition::TUpdateDirtyMapState& args)
+{
+    Y_UNUSED(ctx);
+
+    args.UpdateCompleted.SetValue();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -676,6 +676,27 @@ void TPartitionActor::HandleUpdateVChunkConfig(
             std::move(msg->UpdateCompleted)));
 }
 
+void TPartitionActor::HandleUpdateDirtyMapState(
+    const TEvPartitionDirectPrivate::TEvUpdateDirtyMapState::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Handle UpdateDirtyMapState vchunk %u",
+        LogTitle.GetWithTime().c_str(),
+        msg->VChunkIndex);
+
+    ExecuteTx(
+        ctx,
+        CreateTx<TUpdateDirtyMapState>(
+            msg->VChunkIndex,
+            std::move(msg->State),
+            std::move(msg->UpdateCompleted)));
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 STFUNC(TPartitionActor::StateWork)
@@ -708,6 +729,9 @@ STFUNC(TPartitionActor::StateWork)
         HFunc(
             TEvPartitionDirectPrivate::TEvUpdateVChunkConfig,
             HandleUpdateVChunkConfig);
+        HFunc(
+            TEvPartitionDirectPrivate::TEvUpdateDirtyMapState,
+            HandleUpdateDirtyMapState);
         HFunc(
             TEvPartitionDirectPrivate::TEvFastPathServiceReady,
             HandleFastPathServiceReady);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -155,6 +155,10 @@ private:
         const TEvPartitionDirectPrivate::TEvUpdateVChunkConfig::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleUpdateDirtyMapState(
+        const TEvPartitionDirectPrivate::TEvUpdateDirtyMapState::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleFastPathServiceReady(
         const TEvPartitionDirectPrivate::TEvFastPathServiceReady::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
 #include <ydb/core/base/events.h>
 
@@ -27,6 +29,7 @@ struct TEvPartitionDirectPrivate
                   LocalEventsOffset,
 
         EvUpdateVChunkConfig,
+        EvUpdateDirtyMapState,
         EvFastPathServiceReady,
 
         EvFastPathServiceShutdown,
@@ -46,6 +49,20 @@ struct TEvPartitionDirectPrivate
 
         explicit TEvUpdateVChunkConfig(TVChunkConfig cfg)
             : VChunkConfig(std::move(cfg))
+        {}
+    };
+
+    struct TEvUpdateDirtyMapState
+        : public NActors::
+              TEventLocal<TEvUpdateDirtyMapState, EvUpdateDirtyMapState>
+    {
+        ui32 VChunkIndex;
+        TDirtyMapStateProto State;
+        NThreading::TPromise<void> UpdateCompleted = NThreading::NewPromise();
+
+        TEvUpdateDirtyMapState(ui32 vChunkIndex, TDirtyMapStateProto state)
+            : VChunkIndex(vChunkIndex)
+            , State(std::move(state))
         {}
     };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/service/public.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/scheduler.h>
 #include <ydb/core/nbs/cloud/storage/core/libs/coroutine/public.h>
@@ -33,6 +34,12 @@ struct IPartitionDirectService
     // local DB. Caller must ensure cfg.IsValid().
     virtual NThreading::TFuture<void> UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) = 0;
+
+    // Asynchronously persists the given TDirtyMapStateProto to the partition's
+    // local DB.
+    virtual NThreading::TFuture<void> UpdateDirtyMapState(
+        ui32 vChunkIndex,
+        TDirtyMapStateProto state) = 0;
 
     // Query the addition of a new host to the group. The request is idempotent
     // and can be repeated multiple times.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
@@ -2,6 +2,9 @@
 
 #include "partition_direct_service.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+
 #include <ydb/core/nbs/cloud/storage/core/libs/coroutine/executor.h>
 
 #include <util/generic/vector.h>
@@ -24,6 +27,13 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
         NThreading::TPromise<void> Promise;
     };
 
+    struct TUpdateDirtyMapStateRequest
+    {
+        ui32 VChunkIndex = 0;
+        TDirtyMapStateProto Proto;
+        NThreading::TPromise<void> Promise;
+    };
+
     explicit TPartitionDirectServiceMock(bool dropScheduledCallbacks = false)
         : DropScheduledCallbacks(dropScheduledCallbacks)
     {}
@@ -35,6 +45,7 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
     size_t BlockedGenerationCount = 0;
     TString LastBlockedReason;
     TVector<TUpdateConfigRequest> UpdateConfigRequests;
+    TVector<TUpdateDirtyMapStateRequest> UpdateDirtyMapStateRequests;
 
     [[nodiscard]] TVolumeConfigPtr GetVolumeConfig() const override
     {
@@ -58,6 +69,17 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
     {
         UpdateConfigRequests.emplace_back(cfg, NThreading::NewPromise());
         return UpdateConfigRequests.back().Promise.GetFuture();
+    }
+
+    NThreading::TFuture<void> UpdateDirtyMapState(
+        ui32 vChunkIndex,
+        TDirtyMapStateProto state) override
+    {
+        UpdateDirtyMapStateRequests.emplace_back(TUpdateDirtyMapStateRequest{
+            .VChunkIndex = vChunkIndex,
+            .Proto = std::move(state),
+            .Promise = NThreading::NewPromise()});
+        return UpdateDirtyMapStateRequests.back().Promise.GetFuture();
     }
 
     void QueryAddHost(size_t directBlockGroupId, size_t newHostIndex) override

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace NYdb::NBS::PartitionDirect::NProto {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TBlockField;
+class TDDiskState;
+class TDirtyMapState;
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::PartitionDirect::NProto
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TBlockFieldProto = NYdb::NBS::PartitionDirect::NProto::TBlockField;
+using TDDiskStateProto = NYdb::NBS::PartitionDirect::NProto::TDDiskState;
+using TDirtyMapStateProto = NYdb::NBS::PartitionDirect::NProto::TDirtyMapState;
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -831,19 +831,23 @@ void TVChunk::DoPersistDirtyMap()
     DirtyMapStatePersisting = true;
 
     auto state = BlocksDirtyMap->GetStateForPersist();
+    const ui32 stateGeneration = state.GetStateGeneration();
     LOG_INFO(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,
-        "%s DoPersistDirtyMap: %s",
+        "%s Will persist dirty map. State generation %u",
         LogTitle.GetWithTime().c_str(),
-        state.DebugString().c_str());
+        stateGeneration);
 
-    DirectBlockGroup->Schedule(
-        TDuration::Seconds(1),
+    auto future = PartitionDirectService->UpdateDirtyMapState(
+        VChunkConfig.GetVChunkIndex(),
+        std::move(state));
+    future.Subscribe(
         [weakSelf = weak_from_this(),
-         stateGeneration = state.GetStateGeneration()]   //
-        ()
+         stateGeneration]   //
+        (const TFuture<void>& f)
         {
+            Y_UNUSED(f);
             if (auto self = weakSelf.lock()) {
                 self->OnDirtyMapPersisted(stateGeneration);
             }
@@ -852,6 +856,13 @@ void TVChunk::DoPersistDirtyMap()
 
 void TVChunk::OnDirtyMapPersisted(ui32 stateGeneration)
 {
+    LOG_INFO(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s Dirty map persisted. State generation: %u",
+        LogTitle.GetWithTime().c_str(),
+        stateGeneration);
+
     DirtyMapStatePersisting = false;
     BlocksDirtyMap->StatePersisted(stateGeneration);
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -844,13 +844,18 @@ void TVChunk::DoPersistDirtyMap()
         std::move(state));
     future.Subscribe(
         [weakSelf = weak_from_this(),
+         executor = Executor,
          stateGeneration]   //
         (const TFuture<void>& f)
         {
             Y_UNUSED(f);
-            if (auto self = weakSelf.lock()) {
-                self->OnDirtyMapPersisted(stateGeneration);
-            }
+            executor->ExecuteSimple(
+                [weakSelf = std::move(weakSelf), stateGeneration]()
+                {
+                    if (auto self = weakSelf.lock()) {
+                        self->OnDirtyMapPersisted(stateGeneration);
+                    }
+                });
         });
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/model/disk_description.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/region_geometry.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/error.h>
 #include <ydb/core/nbs/cloud/storage/core/libs/common/future_helper.h>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -2,6 +2,8 @@
 
 #include "base_test_fixture.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h>
+
 #include <ydb/core/nbs/cloud/storage/core/libs/coroutine/executor_ut.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -27,6 +29,31 @@ std::optional<ui64> GetSafeBarrierOnExecutor(
         [promise = std::move(promise), &vchunk]() mutable
         { promise.SetValue(vchunk.GetSafeBarrierForErase()); });
     return future.GetValue(TDuration::Seconds(10));
+}
+
+// Drives dirtyMap into a state where NeedPersist() is true and the persist
+// generation has advanced. Mirrors the flush choreography used in dirty_map_ut:
+// a write above the fresh DDisk's watermark populates its Ahead field, which
+// bumps the behind/ahead generation on flush. Must run on the executor thread.
+void MakeDirtyMapNeedPersist(TBlocksDirtyMap& dirtyMap)
+{
+    THostMask requested;
+    requested.Set(0);
+    requested.Set(1);
+    requested.Set(2);
+    requested.Set(3);
+
+    dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+    dirtyMap.WriteFinished(
+        100,
+        TBlockRange64::WithLength(10, 10),
+        requested,
+        requested);
+
+    auto flushHint = dirtyMap.MakeFlushHint(1);
+    for (const auto& [route, hint]: flushHint.GetAllHints()) {
+        dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+    }
 }
 
 }   // namespace
@@ -812,6 +839,176 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             S_OK,
             writeResult.Error.GetCode(),
             FormatError(writeResult.Error));
+
+        auto onStop = vchunk->Stop();
+        onStop.GetValue(TDuration::Seconds(10));
+    }
+
+    // DoPersistDirtyMap must forward the dirty map state to
+    // IPartitionDirectService::UpdateDirtyMapState (carrying the vchunk index
+    // and the current state generation) and, once that future resolves, run
+    // OnDirtyMapPersisted which clears the in-flight flag and acknowledges the
+    // generation to the dirty map (NeedPersist() becomes false).
+    Y_UNIT_TEST_F(ShouldPersistDirtyMapState, TBaseFixture)
+    {
+        // Host 3 is fresh; a write above its watermark populates its Ahead
+        // field so a flush bumps the persist generation.
+        VChunkConfig.PromoteHost(3);
+        VChunkConfig.SetWatermark(3, BlockSize * 5);
+
+        Init();
+
+        auto vchunk = std::make_shared<TVChunk>(
+            Runtime->GetActorSystem(0),
+            TraceService.get(),
+            PartitionDirectService.get(),
+            DiskDescription,
+            VChunkConfig,
+            DirectBlockGroup,
+            3,   // syncRequestsBatchSize
+            DefaultVChunkSize,
+            Counters);
+        vchunk->Start();
+        DrainExecutor(DirectBlockGroup->GetExecutor());
+
+        // Drive the dirty map into a "need persist" state and trigger persist,
+        // all on the executor thread the vchunk state is confined to.
+        ui32 expectedGeneration = 0;
+        RunOnExecutor(
+            DirectBlockGroup->GetExecutor(),
+            [&]() -> bool
+            {
+                auto& dirtyMap = AccessBlocksDirtyMap(*vchunk);
+                MakeDirtyMapNeedPersist(dirtyMap);
+                UNIT_ASSERT_VALUES_EQUAL(true, dirtyMap.NeedPersist());
+                expectedGeneration =
+                    static_cast<ui32>(dirtyMap.GetCurrentGeneration());
+
+                InvokePersistDirtyMap(*vchunk);
+                return true;
+            })
+            .GetValue(TDuration::Seconds(10));
+
+        // A single UpdateDirtyMapState request must have been issued with the
+        // vchunk index and captured generation; the vchunk marks itself busy.
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            PartitionDirectService->UpdateDirtyMapStateRequests.size());
+        const auto& request =
+            PartitionDirectService->UpdateDirtyMapStateRequests.front();
+        UNIT_ASSERT_VALUES_EQUAL(FixtureVChunkIndex, request.VChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedGeneration,
+            request.Proto.GetStateGeneration());
+        UNIT_ASSERT_VALUES_EQUAL(true, IsDirtyMapStatePersisting(*vchunk));
+
+        // Complete the persist; OnDirtyMapPersisted runs on the callback.
+        UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateDirtyMapStateRequests());
+        DrainExecutor(DirectBlockGroup->GetExecutor());
+
+        // Flag cleared and the generation acknowledged to the dirty map.
+        UNIT_ASSERT_VALUES_EQUAL(false, IsDirtyMapStatePersisting(*vchunk));
+        RunOnExecutor(
+            DirectBlockGroup->GetExecutor(),
+            [&]() -> bool
+            {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    false,
+                    AccessBlocksDirtyMap(*vchunk).NeedPersist());
+                return true;
+            })
+            .GetValue(TDuration::Seconds(10));
+
+        auto onStop = vchunk->Stop();
+        onStop.GetValue(TDuration::Seconds(10));
+    }
+
+    // A second DoPersistDirtyMap call while a persist is already in flight must
+    // be a no-op: no duplicate UpdateDirtyMapState request is issued.
+    Y_UNIT_TEST_F(
+        ShouldNotPersistDirtyMapStateWhileAlreadyPersisting,
+        TBaseFixture)
+    {
+        VChunkConfig.PromoteHost(3);
+        VChunkConfig.SetWatermark(3, BlockSize * 5);
+
+        Init();
+
+        auto vchunk = std::make_shared<TVChunk>(
+            Runtime->GetActorSystem(0),
+            TraceService.get(),
+            PartitionDirectService.get(),
+            DiskDescription,
+            VChunkConfig,
+            DirectBlockGroup,
+            3,   // syncRequestsBatchSize
+            DefaultVChunkSize,
+            Counters);
+        vchunk->Start();
+        DrainExecutor(DirectBlockGroup->GetExecutor());
+
+        RunOnExecutor(
+            DirectBlockGroup->GetExecutor(),
+            [&]() -> bool
+            {
+                auto& dirtyMap = AccessBlocksDirtyMap(*vchunk);
+                MakeDirtyMapNeedPersist(dirtyMap);
+
+                // First call starts a persist; second call must be ignored
+                // while it is still in flight.
+                InvokePersistDirtyMap(*vchunk);
+                InvokePersistDirtyMap(*vchunk);
+                return true;
+            })
+            .GetValue(TDuration::Seconds(10));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            PartitionDirectService->UpdateDirtyMapStateRequests.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateDirtyMapStateRequests());
+        DrainExecutor(DirectBlockGroup->GetExecutor());
+        UNIT_ASSERT_VALUES_EQUAL(false, IsDirtyMapStatePersisting(*vchunk));
+
+        auto onStop = vchunk->Stop();
+        onStop.GetValue(TDuration::Seconds(10));
+    }
+
+    // With no dirty map changes NeedPersist() is false, so DoPersistDirtyMap
+    // must not issue any UpdateDirtyMapState request.
+    Y_UNIT_TEST_F(ShouldNotPersistDirtyMapStateWhenNothingChanged, TBaseFixture)
+    {
+        Init();
+
+        auto vchunk = std::make_shared<TVChunk>(
+            Runtime->GetActorSystem(0),
+            TraceService.get(),
+            PartitionDirectService.get(),
+            DiskDescription,
+            VChunkConfig,
+            DirectBlockGroup,
+            3,   // syncRequestsBatchSize
+            DefaultVChunkSize,
+            Counters);
+        vchunk->Start();
+        DrainExecutor(DirectBlockGroup->GetExecutor());
+
+        RunOnExecutor(
+            DirectBlockGroup->GetExecutor(),
+            [&]() -> bool
+            {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    false,
+                    AccessBlocksDirtyMap(*vchunk).NeedPersist());
+                InvokePersistDirtyMap(*vchunk);
+                return true;
+            })
+            .GetValue(TDuration::Seconds(10));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0u,
+            PartitionDirectService->UpdateDirtyMapStateRequests.size());
+        UNIT_ASSERT_VALUES_EQUAL(false, IsDirtyMapStatePersisting(*vchunk));
 
         auto onStop = vchunk->Stop();
         onStop.GetValue(TDuration::Seconds(10));

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -19,6 +19,7 @@ SRCS(
     part_storepartitionids.cpp
     part_storevolumeconfig.cpp
     part_updatevchunkconfig.cpp
+    part_updatedirtymapstate.cpp
     part_monitoring.cpp
     partition_direct_actor.cpp
     partition_direct.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Persist DirtyMap state (red and green blocks) in local database

### Description for reviewers <!-- (optional) description for those who read this PR -->

