### PR TITLE
feat: mask OriginalUserToken in whoami response

### DIFF
--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -605,7 +605,6 @@ class TestViewer(object):
                                     'CreateTxId',
                                     'PathId',
                                     'PublicKeys',
-                                    'OriginalUserToken',
                                     'HashesInitParams',
                                     })
 

--- a/ydb/core/viewer/viewer_whoami.h
+++ b/ydb/core/viewer/viewer_whoami.h
@@ -77,9 +77,6 @@ public:
                     items:
                         type: string
                     description: User groups
-                OriginalUserToken:
-                    type: string
-                    description: User's token used to authenticate
                 AuthType:
                     type: string
                     description: Authentication type

--- a/ydb/mvp/oidc_proxy/extension_whoami.cpp
+++ b/ydb/mvp/oidc_proxy/extension_whoami.cpp
@@ -55,7 +55,7 @@ void TExtensionWhoamiWorker::PatchResponse(NJson::TJsonValue& json, NJson::TJson
     SetCORS(Context->Params.Request, Context->Params.HeadersOverride.Get());
     Context->Params.HeadersOverride->Set("Content-Type", "application/json; charset=utf-8");
 
-    if (json.Has(USER_SID) && json.Has(ORIGINAL_USER_TOKEN)) {
+    if (json.Has(USER_SID)) {
         statusOverride = "200";
         messageOverride = "OK";
         if (errorJson.Has(EXTENDED_ERRORS)) {
@@ -154,13 +154,6 @@ void TExtensionWhoamiWorker::ApplyExtension() {
         SetExtendedError(errorJson, "Iam", "ResponseStatus", error->Get()->Status);
         SetExtendedError(errorJson, "Iam", "ResponseMessage", error->Get()->Message);
         SetExtendedError(errorJson, "Iam", "ResponseDetails", error->Get()->Details);
-    }
-
-    if (!json.Has(ORIGINAL_USER_TOKEN)) {
-        TStringBuf tail;
-        if (TStringBuf(AuthHeader).AfterPrefix(IAM_TOKEN_SCHEME, tail)) {
-            json[ORIGINAL_USER_TOKEN] = tail;
-        }
     }
 
     PatchResponse(json, errorJson);

--- a/ydb/mvp/oidc_proxy/extension_whoami.cpp
+++ b/ydb/mvp/oidc_proxy/extension_whoami.cpp
@@ -1,5 +1,7 @@
 #include "extension_whoami.h"
 
+#include <ydb/library/security/util.h>
+
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
@@ -55,7 +57,7 @@ void TExtensionWhoamiWorker::PatchResponse(NJson::TJsonValue& json, NJson::TJson
     SetCORS(Context->Params.Request, Context->Params.HeadersOverride.Get());
     Context->Params.HeadersOverride->Set("Content-Type", "application/json; charset=utf-8");
 
-    if (json.Has(USER_SID)) {
+    if (json.Has(USER_SID) && json.Has(ORIGINAL_USER_TOKEN)) {
         statusOverride = "200";
         messageOverride = "OK";
         if (errorJson.Has(EXTENDED_ERRORS)) {
@@ -154,6 +156,16 @@ void TExtensionWhoamiWorker::ApplyExtension() {
         SetExtendedError(errorJson, "Iam", "ResponseStatus", error->Get()->Status);
         SetExtendedError(errorJson, "Iam", "ResponseMessage", error->Get()->Message);
         SetExtendedError(errorJson, "Iam", "ResponseDetails", error->Get()->Details);
+    }
+
+    // Masked, not raw: the session cookie is httpOnly on purpose, so the token it is exchanged
+    // for must not be usable from JS. Kept for access debuggability until observability improves,
+    // then this whole block should go away.
+    if (!json.Has(ORIGINAL_USER_TOKEN)) {
+        TStringBuf tail;
+        if (TStringBuf(AuthHeader).AfterPrefix(IAM_TOKEN_SCHEME, tail)) {
+            json[ORIGINAL_USER_TOKEN] = NKikimr::MaskTicket(tail);
+        }
     }
 
     PatchResponse(json, errorJson);

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -1504,12 +1504,22 @@ Y_UNIT_TEST_SUITE(Mvp) {
         return json;
     }
 
+    // The token is exposed only as a mask, so UI problems stay debuggable without handing
+    // JS a usable credential. Temporary - to be dropped once access observability lands.
+    void AssertTokenIsMasked(const NJson::TJsonValue& json, TStringBuf rawToken) {
+        UNIT_ASSERT(json.Has(ORIGINAL_USER_TOKEN));
+        const TString masked = json[ORIGINAL_USER_TOKEN].GetStringSafe();
+        UNIT_ASSERT_C(!masked.Contains(rawToken),
+                      TStringBuilder() << "mask still contains the raw token: " << masked);
+        UNIT_ASSERT_C(masked.Contains("****"), TStringBuilder() << "not a mask: " << masked);
+    }
+
     Y_UNIT_TEST(OidcWhoami200) {
         auto json = OidcWhoamiExtendedInfoTest(
             TWhoamiContext(TProfileServiceMock::VALID_USER_TOKEN, TWhoamiContext::GetViewerResponse200(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_USER_ACCOUNT_ID);
-        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
+        AssertTokenIsMasked(json, TProfileServiceMock::VALID_USER_TOKEN);
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json.Has(EXTENDED_ERRORS));
     }
@@ -1519,7 +1529,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_SERVICE_TOKEN, TWhoamiContext::GetViewerResponseService200(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_SERVICE_ACCOUNT_ID);
-        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
+        AssertTokenIsMasked(json, TProfileServiceMock::VALID_SERVICE_TOKEN);
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json.Has(EXTENDED_ERRORS));
     }
@@ -1529,7 +1539,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::BAD_TOKEN, TWhoamiContext::GetViewerResponse200(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_USER_ACCOUNT_ID);
-        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
+        AssertTokenIsMasked(json, TProfileServiceMock::BAD_TOKEN);
         UNIT_ASSERT(!json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json[EXTENDED_ERRORS].Has("Ydb"));
         UNIT_ASSERT(json[EXTENDED_ERRORS].Has("Iam"));
@@ -1542,7 +1552,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_USER_TOKEN, TWhoamiContext::GetViewerResponse403(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TProfileServiceMock::USER_ACCOUNT_ID);
-        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
+        AssertTokenIsMasked(json, TProfileServiceMock::VALID_USER_TOKEN);
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(json[EXTENDED_ERRORS].Has("Ydb"));
         UNIT_ASSERT_VALUES_EQUAL(json[EXTENDED_ERRORS]["Ydb"]["ResponseStatus"], "403");
@@ -1556,7 +1566,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_SERVICE_TOKEN, TWhoamiContext::GetViewerResponse403(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TProfileServiceMock::SERVICE_ACCOUNT_ID);
-        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
+        AssertTokenIsMasked(json, TProfileServiceMock::VALID_SERVICE_TOKEN);
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(json[EXTENDED_ERRORS].Has("Ydb"));
         UNIT_ASSERT_VALUES_EQUAL(json[EXTENDED_ERRORS]["Ydb"]["ResponseStatus"], "403");

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -1424,17 +1424,16 @@ Y_UNIT_TEST_SUITE(Mvp) {
             return response;
         }
 
+        // Mirrors the real viewer, which stopped emitting OriginalUserToken in #34970.
         static TString GetViewerResponse200() {
             NJson::TJsonValue json(NJson::JSON_MAP);
             json["UserSID"] = VIEWER_USER_ACCOUNT_ID;
-            json["OriginalUserToken"] = TProfileServiceMock::VALID_USER_TOKEN;
             return MakeHttpResponse("200 OK", NJson::WriteJson(json, false), "application/json");
         }
 
         static TString GetViewerResponseService200() {
             NJson::TJsonValue json(NJson::JSON_MAP);
             json["UserSID"] = VIEWER_SERVICE_ACCOUNT_ID;
-            json["OriginalUserToken"] = TProfileServiceMock::VALID_SERVICE_TOKEN;
             return MakeHttpResponse("200 OK", NJson::WriteJson(json, false), "application/json");
         }
 
@@ -1510,7 +1509,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_USER_TOKEN, TWhoamiContext::GetViewerResponse200(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_USER_ACCOUNT_ID);
-        UNIT_ASSERT_VALUES_EQUAL(json[ORIGINAL_USER_TOKEN], TProfileServiceMock::VALID_USER_TOKEN);
+        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json.Has(EXTENDED_ERRORS));
     }
@@ -1520,7 +1519,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_SERVICE_TOKEN, TWhoamiContext::GetViewerResponseService200(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_SERVICE_ACCOUNT_ID);
-        UNIT_ASSERT_VALUES_EQUAL(json[ORIGINAL_USER_TOKEN], TProfileServiceMock::VALID_SERVICE_TOKEN);
+        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json.Has(EXTENDED_ERRORS));
     }
@@ -1530,7 +1529,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::BAD_TOKEN, TWhoamiContext::GetViewerResponse200(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_USER_ACCOUNT_ID);
-        UNIT_ASSERT_VALUES_EQUAL(json[ORIGINAL_USER_TOKEN], TProfileServiceMock::VALID_USER_TOKEN);
+        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
         UNIT_ASSERT(!json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json[EXTENDED_ERRORS].Has("Ydb"));
         UNIT_ASSERT(json[EXTENDED_ERRORS].Has("Iam"));
@@ -1543,7 +1542,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_USER_TOKEN, TWhoamiContext::GetViewerResponse403(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TProfileServiceMock::USER_ACCOUNT_ID);
-        UNIT_ASSERT_VALUES_EQUAL(json[ORIGINAL_USER_TOKEN], TProfileServiceMock::VALID_USER_TOKEN);
+        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(json[EXTENDED_ERRORS].Has("Ydb"));
         UNIT_ASSERT_VALUES_EQUAL(json[EXTENDED_ERRORS]["Ydb"]["ResponseStatus"], "403");
@@ -1557,7 +1556,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             TWhoamiContext(TProfileServiceMock::VALID_SERVICE_TOKEN, TWhoamiContext::GetViewerResponse403(), "200"));
 
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TProfileServiceMock::SERVICE_ACCOUNT_ID);
-        UNIT_ASSERT_VALUES_EQUAL(json[ORIGINAL_USER_TOKEN], TProfileServiceMock::VALID_SERVICE_TOKEN);
+        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
         UNIT_ASSERT(json.Has(EXTENDED_INFO));
         UNIT_ASSERT(json[EXTENDED_ERRORS].Has("Ydb"));
         UNIT_ASSERT_VALUES_EQUAL(json[EXTENDED_ERRORS]["Ydb"]["ResponseStatus"], "403");
@@ -1596,9 +1595,26 @@ Y_UNIT_TEST_SUITE(Mvp) {
         ctx.AccessServiceType = NMvp::yandex_v2;
         auto json = OidcWhoamiExtendedInfoTest(ctx);
         UNIT_ASSERT_VALUES_EQUAL(json[USER_SID], TWhoamiContext::VIEWER_USER_ACCOUNT_ID);
-        UNIT_ASSERT_VALUES_EQUAL(json[ORIGINAL_USER_TOKEN], TProfileServiceMock::VALID_USER_TOKEN);
+        UNIT_ASSERT(!json.Has(ORIGINAL_USER_TOKEN));
         UNIT_ASSERT(!json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json.Has(EXTENDED_ERRORS));
+    }
+
+    // The session cookie is httpOnly on purpose; the IAM token it is exchanged for must never
+    // reach JS through the whoami body - under any key, at any nesting depth.
+    Y_UNIT_TEST(OidcWhoamiNeverLeaksBearerToken) {
+        const std::pair<TStringBuf, TString> cases[] = {
+            {TProfileServiceMock::VALID_USER_TOKEN, TWhoamiContext::GetViewerResponse200()},
+            {TProfileServiceMock::VALID_SERVICE_TOKEN, TWhoamiContext::GetViewerResponseService200()},
+            {TProfileServiceMock::VALID_USER_TOKEN, TWhoamiContext::GetViewerResponse403()},
+            {TProfileServiceMock::VALID_SERVICE_TOKEN, TWhoamiContext::GetViewerResponse403()},
+        };
+        for (const auto& [token, viewerResponse] : cases) {
+            auto json = OidcWhoamiExtendedInfoTest(TWhoamiContext(token, viewerResponse, "200"));
+            const TString body = NJson::WriteJson(json, false);
+            UNIT_ASSERT_C(!body.Contains(token),
+                          TStringBuilder() << "whoami body leaked the bearer token: " << body);
+        }
     }
 
     Y_UNIT_TEST(GetAddressWithoutPort) {


### PR DESCRIPTION
### Changelog entry

OIDC proxy now returns `OriginalUserToken` masked instead of raw in the `whoami` response.

### Description for reviewers

The session cookie is httpOnly for a reason; the IAM token it is exchanged for was handed to JS as-is. Now masked via `NKikimr::MaskTicket`, so access stays debuggable. To be removed once observability improves.

Also drops the stale `OriginalUserToken` swagger property from viewer, which stopped emitting the field in #34970.