### PR TITLE
Add @ydb-platform/entbuilders to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-* @ydb-platform/ReleaseApprovers
-/.github @ydb-platform/ci
-/.github/workflows/docs_* @ydb-platform/docs
-/.github/workflows/ydbdoc-* @ydb-platform/docs     
-/CHANGELOG.md @ydb-platform/changelog-reviewers
-/ydb/docs/ @ydb-platform/docs
+* @ydb-platform/ReleaseApprovers @ydb-platform/entbuilders
+/.github @ydb-platform/ci @ydb-platform/entbuilders
+/.github/workflows/docs_* @ydb-platform/docs @ydb-platform/entbuilders
+/.github/workflows/ydbdoc-* @ydb-platform/docs @ydb-platform/entbuilders
+/CHANGELOG.md @ydb-platform/changelog-reviewers @ydb-platform/entbuilders
+/ydb/docs/ @ydb-platform/docs @ydb-platform/entbuilders


### PR DESCRIPTION
Backport enterprise CODEOWNERS settings to `stable-26-3-1-ent`.

Original enterprise PR: https://github.com/ydb-platform/ydb/pull/50289

Original commit: https://github.com/ydb-platform/ydb/commit/9eb10a7bf8ed4b0227858dee4ec6555a4fea9aee

## What changed

- Added `@ydb-platform/entbuilders` to the CODEOWNERS rules used by enterprise release branches.

## Verification

- `git diff --check`
- Verified that the change only touches `.github/CODEOWNERS`.
- Verified preserved authorship and the `cherry picked from` source marker.

## Enterprise delta check

The other five enterprise topics from `stable-26-2-1-ent` are already present in `stable-26-3-1` by content. This is the only missing change found in the `26.2-ent → 26.3` comparison.
