### PR TITLE
Fix replicated table split hanging on truncated replication source offsets

### DIFF
--- a/ydb/core/tx/datashard/datashard_repl_offsets_server.cpp
+++ b/ydb/core/tx/datashard/datashard_repl_offsets_server.cpp
@@ -133,6 +133,7 @@ void TReplicationSourceOffsetsServer::ProcessRead(const TReadId& readId, TReadSt
                 ++itSplitKey;
             }
             ++itSource;
+            state.NextSplitKeyId = 0;
         }
     }
 

--- a/ydb/core/tx/datashard/datashard_split_dst.cpp
+++ b/ydb/core/tx/datashard/datashard_split_dst.cpp
@@ -551,7 +551,8 @@ public:
                 LOG_WARN_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID()
                     << " Source " << EscapeC(sourceName)
                     << " has no split key predecessor for range from '"
-                    << EscapeC(range.From.GetBuffer()) << "', skipping left split key");
+                    << EscapeC(range.From.GetBuffer())
+                    << "', skipping left split key, MaxOffset stays -1 (dedup reset for this range)");
             }
 
             // Dump final split keys and offsets for debugging

--- a/ydb/core/tx/datashard/datashard_split_dst.cpp
+++ b/ydb/core/tx/datashard/datashard_split_dst.cpp
@@ -518,7 +518,11 @@ public:
             // Find split keys that are in the (From, To) range
             auto itBegin = std::upper_bound(kvSource.second.begin(), kvSource.second.end(), range.From, leftLess);
             auto itEnd = std::lower_bound(kvSource.second.begin(), kvSource.second.end(), range.To, rightLess);
-            Y_ENSURE(itBegin != kvSource.second.begin());
+            LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID()
+                << " Source " << EscapeC(sourceName)
+                << " " << kvSource.second.size() << " split keys"
+                << ", in-range [" << (itBegin - kvSource.second.begin())
+                << ", " << (itEnd - kvSource.second.begin()) << ")");
 
             // Add the shard right border first
             if (!range.To.GetCells().empty() && !rightFull) {
@@ -536,12 +540,19 @@ public:
                 source.EnsureSplitKey(rdb, it->SplitKey, it->MaxOffset);
             }
 
-            --itBegin;
-            const TSerializedCellVec& leftKey = leftFull ? TSerializedCellVec() : range.From;
-            LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID()
-                << " Source " << EscapeC(sourceName)
-                << " adding left split at key '" << EscapeC(leftKey.GetBuffer()) << "' offset " << itBegin->MaxOffset);
-            source.EnsureSplitKey(rdb, leftKey, itBegin->MaxOffset);
+            if (itBegin != kvSource.second.begin()) {
+                --itBegin;
+                const TSerializedCellVec& leftKey = leftFull ? TSerializedCellVec() : range.From;
+                LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID()
+                    << " Source " << EscapeC(sourceName)
+                    << " adding left split at key '" << EscapeC(leftKey.GetBuffer()) << "' offset " << itBegin->MaxOffset);
+                source.EnsureSplitKey(rdb, leftKey, itBegin->MaxOffset);
+            } else {
+                LOG_WARN_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID()
+                    << " Source " << EscapeC(sourceName)
+                    << " has no split key predecessor for range from '"
+                    << EscapeC(range.From.GetBuffer()) << "', skipping left split key");
+            }
 
             // Dump final split keys and offsets for debugging
             if (IS_LOG_PRIORITY_ENABLED(NLog::PRI_TRACE, NKikimrServices::TX_DATASHARD)) {

--- a/ydb/core/tx/datashard/datashard_ut_replication.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_replication.cpp
@@ -89,6 +89,112 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
         }
     }
 
+    void DoSplitReplicationSourceOffsets(bool rebootSrc) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        NKikimrConfig::TAppConfig app;
+        app.MutableFeatureFlags()->SetEnableTabletRestartOnUnhandledExceptions(true);
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-1", TShardedTableOptions()
+            .Replicated(true)
+            .ReplicationConsistencyLevel(EConsistencyLevel::Row)
+        );
+
+        auto shards = GetTableShards(server, sender, "/Root/table-1");
+        auto tableId = ResolveTableId(server, sender, "/Root/table-1");
+        const ui64 srcShard = shards.at(0);
+
+        ApplyChanges(server, srcShard, tableId, "source-a", {
+            TChange{ .Offset = 0, .WriteTxId = 0, .Key = 1, .Value = 11 },
+            TChange{ .Offset = 1, .WriteTxId = 0, .Key = 5, .Value = 55 },
+        });
+        ApplyChanges(server, srcShard, tableId, "source-b", {
+            TChange{ .Offset = 0, .WriteTxId = 0, .Key = 1, .Value = 11 },
+            TChange{ .Offset = 1, .WriteTxId = 0, .Key = 5, .Value = 55 },
+        });
+
+        SetSplitMergePartCountLimit(server->GetRuntime(), -1);
+
+        auto senderSplit = runtime.AllocateEdgeActor();
+        ui64 txId = AsyncSplitTable(server, senderSplit, "/Root/table-1", srcShard, 5);
+        WaitTxNotification(server, senderSplit, txId);
+
+        shards = GetTableShards(server, sender, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+        const ui64 leftShard = shards.at(0);
+        const ui64 rightShard = shards.at(1);
+
+        ApplyChanges(server, leftShard, tableId, "source-a", {
+            TChange{ .Offset = 10, .WriteTxId = 0, .Key = 1, .Value = 111 },
+        });
+        ApplyChanges(server, leftShard, tableId, "source-b", {
+            TChange{ .Offset = 10, .WriteTxId = 0, .Key = 1, .Value = 111 },
+        });
+        ApplyChanges(server, rightShard, tableId, "source-a", {
+            TChange{ .Offset = 20, .WriteTxId = 0, .Key = 5, .Value = 555 },
+        });
+        ApplyChanges(server, rightShard, tableId, "source-b", {
+            TChange{ .Offset = 20, .WriteTxId = 0, .Key = 5, .Value = 555 },
+        });
+
+        for (ui64 shardId : shards) {
+            CompactTable(runtime, shardId, tableId, true);
+        }
+
+        txId = AsyncMergeTable(server, senderSplit, "/Root/table-1", shards);
+        WaitTxNotification(server, senderSplit, txId);
+
+        shards = GetTableShards(server, sender, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+        const ui64 mergedShard = shards.at(0);
+
+        // Force src to chunk after each split key.
+        auto forceSmallWindow = runtime.AddObserver<TEvDataShard::TEvGetReplicationSourceOffsets>(
+            [&](TEvDataShard::TEvGetReplicationSourceOffsets::TPtr& ev) {
+                ev->Get()->Record.SetWindowSize(1);
+            });
+
+        TTestActorRuntime::TEventObserverHolder rebootObserver;
+        if (rebootSrc) {
+            bool rebooted = false;
+            // Reboot src during offset fetch.
+            rebootObserver = runtime.AddObserver<TEvDataShard::TEvGetReplicationSourceOffsets>(
+                [&](TEvDataShard::TEvGetReplicationSourceOffsets::TPtr& /*ev*/) {
+                    if (!rebooted) {
+                        rebooted = true;
+                        RebootTablet(runtime, mergedShard, sender);
+                    }
+                });
+        }
+
+        AsyncSplitTable(server, senderSplit, "/Root/table-1", mergedShard, 5);
+
+        // Split stays on 1 shard if dst crashes in a restart loop.
+        for (int i = 0; i < 30 && GetTableShards(server, sender, "/Root/table-1").size() < 2; ++i) {
+            TDispatchOptions opts;
+            runtime.DispatchEvents(opts, TDuration::Seconds(1));
+        }
+
+        shards = GetTableShards(server, sender, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        auto result = ReadShardedTable(server, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(result,
+            "key = 1, value = 111\n"
+            "key = 5, value = 555\n");
+    }
+
     void DoSplitMergeChanges(bool withReboots) {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
@@ -226,6 +332,14 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
 
     Y_UNIT_TEST(SplitMergeChangesReboots) {
         DoSplitMergeChanges(true);
+    }
+
+    Y_UNIT_TEST(SplitReplicationSourceOffsetsOnSrcSplit) {
+        DoSplitReplicationSourceOffsets(false);
+    }
+
+    Y_UNIT_TEST(SplitReplicationSourceOffsetsOnSrcRestart) {
+        DoSplitReplicationSourceOffsets(true);
     }
 
     Y_UNIT_TEST(ReplicatedTable) {

--- a/ydb/core/tx/datashard/datashard_ut_replication.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_replication.cpp
@@ -89,7 +89,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
         }
     }
 
-    void DoSplitReplicationSourceOffsets(bool rebootSrc) {
+    Y_UNIT_TEST_TWIN(SplitReplicationSourceOffsets, RebootSrc) {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
         NKikimrConfig::TAppConfig app;
@@ -166,7 +166,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
             });
 
         TTestActorRuntime::TEventObserverHolder rebootObserver;
-        if (rebootSrc) {
+        if (RebootSrc) {
             bool rebooted = false;
             // Reboot src during offset fetch.
             rebootObserver = runtime.AddObserver<TEvDataShard::TEvGetReplicationSourceOffsets>(
@@ -195,7 +195,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
             "key = 5, value = 555\n");
     }
 
-    void DoSplitMergeChanges(bool withReboots) {
+    Y_UNIT_TEST_TWIN(SplitMergeChanges, WithReboots) {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
@@ -250,7 +250,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
             CompactTable(runtime, shardId, tableId1, true);
         }
 
-        if (withReboots) {
+        if (WithReboots) {
             for (ui64 shardId : shards1) {
                 RebootTablet(runtime, shardId, sender);
             }
@@ -269,7 +269,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
 
         CommitWrites(server, { "/Root/table-1" }, 123);
 
-        if (withReboots) {
+        if (WithReboots) {
             for (ui64 shardId : shards1) {
                 RebootTablet(runtime, shardId, sender);
             }
@@ -283,7 +283,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
                 "key = 6, value = 88\n");
         }
 
-        if (withReboots) {
+        if (WithReboots) {
             for (ui64 shardId : shards1) {
                 RebootTablet(runtime, shardId, sender);
             }
@@ -296,7 +296,7 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
         shards1 = GetTableShards(server, sender, "/Root/table-1");
         UNIT_ASSERT_VALUES_EQUAL(shards1.size(), 1u);
 
-        if (withReboots) {
+        if (WithReboots) {
             for (ui64 shardId : shards1) {
                 RebootTablet(runtime, shardId, sender);
             }
@@ -324,22 +324,6 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
                 "key = 7, value = 95\n"
                 "key = 10, value = 94\n");
         }
-    }
-
-    Y_UNIT_TEST(SplitMergeChanges) {
-        DoSplitMergeChanges(false);
-    }
-
-    Y_UNIT_TEST(SplitMergeChangesReboots) {
-        DoSplitMergeChanges(true);
-    }
-
-    Y_UNIT_TEST(SplitReplicationSourceOffsetsOnSrcSplit) {
-        DoSplitReplicationSourceOffsets(false);
-    }
-
-    Y_UNIT_TEST(SplitReplicationSourceOffsetsOnSrcRestart) {
-        DoSplitReplicationSourceOffsets(true);
     }
 
     Y_UNIT_TEST(ReplicatedTable) {

--- a/ydb/core/tx/datashard/datashard_ut_replication.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_replication.cpp
@@ -166,8 +166,8 @@ Y_UNIT_TEST_SUITE(DataShardReplication) {
             });
 
         TTestActorRuntime::TEventObserverHolder rebootObserver;
+        bool rebooted = false;
         if (RebootSrc) {
-            bool rebooted = false;
             // Reboot src during offset fetch.
             rebootObserver = runtime.AddObserver<TEvDataShard::TEvGetReplicationSourceOffsets>(
                 [&](TEvDataShard::TEvGetReplicationSourceOffsets::TPtr& /*ev*/) {


### PR DESCRIPTION
[DROPTABLE-18](http://st/DROPTABLE-18)

## Summary
- Source offset pagination reused `NextSplitKeyId` from source A when moving to source B, so B skipped the empty `-∞` sentinel (`splitKeyId = 0`).
- Destination assumed a predecessor of `range.From` always exists and crashed in `TTxSplitReplicationSourceOffsets`; with tablet restart on unhandled exceptions the split stayed in `TransferData`.
- Reset `NextSplitKeyId` to 0 after `++itSource`. If destination still receives no predecessor, skip installing the left split key instead of `Y_ENSURE`.

## Test plan
- [x] `SplitReplicationSourceOffsetsOnSrcSplit` and `SplitReplicationSourceOffsetsOnSrcRestart` fail with neither fix
- [x] Both tests pass with dst-only
- [x] Both tests pass with src-only
- [x] Both tests pass with dst + src

