### PR TITLE
Re add coverage to main repo

### DIFF
--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -125,6 +125,7 @@ runs:
         ./ya make "${params[@]}" "${TARGETS[@]}"
 
     - name: Export filtered LCOV
+      id: export
       shell: bash
       env:
         SUITE: ${{ inputs.suite }}
@@ -187,11 +188,36 @@ runs:
         fi
         codecovcli upload-coverage "${upload_args[@]}"
 
+    - name: Generate filtered HTML report
+      id: html
+      if: >-
+        ${{
+          always() &&
+          steps.ya.outcome == 'success' &&
+          steps.export.outcome == 'success' &&
+          inputs.aws_access_key_id != '' &&
+          inputs.aws_secret_access_key != ''
+        }}
+      continue-on-error: true
+      shell: bash
+      env:
+        SUITE: ${{ inputs.suite }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
+      run: |
+        set -euo pipefail
+        python3 .github/scripts/codecov/export_coverage_lcov.py \
+          --suite "${SUITE}" \
+          --ya-output "$OUT" \
+          --html-input "$OUT/coverage.lcov" \
+          --html-output "$OUT/coverage.filtered.report"
+
     - name: Install AWS CLI
       if: >-
         ${{
           always() &&
           steps.ya.outcome == 'success' &&
+          steps.export.outcome == 'success' &&
+          steps.html.outcome == 'success' &&
           inputs.aws_access_key_id != '' &&
           inputs.aws_secret_access_key != ''
         }}
@@ -210,6 +236,8 @@ runs:
         ${{
           always() &&
           steps.ya.outcome == 'success' &&
+          steps.export.outcome == 'success' &&
+          steps.html.outcome == 'success' &&
           inputs.aws_access_key_id != '' &&
           inputs.aws_secret_access_key != ''
         }}
@@ -242,9 +270,11 @@ runs:
         fi
         prefix="${STORAGE_PREFIX}"
 
-        report_dir="${OUT}/coverage.report"
-        if [ ! -d "${report_dir}" ]; then
-          echo "No coverage.report directory; skip object storage upload"
+        # Publish the same suite-owned source set that is uploaded to Codecov,
+        # not ya's raw report for the complete dependency closure.
+        report_dir="${OUT}/coverage.filtered.report"
+        if [ ! -f "${report_dir}/index.html" ]; then
+          echo "No filtered coverage HTML directory; skip object storage upload"
           exit 0
         fi
 

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -1,0 +1,262 @@
+name: Run Clang Codecov Suite
+description: Build/test with clang coverage, upload LCOV to Codecov, publish HTML to S3
+inputs:
+  suite:
+    description: "Suite name: cpp_sdk | cli | cli_workload"
+    required: true
+  codecov_token:
+    description: Codecov upload token
+    required: true
+  aws_access_key_id:
+    description: Yandex Object Storage access key
+    required: false
+    default: ""
+  aws_secret_access_key:
+    description: Yandex Object Storage secret key
+    required: false
+    default: ""
+  bazel_remote_uri:
+    description: Remote cache URI
+    required: false
+    default: ""
+  bazel_remote_username:
+    description: Remote cache username
+    required: false
+    default: ""
+  bazel_remote_password:
+    description: Remote cache password
+    required: false
+    default: ""
+  test_threads:
+    description: ya --test-threads
+    required: false
+    default: "28"
+  link_threads:
+    description: ya --link-threads
+    required: false
+    default: "12"
+  pr_number:
+    description: PR number (empty on push)
+    required: false
+    default: ""
+  commit_sha:
+    description: Commit SHA for meta/links
+    required: true
+  branch:
+    description: Branch name for Codecov (ref_name / head_ref)
+    required: false
+    default: ""
+  storage_prefix:
+    description: Object Storage prefix containing suite directories
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Resolve suite config
+      id: suite
+      shell: bash
+      env:
+        SUITE: ${{ inputs.suite }}
+      run: |
+        set -euo pipefail
+        case "${SUITE}" in
+          cpp_sdk|cli|cli_workload) ;;
+          *) echo "Unknown suite: ${SUITE}" >&2; exit 1 ;;
+        esac
+        CFG_FILE=$(mktemp)
+        trap 'rm -f "$CFG_FILE"' EXIT
+        python3 .github/scripts/codecov/codecov_suites.py json-suite "${SUITE}" > "$CFG_FILE"
+        EXCL=$(python3 .github/scripts/codecov/codecov_suites.py exclude-regexp)
+        echo "exclude_regexp=${EXCL}" >> "$GITHUB_OUTPUT"
+        python3 -c 'import json,os,sys; cfg=json.load(open(sys.argv[1],encoding="utf-8")); out=os.environ["GITHUB_OUTPUT"]; open(out,"a",encoding="utf-8").write("regexp="+cfg["regexp"]+"\nflag="+cfg["flag"]+"\ntargets_json="+json.dumps(cfg["targets"])+"\n")' "$CFG_FILE"
+
+    - name: Ya make with clang coverage
+      id: ya
+      shell: bash
+      env:
+        BUILD_PRESET: profile
+        SUITE: ${{ inputs.suite }}
+        REGEXP: ${{ steps.suite.outputs.regexp }}
+        EXCL: ${{ steps.suite.outputs.exclude_regexp }}
+        TARGETS_JSON: ${{ steps.suite.outputs.targets_json }}
+        TEST_THREADS: ${{ inputs.test_threads }}
+        LINK_THREADS: ${{ inputs.link_threads }}
+        BAZEL_REMOTE_URI: ${{ inputs.bazel_remote_uri }}
+        BAZEL_REMOTE_USERNAME: ${{ inputs.bazel_remote_username }}
+        BAZEL_REMOTE_PASSWORD: ${{ inputs.bazel_remote_password }}
+      run: |
+        set -euo pipefail
+        OUT="$(pwd)/coverage_workspace/${SUITE}"
+        mkdir -p "$OUT"
+        echo "out_dir=$OUT" >> "$GITHUB_OUTPUT"
+
+        BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
+        trap 'rm -f "$BAZEL_REMOTE_PASSWORD_FILE"' EXIT
+        printf '%s' "${BAZEL_REMOTE_PASSWORD}" > "$BAZEL_REMOTE_PASSWORD_FILE"
+
+        mapfile -t TARGETS < <(python3 -c 'import json,sys; print("\n".join(json.loads(sys.argv[1])))' "${TARGETS_JSON}")
+        if [ "${#TARGETS[@]}" -eq 0 ]; then
+          echo "No ya targets resolved for suite ${SUITE}" >&2
+          exit 1
+        fi
+
+        params=(
+          -tA --build profile
+          --clang-coverage --coverage-report --keep-temps
+          "-DCOVERAGE_TARGET_REGEXP=${REGEXP}"
+          "--coverage-exclude-regexp=${EXCL}"
+          --test-threads "${TEST_THREADS}"
+          --link-threads "${LINK_THREADS}"
+          --output "$OUT"
+          --no-dir-outputs
+        )
+        if [ -n "${BAZEL_REMOTE_URI}" ]; then
+          params+=(--bazel-remote-store --bazel-remote-base-uri "${BAZEL_REMOTE_URI}")
+          params+=(--bazel-remote-username "${BAZEL_REMOTE_USERNAME}")
+          params+=(--bazel-remote-password-file "$BAZEL_REMOTE_PASSWORD_FILE")
+          params+=(
+            --bazel-remote-put
+            --dist-cache-max-file-size=209715200
+            --dist-cache-evict-test-runs
+            --dist-cache-evict-bins
+          )
+        fi
+
+        ./ya make "${params[@]}" "${TARGETS[@]}"
+
+    - name: Export filtered LCOV
+      shell: bash
+      env:
+        SUITE: ${{ inputs.suite }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
+      run: |
+        set -euo pipefail
+        python3 .github/scripts/codecov/export_coverage_lcov.py \
+          --suite "${SUITE}" \
+          --ya-output "$OUT" \
+          --output "$OUT/coverage.lcov"
+
+    - name: Install Codecov CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Prefer PyPI: self-hosted runners often cannot download cli.codecov.io.
+        pip3 install --user 'codecov-cli==11.3.1'
+
+    - name: Upload to Codecov
+      shell: bash
+      env:
+        CODECOV_TOKEN: ${{ inputs.codecov_token }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
+        FLAG: ${{ steps.suite.outputs.flag }}
+        SUITE: ${{ inputs.suite }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
+        BRANCH: ${{ inputs.branch }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REPOSITORY_SLUG: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        if [ -z "${CODECOV_TOKEN}" ]; then
+          echo "CODECOV_TOKEN is empty" >&2
+          exit 1
+        fi
+        if [[ ! "${COMMIT_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+          echo "Codecov commit SHA must contain exactly 40 hexadecimal characters" >&2
+          exit 1
+        fi
+        if [ -z "${BRANCH}" ]; then
+          echo "Codecov branch is empty" >&2
+          exit 1
+        fi
+        export PATH="${HOME}/.local/bin:${PATH}"
+        upload_args=(
+          --fail-on-error
+          --git-service github
+          --slug "${REPOSITORY_SLUG}"
+          --sha "${COMMIT_SHA}"
+          --branch "${BRANCH}"
+          --disable-search
+          --plugin noop
+          --file "${OUT}/coverage.lcov"
+          --flag "${FLAG}"
+          --name "${SUITE}"
+        )
+        # Needed so Codecov attaches the upload to the PR (statuses / comment), not only the commit.
+        if [ -n "${PR_NUMBER}" ]; then
+          upload_args+=(--pull-request-number "${PR_NUMBER}")
+        fi
+        codecovcli upload-coverage "${upload_args[@]}"
+
+    - name: Install AWS CLI
+      if: >-
+        ${{
+          always() &&
+          steps.ya.outcome == 'success' &&
+          inputs.aws_access_key_id != '' &&
+          inputs.aws_secret_access_key != ''
+        }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -euo pipefail
+        export PATH="${HOME}/.local/bin:${PATH}"
+        if ! command -v aws >/dev/null 2>&1; then
+          pip3 install --user 'awscli==1.46.0'
+        fi
+
+    - name: Publish HTML report to Object Storage
+      # Still publish HTML if Codecov upload fails.
+      if: >-
+        ${{
+          always() &&
+          steps.ya.outcome == 'success' &&
+          inputs.aws_access_key_id != '' &&
+          inputs.aws_secret_access_key != ''
+        }}
+      continue-on-error: true
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
+        AWS_DEFAULT_REGION: ru-central1
+        SUITE: ${{ inputs.suite }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
+        STORAGE_PREFIX: ${{ inputs.storage_prefix }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        export PATH="${HOME}/.local/bin:${PATH}"
+        if ! command -v aws >/dev/null 2>&1; then
+          echo "AWS CLI is unavailable; skip best-effort S3 upload" >&2
+          exit 0
+        fi
+
+        bucket=ydb-appteam-sdk-reports
+        endpoint=https://storage.yandexcloud.net
+
+        if [ -z "${STORAGE_PREFIX}" ]; then
+          echo "Object Storage prefix is empty" >&2
+          exit 1
+        fi
+        prefix="${STORAGE_PREFIX}"
+
+        report_dir="${OUT}/coverage.report"
+        if [ ! -d "${report_dir}" ]; then
+          echo "No coverage.report directory; skip object storage upload"
+          exit 0
+        fi
+
+        # Keep meta.json inside report_dir so sync --delete does not try to remove
+        # a separately uploaded key (Yandex Object Storage returned AccessDenied).
+        meta="${report_dir}/meta.json"
+        META="$meta" python3 -c 'import json,os; from datetime import datetime,timezone; meta={"suite":os.environ["SUITE"],"sha":os.environ["COMMIT_SHA"],"commit":os.environ["COMMIT_SHA"][:12],"event":os.environ.get("GITHUB_EVENT_NAME",""),"run_url":os.environ["RUN_URL"],"generated_at":datetime.now(timezone.utc).isoformat(),"pr":os.environ.get("PR_NUMBER") or None}; open(os.environ["META"],"w",encoding="utf-8").write(json.dumps(meta,indent=2)+"\n")'
+
+        aws --endpoint-url "$endpoint" s3 sync \
+          "${report_dir}/" \
+          "s3://${bucket}/${prefix}/${SUITE}/" \
+          --exclude "coverage.profdata" \
+          --delete
+
+        echo "Uploaded coverage HTML for ${SUITE} to object storage (prefix ${prefix}/${SUITE}/)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,73 @@
+# Codecov config for ydb-platform/ydb (C++ SDK + CLI + workload).
+# Separate from per-language SDK repos (java/go/js) and their native-sdk component.
+
+coverage:
+  status:
+    project:
+      default: off
+      cpp_sdk:
+        flags:
+          - cpp_sdk
+        target: auto
+        threshold: 0.1%
+      cli:
+        flags:
+          - cli
+        target: auto
+        threshold: 5%
+      cli_workload:
+        flags:
+          - cli_workload
+        target: auto
+        threshold: 5%
+    patch:
+      default: off
+      cpp_sdk:
+        flags:
+          - cpp_sdk
+        target: 80%
+        informational: true
+      cli:
+        flags:
+          - cli
+        target: 80%
+        informational: true
+      cli_workload:
+        flags:
+          - cli_workload
+        target: 80%
+        informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: cpp_sdk
+      paths:
+        - ydb/public/sdk/cpp/**
+      carryforward: true
+    - name: cli
+      paths:
+        - ydb/apps/ydb/**
+        - ydb/public/lib/ydb_cli/**
+      carryforward: true
+    - name: cli_workload
+      paths:
+        - ydb/library/workload/**
+      carryforward: true
+
+component_management:
+  individual_components:
+    - component_id: cli_app
+      name: apps/ydb
+      paths:
+        - ydb/apps/ydb/**
+    - component_id: cli_core
+      name: ydb_cli lib
+      paths:
+        - ydb/public/lib/ydb_cli/**
+
+comment:
+  layout: "diff, flags, components, files"
+  behavior: default
+  require_changes: false

--- a/.github/scripts/codecov/codecov_suites.py
+++ b/.github/scripts/codecov/codecov_suites.py
@@ -28,14 +28,14 @@ SHARED_PATHS = {
 SUITES: dict[str, dict] = {
     "cpp_sdk": {
         "flag": "cpp_sdk",
-        "regexp": "ydb/public/sdk/cpp",
+        "regexp": r"^ydb/public/sdk/cpp(?:/|$)",
         "targets": ["ydb/public/sdk/cpp"],
         "lcov_prefixes": ["ydb/public/sdk/cpp/"],
         "path_prefixes": ["ydb/public/sdk/cpp/"],
     },
     "cli": {
         "flag": "cli",
-        "regexp": "ydb/apps/ydb/|ydb/public/lib/ydb_cli",
+        "regexp": r"^(?:ydb/apps/ydb|ydb/public/lib/ydb_cli)(?:/|$)",
         "targets": [
             "ydb/apps/ydb",
             "ydb/public/lib/ydb_cli",
@@ -50,7 +50,7 @@ SUITES: dict[str, dict] = {
     },
     "cli_workload": {
         "flag": "cli_workload",
-        "regexp": "ydb/library/workload",
+        "regexp": r"^ydb/library/workload(?:/|$)",
         "targets": ["ydb/library/workload"],
         "lcov_prefixes": ["ydb/library/workload/"],
         "path_prefixes": ["ydb/library/workload/"],

--- a/.github/scripts/codecov/codecov_suites.py
+++ b/.github/scripts/codecov/codecov_suites.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Shared suite table for C++ Codecov CI (detect + run_clang_codecov)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+# Product-only exclude (same idea as SDK --coverage-exclude-regexp).
+COVERAGE_EXCLUDE_REGEXP = r"/(ut|tests)/|_(ut|it)\.(c|cc|cpp|cxx|h|hh|hpp|hxx)"
+
+# Infra changes validate the pipeline for every suite.
+SHARED_PATH_PREFIXES = [
+    ".github/actions/run_clang_codecov/",
+    ".github/actions/setup_ci_ydb_service_account_key_file_credentials/",
+    ".github/scripts/codecov/",
+]
+
+# Unit tests validate coverage helpers but do not change the runtime pipeline.
+CHECK_ONLY_PATH_PREFIXES = [".github/scripts/codecov/tests/"]
+
+SHARED_PATHS = {
+    ".github/workflows/cpp_codecov.yml",
+    ".github/workflows/cpp_codecov_checks.yml",
+    ".github/codecov.yml",
+}
+
+SUITES: dict[str, dict] = {
+    "cpp_sdk": {
+        "flag": "cpp_sdk",
+        "regexp": "ydb/public/sdk/cpp",
+        "targets": ["ydb/public/sdk/cpp"],
+        "lcov_prefixes": ["ydb/public/sdk/cpp/"],
+        "path_prefixes": ["ydb/public/sdk/cpp/"],
+    },
+    "cli": {
+        "flag": "cli",
+        "regexp": "ydb/apps/ydb/|ydb/public/lib/ydb_cli",
+        "targets": [
+            "ydb/apps/ydb",
+            "ydb/public/lib/ydb_cli",
+            "ydb/tests/functional/ydb_cli",
+        ],
+        "lcov_prefixes": ["ydb/apps/ydb/", "ydb/public/lib/ydb_cli/"],
+        "path_prefixes": [
+            "ydb/apps/ydb/",
+            "ydb/public/lib/ydb_cli/",
+            "ydb/tests/functional/ydb_cli/",
+        ],
+    },
+    "cli_workload": {
+        "flag": "cli_workload",
+        "regexp": "ydb/library/workload",
+        "targets": ["ydb/library/workload"],
+        "lcov_prefixes": ["ydb/library/workload/"],
+        "path_prefixes": ["ydb/library/workload/"],
+    },
+}
+
+
+def _normalize_repo_path(path: str) -> str:
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def _matches_prefix(norm: str, prefixes: list[str]) -> bool:
+    return any(norm.startswith(p) or p.rstrip("/") == norm for p in prefixes)
+
+
+def suites_from_paths(changed_files: list[str]) -> list[str]:
+    found: set[str] = set()
+    for path in changed_files:
+        norm = _normalize_repo_path(path)
+        if _matches_prefix(norm, CHECK_ONLY_PATH_PREFIXES):
+            continue
+        if norm in SHARED_PATHS or _matches_prefix(norm, SHARED_PATH_PREFIXES):
+            found.update(SUITES.keys())
+            continue
+        for name, cfg in SUITES.items():
+            if _matches_prefix(norm, cfg["path_prefixes"]):
+                found.add(name)
+    return sorted(found)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: codecov_suites.py {list|json-suite <name>|exclude-regexp}", file=sys.stderr)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "list":
+        print("\n".join(SUITES.keys()))
+        return 0
+    if cmd == "exclude-regexp":
+        print(COVERAGE_EXCLUDE_REGEXP)
+        return 0
+    if cmd == "json-suite" and len(sys.argv) == 3:
+        name = sys.argv[2]
+        if name not in SUITES:
+            print(f"unknown suite: {name}", file=sys.stderr)
+            return 1
+        print(json.dumps(SUITES[name]))
+        return 0
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/codecov/detect_codecov_matrix.py
+++ b/.github/scripts/codecov/detect_codecov_matrix.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Decide which C++ Codecov suites to run from changed repository paths."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from codecov_suites import suites_from_paths
+
+
+def write_output(name: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        print(f"{name}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        if "\n" in value:
+            fh.write(f"{name}<<EOF\n{value}\nEOF\n")
+        else:
+            fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files",
+        default="",
+        help="Newline-separated list of changed paths",
+    )
+    parser.add_argument(
+        "--changed-files-file",
+        default="",
+        help="File with newline-separated changed paths",
+    )
+    args = parser.parse_args()
+
+    files: list[str] = []
+    if args.changed_files_file:
+        with open(args.changed_files_file, encoding="utf-8") as fh:
+            files = [ln.strip() for ln in fh if ln.strip()]
+    elif args.changed_files:
+        files = [ln.strip() for ln in args.changed_files.splitlines() if ln.strip()]
+
+    suites = suites_from_paths(files)
+
+    matrix = json.dumps(suites)
+    should_run = "true" if suites else "false"
+    write_output("matrix", matrix)
+    write_output("should_run", should_run)
+    print(f"suites={suites}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/codecov/export_coverage_lcov.py
+++ b/.github/scripts/codecov/export_coverage_lcov.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Export filtered LCOV from a ya --coverage-report output directory.
+"""Export suite-filtered LCOV and, optionally, a matching HTML report.
 
 Uses coverage.report/coverage.profdata and the llvm-cov object list from
-build_clang_coverage_report.log (same sources ya used for the HTML report).
+build_clang_coverage_report.log. Both outputs contain only source files owned
+by the selected suite; transitive dependencies may be executed, but they do
+not contribute to the component coverage percentage.
 """
 
 from __future__ import annotations
@@ -10,8 +12,10 @@ from __future__ import annotations
 import argparse
 import ast
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -148,7 +152,12 @@ def path_matches_prefixes(path: str, prefixes: list[str]) -> bool:
     return False
 
 
-def filter_lcov(text: str, prefixes: list[str]) -> str:
+def filter_lcov(
+    text: str,
+    prefixes: list[str],
+    *,
+    excluded_sources: set[str] | frozenset[str] = frozenset(),
+) -> str:
     records: list[str] = []
     current: list[str] = []
     keep = False
@@ -173,6 +182,7 @@ def filter_lcov(text: str, prefixes: list[str]) -> str:
             keep = path_matches_prefixes(path, prefixes) and not EXCLUDE_RE.search(
                 path.replace("\\", "/")
             )
+            keep = keep and path not in excluded_sources
             current.append(line)
             continue
         if line.startswith("end_of_record"):
@@ -185,6 +195,112 @@ def filter_lcov(text: str, prefixes: list[str]) -> str:
     return "".join(records)
 
 
+def lcov_sources(text: str) -> list[str]:
+    """Return unique source paths from a filtered LCOV stream."""
+    seen: set[str] = set()
+    sources: list[str] = []
+    for line in text.splitlines():
+        if not line.startswith("SF:"):
+            continue
+        source = line[3:].strip()
+        if source and source not in seen:
+            seen.add(source)
+            sources.append(source)
+    return sources
+
+
+def is_ephemeral_ya_build_source(path: str) -> bool:
+    """True for generated sources inside ya's disposable build root."""
+    return "/.ya/build/build_root/" in path.replace("\\", "/")
+
+
+def filter_suite_lcov(text: str, prefixes: list[str]) -> tuple[str, list[str]]:
+    """Keep checked-in suite sources and return discarded ya-generated paths."""
+    owned = filter_lcov(text, prefixes)
+    generated_sources = [
+        source for source in lcov_sources(owned) if is_ephemeral_ya_build_source(source)
+    ]
+    filtered = filter_lcov(
+        owned,
+        prefixes,
+        excluded_sources=frozenset(generated_sources),
+    )
+    missing_sources = [source for source in lcov_sources(filtered) if not Path(source).is_file()]
+    if missing_sources:
+        print(
+            f"Error: {len(missing_sources)} checked-in source file(s) missing",
+            file=sys.stderr,
+        )
+        for source in missing_sources[:10]:
+            print(f"  missing source: {source}", file=sys.stderr)
+        raise SystemExit("Refusing to publish LCOV with missing source files")
+    return filtered, generated_sources
+
+
+def generate_html_report(
+    llvm_cov: str,
+    objects: list[str],
+    profdata: Path,
+    filtered_lcov: str,
+    output_dir: Path,
+) -> None:
+    """Generate HTML for exactly the source files retained in filtered LCOV."""
+    sources = lcov_sources(filtered_lcov)
+    if not sources:
+        raise SystemExit("Filtered LCOV contains no source files for the HTML report")
+    missing_sources = [source for source in sources if not Path(source).is_file()]
+    if missing_sources:
+        print(
+            f"Error: {len(missing_sources)}/{len(sources)} filtered source files missing",
+            file=sys.stderr,
+        )
+        for source in missing_sources[:10]:
+            print(f"  missing source: {source}", file=sys.stderr)
+        raise SystemExit("Refusing to generate HTML from an incomplete source set")
+    if output_dir.exists() or output_dir.is_symlink():
+        raise SystemExit(f"Refusing to replace an existing HTML output path: {output_dir}")
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    temporary_dir = Path(
+        tempfile.mkdtemp(prefix=f".{output_dir.name}.", dir=output_dir.parent)
+    )
+
+    cmd = [
+        llvm_cov,
+        "show",
+        "-format=html",
+        f"-output-dir={temporary_dir}",
+        f"-instr-profile={profdata}",
+        objects[0],
+    ]
+    for obj in objects[1:]:
+        cmd.append(f"-object={obj}")
+    # The explicit source list is the important part: llvm-cov otherwise emits
+    # every dependency source present in the instrumented object closure.
+    cmd.append("-sources")
+    cmd.extend(sources)
+
+    print(
+        "+",
+        " ".join(cmd[:6]),
+        f"... ({len(objects)} objects, {len(sources)} sources)",
+        flush=True,
+    )
+    try:
+        proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+        if proc.returncode != 0:
+            print(proc.stdout, file=sys.stderr)
+            print(proc.stderr, file=sys.stderr)
+            raise SystemExit(f"llvm-cov HTML generation failed with exit {proc.returncode}")
+        if not (temporary_dir / "index.html").is_file():
+            raise SystemExit(
+                f"llvm-cov did not create the HTML index: {temporary_dir / 'index.html'}"
+            )
+        temporary_dir.replace(output_dir)
+    finally:
+        if temporary_dir.exists():
+            shutil.rmtree(temporary_dir)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--suite", required=True, choices=sorted(SUITES.keys()))
@@ -194,7 +310,19 @@ def main() -> int:
         type=Path,
         help="Directory passed to ya make --output (contains coverage.report/)",
     )
-    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--output", type=Path, default=None, help="Filtered LCOV output path")
+    parser.add_argument(
+        "--html-input",
+        type=Path,
+        default=None,
+        help="Existing filtered LCOV used as the exact HTML source list",
+    )
+    parser.add_argument(
+        "--html-output",
+        type=Path,
+        default=None,
+        help="Generate an llvm-cov HTML report for the same filtered source set",
+    )
     parser.add_argument(
         "--log",
         type=Path,
@@ -209,6 +337,12 @@ def main() -> int:
     )
     parser.add_argument("--llvm-cov", default="", help="Override llvm-cov binary")
     args = parser.parse_args()
+
+    if args.html_input is not None:
+        if args.output is not None or args.html_output is None:
+            parser.error("--html-input requires --html-output and cannot be combined with --output")
+    elif args.output is None or args.html_output is not None:
+        parser.error("LCOV export requires --output only; use --html-input for HTML")
 
     cfg = SUITES[args.suite]
     ya_out = args.ya_output.resolve()
@@ -233,6 +367,28 @@ def main() -> int:
             print(f"  missing: {m}", file=sys.stderr)
         raise SystemExit("Refusing to publish incomplete coverage")
 
+    if args.html_input is not None:
+        if not args.html_input.is_file():
+            raise SystemExit(f"Missing filtered LCOV input: {args.html_input}")
+        filtered = args.html_input.read_text(encoding="utf-8")
+        sources = lcov_sources(filtered)
+        if not sources:
+            raise SystemExit("Filtered LCOV contains no sources; refusing to generate HTML")
+        unexpected = [
+            source
+            for source in sources
+            if not path_matches_prefixes(source, cfg["lcov_prefixes"])
+            or EXCLUDE_RE.search(source.replace("\\", "/"))
+            or is_ephemeral_ya_build_source(source)
+        ]
+        if unexpected:
+            raise SystemExit(
+                f"Filtered LCOV contains {len(unexpected)} source(s) outside suite {args.suite}"
+            )
+        generate_html_report(llvm_cov, objects, profdata, filtered, args.html_output)
+        print(f"Wrote filtered HTML report to {args.html_output}")
+        return 0
+
     cmd = [
         llvm_cov,
         "export",
@@ -249,7 +405,14 @@ def main() -> int:
         print(proc.stderr, file=sys.stderr)
         raise SystemExit(f"llvm-cov export failed with exit {proc.returncode}")
 
-    filtered = filter_lcov(proc.stdout, cfg["lcov_prefixes"])
+    filtered, generated_sources = filter_suite_lcov(proc.stdout, cfg["lcov_prefixes"])
+    if generated_sources:
+        print(
+            f"Warning: dropping {len(generated_sources)} ephemeral ya-generated source file(s) from LCOV",
+            file=sys.stderr,
+        )
+        for source in generated_sources[:10]:
+            print(f"  dropped source: {source}", file=sys.stderr)
     if not filtered.strip():
         raise SystemExit(
             f"Filtered LCOV is empty for suite {args.suite}; refusing to upload a false 0% report"

--- a/.github/scripts/codecov/export_coverage_lcov.py
+++ b/.github/scripts/codecov/export_coverage_lcov.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Export filtered LCOV from a ya --coverage-report output directory.
+
+Uses coverage.report/coverage.profdata and the llvm-cov object list from
+build_clang_coverage_report.log (same sources ya used for the HTML report).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from codecov_suites import COVERAGE_EXCLUDE_REGEXP, SUITES
+
+EXCLUDE_RE = re.compile(COVERAGE_EXCLUDE_REGEXP)
+
+# ya logs: Executing: ['.../bin/llvm-cov', 'export', ..., '-object', 'path', ...]
+EXECUTING_RE = re.compile(r"Executing:\s*(\[.*bin/llvm-cov',\s*'export'.*\])")
+
+# llvm-cov options that consume the following argv token (not binaries).
+# Store normalized names because LLVM accepts both -option and --option forms.
+_LLVM_COV_VALUE_FLAGS = frozenset(
+    {
+        "instr-profile",
+        "object",
+        "format",
+        "ignore-filename-regex",
+        "include-filename-regex",
+        "name",
+        "name-regex",
+        "name-allowlist",
+        "name-whitelist",
+        "path-equivalence",
+        "j",
+        "num-threads",
+        "Xdemangler",
+        "coverage-watermark",
+        "arch",
+        "tab-size",
+        "output-dir",
+        "compilation-dir",
+        "debug-file-directory",
+        "line-coverage-gt",
+        "line-coverage-lt",
+        "region-coverage-gt",
+        "region-coverage-lt",
+    }
+)
+
+
+def parse_ya_llvm_cov_cmd(log_text: str) -> tuple[str, list[str]]:
+    """Return (llvm_cov_path, object_paths) from ya coverage report log.
+
+    Only real instrumented binaries are returned. Values of flags such as
+    -instr-profile / -ignore-filename-regex must not be treated as -object paths
+    (that bug made llvm-cov export fail with exit 1 in CI).
+    """
+    match = EXECUTING_RE.search(log_text)
+    if not match:
+        match = re.search(
+            r"(\[[^\]]*bin/llvm-cov',\s*'export'[^\]]*\])",
+            log_text,
+            re.S,
+        )
+    if not match:
+        raise SystemExit("Could not find llvm-cov export command in coverage log")
+
+    try:
+        cmd = ast.literal_eval(match.group(1))
+    except (SyntaxError, ValueError) as exc:
+        raise SystemExit(f"Failed to parse llvm-cov command: {exc}") from exc
+
+    if not cmd or "llvm-cov" not in cmd[0]:
+        raise SystemExit(f"Unexpected llvm-cov command: {cmd[:3]!r}")
+
+    llvm_cov = cmd[0]
+    objects: list[str] = []
+    i = 1
+    while i < len(cmd):
+        arg = cmd[i]
+        if arg in ("export", "show", "report"):
+            i += 1
+            continue
+        if arg.startswith("-"):
+            option, separator, value = arg.lstrip("-").partition("=")
+            if option == "object":
+                if separator:
+                    objects.append(value)
+                    i += 1
+                elif i + 1 < len(cmd):
+                    objects.append(cmd[i + 1])
+                    i += 2
+                else:
+                    raise SystemExit(f"Missing value for llvm-cov option: {arg}")
+                continue
+            if option in _LLVM_COV_VALUE_FLAGS:
+                if separator:
+                    i += 1
+                elif i + 1 < len(cmd):
+                    i += 2
+                else:
+                    raise SystemExit(f"Missing value for llvm-cov option: {arg}")
+                continue
+            # Unknown boolean option.
+            i += 1
+            continue
+        # Positional binary (legacy llvm-cov style): path, not .profdata
+        if "/" in arg and not arg.endswith((".profdata", ".profraw")):
+            objects.append(arg)
+        i += 1
+
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for o in objects:
+        if o not in seen:
+            seen.add(o)
+            uniq.append(o)
+
+    if not uniq:
+        raise SystemExit("No -object binaries found in llvm-cov command")
+    return llvm_cov, uniq
+
+
+def path_matches_prefixes(path: str, prefixes: list[str]) -> bool:
+    """True if path is under any prefix as a path segment (not a mere substring)."""
+    norm = path.replace("\\", "/")
+    for pref in prefixes:
+        p = pref.rstrip("/")
+        if not p:
+            continue
+        idx = 0
+        while True:
+            idx = norm.find(p, idx)
+            if idx == -1:
+                break
+            end = idx + len(p)
+            left_ok = idx == 0 or norm[idx - 1] == "/"
+            right_ok = end == len(norm) or norm[end] == "/"
+            if left_ok and right_ok:
+                return True
+            idx = end
+    return False
+
+
+def filter_lcov(text: str, prefixes: list[str]) -> str:
+    records: list[str] = []
+    current: list[str] = []
+    keep = False
+
+    def flush() -> None:
+        nonlocal current, keep
+        if current and keep:
+            records.append("".join(current))
+        current = []
+        keep = False
+
+    for line in text.splitlines(keepends=True):
+        if line.startswith("TN:"):
+            flush()
+            current = [line]
+            keep = False
+            continue
+        if line.startswith("SF:"):
+            if not current:
+                current = ["TN:\n"]
+            path = line[3:].strip()
+            keep = path_matches_prefixes(path, prefixes) and not EXCLUDE_RE.search(
+                path.replace("\\", "/")
+            )
+            current.append(line)
+            continue
+        if line.startswith("end_of_record"):
+            current.append(line)
+            flush()
+            continue
+        if current:
+            current.append(line)
+    flush()
+    return "".join(records)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", required=True, choices=sorted(SUITES.keys()))
+    parser.add_argument(
+        "--ya-output",
+        required=True,
+        type=Path,
+        help="Directory passed to ya make --output (contains coverage.report/)",
+    )
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=None,
+        help="Override path to build_clang_coverage_report.log",
+    )
+    parser.add_argument(
+        "--profdata",
+        type=Path,
+        default=None,
+        help="Override path to coverage.profdata",
+    )
+    parser.add_argument("--llvm-cov", default="", help="Override llvm-cov binary")
+    args = parser.parse_args()
+
+    cfg = SUITES[args.suite]
+    ya_out = args.ya_output.resolve()
+    report_dir = ya_out / "coverage.report"
+    profdata = args.profdata or (report_dir / "coverage.profdata")
+    log_path = args.log or (ya_out / "build_clang_coverage_report.log")
+
+    if not profdata.is_file():
+        raise SystemExit(f"Missing profdata: {profdata}")
+    if not log_path.is_file():
+        raise SystemExit(f"Missing coverage log: {log_path}")
+
+    log_text = log_path.read_text(encoding="utf-8", errors="replace")
+    llvm_cov, objects = parse_ya_llvm_cov_cmd(log_text)
+    if args.llvm_cov:
+        llvm_cov = args.llvm_cov
+
+    missing = [o for o in objects if not Path(o).is_file()]
+    if missing:
+        print(f"Error: {len(missing)}/{len(objects)} instrumented binaries missing", file=sys.stderr)
+        for m in missing[:10]:
+            print(f"  missing: {m}", file=sys.stderr)
+        raise SystemExit("Refusing to publish incomplete coverage")
+
+    cmd = [
+        llvm_cov,
+        "export",
+        "-format=lcov",
+        f"-instr-profile={profdata}",
+        objects[0],
+    ]
+    for obj in objects[1:]:
+        cmd.append(f"-object={obj}")
+
+    print("+", " ".join(cmd[:6]), f"... ({len(objects)} objects)", flush=True)
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    if proc.returncode != 0:
+        print(proc.stderr, file=sys.stderr)
+        raise SystemExit(f"llvm-cov export failed with exit {proc.returncode}")
+
+    filtered = filter_lcov(proc.stdout, cfg["lcov_prefixes"])
+    if not filtered.strip():
+        raise SystemExit(
+            f"Filtered LCOV is empty for suite {args.suite}; refusing to upload a false 0% report"
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(filtered, encoding="utf-8")
+    n_rec = filtered.count("end_of_record")
+    print(f"Wrote {args.output} ({len(filtered)} bytes, {n_rec} records)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/codecov/generate_coverage_landing.py
+++ b/.github/scripts/codecov/generate_coverage_landing.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Generate a simple HTML landing page linking suite coverage reports."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--title", default="YDB C++ coverage")
+    parser.add_argument(
+        "--suite",
+        action="append",
+        default=[],
+        metavar="NAME=REL_URL",
+        help="Suite entry, e.g. cli=./cli/index.html",
+    )
+    parser.add_argument("--meta-json", type=Path, default=None, help="Optional meta.json to embed summary")
+    args = parser.parse_args()
+
+    rows = []
+    for item in args.suite:
+        if "=" not in item:
+            raise SystemExit(f"bad --suite value: {item}")
+        name, url = item.split("=", 1)
+        rows.append((name, url))
+
+    meta_note = ""
+    if args.meta_json and args.meta_json.is_file():
+        meta = json.loads(args.meta_json.read_text(encoding="utf-8"))
+        meta_note = (
+            f"<p>Generated {html.escape(str(meta.get('generated_at', '')))} "
+            f"sha={html.escape(str(meta.get('sha', '')))} "
+            f"event={html.escape(str(meta.get('event', '')))}</p>"
+        )
+
+    lis = "\n".join(
+        f'  <li><a href="{html.escape(url)}">{html.escape(name)}</a></li>' for name, url in rows
+    )
+    body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>{html.escape(args.title)}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; }}
+    a {{ color: #056; }}
+  </style>
+</head>
+<body>
+  <h1>{html.escape(args.title)}</h1>
+  {meta_note}
+  <ul>
+{lis}
+  </ul>
+</body>
+</html>
+"""
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(body, encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/codecov/overlay_trusted_codecov_ci.sh
+++ b/.github/scripts/codecov/overlay_trusted_codecov_ci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Overlay coverage CI helpers from a checkout of the PR base (main) into the
+# current workspace. Invoked only from cpp_codecov.yml on pull_request_target;
+# the script itself must come from the trusted base checkout, not the PR tree.
+set -euo pipefail
+
+src="${1:-_trusted_coverage_ci}"
+if [ ! -d "$src/.github/actions/run_clang_codecov" ]; then
+  echo "Trusted coverage CI checkout missing under ${src}" >&2
+  exit 1
+fi
+
+rm -rf .github/actions/run_clang_codecov
+cp -a "$src/.github/actions/run_clang_codecov" .github/actions/
+
+rm -rf .github/actions/setup_ci_ydb_service_account_key_file_credentials
+cp -a "$src/.github/actions/setup_ci_ydb_service_account_key_file_credentials" .github/actions/
+
+# Replace the whole Python import directory. Copying only known files would let
+# a PR leave a sibling module (for example json.py) that shadows a trusted import.
+rm -rf .github/scripts/codecov
+mkdir -p .github/scripts
+cp -a "$src/.github/scripts/codecov" .github/scripts/

--- a/.github/scripts/codecov/tests/test_helpers.py
+++ b/.github/scripts/codecov/tests/test_helpers.py
@@ -601,7 +601,7 @@ class WorkflowContractTest(unittest.TestCase):
                 "-rjson",
                 "-ryaml",
                 "-e",
-                "puts JSON.generate(YAML.load_file(ARGV.fetch(0)))",
+                "puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), aliases: false))",
                 str(path),
             ],
             check=True,
@@ -656,6 +656,36 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertNotIn("context.payload.pull_request.labels", workflow)
         self.assertIn("if (pr.head.sha !== eventPr.head.sha)", workflow)
         self.assertIn("steps.authorization.outputs.allowed == 'true'", workflow)
+
+    def test_pr_changed_files_are_pinned_to_the_authorized_sha(self) -> None:
+        workflow = (
+            GITHUB_DIR / "workflows" / "cpp_codecov.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PR_HEAD_SHA: ${{ steps.pr.outputs.sha }}", workflow)
+        self.assertIn("PR_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow)
+        self.assertIn('"+refs/pull/${PR_NUMBER}/head:${local_head_ref}"', workflow)
+        self.assertIn('if [ "$fetched_head" != "$PR_HEAD_SHA" ]', workflow)
+        self.assertIn('"$PR_BASE_SHA...$PR_HEAD_SHA"', workflow)
+        self.assertIn("git -c core.quotePath=false diff", workflow)
+        self.assertIn("--name-only --no-renames", workflow)
+        self.assertNotIn("pulls/${PR_NUMBER}/files", workflow)
+
+    def test_untrusted_yaml_is_loaded_safely(self) -> None:
+        checks = (
+            GITHUB_DIR / "workflows" / "cpp_codecov_checks.yml"
+        ).read_text(encoding="utf-8")
+        tests = Path(__file__).read_text(encoding="utf-8")
+        self.assertIn(
+            'YAML.safe_load(File.read(path), aliases: false)',
+            checks,
+        )
+        self.assertIn(
+            'YAML.safe_load(File.read(ARGV.fetch(0)), aliases: false)',
+            tests,
+        )
+        unsafe_loader = "YAML." + "load_file"
+        self.assertNotIn(unsafe_loader, checks)
+        self.assertNotIn(unsafe_loader, tests)
 
     def test_codecov_upload_uses_explicit_safe_arguments(self) -> None:
         action = (

--- a/.github/scripts/codecov/tests/test_helpers.py
+++ b/.github/scripts/codecov/tests/test_helpers.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent
+CODECOV_DIR = TEST_DIR.parent
+GITHUB_DIR = CODECOV_DIR.parent.parent
+sys.path.insert(0, str(CODECOV_DIR))
+
+from codecov_suites import SUITES, suites_from_paths
+from export_coverage_lcov import filter_lcov, parse_ya_llvm_cov_cmd, path_matches_prefixes
+
+
+class CodecovSuitesTest(unittest.TestCase):
+    def test_product_paths_select_only_the_affected_suites(self) -> None:
+        self.assertEqual(suites_from_paths(["ydb/public/sdk/cpp/client/ydb_driver.cpp"]), ["cpp_sdk"])
+        self.assertEqual(suites_from_paths(["ydb/apps/ydb/commands/ydb.cpp"]), ["cli"])
+        self.assertEqual(
+            suites_from_paths(["ydb/tests/functional/ydb_cli/test_cli.py"]),
+            ["cli"],
+        )
+        self.assertEqual(
+            suites_from_paths(["ydb/library/workload/workload.cpp"]),
+            ["cli_workload"],
+        )
+
+    def test_multiple_product_paths_are_combined(self) -> None:
+        self.assertEqual(
+            suites_from_paths(
+                [
+                    "ydb/public/sdk/cpp/client/ydb_driver.cpp",
+                    "ydb/library/workload/workload.cpp",
+                ]
+            ),
+            ["cli_workload", "cpp_sdk"],
+        )
+
+    def test_unrelated_paths_select_nothing(self) -> None:
+        self.assertEqual(suites_from_paths(["ydb/core/base/appdata.h"]), [])
+
+    def test_coverage_infrastructure_selects_every_suite(self) -> None:
+        expected = sorted(SUITES)
+        shared_paths = [
+            ".github/actions/run_clang_codecov/action.yaml",
+            ".github/actions/setup_ci_ydb_service_account_key_file_credentials/action.yaml",
+            ".github/scripts/codecov/export_coverage_lcov.py",
+            ".github/workflows/cpp_codecov.yml",
+            ".github/workflows/cpp_codecov_checks.yml",
+            ".github/codecov.yml",
+        ]
+        for path in shared_paths:
+            with self.subTest(path=path):
+                self.assertEqual(suites_from_paths([path]), expected)
+
+        self.assertEqual(
+            suites_from_paths([".github/scripts/codecov/future_helper.py"]),
+            expected,
+        )
+
+    def test_similarly_named_files_are_not_coverage_infrastructure(self) -> None:
+        self.assertEqual(suites_from_paths([".github/codecov.yml.bak"]), [])
+        self.assertEqual(suites_from_paths([".github/workflows/cpp_codecov.yml.disabled"]), [])
+        self.assertEqual(
+            suites_from_paths([".github/scripts/codecov-extra/helper.py"]),
+            [],
+        )
+
+    def test_helper_unit_tests_do_not_select_product_coverage(self) -> None:
+        self.assertEqual(
+            suites_from_paths([".github/scripts/codecov/tests/test_helpers.py"]),
+            [],
+        )
+
+class DetectCodecovMatrixTest(unittest.TestCase):
+    def run_detector(self, *args: str) -> tuple[dict[str, str], str]:
+        with tempfile.NamedTemporaryFile() as output:
+            env = os.environ.copy()
+            env["GITHUB_OUTPUT"] = output.name
+            proc = subprocess.run(
+                [sys.executable, str(CODECOV_DIR / "detect_codecov_matrix.py"), *args],
+                check=True,
+                text=True,
+                capture_output=True,
+                env=env,
+            )
+            output.seek(0)
+            values = {}
+            for line in output.read().decode().splitlines():
+                name, value = line.split("=", 1)
+                values[name] = value
+            return values, proc.stderr
+
+    def test_paths_mode(self) -> None:
+        values, _ = self.run_detector(
+            "--changed-files",
+            "ydb/apps/ydb/main.cpp\nydb/public/sdk/cpp/client.cpp",
+        )
+        self.assertEqual(json.loads(values["matrix"]), ["cli", "cpp_sdk"])
+        self.assertEqual(values["should_run"], "true")
+
+    def test_rename_out_keeps_the_suite_selected(self) -> None:
+        values, _ = self.run_detector(
+            "--changed-files",
+            "docs/moved-client.cpp\nydb/public/sdk/cpp/client.cpp",
+        )
+        self.assertEqual(json.loads(values["matrix"]), ["cpp_sdk"])
+        self.assertEqual(values["should_run"], "true")
+
+
+class ExportCoverageLcovTest(unittest.TestCase):
+    def test_parse_llvm_cov_command_skips_option_values(self) -> None:
+        log = (
+            "Executing: ['/tools/bin/llvm-cov', 'export', '--instr-profile', "
+            "'/tmp/coverage.profdata', '--ignore-filename-regex', '/(ut|tests)/', "
+            "'/build/bin/ydb', '--object', '/build/bin/ydb-cli', "
+            "'-object=/build/bin/ydb-workload']"
+        )
+        llvm_cov, objects = parse_ya_llvm_cov_cmd(log)
+        self.assertEqual(llvm_cov, "/tools/bin/llvm-cov")
+        self.assertEqual(
+            objects,
+            ["/build/bin/ydb", "/build/bin/ydb-cli", "/build/bin/ydb-workload"],
+        )
+
+    def test_prefix_matching_uses_path_boundaries(self) -> None:
+        prefixes = ["ydb/public/sdk/cpp/"]
+        self.assertTrue(path_matches_prefixes("/repo/ydb/public/sdk/cpp/client.cpp", prefixes))
+        self.assertFalse(path_matches_prefixes("/repo/ydb/public/sdk/cppx/client.cpp", prefixes))
+
+    def test_filter_lcov_keeps_product_and_drops_tests(self) -> None:
+        lcov = """TN:
+SF:/repo/ydb/public/sdk/cpp/client.cpp
+DA:1,1
+end_of_record
+TN:
+SF:/repo/ydb/public/sdk/cpp/tests/client_ut.cpp
+DA:1,1
+end_of_record
+TN:
+SF:/repo/ydb/core/base/appdata.cpp
+DA:1,1
+end_of_record
+"""
+        filtered = filter_lcov(lcov, ["ydb/public/sdk/cpp/"])
+        self.assertIn("client.cpp", filtered)
+        self.assertNotIn("client_ut.cpp", filtered)
+        self.assertNotIn("appdata.cpp", filtered)
+        self.assertEqual(filtered.count("end_of_record"), 1)
+
+    def test_export_refuses_a_missing_instrumented_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            ya_output = Path(directory)
+            report = ya_output / "coverage.report"
+            report.mkdir()
+            (report / "coverage.profdata").touch()
+            missing = ya_output / "missing-llvm-object"
+            (ya_output / "build_clang_coverage_report.log").write_text(
+                f"Executing: ['/tools/bin/llvm-cov', 'export', '{missing}']\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(CODECOV_DIR / "export_coverage_lcov.py"),
+                    "--suite",
+                    "cli",
+                    "--ya-output",
+                    str(ya_output),
+                    "--output",
+                    str(ya_output / "coverage.lcov"),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("Refusing to publish incomplete coverage", proc.stderr)
+
+    def test_export_refuses_an_empty_filtered_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            ya_output = Path(directory)
+            report = ya_output / "coverage.report"
+            report.mkdir()
+            (report / "coverage.profdata").touch()
+            llvm_object = ya_output / "instrumented-binary"
+            llvm_object.touch()
+            tool = ya_output / "bin" / "llvm-cov"
+            tool.parent.mkdir()
+            tool.write_text(
+                "#!/usr/bin/env sh\n"
+                "printf 'TN:\\nSF:/repo/ydb/core/base.cpp\\nDA:1,1\\nend_of_record\\n'\n",
+                encoding="utf-8",
+            )
+            tool.chmod(0o755)
+            (ya_output / "build_clang_coverage_report.log").write_text(
+                f"Executing: ['{tool}', 'export', '{llvm_object}']\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(CODECOV_DIR / "export_coverage_lcov.py"),
+                    "--suite",
+                    "cli",
+                    "--ya-output",
+                    str(ya_output),
+                    "--output",
+                    str(ya_output / "coverage.lcov"),
+                    "--llvm-cov",
+                    str(tool),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("Filtered LCOV is empty", proc.stderr)
+
+
+class GenerateCoverageLandingTest(unittest.TestCase):
+    def test_output_is_deterministic_and_contains_only_requested_suites(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "first.html"
+            second = Path(directory) / "second.html"
+            command = [
+                sys.executable,
+                str(CODECOV_DIR / "generate_coverage_landing.py"),
+                "--title",
+                "Coverage",
+                "--suite",
+                "cli=./cli/index.html",
+            ]
+            subprocess.run([*command, "--output", str(first)], check=True)
+            subprocess.run([*command, "--output", str(second)], check=True)
+            self.assertEqual(first.read_text(), second.read_text())
+            self.assertIn("./cli/index.html", first.read_text())
+            self.assertNotIn("cpp_sdk", first.read_text())
+
+
+class OverlayTrustedCodecovCiTest(unittest.TestCase):
+    def test_overlay_replaces_the_entire_import_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            measured = root / "measured"
+            trusted = root / "trusted"
+
+            for action in (
+                "run_clang_codecov",
+                "setup_ci_ydb_service_account_key_file_credentials",
+            ):
+                measured_action = measured / ".github" / "actions" / action
+                trusted_action = trusted / ".github" / "actions" / action
+                measured_action.mkdir(parents=True)
+                trusted_action.mkdir(parents=True)
+                (measured_action / "untrusted.txt").write_text("untrusted\n")
+                (trusted_action / "trusted.txt").write_text("trusted\n")
+
+            measured_helpers = measured / ".github" / "scripts" / "codecov"
+            trusted_helpers = trusted / ".github" / "scripts" / "codecov"
+            measured_helpers.mkdir(parents=True)
+            trusted_helpers.mkdir(parents=True)
+            (measured_helpers / "json.py").write_text("raise RuntimeError('untrusted')\n")
+            (trusted_helpers / "trusted_helper.py").write_text("TRUSTED = True\n")
+
+            subprocess.run(
+                ["bash", str(CODECOV_DIR / "overlay_trusted_codecov_ci.sh"), str(trusted)],
+                cwd=measured,
+                check=True,
+            )
+
+            self.assertFalse((measured_helpers / "json.py").exists())
+            self.assertTrue((measured_helpers / "trusted_helper.py").is_file())
+            for action in (
+                "run_clang_codecov",
+                "setup_ci_ydb_service_account_key_file_credentials",
+            ):
+                action_dir = measured / ".github" / "actions" / action
+                self.assertFalse((action_dir / "untrusted.txt").exists())
+                self.assertTrue((action_dir / "trusted.txt").is_file())
+
+
+class WorkflowContractTest(unittest.TestCase):
+    def test_only_ok_to_test_label_can_trigger_coverage(self) -> None:
+        workflow = (
+            GITHUB_DIR / "workflows" / "cpp_codecov.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("branches: [main]", workflow)
+        self.assertIn("types: [opened, synchronize, reopened, closed, labeled]", workflow)
+        self.assertIn("github.event.label.name == 'ok-to-test'", workflow)
+        self.assertIn('"!.github/scripts/codecov/tests/**"', workflow)
+        self.assertIn("github.event.label.name != 'ok-to-test'", workflow)
+        self.assertIn("format('-ignore-{0}', github.run_id)", workflow)
+        self.assertIn(
+            "github.event_name == 'pull_request_target' && github.event.action != 'labeled'",
+            workflow,
+        )
+        self.assertNotIn("coverage/sdk", workflow)
+        self.assertNotIn("coverage/cli", workflow)
+        self.assertNotIn("coverage/workload", workflow)
+        self.assertNotIn("coverage/all", workflow)
+        self.assertNotIn("workflow_dispatch", workflow)
+
+    def test_pr_authorization_is_event_and_sha_scoped(self) -> None:
+        workflow = (
+            GITHUB_DIR / "workflows" / "cpp_codecov.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("const permission = await getPermission(sender);", workflow)
+        self.assertIn("if (!isWriter(permission))", workflow)
+        self.assertIn("context.payload.pull_request.user.login", workflow)
+        self.assertIn("context.payload.sender.login", workflow)
+        self.assertNotIn("context.payload.pull_request.labels", workflow)
+        self.assertIn("if (pr.head.sha !== eventPr.head.sha)", workflow)
+        self.assertIn("steps.authorization.outputs.allowed == 'true'", workflow)
+
+    def test_codecov_upload_uses_explicit_safe_arguments(self) -> None:
+        action = (
+            GITHUB_DIR / "actions" / "run_clang_codecov" / "action.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn('--slug "${REPOSITORY_SLUG}"', action)
+        self.assertIn('--sha "${COMMIT_SHA}"', action)
+        self.assertIn("--disable-search", action)
+        self.assertIn("--plugin noop", action)
+        self.assertNotIn('-t "${CODECOV_TOKEN}"', action)
+        self.assertNotIn("set -x", action)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/codecov/tests/test_helpers.py
+++ b/.github/scripts/codecov/tests/test_helpers.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TEST_DIR = Path(__file__).resolve().parent
 CODECOV_DIR = TEST_DIR.parent
@@ -16,7 +20,15 @@ GITHUB_DIR = CODECOV_DIR.parent.parent
 sys.path.insert(0, str(CODECOV_DIR))
 
 from codecov_suites import SUITES, suites_from_paths
-from export_coverage_lcov import filter_lcov, parse_ya_llvm_cov_cmd, path_matches_prefixes
+from export_coverage_lcov import (
+    filter_lcov,
+    filter_suite_lcov,
+    generate_html_report,
+    is_ephemeral_ya_build_source,
+    lcov_sources,
+    parse_ya_llvm_cov_cmd,
+    path_matches_prefixes,
+)
 
 
 class CodecovSuitesTest(unittest.TestCase):
@@ -78,6 +90,52 @@ class CodecovSuitesTest(unittest.TestCase):
             suites_from_paths([".github/scripts/codecov/tests/test_helpers.py"]),
             [],
         )
+
+    def test_suite_instrumentation_regexes_are_path_bounded(self) -> None:
+        cases = {
+            "cpp_sdk": (
+                ["ydb/public/sdk/cpp", "ydb/public/sdk/cpp/client"],
+                ["ydb/public/sdk/cppx", "other/ydb/public/sdk/cpp"],
+            ),
+            "cli": (
+                ["ydb/apps/ydb", "ydb/apps/ydb/commands", "ydb/public/lib/ydb_cli"],
+                ["ydb/apps/ydbx", "ydb/public/lib/ydb_clix"],
+            ),
+            "cli_workload": (
+                ["ydb/library/workload", "ydb/library/workload/tpcc"],
+                ["ydb/library/workloads", "other/ydb/library/workload"],
+            ),
+        }
+        for suite, (matches, misses) in cases.items():
+            regexp = re.compile(SUITES[suite]["regexp"])
+            for path in matches:
+                with self.subTest(suite=suite, path=path, expected=True):
+                    self.assertIsNotNone(regexp.match(path))
+            for path in misses:
+                with self.subTest(suite=suite, path=path, expected=False):
+                    self.assertIsNone(regexp.match(path))
+
+    def test_suite_owned_prefixes_are_exact_and_disjoint(self) -> None:
+        expected = {
+            "cpp_sdk": ["ydb/public/sdk/cpp/"],
+            "cli": ["ydb/apps/ydb/", "ydb/public/lib/ydb_cli/"],
+            "cli_workload": ["ydb/library/workload/"],
+        }
+        self.assertEqual(
+            {name: cfg["lcov_prefixes"] for name, cfg in SUITES.items()},
+            expected,
+        )
+        all_prefixes = [prefix for prefixes in expected.values() for prefix in prefixes]
+        for index, left in enumerate(all_prefixes):
+            for right in all_prefixes[index + 1 :]:
+                with self.subTest(left=left, right=right):
+                    self.assertFalse(left.startswith(right) or right.startswith(left))
+
+    def test_cli_functional_tests_trigger_but_are_not_reported(self) -> None:
+        path = "ydb/tests/functional/ydb_cli/test_cli.py"
+        self.assertEqual(suites_from_paths([path]), ["cli"])
+        self.assertFalse(path_matches_prefixes(path, SUITES["cli"]["lcov_prefixes"]))
+
 
 class DetectCodecovMatrixTest(unittest.TestCase):
     def run_detector(self, *args: str) -> tuple[dict[str, str], str]:
@@ -154,6 +212,249 @@ end_of_record
         self.assertNotIn("client_ut.cpp", filtered)
         self.assertNotIn("appdata.cpp", filtered)
         self.assertEqual(filtered.count("end_of_record"), 1)
+
+    def test_suite_filter_drops_all_ya_build_root_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            existing = root / "ydb" / "library" / "workload" / "source.cpp"
+            existing.parent.mkdir(parents=True)
+            existing.touch()
+            generated = (
+                root
+                / ".ya"
+                / "build"
+                / "build_root"
+                / "hash"
+                / "ydb"
+                / "library"
+                / "workload"
+                / "generated.cpp"
+            )
+            generated.parent.mkdir(parents=True)
+            generated.touch()
+            missing_generated = generated.with_name("missing-generated.cpp")
+            lcov = (
+                f"TN:\nSF:{existing}\nDA:1,1\nend_of_record\n"
+                f"TN:\nSF:{generated}\nDA:1,1\nend_of_record\n"
+                f"TN:\nSF:{missing_generated}\nDA:1,1\nend_of_record\n"
+            )
+            filtered, dropped = filter_suite_lcov(
+                lcov,
+                SUITES["cli_workload"]["lcov_prefixes"],
+            )
+            self.assertEqual(lcov_sources(filtered), [str(existing)])
+            self.assertEqual(dropped, [str(generated), str(missing_generated)])
+
+    def test_suite_filter_refuses_a_missing_checked_in_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "ydb" / "apps" / "ydb" / "missing.cpp"
+            lcov = f"TN:\nSF:{missing}\nDA:1,1\nend_of_record\n"
+            with contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaisesRegex(SystemExit, "missing source files"):
+                    filter_suite_lcov(lcov, SUITES["cli"]["lcov_prefixes"])
+
+    def test_only_ya_build_root_paths_are_classified_as_ephemeral(self) -> None:
+        self.assertTrue(
+            is_ephemeral_ya_build_source(
+                "/home/runner/.ya/build/build_root/hash/node/ydb/apps/ydb/generated.cpp"
+            )
+        )
+        self.assertTrue(
+            is_ephemeral_ya_build_source(
+                r"C:\runner\.ya\build\build_root\hash\ydb\apps\ydb\generated.cpp"
+            )
+        )
+        self.assertFalse(
+            is_ephemeral_ya_build_source(
+                "/home/runner/actions_runner/_work/ydb/ydb/ydb/apps/ydb/source.cpp"
+            )
+        )
+        self.assertFalse(
+            is_ephemeral_ya_build_source(
+                "/home/runner/.ya/build/build_root-old/ydb/apps/ydb/generated.cpp"
+            )
+        )
+
+    def test_each_suite_lcov_keeps_only_owned_sources(self) -> None:
+        owned = {
+            "cpp_sdk": [
+                "/repo/ydb/public/sdk/cpp/client.cpp",
+                "/repo/ydb/public/sdk/cpp/client.h",
+            ],
+            "cli": [
+                "/repo/ydb/apps/ydb/commands.cpp",
+                "/repo/ydb/public/lib/ydb_cli/commands.h",
+            ],
+            "cli_workload": [
+                "/repo/ydb/library/workload/tpcc.cpp",
+                "/repo/ydb/library/workload/tpcc.h",
+            ],
+        }
+        owned_tests = {
+            "cpp_sdk": "/repo/ydb/public/sdk/cpp/tests/client.cpp",
+            "cli": "/repo/ydb/apps/ydb/commands_ut.cpp",
+            "cli_workload": "/repo/ydb/library/workload/tests/tpcc.cpp",
+        }
+        common_unowned = [
+            "/repo/ydb/core/base/appdata.cpp",
+            "/repo/library/cpp/threading/future.cpp",
+            "/repo/contrib/libs/abseil/status.cpp",
+        ]
+        lookalikes = {
+            "cpp_sdk": "/repo/ydb/public/sdk/cppx/client.cpp",
+            "cli": "/repo/ydb/public/lib/ydb_clix/commands.cpp",
+            "cli_workload": "/repo/ydb/library/workloads/tpcc.cpp",
+        }
+
+        def record(path: str) -> str:
+            return f"TN:\nSF:{path}\nDA:1,1\nend_of_record\n"
+
+        for suite, owned_paths in owned.items():
+            lcov = "".join(
+                record(path)
+                for path in [
+                    *owned_paths,
+                    owned_tests[suite],
+                    lookalikes[suite],
+                    *common_unowned,
+                ]
+            )
+            filtered = filter_lcov(lcov, SUITES[suite]["lcov_prefixes"])
+            with self.subTest(suite=suite):
+                self.assertEqual(lcov_sources(filtered), owned_paths)
+
+    def test_html_uses_the_same_filtered_sources_as_lcov(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            ya_output = Path(directory)
+            report = ya_output / "coverage.report"
+            report.mkdir()
+            (report / "coverage.profdata").touch()
+            llvm_object = ya_output / "instrumented-binary"
+            llvm_object.touch()
+            calls = ya_output / "llvm-cov-calls.jsonl"
+            owned_source = ya_output / "repo" / "ydb" / "apps" / "ydb" / "main.cpp"
+            owned_source.parent.mkdir(parents=True)
+            owned_source.touch()
+            tool = ya_output / "bin" / "llvm-cov"
+            tool.parent.mkdir()
+            tool.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                f"calls = pathlib.Path({str(calls)!r})\n"
+                "with calls.open('a', encoding='utf-8') as stream:\n"
+                "    stream.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+                "if sys.argv[1] == 'export':\n"
+                "    print(f'TN:\\nSF:{os.environ[\"FAKE_OWNED_SOURCE\"]}\\nDA:1,1\\nend_of_record')\n"
+                "    print('TN:\\nSF:/repo/contrib/libs/abseil/status.cpp\\nDA:1,0\\nend_of_record')\n"
+                "elif sys.argv[1] == 'show':\n"
+                "    option = next(x for x in sys.argv if x.startswith('-output-dir='))\n"
+                "    output = pathlib.Path(option.split('=', 1)[1])\n"
+                "    output.mkdir(parents=True, exist_ok=True)\n"
+                "    (output / 'index.html').write_text('filtered', encoding='utf-8')\n",
+                encoding="utf-8",
+            )
+            tool.chmod(0o755)
+            (ya_output / "build_clang_coverage_report.log").write_text(
+                f"Executing: ['{tool}', 'export', '{llvm_object}']\n",
+                encoding="utf-8",
+            )
+            lcov_output = ya_output / "coverage.lcov"
+            html_output = ya_output / "coverage.filtered.report"
+            fake_env = os.environ.copy()
+            fake_env["FAKE_OWNED_SOURCE"] = str(owned_source)
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(CODECOV_DIR / "export_coverage_lcov.py"),
+                    "--suite",
+                    "cli",
+                    "--ya-output",
+                    str(ya_output),
+                    "--output",
+                    str(lcov_output),
+                    "--llvm-cov",
+                    str(tool),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+                env=fake_env,
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(CODECOV_DIR / "export_coverage_lcov.py"),
+                    "--suite",
+                    "cli",
+                    "--ya-output",
+                    str(ya_output),
+                    "--html-input",
+                    str(lcov_output),
+                    "--html-output",
+                    str(html_output),
+                    "--llvm-cov",
+                    str(tool),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+                env=fake_env,
+            )
+
+            self.assertEqual(
+                lcov_sources(lcov_output.read_text()),
+                [str(owned_source)],
+            )
+            self.assertTrue((html_output / "index.html").is_file())
+            invocations = [json.loads(line) for line in calls.read_text().splitlines()]
+            show = next(args for args in invocations if args[0] == "show")
+            source_index = show.index("-sources")
+            self.assertEqual(show[source_index + 1 :], [str(owned_source)])
+            self.assertNotIn("/repo/contrib/libs/abseil/status.cpp", show)
+
+    def test_failed_html_generation_leaves_no_publishable_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "coverage.filtered.report"
+            source = root / "repo" / "ydb" / "apps" / "ydb" / "main.cpp"
+            source.parent.mkdir(parents=True)
+            source.touch()
+            completed = subprocess.CompletedProcess(
+                args=["llvm-cov", "show"],
+                returncode=1,
+                stdout="partial output",
+                stderr="show failed",
+            )
+            with mock.patch("export_coverage_lcov.subprocess.run", return_value=completed):
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+                    io.StringIO()
+                ):
+                    with self.assertRaisesRegex(SystemExit, "HTML generation failed"):
+                        generate_html_report(
+                            "llvm-cov",
+                            ["instrumented-object"],
+                            root / "coverage.profdata",
+                            f"TN:\nSF:{source}\nDA:1,1\nend_of_record\n",
+                            output,
+                        )
+            self.assertFalse(output.exists())
+            self.assertEqual(list(root.glob(".coverage.filtered.report.*")), [])
+
+    def test_html_refuses_missing_filtered_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "coverage.filtered.report"
+            with contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaisesRegex(SystemExit, "incomplete source set"):
+                    generate_html_report(
+                        "llvm-cov",
+                        ["instrumented-object"],
+                        root / "coverage.profdata",
+                        "TN:\nSF:/missing/ydb/apps/ydb/main.cpp\nDA:1,1\nend_of_record\n",
+                        output,
+                    )
+            self.assertFalse(output.exists())
 
     def test_export_refuses_a_missing_instrumented_binary(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -292,6 +593,37 @@ class OverlayTrustedCodecovCiTest(unittest.TestCase):
 
 
 class WorkflowContractTest(unittest.TestCase):
+    def test_codecov_flag_paths_match_suite_owned_prefixes(self) -> None:
+        path = GITHUB_DIR / "codecov.yml"
+        proc = subprocess.run(
+            [
+                "ruby",
+                "-rjson",
+                "-ryaml",
+                "-e",
+                "puts JSON.generate(YAML.load_file(ARGV.fetch(0)))",
+                str(path),
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        config = json.loads(proc.stdout)
+        flags = {
+            item["name"]: item["paths"]
+            for item in config["flag_management"]["individual_flags"]
+        }
+        expected = {
+            name: [f"{prefix}**" for prefix in cfg["lcov_prefixes"]]
+            for name, cfg in SUITES.items()
+        }
+        self.assertEqual(flags, expected)
+
+        cli_roots = tuple(SUITES["cli"]["lcov_prefixes"])
+        for component in config["component_management"]["individual_components"]:
+            for component_path in component["paths"]:
+                self.assertTrue(component_path.startswith(cli_roots))
+
     def test_only_ok_to_test_label_can_trigger_coverage(self) -> None:
         workflow = (
             GITHUB_DIR / "workflows" / "cpp_codecov.yml"
@@ -333,6 +665,15 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertIn('--sha "${COMMIT_SHA}"', action)
         self.assertIn("--disable-search", action)
         self.assertIn("--plugin noop", action)
+        self.assertIn('--html-input "$OUT/coverage.lcov"', action)
+        self.assertIn('--html-output "$OUT/coverage.filtered.report"', action)
+        self.assertIn('report_dir="${OUT}/coverage.filtered.report"', action)
+        self.assertNotIn('report_dir="${OUT}/coverage.report"', action)
+        self.assertIn("id: export", action)
+        self.assertIn("id: html", action)
+        self.assertGreaterEqual(action.count("steps.export.outcome == 'success'"), 3)
+        self.assertEqual(action.count("steps.html.outcome == 'success'"), 2)
+        self.assertIn('if [ ! -f "${report_dir}/index.html" ]', action)
         self.assertNotIn('-t "${CODECOV_TOKEN}"', action)
         self.assertNotIn("set -x", action)
 

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -1,0 +1,447 @@
+name: Codecov C++ (SDK / CLI / workload)
+
+# PR coverage intentionally uses pull_request_target: repository secrets and
+# self-hosted runners are available only after the trusted workflow from main
+# verifies that the PR author and event sender have write access, or a repository
+# writer explicitly approves an external PR with ok-to-test. Product code is
+# checked out at the exact PR head SHA, while coverage helpers come from the PR
+# base SHA.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, closed, labeled]
+    paths:
+      - "ydb/public/sdk/cpp/**"
+      - "ydb/apps/ydb/**"
+      - "ydb/public/lib/ydb_cli/**"
+      - "ydb/tests/functional/ydb_cli/**"
+      - "ydb/library/workload/**"
+      - ".github/actions/run_clang_codecov/**"
+      - ".github/actions/setup_ci_ydb_service_account_key_file_credentials/**"
+      - ".github/scripts/codecov/**"
+      - "!.github/scripts/codecov/tests/**"
+      - ".github/workflows/cpp_codecov.yml"
+      - ".github/workflows/cpp_codecov_checks.yml"
+      - ".github/codecov.yml"
+  push:
+    branches: [main]
+    paths:
+      - "ydb/public/sdk/cpp/**"
+      - "ydb/apps/ydb/**"
+      - "ydb/public/lib/ydb_cli/**"
+      - "ydb/tests/functional/ydb_cli/**"
+      - "ydb/library/workload/**"
+      - ".github/actions/run_clang_codecov/**"
+      - ".github/actions/setup_ci_ydb_service_account_key_file_credentials/**"
+      - ".github/scripts/codecov/**"
+      - "!.github/scripts/codecov/tests/**"
+      - ".github/workflows/cpp_codecov.yml"
+      - ".github/workflows/cpp_codecov_checks.yml"
+      - ".github/codecov.yml"
+
+# GitHub cannot filter label names in `on`. Irrelevant labels therefore get a
+# unique workflow group and skip every job. ok-to-test shares the PR group but
+# label events cannot cancel a running workflow before the sender is verified.
+# A later synchronize/closed event can still invalidate the approved PR SHA.
+# Main runs use a unique workflow-level group: a later main push must not cancel
+# a different suite before its new baseline reaches Codecov.
+concurrency:
+  group: >-
+    ${{
+      github.event_name == 'pull_request_target'
+      && format('codecov-pr-{0}{1}', github.event.pull_request.number,
+          github.event.action == 'labeled' && github.event.label.name != 'ok-to-test'
+          && format('-ignore-{0}', github.run_id) || '')
+      || format('codecov-{0}-{1}', github.event_name, github.run_id)
+    }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request_target' && github.event.action != 'labeled' }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    name: Detect suites
+    if: >-
+      github.repository == 'ydb-platform/ydb' &&
+      (github.event_name != 'pull_request_target' ||
+       (github.event.pull_request.state == 'open' &&
+        github.base_ref == 'main' &&
+        (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')))
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.decide.outputs.matrix || '[]' }}
+      should_run: ${{ steps.decide.outputs.should_run || 'false' }}
+      checkout_repository: ${{ steps.metadata.outputs.checkout_repository }}
+      checkout_sha: ${{ steps.metadata.outputs.checkout_sha }}
+      base_sha: ${{ steps.metadata.outputs.base_sha }}
+      report_sha: ${{ steps.metadata.outputs.report_sha }}
+      report_branch: ${{ steps.metadata.outputs.report_branch }}
+      pr_number: ${{ steps.metadata.outputs.pr_number }}
+      storage_prefix: ${{ steps.metadata.outputs.storage_prefix }}
+    steps:
+      - name: Authorize PR coverage
+        id: authorization
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v8
+        with:
+          # The restricted workflow GITHUB_TOKEN returned false 404 responses
+          # for this endpoint. This PAT is used only by the trusted gate.
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const getPermission = async (username) => {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username,
+                });
+                return data.permission;
+              } catch (error) {
+                if (!error.status || error.status !== 404) throw error;
+                return 'none';
+              }
+            };
+            const isWriter = (permission) => ['admin', 'write'].includes(permission);
+
+            if (context.payload.action === 'labeled') {
+              if (context.payload.label?.name !== 'ok-to-test') {
+                core.setOutput('allowed', 'false');
+                return;
+              }
+              const sender = context.payload.sender.login;
+              const permission = await getPermission(sender);
+              if (!isWriter(permission)) {
+                core.warning(
+                  `Ignoring ok-to-test from @${sender}: write permission is required (${permission}).`
+                );
+                core.setOutput('allowed', 'false');
+                return;
+              }
+              core.info(`PR coverage approved by @${sender}.`);
+              core.setOutput('allowed', 'true');
+              return;
+            }
+
+            const users = [...new Set([
+              context.payload.pull_request.user.login,
+              context.payload.sender.login,
+            ])];
+
+            for (const username of users) {
+              const permission = await getPermission(username);
+              if (!isWriter(permission)) {
+                core.notice(
+                  `C++ coverage is waiting for a repository writer to apply ok-to-test ` +
+                  `(@${username}: ${permission}).`
+                );
+                core.setOutput('allowed', 'false');
+                return;
+              }
+            }
+            core.setOutput('allowed', 'true');
+
+      - name: Pin PR head
+        id: pr
+        if: >-
+          github.event_name == 'pull_request_target' &&
+          steps.authorization.outputs.allowed == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const eventPr = context.payload.pull_request;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: eventPr.number,
+            });
+
+            if (pr.state !== 'open' || pr.base.repo.full_name !== context.repo.owner + '/' + context.repo.repo || pr.base.ref !== 'main') {
+              core.setFailed('Coverage runs only for open pull requests targeting ydb-platform/ydb:main.');
+              return;
+            }
+            if (pr.head.sha !== eventPr.head.sha) {
+              core.setFailed('The PR head changed after this workflow started. Please use the latest run.');
+              return;
+            }
+            if (!pr.head.repo) {
+              core.setFailed('The PR head repository is unavailable.');
+              return;
+            }
+
+            const branch = pr.head.repo.full_name === pr.base.repo.full_name
+              ? pr.head.ref
+              : pr.head.label;
+            core.setOutput('repository', pr.head.repo.full_name);
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('base_sha', eventPr.base.sha);
+            core.setOutput('branch', branch);
+
+      - name: Checkout trusted detection helpers
+        if: >-
+          github.event_name != 'pull_request_target' ||
+          steps.authorization.outputs.allowed == 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.pr.outputs.base_sha || github.sha }}
+          fetch-depth: 0
+          sparse-checkout: |
+            .github/scripts/codecov/codecov_suites.py
+            .github/scripts/codecov/detect_codecov_matrix.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Collect changed files
+        id: inputs
+        if: >-
+          github.event_name != 'pull_request_target' ||
+          steps.authorization.outputs.allowed == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          changed_file=$(mktemp)
+
+          case "$EVENT_NAME" in
+            pull_request_target)
+              gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+                --paginate --jq '.[] | .filename, (.previous_filename // empty)' \
+                > "$changed_file"
+              ;;
+            push)
+              if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+                git diff --name-only --no-renames HEAD~1 HEAD > "$changed_file"
+              else
+                git diff --name-only --no-renames "$BEFORE_SHA" "$AFTER_SHA" > "$changed_file"
+              fi
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "changed_files_file=$changed_file" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"
+          head -100 "$changed_file"
+
+      - name: Decide matrix
+        id: decide
+        if: >-
+          github.event_name != 'pull_request_target' ||
+          steps.authorization.outputs.allowed == 'true'
+        env:
+          CHANGED_FILES_FILE: ${{ steps.inputs.outputs.changed_files_file }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/codecov/detect_codecov_matrix.py \
+            --changed-files-file "$CHANGED_FILES_FILE"
+
+      - name: Resolve checkout and report metadata
+        id: metadata
+        if: >-
+          github.event_name != 'pull_request_target' ||
+          steps.authorization.outputs.allowed == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          PR_REPOSITORY: ${{ steps.pr.outputs.repository }}
+          PR_SHA: ${{ steps.pr.outputs.sha }}
+          PR_BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          PR_BRANCH: ${{ steps.pr.outputs.branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = pull_request_target ]; then
+            checkout_repository="$PR_REPOSITORY"
+            checkout_sha="$PR_SHA"
+            base_sha="$PR_BASE_SHA"
+            report_branch="$PR_BRANCH"
+            pr_number="$PR_NUMBER"
+            storage_prefix="ydb/pr-${PR_NUMBER}/coverage"
+          else
+            checkout_repository="$REPOSITORY"
+            checkout_sha="$EVENT_SHA"
+            base_sha=""
+            report_branch="$REF_NAME"
+            pr_number=""
+            storage_prefix="ydb/coverage"
+          fi
+
+          {
+            echo "checkout_repository=$checkout_repository"
+            echo "checkout_sha=$checkout_sha"
+            echo "base_sha=$base_sha"
+            echo "report_sha=$checkout_sha"
+            echo "report_branch=$report_branch"
+            echo "pr_number=$pr_number"
+            echo "storage_prefix=$storage_prefix"
+          } >> "$GITHUB_OUTPUT"
+
+  coverage:
+    name: Coverage (${{ matrix.suite }})
+    needs: detect
+    if: >-
+      needs.detect.result == 'success' &&
+      needs.detect.outputs.should_run == 'true'
+    # A newer main job supersedes only the same suite. It must not cancel a
+    # different flag whose baseline is still being produced by an older push.
+    concurrency:
+      group: >-
+        ${{
+          github.event_name == 'push'
+          && format('codecov-main-{0}', matrix.suite)
+          || format('codecov-run-{0}-{1}', github.run_id, matrix.suite)
+        }}
+      cancel-in-progress: ${{ github.event_name == 'push' }}
+    runs-on: [self-hosted, auto-provisioned, build-preset-relwithdebinfo]
+    timeout-minutes: 480
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJson(needs.detect.outputs.matrix) }}
+    steps:
+      - name: Checkout measured code
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ needs.detect.outputs.checkout_repository }}
+          ref: ${{ needs.detect.outputs.checkout_sha }}
+          fetch-depth: 0
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
+
+      - name: Checkout trusted coverage helpers from PR base
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.detect.outputs.base_sha }}
+          sparse-checkout: |
+            .github/actions/run_clang_codecov
+            .github/actions/setup_ci_ydb_service_account_key_file_credentials
+            .github/scripts/codecov
+          path: _trusted_coverage_ci
+          persist-credentials: false
+
+      - name: Overlay trusted coverage helpers
+        if: github.event_name == 'pull_request_target'
+        run: bash _trusted_coverage_ci/.github/scripts/codecov/overlay_trusted_codecov_ci.sh
+
+      - name: Setup YDB access
+        uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
+        with:
+          ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+          ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
+
+      - name: Run suite
+        uses: ./.github/actions/run_clang_codecov
+        with:
+          suite: ${{ matrix.suite }}
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+          aws_access_key_id: ${{ secrets.YDB_TECH_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.YDB_TECH_AWS_SECRET_ACCESS_KEY }}
+          bazel_remote_uri: ${{ vars.REMOTE_CACHE_URL_YA }}
+          bazel_remote_username: ${{ secrets.REMOTE_CACHE_USERNAME }}
+          bazel_remote_password: ${{ secrets.REMOTE_CACHE_PASSWORD }}
+          pr_number: ${{ needs.detect.outputs.pr_number }}
+          commit_sha: ${{ needs.detect.outputs.report_sha }}
+          branch: ${{ needs.detect.outputs.report_branch }}
+          storage_prefix: ${{ needs.detect.outputs.storage_prefix }}
+
+      - name: Remove YDB credentials
+        if: always()
+        run: rm -f -- /tmp/ydb_service_account.json
+
+  landing:
+    name: Publish HTML landing page
+    needs: [detect, coverage]
+    if: >-
+      always() &&
+      needs.detect.result == 'success' &&
+      needs.detect.outputs.should_run == 'true' &&
+      needs.coverage.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout landing generator
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ needs.detect.outputs.base_sha || needs.detect.outputs.checkout_sha }}
+          sparse-checkout: .github/scripts/codecov/generate_coverage_landing.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Generate landing page
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MATRIX: ${{ needs.detect.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          mkdir -p coverage_landing
+          if [ "$EVENT_NAME" = push ]; then
+            suites=(cpp_sdk cli cli_workload)
+          else
+            mapfile -t suites < <(python3 -c 'import json,os; print("\n".join(json.loads(os.environ["MATRIX"])))')
+          fi
+          args=()
+          for suite in "${suites[@]}"; do
+            case "$suite" in
+              cpp_sdk|cli|cli_workload)
+                args+=(--suite "${suite}=./${suite}/index.html")
+                ;;
+              *)
+                echo "Unexpected suite: $suite" >&2
+                exit 1
+                ;;
+            esac
+          done
+          python3 .github/scripts/codecov/generate_coverage_landing.py \
+            --output coverage_landing/index.html \
+            --title "YDB C++ coverage" \
+            "${args[@]}"
+
+      - name: Check Object Storage credentials
+        id: storage
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.YDB_TECH_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.YDB_TECH_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install AWS CLI
+        if: steps.storage.outputs.enabled == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          pip3 install --user 'awscli==1.46.0'
+
+      - name: Upload landing page
+        if: steps.storage.outputs.enabled == 'true'
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.YDB_TECH_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.YDB_TECH_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ru-central1
+          STORAGE_PREFIX: ${{ needs.detect.outputs.storage_prefix }}
+        run: |
+          set -euo pipefail
+          export PATH="${HOME}/.local/bin:${PATH}"
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "AWS CLI is unavailable; skip best-effort landing upload" >&2
+            exit 0
+          fi
+          aws --endpoint-url https://storage.yandexcloud.net s3 cp \
+            coverage_landing/index.html \
+            "s3://ydb-appteam-sdk-reports/${STORAGE_PREFIX}/index.html"

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -204,22 +204,33 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.sha }}
+          PR_BASE_SHA: ${{ steps.pr.outputs.base_sha }}
         run: |
           set -euo pipefail
           changed_file=$(mktemp)
 
           case "$EVENT_NAME" in
             pull_request_target)
-              gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
-                --paginate --jq '.[] | .filename, (.previous_filename // empty)' \
+              local_head_ref="refs/remotes/origin/codecov-pr-${PR_NUMBER}-head"
+              git fetch --no-tags --no-recurse-submodules origin \
+                "+refs/pull/${PR_NUMBER}/head:${local_head_ref}"
+              fetched_head=$(git rev-parse --verify "${local_head_ref}^{commit}")
+              if [ "$fetched_head" != "$PR_HEAD_SHA" ]; then
+                echo "The PR head changed while collecting files. Please use the latest run." >&2
+                exit 1
+              fi
+              git -c core.quotePath=false diff --name-only --no-renames \
+                "$PR_BASE_SHA...$PR_HEAD_SHA" -- \
                 > "$changed_file"
               ;;
             push)
               if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
-                git diff --name-only --no-renames HEAD~1 HEAD > "$changed_file"
+                git -c core.quotePath=false diff --name-only --no-renames \
+                  HEAD~1 HEAD > "$changed_file"
               else
-                git diff --name-only --no-renames "$BEFORE_SHA" "$AFTER_SHA" > "$changed_file"
+                git -c core.quotePath=false diff --name-only --no-renames \
+                  "$BEFORE_SHA" "$AFTER_SHA" > "$changed_file"
               fi
               ;;
             *)

--- a/.github/workflows/cpp_codecov_checks.yml
+++ b/.github/workflows/cpp_codecov_checks.yml
@@ -1,0 +1,53 @@
+name: Codecov C++ helper checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/actions/run_clang_codecov/**"
+      - ".github/scripts/codecov/**"
+      - ".github/workflows/cpp_codecov.yml"
+      - ".github/workflows/cpp_codecov_checks.yml"
+      - ".github/codecov.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/run_clang_codecov/**"
+      - ".github/scripts/codecov/**"
+      - ".github/workflows/cpp_codecov.yml"
+      - ".github/workflows/cpp_codecov_checks.yml"
+      - ".github/codecov.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: github.repository == 'ydb-platform/ydb'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Test Python helpers
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/codecov/tests/test_helpers.py -v
+          python3 -m py_compile \
+            .github/scripts/codecov/codecov_suites.py \
+            .github/scripts/codecov/detect_codecov_matrix.py \
+            .github/scripts/codecov/export_coverage_lcov.py \
+            .github/scripts/codecov/generate_coverage_landing.py \
+            .github/scripts/codecov/tests/test_helpers.py
+
+      - name: Check shell syntax
+        run: bash -n .github/scripts/codecov/overlay_trusted_codecov_ci.sh
+
+      - name: Parse YAML
+        run: |
+          ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' \
+            .github/actions/run_clang_codecov/action.yaml \
+            .github/workflows/cpp_codecov.yml \
+            .github/workflows/cpp_codecov_checks.yml \
+            .github/codecov.yml

--- a/.github/workflows/cpp_codecov_checks.yml
+++ b/.github/workflows/cpp_codecov_checks.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Parse YAML
         run: |
-          ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' \
+          ruby -e 'require "yaml"; ARGV.each { |path| YAML.safe_load(File.read(path), aliases: false) }' \
             .github/actions/run_clang_codecov/action.yaml \
             .github/workflows/cpp_codecov.yml \
             .github/workflows/cpp_codecov_checks.yml \


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds Clang coverage CI for three independently reported suites / Codecov flags:

- `cpp_sdk` — `ydb/public/sdk/cpp/**`;
- `cli` — `ydb/apps/ydb/**` and `ydb/public/lib/ydb_cli/**`;
- `cli_workload` — `ydb/library/workload/**`.

**Workflow behavior**

- PRs from forks and same-repository branches are handled only when they target `ydb-platform/ydb:main` and touch relevant paths.
- Repository writers are covered automatically. An external contributor's current PR revision can be approved by a repository writer applying `ok-to-test`.
- Other labels are ignored before allocating a runner and cannot cancel an active coverage run.
- A push to `main` publishes an updated baseline for the affected suites. Codecov carryforward preserves unaffected flags.
- Coverage infrastructure changes select all three suites; changes limited to helper tests do not start the expensive coverage workflow.

**Trust model for PRs**

- The privileged workflow is `pull_request_target`, so its definition comes from the default branch.
- The permission gate uses `GH_PERSONAL_ACCESS_TOKEN` only to check repository `write`/`admin` access for the PR author/event sender or the writer applying `ok-to-test`.
- Product code is checked out from the exact pinned PR head SHA only after authorization.
- Coverage actions and scripts are replaced with copies from the PR base SHA before the build receives repository secrets.
- Persisted Git credentials are disabled on both measured and trusted checkouts.

**Reports**

- Suite-filtered LCOV is uploaded to Codecov with the upstream repository slug, exact commit SHA, branch, PR number, and suite flag.
- HTML reports contain only source files owned by the selected component; transitive dependencies and disposable `.ya/build/build_root` sources do not affect component totals.
- HTML is published best-effort to Yandex Object Storage under `ydb/pr-<number>/coverage` for PRs and `ydb/coverage` for `main`.

**Validation**

- `Codecov C++ helper checks` runs 29 unit/contract tests for routing, LCOV filtering, trusted overlay, metadata, and workflow contracts.
- [All-suite dogfood run](https://github.com/ydb-platform/ydb/actions/runs/32132576185): SDK, CLI, workload, Codecov uploads, S3 reports, and landing page completed successfully.
- [Final CLI filtering dogfood run](https://github.com/ydb-platform/ydb/actions/runs/32136397251): LCOV, HTML, and Codecov all contained the same 256 CLI-owned source files; all published HTML links were checked successfully.

The existing `.github/workflows/cpp_sdk_coverage.yml` remains unchanged and can be removed separately after the new workflow has been validated post-merge. Since `pull_request_target` loads its workflow from the default branch, this PR itself can run the unprivileged helper checks but the exact production PR path becomes available only after merge.
