### PR TITLE
Fix signed overflow and OOB reads in Kafka records, MLP storage, and PQ blobs

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -557,7 +557,8 @@ std::pair<EKafkaErrors, THolder<TEvPartitionWriter::TEvWriteRequest>> Convert(
             w->SetSeqNo(GetRecordSeqNo(batch, batchIndex, record));
 
             w->SetData(str);
-            ui64 createTime = batch.BaseTimestamp + record.TimestampDelta;
+            const ui64 createTime = static_cast<ui64>(
+                GetRecordTimestamp(batch.BaseTimestamp, record.TimestampDelta));
             w->SetCreateTimeMS(createTime ? createTime : TInstant::Now().MilliSeconds());
             w->SetDisableDeduplication(true);
             w->SetUncompressedSize(record.Value ? record.Value->size() : 0);

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -117,7 +117,7 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
         if (record.Key) {
             item.SetPartitionKey(TString(record.Key->data(), record.Key->size()));
         }
-        const i64 timestamp = batch.BaseTimestamp + record.TimestampDelta;
+        const i64 timestamp = NKafka::GetRecordTimestamp(batch.BaseTimestamp, record.TimestampDelta);
         if (timestamp > 0) {
             item.SetCreateTimestampMS(timestamp);
         }

--- a/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/ut/batch_cutter_ut.cpp
@@ -10,6 +10,7 @@
 #include <library/cpp/streams/zstd/zstd.h>
 
 #include <util/generic/string.h>
+#include <util/generic/ylimits.h>
 #include <util/stream/mem.h>
 #include <util/stream/zlib.h>
 
@@ -245,6 +246,48 @@ Y_UNIT_TEST_SUITE(TBatchCutterTest) {
         const auto cut = TKafkaBatchCutter().Cut(TBatchCutterData(readResult, std::move(dataChunk)), 10);
         UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(cut[0].GetData(), readResult.GetData());
+    }
+
+    Y_UNIT_TEST(CutSkipsNonPositiveCreateTimestampAfterWrap) {
+        NKafka::TKafkaRecordBatch batch;
+        batch.BaseOffset = 100;
+        batch.Magic = 2;
+        batch.LastOffsetDelta = 0;
+        batch.BaseTimestamp = Max<i64>();
+        batch.MaxTimestamp = Max<i64>();
+        batch.Records.push_back(MakeKafkaRecord(1, 0, "k0", "value0"));
+        batch.BatchLength = batch.Size(2)
+            - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+            - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+
+        const auto readResult = MakeKafkaBatchReadResult(NKafka::WriteKafkaRecordBatch(batch));
+        const auto cut = TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())),
+            10);
+
+        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
+        UNIT_ASSERT(!cut[0].HasCreateTimestampMS());
+    }
+
+    Y_UNIT_TEST(CutAppliesNegativeTimestampDelta) {
+        NKafka::TKafkaRecordBatch batch;
+        batch.BaseOffset = 100;
+        batch.Magic = 2;
+        batch.LastOffsetDelta = 0;
+        batch.BaseTimestamp = 1000;
+        batch.MaxTimestamp = 1000;
+        batch.Records.push_back(MakeKafkaRecord(-5, 0, "k0", "value0"));
+        batch.BatchLength = batch.Size(2)
+            - sizeof(NKafka::TKafkaRecordBatch::BaseOffsetMeta::Type)
+            - sizeof(NKafka::TKafkaRecordBatch::BatchLengthMeta::Type);
+
+        const auto readResult = MakeKafkaBatchReadResult(NKafka::WriteKafkaRecordBatch(batch));
+        const auto cut = TKafkaBatchCutter().Cut(
+            TBatchCutterData(readResult, NKikimr::GetDeserializedData(readResult.GetData())),
+            10);
+
+        UNIT_ASSERT_VALUES_EQUAL(cut.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(cut[0].GetCreateTimestampMS(), 995);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/blob/type_codecs_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/type_codecs_ut.cpp
@@ -2,6 +2,7 @@
 #include <ydb/core/scheme_types/scheme_types_defs.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/packedtypes/longs.h>
 
 #include <util/generic/vector.h>
 #include <util/random/fast.h>
@@ -334,6 +335,17 @@ Y_UNIT_TEST_SUITE(TTypeCodecsTest) {
         chunk->Seal();
         UNIT_ASSERT(estimated >= output.Size() || estimated > 0);
         UNIT_ASSERT(output.Size() > 0);
+    }
+
+    Y_UNIT_TEST(LoadPackedI64ReadsExactBuffer) {
+        char buf[9] = {};
+        const int written = out_long(i64{0}, buf);
+        UNIT_ASSERT(written > 0);
+
+        i64 value = -1;
+        const int read = NScheme::LoadPackedI64(value, buf, buf + written);
+        UNIT_ASSERT_VALUES_EQUAL(read, written);
+        UNIT_ASSERT_VALUES_EQUAL(value, 0);
     }
 
 }

--- a/ydb/core/persqueue/pqtablet/blob/type_codecs_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/type_codecs_ut.cpp
@@ -3,8 +3,10 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/packedtypes/longs.h>
+#include <library/cpp/packedtypes/zigzag.h>
 
 #include <util/generic/vector.h>
+#include <util/generic/ylimits.h>
 #include <util/random/fast.h>
 #include <util/datetime/base.h>
 #include <util/string/cast.h>
@@ -346,6 +348,23 @@ Y_UNIT_TEST_SUITE(TTypeCodecsTest) {
         const int read = NScheme::LoadPackedI64(value, buf, buf + written);
         UNIT_ASSERT_VALUES_EQUAL(read, written);
         UNIT_ASSERT_VALUES_EQUAL(value, 0);
+    }
+
+    Y_UNIT_TEST(DeltaZigZagDecoderWrapsI32LikeUnsigned) {
+        char buf[32] = {};
+        char* p = buf;
+        p += out_long(static_cast<i64>(ZigZagEncode(Max<i32>())), p);
+        p += out_long(static_cast<i64>(ZigZagEncode(i32{1})), p);
+
+        NScheme::TDeltaValueDecoder<NScheme::TZigZagValueDecoder<i32>> decoder;
+        i32 first = 0;
+        i32 second = 0;
+        const size_t firstBytes = decoder.Load(buf, p, first);
+        const size_t secondBytes = decoder.Load(buf + firstBytes, p, second);
+        UNIT_ASSERT(firstBytes > 0);
+        UNIT_ASSERT(secondBytes > 0);
+        UNIT_ASSERT_VALUES_EQUAL(first, Max<i32>());
+        UNIT_ASSERT_VALUES_EQUAL(second, Min<i32>());
     }
 
 }

--- a/ydb/core/persqueue/pqtablet/blob/type_decoders.h
+++ b/ydb/core/persqueue/pqtablet/blob/type_decoders.h
@@ -13,6 +13,7 @@
 #include <util/system/unaligned_mem.h>
 
 #include <cstring>
+#include <type_traits>
 
 namespace NKikimr {
 namespace NScheme {
@@ -356,20 +357,25 @@ public:
     inline TType Peek(const char* data, const char* end) const {
         TType value;
         TValueDecoder::Load(data, end, value);
-        return Rev ? Last - value : Last + value;
+        return ApplyDelta(value);
     }
 
     inline size_t Load(const char* data, const char* end, TType& value) {
         auto bytes = TValueDecoder::Load(data, end, value);
-        if (Rev)
-            Last -= value;
-        else
-            Last += value;
+        Last = ApplyDelta(value);
         value = Last;
         return bytes;
     }
 
 private:
+    TType ApplyDelta(TType delta) const {
+        using TUnsigned = std::make_unsigned_t<TType>;
+        const TUnsigned next = Rev
+            ? static_cast<TUnsigned>(Last) - static_cast<TUnsigned>(delta)
+            : static_cast<TUnsigned>(Last) + static_cast<TUnsigned>(delta);
+        return static_cast<TType>(next);
+    }
+
     TType Last = 0;
 };
 

--- a/ydb/core/persqueue/pqtablet/blob/type_decoders.h
+++ b/ydb/core/persqueue/pqtablet/blob/type_decoders.h
@@ -12,6 +12,8 @@
 #include <util/generic/strbuf.h>
 #include <util/system/unaligned_mem.h>
 
+#include <cstring>
+
 namespace NKikimr {
 namespace NScheme {
 
@@ -297,6 +299,16 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+inline int LoadPackedI64(i64& value, const char* data, const char* end) {
+    AFL_ENSURE(data < end);
+    char buf[9] = {};
+    const size_t remain = static_cast<size_t>(end - data);
+    memcpy(buf, data, remain < sizeof(buf) ? remain : sizeof(buf));
+    const int bytes = in_long(value, buf);
+    AFL_ENSURE(bytes > 0 && static_cast<size_t>(bytes) <= remain);
+    return bytes;
+}
+
 template <typename TIntType>
 class TVarIntValueDecoder {
 public:
@@ -304,15 +316,13 @@ public:
 
     inline TType Peek(const char* data, const char* end) const {
         i64 value;
-        auto bytes = in_long(value, data);
-        AFL_ENSURE(data + bytes <= end);
+        LoadPackedI64(value, data, end);
         return value;
     }
 
     inline size_t Load(const char* data, const char* end, TType& value) const {
         i64 loaded = 0;
-        auto bytes = in_long(loaded, data);
-        AFL_ENSURE(data + bytes <= end);
+        const auto bytes = LoadPackedI64(loaded, data, end);
         value = loaded;
         return bytes;
     }
@@ -326,15 +336,13 @@ public:
 
     inline TType Peek(const char* data, const char* end) const {
         i64 value;
-        auto bytes = in_long(value, data);
-        AFL_ENSURE(data + bytes <= end);
+        LoadPackedI64(value, data, end);
         return ZigZagDecode(static_cast<TUnsigned>(value));
     }
 
     inline size_t Load(const char* data, const char* end, TType& value) const {
         i64 loaded = 0;
-        auto bytes = in_long(loaded, data);
-        AFL_ENSURE(data + bytes <= end);
+        const auto bytes = LoadPackedI64(loaded, data, end);
         value = ZigZagDecode(static_cast<TUnsigned>(loaded));
         return bytes;
     }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage__serialization.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage__serialization.cpp
@@ -80,14 +80,33 @@ void VarintSerialize(TString& buffer, ui64 value) {
     VarintSerialize(buffer, static_cast<i64>(value));
 }
 
-void VarintDeserialize(const char*& data, i64& value) {
-    data += in_long(value, data);
+bool ReadPackedLong(const char*& data, const char* end, i64& value) {
+    if (data >= end) {
+        return false;
+    }
+
+    char buf[9] = {};
+    const size_t remain = static_cast<size_t>(end - data);
+    memcpy(buf, data, Min(remain, sizeof(buf)));
+    const int bytes = in_long(value, buf);
+    if (bytes <= 0 || static_cast<size_t>(bytes) > remain) {
+        return false;
+    }
+    data += bytes;
+    return true;
 }
 
-void VarintDeserialize(const char*& data, ui64& value) {
-    i64 tmp;
-    VarintDeserialize(data, tmp);
+bool VarintDeserialize(const char*& data, const char* end, i64& value) {
+    return ReadPackedLong(data, end, value);
+}
+
+bool VarintDeserialize(const char*& data, const char* end, ui64& value) {
+    i64 tmp = 0;
+    if (!VarintDeserialize(data, end, tmp)) {
+        return false;
+    }
     value = tmp;
+    return true;
 }
 
 template<typename TMsg>
@@ -132,21 +151,24 @@ struct TItemDeserializer<TSnapshotMessage> {
     ui64 LastWriteTimestampDelta = 0;
 
     bool Deserialize(const char*& data, const char* end, TSnapshotMessage& msg) {
-        if (data == end) {
+        if (data + sizeof(TSnapshotMessage::Common.Value) > end) {
             return false;
         }
-        AFL_ENSURE(data < end)("d", std::distance(end, data));
 
         memcpy(&msg.Common.Value, data, sizeof(TSnapshotMessage::Common.Value));  // TODO BIGENDIAN/LOWENDIAN
         data += sizeof(TSnapshotMessage::Common.Value);
 
         ui64 delta;
-        VarintDeserialize(data, delta);
+        if (!VarintDeserialize(data, end, delta)) {
+            return false;
+        }
         LastWriteTimestampDelta += delta;
         msg.WriteTimestampDelta = LastWriteTimestampDelta;
 
         if (msg.Common.Fields.Status == static_cast<ui32>(TStorage::EMessageStatus::Locked)) {
-            VarintDeserialize(data, msg.LockingTimestampMilliSecondsDelta);
+            if (!VarintDeserialize(data, end, msg.LockingTimestampMilliSecondsDelta)) {
+                return false;
+            }
         }
 
         return true;
@@ -169,7 +191,7 @@ struct TItemDeserializer<TAddedMessage> {
     ui64 LastWriteTimestampDelta = 0;
 
     bool Deserialize(const char*& data, const char* end, TAddedMessage& msg) {
-        if (data + sizeof(msg.MessageGroup.Value) + 1 > end) {
+        if (data + sizeof(msg.MessageGroup.Value) > end) {
             return false;
         }
 
@@ -177,7 +199,9 @@ struct TItemDeserializer<TAddedMessage> {
         data += sizeof(msg.MessageGroup.Value);
 
         ui64 delta;
-        VarintDeserialize(data, delta);
+        if (!VarintDeserialize(data, end, delta)) {
+            return false;
+        }
         LastWriteTimestampDelta += delta;
         msg.WriteTimestampDelta = LastWriteTimestampDelta;
 
@@ -198,15 +222,16 @@ struct TItemSerializer<TMessageChange> {
 template<>
 struct TItemDeserializer<TMessageChange> {
     bool Deserialize(const char*& data, const char* end, TMessageChange& msg) {
-        if (data == end) {
+        if (data + sizeof(TMessageChange::Common.Value) > end) {
             return false;
         }
-        AFL_ENSURE(data < end)("d", std::distance(end, data));
 
         memcpy(&msg.Common.Value, data, sizeof(TMessageChange::Common.Value));  // TODO BIGENDIAN/LOWENDIAN
         data += sizeof(TMessageChange::Common.Value);
         if (msg.Common.Fields.Status == static_cast<ui32>(TStorage::EMessageStatus::Locked)) {
-            VarintDeserialize(data, msg.LockingTimestampMilliSecondsDelta);
+            if (!VarintDeserialize(data, end, msg.LockingTimestampMilliSecondsDelta)) {
+                return false;
+            }
         }
 
         return true;
@@ -230,14 +255,14 @@ struct TItemDeserializer<TDLQMessageV1> {
     ui64 LastSeqNo = 0;
 
     bool Deserialize(const char*& data, const char* end, TDLQMessageV1& msg) {
-        if (data + 2 > end) {
+        if (!VarintDeserialize(data, end, msg.Offset)) {
             return false;
         }
 
-        VarintDeserialize(data, msg.Offset);
-
         ui64 delta;
-        VarintDeserialize(data, delta);
+        if (!VarintDeserialize(data, end, delta)) {
+            return false;
+        }
         LastSeqNo += delta;
         msg.SeqNo = LastSeqNo;
 
@@ -312,7 +337,9 @@ struct TDeserializerWithOffset {
         }
 
         ui64 delta;
-        VarintDeserialize(Data, delta);
+        if (!VarintDeserialize(Data, End, delta)) {
+            return false;
+        }
         LastOffset += delta;
         offset = LastOffset;
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/ut/mlp_storage_ut.cpp
@@ -280,6 +280,52 @@ struct TUtils {
     }
 };
 
+Y_UNIT_TEST(InitializeIgnoresTruncatedSlowMessages) {
+    TStorage storage(CreateDefaultTimeProvider(), {.MinMessages = 1, .MaxMessages = 8});
+    NKikimrPQ::TMLPStorageSnapshot snapshot;
+    snapshot.SetFormatVersion(1);
+    snapshot.SetSlowMessages(TString(1, '\xff'));
+    UNIT_ASSERT(storage.Initialize(snapshot));
+}
+
+Y_UNIT_TEST(InitializeIgnoresTruncatedDlqAndPartialSlowVarint) {
+    {
+        TStorage storage(CreateDefaultTimeProvider(), {.MinMessages = 1, .MaxMessages = 8});
+        NKikimrPQ::TMLPStorageSnapshot snapshot;
+        snapshot.SetFormatVersion(1);
+        snapshot.SetDLQMessages(TString(1, '\xff'));
+        UNIT_ASSERT(storage.Initialize(snapshot));
+        UNIT_ASSERT(storage.GetDLQMessages().empty());
+    }
+    {
+        TStorage storage(CreateDefaultTimeProvider(), {.MinMessages = 1, .MaxMessages = 8});
+        NKikimrPQ::TMLPStorageSnapshot snapshot;
+        snapshot.SetFormatVersion(1);
+        snapshot.SetSlowMessages(TString(8, '\0') + '\xff');
+        UNIT_ASSERT(storage.Initialize(snapshot));
+    }
+}
+
+Y_UNIT_TEST(ApplyWALIgnoresTruncatedAddedAndChangedMessages) {
+    TStorage storage(CreateDefaultTimeProvider(), {.MinMessages = 1, .MaxMessages = 8});
+    NKikimrPQ::TMLPStorageSnapshot snapshot;
+    snapshot.SetFormatVersion(1);
+    UNIT_ASSERT(storage.Initialize(snapshot));
+
+    {
+        NKikimrPQ::TMLPStorageWAL wal;
+        wal.SetFormatVersion(1);
+        wal.SetAddedMessages(TString(1, '\xff'));
+        UNIT_ASSERT(storage.ApplyWAL(wal));
+    }
+    {
+        NKikimrPQ::TMLPStorageWAL wal;
+        wal.SetFormatVersion(1);
+        wal.SetChangedMessages(TString(1, '\xff'));
+        UNIT_ASSERT(storage.ApplyWAL(wal));
+    }
+}
+
 Y_UNIT_TEST(NextFromEmptyStorage) {
     TStorage storage(CreateDefaultTimeProvider(), {});
 

--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
@@ -355,7 +355,8 @@ private:
                 Header.MaxTimestamp = timestamp;
             }
         } else {
-            Header.LastOffsetDelta = offset - Header.BaseOffset;
+            Header.LastOffsetDelta = static_cast<TKafkaInt32>(
+                WrapSubI64(offset, Header.BaseOffset));
             if (Magic >= 1) {
                 Header.MaxTimestamp = Max(Header.MaxTimestamp, timestamp);
             }

--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
@@ -24,6 +24,11 @@ static constexpr size_t RecordBatchCrcOffset =
 static constexpr size_t RecordBatchCrcBodyOffset =
     RecordBatchCrcOffset + sizeof(TKafkaRecordBatch::CrcMeta::Type);
 
+// Same bit pattern as Java `long` + / - (two's complement wrap).
+i64 WrapAddI64(i64 a, i64 b) {
+    return static_cast<i64>(static_cast<ui64>(a) + static_cast<ui64>(b));
+}
+
 TBuffer TakeRecordBatchBody(TKafkaReadable& readable, TKafkaInt32 batchLength) {
     if (batchLength < 0) {
         ythrow yexception() << "invalid Kafka record batch length " << batchLength;
@@ -1087,6 +1092,10 @@ ui64 GetRecordSeqNo(const TKafkaRecordBatch& batch, size_t recordIndex, const TK
             % (static_cast<ui64>(std::numeric_limits<i32>::max()) + 1);
     }
     return static_cast<ui64>(batch.BaseOffset) + record.OffsetDelta;
+}
+
+i64 GetRecordTimestamp(i64 baseTimestamp, i64 timestampDelta) {
+    return WrapAddI64(baseTimestamp, timestampDelta);
 }
 
 } // namespace NKafka

--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_records.cpp
@@ -29,6 +29,42 @@ i64 WrapAddI64(i64 a, i64 b) {
     return static_cast<i64>(static_cast<ui64>(a) + static_cast<ui64>(b));
 }
 
+i64 WrapSubI64(i64 a, i64 b) {
+    return static_cast<i64>(static_cast<ui64>(a) - static_cast<ui64>(b));
+}
+
+// Mirrors AbstractLegacyRecordBatch.DeepRecordsIterator (Apache Kafka).
+i64 LegacyAbsoluteBaseOffset(
+    TKafkaVersion magic,
+    i64 wrapperOffset,
+    const std::vector<TKafkaRecordBatchV0>& entries)
+{
+    if (entries.empty()) {
+        ythrow yexception() << "Found invalid compressed record set with no inner records";
+    }
+    if (magic != 1) {
+        return 0;
+    }
+    // Outer offset 0 is produce data from some librdkafka versions.
+    if (wrapperOffset == 0) {
+        return 0;
+    }
+    const i64 lastInnerOffset = entries.back().Offset;
+    if (wrapperOffset < lastInnerOffset) {
+        ythrow yexception() << "Found invalid wrapper offset in compressed v1 message set, wrapper offset '"
+            << wrapperOffset << "' is less than the last inner message offset '" << lastInnerOffset
+            << "' and it is not zero.";
+    }
+    return WrapSubI64(wrapperOffset, lastInnerOffset);
+}
+
+i64 LegacyRecordOffset(TKafkaVersion magic, i64 absoluteBaseOffset, i64 entryOffset) {
+    if (magic != 1) {
+        return entryOffset;
+    }
+    return WrapAddI64(absoluteBaseOffset, entryOffset);
+}
+
 TBuffer TakeRecordBatchBody(TKafkaReadable& readable, TKafkaInt32 batchLength) {
     if (batchLength < 0) {
         ythrow yexception() << "invalid Kafka record batch length " << batchLength;
@@ -211,18 +247,9 @@ void AppendLegacyRecords(
     i64 wrapperOffset = 0,
     std::optional<i64> wrapperTimestamp = std::nullopt)
 {
-    if (entries.empty()) {
-        return;
-    }
-
-    i64 absoluteBaseOffset = 0;
-    if (magic == 1) {
-        absoluteBaseOffset = wrapperOffset == 0 ? 0 : wrapperOffset - entries.back().Offset;
-    }
-
+    const i64 absoluteBaseOffset = LegacyAbsoluteBaseOffset(magic, wrapperOffset, entries);
     for (const auto& entry : entries) {
-        const i64 offset = magic == 1 ? absoluteBaseOffset + entry.Offset : entry.Offset;
-        AppendLegacyRecord(batch, entry, offset, wrapperTimestamp);
+        AppendLegacyRecord(batch, entry, LegacyRecordOffset(magic, absoluteBaseOffset, entry.Offset), wrapperTimestamp);
     }
 }
 
@@ -308,18 +335,13 @@ struct TLegacyHeaderConsumer {
             ? std::optional<i64>(entry.Record.Timestamp)
             : std::nullopt;
 
-        i64 absoluteBaseOffset = 0;
-        if (Magic == 1) {
-            absoluteBaseOffset = entry.Offset == 0 ? 0 : entry.Offset - innerEntries.back().Offset;
-        }
-
+        const i64 absoluteBaseOffset = LegacyAbsoluteBaseOffset(Magic, entry.Offset, innerEntries);
         for (const auto& innerEntry : innerEntries) {
-            const i64 offset = Magic == 1
-                ? absoluteBaseOffset + innerEntry.Offset
-                : innerEntry.Offset;
             const i64 timestamp = wrapperTimestamp.value_or(
                 Magic >= 1 ? innerEntry.Record.Timestamp : 0);
-            AppendHeaderRecord(offset, timestamp);
+            AppendHeaderRecord(
+                LegacyRecordOffset(Magic, absoluteBaseOffset, innerEntry.Offset),
+                timestamp);
         }
     }
 

--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_records.h
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_records.h
@@ -687,5 +687,7 @@ TString WriteKafkaRecordBatch(const TKafkaRecordBatch& batch, TKafkaVersion vers
 std::pair<EKafkaErrors, ui64> GetBatchBaseSeqNo(const TKafkaBatchHeader& header);
 std::pair<EKafkaErrors, ui64> GetBatchMaxSeqNo(const TKafkaBatchHeader& header, ui64 baseSeqNo);
 ui64 GetRecordSeqNo(const TKafkaRecordBatch& batch, size_t recordIndex, const TKafkaRecord& record);
+// Java `long` wrap: baseTimestamp + timestampDelta (C++20 two's-complement).
+i64 GetRecordTimestamp(i64 baseTimestamp, i64 timestampDelta);
 
 } // namespace NKafka

--- a/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
@@ -829,6 +829,20 @@ Y_UNIT_TEST_SUITE(KafkaRecords) {
             yexception,
             "Found invalid wrapper offset in compressed v1 message set");
     }
+
+    Y_UNIT_TEST(ReadLegacyHeaderWrapsLastOffsetDeltaLikeJavaInt) {
+        TOwnedLegacyRecord first(0, 1000, "k0", "v0");
+        TOwnedLegacyRecord second(3'000'000'000LL, 1001, "k1", "v1");
+        const TString bytes = WriteKafkaLegacyRecordBatchWrappers({first.Entry, second.Entry}, 1);
+
+        const auto header = ReadKafkaBatchHeader(bytes);
+        UNIT_ASSERT(header);
+        UNIT_ASSERT_VALUES_EQUAL(header->RecordsCount, 2);
+        UNIT_ASSERT_VALUES_EQUAL(header->BaseOffset, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            header->LastOffsetDelta,
+            static_cast<i32>(static_cast<ui32>(3'000'000'000LL)));
+    }
 }
 
 } // namespace

--- a/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
@@ -4,6 +4,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/ylimits.h>
+
 namespace NKafka {
 namespace {
 
@@ -696,6 +698,15 @@ Y_UNIT_TEST_SUITE(KafkaRecords) {
 
         UNIT_ASSERT_VALUES_EQUAL(parsed.BatchLength, expectedBatchLength);
         UNIT_ASSERT_VALUES_EQUAL(parsed.Records.size(), batch.Records.size());
+    }
+
+    Y_UNIT_TEST(GetRecordTimestampWrapsLikeJavaLong) {
+        UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(100, 5), 105);
+        UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(Max<i64>(), 0), Max<i64>());
+        UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(Min<i64>(), 0), Min<i64>());
+        UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(100, -100), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(Max<i64>(), 1), Min<i64>());
+        UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(Min<i64>(), -1), Max<i64>());
     }
 }
 

--- a/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_records_ut.cpp
@@ -5,6 +5,10 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/ylimits.h>
+#include <util/stream/str.h>
+#include <util/stream/zlib.h>
+
+#include <vector>
 
 namespace NKafka {
 namespace {
@@ -380,6 +384,65 @@ TString WriteKafkaLegacyRecordBatchWrappers(const std::vector<TKafkaRecordBatchV
     return buffer.AsString();
 }
 
+TString GzipPayload(TStringBuf data) {
+    TString compressed;
+    TStringOutput output(compressed);
+    TZLibCompress gzip(&output, ZLib::GZip);
+    if (!data.empty()) {
+        gzip.Write(data.data(), data.size());
+    }
+    gzip.Finish();
+    output.Finish();
+    return compressed;
+}
+
+struct TOwnedLegacyRecord {
+    TString KeyStorage;
+    TString ValueStorage;
+    TKafkaRecordBatchV0 Entry;
+
+    TOwnedLegacyRecord(
+        i64 offset,
+        i64 timestamp,
+        TString key,
+        TString value,
+        ECompressionType compression = ECompressionType::NONE,
+        bool nullKey = false)
+        : KeyStorage(std::move(key))
+        , ValueStorage(std::move(value))
+    {
+        Entry.Offset = offset;
+        Entry.Record.Magic = 1;
+        Entry.Record.Attributes = static_cast<TKafkaRecordV0::AttributesMeta::Type>(compression);
+        Entry.Record.Timestamp = timestamp;
+        if (nullKey) {
+            Entry.Record.Key = std::nullopt;
+        } else {
+            Entry.Record.Key = TKafkaRawBytes(KeyStorage.data(), KeyStorage.size());
+        }
+        Entry.Record.Value = TKafkaRawBytes(ValueStorage.data(), ValueStorage.size());
+        Entry.Record.MessageSize = Entry.Record.Size(1)
+            - sizeof(TKafkaRecordV0::MessageSizeMeta::Type);
+    }
+};
+
+TString WriteCompressedMagic1Wrapper(i64 wrapperOffset, std::vector<TOwnedLegacyRecord>& inners) {
+    std::vector<TKafkaRecordBatchV0> innerEntries;
+    innerEntries.reserve(inners.size());
+    for (auto& inner : inners) {
+        innerEntries.push_back(inner.Entry);
+    }
+
+    TOwnedLegacyRecord wrapper(
+        wrapperOffset,
+        1000,
+        {},
+        GzipPayload(WriteKafkaLegacyRecordBatchWrappers(innerEntries, 1)),
+        ECompressionType::GZIP,
+        true);
+    return WriteKafkaLegacyRecordBatchWrappers({wrapper.Entry}, 1);
+}
+
 void AssertKafkaLegacyProducerBatchDeserialized(
     TKafkaVersion magic,
     ECompressionType compressionType,
@@ -707,6 +770,64 @@ Y_UNIT_TEST_SUITE(KafkaRecords) {
         UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(100, -100), 0);
         UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(Max<i64>(), 1), Min<i64>());
         UNIT_ASSERT_VALUES_EQUAL(GetRecordTimestamp(Min<i64>(), -1), Max<i64>());
+    }
+
+    Y_UNIT_TEST(ReadKafkaBatchHeaderRejectsEmptyCompressedLegacy) {
+        TString compressed;
+        {
+            TStringOutput output(compressed);
+            TZLibCompress gzip(&output, ZLib::GZip);
+            gzip.Finish();
+            output.Finish();
+        }
+
+        TKafkaRecordBatchV0 entry;
+        entry.Offset = 1;
+        entry.Record.Magic = 1;
+        entry.Record.Attributes = static_cast<TKafkaRecordV0::AttributesMeta::Type>(ECompressionType::GZIP);
+        entry.Record.Timestamp = 1000;
+        entry.Record.Value = TKafkaRawBytes(compressed.data(), compressed.size());
+        entry.Record.MessageSize = entry.Record.Size(1)
+            - sizeof(TKafkaRecordV0::MessageSizeMeta::Type);
+
+        TKafkaWriteBuffer buffer(BUFFER_SIZE);
+        TKafkaWritable writable(buffer);
+        entry.Write(writable, 1);
+
+        const TString bytes = buffer.AsString();
+        UNIT_ASSERT(!ReadKafkaBatchHeader(bytes));
+        UNIT_ASSERT_EXCEPTION(ReadRecordBatch(bytes), yexception);
+    }
+
+    Y_UNIT_TEST(ReadCompressedMagic1TreatsZeroWrapperOffsetAsLibrdkafka) {
+        std::vector<TOwnedLegacyRecord> inners;
+        inners.emplace_back(5, 1000, "k0", "v0");
+        inners.emplace_back(6, 1001, "k1", "v1");
+        const TString bytes = WriteCompressedMagic1Wrapper(0, inners);
+
+        const TKafkaRecordBatch parsed = ReadKafkaLegacyProducerBatch(bytes, 1);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Records.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Records[0].OffsetDelta, 5);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Records[1].OffsetDelta, 6);
+
+        const auto header = ReadKafkaBatchHeader(bytes);
+        UNIT_ASSERT(header);
+        UNIT_ASSERT_VALUES_EQUAL(header->RecordsCount, 2);
+        UNIT_ASSERT_VALUES_EQUAL(header->BaseOffset, 5);
+        UNIT_ASSERT_VALUES_EQUAL(header->LastOffsetDelta, 1);
+    }
+
+    Y_UNIT_TEST(ReadCompressedMagic1RejectsWrapperOffsetLessThanLastInner) {
+        std::vector<TOwnedLegacyRecord> inners;
+        inners.emplace_back(8, 1000, "k0", "v0");
+        inners.emplace_back(10, 1001, "k1", "v1");
+        const TString bytes = WriteCompressedMagic1Wrapper(1, inners);
+
+        UNIT_ASSERT(!ReadKafkaBatchHeader(bytes));
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            ReadKafkaLegacyProducerBatch(bytes, 1),
+            yexception,
+            "Found invalid wrapper offset in compressed v1 message set");
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Topics: fix undefined behavior in Kafka timestamp/offset arithmetic, truncated MLP snapshot/WAL decode, and PQ blob packed-integer codecs.

### Description for reviewers <!-- (optional) description for those who read this PR -->

C++ UB in topics code. Kafka-facing arithmetic matches Apache Kafka wrap/throw behavior (Java `long` / `int`, `DeepRecordsIterator`). YMQ `CloseImpl` from destructor (#48382) is out of scope.

1. **Kafka timestamps** — `baseTimestamp + timestampDelta` was a signed `i64` add. Kafka `DefaultRecord` wraps like Java `long`. `GetRecordTimestamp` adds through `ui64` (C++20 two's-complement). Produce still maps timestamp 0 to `Now()`; the cutter still omits `CreateTimestampMS` when the wrapped value is not positive.
2. **Compressed Kafka v0/v1 batches** — empty inner sets skipped records on produce and called `vector::back()` on the header path. Kafka throws `InvalidRecordException` ("Found invalid compressed record set with no inner records"). Magic-1 wrapper offsets: magic 0 keeps inner offsets; wrapper 0 is the librdkafka special case; wrapper < last inner throws; otherwise wrap like Java `long`.
3. **`LastOffsetDelta`** — `offset - BaseOffset` stored in `TKafkaInt32` overflowed. Kafka uses `(int)(offset - baseOffset)`. Subtract through `ui64`, then narrow.
4. **MLP snapshot/WAL** — `in_long` / `memcpy` ran before a length check. Truncated payloads could read past the buffer. Copy at most 9 packed bytes onto the stack and skip the truncated item.
5. **PQ blob packed ints** — `TVarIntValueDecoder` / `TZigZagValueDecoder` passed the blob cursor to `in_long` (up to 9 bytes). Copy onto the stack first; `AFL_ENSURE` still aborts on a corrupt length.
6. **PQ blob deltas** — `TDeltaValueDecoder` did signed `Last +/- delta`. Wrap through unsigned arithmetic.

**Tests**
- [x] `ydb/public/sdk/cpp/src/library/kafka/ut` — timestamp wrap, empty compressed legacy, magic-1 wrapper offsets, `LastOffsetDelta` as Java `int`
- [x] `ydb/core/persqueue/pqtablet/batching/ut` — cutter wrap / negative delta
- [x] `ydb/core/persqueue/pqtablet/partition/mlp/ut` — truncated snapshot/WAL
- [x] `ydb/core/persqueue/pqtablet/blob/ut` — packed i64 decode, zigzag delta wrap
