### PR TITLE
[nbs2] fix releasing of owned transport actor

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
@@ -597,6 +597,33 @@ Y_UNIT_TEST_SUITE(TICDirectStorageTransportTest)
         WaitFuture(executor, readB2Future, WaitTimeout);
         UNIT_ASSERT_VALUES_EQUAL(writeB, readB2);
     }
+
+    Y_UNIT_TEST_F(DestroysOwnedActorAndRejectsPendingConnect, TDBGFixture)
+    {
+        auto transport =
+            std::make_unique<TICStorageTransportTestAdapter>(Runtime.get());
+        const TActorId transportActorId = transport->GetTransportActorId();
+        const auto& ddiskId = transport->GetDDiskIds()[0];
+
+        transport->SetPendingConnect(EConnectionType::DDisk, ddiskId);
+        auto connect = transport->Connect(MakeDDiskConnection(ddiskId));
+        DrainRuntime();
+
+        UNIT_ASSERT(Runtime->FindActor(transportActorId));
+        UNIT_ASSERT(!connect.ConnectFuture.HasValue());
+
+        transport.reset();
+        DrainRuntime();
+
+        UNIT_ASSERT(!Runtime->FindActor(transportActorId));
+        UNIT_ASSERT(connect.ConnectFuture.HasValue());
+        UNIT_ASSERT(
+            connect.ConnectFuture.GetValueSync().GetStatus() ==
+            NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            DestroyErrorMessage,
+            connect.ConnectFuture.GetValueSync().GetErrorReason());
+    }
 }
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -120,10 +120,10 @@ NKikimrBlockStore::TVolumeConfig CreateVolumeConfig(ui64 blockCount)
     return volumeConfig;
 }
 
-void WaitForTabletBoot(TEnvironmentSetup& env)
+TActorId WaitForTabletBoot(TEnvironmentSetup& env)
 {
     // Create tablet like in SetupTablet()
-    env.Runtime->CreateTestBootstrapper(
+    const TActorId bootstrapperId = env.Runtime->CreateTestBootstrapper(
         TTestActorSystem::CreateTestTabletInfo(
             PartitionTabletId,
             TTabletTypes::Unknown,
@@ -140,11 +140,19 @@ void WaitForTabletBoot(TEnvironmentSetup& env)
         [&] { return working; },
         [&](IEventHandle& event)
         { working = event.GetTypeRewrite() != TEvTablet::EvBoot; });
+
+    return bootstrapperId;
 }
 
-ui64 CreatePartitionTablet(TEnvironmentSetup& env, ui64 blockCount = 32768)
+ui64 CreatePartitionTablet(
+    TEnvironmentSetup& env,
+    ui64 blockCount = 32768,
+    TActorId* outBootstrapperId = nullptr)
 {
-    WaitForTabletBoot(env);
+    const TActorId createdBootstrapperId = WaitForTabletBoot(env);
+    if (outBootstrapperId) {
+        *outBootstrapperId = createdBootstrapperId;
+    }
 
     // Send volume config update
     auto volumeConfig = CreateVolumeConfig(blockCount);
@@ -1579,7 +1587,9 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         auto& runtime = env.Runtime;
 
         auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
-        const ui64 tabletId = CreatePartitionTablet(env);
+        TActorId bootstrapperId;
+        const ui64 tabletId =
+            CreatePartitionTablet(env, 32768, &bootstrapperId);
 
         const TActorId edge = runtime->AllocateEdgeActor(
             env.Settings.ControllerNodeId,
@@ -1587,13 +1597,35 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
             __LINE__);
 
         // Observe the tablet death via TEvTabletDead.
-        bool tabletDead = false;
+        bool bootstrapperDeathObserved = false;
+        bool partitionDeathDelivered = false;
+        const auto isExpectedTabletDeath = [&](IEventHandle& ev)
+        {
+            if (ev.GetTypeRewrite() != TEvTablet::TEvTabletDead::EventType) {
+                return false;
+            }
+
+            const auto* msg = ev.Get<TEvTablet::TEvTabletDead>();
+            if (msg->TabletID != tabletId) {
+                return false;
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                TEvTablet::TEvTabletDead::ReasonPill,
+                msg->Reason);
+            return true;
+        };
         runtime->FilterFunction =
             [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev)
         {
             Y_UNUSED(nodeId);
-            if (ev->GetTypeRewrite() == TEvTablet::TEvTabletDead::EventType) {
-                tabletDead = true;
+            if (isExpectedTabletDeath(*ev) &&
+                ev->GetRecipientRewrite() == bootstrapperId)
+            {
+                bootstrapperDeathObserved = true;
+                // Do not let the bootstrapper start a new tablet incarnation:
+                // this test only verifies that the current one dies.
+                return false;
             }
             if (ev->GetRecipientRewrite() == edge) {
                 return false;
@@ -1609,9 +1641,20 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
             0,
             TTestActorSystem::GetPipeConfigWithRetries());
 
-        env.Sim(TDuration::Seconds(1));
+        runtime->Sim(
+            [&]
+            { return !bootstrapperDeathObserved || !partitionDeathDelivered; },
+            [&](IEventHandle& ev)
+            {
+                if (isExpectedTabletDeath(ev) &&
+                    ev.GetRecipientRewrite() != bootstrapperId)
+                {
+                    partitionDeathDelivered = true;
+                }
+            });
 
-        UNIT_ASSERT(tabletDead);
+        UNIT_ASSERT(bootstrapperDeathObserved);
+        UNIT_ASSERT(partitionDeathDelivered);
     }
 
     Y_UNIT_TEST(ShouldKeepOtherDBGConnectionsWhenAddingHosts)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
@@ -16,6 +16,13 @@ TICStorageTransport::TICStorageTransport(
     , ICStorageTransportActorId(icStorageTransportActorId)
 {}
 
+TICStorageTransport::~TICStorageTransport()
+{
+    ActorSystem->Send(
+        ICStorageTransportActorId,
+        std::make_unique<NActors::TEvents::TEvPoisonPill>().release());
+}
+
 IStorageTransport::TConnectResultFutures TICStorageTransport::Connect(
     const THostConnection& connection)
 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
@@ -9,11 +9,17 @@ namespace NYdb::NBS::NBlockStore::NStorage::NTransport {
 class TICStorageTransport: public IStorageTransport
 {
 public:
+    // Owns icStorageTransportActorId. actorSystem must outlive this object.
     TICStorageTransport(
         NActors::TActorSystem* actorSystem,
         NActors::TActorId icStorageTransportActorId);
 
-    ~TICStorageTransport() override = default;
+    ~TICStorageTransport() override;
+
+    TICStorageTransport(const TICStorageTransport&) = delete;
+    TICStorageTransport& operator=(const TICStorageTransport&) = delete;
+    TICStorageTransport(TICStorageTransport&&) = delete;
+    TICStorageTransport& operator=(TICStorageTransport&&) = delete;
 
     TConnectResultFutures Connect(const THostConnection& connection) override;
 
@@ -87,6 +93,7 @@ protected:
 private:
     using EConnectionType = THostConnection::EConnectionType;
 
+    // Owned actor: stopped with TEvPoisonPill in the destructor.
     const NActors::TActorId ICStorageTransportActorId;
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/ic_storage_transport_test_adapter.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/ic_storage_transport_test_adapter.h
@@ -48,6 +48,11 @@ public:
         return NodeId;
     }
 
+    [[nodiscard]] NActors::TActorId GetTransportActorId() const
+    {
+        return TransportActorId;
+    }
+
     // Inject a TFakeDirectSession for NodeId so datapath uses IDirectSession.
     void EnableFakeDirectSession();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
TICStorageTransport, владеющий TICStorageTransportActor, не уничтожает его при своем завершении. 
* Исправлено данное поведение
* исправлен флапающий на связанном сценарии тест
* дописан новый тест
...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
