### PR TITLE
Restrict group_id/node_id/pdisk_id params of /storage/groups for strict database users

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -1334,6 +1334,20 @@
         ],
         "TotalGroups": 5
     },
+    "test.TestViewer.test_storage_groups_pdisk_fields_hidden_for_database_user": {
+        "database": [
+            {
+                "HasPDisk": false,
+                "PDiskId": null
+            }
+        ],
+        "root": [
+            {
+                "HasPDisk": true,
+                "PDiskId": "1-1"
+            }
+        ]
+    },
     "test.TestViewer.test_storage_stats": {
         "Paths": [
             {

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -1334,20 +1334,156 @@
         ],
         "TotalGroups": 5
     },
-    "test.TestViewer.test_storage_groups_pdisk_fields_hidden_for_database_user": {
-        "database": [
-            {
-                "HasPDisk": false,
-                "PDiskId": null
-            }
-        ],
-        "root": [
-            {
-                "HasPDisk": true,
-                "PDiskId": "1-1"
-            }
-        ]
-    },
+    "test.TestViewer.test_storage_groups_pdisk_fields_hidden_for_database_user": [
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "database"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "PDisk": {
+                                    "PDiskId": "1-1"
+                                },
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "root"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId&group_id=2181038082",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "database"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId&group_id=2181038082",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "PDisk": {
+                                    "PDiskId": "1-1"
+                                },
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "root"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId&node_id=1",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "database"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId&node_id=1",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "PDisk": {
+                                    "PDiskId": "1-1"
+                                },
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "root"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId&pdisk_id=1",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "database"
+        },
+        {
+            "request": "/storage/groups?database=/Root/dedicated_db&fields_required=VDisk,PDisk,NodeId,PDiskId&pdisk_id=1",
+            "response": {
+                "StorageGroups": [
+                    {
+                        "GroupId": "2181038082",
+                        "VDisks": [
+                            {
+                                "NodeId": 1,
+                                "PDisk": {
+                                    "PDiskId": "1-1"
+                                },
+                                "VDiskId": "2181038082-2-0-0-0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "user": "root"
+        }
+    ],
     "test.TestViewer.test_storage_stats": {
         "Paths": [
             {

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -822,6 +822,38 @@ class TestViewer(object):
         }))
 
     @classmethod
+    def test_storage_groups_pdisk_fields_hidden_for_database_user(cls):
+        def pdisk_visibility(data):
+            return [
+                {
+                    'HasPDisk': bool((vdisk.get('PDisk') or {}).get('PDiskId')),
+                    'PDiskId': (vdisk.get('PDisk') or {}).get('PDiskId'),
+                }
+                for group in data.get('StorageGroups') or []
+                for vdisk in group.get('VDisks') or []
+            ]
+
+        params = {
+            'database': cls.dedicated_db,
+            'fields_required': 'VDisk,PDisk,NodeId,PDiskId',
+        }
+        probe_visibility = pdisk_visibility(cls.get_viewer("/storage/groups", params))
+        pdisk_id = next((entry['PDiskId'] for entry in probe_visibility if entry['HasPDisk']), None)
+        request_params = {
+            **params,
+            'pdisk_id': str(pdisk_id).rsplit('-', 1)[-1] if pdisk_id else '',
+        }
+
+        return {
+            'database': pdisk_visibility(cls.get_viewer(
+                "/storage/groups",
+                request_params,
+                headers=cls.make_cookie_headers(cls.database_session_id),
+            )),
+            'root': pdisk_visibility(cls.get_viewer("/storage/groups", request_params)),
+        }
+
+    @classmethod
     def test_viewer_groups_group_by_pool_name(cls):
         return [
             cls.get_viewer_normalized("/viewer/groups", {

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -821,6 +821,8 @@ class TestViewer(object):
             'fields_required': 'all'
         }))
 
+    # PDisk fields are used for filtering groups by pdisk id for strict database users,
+    # but they must be hidden in their response.
     @classmethod
     def test_storage_groups_pdisk_fields_hidden_for_database_user(cls):
         def pdisk_visibility(data):

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -821,39 +821,64 @@ class TestViewer(object):
             'fields_required': 'all'
         }))
 
-    # PDisk fields are used for filtering groups by pdisk id for strict database users,
-    # but they must be hidden in their response.
+    # A strict database user is allowed to filter groups by group_id/node_id/pdisk_id, and every such
+    # filter is validated against the storage of the database, so the handler has to fetch GroupId,
+    # NodeId and PDiskId from BS controller. GroupId is a part of the response anyway, but the disks
+    # behind a group are cluster-level data, so they must not be rendered for such a user - unlike
+    # the response of a viewer+ user.
     @classmethod
     def test_storage_groups_pdisk_fields_hidden_for_database_user(cls):
-        def pdisk_visibility(data):
-            return [
-                {
-                    'HasPDisk': bool((vdisk.get('PDisk') or {}).get('PDiskId')),
-                    'PDiskId': (vdisk.get('PDisk') or {}).get('PDiskId'),
-                }
-                for group in data.get('StorageGroups') or []
-                for vdisk in group.get('VDisks') or []
-            ]
+        def disks_of_groups(response):
+            if 'status_code' in response:
+                return response
 
-        params = {
+            def vdisk_disks(vdisk):
+                disks = {key: vdisk[key] for key in ('VDiskId', 'NodeId') if key in vdisk}
+                if 'PDisk' in vdisk:
+                    disks['PDisk'] = {'PDiskId': (vdisk['PDisk'] or {}).get('PDiskId')}
+                return disks
+
+            return {
+                'StorageGroups': [
+                    {
+                        'GroupId': group.get('GroupId'),
+                        'VDisks': [vdisk_disks(vdisk) for vdisk in group.get('VDisks') or []],
+                    }
+                    for group in response.get('StorageGroups') or []
+                ],
+            }
+
+        base_params = {
             'database': cls.dedicated_db,
             'fields_required': 'VDisk,PDisk,NodeId,PDiskId',
         }
-        probe_visibility = pdisk_visibility(cls.get_viewer("/storage/groups", params))
-        pdisk_id = next((entry['PDiskId'] for entry in probe_visibility if entry['HasPDisk']), None)
-        request_params = {
-            **params,
-            'pdisk_id': str(pdisk_id).rsplit('-', 1)[-1] if pdisk_id else '',
-        }
+        # The ids to filter by are taken from the actual response of the database, so they end up
+        # canonized together with the request of every case below.
+        probe = cls.get_viewer("/storage/groups", base_params)
+        probe_group = next(iter(probe.get('StorageGroups') or []), {})
+        probe_vdisk = next(iter(probe_group.get('VDisks') or []), {})
+        # PDiskId is reported as "<node_id>-<pdisk_id>", but the filter takes the local id only
+        pdisk_id = str((probe_vdisk.get('PDisk') or {}).get('PDiskId') or '').rsplit('-', 1)[-1]
 
-        return {
-            'database': pdisk_visibility(cls.get_viewer(
-                "/storage/groups",
-                request_params,
-                headers=cls.make_cookie_headers(cls.database_session_id),
-            )),
-            'root': pdisk_visibility(cls.get_viewer("/storage/groups", request_params)),
+        cases = [
+            base_params,
+            {**base_params, 'group_id': str(probe_group.get('GroupId'))},
+            {**base_params, 'node_id': str(probe_vdisk.get('NodeId'))},
+            {**base_params, 'pdisk_id': pdisk_id},
+        ]
+        users = {
+            'database': cls.make_cookie_headers(cls.database_session_id),
+            'root': cls.default_headers,
         }
+        return [
+            {
+                'request': "/storage/groups?" + urlencode(params, safe='/,'),
+                'user': user,
+                'response': disks_of_groups(cls.get_viewer("/storage/groups", params, headers=headers)),
+            }
+            for params in cases
+            for user, headers in users.items()
+        ]
 
     @classmethod
     def test_viewer_groups_group_by_pool_name(cls):

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -152,8 +152,8 @@ public:
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvPDiskStateResponse>> PDiskStateResponse;
     ui64 PDiskStateRequestsInFlight = 0;
 
-    // Ids requested by a query param. ToApply is emptied as soon as the corresponding filter has
-    // been applied to the group view, while Requested keeps the original set - it's needed to
+    // Ids requested by a query param. ToApply field is emptied as soon as the corresponding filter has
+    // been applied to the group view, while Requested field keeps the original set - it's needed to
     // validate that the request doesn't reach out of the database.
     template<typename TId>
     struct TIdsFilter {
@@ -161,8 +161,8 @@ public:
         std::unordered_set<TId> ToApply; // not applied to the group view yet
 
         void Parse(const TString& value) {
-            SplitIds(value, ',', ToApply);
-            Requested = ToApply;
+            SplitIds(value, ',', Requested);
+            ToApply = Requested;
         }
     };
 
@@ -1023,10 +1023,6 @@ public:
 
     // Storage objects that belong to the requested database: its groups, the nodes and the pdisks
     // holding the vdisks of those groups, plus the nodes of the database itself.
-    // It's built from the raw BS Controller data, so it doesn't depend on the user-provided filters
-    // and on the order in which the responses arrive. An id which is missing here is either out of
-    // the database, or we have no data to prove it belongs to the database - in both cases the
-    // request of a strict database-only user is denied.
     struct TDatabaseStorageScope {
         std::unordered_set<TGroupId> GroupIds;
         std::unordered_set<TNodeId> NodeIds;
@@ -1048,11 +1044,9 @@ public:
                 scope.GroupIds.insert(group.GroupId);
             }
         }
-        // The disks of a group could also be taken from TGroup::VDisks, but GroupView (and hence
-        // the groups whose VDisks are filled in) shrinks every time a filter is applied, so by the
-        // time we get here the disks of a group filtered out by, say, "with=space" would be missing
-        // and its node would look foreign. VSlotsByVSlotId is a plain index over the BS Controller
-        // vslots response: it holds every vslot of the cluster and no filter ever touches it.
+
+        // We can't use GroupView for getting disks of groups because it shrinks every time a filter is applied.
+        // However, VSlotsByVSlotId contains all vslots of the cluster and no filter ever touches it.
         for (const auto& [vslotId, info] : VSlotsByVSlotId) {
             if (info && scope.GroupIds.count(info->GetGroupId())) {
                 scope.NodeIds.insert(vslotId.NodeId);
@@ -1263,7 +1257,9 @@ public:
                 FilterGroup.clear();
                 GroupsByGroupId.clear();
             }
-            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.ToApply.empty() || !FilterPDiskIds.ToApply.empty() || !FilterGroupIds.ToApply.empty() || !FilterGroup.empty();
+            NeedFilter = (With != EWith::Everything) ||
+                !Filter.empty() || !FilterStoragePools.empty() || !FilterGroup.empty()
+                !FilterNodeIds.ToApply.empty() || !FilterPDiskIds.ToApply.empty() || !FilterGroupIds.ToApply.empty();
             FoundGroups = GroupView.size();
         }
     }

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -152,12 +152,27 @@ public:
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvPDiskStateResponse>> PDiskStateResponse;
     ui64 PDiskStateRequestsInFlight = 0;
 
+    // Ids requested by a query param. ToApply is emptied as soon as the corresponding filter has
+    // been applied to the group view, while Requested keeps the original set - it's needed to
+    // validate that the request doesn't reach out of the database.
+    template<typename TId>
+    struct TIdsFilter {
+        std::unordered_set<TId> Requested; // as they came from the query params
+        std::unordered_set<TId> ToApply; // not applied to the group view yet
+
+        void Parse(const TString& value) {
+            SplitIds(value, ',', ToApply);
+            Requested = ToApply;
+        }
+    };
+
     TString Filter;
-    std::unordered_set<TString> DatabaseStoragePools;
+    std::unordered_set<TString> DatabaseStoragePools; // storage pools of the requested database
+    bool DatabaseStoragePoolsApplied = false; // the pre-filter by DatabaseStoragePools is already applied
     std::unordered_set<TString> FilterStoragePools;
-    std::unordered_set<TGroupId> FilterGroupIds;
-    std::unordered_set<TNodeId> FilterNodeIds;
-    std::unordered_set<ui32> FilterPDiskIds;
+    TIdsFilter<TGroupId> FilterGroupIds;
+    TIdsFilter<TNodeId> FilterNodeIds;
+    TIdsFilter<ui32> FilterPDiskIds;
 
     enum class EWith {
         Everything,
@@ -834,22 +849,22 @@ public:
         if (!filterStoragePool.empty()) {
             FilterStoragePools.emplace(filterStoragePool);
         }
-        SplitIds(Params.Get("node_id"), ',', FilterNodeIds);
-        SplitIds(Params.Get("pdisk_id"), ',', FilterPDiskIds);
-        SplitIds(Params.Get("group_id"), ',', FilterGroupIds);
+        FilterNodeIds.Parse(Params.Get("node_id"));
+        FilterPDiskIds.Parse(Params.Get("pdisk_id"));
+        FilterGroupIds.Parse(Params.Get("group_id"));
         if (!FilterStoragePools.empty()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
         }
-        if (!FilterNodeIds.empty()) {
+        if (!FilterNodeIds.ToApply.empty()) {
             FieldsRequired.set(+EGroupFields::NodeId);
             NeedFilter = true;
         }
-        if (!FilterPDiskIds.empty()) {
+        if (!FilterPDiskIds.ToApply.empty()) {
             FieldsRequired.set(+EGroupFields::PDiskId);
             NeedFilter = true;
         }
-        if (!FilterGroupIds.empty()) {
+        if (!FilterGroupIds.ToApply.empty()) {
             FieldsRequired.set(+EGroupFields::PoolName);
             NeedFilter = true;
         }
@@ -937,7 +952,8 @@ public:
             return;
         }
         if (!Viewer->CheckAccessViewer(TBase::GetRequest())) {
-            FieldsRequired.reset(+EGroupFields::NodeId); // fields that are not available for database users
+            // fields that are not available for database users
+            FieldsRequired.reset(+EGroupFields::NodeId);
             FieldsRequired.reset(+EGroupFields::PDiskId);
             FieldsRequired.reset(+EGroupFields::PDisk);
             FieldsRequired.reset(+EGroupFields::PileName);
@@ -949,6 +965,20 @@ public:
                 if (itDependentFields != DependentFields.end()) {
                     FieldsRequired |= itDependentFields->second;
                 }
+            }
+        }
+        // Database-only users normally don't fetch NodeId/PDiskId (see CheckAccessViewer above),
+        // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
+        // These fields are not added to FieldsRequested, so they are not rendered in the response.
+        if (IsStrictDatabaseOnlyRequest()) {
+            if (!FilterGroupIds.Requested.empty() || !FilterNodeIds.Requested.empty() || !FilterPDiskIds.Requested.empty()) {
+                FieldsRequired.set(+EGroupFields::PoolName);
+            }
+            if (!FilterNodeIds.Requested.empty()) {
+                FieldsRequired.set(+EGroupFields::NodeId);
+            }
+            if (!FilterPDiskIds.Requested.empty()) {
+                FieldsRequired.set(+EGroupFields::PDiskId);
             }
         }
         if (Database) {
@@ -991,9 +1021,83 @@ public:
         }
     }
 
+    // Storage objects that belong to the requested database: its groups, the nodes and the pdisks
+    // holding the vdisks of those groups, plus the nodes of the database itself.
+    // It's built from the raw BS Controller data, so it doesn't depend on the user-provided filters
+    // and on the order in which the responses arrive. An id which is missing here is either out of
+    // the database, or we have no data to prove it belongs to the database - in both cases the
+    // request of a strict database-only user is denied.
+    struct TDatabaseStorageScope {
+        std::unordered_set<TGroupId> GroupIds;
+        std::unordered_set<TNodeId> NodeIds;
+        std::unordered_set<ui32> PDiskIds;
+    };
+
+    TDatabaseStorageScope GetDatabaseStorageScope() {
+        TDatabaseStorageScope scope;
+        if (AreDatabaseNodesKnown()) {
+            for (TNodeId nodeId : GetDatabaseNodes()) {
+                scope.NodeIds.insert(nodeId);
+            }
+        }
+        if (DatabaseStoragePools.empty() || !FieldsAvailable.test(+EGroupFields::PoolName)) {
+            return scope; // we don't know which groups belong to the database
+        }
+        for (const TGroup& group : GroupData) {
+            if (DatabaseStoragePools.count(group.PoolName)) {
+                scope.GroupIds.insert(group.GroupId);
+            }
+        }
+        // The disks of a group could also be taken from TGroup::VDisks, but GroupView (and hence
+        // the groups whose VDisks are filled in) shrinks every time a filter is applied, so by the
+        // time we get here the disks of a group filtered out by, say, "with=space" would be missing
+        // and its node would look foreign. VSlotsByVSlotId is a plain index over the BS Controller
+        // vslots response: it holds every vslot of the cluster and no filter ever touches it.
+        for (const auto& [vslotId, info] : VSlotsByVSlotId) {
+            if (info && scope.GroupIds.count(info->GetGroupId())) {
+                scope.NodeIds.insert(vslotId.NodeId);
+                scope.PDiskIds.insert(vslotId.PDiskId);
+            }
+        }
+        return scope;
+    }
+
+    // Strict database-only users must not be able to address storage objects outside their database.
+    // Returns true if the response has been already sent.
+    bool DenyRequestIfStorageIdsAreOutOfDatabase() {
+        if (FilterGroupIds.Requested.empty() && FilterNodeIds.Requested.empty() && FilterPDiskIds.Requested.empty()) {
+            return false;
+        }
+        const TDatabaseStorageScope scope = GetDatabaseStorageScope();
+        auto denyIfOutOfScope = [this](TStringBuf objects, const auto& requested, const auto& allowed) {
+            for (const auto& id : requested) {
+                if (allowed.count(id)) {
+                    continue;
+                }
+                YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Access denied: requested storage id is outside the database",
+                    {"logPrefix", GetLogPrefix()},
+                    {"user", GetUserSID()},
+                    {"database", Database},
+                    {"objects", objects},
+                    {"outOfDatabaseId", id},
+                    {"requestedCount", requested.size()},
+                    {"databaseScopeCount", allowed.size()});
+                TBase::ReplyAndPassAway(
+                    GETHTTPACCESSDENIED("text/plain", TStringBuilder()
+                        << "Some requested " << objects << " are outside the specified database"),
+                    "Access denied");
+                return true;
+            }
+            return false;
+        };
+        return denyIfOutOfScope("storage groups", FilterGroupIds.Requested, scope.GroupIds)
+            || denyIfOutOfScope("nodes", FilterNodeIds.Requested, scope.NodeIds)
+            || denyIfOutOfScope("PDisk identifiers", FilterPDiskIds.Requested, scope.PDiskIds);
+    }
+
     void ApplyFilter() {
         // database pre-filter, affects TotalGroups count
-        if (!DatabaseStoragePools.empty()) {
+        if (!DatabaseStoragePools.empty() && !DatabaseStoragePoolsApplied) {
             if (FieldsAvailable.test(+EGroupFields::PoolName)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
@@ -1002,7 +1106,7 @@ public:
                     }
                 }
                 GroupView.swap(groupView);
-                DatabaseStoragePools.clear();
+                DatabaseStoragePoolsApplied = true;
                 FoundGroups = TotalGroups = GroupView.size();
                 GroupsByGroupId.clear();
             } else {
@@ -1010,16 +1114,16 @@ public:
             }
         }
         // group id pre-filter, affects TotalGroups count
-        if (!FilterGroupIds.empty()) {
+        if (!FilterGroupIds.ToApply.empty()) {
             TGroupView groupView;
             for (TGroup* group : GroupView) {
-                if (FilterGroupIds.count(group->GroupId)) {
+                if (FilterGroupIds.ToApply.count(group->GroupId)) {
                     groupView.push_back(group);
                 }
             }
             GroupView.swap(groupView);
             FoundGroups = TotalGroups = GroupView.size();
-            FilterGroupIds.clear();
+            FilterGroupIds.ToApply.clear();
             GroupsByGroupId.clear();
         }
         // storage pool pre-filter, affects TotalGroups count
@@ -1040,12 +1144,12 @@ public:
             }
         }
         // node_id + pdisk_id pre-filter, affects TotalGroups count
-        if (!FilterNodeIds.empty() && !FilterPDiskIds.empty()) {
+        if (!FilterNodeIds.ToApply.empty() && !FilterPDiskIds.ToApply.empty()) {
             if (FieldsAvailable.test(+EGroupFields::NodeId) && FieldsAvailable.test(+EGroupFields::PDiskId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterNodeIds.count(vdisk.VSlotId.NodeId) && FilterPDiskIds.count(vdisk.VSlotId.PDiskId)) {
+                        if (FilterNodeIds.ToApply.count(vdisk.VSlotId.NodeId) && FilterPDiskIds.ToApply.count(vdisk.VSlotId.PDiskId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1053,20 +1157,20 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterNodeIds.clear();
-                FilterPDiskIds.clear();
+                FilterNodeIds.ToApply.clear();
+                FilterPDiskIds.ToApply.clear();
                 GroupsByGroupId.clear();
             } else {
                 return;
             }
         }
         // node_id pre-filter, affects TotalGroups count
-        if (!FilterNodeIds.empty()) {
+        if (!FilterNodeIds.ToApply.empty()) {
             if (FieldsAvailable.test(+EGroupFields::NodeId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterNodeIds.count(vdisk.VSlotId.NodeId)) {
+                        if (FilterNodeIds.ToApply.count(vdisk.VSlotId.NodeId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1074,19 +1178,19 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterNodeIds.clear();
+                FilterNodeIds.ToApply.clear();
                 GroupsByGroupId.clear();
             } else {
                 return;
             }
         }
         // pdisk_id pre-filter, affects TotalGroups count
-        if (!FilterPDiskIds.empty()) {
+        if (!FilterPDiskIds.ToApply.empty()) {
             if (FieldsAvailable.test(+EGroupFields::PDiskId)) {
                 TGroupView groupView;
                 for (TGroup* group : GroupView) {
                     for (const auto& vdisk : group->VDisks) {
-                        if (FilterPDiskIds.count(vdisk.VSlotId.PDiskId)) {
+                        if (FilterPDiskIds.ToApply.count(vdisk.VSlotId.PDiskId)) {
                             groupView.push_back(group);
                             break;
                         }
@@ -1094,7 +1198,7 @@ public:
                 }
                 GroupView.swap(groupView);
                 FoundGroups = TotalGroups = GroupView.size();
-                FilterPDiskIds.clear();
+                FilterPDiskIds.ToApply.clear();
                 GroupsByGroupId.clear();
             } else {
                 return;
@@ -1159,7 +1263,7 @@ public:
                 FilterGroup.clear();
                 GroupsByGroupId.clear();
             }
-            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.empty() || !FilterPDiskIds.empty() || !FilterGroupIds.empty() || !FilterGroup.empty();
+            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.ToApply.empty() || !FilterPDiskIds.ToApply.empty() || !FilterGroupIds.ToApply.empty() || !FilterGroup.empty();
             FoundGroups = GroupView.size();
         }
     }
@@ -1430,10 +1534,10 @@ public:
         if (!FilterStoragePools.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PoolName)) {
             return true;
         }
-        if (!FilterNodeIds.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
+        if (!FilterNodeIds.ToApply.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
             return true;
         }
-        if (!FilterPDiskIds.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
+        if (!FilterPDiskIds.ToApply.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
             return true;
         }
         if (With == EWith::MissingDisks && NeedToWaitForFieldBeforeHive(EGroupFields::MissingDisks)) {
@@ -2301,6 +2405,9 @@ public:
 
     void ReplyAndPassAway() override {
         AddEvent("ReplyAndPassAway");
+        if (IsStrictDatabaseOnlyRequest() && DenyRequestIfStorageIdsAreOutOfDatabase()) {
+            return;
+        }
         ApplyEverything();
         ApplyLimitForced(); // in case we had a problem and don't want to return too much data
         NKikimrViewer::TStorageGroupsInfo json;

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -959,18 +959,11 @@ public:
             FieldsRequired.reset(+EGroupFields::PileName);
         }
         FieldsRequested = FieldsRequired; // no dependent fields
-        for (auto field = +EGroupFields::GroupId; field != +EGroupFields::COUNT; ++field) {
-            if (FieldsRequired.test(field)) {
-                auto itDependentFields = DependentFields.find(static_cast<EGroupFields>(field));
-                if (itDependentFields != DependentFields.end()) {
-                    FieldsRequired |= itDependentFields->second;
-                }
-            }
-        }
-        // Database-only users normally don't fetch NodeId/PDiskId (see CheckAccessViewer above),
-        // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
-        // These fields are not added to FieldsRequested, so they are not rendered in the response.
+
         if (IsStrictDatabaseOnlyRequest()) {
+            // Database-only users normally don't fetch NodeId/PDiskId (see CheckAccessViewer above),
+            // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
+            // Required fields shoule be set *after* FieldsRequested, so they are not rendered in the response.
             if (!FilterGroupIds.Requested.empty() || !FilterNodeIds.Requested.empty() || !FilterPDiskIds.Requested.empty()) {
                 FieldsRequired.set(+EGroupFields::PoolName);
             }
@@ -979,6 +972,14 @@ public:
             }
             if (!FilterPDiskIds.Requested.empty()) {
                 FieldsRequired.set(+EGroupFields::PDiskId);
+            }
+        }
+        for (auto field = +EGroupFields::GroupId; field != +EGroupFields::COUNT; ++field) {
+            if (FieldsRequired.test(field)) {
+                auto itDependentFields = DependentFields.find(static_cast<EGroupFields>(field));
+                if (itDependentFields != DependentFields.end()) {
+                    FieldsRequired |= itDependentFields->second;
+                }
             }
         }
         if (Database) {

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -963,7 +963,7 @@ public:
         if (IsStrictDatabaseOnlyRequest()) {
             // Database-only users normally don't fetch NodeId/PDiskId (see CheckAccessViewer above),
             // but we need that data from BSC to validate the scope of node_id/pdisk_id/group_id params.
-            // Required fields shoule be set *after* FieldsRequested, so they are not rendered in the response.
+            // Required fields should be set *after* FieldsRequested, so they are not rendered in the response.
             if (!FilterGroupIds.Requested.empty() || !FilterNodeIds.Requested.empty() || !FilterPDiskIds.Requested.empty()) {
                 FieldsRequired.set(+EGroupFields::PoolName);
             }

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -1258,7 +1258,7 @@ public:
                 GroupsByGroupId.clear();
             }
             NeedFilter = (With != EWith::Everything) ||
-                !Filter.empty() || !FilterStoragePools.empty() || !FilterGroup.empty()
+                !Filter.empty() || !FilterStoragePools.empty() || !FilterGroup.empty() ||
                 !FilterNodeIds.ToApply.empty() || !FilterPDiskIds.ToApply.empty() || !FilterGroupIds.ToApply.empty();
             FoundGroups = GroupView.size();
         }

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -1030,15 +1030,17 @@ public:
         std::unordered_set<ui32> PDiskIds;
     };
 
-    TDatabaseStorageScope GetDatabaseStorageScope() {
+    // Returns nothing if the storage of the database could not be determined - an empty scope would
+    // be indistinguishable from a database that legitimately owns nothing.
+    std::optional<TDatabaseStorageScope> GetDatabaseStorageScope() {
+        if (DatabaseStoragePools.empty() || !FieldsAvailable.test(+EGroupFields::PoolName)) {
+            return std::nullopt; // we don't know which groups belong to the database
+        }
         TDatabaseStorageScope scope;
         if (AreDatabaseNodesKnown()) {
             for (TNodeId nodeId : GetDatabaseNodes()) {
                 scope.NodeIds.insert(nodeId);
             }
-        }
-        if (DatabaseStoragePools.empty() || !FieldsAvailable.test(+EGroupFields::PoolName)) {
-            return scope; // we don't know which groups belong to the database
         }
         for (const TGroup& group : GroupData) {
             if (DatabaseStoragePools.count(group.PoolName)) {
@@ -1063,7 +1065,18 @@ public:
         if (FilterGroupIds.Requested.empty() && FilterNodeIds.Requested.empty() && FilterPDiskIds.Requested.empty()) {
             return false;
         }
-        const TDatabaseStorageScope scope = GetDatabaseStorageScope();
+        const std::optional<TDatabaseStorageScope> scope = GetDatabaseStorageScope();
+        if (!scope) {
+            YDB_LOG_NOTICE_COMP(NKikimrServices::VIEWER, "Access denied: the storage of the database is unknown",
+                {"logPrefix", GetLogPrefix()},
+                {"user", GetUserSID()},
+                {"database", Database});
+            TBase::ReplyAndPassAway(
+                GETHTTPACCESSDENIED("text/plain",
+                    "Database storage list is unavailable, request cannot be validated"),
+                "Access denied");
+            return true;
+        }
         auto denyIfOutOfScope = [this](TStringBuf objects, const auto& requested, const auto& allowed) {
             for (const auto& id : requested) {
                 if (allowed.count(id)) {
@@ -1085,9 +1098,9 @@ public:
             }
             return false;
         };
-        return denyIfOutOfScope("storage groups", FilterGroupIds.Requested, scope.GroupIds)
-            || denyIfOutOfScope("nodes", FilterNodeIds.Requested, scope.NodeIds)
-            || denyIfOutOfScope("PDisk identifiers", FilterPDiskIds.Requested, scope.PDiskIds);
+        return denyIfOutOfScope("storage groups", FilterGroupIds.Requested, scope->GroupIds)
+            || denyIfOutOfScope("nodes", FilterNodeIds.Requested, scope->NodeIds)
+            || denyIfOutOfScope("PDisk identifiers", FilterPDiskIds.Requested, scope->PDiskIds);
     }
 
     void ApplyFilter() {

--- a/ydb/tests/functional/security/lib/security_test_helpers.py
+++ b/ydb/tests/functional/security/lib/security_test_helpers.py
@@ -133,6 +133,64 @@ def get_foreign_node_id_for_database(base_url, database, token='root@builtin'):
     return min(foreign_nodes)
 
 
+def get_storage_groups(base_url, database=None, token='root@builtin', timeout=30, **params):
+    if database is not None:
+        params = {'database': database, **params}
+    response = requests.get(
+        base_url + '/storage/groups',
+        params=params,
+        headers={'Authorization': token},
+        verify=False,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_storage_ids(base_url, database=None, token='root@builtin', timeout=60):
+    """Ids covered by the storage groups of the given database, or of the whole cluster
+    when database is None: the groups themselves and the nodes/pdisks holding their vdisks."""
+    data = get_storage_groups(
+        base_url,
+        database,
+        token,
+        fields_required='GroupId,VDisk,PDisk,NodeId,PDiskId',
+        timeout=timeout,
+    )
+    ids = {'group_ids': set(), 'node_ids': set(), 'pdisk_ids': set()}
+    for group in data.get('StorageGroups') or []:
+        ids['group_ids'].add(int(group['GroupId']))
+        for vdisk in group.get('VDisks') or []:
+            # PDiskId is reported as "<node_id>-<pdisk_id>"
+            pdisk_id_str = str((vdisk.get('PDisk') or {}).get('PDiskId') or '')
+            if '-' in pdisk_id_str:
+                node_id_str, _, local_pdisk_id_str = pdisk_id_str.partition('-')
+                ids['node_ids'].add(int(node_id_str))
+                ids['pdisk_ids'].add(int(local_pdisk_id_str))
+    return ids
+
+
+def wait_for_storage_ids(base_url, database, token='root@builtin', timeout_seconds=60):
+    """Same as get_storage_ids, but waits until the database gets its storage groups."""
+    last = {}
+
+    def ready():
+        last['ids'] = get_storage_ids(base_url, database, token)
+        return bool(last['ids']['node_ids'])
+
+    if not wait_for(ready, timeout_seconds=timeout_seconds, step_seconds=1):
+        raise AssertionError(
+            f'no storage groups with disks for database={database} after {timeout_seconds}s; '
+            f'last={last.get("ids")}'
+        )
+    return last['ids']
+
+
+def get_unknown_node_id(base_url, token='root@builtin'):
+    """Returns a node id that does not exist in the cluster at all."""
+    return max(get_nodelist_ids(base_url, token=token)) + 100
+
+
 def wait_for_viewer_ready(
     base_url,
     database=DATABASE,

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -12,7 +12,10 @@ from ydb.tests.functional.security.lib.security_test_helpers import get_foreign_
 from ydb.tests.functional.security.lib.security_test_helpers import get_nodelist_ids
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_path_id
 from ydb.tests.functional.security.lib.security_test_helpers import get_tenant_schemeshard_id
+from ydb.tests.functional.security.lib.security_test_helpers import get_storage_ids
+from ydb.tests.functional.security.lib.security_test_helpers import get_unknown_node_id
 from ydb.tests.functional.security.lib.security_test_helpers import run_viewer_query
+from ydb.tests.functional.security.lib.security_test_helpers import wait_for_storage_ids
 from ydb.tests.functional.security.lib.security_test_helpers import wait_for_viewer_ready
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -237,6 +240,26 @@ def tenant_nodelist_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
 def foreign_node_id(ydb_cluster_with_extra_sids_controls, tenant_database):
     base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
     return get_foreign_node_id_for_database(base_url, tenant_database)
+
+
+# Storage groups of the tenant database and the nodes/pdisks they live on.
+@pytest.fixture(scope='module')
+def tenant_storage_ids(ydb_cluster_with_extra_sids_controls, tenant_database):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return wait_for_storage_ids(base_url, tenant_database)
+
+
+# The same for the whole cluster, so that a test can pick an id outside the tenant database.
+@pytest.fixture(scope='module')
+def cluster_storage_ids(ydb_cluster_with_extra_sids_controls, tenant_storage_ids):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_storage_ids(base_url)
+
+
+@pytest.fixture(scope='module')
+def unknown_node_id(ydb_cluster_with_extra_sids_controls):
+    base_url = get_mon_base_url(ydb_cluster_with_extra_sids_controls)
+    return get_unknown_node_id(base_url)
 
 
 @pytest.fixture

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -398,17 +398,25 @@ def test_storage_groups_scope_params_forbidden_for_strict_database_token(
         {'node_id': str(tenant_nodelist_ids[0])},
         {'node_id': str(min(tenant_storage_ids['node_ids']))},
         {'pdisk_id': str(min(tenant_storage_ids['pdisk_ids']))},
+        {
+            'node_id': str(min(tenant_storage_ids['node_ids'])),
+            'pdisk_id': str(min(tenant_storage_ids['pdisk_ids'])),
+        },
     )
 
     foreign_group_ids = cluster_storage_ids['group_ids'] - tenant_storage_ids['group_ids']
     foreign_pdisk_ids = cluster_storage_ids['pdisk_ids'] - tenant_storage_ids['pdisk_ids']
     assert foreign_group_ids, 'the cluster must have a storage group outside the tenant database'
+    foreign_pdisk_id = str(min(foreign_pdisk_ids) if foreign_pdisk_ids else 999999)
     forbidden_cases = (
         {'group_id': str(min(foreign_group_ids))},
         {'node_id': str(unknown_node_id)},
         # a pdisk which exists but holds nothing of the database may be absent in a small cluster,
         # then an id of a pdisk that doesn't exist at all is checked instead
-        {'pdisk_id': str(min(foreign_pdisk_ids) if foreign_pdisk_ids else 999999)},
+        {'pdisk_id': foreign_pdisk_id},
+        # every parameter is validated on its own, so a single out of scope one is enough to deny
+        {'node_id': str(tenant_nodelist_ids[0]), 'pdisk_id': foreign_pdisk_id},
+        {'group_id': str(min(tenant_storage_ids['group_ids'])), 'node_id': str(unknown_node_id)},
     )
 
     for extra_params in allowed_cases:
@@ -431,6 +439,16 @@ def test_storage_groups_scope_params_forbidden_for_strict_database_token(
         # Scope-param validation must not block tokens above strict database level.
         for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
             _assert_status(base, path, token, 200)
+
+    # Without the database parameter the scope can't be determined at all, so a strict database user
+    # is rejected by the endpoint validation before the scope check even runs.
+    path = _build_endpoint_path(
+        '/storage/groups',
+        with_database_cgi=False,
+        extra_params={'group_id': str(min(tenant_storage_ids['group_ids']))},
+    )
+    _assert_status(base, path, 'database@builtin', 400)
+    _assert_status(base, path, 'root@builtin', 200)
 
 
 def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -381,6 +381,58 @@ def test_out_of_scope_path_nodes_gives_400(mon_base_url_with_extra_sids_control)
         _assert_status(mon_base_url_with_extra_sids_control, path, 'database@builtin', 400)
 
 
+def test_storage_groups_scope_params_forbidden_for_strict_database_token(
+    mon_base_url_with_extra_sids_control,
+    tenant_database,
+    tenant_nodelist_ids,
+    tenant_storage_ids,
+    cluster_storage_ids,
+    unknown_node_id,
+):
+    assert tenant_nodelist_ids, 'tenant database must have at least one node'
+    base = mon_base_url_with_extra_sids_control
+
+    allowed_cases = (
+        {'group_id': str(min(tenant_storage_ids['group_ids']))},
+        # both the nodes of the database itself and the nodes holding its storage are in scope
+        {'node_id': str(tenant_nodelist_ids[0])},
+        {'node_id': str(min(tenant_storage_ids['node_ids']))},
+        {'pdisk_id': str(min(tenant_storage_ids['pdisk_ids']))},
+    )
+
+    foreign_group_ids = cluster_storage_ids['group_ids'] - tenant_storage_ids['group_ids']
+    foreign_pdisk_ids = cluster_storage_ids['pdisk_ids'] - tenant_storage_ids['pdisk_ids']
+    assert foreign_group_ids, 'the cluster must have a storage group outside the tenant database'
+    forbidden_cases = (
+        {'group_id': str(min(foreign_group_ids))},
+        {'node_id': str(unknown_node_id)},
+        # a pdisk which exists but holds nothing of the database may be absent in a small cluster,
+        # then an id of a pdisk that doesn't exist at all is checked instead
+        {'pdisk_id': str(min(foreign_pdisk_ids) if foreign_pdisk_ids else 999999)},
+    )
+
+    for extra_params in allowed_cases:
+        path = _build_endpoint_path(
+            '/storage/groups',
+            with_database_cgi=True,
+            extra_params=extra_params,
+            database=tenant_database,
+        )
+        _assert_status(base, path, 'database@builtin', 200)
+
+    for extra_params in forbidden_cases:
+        path = _build_endpoint_path(
+            '/storage/groups',
+            with_database_cgi=True,
+            extra_params=extra_params,
+            database=tenant_database,
+        )
+        _assert_status(base, path, 'database@builtin', 403)
+        # Scope-param validation must not block tokens above strict database level.
+        for token in ('viewer@builtin', 'monitoring@builtin', 'root@builtin'):
+            _assert_status(base, path, token, 200)
+
+
 def test_viewer_sysinfo_tabletinfo_node_id_forbidden_for_strict_database_token(
     mon_base_url_with_extra_sids_control,
     tenant_database,


### PR DESCRIPTION
### Description for reviewers
Проверяем группы, диски и ноды, переданные в соответствующих query-параметрах, на принадлежность запрошенной базе для пользователей с уровнем доступа database. Для этого приходится запрашивать дополнительные данные из BCS для таких пользователей. Отдельным тестом проверяю, что запрошенные данные не попадают в ответ, т.к. не должны.

Запросы без этих параметров не меняются. Ответы для пользователей уровня viewer+ ничего не меняется.