### PR TITLE
Kafka proxy: keep TCP connections after SASL ticket expiry or topic ACL revoke

### DIFF
--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -82,6 +82,27 @@ struct TReadSession {
     NActors::TActorId ProxyActorId;
 };
 
+struct TCredentials {
+    TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    TString Ticket;
+    TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> TicketParserEntries;
+    TString AuthDatabasePath;
+    TString PeerName;
+    ETokenCheckStatus Status = ETokenCheckStatus::Ok;
+
+    std::optional<EKafkaErrors> UnusableError() const {
+        switch (Status) {
+            case ETokenCheckStatus::Invalid:
+                return EKafkaErrors::TOPIC_AUTHORIZATION_FAILED;
+            case ETokenCheckStatus::Unavailable:
+                return EKafkaErrors::BROKER_NOT_AVAILABLE;
+            case ETokenCheckStatus::Ok:
+                return std::nullopt;
+        }
+        return std::nullopt;
+    }
+};
+
 struct TContext {
     using TPtr = std::shared_ptr<TContext>;
 
@@ -101,15 +122,8 @@ struct TContext {
         , CloudId(other.CloudId)
         , DatabaseId(other.DatabaseId)
         , ResourceDatabasePath(other.ResourceDatabasePath)
-        , Coordinator(other.Coordinator)
-        , RlResourcePath(other.RlResourcePath)
         , InitialServerlessTransactionsFlagValue(other.InitialServerlessTransactionsFlagValue)
-        , UserToken(other.UserToken)
-        , Ticket(other.Ticket)
-        , TicketParserEntries(other.TicketParserEntries)
-        , AuthDatabasePath(other.AuthDatabasePath)
-        , PeerName(other.PeerName)
-        , TokenCheck(other.TokenCheck)
+        , Token(other.Token)
         , ClientDC(other.ClientDC)
         , IsServerless(other.IsServerless)
         , RequireAuthentication(other.RequireAuthentication)
@@ -132,15 +146,8 @@ struct TContext {
     TString CloudId;
     TString DatabaseId;
     TString ResourceDatabasePath;
-    TString Coordinator;
-    TString RlResourcePath;
     std::optional<bool> InitialServerlessTransactionsFlagValue;
-    TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
-    TString Ticket;
-    TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> TicketParserEntries;
-    TString AuthDatabasePath;
-    TString PeerName;
-    ETokenCheckStatus TokenCheck = ETokenCheckStatus::Ok;
+    TCredentials Token;
     TString ClientDC;
     bool IsServerless = false;
     bool RequireAuthentication = false;
@@ -155,29 +162,17 @@ struct TContext {
     }
 
     bool ShouldCheckTopicAcl() const {
-        return RequireAuthentication || bool(UserToken);
+        return RequireAuthentication || bool(Token.UserToken);
     }
 
     bool HasTopicAccess(const NACLib::TSecurityObject* securityObject, NACLib::EAccessRights rights) const {
         if (!ShouldCheckTopicAcl()) {
             return true;
         }
-        if (!UserToken || !securityObject) {
+        if (!Token.UserToken || !securityObject) {
             return false;
         }
-        return securityObject->CheckAccess(rights, *UserToken);
-    }
-
-    std::optional<EKafkaErrors> TokenUnusableError() const {
-        switch (TokenCheck) {
-            case ETokenCheckStatus::Invalid:
-                return EKafkaErrors::TOPIC_AUTHORIZATION_FAILED;
-            case ETokenCheckStatus::Unavailable:
-                return EKafkaErrors::BROKER_NOT_AVAILABLE;
-            case ETokenCheckStatus::Ok:
-                return std::nullopt;
-        }
-        return std::nullopt;
+        return securityObject->CheckAccess(rights, *Token.UserToken);
     }
 
     TDuration TokenRecheckInterval() const {
@@ -185,7 +180,7 @@ struct TContext {
     }
 
     bool TokenRecheckEnabled() const {
-        return Config.GetTokenRecheckIntervalMs() > 0 && !Ticket.empty();
+        return Config.GetTokenRecheckIntervalMs() > 0 && !Token.Ticket.empty();
     }
 
     void RememberTopicAclOk(const TString& topic) {
@@ -311,17 +306,17 @@ inline TString GetTopicNameWithoutDb(const TString& database, TString topic) {
 }
 
 inline TString GetUsernameOrAnonymous(std::shared_ptr<TContext> context) {
-    return context->UserToken ? context->UserToken->GetUserSID() : "anonymous";
+    return context->Token.UserToken ? context->Token.UserToken->GetUserSID() : "anonymous";
 }
 
 inline TString GetUserSerializedToken(std::shared_ptr<TContext> context) {
-    if (!context->UserToken) {
+    if (!context->Token.UserToken) {
         return "";
     }
-    if (!context->UserToken->GetSerializedToken().empty()) {
-        return context->UserToken->GetSerializedToken();
+    if (!context->Token.UserToken->GetSerializedToken().empty()) {
+        return context->Token.UserToken->GetSerializedToken();
     }
-    return context->UserToken->SerializeAsString();
+    return context->Token.UserToken->SerializeAsString();
 }
 
 NActors::IActor* CreateKafkaApiVersionsActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TApiVersionsRequestData>& message,

--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/raw_socket/sock_impl.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/base/ticket_parser.h>
 #include <ydb/core/kafka_proxy/kafka_messages.h>
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
 #include <ydb/core/protos/config.pb.h>
@@ -13,8 +14,11 @@
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
 #include <ydb/public/api/protos/draft/persqueue_error_codes.pb.h> // strange
 
+#include <util/datetime/base.h>
+#include <util/generic/hash_set.h>
 #include <util/system/backtrace.h>
 #include <util/system/type_name.h>
+#include <optional>
 
 namespace NKafka {
 
@@ -61,6 +65,12 @@ enum EAuthSteps {
     FAILED
 };
 
+enum class ETokenCheckStatus {
+    Ok,
+    Invalid,
+    Unavailable
+};
+
 enum class EBalancingMode {
     Server,
     Native,
@@ -81,6 +91,29 @@ struct TContext {
 
     TContext(const TContext& other)
         : Config(other.Config)
+        , ConnectionId(other.ConnectionId)
+        , KafkaClient(other.KafkaClient)
+        , AuthenticationStep(other.AuthenticationStep)
+        , SaslMechanism(other.SaslMechanism)
+        , GroupId(other.GroupId)
+        , DatabasePath(other.DatabasePath)
+        , FolderId(other.FolderId)
+        , CloudId(other.CloudId)
+        , DatabaseId(other.DatabaseId)
+        , ResourceDatabasePath(other.ResourceDatabasePath)
+        , Coordinator(other.Coordinator)
+        , RlResourcePath(other.RlResourcePath)
+        , InitialServerlessTransactionsFlagValue(other.InitialServerlessTransactionsFlagValue)
+        , UserToken(other.UserToken)
+        , Ticket(other.Ticket)
+        , TicketParserEntries(other.TicketParserEntries)
+        , AuthDatabasePath(other.AuthDatabasePath)
+        , PeerName(other.PeerName)
+        , TokenCheck(other.TokenCheck)
+        , ClientDC(other.ClientDC)
+        , IsServerless(other.IsServerless)
+        , RequireAuthentication(other.RequireAuthentication)
+        , RlContext(other.RlContext)
     {
     }
 
@@ -99,8 +132,15 @@ struct TContext {
     TString CloudId;
     TString DatabaseId;
     TString ResourceDatabasePath;
+    TString Coordinator;
+    TString RlResourcePath;
     std::optional<bool> InitialServerlessTransactionsFlagValue;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    TString Ticket;
+    TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> TicketParserEntries;
+    TString AuthDatabasePath;
+    TString PeerName;
+    ETokenCheckStatus TokenCheck = ETokenCheckStatus::Ok;
     TString ClientDC;
     bool IsServerless = false;
     bool RequireAuthentication = false;
@@ -108,9 +148,52 @@ struct TContext {
 
     NKikimr::NPQ::TRlContext RlContext;
 
+    THashSet<TString> TopicAclOk;
 
     bool Authenticated() {
         return !RequireAuthentication || AuthenticationStep == SUCCESS;
+    }
+
+    bool ShouldCheckTopicAcl() const {
+        return RequireAuthentication || bool(UserToken);
+    }
+
+    bool HasTopicAccess(const NACLib::TSecurityObject* securityObject, NACLib::EAccessRights rights) const {
+        if (!ShouldCheckTopicAcl()) {
+            return true;
+        }
+        if (!UserToken || !securityObject) {
+            return false;
+        }
+        return securityObject->CheckAccess(rights, *UserToken);
+    }
+
+    std::optional<EKafkaErrors> TokenUnusableError() const {
+        switch (TokenCheck) {
+            case ETokenCheckStatus::Invalid:
+                return EKafkaErrors::TOPIC_AUTHORIZATION_FAILED;
+            case ETokenCheckStatus::Unavailable:
+                return EKafkaErrors::BROKER_NOT_AVAILABLE;
+            case ETokenCheckStatus::Ok:
+                return std::nullopt;
+        }
+        return std::nullopt;
+    }
+
+    TDuration TokenRecheckInterval() const {
+        return TDuration::MilliSeconds(Config.GetTokenRecheckIntervalMs());
+    }
+
+    bool TokenRecheckEnabled() const {
+        return Config.GetTokenRecheckIntervalMs() > 0 && !Ticket.empty();
+    }
+
+    void RememberTopicAclOk(const TString& topic) {
+        TopicAclOk.insert(topic);
+    }
+
+    bool HadTopicAclOk(const TString& topic) const {
+        return TopicAclOk.find(topic) != TopicAclOk.end();
     }
 
     bool KafkaTableFeatureFlagChanged(bool serverlessTransactionsEnabledNow) const {
@@ -228,11 +311,17 @@ inline TString GetTopicNameWithoutDb(const TString& database, TString topic) {
 }
 
 inline TString GetUsernameOrAnonymous(std::shared_ptr<TContext> context) {
-    return context->RequireAuthentication ? context->UserToken->GetUserSID() : "anonymous";
+    return context->UserToken ? context->UserToken->GetUserSID() : "anonymous";
 }
 
 inline TString GetUserSerializedToken(std::shared_ptr<TContext> context) {
-    return context->RequireAuthentication ? context->UserToken->GetSerializedToken() : "";
+    if (!context->UserToken) {
+        return "";
+    }
+    if (!context->UserToken->GetSerializedToken().empty()) {
+        return context->UserToken->GetSerializedToken();
+    }
+    return context->UserToken->SerializeAsString();
 }
 
 NActors::IActor* CreateKafkaApiVersionsActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TApiVersionsRequestData>& message,

--- a/ydb/core/kafka_proxy/actors/kafka_alter_configs_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_alter_configs_actor.cpp
@@ -187,7 +187,7 @@ void TKafkaAlterConfigsActor::Bootstrap(const NActors::TActorContext& ctx) {
 
         ctx.Register(new TAlterConfigsActor(
             SelfId(),
-            Context->UserToken,
+            Context->Token.UserToken,
             resource.ResourceName.value(),
             Context->DatabasePath,
             convertedRetentions.Ms,

--- a/ydb/core/kafka_proxy/actors/kafka_create_partitions_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_partitions_actor.cpp
@@ -290,7 +290,7 @@ void TKafkaCreatePartitionsActor::Bootstrap(const NActors::TActorContext& ctx) {
 
         ctx.Register(new TCreatePartitionsActor(
             SelfId(),
-            Context->UserToken,
+            Context->Token.UserToken,
             topic.Name.value(),
             Context->DatabasePath,
             topic.Count

--- a/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
@@ -155,7 +155,7 @@ void TKafkaCreateTopicsActor::Bootstrap(const NActors::TActorContext& ctx) {
         ctx.RegisterWithSameMailbox(NKikimr::NPQ::NSchema::CreateCreateTopicActor(SelfId(), NKikimr::NPQ::NSchema::TCreateTopicSettings{
             .Database = Context->DatabasePath,
             .Request = std::move(request),
-            .UserToken = Context->UserToken,
+            .UserToken = Context->Token.UserToken,
             .IfNotExists = false,
         }));
 

--- a/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.cpp
@@ -131,7 +131,7 @@ void TKafkaDescribeConfigsActor::Bootstrap(const NActors::TActorContext& ctx) {
 
         ctx.Register(new TKafkaDescribeTopicActor(
             SelfId(),
-            Context->UserToken,
+            Context->Token.UserToken,
             resource.ResourceName.value(),
             Context->DatabasePath
         ));

--- a/ydb/core/kafka_proxy/actors/kafka_describe_groups_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_describe_groups_actor.cpp
@@ -283,8 +283,12 @@ void TKafkaDescribeGroupsActor::SendToKqpDescribeGroupsMetadataRequest(const TAc
 }
 
 void TKafkaDescribeGroupsActor::SendFailResponse(EKafkaErrors errorCode, const std::optional<TString>& errorMessage) {
+    TDescribeGroupsResponseData response;
     for (auto& groupId : DescribeGroupsRequestData->Groups) {
-        GroupIdToDescription[*groupId].ErrorCode = errorCode;
+        TDescribeGroupsResponseData::TDescribedGroup groupDescription;
+        groupDescription.ErrorCode = errorCode;
+        groupDescription.GroupId = groupId;
+        response.Groups.push_back(std::move(groupDescription));
     }
     if (errorMessage.has_value()) {
         YDB_LOG_WARN("Sending fail response with error",
@@ -298,7 +302,9 @@ void TKafkaDescribeGroupsActor::SendFailResponse(EKafkaErrors errorCode, const s
     }
 
     Send(Context->ConnectionId,
-        new TEvKafka::TEvResponse(CorrelationId, BuildResponse(), errorCode));
+        new TEvKafka::TEvResponse(CorrelationId,
+            std::make_shared<TDescribeGroupsResponseData>(std::move(response)),
+            errorCode));
 }
 
 TMaybe<TString> TKafkaDescribeGroupsActor::GetErrorFromYdbResponse(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev) {

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -74,7 +74,7 @@ void TKafkaFetchActor::SendFetchRequests(const TActorContext& ctx) {
             .CanReadBatches = true,
             .RequestId = 0,
             .RlCtx = Context->RlContext,
-            .UserToken = Context->UserToken
+            .UserToken = Context->Token.UserToken
         };
         auto fetchActor = NKikimr::NPQ::CreatePQFetchRequestActor(request, NKikimr::MakeSchemeCacheID(), ctx.SelfID);
         auto actorId = ctx.Register(fetchActor);

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -178,6 +178,9 @@ void TKafkaFetchActor::HandleSuccessResponse(const NKikimr::TEvPQ::TEvFetchRespo
         partKafkaResponse.HighWatermark = partPQResponse.GetReadResult().GetMaxOffset();
         partKafkaResponse.LastStableOffset = partPQResponse.GetReadResult().GetMaxOffset();
         Response->ThrottleTimeMs = std::max(Response->ThrottleTimeMs, static_cast<i32>(partPQResponse.GetReadResult().GetWaitQuotaTimeMs()));
+        if (partPQResponse.GetReadResult().GetErrorCode() == NPersQueue::NErrorCode::EErrorCode::OK && topicResponse.Topic.has_value()) {
+            Context->RememberTopicAclOk(TString(topicResponse.Topic.value()));
+        }
         if (partPQResponse.GetReadResult().GetResult().size() == 0) {
             continue;
         }

--- a/ydb/core/kafka_proxy/actors/kafka_list_offsets_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_list_offsets_actor.cpp
@@ -132,7 +132,9 @@ void TKafkaListOffsetsActor::Handle(TEvKafka::TEvTopicOffsetsResponse::TPtr& ev,
                 ErrorCode = INVALID_REQUEST;
             }
         } else {
-            responsePartition.ErrorCode = ConvertErrorCode(ev->Get()->Status);
+            auto error = ConvertErrorCode(ev->Get()->Status);
+            responsePartition.ErrorCode = error;
+            ErrorCode = error;
         }
 
         responseTopic.Partitions.emplace_back(std::move(responsePartition));

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -331,7 +331,7 @@ void TKafkaMetadataActor::SendCreateTopicsRequest(const TString& topicName, ui32
     TContext::TPtr ContextForTopicCreation;
     ContextForTopicCreation = std::make_shared<TContext>(TContext(*Context));
     ContextForTopicCreation->ConnectionId = ctx.SelfID;
-    ContextForTopicCreation->UserToken = Context->UserToken;
+    ContextForTopicCreation->Token.UserToken = Context->Token.UserToken;
     ContextForTopicCreation->DatabasePath = Context->DatabasePath;
     ContextForTopicCreation->ResourceDatabasePath = Context->ResourceDatabasePath;
     TActorId actorId = ctx.Register(new TKafkaCreateTopicsActor(ContextForTopicCreation,

--- a/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.cpp
@@ -84,7 +84,7 @@ void TKafkaOffsetCommitActor::CreateConsumerGroupIfNecessary(const TString& topi
     };
     NKikimr::NGRpcService::DoAlterTopicRequest(
         std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
-        topicName, Context->DatabasePath, std::move(request), callback, Context->UserToken),
+        topicName, Context->DatabasePath, std::move(request), callback, Context->Token.UserToken),
         NKikimr::NReplication::TLocalProxyActor(Context->DatabasePath));
 }
 
@@ -408,7 +408,7 @@ void TKafkaOffsetCommitActor::SendAuthRequest(const NActors::TActorContext& ctx)
 
     AuthInitActor = ctx.Register(new NKikimr::NGRpcProxy::V1::TReadInitAndAuthActor(
             ctx, ctx.SelfID, Message->GroupId.value(), 0, "",
-            NKikimr::NMsgBusProxy::CreatePersQueueMetaCacheV2Id(), NKikimr::MakeSchemeCacheID(), nullptr, Context->UserToken, topicsToConverter,
+            NKikimr::NMsgBusProxy::CreatePersQueueMetaCacheV2Id(), NKikimr::MakeSchemeCacheID(), nullptr, Context->Token.UserToken, topicsToConverter,
         topicHandler->GetLocalCluster(), false)
     );
 }

--- a/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.cpp
@@ -100,7 +100,7 @@ void TKafkaOffsetCommitActor::SendFailedForAllPartitions(EKafkaErrors error, con
         }
         Response->Topics.push_back(topic);
     }
-    Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, Response, Error));
+    Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, Response, error));
     Die(ctx);
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -323,7 +323,7 @@ void TKafkaOffsetFetchActor::Bootstrap(const NActors::TActorContext& ctx) {
                 topicToEntities.second.Partitions,
                 topicToEntities.first,
                 GetUsernameOrAnonymous(Context),
-                Context->UserToken,
+                Context->Token.UserToken,
                 Context->RequireAuthentication
             ));
             InflyTopics++;
@@ -405,7 +405,7 @@ void TKafkaOffsetFetchActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const
         TopicToEntities[createdTopicName].Partitions,
         createdTopicName,
         GetUsernameOrAnonymous(Context),
-        Context->UserToken,
+        Context->Token.UserToken,
         Context->RequireAuthentication
     ));
 }
@@ -445,7 +445,7 @@ void TKafkaOffsetFetchActor::Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlter
         TopicToEntities[alteredTopicName].Partitions,
         alteredTopicName,
         GetUsernameOrAnonymous(Context),
-        Context->UserToken,
+        Context->Token.UserToken,
         Context->RequireAuthentication
     ));
 
@@ -517,7 +517,7 @@ void NKafka::TKafkaOffsetFetchActor::Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr
             topicToEntities.second.Partitions,
             topicToEntities.first,
             GetUsernameOrAnonymous(Context),
-            Context->UserToken,
+            Context->Token.UserToken,
             Context->RequireAuthentication
         ));
         InflyTopics++;
@@ -594,7 +594,7 @@ void TKafkaOffsetFetchActor::CreateConsumerGroupIfNecessary(const TString& topic
     };
     NKikimr::NGRpcService::DoAlterTopicRequest(
         std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
-        topicName, DatabasePath, std::move(request), callback, Context->UserToken),
+        topicName, DatabasePath, std::move(request), callback, Context->Token.UserToken),
         NKikimr::NReplication::TLocalProxyActor(DatabasePath));
 
 }
@@ -617,7 +617,7 @@ void TKafkaOffsetFetchActor::CreateTopicIfNecessary(const TString& topicName,
     TContext::TPtr ContextForTopicCreation;
     ContextForTopicCreation = std::make_shared<TContext>(TContext(*Context));
     ContextForTopicCreation->ConnectionId = ctx.SelfID;
-    ContextForTopicCreation->UserToken = Context->UserToken;
+    ContextForTopicCreation->Token.UserToken = Context->Token.UserToken;
     ContextForTopicCreation->DatabasePath = Context->DatabasePath;
     ContextForTopicCreation->ResourceDatabasePath = Context->ResourceDatabasePath;
     ContextForTopicCreation->RequireAuthentication = Context->RequireAuthentication;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -1,12 +1,14 @@
 #include "kafka_offset_fetch_actor.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
 
 #include <ydb/core/kafka_proxy/actors/kafka_create_topics_actor.h>
 #include <ydb/core/kafka_proxy/actors/kafka_metadata_service.h>
 #include <ydb/core/kafka_proxy/kafka_consumer_groups_metadata_initializers.h>
 #include "ydb/core/kafka_proxy/kafka_consumer_members_metadata_initializers.h"
 #include <ydb/core/kafka_proxy/kafka_events.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/services/lib/actors/pq_schema_actor.h>
 
 #include <ydb/core/kafka_proxy/kafka_events.h>
@@ -160,18 +162,42 @@ class TTopicOffsetActor: public NKikimr::NGRpcProxy::V1::TPQInternalSchemaActor<
             {"originalTopicName", OriginalTopicName},
             {"userSID", UserSID},
             {"present", (response.PQGroupInfo.Get() != nullptr)});
+
+        if (CheckingTopicExistence) {
+            // Unauthenticated describe: if the topic exists, the user was denied by ACL.
+            if (response.PQGroupInfo) {
+                RaiseError(
+                    "access denied",
+                    Ydb::PersQueue::ErrorCode::ACCESS_DENIED,
+                    Ydb::StatusIds::UNAUTHORIZED,
+                    ActorContext());
+            } else {
+                ReplyUnknownTopic();
+            }
+            return;
+        }
+
+        if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::AccessDenied) {
+            RaiseError(
+                "access denied",
+                Ydb::PersQueue::ErrorCode::ACCESS_DENIED,
+                Ydb::StatusIds::UNAUTHORIZED,
+                ActorContext());
+            return;
+        }
         if (!response.PQGroupInfo) {
-            THolder<TEvKafka::TEvCommitedOffsetsResponse> response(new TEvKafka::TEvCommitedOffsetsResponse());
-            response->TopicName = OriginalTopicName;
-            response->Status = UNKNOWN_TOPIC_OR_PARTITION;
-            Send(Requester, response.Release());
-            TActorBootstrapped::PassAway();
+            if (UserToken) {
+                CheckingTopicExistence = true;
+                SendUnauthenticatedExistenceCheck();
+                return;
+            }
+            ReplyUnknownTopic();
             return;
         }
         auto path = CanonizePath(NKikimr::JoinPath(response.Path));
         bool hasRights = true;
-        if (UserToken && UserToken->GetSerializedToken()) {
-            hasRights = response.SecurityObject->CheckAccess(NACLib::EAccessRights::SelectRow, *UserToken);
+        if (UserToken) {
+            hasRights = response.SecurityObject && response.SecurityObject->CheckAccess(NACLib::EAccessRights::SelectRow, *UserToken);
         } else if (RequireAuthentication) {
             hasRights = false;
         }
@@ -202,12 +228,33 @@ class TTopicOffsetActor: public NKikimr::NGRpcProxy::V1::TPQInternalSchemaActor<
         Die(ctx);
     };
 
+    void ReplyUnknownTopic() {
+        THolder<TEvKafka::TEvCommitedOffsetsResponse> response(new TEvKafka::TEvCommitedOffsetsResponse());
+        response->TopicName = OriginalTopicName;
+        response->Status = UNKNOWN_TOPIC_OR_PARTITION;
+        Send(Requester, response.Release());
+        TActorBootstrapped::PassAway();
+    }
+
+    void SendUnauthenticatedExistenceCheck() {
+        auto navigateRequest = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
+        navigateRequest->DatabaseName = Database;
+        navigateRequest->ResultSet.emplace_back(NSchemeCache::TSchemeCacheNavigate::TEntry{
+            .Path = NKikimr::SplitPath(GetTopicPath()),
+            .Access = NACLib::DescribeSchema,
+            .Operation = NSchemeCache::TSchemeCacheNavigate::OpList,
+            .SyncVersion = true,
+        });
+        Send(NKikimr::MakeSchemeCacheID(), new NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySet(navigateRequest.release()));
+    }
+
     private:
         const TActorId Requester;
         const TString OriginalTopicName;
         const TString UserSID;
         const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
         bool RequireAuthentication;
+        bool CheckingTopicExistence = false;
         std::shared_ptr<std::unordered_map<ui32, std::unordered_map<TString, TEvKafka::PartitionConsumerOffset>>> PartitionIdToOffsets = std::make_shared<std::unordered_map<ui32, std::unordered_map<TString, TEvKafka::PartitionConsumerOffset>>>();
 };
 
@@ -290,14 +337,15 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
 
     auto eventPtr = ev->Release();
     TString topicName = eventPtr->TopicName;
+    if (eventPtr->Status == NONE_ERROR) {
+        Context->RememberTopicAclOk(topicName);
+    } else if (eventPtr->Status == UNKNOWN_TOPIC_OR_PARTITION && Context->HadTopicAclOk(topicName)) {
+        eventPtr->Status = TOPIC_AUTHORIZATION_FAILED;
+    }
     const bool topicExists = eventPtr->Status == NONE_ERROR;
     TopicsToResponses[topicName] = eventPtr;
-    bool topicNotCreatedYet = false;
     auto& topicGroupRequests = GroupRequests[topicName];
     for (const auto& [topicRequest, groupId] : topicGroupRequests) {
-        if (topicNotCreatedYet) {
-            break;
-        }
         TString topicNameWithoutDb = GetTopicNameWithoutDb(DatabasePath, *topicRequest.Name);
         TString topicPath = NormalizePath(DatabasePath, topicNameWithoutDb);
         if (topicExists && Context->Config.GetAutoCreateConsumersEnable()) {
@@ -314,12 +362,13 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
             if (!consumerOnTopic) {
                 CreateConsumerGroupIfNecessary(topicNameWithoutDb, topicPath, topicNameWithoutDb, groupId);
             }
-        } else if (!topicExists &&
-                    TopicsToResponses[topicName]->Status == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION &&
-                    Context->Config.GetAutoCreateTopicsEnable()) {
-            CreateTopicIfNecessary(topicNameWithoutDb, *topicRequest.Name, ctx);
-            topicNotCreatedYet = true;
         }
+        // Do not auto-create a topic reported as unknown. Apache Kafka OffsetFetch never creates
+        // topics (auto.create.topics.enable applies to Metadata, not OffsetFetch). For a missing
+        // topic/partition the group coordinator returns NONE + committedOffset -1; see
+        // https://issues.apache.org/jira/browse/KAFKA-20165. Scheme cache also uses "unknown" to
+        // hide topics without DescribeSchema; auto-create on that path would grant access. If this
+        // connection already saw the topic with access, the unknown describe is mapped to AUTH.
     }
     if (InflyTopics == 0) {
         auto response = GetOffsetFetchResponse();

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "actors.h"
 #include <ydb/core/kafka_proxy/kafka_consumer_protocol.h>
 #include <ydb/core/kafka_proxy/kafka_events.h>

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -1,5 +1,6 @@
 #include "kafka_produce_actor.h"
 #include <library/cpp/string_utils/base64/base64.h>
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/kafka_proxy/kafka_metrics.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
 
@@ -21,11 +22,25 @@ namespace NKafka {
 namespace {
 
 static constexpr TDuration WAKEUP_INTERVAL = TDuration::Seconds(1);
-static constexpr TDuration TOPIC_OK_EXPIRATION_INTERVAL = TDuration::Minutes(15);
 static constexpr TDuration TOPIC_NOT_FOUND_EXPIRATION_INTERVAL = TDuration::Seconds(15);
 static constexpr TDuration TOPIC_UNATHORIZED_EXPIRATION_INTERVAL = TDuration::Minutes(1);
 static constexpr TDuration REQUEST_EXPIRATION_INTERVAL = TDuration::Seconds(30);
 static constexpr TDuration WRITER_EXPIRATION_INTERVAL = TDuration::Minutes(5);
+
+TDuration TopicOkExpirationInterval() {
+    return TDuration::Seconds(Max<ui32>(1, NKikimr::AppData()->PQConfig.GetACLRetryTimeoutSec()));
+}
+
+TIntrusivePtr<TSecurityObject> TryMakeSecurityObject(const TString& owner, const TString& acl) {
+    if (acl.empty()) {
+        return nullptr;
+    }
+    NACLibProto::TACL parsed;
+    if (!parsed.ParseFromString(acl)) {
+        return nullptr;
+    }
+    return MakeIntrusive<TSecurityObject>(owner, acl, false);
+}
 
 NPersQueueCommon::ECodec KafkaBatchCodec() {
     return static_cast<NPersQueueCommon::ECodec>(static_cast<int>(Ydb::Topic::CODEC_KAFKA_BATCH) - 1);
@@ -260,11 +275,13 @@ void TKafkaProduceActor::HandleInit(TEvTxProxySchemeCache::TEvNavigateKeySetResu
             auto& topic = Topics[topicPath];
 
             topic.MeteringMode = info.PQGroupInfo->Description.GetPQTabletConfig().GetMeteringMode();
+            topic.SecurityObject = info.SecurityObject;
 
-            if (!Context->RequireAuthentication || info.SecurityObject->CheckAccess(NACLib::EAccessRights::UpdateRow, *Context->UserToken)) {
+            if (Context->HasTopicAccess(info.SecurityObject.Get(), NACLib::EAccessRights::UpdateRow)) {
                 topic.Status = OK;
-                topic.ExpirationTime = now + TOPIC_OK_EXPIRATION_INTERVAL;
+                topic.ExpirationTime = now + TopicOkExpirationInterval();
                 topic.PartitionChooser = CreatePartitionChooser(info.PQGroupInfo->Description);
+                Context->RememberTopicAclOk(topicPath);
             } else {
                 YDB_LOG_WARN("Produce actor: Unauthorized PRODUCE to topic",
                     {LogPrefix()},
@@ -298,47 +315,120 @@ void TKafkaProduceActor::HandleInit(TEvTxProxySchemeCache::TEvNavigateKeySetResu
     ProcessRequests(ctx);
 }
 
+void TKafkaProduceActor::FailPendingWritesForTopic(const TString& path, EKafkaErrors errorCode, TStringBuf errorMessage) {
+    for (auto it = Cookies.begin(); it != Cookies.end();) {
+        const ui64 cookie = it->first;
+        auto& info = it->second;
+        if (info.TopicPath != path) {
+            ++it;
+            continue;
+        }
+
+        auto& result = info.Request->Results[info.Position];
+        result.ErrorCode = errorCode;
+        result.ErrorMessage = TString{errorMessage};
+        info.Request->WaitAcceptingCookies.erase(cookie);
+        info.Request->WaitResultCookies.erase(cookie);
+        it = Cookies.erase(it);
+    }
+}
+
+void TKafkaProduceActor::InvalidateTopic(const TString& path, bool deleted, const TActorContext& ctx) {
+    const auto error = deleted
+        ? EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION
+        : EKafkaErrors::TOPIC_AUTHORIZATION_FAILED;
+    const TStringBuf errorMessage = deleted
+        ? "topic was deleted"
+        : "topic ACL changed, access denied";
+
+    // Close cookies before dropping writers. Poisoning first makes WriterDied miss the maps,
+    // leaving WaitResultCookies stuck until the 30s produce timeout (HOL).
+    FailPendingWritesForTopic(path, error, errorMessage);
+
+    if (deleted) {
+        auto it = NonTransactionalWriters.find(path);
+        if (it != NonTransactionalWriters.end()) {
+            for (auto& [_, writer] : it->second) {
+                Send(writer.ActorId, new TEvents::TEvPoison());
+            }
+            NonTransactionalWriters.erase(it);
+        }
+        for (auto twIt = TransactionalWriters.begin(); twIt != TransactionalWriters.end(); ) {
+            if (twIt->first.TopicPath == path) {
+                Send(twIt->second.ActorId, new TEvents::TEvPoison());
+                twIt = TransactionalWriters.erase(twIt);
+            } else {
+                ++twIt;
+            }
+        }
+
+        auto& topicInfo = Topics[path];
+        topicInfo.Status = NOT_FOUND;
+        topicInfo.ExpirationTime = ctx.Now() + TOPIC_NOT_FOUND_EXPIRATION_INTERVAL;
+        topicInfo.PartitionChooser.reset();
+        topicInfo.SecurityObject = nullptr;
+    } else {
+        // Keep in-flight partition writers alive so a late TEvWriteResponse/TEvDisconnected
+        // does not race with cookie completion. New produces are rejected via HasTopicAccess
+        // after the topic is re-described. Idle writers are collected by CleanWriters.
+        Topics.erase(path);
+    }
+
+    SendResults(ctx);
+    ProcessRequests(ctx);
+}
+
 void TKafkaProduceActor::Handle(TEvTxProxySchemeCache::TEvWatchNotifyDeleted::TPtr& ev, const TActorContext& ctx) {
     auto& path = ev->Get()->Path;
     YDB_LOG_INFO("Produce actor: Topic was deleted",
         {LogPrefix()},
         {"path", path});
-
-    auto it = NonTransactionalWriters.find(path);
-    if (it != NonTransactionalWriters.end()) {
-        auto itCopy = it++;
-        for(auto& [_, writer] : itCopy->second) {
-            Send(writer.ActorId, new TEvents::TEvPoison());
-        }
-        NonTransactionalWriters.erase(itCopy);
-    }
-    for (auto& [topicPartition, writer] : TransactionalWriters) {
-        if (topicPartition.TopicPath == path) {
-            Send(writer.ActorId, new TEvents::TEvPoison());
-        }
-        TransactionalWriters.erase(topicPartition);
-    }
-
-    auto& topicInfo = Topics[path];
-    topicInfo.Status = NOT_FOUND;
-    topicInfo.ExpirationTime = ctx.Now() + TOPIC_NOT_FOUND_EXPIRATION_INTERVAL;
-    topicInfo.PartitionChooser.reset();
+    InvalidateTopic(path, true, ctx);
 }
 
 void TKafkaProduceActor::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx) {
-    auto* e = ev->Get();
-    auto& path = e->Path;
-    YDB_LOG_INFO("Produce actor: Topic was updated",
-        {LogPrefix()},
-        {"path", path});
-
-    auto& topic = Topics[path];
-    if (topic.Status == UNAUTHORIZED) {
+    const auto& path = ev->Get()->Path;
+    auto it = Topics.find(path);
+    if (it == Topics.end()) {
         return;
     }
-    topic.Status = OK;
-    topic.ExpirationTime = ctx.Now() + TOPIC_OK_EXPIRATION_INTERVAL;
-    topic.PartitionChooser = CreatePartitionChooser(e->Result->GetPathDescription().GetPersQueueGroup());
+
+    // Scheme cache sends an initial WatchNotifyUpdated with the current version right after
+    // TEvWatchPathId. Do not treat a missing/empty Self as ACL deny: that poisons in-flight produces.
+    if (const auto& result = ev->Get()->Result) {
+        const auto& pathDescription = result->GetPathDescription();
+        if (pathDescription.HasPersQueueGroup()) {
+            const auto& pqGroup = pathDescription.GetPersQueueGroup();
+            it->second.PartitionChooser = CreatePartitionChooser(pqGroup);
+            it->second.MeteringMode = pqGroup.GetPQTabletConfig().GetMeteringMode();
+        }
+        if (pathDescription.HasSelf()) {
+            const auto& self = pathDescription.GetSelf();
+            if (auto securityObject = TryMakeSecurityObject(self.GetOwner(), self.GetEffectiveACL())) {
+                it->second.SecurityObject = std::move(securityObject);
+            } else if (!self.GetEffectiveACL().empty()) {
+                YDB_LOG_WARN("Produce actor: Ignoring unparseable topic ACL",
+                    {LogPrefix()},
+                    {"path", path});
+            }
+        }
+    }
+
+    if (!Context->HasTopicAccess(it->second.SecurityObject.Get(), NACLib::EAccessRights::UpdateRow)) {
+        YDB_LOG_INFO("Produce actor: Topic ACL changed, access denied",
+            {LogPrefix()},
+            {"path", path});
+        InvalidateTopic(path, false, ctx);
+        return;
+    }
+
+    it->second.Status = OK;
+    it->second.ExpirationTime = ctx.Now() + TopicOkExpirationInterval();
+    Context->RememberTopicAclOk(path);
+
+    YDB_LOG_DEBUG("Produce actor: Topic was updated",
+        {LogPrefix()},
+        {"path", path});
 }
 
 void TKafkaProduceActor::Handle(TEvKafka::TEvProduceRequest::TPtr request, const TActorContext& ctx) {
@@ -1080,8 +1170,14 @@ std::pair<TKafkaProduceActor::ETopicStatus, TActorId> TKafkaProduceActor::Partit
     }
 
     auto& topicInfo = it->second;
+    if (!Context->HasTopicAccess(topicInfo.SecurityObject.Get(), NACLib::EAccessRights::UpdateRow)) {
+        return { UNAUTHORIZED, TActorId{} };
+    }
     if (topicInfo.Status != OK) {
         return { topicInfo.Status, TActorId{} };
+    }
+    if (!topicInfo.PartitionChooser) {
+        return { NOT_FOUND, TActorId{} };
     }
 
     if (transactionalId) {

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -1170,11 +1170,13 @@ std::pair<TKafkaProduceActor::ETopicStatus, TActorId> TKafkaProduceActor::Partit
     }
 
     auto& topicInfo = it->second;
-    if (!Context->HasTopicAccess(topicInfo.SecurityObject.Get(), NACLib::EAccessRights::UpdateRow)) {
-        return { UNAUTHORIZED, TActorId{} };
-    }
+    // Status first: a missing topic has no SecurityObject, and HasTopicAccess would
+    // otherwise map that to AUTH for any SASL session (UserToken set).
     if (topicInfo.Status != OK) {
         return { topicInfo.Status, TActorId{} };
+    }
+    if (!Context->HasTopicAccess(topicInfo.SecurityObject.Get(), NACLib::EAccessRights::UpdateRow)) {
+        return { UNAUTHORIZED, TActorId{} };
     }
     if (!topicInfo.PartitionChooser) {
         return { NOT_FOUND, TActorId{} };

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
@@ -63,6 +63,8 @@ private:
 
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyDeleted::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx);
+    void FailPendingWritesForTopic(const TString& path, EKafkaErrors errorCode, TStringBuf errorMessage);
+    void InvalidateTopic(const TString& path, bool deleted, const TActorContext& ctx);
 
     // StateInit - describe topics
     void HandleInit(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx);
@@ -176,6 +178,7 @@ private:
 
         NKikimrPQ::TPQTabletConfig::EMeteringMode MeteringMode;
         std::shared_ptr<IPartitionChooser> PartitionChooser;
+        TIntrusivePtr<TSecurityObject> SecurityObject;
     };
     std::map<TString, TTopicInfo> Topics;
 

--- a/ydb/core/kafka_proxy/actors/kafka_read_session_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_actor.cpp
@@ -472,7 +472,7 @@ void TKafkaReadSessionActor::AuthAndFindBalancers(const TActorContext& ctx) {
     }
 
     ctx.Register(new NGRpcProxy::V1::TReadInitAndAuthActor(
-        ctx, ctx.SelfID, GroupId, Cookie, Session, NMsgBusProxy::CreatePersQueueMetaCacheV2Id(), MakeSchemeCacheID(), nullptr, Context->UserToken, TopicsToConverter,
+        ctx, ctx.SelfID, GroupId, Cookie, Session, NMsgBusProxy::CreatePersQueueMetaCacheV2Id(), MakeSchemeCacheID(), nullptr, Context->Token.UserToken, TopicsToConverter,
         topicHandler->GetLocalCluster(), false));
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_read_session_proxy.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_proxy.cpp
@@ -72,7 +72,7 @@ void KafkaReadSessionProxyActor::Handle(TEvKafka::TEvLeaveGroupRequest::TPtr& ev
 void KafkaReadSessionProxyActor::Handle(TEvKafka::TEvFetchRequest::TPtr& ev) {
     YDB_LOG_DEBUG("Handle TEvKafka::TEvFetchRequest",
         {LogPrefix()});
-    Register(CreateKafkaFetchActor(Context, ev->Get()->CorrelationId, ev->Get()->Request));
+    RegisterWithSameMailbox(CreateKafkaFetchActor(Context, ev->Get()->CorrelationId, ev->Get()->Request));
 }
 
 TSyncGroupResponseData::TPtr KafkaReadSessionProxyActor::CreateChangeResponse(TSyncGroupRequestData&) {

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -297,7 +297,9 @@ void TKafkaSaslAuthActor::SendResponseAndDie(EKafkaErrors errorCode, Ydb::Status
         auto evResponse = std::make_shared<TEvKafka::TEvResponse>(CorrelationId, responseToClient, errorCode);
         auto authResult = new TEvKafka::TEvAuthResult(EAuthSteps::SUCCESS, evResponse, UserToken, DatabasePath,
                                                         DatabaseId, FolderId, CloudId, ServiceAccountId, Coordinator,
-                                                        ResourcePath, IsServerless, errorMessage, ResourseDatabasePath);
+                                                        ResourcePath, IsServerless, errorMessage, ResourseDatabasePath,
+                                                        Ticket, TicketParserEntries, AuthDatabasePath,
+                                                        TStringBuilder() << Address);
         Send(Context->ConnectionId, authResult);
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/kafka_proxy/kafka_events.h>
 #include <ydb/services/persqueue_v1/actors/schema_actors.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 
 
 namespace NKafka {
@@ -22,11 +23,21 @@ void TTopicOffsetsActor::Bootstrap(const NActors::TActorContext&)
 }
 
 void TTopicOffsetsActor::StateWork(TAutoPtr<IEventHandle>& ev) {
-    switch (ev->GetTypeRewrite()) {
-        default:
-        if (!TDescribeTopicActorImpl::StateWork(ev, ActorContext())) {
-            TBase::StateWork(ev);
-        };
+    if (ev->GetTypeRewrite() == NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySetResult::EventType) {
+        auto* result = ev->Get<NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySetResult>();
+        if (result && result->Request && result->Request->ResultSet.size() == 1 &&
+            result->Request->ResultSet[0].Status == NKikimr::NSchemeCache::TSchemeCacheNavigate::EStatus::AccessDenied)
+        {
+            return RaiseError(
+                "access denied",
+                Ydb::PersQueue::ErrorCode::ACCESS_DENIED,
+                Ydb::StatusIds::UNAUTHORIZED,
+                ActorContext()
+            );
+        }
+    }
+    if (!TDescribeTopicActorImpl::StateWork(ev, ActorContext())) {
+        TBase::StateWork(ev);
     }
 }
 
@@ -36,6 +47,20 @@ void TTopicOffsetsActor::HandleCacheNavigateResponse(
     if (!TBase::HandleCacheNavigateResponseBase(ev)) {
         return;
     }
+
+    auto& item = ev->Get()->Request->ResultSet[0];
+    if (!this->GetRequest().Token.empty() && item.SecurityObject) {
+        TIntrusiveConstPtr<NACLib::TUserToken> userToken = new NACLib::TUserToken(this->GetRequest().Token);
+        if (!item.SecurityObject->CheckAccess(NACLib::EAccessRights::SelectRow, *userToken)) {
+            return RaiseError(
+                "access denied",
+                Ydb::PersQueue::ErrorCode::ACCESS_DENIED,
+                Ydb::StatusIds::UNAUTHORIZED,
+                ActorContext()
+            );
+        }
+    }
+
     std::unordered_set<ui32> partititons;
     for (ui32 i = 0; i < PQGroupInfo->Description.PartitionsSize(); i++) {
         auto part = PQGroupInfo->Description.GetPartitions(i).GetPartitionId();

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -11,6 +11,7 @@
 #include "actors/actors.h"
 #include "actors/kafka_api_versions_actor.h"
 #include "kafka_connection.h"
+#include "kafka_error_response.h"
 #include "kafka_events.h"
 
 
@@ -452,6 +453,29 @@ protected:
             Context->KafkaClient = Request->Header.ClientId.value();
         }
 
+        if (auto error = Context->TokenUnusableError()) {
+            switch (Request->Header.RequestApiKey) {
+                case API_VERSIONS:
+                case SASL_HANDSHAKE:
+                case SASL_AUTHENTICATE:
+                    break;
+                default: {
+                    auto response = BuildErrorResponse(*Request->Message, *error);
+                    if (!response) {
+                        YDB_LOG_ERROR("Unsupported message",
+                            {LogPrefix()},
+                            {"apiKey", Request->Header.RequestApiKey});
+                        PassAway();
+                        return false;
+                    }
+                    Reply(Request->Header.CorrelationId, response, *error, ctx);
+                    Request->Message.reset();
+                    Request->Buffer.reset();
+                    Request.reset();
+                    return true;
+                }
+            }
+        }
 
         if (IsTransactionalApiKey(Request->Header.RequestApiKey) && !TransactionsEnabled()) {
             YDB_LOG_ERROR("Transactional API keys are not enabled. To enable them set \"EnableKafkaTransactions\" feature flag to true in cluster configuration",

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -453,7 +453,7 @@ protected:
             Context->KafkaClient = Request->Header.ClientId.value();
         }
 
-        if (auto error = Context->TokenUnusableError()) {
+        if (auto error = Context->Token.UnusableError()) {
             switch (Request->Header.RequestApiKey) {
                 case API_VERSIONS:
                 case SASL_HANDSHAKE:
@@ -653,12 +653,12 @@ protected:
         }
 
         Context->RequireAuthentication = NKikimr::AppData()->EnforceUserTokenRequirement || NKikimr::AppData()->PQConfig.GetRequireCredentialsInNewProtocol();
-        Context->UserToken = event->UserToken;
-        Context->Ticket = event->Ticket;
-        Context->TicketParserEntries = event->TicketParserEntries;
-        Context->AuthDatabasePath = event->AuthDatabasePath;
-        Context->PeerName = event->PeerName;
-        Context->TokenCheck = ETokenCheckStatus::Ok;
+        Context->Token.UserToken = event->UserToken;
+        Context->Token.Ticket = event->Ticket;
+        Context->Token.TicketParserEntries = event->TicketParserEntries;
+        Context->Token.AuthDatabasePath = event->AuthDatabasePath;
+        Context->Token.PeerName = event->PeerName;
+        Context->Token.Status = ETokenCheckStatus::Ok;
         Context->DatabasePath = event->DatabasePath;
         Context->AuthenticationStep = authStep;
         Context->RlContext = {event->Coordinator, event->ResourcePath, event->DatabasePath, event->UserToken->GetSerializedToken()};
@@ -666,14 +666,12 @@ protected:
         Context->CloudId = event->CloudId;
         Context->FolderId = event->FolderId;
         Context->IsServerless = event->IsServerless;
-        Context->Coordinator = event->Coordinator;
-        Context->RlResourcePath = event->ResourcePath;
         Context->ResourceDatabasePath = event->ResourceDatabasePath ? NKikimr::CanonizePath(event->ResourceDatabasePath) : Context->DatabasePath;
         Context->InitialServerlessTransactionsFlagValue = NKikimr::AppData()->FeatureFlags.GetEnableKafkaServerlessTransactions();
 
         YDB_LOG_DEBUG("Authentication successful",
             {LogPrefix()},
-            {"SID", Context->UserToken->GetUserSID()});
+            {"SID", Context->Token.UserToken->GetUserSID()});
         ScheduleTokenRecheck(ctx);
         if (Context->SaslMechanism != "MTLS") {
             Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
@@ -709,7 +707,7 @@ protected:
             return;
         }
         TokenRecheckInFlight = false;
-        Context->TokenCheck = ETokenCheckStatus::Unavailable;
+        Context->Token.Status = ETokenCheckStatus::Unavailable;
         YDB_LOG_WARN("Token recheck timed out",
             {LogPrefix()},
             {"cookie", cookie});
@@ -720,10 +718,10 @@ protected:
         TokenRecheckInFlight = true;
         ++TokenRecheckCookie;
         Send(MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket({
-            .Ticket = Context->Ticket,
-            .Database = Context->AuthDatabasePath ? Context->AuthDatabasePath : Context->DatabasePath,
-            .PeerName = Context->PeerName,
-            .Entries = Context->TicketParserEntries,
+            .Ticket = Context->Token.Ticket,
+            .Database = Context->Token.AuthDatabasePath ? Context->Token.AuthDatabasePath : Context->DatabasePath,
+            .PeerName = Context->Token.PeerName,
+            .Entries = Context->Token.TicketParserEntries,
         }), 0, TokenRecheckCookie);
         ctx.Schedule(TokenRecheckRequestTimeout, new TEvKafka::TEvTokenRecheck(
             TEvKafka::TEvTokenRecheck::EKind::Timeout, TokenRecheckCookie));
@@ -731,7 +729,7 @@ protected:
 
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr ev, const TActorContext& ctx) {
         // Accept a matching cookie even after timeout cleared InFlight, so a late
-        // success can recover TokenCheck from Unavailable. Ignore cookie 0 (no recheck
+        // success can recover Token.Status from Unavailable. Ignore cookie 0 (no recheck
         // has been issued yet) and cookies from a newer in-flight request.
         if (TokenRecheckCookie == 0 || ev->Cookie != TokenRecheckCookie) {
             YDB_LOG_DEBUG("Ignoring stale token recheck result",
@@ -744,29 +742,30 @@ protected:
         auto* result = ev->Get();
         if (result->HasError()) {
             if (result->Error.Retryable) {
-                Context->TokenCheck = ETokenCheckStatus::Unavailable;
+                Context->Token.Status = ETokenCheckStatus::Unavailable;
                 YDB_LOG_WARN("Token recheck unavailable",
                     {LogPrefix()},
                     {"error", result->Error.ToString()});
             } else {
-                Context->TokenCheck = ETokenCheckStatus::Invalid;
+                Context->Token.Status = ETokenCheckStatus::Invalid;
                 YDB_LOG_ERROR("Token recheck failed",
                     {LogPrefix()},
                     {"error", result->Error.ToString()});
             }
         } else if (result->Token && !result->Token->GetSerializedToken().empty()) {
-            Context->TokenCheck = ETokenCheckStatus::Ok;
-            Context->UserToken = result->Token;
+            Context->Token.Status = ETokenCheckStatus::Ok;
+            Context->Token.UserToken = result->Token;
+            const auto& path = Context->RlContext.GetPath();
             Context->RlContext = NKikimr::NPQ::TRlContext(
-                Context->Coordinator,
-                Context->RlResourcePath,
+                path.CoordinationNode,
+                path.ResourcePath,
                 Context->DatabasePath,
                 result->Token->GetSerializedToken());
             YDB_LOG_DEBUG("Token recheck successful",
                 {LogPrefix()},
-                {"SID", Context->UserToken->GetUserSID()});
+                {"SID", Context->Token.UserToken->GetUserSID()});
         } else {
-            Context->TokenCheck = ETokenCheckStatus::Invalid;
+            Context->Token.Status = ETokenCheckStatus::Invalid;
             YDB_LOG_ERROR("Token recheck returned empty token",
                 {LogPrefix()});
         }

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -55,6 +55,7 @@ public:
     };
 
     static constexpr TDuration InactivityTimeout = TDuration::Minutes(10);
+    static constexpr TDuration TokenRecheckRequestTimeout = TDuration::Seconds(30);
     TEvPollerReady* InactivityEvent = nullptr;
 
     const TActorId ListenerActorId;
@@ -99,6 +100,8 @@ public:
     enum SslHandshakeErrors {ERROR_NONE = 0, ERROR_WANT_READ = 1, ERROR_WANT_WRITE = 2};
 
     TContext::TPtr Context;
+    bool TokenRecheckInFlight = false;
+    ui64 TokenRecheckCookie = 0;
 
     TKafkaConnection(const TActorId& listenerActorId,
                      TIntrusivePtr<TSocketDescriptor> socket,
@@ -449,6 +452,7 @@ protected:
             Context->KafkaClient = Request->Header.ClientId.value();
         }
 
+
         if (IsTransactionalApiKey(Request->Header.RequestApiKey) && !TransactionsEnabled()) {
             YDB_LOG_ERROR("Transactional API keys are not enabled. To enable them set \"EnableKafkaTransactions\" feature flag to true in cluster configuration",
                 {LogPrefix()});
@@ -626,6 +630,11 @@ protected:
 
         Context->RequireAuthentication = NKikimr::AppData()->EnforceUserTokenRequirement || NKikimr::AppData()->PQConfig.GetRequireCredentialsInNewProtocol();
         Context->UserToken = event->UserToken;
+        Context->Ticket = event->Ticket;
+        Context->TicketParserEntries = event->TicketParserEntries;
+        Context->AuthDatabasePath = event->AuthDatabasePath;
+        Context->PeerName = event->PeerName;
+        Context->TokenCheck = ETokenCheckStatus::Ok;
         Context->DatabasePath = event->DatabasePath;
         Context->AuthenticationStep = authStep;
         Context->RlContext = {event->Coordinator, event->ResourcePath, event->DatabasePath, event->UserToken->GetSerializedToken()};
@@ -633,18 +642,111 @@ protected:
         Context->CloudId = event->CloudId;
         Context->FolderId = event->FolderId;
         Context->IsServerless = event->IsServerless;
+        Context->Coordinator = event->Coordinator;
+        Context->RlResourcePath = event->ResourcePath;
         Context->ResourceDatabasePath = event->ResourceDatabasePath ? NKikimr::CanonizePath(event->ResourceDatabasePath) : Context->DatabasePath;
         Context->InitialServerlessTransactionsFlagValue = NKikimr::AppData()->FeatureFlags.GetEnableKafkaServerlessTransactions();
 
         YDB_LOG_DEBUG("Authentication successful",
             {LogPrefix()},
             {"SID", Context->UserToken->GetUserSID()});
+        ScheduleTokenRecheck(ctx);
         if (Context->SaslMechanism != "MTLS") {
             Reply(event->ClientResponse->CorrelationId, event->ClientResponse->Response, event->ClientResponse->ErrorCode, ctx);
         } else {
             MtlsAuthStage = AUTH_SUCCESSFUL;
             HandleConnected(PollerEventSaved, ctx);
         }
+    }
+
+    void ScheduleTokenRecheck(const TActorContext& ctx) {
+        if (!Context->TokenRecheckEnabled() || Context->AuthenticationStep != EAuthSteps::SUCCESS) {
+            return;
+        }
+        ctx.Schedule(Context->TokenRecheckInterval(), new TEvKafka::TEvTokenRecheck(TEvKafka::TEvTokenRecheck::EKind::Periodic));
+    }
+
+    void Handle(TEvKafka::TEvTokenRecheck::TPtr ev, const TActorContext& ctx) {
+        if (!Context->TokenRecheckEnabled() || Context->AuthenticationStep != EAuthSteps::SUCCESS) {
+            return;
+        }
+        if (ev->Get()->Kind == TEvKafka::TEvTokenRecheck::EKind::Timeout) {
+            HandleTokenRecheckTimeout(ev->Get()->Cookie, ctx);
+            return;
+        }
+        if (TokenRecheckInFlight) {
+            return;
+        }
+        StartTokenRecheck(ctx);
+    }
+
+    void HandleTokenRecheckTimeout(ui64 cookie, const TActorContext& ctx) {
+        if (!TokenRecheckInFlight || cookie != TokenRecheckCookie) {
+            return;
+        }
+        TokenRecheckInFlight = false;
+        Context->TokenCheck = ETokenCheckStatus::Unavailable;
+        YDB_LOG_WARN("Token recheck timed out",
+            {LogPrefix()},
+            {"cookie", cookie});
+        ScheduleTokenRecheck(ctx);
+    }
+
+    void StartTokenRecheck(const TActorContext& ctx) {
+        TokenRecheckInFlight = true;
+        ++TokenRecheckCookie;
+        Send(MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket({
+            .Ticket = Context->Ticket,
+            .Database = Context->AuthDatabasePath ? Context->AuthDatabasePath : Context->DatabasePath,
+            .PeerName = Context->PeerName,
+            .Entries = Context->TicketParserEntries,
+        }), 0, TokenRecheckCookie);
+        ctx.Schedule(TokenRecheckRequestTimeout, new TEvKafka::TEvTokenRecheck(
+            TEvKafka::TEvTokenRecheck::EKind::Timeout, TokenRecheckCookie));
+    }
+
+    void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr ev, const TActorContext& ctx) {
+        // Accept a matching cookie even after timeout cleared InFlight, so a late
+        // success can recover TokenCheck from Unavailable. Ignore cookie 0 (no recheck
+        // has been issued yet) and cookies from a newer in-flight request.
+        if (TokenRecheckCookie == 0 || ev->Cookie != TokenRecheckCookie) {
+            YDB_LOG_DEBUG("Ignoring stale token recheck result",
+                {LogPrefix()},
+                {"cookie", ev->Cookie},
+                {"expectedCookie", TokenRecheckCookie});
+            return;
+        }
+        TokenRecheckInFlight = false;
+        auto* result = ev->Get();
+        if (result->HasError()) {
+            if (result->Error.Retryable) {
+                Context->TokenCheck = ETokenCheckStatus::Unavailable;
+                YDB_LOG_WARN("Token recheck unavailable",
+                    {LogPrefix()},
+                    {"error", result->Error.ToString()});
+            } else {
+                Context->TokenCheck = ETokenCheckStatus::Invalid;
+                YDB_LOG_ERROR("Token recheck failed",
+                    {LogPrefix()},
+                    {"error", result->Error.ToString()});
+            }
+        } else if (result->Token && !result->Token->GetSerializedToken().empty()) {
+            Context->TokenCheck = ETokenCheckStatus::Ok;
+            Context->UserToken = result->Token;
+            Context->RlContext = NKikimr::NPQ::TRlContext(
+                Context->Coordinator,
+                Context->RlResourcePath,
+                Context->DatabasePath,
+                result->Token->GetSerializedToken());
+            YDB_LOG_DEBUG("Token recheck successful",
+                {LogPrefix()},
+                {"SID", Context->UserToken->GetUserSID()});
+        } else {
+            Context->TokenCheck = ETokenCheckStatus::Invalid;
+            YDB_LOG_ERROR("Token recheck returned empty token",
+                {LogPrefix()});
+        }
+        ScheduleTokenRecheck(ctx);
     }
 
     void Handle(TEvKafka::TEvHandshakeResult::TPtr ev, const TActorContext& ctx) {
@@ -1133,6 +1235,8 @@ protected:
             hFunc(TEvPollerRegisterResult, HandleConnected);
             HFunc(TEvKafka::TEvResponse, Handle);
             HFunc(TEvKafka::TEvAuthResult, Handle);
+            HFunc(TEvKafka::TEvTokenRecheck, Handle);
+            HFunc(TEvTicketParser::TEvAuthorizeTicketResult, Handle);
             HFunc(TEvKafka::TEvReadSessionInfo, Handle);
             HFunc(TEvKafka::TEvHandshakeResult, Handle);
             sFunc(TEvKafka::TEvKillReadSession, HandleKillReadSession);

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -132,6 +132,15 @@ TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafk
 }
 
 
+TApiMessage::TPtr SyncGroupError(EKafkaErrors error) {
+    auto response = std::make_shared<TSyncGroupResponseData>();
+    response->ErrorCode = error;
+    // Non-nullable on the wire; a default (null) value fails serialization.
+    response->Assignment = "";
+    return response;
+}
+
+
 TApiMessage::TPtr CreateTopicsError(const TCreateTopicsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TCreateTopicsResponseData>();
     for (const auto& topic : request.Topics) {
@@ -198,6 +207,14 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return OffsetCommitError(static_cast<const TOffsetCommitRequestData&>(request), error);
         case OFFSET_FETCH:
             return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
+        case JOIN_GROUP:
+            return TopLevelError<TJoinGroupResponseData>(error);
+        case HEARTBEAT:
+            return TopLevelError<THeartbeatResponseData>(error);
+        case LEAVE_GROUP:
+            return TopLevelError<TLeaveGroupResponseData>(error);
+        case SYNC_GROUP:
+            return SyncGroupError(error);
         case CREATE_TOPICS:
             return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
         case INIT_PRODUCER_ID:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -54,6 +54,17 @@ TApiMessage::TPtr ListOffsetsError(const TListOffsetsRequestData& request, EKafk
 }
 
 
+TApiMessage::TPtr MetadataError(const TMetadataRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TMetadataResponseData>();
+    response->Topics.resize(request.Topics.size());
+    for (size_t i = 0; i < request.Topics.size(); ++i) {
+        response->Topics[i].Name = request.Topics[i].Name;
+        response->Topics[i].ErrorCode = error;
+    }
+    return response;
+}
+
+
 TApiMessage::TPtr OffsetCommitError(const TOffsetCommitRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TOffsetCommitResponseData>();
     for (const auto& topic : request.Topics) {
@@ -122,6 +133,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return FetchError(static_cast<const TFetchRequestData&>(request), error);
         case LIST_OFFSETS:
             return ListOffsetsError(static_cast<const TListOffsetsRequestData&>(request), error);
+        case METADATA:
+            return MetadataError(static_cast<const TMetadataRequestData&>(request), error);
         case OFFSET_COMMIT:
             return OffsetCommitError(static_cast<const TOffsetCommitRequestData&>(request), error);
         case OFFSET_FETCH:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -135,6 +135,18 @@ TApiMessage::TPtr CreateTopicsError(const TCreateTopicsRequestData& request, EKa
     return response;
 }
 
+
+TApiMessage::TPtr CreatePartitionsError(const TCreatePartitionsRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TCreatePartitionsResponseData>();
+    for (const auto& topic : request.Topics) {
+        TCreatePartitionsResponseData::TCreatePartitionsTopicResult topicResponse;
+        topicResponse.Name = topic.Name;
+        topicResponse.ErrorCode = error;
+        response->Results.push_back(std::move(topicResponse));
+    }
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
@@ -153,6 +165,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
         case CREATE_TOPICS:
             return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
+        case CREATE_PARTITIONS:
+            return CreatePartitionsError(static_cast<const TCreatePartitionsRequestData&>(request), error);
         default:
             return nullptr;
     }

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -11,7 +11,6 @@ TApiMessage::TPtr TopLevelError(EKafkaErrors error) {
     return response;
 }
 
-
 TApiMessage::TPtr ProduceError(const TProduceRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TProduceResponseData>();
     response->Responses.resize(request.TopicData.size());
@@ -26,7 +25,6 @@ TApiMessage::TPtr ProduceError(const TProduceRequestData& request, EKafkaErrors 
     }
     return response;
 }
-
 
 TApiMessage::TPtr FetchError(const TFetchRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TFetchResponseData>();
@@ -44,7 +42,6 @@ TApiMessage::TPtr FetchError(const TFetchRequestData& request, EKafkaErrors erro
     return response;
 }
 
-
 TApiMessage::TPtr ListOffsetsError(const TListOffsetsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TListOffsetsResponseData>();
     response->Topics.resize(request.Topics.size());
@@ -61,7 +58,6 @@ TApiMessage::TPtr ListOffsetsError(const TListOffsetsRequestData& request, EKafk
     return response;
 }
 
-
 TApiMessage::TPtr MetadataError(const TMetadataRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TMetadataResponseData>();
     response->Topics.resize(request.Topics.size());
@@ -71,7 +67,6 @@ TApiMessage::TPtr MetadataError(const TMetadataRequestData& request, EKafkaError
     }
     return response;
 }
-
 
 TApiMessage::TPtr OffsetCommitError(const TOffsetCommitRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TOffsetCommitResponseData>();
@@ -88,7 +83,6 @@ TApiMessage::TPtr OffsetCommitError(const TOffsetCommitRequestData& request, EKa
     }
     return response;
 }
-
 
 TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TOffsetFetchResponseData>();
@@ -131,7 +125,6 @@ TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafk
     return response;
 }
 
-
 TApiMessage::TPtr FindCoordinatorError(const TFindCoordinatorRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TFindCoordinatorResponseData>();
     response->ErrorCode = error;
@@ -144,7 +137,6 @@ TApiMessage::TPtr FindCoordinatorError(const TFindCoordinatorRequestData& reques
     return response;
 }
 
-
 TApiMessage::TPtr SyncGroupError(EKafkaErrors error) {
     auto response = std::make_shared<TSyncGroupResponseData>();
     response->ErrorCode = error;
@@ -152,7 +144,6 @@ TApiMessage::TPtr SyncGroupError(EKafkaErrors error) {
     response->Assignment = "";
     return response;
 }
-
 
 TApiMessage::TPtr DescribeGroupsError(const TDescribeGroupsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TDescribeGroupsResponseData>();
@@ -165,7 +156,6 @@ TApiMessage::TPtr DescribeGroupsError(const TDescribeGroupsRequestData& request,
     return response;
 }
 
-
 TApiMessage::TPtr CreateTopicsError(const TCreateTopicsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TCreateTopicsResponseData>();
     for (const auto& topic : request.Topics) {
@@ -177,7 +167,6 @@ TApiMessage::TPtr CreateTopicsError(const TCreateTopicsRequestData& request, EKa
     return response;
 }
 
-
 TApiMessage::TPtr CreatePartitionsError(const TCreatePartitionsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TCreatePartitionsResponseData>();
     for (const auto& topic : request.Topics) {
@@ -188,7 +177,6 @@ TApiMessage::TPtr CreatePartitionsError(const TCreatePartitionsRequestData& requ
     }
     return response;
 }
-
 
 TApiMessage::TPtr DescribeConfigsError(const TDescribeConfigsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TDescribeConfigsResponseData>();
@@ -203,7 +191,6 @@ TApiMessage::TPtr DescribeConfigsError(const TDescribeConfigsRequestData& reques
     return response;
 }
 
-
 TApiMessage::TPtr AlterConfigsError(const TAlterConfigsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TAlterConfigsResponseData>();
     for (const auto& resource : request.Resources) {
@@ -212,6 +199,38 @@ TApiMessage::TPtr AlterConfigsError(const TAlterConfigsRequestData& request, EKa
         resourceResponse.ErrorCode = error;
         resourceResponse.ErrorMessage = "token is invalid or unavailable";
         response->Responses.push_back(std::move(resourceResponse));
+    }
+    return response;
+}
+
+TApiMessage::TPtr AddPartitionsToTxnError(const TAddPartitionsToTxnRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TAddPartitionsToTxnResponseData>();
+    for (const auto& topic : request.Topics) {
+        TAddPartitionsToTxnResponseData::TAddPartitionsToTxnTopicResult topicResponse;
+        topicResponse.Name = topic.Name;
+        for (const auto& partition : topic.Partitions) {
+            TAddPartitionsToTxnResponseData::TAddPartitionsToTxnTopicResult::TAddPartitionsToTxnPartitionResult partitionResponse;
+            partitionResponse.PartitionIndex = partition;
+            partitionResponse.ErrorCode = error;
+            topicResponse.Results.push_back(partitionResponse);
+        }
+        response->Results.push_back(std::move(topicResponse));
+    }
+    return response;
+}
+
+TApiMessage::TPtr TxnOffsetCommitError(const TTxnOffsetCommitRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TTxnOffsetCommitResponseData>();
+    for (const auto& topic : request.Topics) {
+        TTxnOffsetCommitResponseData::TTxnOffsetCommitResponseTopic topicResponse;
+        topicResponse.Name = topic.Name;
+        for (const auto& partition : topic.Partitions) {
+            TTxnOffsetCommitResponseData::TTxnOffsetCommitResponseTopic::TTxnOffsetCommitResponsePartition partitionResponse;
+            partitionResponse.PartitionIndex = partition.PartitionIndex;
+            partitionResponse.ErrorCode = error;
+            topicResponse.Partitions.push_back(partitionResponse);
+        }
+        response->Topics.push_back(std::move(topicResponse));
     }
     return response;
 }
@@ -250,6 +269,14 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
         case INIT_PRODUCER_ID:
             return TopLevelError<TInitProducerIdResponseData>(error);
+        case ADD_PARTITIONS_TO_TXN:
+            return AddPartitionsToTxnError(static_cast<const TAddPartitionsToTxnRequestData&>(request), error);
+        case ADD_OFFSETS_TO_TXN:
+            return TopLevelError<TAddOffsetsToTxnResponseData>(error);
+        case END_TXN:
+            return TopLevelError<TEndTxnResponseData>(error);
+        case TXN_OFFSET_COMMIT:
+            return TxnOffsetCommitError(static_cast<const TTxnOffsetCommitRequestData&>(request), error);
         case DESCRIBE_CONFIGS:
             return DescribeConfigsError(static_cast<const TDescribeConfigsRequestData&>(request), error);
         case ALTER_CONFIGS:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -141,6 +141,18 @@ TApiMessage::TPtr SyncGroupError(EKafkaErrors error) {
 }
 
 
+TApiMessage::TPtr DescribeGroupsError(const TDescribeGroupsRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TDescribeGroupsResponseData>();
+    for (const auto& groupId : request.Groups) {
+        TDescribeGroupsResponseData::TDescribedGroup group;
+        group.ErrorCode = error;
+        group.GroupId = groupId;
+        response->Groups.push_back(std::move(group));
+    }
+    return response;
+}
+
+
 TApiMessage::TPtr CreateTopicsError(const TCreateTopicsRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TCreateTopicsResponseData>();
     for (const auto& topic : request.Topics) {
@@ -215,6 +227,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return TopLevelError<TLeaveGroupResponseData>(error);
         case SYNC_GROUP:
             return SyncGroupError(error);
+        case DESCRIBE_GROUPS:
+            return DescribeGroupsError(static_cast<const TDescribeGroupsRequestData&>(request), error);
         case LIST_GROUPS:
             return TopLevelError<TListGroupsResponseData>(error);
         case CREATE_TOPICS:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -155,6 +155,20 @@ TApiMessage::TPtr CreatePartitionsError(const TCreatePartitionsRequestData& requ
     return response;
 }
 
+
+TApiMessage::TPtr DescribeConfigsError(const TDescribeConfigsRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TDescribeConfigsResponseData>();
+    for (const auto& resource : request.Resources) {
+        TDescribeConfigsResponseData::TDescribeConfigsResult result;
+        result.ResourceType = resource.ResourceType;
+        result.ResourceName = resource.ResourceName;
+        result.ErrorCode = error;
+        result.ErrorMessage = "token is invalid or unavailable";
+        response->Results.push_back(std::move(result));
+    }
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
@@ -175,6 +189,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
         case INIT_PRODUCER_ID:
             return TopLevelError<TInitProducerIdResponseData>(error);
+        case DESCRIBE_CONFIGS:
+            return DescribeConfigsError(static_cast<const TDescribeConfigsRequestData&>(request), error);
         case CREATE_PARTITIONS:
             return CreatePartitionsError(static_cast<const TCreatePartitionsRequestData&>(request), error);
         default:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -123,6 +123,18 @@ TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafk
     return response;
 }
 
+
+TApiMessage::TPtr CreateTopicsError(const TCreateTopicsRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TCreateTopicsResponseData>();
+    for (const auto& topic : request.Topics) {
+        TCreateTopicsResponseData::TCreatableTopicResult topicResponse;
+        topicResponse.Name = topic.Name;
+        topicResponse.ErrorCode = error;
+        response->Topics.push_back(std::move(topicResponse));
+    }
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
@@ -139,6 +151,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return OffsetCommitError(static_cast<const TOffsetCommitRequestData&>(request), error);
         case OFFSET_FETCH:
             return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
+        case CREATE_TOPICS:
+            return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
         default:
             return nullptr;
     }

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -132,6 +132,19 @@ TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafk
 }
 
 
+TApiMessage::TPtr FindCoordinatorError(const TFindCoordinatorRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TFindCoordinatorResponseData>();
+    response->ErrorCode = error;
+    for (const auto& key : request.CoordinatorKeys) {
+        TFindCoordinatorResponseData::TCoordinator coordinator;
+        coordinator.ErrorCode = error;
+        coordinator.Key = key;
+        response->Coordinators.push_back(std::move(coordinator));
+    }
+    return response;
+}
+
+
 TApiMessage::TPtr SyncGroupError(EKafkaErrors error) {
     auto response = std::make_shared<TSyncGroupResponseData>();
     response->ErrorCode = error;
@@ -219,6 +232,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return OffsetCommitError(static_cast<const TOffsetCommitRequestData&>(request), error);
         case OFFSET_FETCH:
             return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
+        case FIND_COORDINATOR:
+            return FindCoordinatorError(static_cast<const TFindCoordinatorRequestData&>(request), error);
         case JOIN_GROUP:
             return TopLevelError<TJoinGroupResponseData>(error);
         case HEARTBEAT:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -53,6 +53,48 @@ TApiMessage::TPtr ListOffsetsError(const TListOffsetsRequestData& request, EKafk
     return response;
 }
 
+
+TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TOffsetFetchResponseData>();
+    response->ErrorCode = error;
+
+    auto appendGroup = [&](const TOffsetFetchRequestData::TOffsetFetchRequestGroup& group) {
+        TOffsetFetchResponseData::TOffsetFetchResponseGroup groupResponse;
+        groupResponse.GroupId = group.GroupId;
+        groupResponse.ErrorCode = error;
+        for (const auto& topic : group.Topics) {
+            TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics topicResponse;
+            topicResponse.Name = topic.Name;
+            for (auto partitionIndex : topic.PartitionIndexes) {
+                TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics::TOffsetFetchResponsePartitions partition;
+                partition.PartitionIndex = partitionIndex;
+                partition.ErrorCode = error;
+                topicResponse.Partitions.push_back(partition);
+            }
+            groupResponse.Topics.push_back(std::move(topicResponse));
+        }
+        response->Groups.push_back(std::move(groupResponse));
+    };
+
+    if (!request.Groups.empty()) {
+        for (const auto& group : request.Groups) {
+            appendGroup(group);
+        }
+        return response;
+    }
+
+    TOffsetFetchRequestData::TOffsetFetchRequestGroup group;
+    group.GroupId = request.GroupId;
+    for (const auto& topic : request.Topics) {
+        TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics topicRequest;
+        topicRequest.Name = topic.Name;
+        topicRequest.PartitionIndexes = topic.PartitionIndexes;
+        group.Topics.push_back(std::move(topicRequest));
+    }
+    appendGroup(group);
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
@@ -63,6 +105,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return FetchError(static_cast<const TFetchRequestData&>(request), error);
         case LIST_OFFSETS:
             return ListOffsetsError(static_cast<const TListOffsetsRequestData&>(request), error);
+        case OFFSET_FETCH:
+            return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
         default:
             return nullptr;
     }

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -169,6 +169,19 @@ TApiMessage::TPtr DescribeConfigsError(const TDescribeConfigsRequestData& reques
     return response;
 }
 
+
+TApiMessage::TPtr AlterConfigsError(const TAlterConfigsRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TAlterConfigsResponseData>();
+    for (const auto& resource : request.Resources) {
+        TAlterConfigsResponseData::TAlterConfigsResourceResponse resourceResponse;
+        resourceResponse.ResourceName = resource.ResourceName;
+        resourceResponse.ErrorCode = error;
+        resourceResponse.ErrorMessage = "token is invalid or unavailable";
+        response->Responses.push_back(std::move(resourceResponse));
+    }
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
@@ -191,6 +204,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return TopLevelError<TInitProducerIdResponseData>(error);
         case DESCRIBE_CONFIGS:
             return DescribeConfigsError(static_cast<const TDescribeConfigsRequestData&>(request), error);
+        case ALTER_CONFIGS:
+            return AlterConfigsError(static_cast<const TAlterConfigsRequestData&>(request), error);
         case CREATE_PARTITIONS:
             return CreatePartitionsError(static_cast<const TCreatePartitionsRequestData&>(request), error);
         default:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -54,6 +54,23 @@ TApiMessage::TPtr ListOffsetsError(const TListOffsetsRequestData& request, EKafk
 }
 
 
+TApiMessage::TPtr OffsetCommitError(const TOffsetCommitRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TOffsetCommitResponseData>();
+    for (const auto& topic : request.Topics) {
+        TOffsetCommitResponseData::TOffsetCommitResponseTopic topicResponse;
+        topicResponse.Name = topic.Name;
+        for (const auto& partition : topic.Partitions) {
+            TOffsetCommitResponseData::TOffsetCommitResponseTopic::TOffsetCommitResponsePartition partitionResponse;
+            partitionResponse.PartitionIndex = partition.PartitionIndex;
+            partitionResponse.ErrorCode = error;
+            topicResponse.Partitions.push_back(partitionResponse);
+        }
+        response->Topics.push_back(std::move(topicResponse));
+    }
+    return response;
+}
+
+
 TApiMessage::TPtr OffsetFetchError(const TOffsetFetchRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TOffsetFetchResponseData>();
     response->ErrorCode = error;
@@ -105,6 +122,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return FetchError(static_cast<const TFetchRequestData&>(request), error);
         case LIST_OFFSETS:
             return ListOffsetsError(static_cast<const TListOffsetsRequestData&>(request), error);
+        case OFFSET_COMMIT:
+            return OffsetCommitError(static_cast<const TOffsetCommitRequestData&>(request), error);
         case OFFSET_FETCH:
             return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
         default:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -4,6 +4,14 @@
 namespace NKafka {
 namespace {
 
+template <class TResponse>
+TApiMessage::TPtr TopLevelError(EKafkaErrors error) {
+    auto response = std::make_shared<TResponse>();
+    response->ErrorCode = error;
+    return response;
+}
+
+
 TApiMessage::TPtr ProduceError(const TProduceRequestData& request, EKafkaErrors error) {
     auto response = std::make_shared<TProduceResponseData>();
     response->Responses.resize(request.TopicData.size());
@@ -165,6 +173,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return OffsetFetchError(static_cast<const TOffsetFetchRequestData&>(request), error);
         case CREATE_TOPICS:
             return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
+        case INIT_PRODUCER_ID:
+            return TopLevelError<TInitProducerIdResponseData>(error);
         case CREATE_PARTITIONS:
             return CreatePartitionsError(static_cast<const TCreatePartitionsRequestData&>(request), error);
         default:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -215,6 +215,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return TopLevelError<TLeaveGroupResponseData>(error);
         case SYNC_GROUP:
             return SyncGroupError(error);
+        case LIST_GROUPS:
+            return TopLevelError<TListGroupsResponseData>(error);
         case CREATE_TOPICS:
             return CreateTopicsError(static_cast<const TCreateTopicsRequestData&>(request), error);
         case INIT_PRODUCER_ID:

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -1,0 +1,33 @@
+#include "kafka_error_response.h"
+#include "kafka_messages.h"
+
+namespace NKafka {
+namespace {
+
+TApiMessage::TPtr ProduceError(const TProduceRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TProduceResponseData>();
+    response->Responses.resize(request.TopicData.size());
+    for (size_t i = 0; i < request.TopicData.size(); ++i) {
+        auto& topicResponse = response->Responses[i];
+        topicResponse.Name = request.TopicData[i].Name;
+        topicResponse.PartitionResponses.resize(request.TopicData[i].PartitionData.size());
+        for (size_t j = 0; j < request.TopicData[i].PartitionData.size(); ++j) {
+            topicResponse.PartitionResponses[j].Index = request.TopicData[i].PartitionData[j].Index;
+            topicResponse.PartitionResponses[j].ErrorCode = error;
+        }
+    }
+    return response;
+}
+
+} // namespace
+
+TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
+    switch (request.ApiKey()) {
+        case PRODUCE:
+            return ProduceError(static_cast<const TProduceRequestData&>(request), error);
+        default:
+            return nullptr;
+    }
+}
+
+} // namespace NKafka

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -36,6 +36,23 @@ TApiMessage::TPtr FetchError(const TFetchRequestData& request, EKafkaErrors erro
     return response;
 }
 
+
+TApiMessage::TPtr ListOffsetsError(const TListOffsetsRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TListOffsetsResponseData>();
+    response->Topics.resize(request.Topics.size());
+    for (size_t i = 0; i < request.Topics.size(); ++i) {
+        auto& topicResponse = response->Topics[i];
+        topicResponse.Name = request.Topics[i].Name;
+        for (const auto& partition : request.Topics[i].Partitions) {
+            TListOffsetsResponseData::TListOffsetsTopicResponse::TListOffsetsPartitionResponse partitionResponse;
+            partitionResponse.PartitionIndex = partition.PartitionIndex;
+            partitionResponse.ErrorCode = error;
+            topicResponse.Partitions.push_back(std::move(partitionResponse));
+        }
+    }
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
@@ -44,6 +61,8 @@ TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors er
             return ProduceError(static_cast<const TProduceRequestData&>(request), error);
         case FETCH:
             return FetchError(static_cast<const TFetchRequestData&>(request), error);
+        case LIST_OFFSETS:
+            return ListOffsetsError(static_cast<const TListOffsetsRequestData&>(request), error);
         default:
             return nullptr;
     }

--- a/ydb/core/kafka_proxy/kafka_error_response.cpp
+++ b/ydb/core/kafka_proxy/kafka_error_response.cpp
@@ -19,12 +19,31 @@ TApiMessage::TPtr ProduceError(const TProduceRequestData& request, EKafkaErrors 
     return response;
 }
 
+
+TApiMessage::TPtr FetchError(const TFetchRequestData& request, EKafkaErrors error) {
+    auto response = std::make_shared<TFetchResponseData>();
+    response->ErrorCode = error;
+    response->Responses.resize(request.Topics.size());
+    for (size_t i = 0; i < request.Topics.size(); ++i) {
+        auto& topicResponse = response->Responses[i];
+        topicResponse.Topic = request.Topics[i].Topic;
+        topicResponse.Partitions.resize(request.Topics[i].Partitions.size());
+        for (size_t j = 0; j < request.Topics[i].Partitions.size(); ++j) {
+            topicResponse.Partitions[j].PartitionIndex = request.Topics[i].Partitions[j].Partition;
+            topicResponse.Partitions[j].ErrorCode = error;
+        }
+    }
+    return response;
+}
+
 } // namespace
 
 TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error) {
     switch (request.ApiKey()) {
         case PRODUCE:
             return ProduceError(static_cast<const TProduceRequestData&>(request), error);
+        case FETCH:
+            return FetchError(static_cast<const TFetchRequestData&>(request), error);
         default:
             return nullptr;
     }

--- a/ydb/core/kafka_proxy/kafka_error_response.h
+++ b/ydb/core/kafka_proxy/kafka_error_response.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka.h>
+
+namespace NKafka {
+
+TApiMessage::TPtr BuildErrorResponse(const TApiMessage& request, EKafkaErrors error);
+
+} // namespace NKafka

--- a/ydb/core/kafka_proxy/kafka_events.h
+++ b/ydb/core/kafka_proxy/kafka_events.h
@@ -47,6 +47,7 @@ struct TEvKafka {
         EvFetchActorStateRequest,
         EvFetchActorStateResponse,
         EvMtlsAuthRequest,
+        EvTokenRecheck,
         EvResponse = EvRequest + 256,
         EvInternalEvents = EvResponse + 256,
         EvEnd
@@ -172,7 +173,9 @@ struct TEvKafka {
 
         TEvAuthResult(EAuthSteps authStep, std::shared_ptr<TEvKafka::TEvResponse> clientResponse, TIntrusiveConstPtr<NACLib::TUserToken> token, TString databasePath, TString databaseId,
                       TString folderId, TString cloudId, TString serviceAccountId, TString coordinator, TString resourcePath,
-                      bool isServerless, TString error = "", TString resourceDatabasePath = "")
+                      bool isServerless, TString error = "", TString resourceDatabasePath = "",
+                      TString ticket = {}, TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> ticketParserEntries = {},
+                      TString authDatabasePath = {}, TString peerName = {})
             : AuthStep(authStep)
             , UserToken(token)
             , DatabasePath(databasePath)
@@ -185,7 +188,11 @@ struct TEvKafka {
             , IsServerless(isServerless)
             , ResourceDatabasePath(resourceDatabasePath)
             , Error(error)
-            , ClientResponse(std::move(clientResponse)) {
+            , ClientResponse(std::move(clientResponse))
+            , Ticket(std::move(ticket))
+            , TicketParserEntries(std::move(ticketParserEntries))
+            , AuthDatabasePath(std::move(authDatabasePath))
+            , PeerName(std::move(peerName)) {
         }
 
         EAuthSteps AuthStep;
@@ -203,6 +210,26 @@ struct TEvKafka {
         TString Error;
         TString SaslMechanism;
         std::shared_ptr<TEvKafka::TEvResponse> ClientResponse;
+        TString Ticket;
+        TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> TicketParserEntries;
+        TString AuthDatabasePath;
+        TString PeerName;
+    };
+
+    struct TEvTokenRecheck : public TEventLocal<TEvTokenRecheck, EvTokenRecheck> {
+        enum class EKind {
+            Periodic,
+            Timeout,
+        };
+
+        TEvTokenRecheck() = default;
+        explicit TEvTokenRecheck(EKind kind, ui64 cookie = 0)
+            : Kind(kind)
+            , Cookie(cookie)
+        {}
+
+        EKind Kind = EKind::Periodic;
+        ui64 Cookie = 0;
     };
 
     struct TEvHandshakeResult : public TEventLocal<TEvHandshakeResult, EvHandshakeResult> {

--- a/ydb/core/kafka_proxy/ut/actors_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/actors_ut.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/kafka_proxy/actors/kafka_fetch_actor.h>
 #include <ydb/core/kafka_proxy/actors/kafka_metadata_actor.h>
 #include <ydb/core/discovery/discovery.h>
+#include <ydb/library/aclib/aclib.h>
 
 
 using namespace NKikimr;
@@ -567,5 +568,74 @@ namespace NKafka::NTests {
             UNIT_ASSERT(ev->Status == EKafkaErrors::NONE_ERROR);
             UNIT_ASSERT_VALUES_EQUAL(ev->Response.partitioning_settings().min_active_partitions(), 1);
         }
+    }
+
+    Y_UNIT_TEST_SUITE(KafkaContextAuthz) {
+        Y_UNIT_TEST(CopyCtorPreservesAuthFields) {
+            NKikimrConfig::TKafkaProxyConfig config;
+            config.SetTokenRecheckIntervalMs(500);
+            TContext original(config);
+            original.DatabasePath = "/Root";
+            original.RequireAuthentication = true;
+            original.Ticket = "ticket";
+            original.AuthDatabasePath = "/Root";
+            original.PeerName = "127.0.0.1";
+            original.TokenCheck = ETokenCheckStatus::Invalid;
+            original.UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
+            original.ReadSession.BalancingMode = EBalancingMode::Server;
+
+            TContext copy(original);
+            UNIT_ASSERT_VALUES_EQUAL(copy.DatabasePath, "/Root");
+            UNIT_ASSERT_VALUES_EQUAL(copy.RequireAuthentication, true);
+            UNIT_ASSERT_VALUES_EQUAL(copy.Ticket, "ticket");
+            UNIT_ASSERT_VALUES_EQUAL(copy.AuthDatabasePath, "/Root");
+            UNIT_ASSERT_VALUES_EQUAL(copy.PeerName, "127.0.0.1");
+            UNIT_ASSERT_EQUAL(copy.TokenCheck, ETokenCheckStatus::Invalid);
+            UNIT_ASSERT(copy.UserToken);
+            UNIT_ASSERT_VALUES_EQUAL(copy.UserToken->GetUserSID(), "user@builtin");
+            UNIT_ASSERT_EQUAL(copy.ReadSession.BalancingMode, EBalancingMode::Native);
+        }
+
+        Y_UNIT_TEST(TokenRecheckEnabledRequiresPositiveIntervalAndTicket) {
+            NKikimrConfig::TKafkaProxyConfig disabledConfig;
+            disabledConfig.SetTokenRecheckIntervalMs(0);
+            TContext disabled(disabledConfig);
+            disabled.Ticket = "ticket";
+            UNIT_ASSERT(!disabled.TokenRecheckEnabled());
+
+            NKikimrConfig::TKafkaProxyConfig enabledConfig;
+            enabledConfig.SetTokenRecheckIntervalMs(500);
+            TContext noTicket(enabledConfig);
+            UNIT_ASSERT(!noTicket.TokenRecheckEnabled());
+
+            TContext enabled(enabledConfig);
+            enabled.Ticket = "ticket";
+            UNIT_ASSERT(enabled.TokenRecheckEnabled());
+        }
+
+        Y_UNIT_TEST(TokenUnusableErrorMapsInvalidAndUnavailable) {
+            NKikimrConfig::TKafkaProxyConfig config;
+            TContext ctx(config);
+            UNIT_ASSERT(!ctx.TokenUnusableError().has_value());
+
+            ctx.TokenCheck = ETokenCheckStatus::Invalid;
+            UNIT_ASSERT_EQUAL(*ctx.TokenUnusableError(), EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+
+            ctx.TokenCheck = ETokenCheckStatus::Unavailable;
+            UNIT_ASSERT_EQUAL(*ctx.TokenUnusableError(), EKafkaErrors::BROKER_NOT_AVAILABLE);
+        }
+
+        Y_UNIT_TEST(GetUserSerializedTokenFallsBackToSerializeAsString) {
+            NKikimrConfig::TKafkaProxyConfig config;
+            auto ctx = std::make_shared<TContext>(config);
+            UNIT_ASSERT_VALUES_EQUAL(GetUserSerializedToken(ctx), "");
+
+            ctx->UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
+            UNIT_ASSERT(ctx->UserToken->GetSerializedToken().empty());
+            const TString serialized = GetUserSerializedToken(ctx);
+            UNIT_ASSERT(!serialized.empty());
+            UNIT_ASSERT_VALUES_EQUAL(serialized, ctx->UserToken->SerializeAsString());
+        }
+
     }
 }

--- a/ydb/core/kafka_proxy/ut/actors_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/actors_ut.cpp
@@ -637,5 +637,14 @@ namespace NKafka::NTests {
             UNIT_ASSERT_VALUES_EQUAL(serialized, ctx->UserToken->SerializeAsString());
         }
 
+        Y_UNIT_TEST(RememberTopicAclOkIsNotCopied) {
+            NKikimrConfig::TKafkaProxyConfig config;
+            TContext original(config);
+            original.RememberTopicAclOk("/Root/topic");
+            UNIT_ASSERT(original.HadTopicAclOk("/Root/topic"));
+
+            TContext copy(original);
+            UNIT_ASSERT(!copy.HadTopicAclOk("/Root/topic"));
+        }
     }
 }

--- a/ydb/core/kafka_proxy/ut/actors_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/actors_ut.cpp
@@ -222,7 +222,7 @@ namespace NKafka::NTests {
             context->ConnectionId = edge;
             context->DatabasePath = "/Root";
             context->ResourceDatabasePath = "/Root";
-            context->UserToken = new NACLib::TUserToken("root@builtin", {});
+            context->Token.UserToken = new NACLib::TUserToken("root@builtin", {});
 
             TActorId actorId;
             if (fakeCacheId) {
@@ -494,7 +494,7 @@ namespace NKafka::NTests {
             context->ConnectionId = edge;
             context->DatabasePath = "/Root";
             context->ResourceDatabasePath = "/Root";
-            context->UserToken = new NACLib::TUserToken("root@builtin", {});
+            context->Token.UserToken = new NACLib::TUserToken("root@builtin", {});
 
             auto* actor = new NKafka::TKafkaFetchActor(context, 1, TMessagePtr<TFetchRequestData>(std::make_shared<TBuffer>(), request));
             TActorId actorId = runtime->Register(actor);
@@ -577,22 +577,22 @@ namespace NKafka::NTests {
             TContext original(config);
             original.DatabasePath = "/Root";
             original.RequireAuthentication = true;
-            original.Ticket = "ticket";
-            original.AuthDatabasePath = "/Root";
-            original.PeerName = "127.0.0.1";
-            original.TokenCheck = ETokenCheckStatus::Invalid;
-            original.UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
+            original.Token.Ticket = "ticket";
+            original.Token.AuthDatabasePath = "/Root";
+            original.Token.PeerName = "127.0.0.1";
+            original.Token.Status = ETokenCheckStatus::Invalid;
+            original.Token.UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
             original.ReadSession.BalancingMode = EBalancingMode::Server;
 
             TContext copy(original);
             UNIT_ASSERT_VALUES_EQUAL(copy.DatabasePath, "/Root");
             UNIT_ASSERT_VALUES_EQUAL(copy.RequireAuthentication, true);
-            UNIT_ASSERT_VALUES_EQUAL(copy.Ticket, "ticket");
-            UNIT_ASSERT_VALUES_EQUAL(copy.AuthDatabasePath, "/Root");
-            UNIT_ASSERT_VALUES_EQUAL(copy.PeerName, "127.0.0.1");
-            UNIT_ASSERT_EQUAL(copy.TokenCheck, ETokenCheckStatus::Invalid);
-            UNIT_ASSERT(copy.UserToken);
-            UNIT_ASSERT_VALUES_EQUAL(copy.UserToken->GetUserSID(), "user@builtin");
+            UNIT_ASSERT_VALUES_EQUAL(copy.Token.Ticket, "ticket");
+            UNIT_ASSERT_VALUES_EQUAL(copy.Token.AuthDatabasePath, "/Root");
+            UNIT_ASSERT_VALUES_EQUAL(copy.Token.PeerName, "127.0.0.1");
+            UNIT_ASSERT_EQUAL(copy.Token.Status, ETokenCheckStatus::Invalid);
+            UNIT_ASSERT(copy.Token.UserToken);
+            UNIT_ASSERT_VALUES_EQUAL(copy.Token.UserToken->GetUserSID(), "user@builtin");
             UNIT_ASSERT_EQUAL(copy.ReadSession.BalancingMode, EBalancingMode::Native);
         }
 
@@ -600,7 +600,7 @@ namespace NKafka::NTests {
             NKikimrConfig::TKafkaProxyConfig disabledConfig;
             disabledConfig.SetTokenRecheckIntervalMs(0);
             TContext disabled(disabledConfig);
-            disabled.Ticket = "ticket";
+            disabled.Token.Ticket = "ticket";
             UNIT_ASSERT(!disabled.TokenRecheckEnabled());
 
             NKikimrConfig::TKafkaProxyConfig enabledConfig;
@@ -609,20 +609,20 @@ namespace NKafka::NTests {
             UNIT_ASSERT(!noTicket.TokenRecheckEnabled());
 
             TContext enabled(enabledConfig);
-            enabled.Ticket = "ticket";
+            enabled.Token.Ticket = "ticket";
             UNIT_ASSERT(enabled.TokenRecheckEnabled());
         }
 
         Y_UNIT_TEST(TokenUnusableErrorMapsInvalidAndUnavailable) {
             NKikimrConfig::TKafkaProxyConfig config;
             TContext ctx(config);
-            UNIT_ASSERT(!ctx.TokenUnusableError().has_value());
+            UNIT_ASSERT(!ctx.Token.UnusableError().has_value());
 
-            ctx.TokenCheck = ETokenCheckStatus::Invalid;
-            UNIT_ASSERT_EQUAL(*ctx.TokenUnusableError(), EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+            ctx.Token.Status = ETokenCheckStatus::Invalid;
+            UNIT_ASSERT_EQUAL(*ctx.Token.UnusableError(), EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
 
-            ctx.TokenCheck = ETokenCheckStatus::Unavailable;
-            UNIT_ASSERT_EQUAL(*ctx.TokenUnusableError(), EKafkaErrors::BROKER_NOT_AVAILABLE);
+            ctx.Token.Status = ETokenCheckStatus::Unavailable;
+            UNIT_ASSERT_EQUAL(*ctx.Token.UnusableError(), EKafkaErrors::BROKER_NOT_AVAILABLE);
         }
 
         Y_UNIT_TEST(GetUserSerializedTokenFallsBackToSerializeAsString) {
@@ -630,11 +630,11 @@ namespace NKafka::NTests {
             auto ctx = std::make_shared<TContext>(config);
             UNIT_ASSERT_VALUES_EQUAL(GetUserSerializedToken(ctx), "");
 
-            ctx->UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
-            UNIT_ASSERT(ctx->UserToken->GetSerializedToken().empty());
+            ctx->Token.UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
+            UNIT_ASSERT(ctx->Token.UserToken->GetSerializedToken().empty());
             const TString serialized = GetUserSerializedToken(ctx);
             UNIT_ASSERT(!serialized.empty());
-            UNIT_ASSERT_VALUES_EQUAL(serialized, ctx->UserToken->SerializeAsString());
+            UNIT_ASSERT_VALUES_EQUAL(serialized, ctx->Token.UserToken->SerializeAsString());
         }
 
         Y_UNIT_TEST(RememberTopicAclOkIsNotCopied) {

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
@@ -579,6 +579,15 @@ TMessagePtr<TDescribeGroupsResponseData> TKafkaTestClient::DescribeGroups(const 
     return WriteAndRead<TDescribeGroupsResponseData>(header, request);
 }
 
+TMessagePtr<TFindCoordinatorResponseData> TKafkaTestClient::FindCoordinator(const TString& key, i8 keyType) {
+    Cerr << ">>>>> TFindCoordinatorRequestData\n";
+    TRequestHeaderData header = Header(NKafka::EApiKey::FIND_COORDINATOR, 3);
+    TFindCoordinatorRequestData request;
+    request.Key = key;
+    request.KeyType = keyType;
+    return WriteAndRead<TFindCoordinatorResponseData>(header, request);
+}
+
 TMessagePtr<TFetchResponseData> TKafkaTestClient::Fetch(const std::vector<std::pair<TString, std::vector<i32>>>& topics, i64 offset) {
     Cerr << ">>>>> TFetchRequestData\n";
 

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.h
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.h
@@ -133,6 +133,8 @@ class TKafkaTestClient {
 
         TMessagePtr<TDescribeGroupsResponseData> DescribeGroups(const std::vector<std::optional<TString>>& groups);
 
+        TMessagePtr<TFindCoordinatorResponseData> FindCoordinator(const TString& key, i8 keyType = 0);
+
         TMessagePtr<TFetchResponseData> Fetch(const std::vector<std::pair<TKafkaUuid, std::vector<i32>>>& topics, i64 offset = 0);
         TMessagePtr<TFetchResponseData> Fetch(const std::vector<std::pair<TString, std::vector<i32>>>& topics, i64 offset = 0);
         void ValidateNoDataInTopics(const std::vector<std::pair<TString, std::vector<i32>>>& topics, i64 offset = 0);

--- a/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
@@ -33,7 +33,7 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
         context->ConnectionId = edgeActor;
         context->DatabasePath = "/Root";
         context->ResourceDatabasePath = "/Root";
-        context->UserToken = new NACLib::TUserToken("root@builtin", {});
+        context->Token.UserToken = new NACLib::TUserToken("root@builtin", {});
 
         auto actorId = runtime->Register(new TKafkaMetadataActor(context, 1, TMessagePtr<TMetadataRequestData>(std::make_shared<TBuffer>(), request),
                                                                  NKafka::MakeKafkaDiscoveryCacheID()));

--- a/ydb/core/kafka_proxy/ut/test_server.cpp
+++ b/ydb/core/kafka_proxy/ut/test_server.cpp
@@ -23,6 +23,18 @@ TTestServer<TKikimr, secure>::TTestServer(const TTestServerSettings& settings) {
     if (!settings.CheckACL) {
         appConfig.MutablePQConfig()->SetCheckACL(false);
     }
+    if (settings.ACLRetryTimeoutSec) {
+        appConfig.MutablePQConfig()->SetACLRetryTimeoutSec(settings.ACLRetryTimeoutSec);
+    }
+    if (settings.TokenRecheckIntervalMs.has_value()) {
+        appConfig.MutableKafkaProxyConfig()->SetTokenRecheckIntervalMs(*settings.TokenRecheckIntervalMs);
+    }
+    if (settings.LoginTokenExpireTime) {
+        appConfig.MutableAuthConfig()->SetLoginTokenExpireTime(settings.LoginTokenExpireTime);
+    }
+    if (settings.AuthRefreshTime) {
+        appConfig.MutableAuthConfig()->SetRefreshTime(settings.AuthRefreshTime);
+    }
     appConfig.MutablePQConfig()->SetRequireCredentialsInNewProtocol(false);
 
     auto cst = appConfig.MutablePQConfig()->AddClientServiceType();
@@ -214,7 +226,8 @@ TTestServer<TKikimr, secure>::TTestServer(const TString& kafkaApiMode, bool serv
             bool enableAutoTopicCreation, bool enableAutoConsumerCreation, bool enableQuoting, bool checkACL, bool EnableKafkaServerlessTransactions)
     : TTestServer(TTestServerSettings{kafkaApiMode, serverless, enableNativeKafkaBalancing,
                 enableAutoTopicCreation, enableAutoConsumerCreation,
-                    enableQuoting, checkACL, false, EnableKafkaServerlessTransactions})
+                    enableQuoting, checkACL, false, EnableKafkaServerlessTransactions,
+                    std::nullopt, {}, {}, 0})
 {}
 
 // Explicit template instantiations

--- a/ydb/core/kafka_proxy/ut/test_server.h
+++ b/ydb/core/kafka_proxy/ut/test_server.h
@@ -19,6 +19,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
 
 #include <util/system/tempfile.h>
+#include <optional>
 
 using namespace NYdb;
 
@@ -44,6 +45,10 @@ struct TTestServerSettings {
     bool CheckACL = false;
     bool HideAuthenticationFailureReasons = false;
     bool EnableKafkaServerlessTransactions = false;
+    std::optional<ui32> TokenRecheckIntervalMs;
+    TString LoginTokenExpireTime;
+    TString AuthRefreshTime;
+    ui32 ACLRetryTimeoutSec = 0;
 };
 
 template <class TKikimr, bool secure>

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -79,6 +79,16 @@ TKafkaInt16 ListOffsetsPartitionError(TKafkaTestClient& client, const TString& t
     return msg->Topics[0].Partitions[0].ErrorCode;
 }
 
+TKafkaInt16 OffsetFetchPartitionError(TKafkaTestClient& client, const TString& topicName, const TString& groupId) {
+    std::map<TString, std::vector<i32>> topicsToPartitions;
+    topicsToPartitions[topicName] = {0};
+    auto msg = client.OffsetFetch(groupId, topicsToPartitions);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
+    return msg->Groups[0].Topics[0].Partitions[0].ErrorCode;
+}
+
 void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}
 
 void AlterTopicPartitions(NTopic::TTopicClient& pqClient, const TString& topicName, ui64 minActivePartitions) {
@@ -134,6 +144,7 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
         }, TDuration::Seconds(20));
         UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(ListOffsetsPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        UNIT_ASSERT_VALUES_EQUAL(OffsetFetchPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
@@ -151,6 +162,28 @@ Y_UNIT_TEST(ListOffsetsUnknownTopicStaysUnknownAfterSasl) {
         UNIT_ASSERT_VALUES_EQUAL(
             ListOffsetsPartitionError(client, "/Root/topic-does-not-exist"),
             static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION));
+    }
+
+
+Y_UNIT_TEST(OffsetFetchUnknownTopicIsNoneMinusOneAfterSasl) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+        });
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+
+        std::map<TString, std::vector<i32>> topicsToPartitions;
+        topicsToPartitions["/Root/topic-does-not-exist"] = {0};
+        auto msg = client.OffsetFetch("unknown-group", topicsToPartitions);
+        UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            msg->Groups[0].Topics[0].Partitions[0].ErrorCode,
+            static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].CommittedOffset, -1);
     }
 
 

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -89,6 +89,15 @@ TKafkaInt16 OffsetFetchPartitionError(TKafkaTestClient& client, const TString& t
     return msg->Groups[0].Topics[0].Partitions[0].ErrorCode;
 }
 
+TKafkaInt16 OffsetCommitPartitionError(TKafkaTestClient& client, const TString& topicName, const TString& groupId) {
+    std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
+    offsets[topicName] = {NKafka::TEvKafka::PartitionConsumerOffset(0, 0)};
+    auto msg = client.OffsetCommit(groupId, offsets);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Topics[0].Partitions.size(), 1);
+    return msg->Topics[0].Partitions[0].ErrorCode;
+}
+
 void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}
 
 void AlterTopicPartitions(NTopic::TTopicClient& pqClient, const TString& topicName, ui64 minActivePartitions) {
@@ -145,6 +154,7 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
         UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(ListOffsetsPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(OffsetFetchPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        UNIT_ASSERT_VALUES_EQUAL(OffsetCommitPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -34,6 +34,13 @@ TKafkaInt16 ProduceError(TKafkaTestClient& client, const TString& topicName, TSt
     return msg->Responses[0].PartitionResponses[0].ErrorCode;
 }
 
+TKafkaInt16 FetchPartitionError(TKafkaTestClient& client, const TString& topicName) {
+    auto msg = client.Fetch({{topicName, {0}}});
+    UNIT_ASSERT_VALUES_EQUAL(msg->Responses.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions.size(), 1);
+    return msg->Responses[0].Partitions[0].ErrorCode;
+}
+
 std::vector<TString> FetchRecordValues(TKafkaTestClient& client, const TString& topicName) {
     auto msg = client.Fetch({{topicName, {0}}});
     UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
@@ -112,13 +119,40 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
         client.PlainAuthenticateToKafka();
 
         UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "before-expire"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
         WaitUntil([&] {
             return ProduceError(client, topicName, "after-expire") == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
         }, TDuration::Seconds(20));
+        UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
+
+Y_UNIT_TEST(ReadOnlyUserCanFetchButNotProduce) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+        });
+
+        TString topicName = "/Root/topic-read-only";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName);
+
+        {
+            TKafkaTestClient writer(testServer.Port);
+            writer.PlainAuthenticateToKafka();
+            UNIT_ASSERT_VALUES_EQUAL(ProduceError(writer, topicName, "readable"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        }
+
+        TKafkaTestClient reader(testServer.Port);
+        reader.PlainAuthenticateToKafka("useronlyreadrights@/Root", "AbAcAbA");
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(reader, topicName, "forbidden"), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(reader, topicName), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(FetchRecordValues(reader, topicName), std::vector<TString>{"readable"});
+    }
+
 
 Y_UNIT_TEST(DroppedTopicFailsProduceWithoutDroppingConnection) {
         TInsecureTestServer testServer(TTestServerSettings{

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -180,6 +180,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             UNIT_ASSERT_VALUES_EQUAL(describe->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(describe->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
+        {
+            auto alter = client.AlterConfigs({TTopicConfig(topicName, 1)});
+            UNIT_ASSERT_VALUES_EQUAL(alter->Responses.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(alter->Responses[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -176,6 +176,26 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
         {
+            TString joinGroupId = groupId;
+            std::vector<TString> topics{topicName};
+            auto join = client.JoinGroup(topics, joinGroupId, "roundrobin");
+            UNIT_ASSERT_VALUES_EQUAL(join->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
+            TString memberId = "expired-member";
+            TString protocolName = "roundrobin";
+            std::vector<NKafka::TSyncGroupRequestData::TSyncGroupRequestAssignment> assignments;
+            auto sync = client.SyncGroup(memberId, 0, groupId, assignments, protocolName);
+            UNIT_ASSERT_VALUES_EQUAL(sync->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+            UNIT_ASSERT(sync->Assignment);
+            UNIT_ASSERT_VALUES_EQUAL(
+                client.Heartbeat(memberId, 0, groupId)->ErrorCode,
+                static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+            UNIT_ASSERT_VALUES_EQUAL(
+                client.LeaveGroup(memberId, groupId)->ErrorCode,
+                static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
             auto describe = client.DescribeConfigs({topicName});
             UNIT_ASSERT_VALUES_EQUAL(describe->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(describe->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -66,9 +66,90 @@ std::vector<TString> FetchRecordValues(TKafkaTestClient& client, const TString& 
 
 void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}
 
+void AlterTopicPartitions(NTopic::TTopicClient& pqClient, const TString& topicName, ui64 minActivePartitions) {
+    auto result = pqClient
+        .AlterTopic(topicName, NTopic::TAlterTopicSettings().AlterPartitioningSettings(minActivePartitions, 100))
+        .ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+}
+
+void DropTopic(NTopic::TTopicClient& pqClient, const TString& topicName) {
+    auto result = pqClient.DropTopic(topicName).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+}
+
+template <typename TFn>
+void WaitUntil(TFn&& fn, TDuration timeout = TDuration::Seconds(20)) {
+    const auto deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        if (fn()) {
+            return;
+        }
+        Sleep(TDuration::MilliSeconds(200));
+    }
+    UNIT_ASSERT_C(false, "timed out waiting for authorization error");
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
+    Y_UNIT_TEST(ProduceAndFetchFailAfterTokenExpires) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .TokenRecheckIntervalMs = 500,
+            .LoginTokenExpireTime = "2s",
+            .AuthRefreshTime = "1s",
+            .ACLRetryTimeoutSec = 1,
+        });
+
+        TString topicName = "/Root/topic-token-expire";
+        TString groupId = "authz-expire-group";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName, groupId);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "before-expire"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        WaitUntil([&] {
+            return ProduceError(client, topicName, "after-expire") == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        }, TDuration::Seconds(20));
+
+        auto apiVersions = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+Y_UNIT_TEST(DroppedTopicFailsProduceWithoutDroppingConnection) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .ACLRetryTimeoutSec = 300,
+        });
+
+        TString topicName = "/Root/topic-dropped";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "before-drop"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        DropTopic(pqClient, topicName);
+
+        WaitUntil([&] {
+            auto error = ProduceError(client, topicName, "after-drop");
+            UNIT_ASSERT_VALUES_UNEQUAL(error, static_cast<TKafkaInt16>(EKafkaErrors::REQUEST_TIMED_OUT));
+            UNIT_ASSERT_VALUES_UNEQUAL(error, static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_SERVER_ERROR));
+            return error == static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION)
+                || error == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+
+        auto apiVersions = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+
 Y_UNIT_TEST(LongSessionWithValidTokenKeepsProduceAndFetchWorking) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
@@ -128,5 +209,29 @@ Y_UNIT_TEST(TokenRecheckDisabledDoesNotDropConnection) {
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
 
+
+Y_UNIT_TEST(ProduceToNewPartitionAfterAlterTopic) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .ACLRetryTimeoutSec = 300,
+        });
+
+        TString topicName = "/Root/topic-alter-partitions";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "p0", 0), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "p1-before-alter", 1), static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION));
+
+        AlterTopicPartitions(pqClient, topicName, 2);
+
+        WaitUntil([&] {
+            return ProduceError(client, topicName, "p1-after-alter", 1) == static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR);
+        }, TDuration::Seconds(20));
+    }
 
 }

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -160,6 +160,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             UNIT_ASSERT_VALUES_EQUAL(metadata->Topics.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(metadata->Topics[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
+        {
+            auto createTopics = client.CreateTopics({TTopicConfig("/Root/topic-after-expire", 1)});
+            UNIT_ASSERT_VALUES_EQUAL(createTopics->Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(createTopics->Topics[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -175,6 +175,29 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
+
+        const TProducerInstanceId producerInstanceId{1, 0};
+        {
+            auto addPartitions = client.AddPartitionsToTxn("txn-after-expire", producerInstanceId, {{topicName, {0}}});
+            UNIT_ASSERT_VALUES_EQUAL(addPartitions->Results.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(addPartitions->Results[0].Results.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(addPartitions->Results[0].Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
+            auto addOffsets = client.AddOffsetsToTxn("txn-after-expire", producerInstanceId, groupId);
+            UNIT_ASSERT_VALUES_EQUAL(addOffsets->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
+            auto txnOffsetCommit = client.TxnOffsetCommit(
+                "txn-after-expire", producerInstanceId, groupId, 0, {{topicName, {{0, 0}}}});
+            UNIT_ASSERT_VALUES_EQUAL(txnOffsetCommit->Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(txnOffsetCommit->Topics[0].Partitions.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(txnOffsetCommit->Topics[0].Partitions[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
+            auto endTxn = client.EndTxn("txn-after-expire", producerInstanceId, true);
+            UNIT_ASSERT_VALUES_EQUAL(endTxn->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
         {
             TString joinGroupId = groupId;
             std::vector<TString> topics{topicName};

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -155,6 +155,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
         UNIT_ASSERT_VALUES_EQUAL(ListOffsetsPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(OffsetFetchPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(OffsetCommitPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        {
+            auto metadata = client.Metadata({topicName}, false);
+            UNIT_ASSERT_VALUES_EQUAL(metadata->Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(metadata->Topics[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -208,6 +208,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
                 static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
         {
+            UNIT_ASSERT_VALUES_EQUAL(
+                client.FindCoordinator(groupId)->ErrorCode,
+                static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
             auto describe = client.DescribeConfigs({topicName});
             UNIT_ASSERT_VALUES_EQUAL(describe->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(describe->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -196,6 +196,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
                 static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
         {
+            UNIT_ASSERT_VALUES_EQUAL(
+                client.ListGroups()->ErrorCode,
+                static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
             auto describe = client.DescribeConfigs({topicName});
             UNIT_ASSERT_VALUES_EQUAL(describe->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(describe->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -175,6 +175,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
+        {
+            auto describe = client.DescribeConfigs({topicName});
+            UNIT_ASSERT_VALUES_EQUAL(describe->Results.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(describe->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -98,7 +98,14 @@ TKafkaInt16 OffsetCommitPartitionError(TKafkaTestClient& client, const TString& 
     return msg->Topics[0].Partitions[0].ErrorCode;
 }
 
-void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}
+void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}, ui32 partitions = 1) {
+    auto settings = NTopic::TCreateTopicSettings().PartitioningSettings(partitions, 100);
+    if (consumer) {
+        settings.BeginAddConsumer(consumer).EndAddConsumer();
+    }
+    auto result = pqClient.CreateTopic(topicName, settings).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+}
 
 void AlterTopicPartitions(NTopic::TTopicClient& pqClient, const TString& topicName, ui64 minActivePartitions) {
     auto result = pqClient
@@ -109,6 +116,22 @@ void AlterTopicPartitions(NTopic::TTopicClient& pqClient, const TString& topicNa
 
 void DropTopic(NTopic::TTopicClient& pqClient, const TString& topicName) {
     auto result = pqClient.DropTopic(topicName).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+}
+
+void ModifyTopicPermissions(
+    TDriver& driver,
+    const TString& path,
+    const TString& user,
+    const std::vector<std::string>& names,
+    bool grant)
+{
+    NYdb::NScheme::TSchemeClient schemeClient(driver);
+    NYdb::NScheme::TPermissions permissions(user, names);
+    auto settings = grant
+        ? NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions)
+        : NYdb::NScheme::TModifyPermissionsSettings().AddRevokePermissions(permissions);
+    auto result = schemeClient.ModifyPermissions(path, settings).ExtractValueSync();
     UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
 }
 
@@ -127,6 +150,69 @@ void WaitUntil(TFn&& fn, TDuration timeout = TDuration::Seconds(20)) {
 } // namespace
 
 Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
+    Y_UNIT_TEST(ProduceAndFetchFailAfterTopicAclRevoke) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .ACLRetryTimeoutSec = 300,
+        });
+
+        TString topicName = "/Root/topic-acl-revoke";
+        TString groupId = "authz-group";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName, groupId);
+        ModifyTopicPermissions(
+            *testServer.Driver,
+            topicName,
+            "usernorights",
+            {"ydb.generic.read", "ydb.generic.write"},
+            true);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka("usernorights@/Root", "dummyPass");
+
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "before-revoke"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(ListOffsetsPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(OffsetFetchPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(OffsetCommitPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        ModifyTopicPermissions(
+            *testServer.Driver,
+            topicName,
+            "usernorights",
+            {"ydb.generic.read", "ydb.generic.write"},
+            false);
+
+        const auto revokeWaitStart = TInstant::Now();
+        WaitUntil([&] {
+            auto error = ProduceError(client, topicName, "after-revoke");
+            UNIT_ASSERT_VALUES_UNEQUAL(error, static_cast<TKafkaInt16>(EKafkaErrors::REQUEST_TIMED_OUT));
+            UNIT_ASSERT_VALUES_UNEQUAL(error, static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_SERVER_ERROR));
+            return error == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+        UNIT_ASSERT_C(
+            TInstant::Now() - revokeWaitStart < TDuration::Seconds(10),
+            "produce after ACL revoke must fail immediately, not after the 30s cookie timeout");
+        WaitUntil([&] {
+            return FetchPartitionError(client, topicName) == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+        // Scheme cache hides topics without DescribeSchema as PathErrorUnknown.
+        // ListOffsets must keep UNKNOWN_TOPIC_OR_PARTITION for missing topics (mixed-version / auto-create).
+        WaitUntil([&] {
+            return ListOffsetsPartitionError(client, topicName) == static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+        });
+        WaitUntil([&] {
+            return OffsetFetchPartitionError(client, topicName, groupId) == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+        WaitUntil([&] {
+            return OffsetCommitPartitionError(client, topicName, groupId) == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+
+        auto apiVersions = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
     Y_UNIT_TEST(ProduceAndFetchFailAfterTokenExpires) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
@@ -250,7 +336,7 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
 
-Y_UNIT_TEST(ListOffsetsUnknownTopicStaysUnknownAfterSasl) {
+    Y_UNIT_TEST(ListOffsetsUnknownTopicStaysUnknownAfterSasl) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -264,8 +350,9 @@ Y_UNIT_TEST(ListOffsetsUnknownTopicStaysUnknownAfterSasl) {
             static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION));
     }
 
-
-Y_UNIT_TEST(OffsetFetchUnknownTopicIsNoneMinusOneAfterSasl) {
+    // Matches Apache Kafka OffsetFetch v1+: missing topic → NONE + committedOffset -1,
+    // no auto-create. See https://issues.apache.org/jira/browse/KAFKA-20165
+    Y_UNIT_TEST(OffsetFetchUnknownTopicIsNoneMinusOneAfterSasl) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -286,8 +373,93 @@ Y_UNIT_TEST(OffsetFetchUnknownTopicIsNoneMinusOneAfterSasl) {
         UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].CommittedOffset, -1);
     }
 
+    Y_UNIT_TEST(AclRevokeThenGrantRestoresProduceAndFetch) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .ACLRetryTimeoutSec = 300,
+        });
 
-Y_UNIT_TEST(ReadOnlyUserCanFetchButNotProduce) {
+        TString topicName = "/Root/topic-acl-regrant";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName);
+        ModifyTopicPermissions(
+            *testServer.Driver,
+            topicName,
+            "usernorights",
+            {"ydb.generic.read", "ydb.generic.write"},
+            true);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka("usernorights@/Root", "dummyPass");
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "before-revoke"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        ModifyTopicPermissions(
+            *testServer.Driver,
+            topicName,
+            "usernorights",
+            {"ydb.generic.read", "ydb.generic.write"},
+            false);
+        WaitUntil([&] {
+            return ProduceError(client, topicName, "revoked") == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+
+        ModifyTopicPermissions(
+            *testServer.Driver,
+            topicName,
+            "usernorights",
+            {"ydb.generic.read", "ydb.generic.write"},
+            true);
+        WaitUntil([&] {
+            return ProduceError(client, topicName, "after-grant") == static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        auto apiVersions = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+    Y_UNIT_TEST(AclRevokeOnOneTopicDoesNotAffectAnother) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .ACLRetryTimeoutSec = 300,
+        });
+
+        TString revokedTopic = "/Root/topic-acl-revoked";
+        TString keptTopic = "/Root/topic-acl-kept";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, revokedTopic);
+        CreateTopic(pqClient, keptTopic);
+        for (const auto& topicName : {revokedTopic, keptTopic}) {
+            ModifyTopicPermissions(
+                *testServer.Driver,
+                topicName,
+                "usernorights",
+                {"ydb.generic.read", "ydb.generic.write"},
+                true);
+        }
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka("usernorights@/Root", "dummyPass");
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, revokedTopic, "revoked-before"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, keptTopic, "kept-before"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        ModifyTopicPermissions(
+            *testServer.Driver,
+            revokedTopic,
+            "usernorights",
+            {"ydb.generic.read", "ydb.generic.write"},
+            false);
+
+        WaitUntil([&] {
+            return ProduceError(client, revokedTopic, "revoked-after") == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        });
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, keptTopic, "kept-after"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, keptTopic), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+    Y_UNIT_TEST(ReadOnlyUserCanFetchButNotProduce) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -310,8 +482,7 @@ Y_UNIT_TEST(ReadOnlyUserCanFetchButNotProduce) {
         UNIT_ASSERT_VALUES_EQUAL(FetchRecordValues(reader, topicName), std::vector<TString>{"readable"});
     }
 
-
-Y_UNIT_TEST(DroppedTopicFailsProduceWithoutDroppingConnection) {
+    Y_UNIT_TEST(DroppedTopicFailsProduceWithoutDroppingConnection) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -340,8 +511,7 @@ Y_UNIT_TEST(DroppedTopicFailsProduceWithoutDroppingConnection) {
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
 
-
-Y_UNIT_TEST(LongSessionWithValidTokenKeepsProduceAndFetchWorking) {
+    Y_UNIT_TEST(LongSessionWithValidTokenKeepsProduceAndFetchWorking) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -375,8 +545,7 @@ Y_UNIT_TEST(LongSessionWithValidTokenKeepsProduceAndFetchWorking) {
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
 
-
-Y_UNIT_TEST(TokenRecheckDisabledDoesNotDropConnection) {
+    Y_UNIT_TEST(TokenRecheckDisabledDoesNotDropConnection) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -400,8 +569,7 @@ Y_UNIT_TEST(TokenRecheckDisabledDoesNotDropConnection) {
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
 
-
-Y_UNIT_TEST(ProduceToNewPartitionAfterAlterTopic) {
+    Y_UNIT_TEST(ProduceToNewPartitionAfterAlterTopic) {
         TInsecureTestServer testServer(TTestServerSettings{
             .KafkaApiMode = "2",
             .CheckACL = true,
@@ -424,5 +592,4 @@ Y_UNIT_TEST(ProduceToNewPartitionAfterAlterTopic) {
             return ProduceError(client, topicName, "p1-after-alter", 1) == static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR);
         }, TDuration::Seconds(20));
     }
-
 }

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -155,6 +155,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
         UNIT_ASSERT_VALUES_EQUAL(ListOffsetsPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(OffsetFetchPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         UNIT_ASSERT_VALUES_EQUAL(OffsetCommitPartitionError(client, topicName, groupId), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+
+        {
+            auto init = client.InitProducerId();
+            UNIT_ASSERT_VALUES_EQUAL(init->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
         {
             auto metadata = client.Metadata({topicName}, false);
             UNIT_ASSERT_VALUES_EQUAL(metadata->Topics.size(), 1);

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -165,6 +165,11 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             UNIT_ASSERT_VALUES_EQUAL(createTopics->Topics.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(createTopics->Topics[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
+        {
+            auto createPartitions = client.CreatePartitions({TTopicConfig(topicName, 2)});
+            UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(createPartitions->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -1,0 +1,132 @@
+#include "kafka_test_client.h"
+#include "test_server.h"
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/base.h>
+#include <util/string/cast.h>
+
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+using namespace NKafka;
+using namespace NYdb;
+
+namespace {
+
+TKafkaRecordBatch MakeTestBatch(TStringBuf value) {
+    TKafkaRecordBatch batch;
+    batch.Magic = 2;
+    batch.Records.resize(1);
+    batch.Records[0].Value = TKafkaRawBytes(value.data(), value.size());
+    return batch;
+}
+
+TKafkaInt16 ProduceError(TKafkaTestClient& client, const TString& topicName, TStringBuf value = "record", ui32 partition = 0) {
+    auto msg = client.Produce(topicName, partition, MakeTestBatch(value));
+    UNIT_ASSERT_VALUES_EQUAL(msg->Responses.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].PartitionResponses.size(), 1);
+    return msg->Responses[0].PartitionResponses[0].ErrorCode;
+}
+
+std::vector<TString> FetchRecordValues(TKafkaTestClient& client, const TString& topicName) {
+    auto msg = client.Fetch({{topicName, {0}}});
+    UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    UNIT_ASSERT_VALUES_EQUAL(msg->Responses.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(
+        msg->Responses[0].Partitions[0].ErrorCode,
+        static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    UNIT_ASSERT(msg->Responses[0].Partitions[0].Records);
+
+        TStringBuf data(
+            msg->Responses[0].Partitions[0].Records->data(),
+            msg->Responses[0].Partitions[0].Records->size());
+    std::vector<TString> values;
+    while (!data.empty()) {
+        const auto header = ReadKafkaBatchHeader(data);
+        UNIT_ASSERT(header);
+        const size_t batchSize = sizeof(TKafkaRecordBatch::BaseOffsetMeta::Type)
+            + sizeof(TKafkaRecordBatch::BatchLengthMeta::Type)
+            + header->BatchLength;
+        UNIT_ASSERT_LE(batchSize, data.size());
+        const auto batch = ReadRecordBatch(TStringBuf(data.data(), batchSize));
+        for (const auto& record : batch.Records) {
+            values.emplace_back(record.Value->data(), record.Value->size());
+        }
+        data.Skip(batchSize);
+    }
+    return values;
+}
+
+void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
+Y_UNIT_TEST(LongSessionWithValidTokenKeepsProduceAndFetchWorking) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .TokenRecheckIntervalMs = 500,
+            .LoginTokenExpireTime = "1h",
+        });
+
+        TString topicName = "/Root/topic-long-valid-token";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+
+        std::vector<TString> expected;
+        const int rounds = 6;
+        for (int i = 0; i < rounds; ++i) {
+            if (i != 0) {
+                Sleep(TDuration::MilliSeconds(500));
+            }
+            TString value = "record-" + ToString(i);
+            expected.push_back(value);
+            UNIT_ASSERT_VALUES_EQUAL(
+                ProduceError(client, topicName, value),
+                static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(FetchRecordValues(client, topicName), expected);
+
+        auto apiVersions = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+
+Y_UNIT_TEST(TokenRecheckDisabledDoesNotDropConnection) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+            .TokenRecheckIntervalMs = 0,
+            .LoginTokenExpireTime = "2s",
+            .AuthRefreshTime = "1s",
+        });
+
+        TString topicName = "/Root/topic-recheck-disabled";
+        NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName);
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "before-sleep"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        Sleep(TDuration::Seconds(5));
+
+        UNIT_ASSERT_VALUES_EQUAL(ProduceError(client, topicName, "after-sleep"), static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        auto apiVersions = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+
+}

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -201,6 +201,13 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
                 static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
         }
         {
+            auto describeGroups = client.DescribeGroups({groupId});
+            UNIT_ASSERT_VALUES_EQUAL(describeGroups->Groups.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                describeGroups->Groups[0].ErrorCode,
+                static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        }
+        {
             auto describe = client.DescribeConfigs({topicName});
             UNIT_ASSERT_VALUES_EQUAL(describe->Results.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(describe->Results[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));

--- a/ydb/core/kafka_proxy/ut/ut_authz.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_authz.cpp
@@ -71,6 +71,14 @@ std::vector<TString> FetchRecordValues(TKafkaTestClient& client, const TString& 
     return values;
 }
 
+TKafkaInt16 ListOffsetsPartitionError(TKafkaTestClient& client, const TString& topicName) {
+    std::vector<std::pair<i32, i64>> partitions{{0, -1}};
+    auto msg = client.ListOffsets(partitions, topicName);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(msg->Topics[0].Partitions.size(), 1);
+    return msg->Topics[0].Partitions[0].ErrorCode;
+}
+
 void CreateTopic(NTopic::TTopicClient& pqClient, const TString& topicName, const TString& consumer = {}
 
 void AlterTopicPartitions(NTopic::TTopicClient& pqClient, const TString& topicName, ui64 minActivePartitions) {
@@ -125,10 +133,26 @@ Y_UNIT_TEST_SUITE(KafkaAuthzRecheck) {
             return ProduceError(client, topicName, "after-expire") == static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
         }, TDuration::Seconds(20));
         UNIT_ASSERT_VALUES_EQUAL(FetchPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
+        UNIT_ASSERT_VALUES_EQUAL(ListOffsetsPartitionError(client, topicName), static_cast<TKafkaInt16>(EKafkaErrors::TOPIC_AUTHORIZATION_FAILED));
 
         auto apiVersions = client.ApiVersions();
         UNIT_ASSERT_VALUES_EQUAL(apiVersions->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
+
+Y_UNIT_TEST(ListOffsetsUnknownTopicStaysUnknownAfterSasl) {
+        TInsecureTestServer testServer(TTestServerSettings{
+            .KafkaApiMode = "2",
+            .CheckACL = true,
+        });
+
+        TKafkaTestClient client(testServer.Port);
+        client.PlainAuthenticateToKafka();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            ListOffsetsPartitionError(client, "/Root/topic-does-not-exist"),
+            static_cast<TKafkaInt16>(EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION));
+    }
+
 
 Y_UNIT_TEST(ReadOnlyUserCanFetchButNotProduce) {
         TInsecureTestServer testServer(TTestServerSettings{

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -4,6 +4,11 @@
 #include <ydb/core/persqueue/ut/common/pq_ut_common.h>
 #include <ydb/core/persqueue/writer/writer.h>
 #include <ydb/public/sdk/cpp/src/library/kafka/kafka_records.h>
+#include <ydb/core/protos/flat_tx_scheme.pb.h>
+#include <ydb/core/scheme/scheme_pathid.h>
+#include <ydb/core/scheme/scheme_tabledefs.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/library/aclib/aclib.h>
 
 namespace {
     using namespace NKafka;
@@ -35,6 +40,7 @@ namespace {
                     partitionDesc->SetPartitionId(0);
                     partitionDesc->SetTabletId(PqTabletId);
                     entry.PQGroupInfo = TIntrusivePtr<NKikimr::NSchemeCache::TSchemeCacheNavigate::TPQGroupInfo>(groupInfo.release());
+                    entry.SecurityObject = MakeIntrusive<NKikimr::TSecurityObject>("owner@builtin", TString{}, false);
                     entry.TableId = {};
                     response->ResultSet.push_back(entry);
                 }
@@ -66,8 +72,10 @@ namespace {
         public:
             TMaybe<NKikimr::NPQ::TTestContext> Ctx;
             TActorId ActorId;
+            TContext::TPtr KafkaContext;
             const TString Database = "/Root/PQ";
             const TString TopicName = "topic"; // as specified in pq_ut_common
+            const TString TopicPath = "/Root/PQ/my-topic";
             const NKikimrConfig::TKafkaProxyConfig KafkaConfig = {};
             const TString KeyToProduce = "record-key";
             const TString ValueToProduce = "record-value";
@@ -77,17 +85,17 @@ namespace {
                 Ctx.ConstructInPlace();
 
                 Ctx->Prepare();
-                PQTabletPrepare({.partitions=1}, {}, *Ctx);
+                PQTabletPrepare({.partitions=2}, {}, *Ctx);
                 Ctx->Runtime->SetScheduledLimit(5'000);
                 Ctx->Runtime->DisableBreakOnStopCondition();
                 Ctx->Runtime->SetLogPriority(NKikimrServices::KAFKA_PROXY, NLog::PRI_TRACE);
                 Ctx->Runtime->SetLogPriority(NKikimrServices::PQ_WRITE_PROXY, NLog::PRI_TRACE);
                 Ctx->Runtime->SetLogPriority(NKikimrServices::PERSQUEUE, NLog::PRI_DEBUG);
-                TContext::TPtr kafkaContext = std::make_shared<TContext>(KafkaConfig);
-                kafkaContext->DatabasePath = "/Root/PQ";
-                kafkaContext->ResourceDatabasePath = "/Root/PQ";
-                kafkaContext->ConnectionId = Ctx->Edge;
-                ActorId = Ctx->Runtime->Register(CreateKafkaProduceActor(kafkaContext));
+                KafkaContext = std::make_shared<TContext>(KafkaConfig);
+                KafkaContext->DatabasePath = "/Root/PQ";
+                KafkaContext->ResourceDatabasePath = "/Root/PQ";
+                KafkaContext->ConnectionId = Ctx->Edge;
+                ActorId = Ctx->Runtime->Register(CreateKafkaProduceActor(KafkaContext));
                 auto dummySchemeCacheId = Ctx->Runtime->Register(new TDummySchemeCacheActor(Ctx->TabletId));
                 Ctx->Runtime->RegisterService(MakeSchemeCacheID(), dummySchemeCacheId);
             }
@@ -96,7 +104,7 @@ namespace {
                 Ctx->Finalize();
             }
 
-            void SendProduce(TMaybe<TString> transactionalId = {}, ui64 producerId = 0, ui16 producerEpoch = 0, i32 baseSequence = 0) {
+            void SendProduce(TMaybe<TString> transactionalId = {}, ui64 producerId = 0, ui16 producerEpoch = 0, i32 baseSequence = 0, i32 partitionIndex = 0) {
                 auto message = std::make_shared<NKafka::TProduceRequestData>();
                 if (transactionalId) {
                     message->TransactionalId = transactionalId->data();
@@ -104,7 +112,7 @@ namespace {
                 NKafka::TProduceRequestData::TTopicProduceData topicData;
                 topicData.Name = "my-topic";
                 NKafka::TProduceRequestData::TTopicProduceData::TPartitionProduceData partitionData;
-                partitionData.Index = 0;
+                partitionData.Index = partitionIndex;
                 NKafka::TKafkaRecords records(std::in_place);
                 records->ProducerId = producerId;
                 records->ProducerEpoch = producerEpoch;
@@ -151,6 +159,45 @@ namespace {
             void SetSchemeCacheReplyTopicNotFound() {
                 auto ev = std::make_unique<TDummySchemeCacheActor::TEvReplyTopicNotFound>();
                 Ctx->Runtime->SingleSys()->Send(new IEventHandle(MakeSchemeCacheID(), Ctx->Edge, ev.release()));
+            }
+
+            NSchemeCache::TDescribeResult::TPtr MakeDescribeResult(
+                    const std::vector<ui32>& partitionIds,
+                    bool withSelf,
+                    const TString& owner = {},
+                    const TString& effectiveAcl = {}) {
+                NKikimrScheme::TEvDescribeSchemeResult proto;
+                if (!partitionIds.empty()) {
+                    auto* pqGroup = proto.MutablePathDescription()->MutablePersQueueGroup();
+                    for (ui32 partitionId : partitionIds) {
+                        auto* partition = pqGroup->AddPartitions();
+                        partition->SetPartitionId(partitionId);
+                        partition->SetTabletId(Ctx->TabletId);
+                    }
+                }
+                if (withSelf) {
+                    auto* self = proto.MutablePathDescription()->MutableSelf();
+                    self->SetOwner(owner);
+                    self->SetEffectiveACL(effectiveAcl);
+                }
+                return NSchemeCache::TDescribeResult::Create(std::move(proto));
+            }
+
+            void SendWatchNotifyUpdated(NSchemeCache::TDescribeResult::TCPtr result) {
+                auto ev = MakeHolder<TEvTxProxySchemeCache::TEvWatchNotifyUpdated>(
+                    0, TopicPath, TPathId{}, std::move(result));
+                Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, ev.Release()));
+            }
+
+            void SendWatchNotifyDeleted() {
+                auto ev = MakeHolder<TEvTxProxySchemeCache::TEvWatchNotifyDeleted>(0, TopicPath, TPathId{});
+                Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, ev.Release()));
+            }
+
+            THolder<NKafka::TEvKafka::TEvResponse> GrabProduceResponse() {
+                auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+                UNIT_ASSERT(response != nullptr);
+                return response;
             }
         };
 
@@ -403,6 +450,84 @@ namespace {
 
             response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
             UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+        }
+
+        Y_UNIT_TEST(WatchNotifyUpdatedWithoutSelfDoesNotFailInFlightProduce) {
+            KafkaContext->UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
+
+            SendProduce();
+            auto first = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(first->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+
+            SendWatchNotifyUpdated(MakeDescribeResult({0}, false));
+            SendProduce();
+            auto second = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(second->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+        }
+
+        Y_UNIT_TEST(WatchNotifyUpdatedWithEmptyAclDoesNotDenyAccess) {
+            KafkaContext->UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
+
+            SendProduce();
+            auto first = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(first->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+
+            SendWatchNotifyUpdated(MakeDescribeResult({0}, true, "owner@builtin", {}));
+            SendProduce();
+            auto second = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(second->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+        }
+
+        Y_UNIT_TEST(WatchNotifyUpdatedWithBrokenAclDoesNotAbort) {
+            KafkaContext->UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
+
+            SendProduce();
+            auto first = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(first->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+
+            SendWatchNotifyUpdated(MakeDescribeResult({0}, true, "owner@builtin", TString("\xFF\xFF\xFF\x0F")));
+            SendProduce();
+            auto second = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(second->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+        }
+
+        Y_UNIT_TEST(WatchNotifyUpdatedRebuildsPartitionChooser) {
+            SendProduce({}, 0, 0, 0, 0);
+            auto first = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(first->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+
+            SendProduce({}, 0, 0, 0, 1);
+            auto missing = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(missing->ErrorCode, NKafka::EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+
+            SendWatchNotifyUpdated(MakeDescribeResult({0, 1}, false));
+            SendProduce({}, 0, 0, 0, 1);
+            auto added = GrabProduceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(added->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+        }
+
+        Y_UNIT_TEST(WatchNotifyDeletedFailsPendingWritesWithoutTimeout) {
+            ui32 writeRequests = 0;
+            auto observer = [&](TAutoPtr<IEventHandle>& input) {
+                if (input->CastAsLocal<TEvPartitionWriter::TEvWriteRequest>()) {
+                    ++writeRequests;
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            };
+            Ctx->Runtime->SetObserverFunc(observer);
+            Ctx->Runtime->SetDispatchTimeout(TDuration::Seconds(5));
+
+            SendProduce();
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&writeRequests]() {
+                return writeRequests > 0;
+            };
+            UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+
+            SendWatchNotifyDeleted();
+            auto response = GrabProduceResponse();
             UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
         }
     }

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -434,7 +434,7 @@ namespace {
             const i64 producerId = 0;
             const i32 producerEpoch = 0;
 
-            KafkaContext->UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
+            KafkaContext->Token.UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
             SetSchemeCacheReplyTopicNotFound();
 
             SendProduce(TransactionalId, producerId, producerEpoch + 0);
@@ -455,7 +455,7 @@ namespace {
         }
 
         Y_UNIT_TEST(WatchNotifyUpdatedWithoutSelfDoesNotFailInFlightProduce) {
-            KafkaContext->UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
+            KafkaContext->Token.UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
 
             SendProduce();
             auto first = GrabProduceResponse();
@@ -468,7 +468,7 @@ namespace {
         }
 
         Y_UNIT_TEST(WatchNotifyUpdatedWithEmptyAclDoesNotDenyAccess) {
-            KafkaContext->UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
+            KafkaContext->Token.UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
 
             SendProduce();
             auto first = GrabProduceResponse();
@@ -481,7 +481,7 @@ namespace {
         }
 
         Y_UNIT_TEST(WatchNotifyUpdatedWithBrokenAclDoesNotAbort) {
-            KafkaContext->UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
+            KafkaContext->Token.UserToken = new NACLib::TUserToken("owner@builtin", TVector<TString>{});
 
             SendProduce();
             auto first = GrabProduceResponse();

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -434,6 +434,7 @@ namespace {
             const i64 producerId = 0;
             const i32 producerEpoch = 0;
 
+            KafkaContext->UserToken = new NACLib::TUserToken("user@builtin", TVector<TString>{});
             SetSchemeCacheReplyTopicNotFound();
 
             SendProduce(TransactionalId, producerId, producerEpoch + 0);

--- a/ydb/core/kafka_proxy/ut/ya.make
+++ b/ydb/core/kafka_proxy/ut/ya.make
@@ -25,6 +25,7 @@ SRCS(
     ut_produce_actor.cpp
     actors_ut.cpp
     ut_consumer_protocol.cpp
+    ut_authz.cpp
 )
 
 PEERDIR(

--- a/ydb/core/kafka_proxy/ya.make
+++ b/ydb/core/kafka_proxy/ya.make
@@ -35,6 +35,7 @@ SRCS(
     kafka_connection.cpp
     kafka_connection.h
     kafka_constants.h
+    kafka_error_response.cpp
     kafka_listener.h
     kafka_messages.cpp
     kafka_messages.h

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3290,6 +3290,9 @@ message TKafkaProxyConfig {
     optional uint32 TopicCreationDefaultPartitions = 14 [default = 1];
     optional bool AutoCreateConsumersEnable = 15 [default = true];
     optional string PublicHost = 16;
+    // How often an authenticated Kafka connection re-validates the SASL ticket via TicketParser.
+    // Zero disables periodic rechecks.
+    optional uint32 TokenRecheckIntervalMs = 21 [default = 300000];
 }
 
 message TAwsCompatibilityConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Kafka proxy no longer closes the client TCP connection when a SASL ticket expires or a topic ACL is revoked. Affected requests return Kafka errors (`TOPIC_AUTHORIZATION_FAILED` / `BROKER_NOT_AVAILABLE`); `ApiVersions` continues to work on the same connection.

### Description for reviewers <!-- (optional) description for those who read this PR -->

After SASL the TCP session must stay up even if the ticket later becomes invalid or topic access is revoked. The proxy now:

1. **Rechecks the SASL ticket** periodically via `TEvAuthorizeTicket` (`KafkaProxyConfig.TokenRecheckIntervalMs`, default 5 minutes; `0` disables). Invalid → `TokenCheck=Invalid` (`TOPIC_AUTHORIZATION_FAILED`); timeout/retryable parser error → `Unavailable` (`BROKER_NOT_AVAILABLE`). `UserToken` is not cleared on Invalid (that would skip ACL checks on an insecure cluster).
2. **Checks topic ACL on data/control APIs** with the current `UserToken` and scheme cache. A 15-minute “topic OK” cache is no longer treated as still authorized; `WatchNotifyUpdated` is not treated as “still allowed”.
3. **Returns Kafka errors** instead of dropping TCP. `ApiVersions` is intentionally ungated so the client can keep the session.

Gated APIs: Produce, Fetch, ListOffsets, OffsetFetch, OffsetCommit, InitProducerId, Metadata, CreateTopics, CreatePartitions, txn APIs, JoinGroup/SyncGroup/Heartbeat/LeaveGroup, DescribeConfigs, AlterConfigs, ListGroups, DescribeGroups, FindCoordinator.

SyncGroup AUTH responses set `Assignment` to empty bytes (null fails serialization). OffsetFetch no longer auto-creates on `UNKNOWN_TOPIC_OR_PARTITION` (that path also hides ACL-denied topics); a missing topic still returns `NONE` + offset `-1`.

Tests: `ydb/core/kafka_proxy/ut` suite `KafkaAuthzRecheck` / `KafkaContextAuthz`.
