### PR TITLE
fast ilike has been supported

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -73,7 +73,7 @@ PEERDIR(
     yql/essentials/udfs/common/set
     yql/essentials/udfs/common/stat
     yql/essentials/udfs/common/string
-    ydb/core/formats/arrow/program/string_fast
+    ydb/core/formats/arrow/program/olap_kernels
     yql/essentials/udfs/common/top
     yql/essentials/udfs/common/topfreq
     yql/essentials/udfs/common/unicode_base

--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -73,6 +73,7 @@ PEERDIR(
     yql/essentials/udfs/common/set
     yql/essentials/udfs/common/stat
     yql/essentials/udfs/common/string
+    ydb/core/formats/arrow/program/string_fast
     yql/essentials/udfs/common/top
     yql/essentials/udfs/common/topfreq
     yql/essentials/udfs/common/unicode_base

--- a/ydb/core/formats/arrow/program/ascii_contains/ascii_contains.cpp
+++ b/ydb/core/formats/arrow/program/ascii_contains/ascii_contains.cpp
@@ -1,0 +1,87 @@
+#include "ascii_contains.h"
+
+#include <util/string/ascii.h>
+#include <util/system/compiler.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace NKikimr::NArrow::NSSA {
+namespace {
+
+constexpr size_t MemchrMinHaystack = 32;
+
+bool IgnoreCaseEquals(char a, char b) noexcept {
+    return AsciiToUpper(a) == AsciiToUpper(b);
+}
+
+bool AsciiContainsIgnoreCaseScalar(const TStringBuf haystack, const TStringBuf needle) noexcept {
+    return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), IgnoreCaseEquals) != haystack.end();
+}
+
+const char* FindFirstIgnoreCaseChar(const char* begin, const char* end, const char lo, const char up) noexcept {
+    const size_t len = static_cast<size_t>(end - begin);
+    if (len == 0) {
+        return nullptr;
+    }
+    if (lo == up) {
+        return static_cast<const char*>(std::memchr(begin, lo, len));
+    }
+
+    const char* pLo = static_cast<const char*>(std::memchr(begin, lo, len));
+    if (pLo == begin) {
+        return pLo;
+    }
+    if (pLo) {
+        const char* pUp = static_cast<const char*>(std::memchr(begin, up, static_cast<size_t>(pLo - begin)));
+        return pUp ? pUp : pLo;
+    }
+    return static_cast<const char*>(std::memchr(begin, up, len));
+}
+
+} // namespace
+
+bool AsciiContainsIgnoreCaseMemchr(const TStringBuf haystack, const TStringBuf needle) noexcept {
+    const size_t m = needle.size();
+    if (Y_UNLIKELY(m == 0)) {
+        return true;
+    }
+
+    const size_t n = haystack.size();
+    if (m > n) {
+        return false;
+    }
+
+    if (n <= MemchrMinHaystack) {
+        return AsciiContainsIgnoreCaseScalar(haystack, needle);
+    }
+
+    const char* const hay = haystack.data();
+    const char* const nee = needle.data();
+    const char* const last = hay + (n - m) + 1; // exclusive end of valid start positions
+    const char lo = AsciiToLower(nee[0]);
+    const char up = AsciiToUpper(nee[0]);
+
+    const char* p = hay;
+    while (p < last) {
+        const char* candidate = FindFirstIgnoreCaseChar(p, last, lo, up);
+        if (!candidate) {
+            return false;
+        }
+
+        bool match = true;
+        for (size_t i = 1; i < m; ++i) {
+            if (AsciiToUpper(candidate[i]) != AsciiToUpper(nee[i])) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            return true;
+        }
+        p = candidate + 1;
+    }
+    return false;
+}
+
+} // namespace NKikimr::NArrow::NSSA

--- a/ydb/core/formats/arrow/program/ascii_contains/ascii_contains.h
+++ b/ydb/core/formats/arrow/program/ascii_contains/ascii_contains.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <util/generic/strbuf.h>
+
+namespace NKikimr::NArrow::NSSA {
+
+bool AsciiContainsIgnoreCaseMemchr(TStringBuf haystack, TStringBuf needle) noexcept;
+
+} // namespace NKikimr::NArrow::NSSA

--- a/ydb/core/formats/arrow/program/ascii_contains/ya.make
+++ b/ydb/core/formats/arrow/program/ascii_contains/ya.make
@@ -1,0 +1,7 @@
+LIBRARY()
+
+SRCS(
+    ascii_contains.cpp
+)
+
+END()

--- a/ydb/core/formats/arrow/program/benchmark/main.cpp
+++ b/ydb/core/formats/arrow/program/benchmark/main.cpp
@@ -1,0 +1,171 @@
+#include <ydb/core/formats/arrow/program/ascii_contains/ascii_contains.h>
+
+#include <benchmark/benchmark.h>
+
+#include <util/generic/string.h>
+#include <util/generic/strbuf.h>
+#include <util/generic/vector.h>
+#include <util/generic/yexception.h>
+#include <util/random/random.h>
+#include <util/string/ascii.h>
+
+#include <algorithm>
+
+using NKikimr::NArrow::NSSA::AsciiContainsIgnoreCaseMemchr;
+
+namespace {
+
+bool IgnoreCaseComparator(char a, char b) {
+    return AsciiToUpper(a) == AsciiToUpper(b);
+}
+
+// Same algorithm the String._yql_AsciiContainsIgnoreCase UDF used before the Memchr kernel.
+bool AsciiContainsIgnoreCaseScalar(const TStringBuf haystack, const TStringBuf needle) noexcept {
+    if (needle.empty()) {
+        return true;
+    }
+    return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), IgnoreCaseComparator) != haystack.end();
+}
+
+TString MakeNoMatchHaystack(size_t n) {
+    SetRandomSeed(n * 2654435761ull + 1);
+    TString s;
+    s.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        s.push_back('a' + RandomNumber<unsigned char>(25)); // 'a'..'y'
+    }
+    return s;
+}
+
+TString MakeNeedle(size_t n, bool upperCase) {
+    static const TStringBuf pattern = "needlepatternforbenchmarkingcontains";
+    TString s;
+    s.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        s.push_back(pattern[i % pattern.size()]);
+    }
+    if (upperCase) {
+        for (char& c : s) {
+            c = AsciiToUpper(c);
+        }
+    }
+    return s;
+}
+
+TString MakeMatchAtEndHaystack(size_t n, const TStringBuf needle) {
+    if (n < needle.size()) {
+        return MakeNoMatchHaystack(n);
+    }
+    TString s = MakeNoMatchHaystack(n - needle.size());
+    s += needle;
+    return s;
+}
+
+constexpr size_t kCorpusSize = 15000;
+constexpr size_t kMinRowLen = 100;
+constexpr size_t kMaxRowLen = 200;
+constexpr double kMatchRate = 0.05;
+
+TVector<TString> MakeCorpus(const TStringBuf plantedNeedle) {
+    SetRandomSeed(20260819);
+    TVector<TString> corpus;
+    corpus.reserve(kCorpusSize);
+    for (size_t i = 0; i < kCorpusSize; ++i) {
+        const size_t len = kMinRowLen + RandomNumber<size_t>(kMaxRowLen - kMinRowLen + 1);
+        TString s;
+        s.reserve(len);
+        for (size_t j = 0; j < len; ++j) {
+            s.push_back('a' + RandomNumber<unsigned char>(25));
+        }
+        if (len >= plantedNeedle.size() && RandomNumber<double>() < kMatchRate) {
+            const size_t pos = RandomNumber<size_t>(len - plantedNeedle.size() + 1);
+            s.replace(pos, plantedNeedle.size(), plantedNeedle);
+        }
+        corpus.push_back(std::move(s));
+    }
+    return corpus;
+}
+
+size_t CorpusBytes(const TVector<TString>& corpus) noexcept {
+    size_t total = 0;
+    for (const auto& row : corpus) {
+        total += row.size();
+    }
+    return total;
+}
+
+TString MakeRowsNeedle(size_t n) {
+    TString needle = "z";
+    needle += MakeNeedle(n - 1, /*upperCase*/ false);
+    return needle;
+}
+
+template <auto Impl>
+void BenchNoMatch(benchmark::State& state) {
+    const size_t haystackLen = state.range(0);
+    const size_t needleLen = state.range(1);
+    const TString haystack = MakeNoMatchHaystack(haystackLen);
+    const TString needle = MakeNeedle(needleLen, /*upperCase*/ true);
+    for (auto _ : state) {
+        bool found = Impl(haystack, needle);
+        benchmark::DoNotOptimize(found);
+    }
+    state.SetBytesProcessed(state.iterations() * haystack.size());
+}
+
+template <auto Impl>
+void BenchMatchAtEnd(benchmark::State& state) {
+    const size_t haystackLen = state.range(0);
+    const size_t needleLen = state.range(1);
+    const TString needle = MakeNeedle(needleLen, /*upperCase*/ true);
+    TString planted = needle;
+    for (char& c : planted) {
+        c = AsciiToLower(c);
+    }
+    const TString haystack = MakeMatchAtEndHaystack(haystackLen, planted);
+    for (auto _ : state) {
+        bool found = Impl(haystack, needle);
+        benchmark::DoNotOptimize(found);
+    }
+    state.SetBytesProcessed(state.iterations() * haystack.size());
+}
+
+template <auto Impl>
+void BenchManyRows(benchmark::State& state) {
+    const size_t needleLen = state.range(0);
+    const TString needle = MakeRowsNeedle(needleLen);
+    TString planted = needle;
+    for (char& c : planted) {
+        c = AsciiToUpper(c);
+    }
+    const TVector<TString> corpus = MakeCorpus(planted);
+    for (auto _ : state) {
+        size_t hits = 0;
+        for (const auto& row : corpus) {
+            hits += Impl(row, needle) ? 1 : 0;
+        }
+        benchmark::DoNotOptimize(hits);
+    }
+    state.SetItemsProcessed(state.iterations() * corpus.size());
+    state.SetBytesProcessed(state.iterations() * CorpusBytes(corpus));
+}
+
+} // namespace
+
+#define CONTAINS_ARGS \
+    ArgNames({"haystack", "needle"})->ArgsProduct({{8, 32, 256, 4096, 65536}, {1, 8, 32}})
+
+BENCHMARK(BenchNoMatch<AsciiContainsIgnoreCaseScalar>)->CONTAINS_ARGS;
+BENCHMARK(BenchNoMatch<AsciiContainsIgnoreCaseMemchr>)->CONTAINS_ARGS;
+
+BENCHMARK(BenchMatchAtEnd<AsciiContainsIgnoreCaseScalar>)->CONTAINS_ARGS;
+BENCHMARK(BenchMatchAtEnd<AsciiContainsIgnoreCaseMemchr>)->CONTAINS_ARGS;
+
+#undef CONTAINS_ARGS
+
+#define ROWS_ARGS ArgName("needleLen")->Arg(5)->Arg(10)->Arg(20)
+
+BENCHMARK(BenchManyRows<AsciiContainsIgnoreCaseScalar>)->ROWS_ARGS;
+BENCHMARK(BenchManyRows<AsciiContainsIgnoreCaseMemchr>)->ROWS_ARGS;
+
+#undef ROWS_ARGS

--- a/ydb/core/formats/arrow/program/benchmark/ya.make
+++ b/ydb/core/formats/arrow/program/benchmark/ya.make
@@ -1,0 +1,13 @@
+G_BENCHMARK()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/core/formats/arrow/program/ascii_contains
+)
+
+SRCS(
+    main.cpp
+)
+
+END()

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -164,17 +164,17 @@ public:
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiContainsIgnoreCase>(GetClassNameStatic());
 };
 
-class TLogicMatchStringFastAsciiContainsIgnoreCase: public TLogicMatchString {
+class TLogicMatchOlapKernelsAsciiContainsIgnoreCase: public TLogicMatchString {
 private:
     static TString GetClassNameStatic() {
-        return "StringFast._yql_AsciiContainsIgnoreCase";
+        return "OlapKernels._yql_AsciiContainsIgnoreCase";
     }
 
 public:
-    TLogicMatchStringFastAsciiContainsIgnoreCase()
+    TLogicMatchOlapKernelsAsciiContainsIgnoreCase()
         : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false) {
     }
-    static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchStringFastAsciiContainsIgnoreCase>(GetClassNameStatic());
+    static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchOlapKernelsAsciiContainsIgnoreCase>(GetClassNameStatic());
 };
 
 class TLogicMatchAsciiStartsWithIgnoreCase: public TLogicMatchString {

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -164,6 +164,19 @@ public:
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiContainsIgnoreCase>(GetClassNameStatic());
 };
 
+class TLogicMatchStringFastAsciiContainsIgnoreCase: public TLogicMatchString {
+private:
+    static TString GetClassNameStatic() {
+        return "StringFast._yql_AsciiContainsIgnoreCase";
+    }
+
+public:
+    TLogicMatchStringFastAsciiContainsIgnoreCase()
+        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false) {
+    }
+    static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchStringFastAsciiContainsIgnoreCase>(GetClassNameStatic());
+};
+
 class TLogicMatchAsciiStartsWithIgnoreCase: public TLogicMatchString {
 private:
     static TString GetClassNameStatic() {

--- a/ydb/core/formats/arrow/program/olap_kernels/olap_kernels_udf.cpp
+++ b/ydb/core/formats/arrow/program/olap_kernels/olap_kernels_udf.cpp
@@ -38,6 +38,6 @@ BEGIN_SIMPLE_STRICT_ARROW_UDF(T_yql_AsciiContainsIgnoreCase, bool(TOptional<char
 
 END_SIMPLE_ARROW_UDF(T_yql_AsciiContainsIgnoreCase, TAsciiContainsIgnoreCaseKernelExec::Do);
 
-SIMPLE_MODULE(TStringFastModule, T_yql_AsciiContainsIgnoreCase)
+SIMPLE_MODULE(TOlapKernelsModule, T_yql_AsciiContainsIgnoreCase)
 
-REGISTER_MODULES(TStringFastModule)
+REGISTER_MODULES(TOlapKernelsModule)

--- a/ydb/core/formats/arrow/program/olap_kernels/ya.make
+++ b/ydb/core/formats/arrow/program/olap_kernels/ya.make
@@ -1,4 +1,4 @@
-YQL_UDF_YDB(string_fast_udf)
+YQL_UDF_YDB(olap_kernels_udf)
 
 YQL_ABI_VERSION(
     2
@@ -7,7 +7,7 @@ YQL_ABI_VERSION(
 )
 
 SRCS(
-    string_fast_udf.cpp
+    olap_kernels_udf.cpp
 )
 
 PEERDIR(

--- a/ydb/core/formats/arrow/program/string_fast/string_fast_udf.cpp
+++ b/ydb/core/formats/arrow/program/string_fast/string_fast_udf.cpp
@@ -1,0 +1,43 @@
+#include <ydb/core/formats/arrow/program/ascii_contains/ascii_contains.h>
+
+#include <yql/essentials/public/udf/arrow/udf_arrow_helpers.h>
+#include <yql/essentials/public/udf/udf_helpers.h>
+
+using namespace NYql;
+using namespace NYql::NUdf;
+using NKikimr::NArrow::NSSA::AsciiContainsIgnoreCaseMemchr;
+
+struct TAsciiContainsIgnoreCaseKernelExec: public TBinaryKernelExec<TAsciiContainsIgnoreCaseKernelExec> {
+    template <typename TSink>
+    static void Process(const IValueBuilder*, TBlockItem arg1, TBlockItem arg2, const TSink& sink) {
+        if (!arg1) {
+            return sink(TBlockItem(!static_cast<bool>(arg2)));
+        }
+
+        const TStringBuf haystack(arg1.AsStringRef());
+        const TStringBuf needle(arg2.AsStringRef());
+        sink(TBlockItem(AsciiContainsIgnoreCaseMemchr(haystack, needle)));
+    }
+};
+
+TUnboxedValuePod AsciiContainsIgnoreCaseImpl(const TUnboxedValuePod* args) {
+    if (!args[0]) {
+        return TUnboxedValuePod(false);
+    }
+
+    const TStringBuf haystack(args[0].AsStringRef());
+    const TStringBuf needle(args[1].AsStringRef());
+    return TUnboxedValuePod(AsciiContainsIgnoreCaseMemchr(haystack, needle));
+}
+
+BEGIN_SIMPLE_STRICT_ARROW_UDF(T_yql_AsciiContainsIgnoreCase, bool(TOptional<char*>, char*)) // NOLINT(readability-identifier-naming)
+{
+    Y_UNUSED(valueBuilder);
+    return AsciiContainsIgnoreCaseImpl(args);
+}
+
+END_SIMPLE_ARROW_UDF(T_yql_AsciiContainsIgnoreCase, TAsciiContainsIgnoreCaseKernelExec::Do);
+
+SIMPLE_MODULE(TStringFastModule, T_yql_AsciiContainsIgnoreCase)
+
+REGISTER_MODULES(TStringFastModule)

--- a/ydb/core/formats/arrow/program/string_fast/ya.make
+++ b/ydb/core/formats/arrow/program/string_fast/ya.make
@@ -1,0 +1,18 @@
+YQL_UDF_YDB(string_fast_udf)
+
+YQL_ABI_VERSION(
+    2
+    43
+    0
+)
+
+SRCS(
+    string_fast_udf.cpp
+)
+
+PEERDIR(
+    ydb/core/formats/arrow/program/ascii_contains
+    yql/essentials/public/udf/arrow
+)
+
+END()

--- a/ydb/core/formats/arrow/program/ya.make
+++ b/ydb/core/formats/arrow/program/ya.make
@@ -69,11 +69,11 @@ END()
 
 
 RECURSE_FOR_TESTS(
+    benchmark
     ut
 )
 
 RECURSE(
     ascii_contains
-    benchmark
     olap_kernels
 )

--- a/ydb/core/formats/arrow/program/ya.make
+++ b/ydb/core/formats/arrow/program/ya.make
@@ -75,5 +75,5 @@ RECURSE_FOR_TESTS(
 RECURSE(
     ascii_contains
     benchmark
-    string_fast
+    olap_kernels
 )

--- a/ydb/core/formats/arrow/program/ya.make
+++ b/ydb/core/formats/arrow/program/ya.make
@@ -67,6 +67,13 @@ CFLAGS(
 
 END()
 
+
 RECURSE_FOR_TESTS(
     ut
+)
+
+RECURSE(
+    ascii_contains
+    benchmark
+    string_fast
 )

--- a/ydb/core/formats/arrow/ut/ut_program_step.cpp
+++ b/ydb/core/formats/arrow/ut/ut_program_step.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/program/aggr_keys.h>
+#include <ydb/core/formats/arrow/program/ascii_contains/ascii_contains.h>
 #include <ydb/core/formats/arrow/program/assign_const.h>
 #include <ydb/core/formats/arrow/program/assign_internal.h>
 #include <ydb/core/formats/arrow/program/collection.h>
@@ -499,6 +500,28 @@ Y_UNIT_TEST_SUITE(ProgramStep) {
             UNIT_ASSERT_VALUES_EQUAL(res[2], true);
             UNIT_ASSERT_VALUES_EQUAL(res[3], false);
         }
+    }
+
+    Y_UNIT_TEST(AsciiContainsIgnoreCaseMemchrDirect) {
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("", ""));
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("abc", ""));
+        UNIT_ASSERT(!AsciiContainsIgnoreCaseMemchr("", "a"));
+
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("fdsa", "DS"));
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("fdsa", "FdSa"));
+        UNIT_ASSERT(!AsciiContainsIgnoreCaseMemchr("fdsa", "AS"));
+        UNIT_ASSERT(!AsciiContainsIgnoreCaseMemchr("fdsa", "xyz"));
+
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("AbC", "b"));
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("AbC", "B"));
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("a12b", "12"));
+        UNIT_ASSERT(!AsciiContainsIgnoreCaseMemchr("a12b", "13"));
+
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("xxxAAAyyy", "aaa"));
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("ababcabcd", "AbCd"));
+
+        UNIT_ASSERT(AsciiContainsIgnoreCaseMemchr("`Привет, мир!`", "Привет"));
+        UNIT_ASSERT(!AsciiContainsIgnoreCaseMemchr("`Привет, мир!`", "привет"));
     }
 
     Y_UNIT_TEST(ScalarTest) {

--- a/ydb/core/formats/arrow/ut/ya.make
+++ b/ydb/core/formats/arrow/ut/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/core/formats/arrow/hash
     ydb/core/formats/arrow/printer
     ydb/core/formats/arrow/program
+    ydb/core/formats/arrow/program/ascii_contains
     ydb/core/formats/arrow/reader
     ydb/core/formats/arrow/serializer
     ydb/core/base

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
@@ -537,11 +537,11 @@ TExprBase BuildOneElementComparison(const std::pair<TExprBase, TExprBase>& param
             .Done();
     }
 
-    // Opt-in Memchr-based UDF (StringFast._yql_AsciiContainsIgnoreCase) via YQL_KERNEL ScalarApply.
+    // Opt-in Memchr-based UDF (OlapKernels._yql_AsciiContainsIgnoreCase) via YQL_KERNEL ScalarApply.
     // Default remains TKqpOlapApply + String._yql_AsciiContainsIgnoreCase.
     TString udfName;
     if (pushdownOptions.FastAsciiIgnoreCaseContains && predicate.CallableName() == "StringContainsIgnoreCase") {
-        udfName = "StringFast._yql_AsciiContainsIgnoreCase";
+        udfName = "OlapKernels._yql_AsciiContainsIgnoreCase";
     } else if (const auto* stringUdfFunction = IgnoreCaseSubstringMatchFunctions.FindPtr(predicate.CallableName())) {
         udfName = *stringUdfFunction;
     }

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
@@ -203,7 +203,7 @@ std::vector<std::pair<TExprBase, TExprBase>> ExtractComparisonParameters(const T
 }
 
 TMaybeNode<TExprBase> ComparisonPushdown(const std::vector<std::pair<TExprBase, TExprBase>>& parameters, const TCoCompare& predicate, TExprContext& ctx,
-                                         TPositionHandle pos);
+                                         TPositionHandle pos, const TPushdownOptions& pushdownOptions);
 
 TMaybeNode<TExprBase> CoalescePushdown(const TCoCoalesce& coalesce, const TExprNode& argument, TExprContext& ctx, const TPushdownOptions& pushdownOptions) {
     if (const auto params = ExtractBinaryFunctionParameters(coalesce, argument, ctx, coalesce.Pos(), pushdownOptions)) {
@@ -250,7 +250,7 @@ TMaybeNode<TExprBase> SimplePredicatePushdown(const TCoCompare& predicate, const
         return NullNode;
     }
 
-    return ComparisonPushdown(parameters, predicate, ctx, pos);
+    return ComparisonPushdown(parameters, predicate, ctx, pos, pushdownOptions);
 }
 
 TMaybeNode<TExprBase> SafeCastPredicatePushdown(const TCoFlatMap& inputFlatmap, const TExprNode& argument, TExprContext& ctx, TPositionHandle pos,
@@ -287,7 +287,7 @@ TMaybeNode<TExprBase> SafeCastPredicatePushdown(const TCoFlatMap& inputFlatmap, 
         parameters.emplace_back(std::move(std::make_pair(left[i], right[i])));
     }
 
-    return ComparisonPushdown(parameters, predicate, ctx, pos);
+    return ComparisonPushdown(parameters, predicate, ctx, pos, pushdownOptions);
 }
 
 namespace {
@@ -457,7 +457,7 @@ std::vector<TExprBase> ConvertComparisonNode(const TExprBase& nodeIn, const TExp
 
         if (const auto maybeCompare = node.Maybe<TCoCompare>()) {
             if (const auto params = ExtractComparisonParameters(maybeCompare.Cast(), argument, ctx, pos, pushdownOptions); !params.empty()) {
-                return ComparisonPushdown(params, maybeCompare.Cast(), ctx, pos);
+                return ComparisonPushdown(params, maybeCompare.Cast(), ctx, pos, pushdownOptions);
             }
         }
 
@@ -514,7 +514,7 @@ std::vector<TExprBase> ConvertComparisonNode(const TExprBase& nodeIn, const TExp
 }
 
 TExprBase BuildOneElementComparison(const std::pair<TExprBase, TExprBase>& parameter, const TCoCompare& predicate,
-    TExprContext& ctx, TPositionHandle pos, bool forceStrictComparison)
+    TExprContext& ctx, TPositionHandle pos, bool forceStrictComparison, const TPushdownOptions& pushdownOptions)
 {
     auto isNull = [](const TExprBase& node) {
         if (node.Maybe<TCoNull>()) {
@@ -537,7 +537,16 @@ TExprBase BuildOneElementComparison(const std::pair<TExprBase, TExprBase>& param
             .Done();
     }
 
-    if (const auto* stringUdfFunction = IgnoreCaseSubstringMatchFunctions.FindPtr(predicate.CallableName())) {
+    // Opt-in Memchr-based UDF (StringFast._yql_AsciiContainsIgnoreCase) via YQL_KERNEL ScalarApply.
+    // Default remains TKqpOlapApply + String._yql_AsciiContainsIgnoreCase.
+    TString udfName;
+    if (pushdownOptions.FastAsciiIgnoreCaseContains && predicate.CallableName() == "StringContainsIgnoreCase") {
+        udfName = "StringFast._yql_AsciiContainsIgnoreCase";
+    } else if (const auto* stringUdfFunction = IgnoreCaseSubstringMatchFunctions.FindPtr(predicate.CallableName())) {
+        udfName = *stringUdfFunction;
+    }
+
+    if (!udfName.empty()) {
         const auto& leftArg = ctx.NewArgument(pos, "left");
         const auto& rightArg = ctx.NewArgument(pos, "right");
 
@@ -545,7 +554,7 @@ TExprBase BuildOneElementComparison(const std::pair<TExprBase, TExprBase>& param
             ctx.Builder(pos)
                 .Callable("Apply")
                     .Callable(0, "Udf")
-                        .Atom(0, *stringUdfFunction)
+                        .Atom(0, udfName)
                     .Seal()
                     .Add(1, leftArg)
                     .Add(2, rightArg)
@@ -559,7 +568,7 @@ TExprBase BuildOneElementComparison(const std::pair<TExprBase, TExprBase>& param
                 .Add(parameter.first)
                 .Add(parameter.second)
             .Build()
-            .KernelName(ctx.NewAtom(pos, *stringUdfFunction))
+            .KernelName(ctx.NewAtom(pos, udfName))
         .Done();
     }
 
@@ -599,12 +608,12 @@ TExprBase BuildOneElementComparison(const std::pair<TExprBase, TExprBase>& param
 }
 
 TMaybeNode<TExprBase> ComparisonPushdown(const std::vector<std::pair<TExprBase, TExprBase>>& parameters, const TCoCompare& predicate,
-    TExprContext& ctx, TPositionHandle pos)
+    TExprContext& ctx, TPositionHandle pos, const TPushdownOptions& pushdownOptions)
 {
     ui32 conditionsCount = parameters.size();
 
     if (conditionsCount == 1) {
-        auto condition = BuildOneElementComparison(parameters[0], predicate, ctx, pos, false);
+        auto condition = BuildOneElementComparison(parameters[0], predicate, ctx, pos, false, pushdownOptions);
         return IsFalseLiteral(condition) ? NullNode : condition;
     }
 
@@ -614,7 +623,7 @@ TMaybeNode<TExprBase> ComparisonPushdown(const std::vector<std::pair<TExprBase, 
         bool hasFalseCondition = false;
 
         for (ui32 i = 0; i < conditionsCount; ++i) {
-            auto condition = BuildOneElementComparison(parameters[i], predicate, ctx, pos, false);
+            auto condition = BuildOneElementComparison(parameters[i], predicate, ctx, pos, false, pushdownOptions);
             if (IsFalseLiteral(condition)) {
                 hasFalseCondition = true;
             } else {
@@ -646,7 +655,7 @@ TMaybeNode<TExprBase> ComparisonPushdown(const std::vector<std::pair<TExprBase, 
 
         // We need strict < and > in beginning columns except the last one
         // For example: (c1, c2, c3) >= (1, 2, 3) ==> (c1 > 1) OR (c2 > 2 AND c1 = 1) OR (c3 >= 3 AND c2 = 2 AND c1 = 1)
-        auto condition = BuildOneElementComparison(parameters[i], predicate, ctx, pos, i < conditionsCount - 1);
+        auto condition = BuildOneElementComparison(parameters[i], predicate, ctx, pos, i < conditionsCount - 1, pushdownOptions);
         if (IsFalseLiteral(condition)) {
             continue;
         }
@@ -1060,7 +1069,8 @@ TExprBase KqpPushOlapProjections(TExprBase node, TExprContext& ctx, const TKqpOp
 
 TExprBase KqpPushOlapFilter(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx, TTypeAnnotationContext& typesCtx) {
     const TPushdownOptions pushdownOptions(kqpCtx.Config->GetEnableOlapScalarApply(), kqpCtx.Config->GetEnableOlapSubstringPushdown(),
-        /*stripAliasPrefixFromColName=*/false, kqpCtx.Config->GetEnableOlapPushdownRegexp());
+        /*stripAliasPrefixFromColName=*/false, kqpCtx.Config->GetEnableOlapPushdownRegexp(),
+        kqpCtx.Config->GetEnableOlapFastAsciiIgnoreCase());
     if (!kqpCtx.Config->HasOptEnableOlapPushdown()) {
         return node;
     }
@@ -1159,8 +1169,7 @@ TExprBase KqpPushOlapFilter(TExprBase node, TExprContext& ctx, const TKqpOptimiz
             predicate = maybeIf.Cast().Predicate();
             TOLAPPredicateNode predicateTree;
             predicateTree.ExprNode = predicate.Ptr();
-            CollectPredicates(predicate, predicateTree, &lArg, lArg.GetTypeAnn(),
-                {true, pushdownOptions.PushdownSubstring, pushdownOptions.StripAliasPrefixFromColName, pushdownOptions.PushdownRegexp});
+            CollectPredicates(predicate, predicateTree, &lArg, lArg.GetTypeAnn(), pushdownOptions.WithAllowOlapApply(true));
 
             YQL_ENSURE(predicateTree.IsValid(), "Collected OLAP predicates are invalid");
             auto [pushable, remaining] = SplitForPartialPushdown(predicateTree, true);

--- a/ydb/core/kqp/opt/physical/predicate_collector.cpp
+++ b/ydb/core/kqp/opt/physical/predicate_collector.cpp
@@ -127,7 +127,7 @@ bool CanPushdownStringUdf(const TExprNode& udf, bool pushdownSubstring) {
 
         "String.Contains",
         "String._yql_AsciiContainsIgnoreCase",
-        "StringFast._yql_AsciiContainsIgnoreCase",
+        "OlapKernels._yql_AsciiContainsIgnoreCase",
         "String.StartsWith",
         "String._yql_AsciiStartsWithIgnoreCase",
         "String.EndsWith",

--- a/ydb/core/kqp/opt/physical/predicate_collector.cpp
+++ b/ydb/core/kqp/opt/physical/predicate_collector.cpp
@@ -127,6 +127,7 @@ bool CanPushdownStringUdf(const TExprNode& udf, bool pushdownSubstring) {
 
         "String.Contains",
         "String._yql_AsciiContainsIgnoreCase",
+        "StringFast._yql_AsciiContainsIgnoreCase",
         "String.StartsWith",
         "String._yql_AsciiStartsWithIgnoreCase",
         "String.EndsWith",
@@ -452,11 +453,11 @@ void CollectPredicates(const TExprBase& predicate, TOLAPPredicateNode& predicate
     if (predicate.Maybe<TCoNot>() || predicate.Maybe<TCoAnd>() || predicate.Maybe<TCoOr>() || predicate.Maybe<TCoXor>()) {
         CollectChildrenPredicates(predicate.Ref(), predicateTree, lambdaArg, inputType, options);
     } else if (const auto maybeCoalesce = predicate.Maybe<TCoCoalesce>()) {
-        predicateTree.CanBePushed = CoalesceCanBePushed(maybeCoalesce.Cast(), lambdaArg, inputType, {false, options.PushdownSubstring, options.StripAliasPrefixFromColName, options.PushdownRegexp});
-        predicateTree.CanBePushedApply = CoalesceCanBePushed(maybeCoalesce.Cast(), lambdaArg, inputType, {true, options.PushdownSubstring, options.StripAliasPrefixFromColName, options.PushdownRegexp});
+        predicateTree.CanBePushed = CoalesceCanBePushed(maybeCoalesce.Cast(), lambdaArg, inputType, options.WithAllowOlapApply(false));
+        predicateTree.CanBePushedApply = CoalesceCanBePushed(maybeCoalesce.Cast(), lambdaArg, inputType, options.WithAllowOlapApply(true));
     } else if (const auto maybeCompare = predicate.Maybe<TCoCompare>()) {
-        predicateTree.CanBePushed = CompareCanBePushed(maybeCompare.Cast(), lambdaArg, inputType, {false, options.PushdownSubstring, options.StripAliasPrefixFromColName, options.PushdownRegexp});
-        predicateTree.CanBePushedApply = CompareCanBePushed(maybeCompare.Cast(), lambdaArg, inputType, {true, options.PushdownSubstring, options.StripAliasPrefixFromColName, options.PushdownRegexp});
+        predicateTree.CanBePushed = CompareCanBePushed(maybeCompare.Cast(), lambdaArg, inputType, options.WithAllowOlapApply(false));
+        predicateTree.CanBePushedApply = CompareCanBePushed(maybeCompare.Cast(), lambdaArg, inputType, options.WithAllowOlapApply(true));
     } else if (const auto maybeExists = predicate.Maybe<TCoExists>()) {
         predicateTree.CanBePushed = ExistsCanBePushed(maybeExists.Cast(), lambdaArg);
         predicateTree.CanBePushedApply = predicateTree.CanBePushed;
@@ -467,7 +468,7 @@ void CollectPredicates(const TExprBase& predicate, TOLAPPredicateNode& predicate
 
     if (options.AllowOlapApply && !predicateTree.CanBePushedApply){
         if (predicate.Maybe<TCoIf>() || predicate.Maybe<TCoJust>() || predicate.Maybe<TCoCoalesce>()) {
-            CollectChildrenPredicates(predicate.Ref(), predicateTree, lambdaArg, inputType, {true, options.PushdownSubstring, options.StripAliasPrefixFromColName, options.PushdownRegexp});
+            CollectChildrenPredicates(predicate.Ref(), predicateTree, lambdaArg, inputType, options.WithAllowOlapApply(true));
         }
         if (!predicateTree.CanBePushedApply) {
             predicateTree.CanBePushedApply = AbstractTreeCanBePushed(predicate, options);

--- a/ydb/core/kqp/opt/physical/predicate_collector.h
+++ b/ydb/core/kqp/opt/physical/predicate_collector.h
@@ -18,17 +18,26 @@ struct TOLAPPredicateNode {
 };
 
 struct TPushdownOptions {
-    TPushdownOptions(bool allowOlapApply, bool pushdownSubstring, bool stripAliasPrefixFromColName = false, bool pushdownRegexp = false)
+    TPushdownOptions(bool allowOlapApply, bool pushdownSubstring, bool stripAliasPrefixFromColName = false,
+                     bool pushdownRegexp = false, bool fastAsciiIgnoreCaseContains = false)
         : AllowOlapApply(allowOlapApply)
         , PushdownSubstring(pushdownSubstring)
         , StripAliasPrefixFromColName(stripAliasPrefixFromColName)
-        , PushdownRegexp(pushdownRegexp) {
+        , PushdownRegexp(pushdownRegexp)
+        , FastAsciiIgnoreCaseContains(fastAsciiIgnoreCaseContains) {
+    }
+
+    TPushdownOptions WithAllowOlapApply(bool allow) const {
+        TPushdownOptions copy = *this;
+        copy.AllowOlapApply = allow;
+        return copy;
     }
 
     bool AllowOlapApply{false};
     bool PushdownSubstring{false};
     bool StripAliasPrefixFromColName{false};
     bool PushdownRegexp{false};
+    bool FastAsciiIgnoreCaseContains{false};
 };
 
 extern THashMap<TString, TString> IgnoreCaseSubstringMatchFunctions;

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
@@ -97,7 +97,8 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
     }
 
     const TPushdownOptions pushdownOptions(ctx.KqpCtx.Config->GetEnableOlapScalarApply(), ctx.KqpCtx.Config->GetEnableOlapSubstringPushdown(),
-                                           /*StripAliasPrefixForColumnName=*/true, ctx.KqpCtx.Config->GetEnableOlapPushdownRegexp());
+                                           /*StripAliasPrefixForColumnName=*/true, ctx.KqpCtx.Config->GetEnableOlapPushdownRegexp(),
+                                           ctx.KqpCtx.Config->GetEnableOlapFastAsciiIgnoreCase());
     if (!IsSuitableToPushPredicateToColumnTables(input)) {
         return input;
     }
@@ -142,7 +143,7 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
             TOLAPPredicateNode predicateTree;
             predicateTree.ExprNode = predicate.Ptr();
             CollectPredicates(predicate, predicateTree, &lArg.Ref(), lArg.Ptr()->GetTypeAnn(),
-                {true, pushdownOptions.PushdownSubstring, pushdownOptions.StripAliasPrefixFromColName, pushdownOptions.PushdownRegexp});
+                pushdownOptions.WithAllowOlapApply(true));
 
             YQL_ENSURE(predicateTree.IsValid(), "Collected OLAP predicates are invalid");
             auto [pushable, remaining] = SplitForPartialPushdown(predicateTree, true);

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -91,6 +91,7 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, OptForceOlapPushdownDistinctLimit);
     REGISTER_SETTING(*this, OptEnableOlapPushdownProjections);
     REGISTER_SETTING(*this, OptEnableOlapPushdownRegexp);
+    REGISTER_SETTING(*this, OptEnableOlapFastAsciiIgnoreCase);
     REGISTER_SETTING(*this, OptEnableOlapProvideComputeSharding);
     REGISTER_SETTING(*this, OptOverrideStatistics);
     REGISTER_SETTING(*this, OptimizerHints).Parser([](const TString& v) { return NKikimr::NKqp::TOptimizerHints::Parse(v); });
@@ -326,6 +327,10 @@ bool TKikimrConfiguration::GetEnableOlapPushdownAggregate() const {
 bool TKikimrConfiguration::GetEnableOlapPushdownRegexp() const {
     return ((GetOptionalFlagValue(OptEnableOlapPushdownRegexp.Get()) == EOptionalFlag::Enabled) ||
         TTableServiceConfig::GetEnableOlapPushdownRegexp());
+}
+
+bool TKikimrConfiguration::GetEnableOlapFastAsciiIgnoreCase() const {
+    return GetOptionalFlagValue(OptEnableOlapFastAsciiIgnoreCase.Get()) == EOptionalFlag::Enabled;
 }
 
 bool TKikimrConfiguration::GetUseDqHashCombine() const {

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -91,6 +91,7 @@ public:
     NCommon::TConfSetting<ui64, Static> OptForceOlapPushdownDistinctLimit;
     NCommon::TConfSetting<bool, Static> OptEnableOlapPushdownProjections;
     NCommon::TConfSetting<bool, Static> OptEnableOlapPushdownRegexp;
+    NCommon::TConfSetting<bool, Static> OptEnableOlapFastAsciiIgnoreCase;
     NCommon::TConfSetting<bool, Static> OptEnableOlapProvideComputeSharding;
     NCommon::TConfSetting<bool, Static> OptUseFinalizeByKey;
     NCommon::TConfSetting<bool, Static> OptShuffleElimination;
@@ -252,6 +253,7 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool GetEnableParallelUnionAllConnectionsForExtend() const;
     bool GetEnableOlapPushdownAggregate() const;
     bool GetEnableOlapPushdownRegexp() const;
+    bool GetEnableOlapFastAsciiIgnoreCase() const;
     bool GetUseDqHashCombine() const;
     bool GetUseDqHashAggregate() const;
     bool GetDqHashOperatorsUseBlocks() const;

--- a/ydb/core/kqp/ut/common/ya.make
+++ b/ydb/core/kqp/ut/common/ya.make
@@ -20,7 +20,7 @@ PEERDIR(
     yql/essentials/udfs/common/math
     yql/essentials/udfs/common/re2
     yql/essentials/udfs/common/string
-    ydb/core/formats/arrow/program/string_fast
+    ydb/core/formats/arrow/program/olap_kernels
     yql/essentials/udfs/common/unicode_base
     yql/essentials/utils/backtrace
     ydb/public/lib/yson_value

--- a/ydb/core/kqp/ut/common/ya.make
+++ b/ydb/core/kqp/ut/common/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
     yql/essentials/udfs/common/math
     yql/essentials/udfs/common/re2
     yql/essentials/udfs/common/string
+    ydb/core/formats/arrow/program/string_fast
     yql/essentials/udfs/common/unicode_base
     yql/essentials/utils/backtrace
     ydb/public/lib/yson_value

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -1780,13 +1780,13 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
                 UNIT_ASSERT_C(ast->find("KqpOlapFilter") != std::string::npos,
                     TStringBuilder() << "ILIKE contains not pushed down. Query: " << query);
                 if (expectFastKernel) {
-                    UNIT_ASSERT_C(ast->find("StringFast._yql_AsciiContainsIgnoreCase") != std::string::npos,
-                        TStringBuilder() << "StringFast UDF not used. Query: " << query << " AST: " << *ast);
+                    UNIT_ASSERT_C(ast->find("OlapKernels._yql_AsciiContainsIgnoreCase") != std::string::npos,
+                        TStringBuilder() << "OlapKernels UDF not used. Query: " << query << " AST: " << *ast);
                     UNIT_ASSERT_C(ast->find("String._yql_AsciiContainsIgnoreCase") == std::string::npos,
                         TStringBuilder() << "String UDF path still used with pragma on. Query: " << query);
                 } else {
-                    UNIT_ASSERT_C(ast->find("StringFast._yql_AsciiContainsIgnoreCase") == std::string::npos,
-                        TStringBuilder() << "StringFast UDF used with pragma off. Query: " << query);
+                    UNIT_ASSERT_C(ast->find("OlapKernels._yql_AsciiContainsIgnoreCase") == std::string::npos,
+                        TStringBuilder() << "OlapKernels UDF used with pragma off. Query: " << query);
                     UNIT_ASSERT_C(ast->find("String._yql_AsciiContainsIgnoreCase") != std::string::npos,
                         TStringBuilder() << "UDF path missing with pragma off. Query: " << query << " AST: " << *ast);
                 }

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -1707,6 +1707,97 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         }
     }
 
+    Y_UNIT_TEST(PredicatePushdown_FastAsciiContainsIgnoreCase) {
+        auto settings = TKikimrSettings().SetWithSampleTables(false);
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
+        TKikimrRunner kikimr(settings);
+
+        {
+            auto tableClient = kikimr.GetTableClient();
+            auto session = tableClient.CreateSession().GetValueSync().GetSession();
+            const auto res = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/foo` (
+                    id Int64 NOT NULL,
+                    str String,
+                    u_str Utf8,
+                    PRIMARY KEY(id)
+                )
+                WITH (STORE = COLUMN);
+            )").GetValueSync();
+            UNIT_ASSERT(res.IsSuccess());
+        }
+
+        auto queryClient = kikimr.GetQueryClient();
+        auto session = queryClient.GetSession().GetValueSync().GetSession();
+        {
+            const auto res = session.ExecuteQuery(R"(
+                INSERT INTO `/Root/foo` (id, str, u_str) VALUES
+                    (1, "foobar", "foobar"),
+                    (2, "baz", "baz"),
+                    (3, "fooqux", "fooqux"),
+                    (4, NULL, NULL)
+            )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues());
+        }
+
+        std::vector<TString> predicates = {
+            "str ILIKE '%foo%'",
+            "str ILIKE '%FOO%'",
+            "str ILIKE '%Foo%'",
+            "str ILIKE '%nomatch%'",
+            "u_str ILIKE '%foo%'",
+            "u_str ILIKE '%FOO%'",
+        };
+
+        std::vector<TString> expectedResults = {
+            "[[1];[3]]",
+            "[[1];[3]]",
+            "[[1];[3]]",
+            "[]",
+            "[[1];[3]]",
+            "[[1];[3]]",
+        };
+
+        UNIT_ASSERT_EQUAL(expectedResults.size(), predicates.size());
+
+        auto run = [&](const TString& extraPragma, bool expectFastKernel) {
+            for (ui32 i = 0; i < predicates.size(); ++i) {
+                const auto& query = TString(R"(
+                    PRAGMA OptimizeSimpleILike;
+                    PRAGMA AnsiLike;
+                    )") + extraPragma + R"(
+                    SELECT id FROM `/Root/foo` WHERE
+                    )" + predicates[i] + " ORDER BY id";
+                Cerr << "QUERY " << i << Endl << query << Endl;
+
+                const auto res = session
+                                     .ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx(),
+                                         NYdb::NQuery::TExecuteQuerySettings().StatsMode(NQuery::EStatsMode::Full))
+                                     .ExtractValueSync();
+                UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues());
+
+                const auto ast = res.GetStats()->GetAst();
+                UNIT_ASSERT_C(ast->find("KqpOlapFilter") != std::string::npos,
+                    TStringBuilder() << "ILIKE contains not pushed down. Query: " << query);
+                if (expectFastKernel) {
+                    UNIT_ASSERT_C(ast->find("StringFast._yql_AsciiContainsIgnoreCase") != std::string::npos,
+                        TStringBuilder() << "StringFast UDF not used. Query: " << query << " AST: " << *ast);
+                    UNIT_ASSERT_C(ast->find("String._yql_AsciiContainsIgnoreCase") == std::string::npos,
+                        TStringBuilder() << "String UDF path still used with pragma on. Query: " << query);
+                } else {
+                    UNIT_ASSERT_C(ast->find("StringFast._yql_AsciiContainsIgnoreCase") == std::string::npos,
+                        TStringBuilder() << "StringFast UDF used with pragma off. Query: " << query);
+                    UNIT_ASSERT_C(ast->find("String._yql_AsciiContainsIgnoreCase") != std::string::npos,
+                        TStringBuilder() << "UDF path missing with pragma off. Query: " << query << " AST: " << *ast);
+                }
+                CompareYson(FormatResultSetYson(res.GetResultSet(0)), expectedResults[i]);
+            }
+        };
+
+        run(R"(PRAGMA kikimr.OptEnableOlapFastAsciiIgnoreCase = "true";)", true);
+        run("", false);
+    }
+
     Y_UNIT_TEST(PredicatePushdown_MixStrictAndNotStrict) {
         auto settings = TKikimrSettings()
             .SetWithSampleTables(false);

--- a/ydb/tests/tools/fqrun/ya.make
+++ b/ydb/tests/tools/fqrun/ya.make
@@ -28,7 +28,7 @@ PEERDIR(
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/re2
     yql/essentials/udfs/common/string
-    ydb/core/formats/arrow/program/string_fast
+    ydb/core/formats/arrow/program/olap_kernels
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/common/json2
 )

--- a/ydb/tests/tools/fqrun/ya.make
+++ b/ydb/tests/tools/fqrun/ya.make
@@ -28,6 +28,7 @@ PEERDIR(
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/re2
     yql/essentials/udfs/common/string
+    ydb/core/formats/arrow/program/string_fast
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/common/json2
 )

--- a/ydb/tests/tools/kqprun/ya.make
+++ b/ydb/tests/tools/kqprun/ya.make
@@ -30,7 +30,7 @@ PEERDIR(
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/re2
     yql/essentials/udfs/common/string
-    ydb/core/formats/arrow/program/string_fast
+    ydb/core/formats/arrow/program/olap_kernels
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/common/json2
     ydb/apps/ydbd/export

--- a/ydb/tests/tools/kqprun/ya.make
+++ b/ydb/tests/tools/kqprun/ya.make
@@ -30,6 +30,7 @@ PEERDIR(
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/re2
     yql/essentials/udfs/common/string
+    ydb/core/formats/arrow/program/string_fast
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/common/json2
     ydb/apps/ydbd/export


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
Короткие haystack (≤32) — Memchr идёт в Scalar, плюс накладные проверки
кейс | Scalar | Memchr | vs Scalar
-- | -- | -- | --
NoMatch 8/1 | 6.13 ns | 9.03 ns | −32%
NoMatch 8/8 | 4.33 ns | 7.16 ns | −40%
NoMatch 32/8 | 25.7 ns | 29.4 ns | −13%
NoMatch 32/32 | 4.08 ns | 8.04 ns | −49%

Длинные haystack — memchr-дорожка быстрее
кейс | Scalar | Memchr | ускорение
-- | -- | -- | --
NoMatch 256/8 | 277 ns | 120 ns | 2.3×
NoMatch 4096/8 | 5214 ns | 1716 ns | 3.0×
NoMatch 64KB/8 | 86 µs | 40 µs | 2.1×
MatchAtEnd 64KB/8 | 87 µs | 42 µs | 2.0×

ManyRows (строки 100–200 байт)
needle | Scalar | Memchr | ускорение
-- | -- | -- | --
5 | 2.13 ms | 0.44 ms | 4.9×
10 | 2.01 ms | 0.47 ms | 4.2×
20 | 1.90 ms | 0.51 ms | 3.7×
```
