### PR TITLE
Do not use dictionary table in fulltext searches and remove it for fulltext_relevance indexes at all

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -80,6 +80,13 @@ constexpr std::string_view GlobalFulltextWithRelevanceImplTables[] = {
 };
 static_assert(std::is_sorted(std::begin(GlobalFulltextWithRelevanceImplTables), std::end(GlobalFulltextWithRelevanceImplTables)));
 
+constexpr std::string_view GlobalFulltextCompactRelevanceImplTables[] = {
+    NFulltext::DocsTable,
+    NFulltext::StatsTable,
+    ImplTable,
+};
+static_assert(std::is_sorted(std::begin(GlobalFulltextCompactRelevanceImplTables), std::end(GlobalFulltextCompactRelevanceImplTables)));
+
 bool IsSecondaryIndex(NKikimrSchemeOp::EIndexType indexType) {
     switch (indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobal:
@@ -328,8 +335,9 @@ std::span<const std::string_view> GetImplTables(
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
             return GlobalFulltextPlainImplTables;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
-        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             return GlobalFulltextWithRelevanceImplTables;
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+            return GlobalFulltextCompactRelevanceImplTables;
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
         case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             return GlobalFulltextPlainImplTables;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -754,10 +754,6 @@ void TKqpTasksGraph::FillStages() {
                             meta.IndexMetas.back().TablePath = indexSettings.GetDocsTable().GetPath();
                             meta.IndexMetas.back().TableConstInfo = tx.Body->GetTableConstInfoById()->Map.at(meta.IndexMetas.back().TableId);
                             meta.IndexMetas.emplace_back();
-                            meta.IndexMetas.back().TableId = MakeTableId(indexSettings.GetDictTable());
-                            meta.IndexMetas.back().TablePath = indexSettings.GetDictTable().GetPath();
-                            meta.IndexMetas.back().TableConstInfo = tx.Body->GetTableConstInfoById()->Map.at(meta.IndexMetas.back().TableId);
-                            meta.IndexMetas.emplace_back();
                             meta.IndexMetas.back().TableId = MakeTableId(indexSettings.GetStatsTable());
                             meta.IndexMetas.back().TablePath = indexSettings.GetStatsTable().GetPath();
                             meta.IndexMetas.back().TableConstInfo = tx.Body->GetTableConstInfoById()->Map.at(meta.IndexMetas.back().TableId);

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -217,14 +217,19 @@ struct TKiExploreTxResults {
                 YQL_ENSURE(indexTables.size() == 1, "Global fulltext plain index should have 1 table");
                 dataTable = indexTable = indexTables[0];
                 YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::ImplTable));
-            } else if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance ||
-                index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
+            } else if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance) {
                 YQL_ENSURE(indexTables.size() == 4, "Global fulltext relevance index should have 4 tables");
                 indexTable = indexTables[3];
                 YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::ImplTable));
                 dictTable = indexTables[0];
                 YQL_ENSURE(dictTable.EndsWith(NKikimr::NTableIndex::NFulltext::DictTable));
                 dataTable = indexTables[1];
+                YQL_ENSURE(dataTable.EndsWith(NKikimr::NTableIndex::NFulltext::DocsTable));
+            } else if (index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
+                YQL_ENSURE(indexTables.size() == 3, "Global fulltext compact relevance index should have 3 tables");
+                indexTable = indexTables[2];
+                YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::ImplTable));
+                dataTable = indexTables[0];
                 YQL_ENSURE(dataTable.EndsWith(NKikimr::NTableIndex::NFulltext::DocsTable));
             } else {
                 YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
@@ -233,8 +238,7 @@ struct TKiExploreTxResults {
 
             if (!isUpdate) {
                 ops[indexTable] = TPrimitiveYdbOperation::Write;
-                if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance ||
-                    index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
+                if (!dictTable.empty()) {
                     ops[dictTable] |= TPrimitiveYdbOperation::Read|TPrimitiveYdbOperation::Write;
                 }
             } else {
@@ -242,8 +246,7 @@ struct TKiExploreTxResults {
                     if (updateColumns.contains(column)) {
                         // delete old index values and upsert rows into index table
                         ops[indexTable] = TPrimitiveYdbOperation::Write;
-                        if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance ||
-                            index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
+                        if (!dictTable.empty()) {
                             ops[dictTable] |= TPrimitiveYdbOperation::Read|TPrimitiveYdbOperation::Write;
                         }
                         break;

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -2161,18 +2161,22 @@ private:
             *indexSettings->MutableFulltextSettings() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexDescription.SpecializedIndexDescription).GetSettings();
             // Get dict, docs, stats tables
             auto dictTable = tableMeta->ImplTables[index];
-            YQL_ENSURE(dictTable->Name.EndsWith(NTableIndex::NFulltext::DictTable));
-            auto docsTable = dictTable->Next;
+            if (!dictTable->Name.EndsWith(NTableIndex::NFulltext::DictTable)) {
+                dictTable = nullptr;
+            }
+            auto docsTable = dictTable ? dictTable->Next : tableMeta->ImplTables[index];
             YQL_ENSURE(docsTable->Name.EndsWith(NTableIndex::NFulltext::DocsTable));
             auto statsTable = docsTable->Next;
             YQL_ENSURE(statsTable->Name.EndsWith(NTableIndex::NFulltext::StatsTable));
             // And pass their metadata
-            FillTableId(*dictTable, *indexSettings->MutableDictTable());
-            FillTablesMap(dictTable->Name, tablesMap);
-            for (const auto& columnName: {NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::FreqColumn}) {
-                const auto& columnMeta = dictTable->Columns.at(columnName);
-                FillColumnProto(columnName, &columnMeta, indexSettings->AddDictColumns());
-                tablesMap[dictTable->Name].emplace(columnName);
+            if (dictTable) {
+                FillTableId(*dictTable, *indexSettings->MutableDictTable());
+                FillTablesMap(dictTable->Name, tablesMap);
+                for (const auto& columnName: {NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::FreqColumn}) {
+                    const auto& columnMeta = dictTable->Columns.at(columnName);
+                    FillColumnProto(columnName, &columnMeta, indexSettings->AddDictColumns());
+                    tablesMap[dictTable->Name].emplace(columnName);
+                }
             }
             FillTableId(*statsTable, *indexSettings->MutableStatsTable());
             FillTablesMap(statsTable->Name, tablesMap);
@@ -2314,9 +2318,9 @@ private:
                 indexDescription.Type == TIndexDescription::EType::GlobalJsonCompact);
             auto implTable = tableMeta->ImplTables[index];
             if (indexDescription.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
-                // Alphabetically impl (posting) is the last table, after Dict, Docs and Stats
-                YQL_ENSURE(implTable->Next && implTable->Next->Next && implTable->Next->Next->Next);
-                implTable = implTable->Next->Next->Next;
+                // Alphabetically impl (posting) is the last table, after Docs and Stats
+                YQL_ENSURE(implTable->Next && implTable->Next->Next);
+                implTable = implTable->Next->Next;
                 YQL_ENSURE(implTable->Name.EndsWith(NTableIndex::ImplTable));
             }
 

--- a/ydb/core/kqp/query_data/kqp_prepared_query.cpp
+++ b/ydb/core/kqp/query_data/kqp_prepared_query.cpp
@@ -231,7 +231,9 @@ TPreparedQueryHolder::TPreparedQueryHolder(NKikimrKqp::TPreparedQuery* proto,
                     tablesSet.insert(indexSettings.GetTable().GetPath());
                     if (indexSettings.HasFulltextSettings()) {
                         tablesSet.insert(indexSettings.GetDocsTable().GetPath());
-                        tablesSet.insert(indexSettings.GetDictTable().GetPath());
+                        if (indexSettings.HasDictTable()) {
+                            tablesSet.insert(indexSettings.GetDictTable().GetPath());
+                        }
                         tablesSet.insert(indexSettings.GetStatsTable().GetPath());
                     }
                 }
@@ -333,7 +335,9 @@ void TPreparedQueryHolder::FillTables(const google::protobuf::RepeatedPtrField< 
                             }
                         };
                         fillColumns(indexSettings.GetDocsTable(), indexSettings.GetDocsColumns());
-                        fillColumns(indexSettings.GetDictTable(), indexSettings.GetDictColumns());
+                        if (indexSettings.HasDictTable()) {
+                            fillColumns(indexSettings.GetDictTable(), indexSettings.GetDictColumns());
+                        }
                         fillColumns(indexSettings.GetStatsTable(), indexSettings.GetStatsColumns());
                     }
                 }

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -1587,8 +1587,9 @@ public:
             return nullptr;
         }
 
-        YQL_ENSURE(settings->GetIndexTables().size() >= 2);
-        auto& info = settings->GetIndexTables(1);
+        int docsPos = settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance ? 1 : 0;
+        YQL_ENSURE(settings->GetIndexTables().size() > docsPos);
+        auto& info = settings->GetIndexTables(docsPos);
         YQL_ENSURE(info.GetTable().GetPath().EndsWith(DocsTable));
         auto& columns = info.GetColumns();
         auto& keyColumns = info.GetKeyColumns();
@@ -1690,8 +1691,9 @@ public:
             return nullptr;
         }
 
-        YQL_ENSURE(settings->GetIndexTables().size() >= 3);
-        auto& info = settings->GetIndexTables(2);
+        int statsPos = settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance ? 2 : 1;
+        YQL_ENSURE(settings->GetIndexTables().size() > statsPos);
+        auto& info = settings->GetIndexTables(statsPos);
         YQL_ENSURE(info.GetTable().GetPath().EndsWith(StatsTable));
         auto& columns = info.GetColumns();
         auto& keyColumns = info.GetKeyColumns();

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -11,7 +11,7 @@
  *  1. Bootstrap: resolve table partitioning for all involved tables via SchemeCache.
  *  2. Tokenize the user's search query using the analyzer configured on the index.
  *  3. (Relevance mode) Read aggregate statistics (doc count, total doc length) from
- *     the stats table, and per-token document frequencies from the dict table.
+ *     the stats table.
  *  4. Issue range reads against the posting (index impl) table to stream sorted
  *     doc_id lists for each query token.
  *  5. Merge posting lists using one of two algorithms:
@@ -30,8 +30,6 @@
  *  - Main table: the user's original table (fetches full rows for matched doc_ids).
  *  - Posting table (indexImplTable): key=(token, doc_id), value=[freq].
  *      Stores the inverted index.  Read in Arrow FORMAT_ARROW batches.
- *  - Dict table (indexImplDictTable): key=(token), value=(document_frequency).
- *      Provides per-token DF values for IDF computation.
  *  - Docs table (indexImplDocsTable): key=(doc_id), value=(doc_length).
  *      Provides per-document lengths for BM25 normalization.
  *  - Stats table (indexImplStatsTable): key=(partition_id),
@@ -108,10 +106,6 @@ constexpr double EPSILON = 1e-6;
 // Sentinel column index used in ResultCellIndices to indicate that the column
 // should be filled with the computed BM25 relevance score rather than a table cell.
 constexpr i32 RELEVANCE_COLUMN_MARKER = -1;
-
-// For n-gram queries, when token document-frequencies differ by more than this factor,
-// the frequent n-grams are skipped during search because n-gram results are post-filtered.
-constexpr double NGRAM_IMBALANCE_FACTOR = 10;
 
 // Traits for the doc-id integer type. Specialised for the four supported PK widths.
 template <typename T> struct TDocIdTraits;
@@ -241,7 +235,7 @@ public:
         return GetReadRequest(readId, std::deque<TableRange>{range});
     }
 
-    // Build a TEvRead protobuf request addressed to the posting/docs/dict/main table.
+    // Build a TEvRead protobuf request addressed to the posting/docs/main table.
     // Point lookups go into request->Keys; range scans go into request->Ranges.
     // When the `To` key is a prefix (fewer cells than the full key), the range
     // endpoint is treated as inclusive to capture all rows sharing that prefix.
@@ -395,6 +389,7 @@ public:
 
     double GetIDFValue(ui64 wordIndex) const {
         YQL_ENSURE(wordIndex < IDFValues.size());
+        YQL_ENSURE(IDFValues[wordIndex] != 0);
         return IDFValues[wordIndex];
     }
 
@@ -768,6 +763,7 @@ public:
     virtual bool MoveToNext() = 0;
     virtual ui32 GetLeastDocFrequency() const = 0;
     virtual TDocId GetLeastDocId() const = 0;
+    virtual ui64 GetTotalFrequency() const = 0;
 };
 
 /**
@@ -799,6 +795,7 @@ class TArrowTokenStream: public TTokenStream<TDocId> {
     ui64 UnprocessedDocumentCount = 0;
     ui64 Bytes = 0;
     ui64 Rows = 0;
+    ui64 TotalFreq = 0;
     TDocId MaxKey = std::numeric_limits<TDocId>::min();
     bool MaxKeySet = false;
 
@@ -848,6 +845,7 @@ public:
 
     bool MoveToNext() override {
         YQL_ENSURE(!PendingDocumentIds.empty());
+        TotalFreq++;
         UnprocessedDocumentPos++;
         UnprocessedDocumentCount--;
 
@@ -872,6 +870,10 @@ public:
         YQL_ENSURE(!PendingDocumentIds.empty());
         return PendingDocumentIds.front()->Value(UnprocessedDocumentPos);
     }
+
+    ui64 GetTotalFrequency() const override {
+        return TotalFreq;
+    }
 };
 
 /**
@@ -888,6 +890,7 @@ class TCompactTokenStream: public TTokenStream<TDocId> {
     size_t DeltaResultIdx = 0;
     size_t DeltaRowIdx = 0;
     bool HasDeltas = false;
+    ui64 TotalFreq = 0;
 
     bool Started = false;
     NFulltext::TMultiDeltaReader Reader;
@@ -915,6 +918,7 @@ class TCompactTokenStream: public TTokenStream<TDocId> {
                     Started = true;
                     Reader.Start();
                     if (Reader.Read(CurDocId, CurFreq)) {
+                        TotalFreq++;
                         break;
                     }
                     FreeReader();
@@ -937,6 +941,8 @@ class TCompactTokenStream: public TTokenStream<TDocId> {
                 if (!Reader.Read(CurDocId, CurFreq)) {
                     // Segment may be logically empty, then we have to switch to the next one
                     FreeReader();
+                } else {
+                    TotalFreq++;
                 }
             } else {
                 // This is a delta segment from updates
@@ -979,7 +985,7 @@ public:
     }
 
     TDocId GetMaxKey() const override {
-        return (TDocId)CurDocId;
+        return std::numeric_limits<TDocId>::min();
     }
 
     std::pair<ui64, ui64> GetStats() const override {
@@ -1013,6 +1019,7 @@ public:
             FreeReader();
             return StartReader();
         }
+        TotalFreq++;
         return true;
     }
 
@@ -1022,6 +1029,10 @@ public:
 
     ui32 GetLeastDocFrequency() const override {
         return CurFreq;
+    }
+
+    ui64 GetTotalFrequency() const override {
+        return TotalFreq;
     }
 };
 
@@ -1041,7 +1052,7 @@ public:
  *   - Word: the tokenized search term string.
  *   - StartReadKeyFrom: resume point after a completed shard read; set to
  *     maxDocId+1 so the next BuildRangesToRead() continues from where we left off.
- *   - Frequency: document frequency from the dict table (used for IDF and
+ *   - Frequency: total frequency from the read source (used for IDF and
  *     imbalance detection).
  */
 template <typename TDocId>
@@ -1075,9 +1086,6 @@ public:
         , Reader(reader)
         , TokenCell(Word.data(), Word.size())
         , Prefix(prefix)
-        // WordKeyCells is the dictionary-table lookup key (token only, no prefix): the dict table is
-        // global (corpus-wide IDF). The prefix is applied only to posting-table reads (BuildRangesToRead).
-        , WordKeyCells(TOwnedTableRange(TVector<TCell>{TokenCell}))
     {
         BuildRangesToRead();
     }
@@ -1135,7 +1143,6 @@ public:
         TVector<TCell> fromCells = MakePrefixedKey(tokenCell, TCell::Make<TDocId>(StartReadKeyFrom));
         TVector<TCell> toCells = MakePrefixedKey(tokenCell);
         if (Reader->GetIsCompact()) {
-            // With the compact format, we always have to read all rows with __ydb_gen < MAX (these are updates)
             fromCells.insert(fromCells.end()-1, TCell::Make<NTableIndex::NFulltext::TGen>(std::numeric_limits<NTableIndex::NFulltext::TGen>::max()));
         }
         auto range = TTableRange(fromCells, StartReadKeyFromInclusive, toCells, false /*toInclusive*/);
@@ -1214,6 +1221,16 @@ public:
         return total;
     }
 
+    ui64 GetStreamTotalFrequency(ui64 tokenIndex) const {
+        YQL_ENSURE(tokenIndex < Streams.size(), "Token index out of bounds");
+        YQL_ENSURE(Streams[tokenIndex]->IsEof());
+        return Streams[tokenIndex]->GetTotalFrequency();
+    }
+
+    ui64 GetStreamCount() const {
+        return TokenCount;
+    }
+
     virtual std::vector<TDocInfoPtr> FindMatches() = 0;
     virtual ~IMergeAlgorithm() = default;
 };
@@ -1289,7 +1306,7 @@ public:
     }
 
     bool Done() const override {
-        return FinishedTokens > 0;
+        return FinishedTokens == TokenCount;
     }
 
     // Move all currently matched streams past their current entry.
@@ -1303,6 +1320,23 @@ public:
                 ReadyStreams.push_back(tokenIndex);
             }
 
+            if (stream->IsEof()) {
+                FinishedTokens++;
+            }
+        }
+        MatchedTokens.clear();
+    }
+
+    void ConsumeRest() {
+        for(ui32 tokenIndex : ReadyStreams) {
+            MatchedTokens.push_back(tokenIndex);
+        }
+        ReadyStreams.clear();
+        for(ui32 tokenIndex : MatchedTokens) {
+            YQL_ENSURE(tokenIndex < Streams.size(), "Token index out of bounds");
+            auto& stream = Streams[tokenIndex];
+            while (stream->MoveToNext()) {
+            }
             if (stream->IsEof()) {
                 FinishedTokens++;
             }
@@ -1343,6 +1377,7 @@ public:
 
     std::vector<TDocInfoPtr> FindMatches() override {
         if (FinishedTokens > 0) {
+            ConsumeRest();
             return std::vector<TDocInfoPtr>();
         }
 
@@ -1382,6 +1417,10 @@ public:
             AdvanceStreams();
 
             matches.push_back(std::move(match));
+        }
+
+        if (FinishedTokens > 0) {
+            ConsumeRest();
         }
 
         return matches;
@@ -1460,7 +1499,7 @@ public:
     }
 
     virtual bool Done() const override {
-        return Streams.size() - FinishedTokens < MinShouldMatch;
+        return FinishedTokens == TokenCount;
     }
 
     std::vector<TDocInfoPtr> FindMatches() override {
@@ -1468,10 +1507,6 @@ public:
         std::vector<size_t> matchedTokens;
         size_t matchedRequired = 0;
         while(!MergeQueue.empty() && MergeQueue.size() + FinishedTokens == TokenCount) {
-            if (MergeQueue.size() < MinShouldMatch) {
-                break;
-            }
-
             THeapEntry doc = std::move(MergeQueue.top());
             matchedTokens.clear();
             matchedTokens.push_back(doc.WordIndex);
@@ -1747,93 +1782,10 @@ public:
     }
 };
 
-/**
- * TDictTableReader -- reader for the dictionary table (indexImplDictTable).
- *
- * Schema: key = (token), value = (document_frequency).
- * Stores how many documents contain each token.  Read during the enrichment
- * phase (EnrichWordInfo) to populate TWordReadState::Frequency for each query
- * token, which is then used for:
- *   - IDF computation in TQueryCtx::AddIDFValue().
- *   - Token frequency imbalance detection in StartWordReads().
- */
-class TDictTableReader : public TTableReader<TDictTableReader> {
-public:
-    TDictTableReader(const TIntrusivePtr<TKqpCounters>& counters,
-        const TTableId& tableId,
-        const TString& tablePath,
-        const IKqpGateway::TKqpSnapshot& snapshot,
-        const TString& logPrefix,
-        const TString& database,
-        const TString& poolId,
-        const TVector<NScheme::TTypeInfo>& keyColumnTypes,
-        const TVector<NScheme::TTypeInfo>& resultColumnTypes,
-        const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
-    {}
-
-    static TIntrusivePtr<TDictTableReader> FromSettings(
-        const TIntrusivePtr<TKqpCounters>& counters,
-        const IKqpGateway::TKqpSnapshot& snapshot,
-        const TString& logPrefix,
-        const NKikimrKqp::TKqpFullTextSourceSettings* settings)
-    {
-        if (settings->GetIndexType() != NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance &&
-            settings->GetIndexType() != NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompactRelevance) {
-            return nullptr;
-        }
-
-        YQL_ENSURE(settings->GetIndexTables().size() >= 1);
-        auto& info = settings->GetIndexTables(0);
-        YQL_ENSURE(info.GetTable().GetPath().EndsWith(DictTable));
-        auto& columns = info.GetColumns();
-        auto& keyColumns = info.GetKeyColumns();
-
-        TVector<NScheme::TTypeInfo> keyColumnTypes;
-        TVector<NScheme::TTypeInfo> resultKeyColumnTypes;
-        TVector<i32> resultKeyColumnIds;
-
-        i32 freqColumnIndex = -1;
-        NScheme::TTypeInfo freqColumnType;
-        for (const auto& column : columns) {
-            if (column.GetName() == FreqColumn) {
-                freqColumnIndex = column.GetId();
-                freqColumnType = NScheme::TypeInfoFromProto(
-                    column.GetTypeId(), column.GetTypeInfo());
-            }
-        }
-
-        for (const auto& keyColumn : keyColumns) {
-            keyColumnTypes.push_back(NScheme::TypeInfoFromProto(
-                keyColumn.GetTypeId(), keyColumn.GetTypeInfo()));
-            resultKeyColumnTypes.push_back(keyColumnTypes.back());
-            resultKeyColumnIds.push_back(keyColumn.GetId());
-        }
-
-        YQL_ENSURE(freqColumnIndex != -1);
-        resultKeyColumnTypes.push_back(freqColumnType);
-        resultKeyColumnIds.push_back(freqColumnIndex);
-
-        return MakeIntrusive<TDictTableReader>(
-            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
-            settings->GetDatabase(), settings->GetPoolId(),
-            keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
-    }
-
-    TStringBuf GetWord(const TConstArrayRef<TCell>& row) const {
-        return row[0].AsBuf();
-    }
-
-    ui64 GetWordFrequency(const TConstArrayRef<TCell>& row) const {
-        return row[GetResultColumnTypes().size() - 1].AsValue<ui64>();
-    }
-};
-
 // Discriminator for in-flight TEvRead requests so HandleReadResult can
 // dispatch the response to the correct processing path.
 enum EReadKind : ui32 {
     EReadKind_Word = 0,           // Posting list range scan
-    EReadKind_WordStats = 1,      // Dict table: per-token document frequency
     EReadKind_DocumentStats = 2,  // Docs table: per-document length
     EReadKind_Document = 3,       // Main table: full row data for matched docs
     EReadKind_TotalStats = 4,     // Stats table: corpus-wide aggregates
@@ -2206,8 +2158,6 @@ public:
  * Used for three kinds of reads:
  *   - DocsReadingQueue (TItem = TDocumentInfo::TPtr): reads from docs table
  *     (document lengths) and main table (full rows).
- *   - WordsReadingQueue (TItem = TWordReadState::TPtr): dict table lookups for
- *     per-token document frequencies.
  *
  * Key concepts:
  *   - TSentReadItems: a group of items sent in a single TEvRead to one shard.
@@ -2400,8 +2350,8 @@ public:
  *     for all involved tables.  HandleResolve() receives partition info.
  *
  *   Phase 2 - Tokenize & enrich: ExtractAndTokenizeExpression() splits the
- *     search query into tokens.  If relevance mode, ReadTotalStats() and
- *     EnrichWordInfo() issue reads against the stats and dict tables.
+ *     search query into tokens.  If relevance mode, ReadTotalStats() issues
+ *     reads against the stats table.
  *
  *   Phase 3 - Merge: StartWordReads() configures the merge algorithm and
  *     kicks off posting list reads.  WordResult() feeds data into MergeAlgo;
@@ -2538,11 +2488,10 @@ private:
     ui64 SumDocLength = 0;
 
     // Table readers -- one per involved table.  Null readers indicate that the
-    // table is not needed (e.g., dict/docs/stats are null for plain indexes).
+    // table is not needed (e.g., docs/stats are null for plain indexes).
     TIntrusivePtr<TMainTableReader> MainTableReader;
     TIntrusivePtr<TIndexTableImplReader> IndexTableReader;
     TIntrusivePtr<TDocsTableReader> DocsTableReader;
-    TIntrusivePtr<TDictTableReader> DictTableReader;
     TIntrusivePtr<TStatsTableReader> StatsTableReader;
     TIntrusivePtr<TUniqueIndexReader> UniqueIndexReader;  // Resolves __ydb_row_id -> PK via unique secondary index
 
@@ -2566,11 +2515,16 @@ private:
     // Read infrastructure.
     TReadsState ReadsState;                                // Tracks all in-flight reads
     TReadItemsQueue<TDocInfoPtr> DocsReadingQueue;         // Docs table + main table reads
-    TReadItemsQueue<TWordStatePtr> WordsReadingQueue;      // Dict table lookups
     TVector<TWordStatePtr> Words;                          // Tokenized query terms
 
     // Merge algorithm.
     std::unique_ptr<TMergeAlgo> MergeAlgo;
+
+    // IDF computation is deferred until all token streams are fully consumed,
+    // so that GetTotalFrequency() reflects accurate document frequencies.
+    // Documents matched before IDF is ready are buffered here.
+    bool IDFComputed = false;
+    std::vector<TDocInfoPtr> PendingBM25Documents;
 
     // Helper to bind allocator
     TGuard<NMiniKQL::TScopedAlloc> BindAllocator() {
@@ -2633,11 +2587,67 @@ private:
         return true;
     }
 
+    // Check whether all merge streams have finished and, if so, compute IDF
+    // values from the accumulated total frequencies.  Returns true when IDF is ready.
+    bool TryComputeIDF() {
+        if (IDFComputed) {
+            return true;
+        }
+        if (!MergeAlgo->Done()) {
+            return false;
+        }
+
+        // All streams are exhausted -- their TotalFrequency now reflects
+        // the true document frequency for each token.
+        for (size_t i = 0; i < Words.size(); ++i) {
+            ui64 docFreq = MergeAlgo->GetStreamTotalFrequency(i);
+            if (docFreq == 0) {
+                docFreq = 1; // avoid log(0) for tokens with no matches
+            }
+            QueryCtx->AddIDFValue(i, docFreq);
+        }
+        IDFComputed = true;
+        return true;
+    }
+
+    // Flush PendingBM25Documents through the BM25 scoring / TopK pipeline
+    // once IDF values are available.
+    void FlushPendingBM25Documents() {
+        if (PendingBM25Documents.empty()) {
+            NotifyCA();
+            return;
+        }
+
+        std::vector<TDocInfoPtr> docs;
+        docs.swap(PendingBM25Documents);
+
+        if (Limit > 0) {
+            for (auto& doc : docs) {
+                TopKQueue.emplace_back(doc->GetBM25Score(QueryCtx.GetRef()), std::move(doc));
+            }
+            CompactTopK(static_cast<size_t>(Limit) * 2);
+            docs.clear();
+
+            // All merges are done at this point (IDF was just computed),
+            // so drain TopK into docs for downstream processing.
+            CompactTopK(static_cast<size_t>(Limit) + 1);
+            docs.reserve(TopKQueue.size());
+            for (auto& [score, documentInfo] : TopKQueue) {
+                docs.emplace_back(std::move(documentInfo));
+            }
+            TopKQueue.clear();
+        }
+
+        FetchDocumentDetailsImpl(docs);
+    }
+
     // Route matched documents through the remaining pipeline stages:
     //   1. If relevance mode and documents lack doc_length -> read from docs table.
-    //   2. If LIMIT + relevance -> insert into TopK buffer; compact with nth_element when buffer is full; drain when merge is done.
-    //   3. If documents are "covered" -> push directly to ResultQueue.
-    //   4. Otherwise -> enqueue main table reads for full row data.
+    //   2. If relevance mode and IDF not yet computed -> buffer documents.
+    //   3. If LIMIT + relevance -> insert into TopK buffer; compact with nth_element
+    //      when buffer is full; drain when merge is done.
+    //   4. If documents are "covered" -> push directly to ResultQueue.
+    //   5. Otherwise -> enqueue main table reads for full row data.
     void FetchDocumentDetails(std::vector<TDocInfoPtr>& docInfos) {
         if (Limit > 0 && ProducedItemsCount + ResultQueue.size() >= static_cast<ui64>(Limit)) {
             RowIdResolvePendingQueue.clear();
@@ -2649,14 +2659,27 @@ private:
                 DocsReadingQueue.Enqueue(DocsTableReader.Get(), EReadKind_DocumentStats, docInfos, 0);
                 return;
             }
-        }
 
-        if (Limit > 0 && MainTableReader->GetWithRelevance()) {
-            for(auto& doc: docInfos) {
-                TopKQueue.emplace_back(doc->GetBM25Score(QueryCtx.GetRef()), std::move(doc));
+            // Buffer documents until all streams finish and IDF is computed.
+            if (!IDFComputed) {
+                PendingBM25Documents.insert(PendingBM25Documents.end(),
+                    std::make_move_iterator(docInfos.begin()),
+                    std::make_move_iterator(docInfos.end()));
+                docInfos.clear();
+
+                if (TryComputeIDF()) {
+                    FlushPendingBM25Documents();
+                }
+                return;
             }
-            CompactTopK(static_cast<size_t>(Limit) * 2);
-            docInfos.clear();
+
+            if (Limit > 0) {
+                for (auto& doc : docInfos) {
+                    TopKQueue.emplace_back(doc->GetBM25Score(QueryCtx.GetRef()), std::move(doc));
+                }
+                CompactTopK(static_cast<size_t>(Limit) * 2);
+                docInfos.clear();
+            }
         }
 
         if (Limit > 0 && !TopKQueue.empty() && MergeAlgo->Done()) {
@@ -2669,6 +2692,12 @@ private:
             TopKQueue.clear();
         }
 
+        FetchDocumentDetailsImpl(docInfos);
+    }
+
+    // Shared implementation for the downstream stages of FetchDocumentDetails
+    // (row-id resolution, covered check, main-table reads).
+    void FetchDocumentDetailsImpl(std::vector<TDocInfoPtr>& docInfos) {
         // __ydb_row_id mode: resolve doc_id (__ydb_row_id) -> primary key via the unique
         // index before doing main-table reads.  Skipped once docs are resolved
         // (HasPkResolved == true), so re-entry from RowIdResolveResult proceeds
@@ -2714,13 +2743,6 @@ private:
         return false;
     }
 
-    // Read per-token document frequencies from the dict table.
-    // Results are stored in TWordReadState::Frequency and later used for
-    // IDF computation and token imbalance detection.
-    void EnrichWordInfo() {
-        WordsReadingQueue.Enqueue(DictTableReader.Get(), EReadKind_WordStats, Words, 0);
-    }
-
     std::unique_ptr<TTokenStream<TDocId>> MakeStream() {
         if (Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompact ||
             Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompactRelevance ||
@@ -2734,18 +2756,17 @@ private:
 
     // Configure merge algorithms and begin posting list reads.
     //
-    // This is the central orchestration point called after stats/dict reads complete.
+    // This is the central orchestration point called after stats reads complete.
     // Steps:
     //   1. Detect token frequency imbalance.  For n-gram queries, drop the
     //      most frequent n-grams.
     //   2. Compute MinimumShouldMatch from the query operator and settings.
-    //   3. Create TQueryCtx with IDF values from dict table frequencies.
-    //   4. Build TTokenStream instances and instantiate the appropriate
+    //   3. Build TTokenStream instances and instantiate the appropriate
     //      merge algorithm:
     //        - AND -> TAndOptimizedMergeAlgorithm (leapfrog)
     //        - OR  -> TDefaultMergeAlgorithm (min-heap)
-    //   5. Apply user-overridden BM25 K1/B factors.
-    //   6. Issue initial posting list reads for all tokens.
+    //   4. Apply user-overridden BM25 K1/B factors.
+    //   5. Issue initial posting list reads for all tokens.
     void StartWordReads() {
         TString explain;
         EDefaultOperator defaultOperator = DefaultOperatorFromString(Settings->GetDefaultOperator(), explain);
@@ -2766,58 +2787,10 @@ private:
                 ++requiredCount;
             }
         }
-        const bool hasRequired = defaultOperator == EDefaultOperator::Or && requiredCount >= 1;
-        const bool requiredDriven = hasRequired && requiredCount < Words.size();
 
-        if (defaultOperator == EDefaultOperator::And && IsNgram) {
-            // Queries often contain 'imbalanced' ngrams. I.e. some ngrams
-            // are really frequent and others aren't, like one with 5.5 million
-            // documents and other with 400 documents. In such cases we can
-            // only leave the second one because we anyway postfilter documents.
-            // The only concern is to not make ourselves postfilter too many
-            // documents... So it's just a heuristic which we can control with
-            // the NGRAM_IMBALANCE_FACTOR parameter.
-            TVector<size_t> byFreq;
-            for (size_t i = 0; i < Words.size(); i++) {
-                byFreq.push_back(i);
-            }
-            std::sort(byFreq.begin(), byFreq.end(), [&](const size_t a, const size_t b) {
-                return Words[a]->Frequency < Words[b]->Frequency;
-            });
-            size_t bestTokenLimit = byFreq.size();
-            for (size_t i = 1; i < byFreq.size(); i++) {
-                if (Words[byFreq[i]]->Frequency > NGRAM_IMBALANCE_FACTOR * Words[byFreq[0]]->Frequency) {
-                    bestTokenLimit = i;
-                    break;
-                }
-            }
-            if (IsNgram && bestTokenLimit < Words.size()) {
-                YDB_LOG_INFO("Selecting balanced ngrams from token frequency list",
-                    {"logPrefix", this->LogPrefix},
-                    {"bestTokenLimit", bestTokenLimit},
-                    {"wordCount", Words.size()},
-                    {"maxFrequency", Words[byFreq[0]]->Frequency},
-                    {"cutoffFrequency", Words[byFreq[bestTokenLimit]]->Frequency});
-                TVector<TWordStatePtr> newWords;
-                for (size_t i = 0; i < bestTokenLimit; i++) {
-                    newWords.emplace_back(std::move(Words[byFreq[i]]));
-                    newWords[i]->WordIndex = i;
-                }
-                std::swap(Words, newWords);
-            }
-        }
-
-        ui32 minimumShouldMatch;
-        if (requiredDriven) {
-            // minimum_should_match counts only the optional (non-required) terms.
-            const size_t optionalCount = Words.size() - requiredCount;
-            minimumShouldMatch = requiredCount + MinimumShouldMatchFromString(optionalCount, defaultOperator, Settings->GetMinimumShouldMatch(), explain);
-        } else if (hasRequired) {
-            // Every term is required -> strict AND; minimum_should_match is moot.
-            minimumShouldMatch = Words.size();
-        } else {
-            minimumShouldMatch = MinimumShouldMatchFromString(Words.size(), defaultOperator, Settings->GetMinimumShouldMatch(), explain);
-        }
+        // minimum_should_match counts only the optional (non-required) terms.
+        const size_t optionalCount = Words.size() - requiredCount;
+        ui32 minimumShouldMatch = requiredCount + MinimumShouldMatchFromString(optionalCount, defaultOperator, Settings->GetMinimumShouldMatch(), explain);
         if (!explain.empty()) {
             RuntimeError(explain, NYql::NDqProto::StatusIds::BAD_REQUEST);
             return;
@@ -2825,12 +2798,6 @@ private:
 
         QueryCtx = MakeIntrusive<TQueryCtx>(
             Words.size(), SumDocLength, DocCount, defaultOperator, minimumShouldMatch, ResultCellIndices, UseRowIdAsDocId);
-
-        if (DictTableReader) {
-            for (auto& word: Words) {
-                QueryCtx->AddIDFValue(word->WordIndex, word->Frequency);
-            }
-        }
 
         std::vector<std::unique_ptr<TTokenStream<TDocId>>> streams;
         std::vector<bool> required;
@@ -2881,7 +2848,6 @@ private:
         IndexTableReader->AddResolvePartitioningRequest(request);
         if (Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance ||
             Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompactRelevance) {
-            DictTableReader->AddResolvePartitioningRequest(request);
             if (DocsTableReader) {
                 DocsTableReader->AddResolvePartitioningRequest(request);
             }
@@ -2931,14 +2897,12 @@ public:
         , MainTableReader(TMainTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings))
         , IndexTableReader(TIndexTableImplReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance()))
         , DocsTableReader(TDocsTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance()))
-        , DictTableReader(TDictTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings))
         , StatsTableReader(TStatsTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance()))
         , UniqueIndexReader(TUniqueIndexReader::FromSettings(Counters, Snapshot, LogPrefix, Settings))
         , PrefixCells(TIndexTableImplReader::ParsePrefixCells(Settings))
         , UseRowIdAsDocId(UniqueIndexReader != nullptr)
         , ReadsState(Counters, LogPrefix)
         , DocsReadingQueue(this->SelfId(), ReadsState)
-        , WordsReadingQueue(this->SelfId(), ReadsState)
     {
         Y_ABORT_UNLESS(Arena);
         Y_ABORT_UNLESS(Settings->GetArena() == Arena->Get());
@@ -3128,9 +3092,6 @@ public:
             case EReadKind_Word:
                 RetryWordRead(readInfo.Cookie, readId);
                 break;
-            case EReadKind_WordStats:
-                WordsReadingQueue.Retry(DictTableReader.Get(), EReadKind_WordStats, readId);
-                break;
             case EReadKind_TotalStats:
                 RetryTotalStatsRead(readId);
                 break;
@@ -3208,7 +3169,7 @@ public:
     // Phase 1 completion: SchemeCache returns partition boundaries for all tables.
     // Stores partition info in each reader, then kicks off Phase 2:
     //   - Tokenize the search query.
-    //   - If relevance mode: read stats + dict tables, then proceed to StartWordReads.
+    //   - If relevance mode: read stats, then proceed to StartWordReads.
     //   - If plain mode: go directly to StartWordReads.
     void HandleResolve(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev) {
         YDB_LOG_DEBUG("Received TEvResolveKeySetResult",
@@ -3228,35 +3189,31 @@ public:
         }
 
         auto& resultSet = ev->Get()->Request->ResultSet;
-        YQL_ENSURE(resultSet.size() >= 2, "Expected at least 2 tables for fulltext index");
+        size_t expectedCount = 2;
+        YQL_ENSURE(resultSet.size() >= expectedCount, "Expected at least " << expectedCount << " tables for fulltext index");
         MainTableReader->SetPartitionInfo(resultSet[0].KeyDescription);
         IndexTableReader->SetPartitionInfo(resultSet[1].KeyDescription);
-        size_t expectedCount = 2;
         if (Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance ||
             Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompactRelevance) {
-            expectedCount = 3 + (DocsTableReader ? 1 : 0) + (StatsTableReader ? 1 : 0);
-            DictTableReader->SetPartitionInfo(resultSet[2].KeyDescription);
+            expectedCount += (DocsTableReader ? 1 : 0) + (StatsTableReader ? 1 : 0);
+            YQL_ENSURE(resultSet.size() >= expectedCount, "Expected at least " << expectedCount << " tables for fulltext_relevance index");
             if (DocsTableReader) {
-                DocsTableReader->SetPartitionInfo(resultSet[3].KeyDescription);
+                DocsTableReader->SetPartitionInfo(resultSet[expectedCount-2].KeyDescription);
             }
             if (StatsTableReader) {
-                StatsTableReader->SetPartitionInfo(resultSet[3 + (DocsTableReader ? 1 : 0)].KeyDescription);
+                StatsTableReader->SetPartitionInfo(resultSet[expectedCount-1].KeyDescription);
             }
         }
         if (UniqueIndexReader) {
-            UniqueIndexReader->SetPartitionInfo(resultSet[expectedCount].KeyDescription);
             expectedCount++;
+            YQL_ENSURE(resultSet.size() >= expectedCount, "Expected at least " << expectedCount << " tables for fulltext index with surrogate key");
+            UniqueIndexReader->SetPartitionInfo(resultSet[expectedCount-1].KeyDescription);
         }
         YQL_ENSURE(resultSet.size() == expectedCount, "Expected " << expectedCount << " tables for fulltext index");
 
         if (ExtractAndTokenizeExpression()) {
-            if (StatsTableReader || DictTableReader) {
-                if (StatsTableReader) {
-                    ReadTotalStats();
-                }
-                if (DictTableReader) {
-                    EnrichWordInfo();
-                }
+            if (StatsTableReader) {
+                ReadTotalStats();
             } else {
                 StartWordReads();
             }
@@ -3446,7 +3403,7 @@ public:
     }
 
     // Process stats table result: extract DocCount and SumDocLength.
-    // When all prerequisite reads (stats + dict) are done, proceed to StartWordReads.
+    // When all prerequisite reads (stats) are done, proceed to StartWordReads.
     void HandleTotalStatsResult(TEvDataShard::TEvReadResult& msg) {
         size_t rows = msg.GetRowsCount();
         size_t bytes = 0;
@@ -3461,47 +3418,6 @@ public:
         }
 
         StatsTableReader->RecvStats(rows, bytes);
-
-        if (ReadsState.Empty()) {
-            StartWordReads();
-        }
-    }
-
-    // Process dict table results: match returned (token, doc_frequency) rows to
-    // TWordReadState entries.  Words not found in the dict get Frequency=0.
-    // When all prerequisite reads are done, proceed to StartWordReads.
-    void WordStatsResult(NKikimr::TEvDataShard::TEvReadResult &msg, ui64 readId, bool finished) {
-        auto& readItems = WordsReadingQueue.GetReadItems(readId);
-
-        ui64 rows = 0;
-        ui64 bytes = 0;
-        for (size_t i = 0; i < msg.GetRowsCount(); i++) {
-            const auto& row = msg.GetCells(i);
-            const auto& wordBuf = DictTableReader->GetWord(row);
-
-            while (!readItems.Empty() && readItems.GetItem()->Word != wordBuf) {
-                readItems.GetItem()->Frequency = 0;
-                readItems.PopItem();
-            }
-
-            rows++;
-            bytes += sizeof(ui32) + wordBuf.size();
-            YQL_ENSURE(!readItems.Empty(), "Word not found in read items");
-            auto& word = readItems.GetItem();
-            word->Frequency = DictTableReader->GetWordFrequency(row);
-            readItems.PopItem();
-        }
-
-        DictTableReader->RecvStats(rows, bytes);
-
-        if (finished) {
-            while (!readItems.Empty()) {
-                readItems.GetItem()->Frequency = 0;
-                readItems.PopItem();
-            }
-        }
-
-        WordsReadingQueue.UpdateReadStatus(readId, readItems, finished);
 
         if (ReadsState.Empty()) {
             StartWordReads();
@@ -3531,6 +3447,12 @@ public:
 
         std::vector<TDocInfoPtr> matches = MergeAlgo->FindMatches();
         FetchDocumentDetails(matches);
+
+        // When the last stream finishes but FindMatches produces no new docs,
+        // we still need to compute IDF and flush any buffered documents.
+        if (!IDFComputed && TryComputeIDF()) {
+            FlushPendingBM25Documents();
+        }
     }
 
     template<typename TReader>
@@ -3567,9 +3489,6 @@ public:
             if (StatsTableReader) {
                 ExportTableReaderStats(stats, StatsTableReader);
             }
-            if (DictTableReader) {
-                ExportTableReaderStats(stats, DictTableReader);
-            }
             if (UniqueIndexReader) {
                 ExportTableReaderStats(stats, UniqueIndexReader);
             }
@@ -3603,7 +3522,6 @@ public:
     static TStringBuf ReadKindName(EReadKind readKind) {
         switch (readKind) {
             case EReadKind_Word:          return "posting";
-            case EReadKind_WordStats:     return "dict";
             case EReadKind_DocumentStats: return "docs";
             case EReadKind_Document:      return "main";
             case EReadKind_TotalStats:    return "stats";
@@ -3616,8 +3534,6 @@ public:
         switch (readKind) {
             case EReadKind_Word:
                 return IndexTableReader ? IndexTableReader->GetTablePath() : TString();
-            case EReadKind_WordStats:
-                return DictTableReader ? DictTableReader->GetTablePath() : TString();
             case EReadKind_DocumentStats:
                 return DocsTableReader ? DocsTableReader->GetTablePath() : TString();
             case EReadKind_Document:
@@ -3739,9 +3655,6 @@ public:
                 break;
             case EReadKind_DocumentStats:
                 DocumentStatsResult(msg, readId, record.GetFinished());
-                break;
-            case EReadKind_WordStats:
-                WordStatsResult(msg, readId, record.GetFinished());
                 break;
             case EReadKind_Word:
                 WordResult(std::unique_ptr<NKikimr::TEvDataShard::TEvReadResult>(ev->Release().Release()), cookie, record.GetFinished());

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -756,7 +756,7 @@ public:
     void SetReadFinished() {
         ReadFinished = true;
     }
-    virtual TDocId GetMaxKey() const = 0;
+    virtual TVector<TCell> GetResumeKey() const = 0;
     virtual std::pair<ui64, ui64> GetStats() const = 0;
     virtual ui32 GetUnprocessedDocumentCount() const = 0;
     virtual void AddResult(std::unique_ptr<TEvDataShard::TEvReadResult> result) = 0;
@@ -778,7 +778,7 @@ public:
  *   - PendingDocumentIds: deque of Arrow UInt64 arrays (doc_id batches).
  *   - PendingDocumentFrequencies: matching deque of UInt32 arrays (term freq).
  *   - UnprocessedDocumentPos/Count: cursor within the current front batch.
- *   - MaxKey: the largest doc_id seen so far (used as a resume key for
+ *   - ResumeKey: the largest doc_id seen so far (used as a resume key for
  *     continued reads when partitions span multiple TEvRead responses).
  *   - ReadFinished: set when the last TEvReadResult for this token arrives.
  *
@@ -804,8 +804,8 @@ public:
         return UnprocessedDocumentCount == 0 && this->ReadFinished;
     }
 
-    TDocId GetMaxKey() const override {
-        return MaxKey;
+    TVector<TCell> GetResumeKey() const override {
+        return {TCell::Make(MaxKey)};
     }
 
     std::pair<ui64, ui64> GetStats() const override {
@@ -894,6 +894,9 @@ class TCompactTokenStream: public TTokenStream<TDocId> {
 
     bool Started = false;
     NFulltext::TMultiDeltaReader Reader;
+
+    NTableIndex::NFulltext::TGen ResumeGen = 0;
+    TDocId ResumeMaxId = 0;
 
     ui64 CurDocId = 0;
     ui32 CurFreq = 0;
@@ -984,8 +987,8 @@ public:
         return !Started && this->ReadFinished;
     }
 
-    TDocId GetMaxKey() const override {
-        return std::numeric_limits<TDocId>::min();
+    TVector<TCell> GetResumeKey() const override {
+        return {TCell::Make(ResumeGen), TCell::Make(ResumeMaxId)};
     }
 
     std::pair<ui64, ui64> GetStats() const override {
@@ -1007,6 +1010,10 @@ public:
                 Bytes += cell.Size();
             }
         }
+        auto lastRow = result->GetCells(result->GetRowsCount()-1);
+        // row = { gen, max_id, added, segment }
+        ResumeGen = lastRow[0].AsValue<NTableIndex::NFulltext::TGen>();
+        ResumeMaxId = lastRow[1].AsValue<TDocId>();
         Results.push_back(std::move(result));
         StartReader();
     }
@@ -1073,7 +1080,7 @@ public:
     // Set from the `+term` query syntax: a required (Lucene MUST) term that every
     // matching document must contain.
     bool Required = false;
-    TDocId StartReadKeyFrom = std::numeric_limits<TDocId>::min();
+    TVector<TCell> StartReadKeyFrom;
     // at the start we begin with the inclusive boundary
     bool StartReadKeyFromInclusive = true;
 
@@ -1088,18 +1095,6 @@ public:
         , Prefix(prefix)
     {
         BuildRangesToRead();
-    }
-
-    // Build [prefix..., token, extra...] key cells.
-    TVector<TCell> MakePrefixedKey(const TCell& tokenCell, const TMaybe<TCell>& extra = {}) const {
-        TVector<TCell> cells;
-        cells.reserve(Prefix.size() + 1 + (extra.Defined() ? 1 : 0));
-        cells.insert(cells.end(), Prefix.begin(), Prefix.end());
-        cells.push_back(tokenCell);
-        if (extra.Defined()) {
-            cells.push_back(*extra);
-        }
-        return cells;
     }
 
     TOwnedTableRange GetWordKeyCells() const {
@@ -1128,23 +1123,15 @@ public:
     void BuildRangesToRead() {
         RangesToRead.clear();
 
-        TCell tokenCell(Word.data(), Word.size());
-        if (Reader->GetIsCompact()) {
-            // With the compact format, we always have to read all rows with __ydb_gen < MAX (these are updates)
-            TVector<TCell> fromCells = MakePrefixedKey(tokenCell, TCell::Make<NTableIndex::NFulltext::TGen>(0));
-            TVector<TCell> toCells = MakePrefixedKey(tokenCell, TCell::Make<NTableIndex::NFulltext::TGen>(std::numeric_limits<NTableIndex::NFulltext::TGen>::max()-1));
-            auto range = TTableRange(fromCells, true /*fromInclusive*/, toCells, false /*toInclusive*/);
-            auto rangePartition = Reader->GetRangePartitioning(range);
-            for (const auto& [shardId, range] : rangePartition) {
-                RangesToRead.emplace_back(shardId, std::move(range));
-            }
-        }
+        TVector<TCell> prefixed(Prefix.begin(), Prefix.end());
+        prefixed.push_back(TCell(Word.data(), Word.size()));
 
-        TVector<TCell> fromCells = MakePrefixedKey(tokenCell, TCell::Make<TDocId>(StartReadKeyFrom));
-        TVector<TCell> toCells = MakePrefixedKey(tokenCell);
-        if (Reader->GetIsCompact()) {
-            fromCells.insert(fromCells.end()-1, TCell::Make<NTableIndex::NFulltext::TGen>(std::numeric_limits<NTableIndex::NFulltext::TGen>::max()));
+        // Resume process expects a single range, maybe split across shards
+        TVector<TCell> fromCells = prefixed;
+        if (StartReadKeyFrom.size()) {
+            fromCells.insert(fromCells.end(), StartReadKeyFrom.begin(), StartReadKeyFrom.end());
         }
+        TVector<TCell> toCells = prefixed;
         auto range = TTableRange(fromCells, StartReadKeyFromInclusive, toCells, false /*toInclusive*/);
 
         auto rangePartition = Reader->GetRangePartitioning(range);
@@ -1200,10 +1187,10 @@ public:
 
     virtual void AddResult(ui64 tokenIndex, std::unique_ptr<TEvDataShard::TEvReadResult> msg) = 0;
 
-    TDocId GetMaxTokenKey(ui64 tokenIndex) {
+    TVector<TCell> GetResumeKey(ui64 tokenIndex) {
         YQL_ENSURE(tokenIndex < Streams.size(), "Token index out of bounds");
         auto& stream = Streams[tokenIndex];
-        return stream->GetMaxKey();
+        return stream->GetResumeKey();
     }
 
     virtual void FinishTokenStream(ui64 tokenIndex) = 0;
@@ -3437,7 +3424,7 @@ public:
         const bool hasRows = msg->GetRowsCount() > 0;
         MergeAlgo->AddResult(wordIndex, std::move(msg));
         if (hasRows) {
-            incomingWordInfo->StartReadKeyFrom = MergeAlgo->GetMaxTokenKey(wordIndex);
+            incomingWordInfo->StartReadKeyFrom = MergeAlgo->GetResumeKey(wordIndex);
             incomingWordInfo->StartReadKeyFromInclusive = false;
         }
 

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -2508,7 +2508,6 @@ private:
     void FlushFulltextRelevanceAuxTables(TPathWriteInfo& actorInfo,
             IFulltextTokenizeProjection* ft, bool isDelete) {
         auto& docs = PathWriteInfo.at(actorInfo.FulltextDocsTableId);
-        auto& dict = PathWriteInfo.at(actorInfo.FulltextDictTableId);
         auto& stats = PathWriteInfo.at(actorInfo.FulltextStatsTableId);
         if (isDelete) {
             docs.WriteActor->Write(DeleteCookie, ft->FlushDocs());
@@ -2517,10 +2516,13 @@ private:
             docs.WriteActor->Write(Cookie, ft->FlushDocs());
             docs.WriteActor->FlushBuffer(Cookie);
         }
-        dict.WriteActor->Write(Cookie, ft->FlushDict());
-        dict.WriteActor->FlushBuffer(Cookie);
         stats.WriteActor->Write(Cookie, ft->FlushStats());
         stats.WriteActor->FlushBuffer(Cookie);
+        if (actorInfo.FulltextDictTableId != TPathId()) {
+            auto& dict = PathWriteInfo.at(actorInfo.FulltextDictTableId);
+            dict.WriteActor->Write(Cookie, ft->FlushDict());
+            dict.WriteActor->FlushBuffer(Cookie);
+        }
     }
 
     IDataBatchProjectionPtr CreateWriteProjection(TPathWriteInfo& info, bool added,
@@ -3771,14 +3773,16 @@ public:
                     indexSettings.DocsTableId, indexSettings.DocsTablePath)) {
                     return false;
                 }
-                if (!writeInfo.Actors.contains(indexSettings.DictTableId.PathId)) {
-                    if (!EnsureWriteActor(settings, writeInfo, indexSettings.DictTableId,
-                            indexSettings.DictTablePath, {indexSettings.DictColumns.at(0)})) {
+                if (indexSettings.DictTableId.PathId != TPathId()) {
+                    if (!writeInfo.Actors.contains(indexSettings.DictTableId.PathId)) {
+                        if (!EnsureWriteActor(settings, writeInfo, indexSettings.DictTableId,
+                                indexSettings.DictTablePath, {indexSettings.DictColumns.at(0)})) {
+                            return false;
+                        }
+                    } else if (!CheckSchemaVersion(writeInfo.Actors.at(indexSettings.DictTableId.PathId).WriteActor,
+                        indexSettings.DictTableId, indexSettings.DictTablePath)) {
                         return false;
                     }
-                } else if (!CheckSchemaVersion(writeInfo.Actors.at(indexSettings.DictTableId.PathId).WriteActor,
-                    indexSettings.DictTableId, indexSettings.DictTablePath)) {
-                    return false;
                 }
                 if (!writeInfo.Actors.contains(indexSettings.StatsTableId.PathId)) {
                     if (!EnsureWriteActor(settings, writeInfo, indexSettings.StatsTableId,
@@ -3864,17 +3868,19 @@ public:
                             settings.Priority);
                     }
 
-                    writes.emplace_back(TKqpWriteTask::TPathWriteInfo{
-                        .WriteActor = writeInfo.Actors.at(indexSettings.DictTableId.PathId).WriteActor,
-                        .PathType = TKqpWriteTask::EPathWriteType::FulltextDict,
-                    });
-                    writeInfo.Actors.at(indexSettings.DictTableId.PathId).WriteActor->Open(
-                        writeCookie,
-                        NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT_INCREMENT,
-                        {indexSettings.DictColumns.at(0)},
-                        indexSettings.DictColumns,
-                        0,
-                        settings.Priority);
+                    if (indexSettings.DictTableId.PathId != TPathId()) {
+                        writes.emplace_back(TKqpWriteTask::TPathWriteInfo{
+                            .WriteActor = writeInfo.Actors.at(indexSettings.DictTableId.PathId).WriteActor,
+                            .PathType = TKqpWriteTask::EPathWriteType::FulltextDict,
+                        });
+                        writeInfo.Actors.at(indexSettings.DictTableId.PathId).WriteActor->Open(
+                            writeCookie,
+                            NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT_INCREMENT,
+                            {indexSettings.DictColumns.at(0)},
+                            indexSettings.DictColumns,
+                            0,
+                            settings.Priority);
+                    }
 
                     writes.emplace_back(TKqpWriteTask::TPathWriteInfo{
                         .WriteActor = writeInfo.Actors.at(indexSettings.StatsTableId.PathId).WriteActor,
@@ -6559,14 +6565,16 @@ private:
                     idx.DocsTablePath = indexSettings.GetDocsTable().GetPath();
                     idx.DocsColumns = TVector<NKikimrKqp::TKqpColumnMetadataProto>(
                         indexSettings.GetDocsColumns().begin(),
-                        indexSettings.GetDocsColumns().end()),
-                    idx.DictTableId = TTableId(indexSettings.GetDictTable().GetOwnerId(),
-                        indexSettings.GetDictTable().GetTableId(),
-                        indexSettings.GetDictTable().GetVersion());
-                    idx.DictTablePath = indexSettings.GetDictTable().GetPath();
-                    idx.DictColumns = TVector<NKikimrKqp::TKqpColumnMetadataProto>(
-                        indexSettings.GetDictColumns().begin(),
-                        indexSettings.GetDictColumns().end()),
+                        indexSettings.GetDocsColumns().end());
+                    if (indexSettings.HasDictTable()) {
+                        idx.DictTableId = TTableId(indexSettings.GetDictTable().GetOwnerId(),
+                            indexSettings.GetDictTable().GetTableId(),
+                            indexSettings.GetDictTable().GetVersion());
+                        idx.DictTablePath = indexSettings.GetDictTable().GetPath();
+                        idx.DictColumns = TVector<NKikimrKqp::TKqpColumnMetadataProto>(
+                            indexSettings.GetDictColumns().begin(),
+                            indexSettings.GetDictColumns().end());
+                    }
                     idx.StatsTableId = TTableId(indexSettings.GetStatsTable().GetOwnerId(),
                         indexSettings.GetStatsTable().GetTableId(),
                         indexSettings.GetStatsTable().GetVersion());

--- a/ydb/core/kqp/ut/indexes/compact/kqp_fulltext_compact_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/compact/kqp_fulltext_compact_ut.cpp
@@ -114,17 +114,6 @@ Y_UNIT_TEST_TWIN(AddIndexCompactRelevance, Covered) {
         ])", NYdb::FormatResultSetYson(index));
     }
 
-    index = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"animals"];
-        [3u;"cats"];
-        [2u;"chase"];
-        [2u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"];
-        [2u;"small"]
-    ])", NYdb::FormatResultSetYson(index));
-
     index = ReadIndex(db, NTableIndex::NFulltext::StatsTable);
     CompareYson(R"([
         [4u;0u;14u]
@@ -163,10 +152,8 @@ Y_UNIT_TEST_TWIN(InsertRow, WithRelevance) {
     Cerr << "indexImplTable: " << index << Endl;
     if (WithRelevance) {
         auto docs = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::DocsTable));
-        auto dict = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::DictTable));
         auto stats = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::StatsTable));
         Cerr << "indexImplDocsTable: " << docs << Endl;
-        Cerr << "indexImplDictTable: " << dict << Endl;
         Cerr << "indexImplStatsTable: " << stats << Endl;
         CompareYson(R"([
             [%true;18446744073709551615u;100u;"\xE4\1\2";"cats"];
@@ -178,12 +165,6 @@ Y_UNIT_TEST_TWIN(InsertRow, WithRelevance) {
             [[100u];3u];
             [[200u];3u]
         ])", docs);
-        CompareYson(R"([
-            [1u;"cats"];
-            [1u;"dogs"];
-            [1u;"foxes"];
-            [2u;"love"]
-        ])", dict);
         CompareYson(R"([
             [2u;0u;6u]
         ])", stats);
@@ -209,10 +190,8 @@ Y_UNIT_TEST_TWIN(InsertRow, WithRelevance) {
     Cerr << "indexImplTable: " << index << Endl;
     if (WithRelevance) {
         auto docs = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::DocsTable));
-        auto dict = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::DictTable));
         auto stats = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::StatsTable));
         Cerr << "indexImplDocsTable: " << docs << Endl;
-        Cerr << "indexImplDictTable: " << dict << Endl;
         Cerr << "indexImplStatsTable: " << stats << Endl;
         CompareYson(R"([
             [%true;18446744073709551614u;150u;"\x96\2";"cats"];
@@ -228,12 +207,6 @@ Y_UNIT_TEST_TWIN(InsertRow, WithRelevance) {
             [[150u];3u];
             [[200u];3u]
         ])", docs);
-        CompareYson(R"([
-            [2u;"cats"];
-            [1u;"dogs"];
-            [2u;"foxes"];
-            [3u;"love"]
-        ])", dict);
         CompareYson(R"([
             [3u;0u;9u]
         ])", stats);
@@ -358,14 +331,6 @@ Y_UNIT_TEST(UpsertNewRowRelevance) {
         [[100u];["Cats love cats."];["cats data"]];
         [[150u];["Foxes love cats."];["foxes data"]]
     ])", FulltextSearch(db, "cats"));
-
-    auto dict = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::DictTable));
-    CompareYson(R"([
-        [2u;"cats"];
-        [1u;"dogs"];
-        [2u;"foxes"];
-        [3u;"love"]
-    ])", dict);
 
     auto stats = NYdb::FormatResultSetYson(ReadIndex(db, NTableIndex::NFulltext::StatsTable));
     CompareYson(R"([[3u;0u;9u]])", stats);

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_build_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_build_ut.cpp
@@ -246,17 +246,6 @@ Y_UNIT_TEST_TWIN(AddIndexWithRelevance, Covered) {
         ])", NYdb::FormatResultSetYson(index));
     }
 
-    index = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"animals"];
-        [3u;"cats"];
-        [2u;"chase"];
-        [2u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"];
-        [2u;"small"]
-    ])", NYdb::FormatResultSetYson(index));
-
     index = ReadIndex(db, NTableIndex::NFulltext::StatsTable);
     CompareYson(R"([
         [4u;0u;14u]
@@ -544,13 +533,6 @@ Y_UNIT_TEST_QUAD(InsertRowsWithRelevance, Covered, UseUpsert) {
         [[100u];1u;"love"];
         [[200u];1u;"love"]
     ])", NYdb::FormatResultSetYson(index));
-    auto dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"cats"];
-        [1u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"]
-    ])", NYdb::FormatResultSetYson(dict));
     auto docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -589,13 +571,6 @@ Y_UNIT_TEST_QUAD(InsertRowsWithRelevance, Covered, UseUpsert) {
         [[150u];1u;"love"];
         [[200u];1u;"love"]
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [2u;"cats"];
-        [1u;"dogs"];
-        [2u;"foxes"];
-        [3u;"love"]
-    ])", NYdb::FormatResultSetYson(dict));
     docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -639,15 +614,6 @@ Y_UNIT_TEST_QUAD(InsertRowsWithRelevance, Covered, UseUpsert) {
         [[152u];1u;"rabbits"];
         [[151u];1u;"wolves"]
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [2u;"cats"];
-        [1u;"dogs"];
-        [4u;"foxes"];
-        [5u;"love"];
-        [1u;"rabbits"];
-        [1u;"wolves"]
-    ])", NYdb::FormatResultSetYson(dict));
     docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -1005,13 +971,6 @@ Y_UNIT_TEST_TWIN(UpsertWithRelevance, Covered) {
         AddIndexCovered(db, "fulltext_relevance");
     else
         AddIndex(db, "fulltext_relevance");
-    auto dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"cats"];
-        [1u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"]
-    ])", NYdb::FormatResultSetYson(dict));
     // Dataset is the same as in InsertWithRelevance - don't check index table contents
 
     // Pure upsert of new rows is already checked in InsertWithRelevance
@@ -1041,16 +1000,6 @@ Y_UNIT_TEST_TWIN(UpsertWithRelevance, Covered) {
         [[100u];1u;"rabbits"];
         [[151u];1u;"wolves"]
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"birds"];
-        [1u;"cats"];
-        [1u;"dogs"];
-        [3u;"foxes"];
-        [4u;"love"];
-        [1u;"rabbits"];
-        [1u;"wolves"]
-    ])", NYdb::FormatResultSetYson(dict));
     auto docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -1081,13 +1030,6 @@ Y_UNIT_TEST_TWIN(UpdateWithRelevance, Covered) {
         AddIndexCovered(db, "fulltext_relevance");
     else
         AddIndex(db, "fulltext_relevance");
-    auto dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"cats"];
-        [1u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"]
-    ])", NYdb::FormatResultSetYson(dict));
     // Dataset is the same as in InsertWithRelevance - don't check index table contents
 
     // Pure upsert of new rows is already checked in InsertWithRelevance
@@ -1108,15 +1050,6 @@ Y_UNIT_TEST_TWIN(UpdateWithRelevance, Covered) {
         [[200u];1u;"love"];
         [[100u];1u;"rabbits"];
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"birds"];
-        [0u;"cats"];
-        [1u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"];
-        [1u;"rabbits"]
-    ])", NYdb::FormatResultSetYson(dict));
     auto docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -1858,16 +1791,6 @@ Y_UNIT_TEST_TWIN(DeleteRowWithRelevance, Covered) {
         [[100u];1u;"small"];
         [[200u];1u;"small"]
     ])", NYdb::FormatResultSetYson(index));
-    auto dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"animals"];
-        [3u;"cats"];
-        [2u;"chase"];
-        [2u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"];
-        [2u;"small"]
-    ])", NYdb::FormatResultSetYson(dict));
     auto docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -1906,16 +1829,6 @@ Y_UNIT_TEST_TWIN(DeleteRowWithRelevance, Covered) {
         [[400u];1u;"love"];
         [[100u];1u;"small"]
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"animals"];
-        [2u;"cats"];
-        [1u;"chase"];
-        [1u;"dogs"];
-        [1u;"foxes"];
-        [2u;"love"];
-        [1u;"small"]
-    ])", NYdb::FormatResultSetYson(dict));
     docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -1949,16 +1862,6 @@ Y_UNIT_TEST_TWIN(DeleteRowWithRelevance, Covered) {
         [[300u];1u;"love"];
         [[100u];1u;"small"]
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"animals"];
-        [2u;"cats"];
-        [1u;"chase"];
-        [0u;"dogs"];
-        [0u;"foxes"];
-        [1u;"love"];
-        [1u;"small"]
-    ])", NYdb::FormatResultSetYson(dict));
     docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([
@@ -1988,16 +1891,6 @@ Y_UNIT_TEST_TWIN(DeleteRowWithRelevance, Covered) {
         [[100u];1u;"chase"];
         [[100u];1u;"small"]
     ])", NYdb::FormatResultSetYson(index));
-    dict = ReadIndex(db, NTableIndex::NFulltext::DictTable);
-    CompareYson(R"([
-        [1u;"animals"];
-        [1u;"cats"];
-        [1u;"chase"];
-        [0u;"dogs"];
-        [0u;"foxes"];
-        [0u;"love"];
-        [1u;"small"]
-    ])", NYdb::FormatResultSetYson(dict));
     docs = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
     if (Covered) {
         CompareYson(R"([

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_search_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_search_ut.cpp
@@ -2485,6 +2485,8 @@ Y_UNIT_TEST_QUAD(FullTextDeliveryProblem, LimitRowsPerRequest, EnableIndexStream
     auto& runtime = *kikimr.GetTestServer().GetRuntime();
     auto db = kikimr.GetQueryClient();
 
+    const bool compact = kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.GetEnableCompactFulltextIndex();
+
     // Create table with fulltext index using RunCall to properly handle fake threads
     kikimr.RunCall([&]() { CreateTexts(db); return true; });
     kikimr.RunCall([&]() { UpsertTexts(db); return true; });
@@ -2506,7 +2508,7 @@ Y_UNIT_TEST_QUAD(FullTextDeliveryProblem, LimitRowsPerRequest, EnableIndexStream
     THashMap<ui64, int> shardSet;
     UNIT_ASSERT(!docsShards.empty());
     UNIT_ASSERT(!implShards.empty());
-    UNIT_ASSERT(!dictShards.empty());
+    UNIT_ASSERT(compact || !dictShards.empty());
     UNIT_ASSERT(!statsShards.empty());
     UNIT_ASSERT(!mainShards.empty());
 

--- a/ydb/core/tx/datashard/build_index/fulltext_dict.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext_dict.cpp
@@ -32,7 +32,7 @@ using namespace NKikimr::NFulltext;
  *    (FulltextCompact/FulltextCompactRelevance/JsonCompact).
  *
  * For simple index formats:
- * - This scan takes the indexImplTable and writes output to indexImplDictTable.
+ * - This scan takes the indexImplTable and writes output to indexImplDictTable (optionally).
  * - Source columns: __ydb_token, <PK columns>, __ydb_freq
  * For compact index formats:
  * - This scan takes the indexImplTable0build and writes output to indexImplTable and indexImplDictTable.
@@ -146,8 +146,9 @@ public:
             uploadTypes->emplace_back(column, type);
         };
 
-        if (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance ||
-            request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance)
+        if ((request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance ||
+            request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance) &&
+            request.GetDictTableName())
         {
             auto uploadTypes = std::make_shared<NTxProxy::TUploadTypes>();
             addType(uploadTypes, TokenColumn);
@@ -566,8 +567,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildFulltextDictRequest::TPtr& ev,
             }
         }
 
-        if (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance ||
-            request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance) {
+        if (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance) {
             if (!request.GetDictTableName()) {
                 badRequest(TStringBuilder() << "Empty output dictionary table name");
             }

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -1551,7 +1551,7 @@ private:
             ev->Record.SetReadShadowData(true);
         }
 
-        if (buildInfo.IsBuildFulltextRelevance()) {
+        if (buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance) {
             path.Rise().Dive(NTableIndex::NFulltext::DictTable);
             ev->Record.SetDictTableName(path.PathString());
         }
@@ -2471,7 +2471,7 @@ private:
             if (done) {
                 LOG_D("FillFulltextIndex Dictionary Done");
                 NIceDb::TNiceDb db{txc.DB};
-                if (buildInfo.IsBuildFulltextRelevance()) {
+                if (buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance) {
                     buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
                     buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexBorders;
                     done = false;

--- a/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
@@ -313,7 +313,6 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance) {
                 const THashSet<TString> indexDataColumns{indexDesc.GetDataColumnNames().begin(), indexDesc.GetDataColumnNames().end()};
                 result.push_back(createImplTable(CalcFulltextDocsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns, docsTableDesc, indexDesc.GetFulltextIndexDescription())));
-                result.push_back(createImplTable(CalcFulltextDictImplTableDesc(tableInfo, tableInfo->PartitionConfig(), dictTableDesc, indexDesc.GetFulltextIndexDescription())));
                 result.push_back(createImplTable(CalcFulltextStatsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), statsTableDesc)));
             }
             break;

--- a/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
@@ -520,7 +520,6 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance) {
                     const THashSet<TString> indexDataColumns{indexDescription.GetDataColumnNames().begin(), indexDescription.GetDataColumnNames().end()};
                     result.push_back(createIndexImplTable(CalcFulltextDocsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), indexDataColumns, docsTableDesc, indexDescription.GetFulltextIndexDescription())));
-                    result.push_back(createIndexImplTable(CalcFulltextDictImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), dictTableDesc, indexDescription.GetFulltextIndexDescription())));
                     result.push_back(createIndexImplTable(CalcFulltextStatsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), statsTableDesc)));
                 }
                 break;

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
@@ -117,18 +117,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
             R"(["1";"yellow";["3"]]];)"
         "%false]]]", rows);
 
-        rows = ReadShards(runtime, TTestTxConfig::SchemeShard, index+"/indexImplDictTable").at(0);
-        Cerr << index << "/indexImplDictTable rows: " << rows << "\n";
-        UNIT_ASSERT_VALUES_EQUAL("[[[["
-            R"(["1";"and"];)"
-            R"(["3";"apple"];)"
-            R"(["1";"blue"];)"
-            R"(["1";"car"];)"
-            R"(["1";"green"];)"
-            R"(["2";"red"];)"
-            R"(["1";"yellow"]];)"
-        "%false]]]", rows);
-
         rows = ReadShards(runtime, TTestTxConfig::SchemeShard, index+"/indexImplDocsTable").at(0);
         Cerr << index << "/indexImplDocsTable rows: " << rows << "\n";
         UNIT_ASSERT_VALUES_EQUAL("[[[["
@@ -251,7 +239,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
     // Regression test for the crash at build_index__progress.cpp SendUploadFulltextBordersRequest:
     // building a *prefixed* relevance index (e.g. ALTER TABLE ... ADD INDEX ... ON (lang, text))
     // hit `Y_ENSURE(buildInfo.IndexColumns.size() == 1)` because IndexColumns is [lang, text].
-    // The borders upload (indexImplDictTable) must use the text column (IndexColumns.back()), not [0].
     Y_UNIT_TEST(PrefixedRelevanceBuilds) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -275,16 +262,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
             UNIT_ASSERT_VALUES_EQUAL_C(op.GetIndexBuild().GetState(),
                 Ydb::Table::IndexBuildState::STATE_DONE, op.DebugString());
         }
-
-        // The dictionary table (produced by SendUploadFulltextBordersRequest) exists and is populated.
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/fulltext_idx/indexImplDictTable"), {
-            NLs::PathExist,
-        });
-        auto dictRows = ReadShards(runtime, TTestTxConfig::SchemeShard,
-            "/MyRoot/texts/fulltext_idx/indexImplDictTable").at(0);
-        Cerr << "indexImplDictTable rows: " << dictRows << "\n";
-        // "apple" appears in the corpus, so the dictionary borders must contain it.
-        UNIT_ASSERT_C(dictRows.Contains("apple"), "indexImplDictTable missing tokens: " << dictRows);
 
         // The posting impl-table is keyed with the prefix column prepended before the token.
         TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/fulltext_idx/indexImplTable"), {
@@ -1078,7 +1055,7 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
 
     Y_UNIT_TEST(RowIdOptIn_CompactBuildsOverCustomPkAndDropsRowIdSrc) {
         // Compact rowid-mode build over a custom (Utf8) PK: it runs the row-id source prepass, builds the
-        // compact posting/dict tables and, on completion, the transient "rowidsrc" build table is dropped.
+        // compact posting tables and, on completion, the transient "rowidsrc" build table is dropped.
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         EnableCompactAutoProvisionFlags(runtime);

--- a/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_fulltext_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_fulltext_index_build_reboots.cpp
@@ -93,7 +93,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTestReboots) {
                 TestDescribeResult(DescribePath(runtime, indexPath, true, true, true),
                     {NLs::PathExist, NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
                 TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::ImplTable, true, true, true), {NLs::PathExist});
-                TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::NFulltext::DictTable, true, true, true), {NLs::PathExist});
                 TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::NFulltext::DocsTable, true, true, true), {NLs::PathExist});
                 TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::NFulltext::StatsTable, true, true, true), {NLs::PathExist});
 
@@ -102,12 +101,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTestReboots) {
                     auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/texts/index1/" + TString(NTableIndex::ImplTable));
                     Cerr << "... posting table contains " << rows << " rows" << Endl;
                     UNIT_ASSERT_VALUES_EQUAL(rows, 38);
-                }
-
-                {
-                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/texts/index1/" + TString(NTableIndex::NFulltext::DictTable));
-                    Cerr << "... dictionary table contains " << rows << " rows" << Endl;
-                    UNIT_ASSERT_VALUES_EQUAL(rows, 24);
                 }
 
                 {

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -2019,7 +2019,6 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
 
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
-        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             FillGlobalIndexSettings(
                 *index->mutable_global_fulltext_relevance_index()->mutable_dict_table_settings(),
                 tableIndex.GetIndexImplTableDescriptions(NTableIndex::NFulltext::DictTablePosition)
@@ -2035,6 +2034,23 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
             FillGlobalIndexSettings(
                 *index->mutable_global_fulltext_relevance_index()->mutable_posting_table_settings(),
                 tableIndex.GetIndexImplTableDescriptions(NTableIndex::NFulltext::PostingTablePosition)
+            );
+
+            *index->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings() = tableIndex.GetFulltextIndexDescription().GetSettings();
+
+            break;
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+            FillGlobalIndexSettings(
+                *index->mutable_global_fulltext_relevance_index()->mutable_docs_table_settings(),
+                tableIndex.GetIndexImplTableDescriptions(NTableIndex::NFulltext::DocsTablePosition - 1)
+            );
+            FillGlobalIndexSettings(
+                *index->mutable_global_fulltext_relevance_index()->mutable_stats_table_settings(),
+                tableIndex.GetIndexImplTableDescriptions(NTableIndex::NFulltext::StatsTablePosition - 1)
+            );
+            FillGlobalIndexSettings(
+                *index->mutable_global_fulltext_relevance_index()->mutable_posting_table_settings(),
+                tableIndex.GetIndexImplTableDescriptions(NTableIndex::NFulltext::PostingTablePosition - 1)
             );
 
             *index->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings() = tableIndex.GetFulltextIndexDescription().GetSettings();


### PR DESCRIPTION
### Description for reviewers

Здесь удалено использование таблицы Dict. Общую частоту слова можно считать просто по самим постингам.

При этом чтобы сильно не усложнять и не добавлять опять очередной фича-флаг, построение dict таблицы отключено (удалено) для компактных индексов. Они ещё никуда не выкачены, так что по идее это можно так поменять.

Плюсы:
- Собственно, не нужно поддерживать таблицу Dict. Это заметно ускоряет как построение, так и обновление индекса.
- Не нужно отдельно читать статистику при поиске, это улучшает задержку.
- Упрощаются префиксные индексы - опять-таки, не нужно реализовывать раздельную статистику по словам. Правда, появляется необходимость раздельной общей статистики. Но так как у нас оказалось, что префиксные индексы с релевантностью вообще не доделаны и на самом деле не умеют считать глобальную статистику по словам, то тут всё равно нужно доделывать.

Потенциальные минусы ограниченные:
- При поиске с релевантностью теперь точно всегда нужно будет читать всю "кишку" по каждому термину. Скорее всего это не очень критично, потому что:
  а) раньше "не читать" можно было только хвосты. То есть, допустим, мы пересекаем в режиме AND три слова, одно кончилось - значит два других можно не дочитывать. Но аналогичная ситуация в начале, а не конце, списка никак не оптимизировалась.
  б) статистику потом можно будет вернуть, реализовав её вместе со списками чемпионов, встроенную в первый сегмент. тогда хвосты можно будет снова не читать.
- Отваливается моя оптимизация "несбалансированных n-грамм", работавшая на индексах с релевантностью. Но в принципе она тоже не супер важная и её потом тоже можно реанимировать, игнорируя длинные "кишки".

На fulltext workload run select производительность фактически без изменений. Только чуть улучшается p99 latency.
