### PR TITLE
Fix SQS-over-topics QueueUrl to use HTTP request origin

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -52,6 +52,7 @@ struct TAppData::TImpl {
     NKikimrPQ::TPQConfig PQConfig;
     NKikimrPQ::TPQClusterDiscoveryConfig PQClusterDiscoveryConfig;
     NKikimrConfig::TKafkaProxyConfig KafkaProxyConfig;
+    NKikimrConfig::THttpProxyConfig HttpProxyConfig;
     NKikimrNetClassifier::TNetClassifierConfig NetClassifierConfig;
     NKikimrNetClassifier::TNetClassifierDistributableConfig NetClassifierDistributableConfig;
     NKikimrConfig::TSqsConfig SqsConfig;
@@ -123,6 +124,7 @@ TAppData::TAppData(
     , PQConfig(Impl->PQConfig)
     , PQClusterDiscoveryConfig(Impl->PQClusterDiscoveryConfig)
     , KafkaProxyConfig(Impl->KafkaProxyConfig)
+    , HttpProxyConfig(Impl->HttpProxyConfig)
     , NetClassifierConfig(Impl->NetClassifierConfig)
     , NetClassifierDistributableConfig(Impl->NetClassifierDistributableConfig)
     , SqsConfig(Impl->SqsConfig)

--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -58,6 +58,7 @@ namespace NKikimrConfig {
     class TMeteringConfig;
     class TSqsConfig;
     class TKafkaProxyConfig;
+    class THttpProxyConfig;
     class TAuthConfig;
 
     class THiveConfig;
@@ -249,6 +250,7 @@ struct TAppData {
     NKikimrPQ::TPQConfig& PQConfig;
     NKikimrPQ::TPQClusterDiscoveryConfig& PQClusterDiscoveryConfig;
     NKikimrConfig::TKafkaProxyConfig& KafkaProxyConfig;
+    NKikimrConfig::THttpProxyConfig& HttpProxyConfig;
     NKikimrNetClassifier::TNetClassifierConfig& NetClassifierConfig;
     NKikimrNetClassifier::TNetClassifierDistributableConfig& NetClassifierDistributableConfig;
     NKikimrConfig::TSqsConfig& SqsConfig;

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1552,6 +1552,10 @@ void TKikimrRunner::InitializeAppData(const TKikimrRunConfig& runConfig)
         AppData->KafkaProxyConfig.CopyFrom(runConfig.AppConfig.GetKafkaProxyConfig());
     }
 
+    if (runConfig.AppConfig.HasHttpProxyConfig()) {
+        AppData->HttpProxyConfig.CopyFrom(runConfig.AppConfig.GetHttpProxyConfig());
+    }
+
     if (runConfig.AppConfig.HasNetClassifierConfig()) {
         AppData->NetClassifierConfig.CopyFrom(runConfig.AppConfig.GetNetClassifierConfig());
     }

--- a/ydb/core/http_proxy/sqs.cpp
+++ b/ydb/core/http_proxy/sqs.cpp
@@ -108,6 +108,9 @@ namespace NKikimr::NHttpProxy {
                     {NYmq::V1::REQUEST_ID, HttpContext.RequestId},
                     {NYmq::V1::SOURCE_ADDRESS, HttpContext.SourceAddress},
                 };
+                if (TString requestEndpoint = MakeSqsRequestEndpoint(HttpContext)) {
+                    peerMetadata[TString{NSqsTopic::REQUEST_ENDPOINT_METADATA_KEY}] = std::move(requestEndpoint);
+                }
 
                 RpcFuture = NRpcService::DoLocalRpc<TRpcEv>(
                     std::move(Request),

--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
@@ -270,7 +270,8 @@ THttpResult THttpProxyTestMock::SendHttpRequestRawSpecified(const TString& handl
                                 const TString& host, const TString& date, const TString& userAgent,
                                 const TString& acceptEncoding,
                                 const IOutputStream::TPart& body, const TString& authorizationStr,
-                                const TString& contentType) {
+                                const TString& contentType,
+                                const TVector<std::pair<TString, TString>>& extraHeaders) {
     TNetworkAddress addr("::", HttpServicePort);
     TSocket sock(addr);
     TSocketOutput so(sock);
@@ -308,6 +309,12 @@ THttpResult THttpProxyTestMock::SendHttpRequestRawSpecified(const TString& handl
     if (!contentType.empty()) {
         parts.push_back(IOutputStream::TPart(TStringBuf("Content-Type:")));
         parts.push_back(IOutputStream::TPart(TStringBuf(contentType)));
+        parts.push_back(IOutputStream::TPart::CrLf());
+    }
+    for (const auto& [name, value] : extraHeaders) {
+        parts.push_back(IOutputStream::TPart(TStringBuf(name)));
+        parts.push_back(IOutputStream::TPart(TStringBuf(":")));
+        parts.push_back(IOutputStream::TPart(TStringBuf(value)));
         parts.push_back(IOutputStream::TPart::CrLf());
     }
     parts.push_back(IOutputStream::TPart::CrLf());
@@ -357,10 +364,11 @@ NJson::TJsonMap THttpProxyTestMock::CreateQueueWithSecurityToken(NJson::TJsonMap
 THttpResult THttpProxyTestMock::SendHttpRequestSpecified(const TString& handler, const TString& target, NJson::TJsonValue value,
                             const TString& host, const TString& date, const TString& userAgent,
                             const TString& acceptEncoding, const TString& authorizationStr,
-                            const TString& contentType) {
+                            const TString& contentType,
+                            const TVector<std::pair<TString, TString>>& extraHeaders) {
     TString jsonStr = NJson::WriteJson(value);
     return SendHttpRequestRawSpecified(handler, target, host, date, userAgent, acceptEncoding,
-                                {&jsonStr[0], jsonStr.size()}, authorizationStr, contentType);
+                                {&jsonStr[0], jsonStr.size()}, authorizationStr, contentType, extraHeaders);
 }
 
 THttpResult THttpProxyTestMock::SendPing() {
@@ -1065,6 +1073,8 @@ void THttpProxyTestMock::InitHttpServer(bool yandexCloudMode, bool enableSqsTopi
     httpProxyConfig.Config = config;
     httpProxyConfig.CredentialsProvider = credentialsProvider;
     httpProxyConfig.UseSDK = GetEnv("INSIDE_YDB").empty();
+
+    AppData(as)->HttpProxyConfig.CopyFrom(config.GetHttpConfig());
 
     actorId = as->Register(NKikimr::NHttpProxy::CreateHttpProxy(httpProxyConfig));
     as->RegisterLocalService(MakeHttpProxyID(), actorId);

--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.h
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.h
@@ -126,7 +126,8 @@ public:
                                    const TString& host, const TString& date, const TString& userAgent,
                                    const TString& acceptEncoding,
                                    const IOutputStream::TPart& body, const TString& authorizationStr,
-                                   const TString& contentType = "application/json");
+                                   const TString& contentType = "application/json",
+                                   const TVector<std::pair<TString, TString>>& extraHeaders = {});
 
     THttpResult SendHttpRequest(const TString& handler, const TString& target, NJson::TJsonValue value,
                                 const TString& authorizationStr,
@@ -140,7 +141,8 @@ public:
     THttpResult SendHttpRequestSpecified(const TString& handler, const TString& target, NJson::TJsonValue value,
                                 const TString& host, const TString& date, const TString& userAgent,
                                 const TString& acceptEncoding, const TString& authorizationStr,
-                                const TString& contentType = "application/json");
+                                const TString& contentType = "application/json",
+                                const TVector<std::pair<TString, TString>>& extraHeaders = {});
 
     THttpResult SendPing();
 

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -113,8 +113,9 @@ namespace {
         const TString& authorizationStr = "")
     {
         TString authorization = authorizationStr;
-        if (authorization.StartsWith("Authorization: ")) {
-            authorization.erase(0, 14);
+        constexpr TStringBuf authorizationPrefix = "Authorization: ";
+        if (authorization.StartsWith(authorizationPrefix)) {
+            authorization = authorization.substr(authorizationPrefix.size());
         }
         auto res = fixture.SendHttpRequestSpecified(
             "/Root",

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -109,8 +109,13 @@ namespace {
         const TString& host,
         const TString& method,
         NJson::TJsonMap request,
-        const TVector<std::pair<TString, TString>>& extraHeaders = {})
+        const TVector<std::pair<TString, TString>>& extraHeaders = {},
+        const TString& authorizationStr = "")
     {
+        TString authorization = authorizationStr;
+        if (authorization.StartsWith("Authorization: ")) {
+            authorization.erase(0, 14);
+        }
         auto res = fixture.SendHttpRequestSpecified(
             "/Root",
             TStringBuilder() << "AmazonSQS." << method,
@@ -118,8 +123,8 @@ namespace {
             host,
             "20150830T123600Z",
             "sqs-topic-ut",
-            "identity",
             "",
+            authorization,
             "application/json",
             extraHeaders);
         UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
@@ -461,6 +466,24 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
             auto json = SendSqsJsonWithHost(*this, host, "CreateQueue", {{"QueueName", queueName}});
             const TString queueUrl = GetByPath<TString>(json, "QueueUrl");
             UNIT_ASSERT(queueUrl.StartsWith(TStringBuilder() << "http://" << host << "/v1/"));
+            UNIT_ASSERT(queueUrl.Contains(queueName));
+        }
+
+        Y_UNIT_TEST_F(TestCreateQueueUsesForwardedHost, TNoAuthFixture) {
+            const TString queueName = "CreateQueueForwardedHost";
+            const TString backendHost = "vla5-2135.lbkx.example.net:8771";
+            const TString publicHost = "lbkx.example.net:8443";
+            auto json = SendSqsJsonWithHost(
+                *this,
+                backendHost,
+                "CreateQueue",
+                {{"QueueName", queueName}},
+                {
+                    {"X-Forwarded-Host", publicHost},
+                    {"X-Forwarded-Proto", "HTTPS, http"},
+                });
+            const TString queueUrl = GetByPath<TString>(json, "QueueUrl");
+            UNIT_ASSERT(queueUrl.StartsWith(TStringBuilder() << "https://" << publicHost << "/v1/"));
             UNIT_ASSERT(queueUrl.Contains(queueName));
         }
 
@@ -1174,6 +1197,36 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
                 {"QueueName", "my_topic@my/consumer"},
             });
             UNIT_ASSERT_VALUES_EQUAL(listPath, GetPathFromQueueUrlMap(getJson));
+        }
+
+        Y_UNIT_TEST_F(TestListQueuesUsesForwardedHost, TFixture) {
+            const TString queueName = "ListQueuesForwardedHost";
+            const TString consumer = "ydb-sqs-consumer";
+            {
+                auto driver = MakeDriver(*this);
+                Y_ENSURE(CreateTopic(driver, queueName, consumer));
+            }
+
+            const TString backendHost = "vla5-2135.lbkx.example.net:8771";
+            const TString publicHost = "lbkx.example.net:8443";
+            auto json = SendSqsJsonWithHost(
+                *this,
+                backendHost,
+                "ListQueues",
+                {{"QueueNamePrefix", queueName}},
+                {
+                    {"X-Forwarded-Host", publicHost},
+                    {"X-Forwarded-Proto", "HTTPS, http"},
+                },
+                FormAuthorizationStr("ru-central1"));
+            const TString expectedPath = std::format(
+                "/v1/5//Root/{}/{}/{}/{}",
+                queueName.size(), queueName.c_str(), consumer.size(), consumer.c_str());
+            const auto& urls = json["QueueUrls"].GetArray();
+            UNIT_ASSERT_VALUES_EQUAL(urls.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                urls[0].GetString(),
+                TStringBuilder() << "https://" << publicHost << expectedPath);
         }
 
         struct TSqsTopicPaths {

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -104,6 +104,30 @@ namespace {
         return GetPathFromFullQueueUrl(url);
     }
 
+    NJson::TJsonMap SendSqsJsonWithHost(
+        THttpProxyTestMock& fixture,
+        const TString& host,
+        const TString& method,
+        NJson::TJsonMap request,
+        const TVector<std::pair<TString, TString>>& extraHeaders = {})
+    {
+        auto res = fixture.SendHttpRequestSpecified(
+            "/Root",
+            TStringBuilder() << "AmazonSQS." << method,
+            request,
+            host,
+            "20150830T123600Z",
+            "sqs-topic-ut",
+            "identity",
+            "",
+            "application/json",
+            extraHeaders);
+        UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
+        NJson::TJsonMap json;
+        UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &json, true));
+        return json;
+    }
+
     NYdb::TDriverConfig MakeDriverConfig(std::derived_from<THttpProxyTestMock> auto& fixture) {
         NYdb::TDriverConfig config;
         config.SetEndpoint("localhost:" + ToString(fixture.KikimrGrpcPort));
@@ -388,6 +412,56 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
 
             json = GetQueueUrl({{"QueueName", queueName}, {"WrongParameter", "some-value"}}, 400);
             UNIT_ASSERT_VALUES_EQUAL(GetByPath<TString>(json, "__type"), "InvalidArgumentException");
+        }
+
+        Y_UNIT_TEST_F(TestGetQueueUrlUsesRequestHost, TNoAuthFixture) {
+            auto driver = MakeDriver(*this);
+            const TString topicName = "ExampleQueueName";
+            const TString consumer = "ydb-sqs-consumer";
+            Y_ENSURE(CreateTopic(driver, topicName, consumer));
+
+            const TString host = "sqs.ydb.test:8443";
+            auto json = SendSqsJsonWithHost(*this, host, "GetQueueUrl", {{"QueueName", topicName}});
+            const TString expectedPath = std::format(
+                "/v1/5//Root/{}/{}/{}/{}",
+                topicName.size(), topicName.c_str(), consumer.size(), consumer.c_str());
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetByPath<TString>(json, "QueueUrl"),
+                TStringBuilder() << "http://" << host << expectedPath);
+        }
+
+        Y_UNIT_TEST_F(TestGetQueueUrlUsesForwardedHost, TNoAuthFixture) {
+            auto driver = MakeDriver(*this);
+            const TString topicName = "ExampleQueueName";
+            const TString consumer = "ydb-sqs-consumer";
+            Y_ENSURE(CreateTopic(driver, topicName, consumer));
+
+            const TString backendHost = "vla5-2135.lbkx.example.net:8771";
+            const TString publicHost = "lbkx.example.net:8443";
+            auto json = SendSqsJsonWithHost(
+                *this,
+                backendHost,
+                "GetQueueUrl",
+                {{"QueueName", topicName}},
+                {
+                    {"X-Forwarded-Host", publicHost},
+                    {"X-Forwarded-Proto", "HTTPS, http"},
+                });
+            const TString expectedPath = std::format(
+                "/v1/5//Root/{}/{}/{}/{}",
+                topicName.size(), topicName.c_str(), consumer.size(), consumer.c_str());
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetByPath<TString>(json, "QueueUrl"),
+                TStringBuilder() << "https://" << publicHost << expectedPath);
+        }
+
+        Y_UNIT_TEST_F(TestCreateQueueUsesRequestHost, TNoAuthFixture) {
+            const TString queueName = "CreateQueueHost";
+            const TString host = "sqs.ydb.test:8443";
+            auto json = SendSqsJsonWithHost(*this, host, "CreateQueue", {{"QueueName", queueName}});
+            const TString queueUrl = GetByPath<TString>(json, "QueueUrl");
+            UNIT_ASSERT(queueUrl.StartsWith(TStringBuilder() << "http://" << host << "/v1/"));
+            UNIT_ASSERT(queueUrl.Contains(queueName));
         }
 
         Y_UNIT_TEST_F(TestGetQueueUrlOfNotExistingQueue, TFixture) {
@@ -1084,6 +1158,22 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
                 TString queueUrl2 = GetPathFromFullQueueUrl(json["QueueUrls"][0]);
                 UNIT_ASSERT_VALUES_UNEQUAL(queueUrl1, queueUrl2);
             }
+        }
+
+        Y_UNIT_TEST_F(TestListQueuesConvertsConsumerNameInFederation, TNonFirstClassCitizenFixture) {
+            CreateFederationTopicWithConsumer(*this);
+            const TString database = TString{TNonFirstClassCitizenFixture::FederationDatabase};
+            auto json = FederationSqsRequest(*this, database, "ListQueues", {});
+            const auto& urls = json["QueueUrls"].GetArray();
+            UNIT_ASSERT_VALUES_EQUAL(urls.size(), 1);
+            const TString listPath = GetPathFromFullQueueUrl(urls[0]);
+            UNIT_ASSERT(listPath.Contains("my/consumer"));
+            UNIT_ASSERT(!listPath.Contains("my@consumer"));
+
+            auto getJson = FederationSqsRequest(*this, database, "GetQueueUrl", {
+                {"QueueName", "my_topic@my/consumer"},
+            });
+            UNIT_ASSERT_VALUES_EQUAL(listPath, GetPathFromQueueUrlMap(getJson));
         }
 
         struct TSqsTopicPaths {

--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -1,0 +1,65 @@
+#include <ydb/core/http_proxy/utils.h>
+
+#include <ydb/library/actors/http/http.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/ptr.h>
+
+using namespace NKikimr::NHttpProxy;
+
+Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
+    Y_UNIT_TEST(EmptyHostWithoutForwardedHost) {
+        UNIT_ASSERT_VALUES_EQUAL(MakeSqsRequestEndpoint("", "", false), "");
+        UNIT_ASSERT_VALUES_EQUAL(MakeSqsRequestEndpoint("", "X-Forwarded-Proto: https\r\n", false), "");
+    }
+
+    Y_UNIT_TEST(UsesHostAndPlainHttp) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint("sqs.ydb.test:8443", "", false),
+            "http://sqs.ydb.test:8443");
+    }
+
+    Y_UNIT_TEST(UsesTlsWhenEndpointIsSecure) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint("sqs.ydb.test:8443", "", true),
+            "https://sqs.ydb.test:8443");
+    }
+
+    Y_UNIT_TEST(PrefersForwardedHostAndProto) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "vla5-2135.lbkx.example.net:8771",
+                "X-Forwarded-Host: lbkx.example.net:8443\r\n"
+                "X-Forwarded-Proto: HTTPS\r\n",
+                false),
+            "https://lbkx.example.net:8443");
+    }
+
+    Y_UNIT_TEST(TakesFirstForwardedTokenAndLowercasesProto) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend:8771",
+                "X-Forwarded-Host: lbkx.example.net:8443, backend:8771\r\n"
+                "X-Forwarded-Proto: HTTPS, http\r\n",
+                false),
+            "https://lbkx.example.net:8443");
+    }
+
+    Y_UNIT_TEST(ParsedHttpRequestWithTlsEndpoint) {
+        auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        endpoint->Secure = true;
+        const TString raw =
+            "POST / HTTP/1.1\r\n"
+            "Host: vla5-2135.lbkx.example.net:8771\r\n"
+            "X-Forwarded-Host: lbkx.example.net:8443\r\n"
+            "X-Forwarded-Proto: HTTPS, http\r\n"
+            "\r\n";
+        auto request = MakeIntrusive<NHttp::THttpIncomingRequest>(
+            raw, endpoint, NHttp::THttpConfig::SocketAddressType{});
+        const bool tlsSecure = request->Endpoint && request->Endpoint->Secure;
+        UNIT_ASSERT(tlsSecure);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(request->Host, request->Headers, tlsSecure),
+            "https://lbkx.example.net:8443");
+    }
+}

--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -45,6 +45,21 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
             "https://lbkx.example.net:8443");
     }
 
+    Y_UNIT_TEST(IgnoresUnknownForwardedProtoAndUsesConnectionScheme) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "sqs.ydb.test:8443",
+                "X-Forwarded-Proto: ftp\r\n",
+                false),
+            "http://sqs.ydb.test:8443");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "sqs.ydb.test:8443",
+                "X-Forwarded-Proto: FTP, https\r\n",
+                true),
+            "https://sqs.ydb.test:8443");
+    }
+
     Y_UNIT_TEST(ParsedHttpRequestWithTlsEndpoint) {
         auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
         endpoint->Secure = true;

--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -45,6 +45,27 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
             "https://lbkx.example.net:8443");
     }
 
+    Y_UNIT_TEST(IgnoresInvalidForwardedHostAndUsesRequestHost) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "sqs.ydb.test:8443",
+                "X-Forwarded-Host: evil.com/phishing#\r\n",
+                false),
+            "http://sqs.ydb.test:8443");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "sqs.ydb.test:8443",
+                "X-Forwarded-Host: evil.com?next=1\r\n",
+                true),
+            "https://sqs.ydb.test:8443");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "evil.com/phishing#",
+                "X-Forwarded-Host: evil.com/phishing#\r\n",
+                false),
+            "");
+    }
+
     Y_UNIT_TEST(IgnoresUnknownForwardedProtoAndUsesConnectionScheme) {
         UNIT_ASSERT_VALUES_EQUAL(
             MakeSqsRequestEndpoint(

--- a/ydb/core/http_proxy/ut/ya.make
+++ b/ydb/core/http_proxy/ut/ya.make
@@ -33,6 +33,7 @@ PEERDIR(
 SRCS(
     json_proto_conversion_ut.cpp
     http_ut.cpp
+    utils_ut.cpp
 )
 
 RESOURCE(

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -2,6 +2,10 @@
 
 #include "http_req.h"
 
+#include <util/string/ascii.h>
+#include <util/string/builder.h>
+#include <util/string/strip.h>
+
 namespace NKikimr::NHttpProxy {
 
 TException MapToException(NYdb::EStatus status, const TString& method, size_t issueCode) {
@@ -75,6 +79,50 @@ TString LogHttpRequestResponseCommonInfoString(const THttpRequestContext& httpCo
         logString << " Response [" << httpResponseMessage << "]";
     }
     return logString;
+}
+
+namespace {
+
+TStringBuf FirstForwardedValue(TStringBuf value) {
+    return StripString(value.Before(','));
+}
+
+TString NormalizeForwardedProto(TStringBuf proto) {
+    TStringBuf first = FirstForwardedValue(proto);
+    TString scheme;
+    scheme.reserve(first.size());
+    for (char c : first) {
+        scheme.push_back(AsciiToLower(c));
+    }
+    return scheme;
+}
+
+} // namespace
+
+TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tlsSecure) {
+    const NHttp::THeaders headers(headersBlob);
+    if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host")); !forwardedHost.empty()) {
+        host = forwardedHost;
+    }
+    if (host.empty()) {
+        return {};
+    }
+    TString scheme = tlsSecure ? "https" : "http";
+    if (TStringBuf proto = headers.Get("x-forwarded-proto"); !proto.empty()) {
+        if (TString normalized = NormalizeForwardedProto(proto); !normalized.empty()) {
+            scheme = std::move(normalized);
+        }
+    }
+    return TStringBuilder() << scheme << "://" << host;
+}
+
+TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext) {
+    if (!httpContext.Request) {
+        return {};
+    }
+    const auto& request = *httpContext.Request;
+    const bool tlsSecure = request.Endpoint && request.Endpoint->Secure;
+    return MakeSqsRequestEndpoint(request.Host, request.Headers, tlsSecure);
 }
 
 } // namespace NKikimr::NHttpProxy

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -100,14 +100,22 @@ TString NormalizeForwardedProto(TStringBuf proto) {
     return scheme;
 }
 
+// Host / X-Forwarded-Host must be host[:port] (or [ipv6]:port). Reject path, query and fragment
+// so they cannot leak into QueueUrl as https://evil.com/phishing#/v1/...
+bool IsValidRequestHost(TStringBuf host) {
+    return !host.empty() && host.find_first_of("/?#") == TStringBuf::npos;
+}
+
 } // namespace
 
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tlsSecure) {
     const NHttp::THeaders headers(headersBlob);
-    if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host")); !forwardedHost.empty()) {
+    if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host"));
+        IsValidRequestHost(forwardedHost))
+    {
         host = forwardedHost;
     }
-    if (host.empty()) {
+    if (!IsValidRequestHost(host)) {
         return {};
     }
     TString scheme = tlsSecure ? "https" : "http";

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -94,6 +94,9 @@ TString NormalizeForwardedProto(TStringBuf proto) {
     for (char c : first) {
         scheme.push_back(AsciiToLower(c));
     }
+    if (scheme != "http" && scheme != "https") {
+        return {};
+    }
     return scheme;
 }
 

--- a/ydb/core/http_proxy/utils.h
+++ b/ydb/core/http_proxy/utils.h
@@ -17,6 +17,8 @@ TString LogHttpRequestResponseCommonInfoString(const THttpRequestContext& httpCo
 
 // host is the HTTP Host / :authority value. headers is the raw header blob.
 // tlsSecure is true when the connection to http_proxy itself is TLS.
+// Prefers the first X-Forwarded-Host token when it is a host[:port] without '/', '#' or '?';
+// otherwise uses host. Unknown X-Forwarded-Proto values fall back to tlsSecure.
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headers, bool tlsSecure);
 TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext);
 

--- a/ydb/core/http_proxy/utils.h
+++ b/ydb/core/http_proxy/utils.h
@@ -5,6 +5,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status_codes.h>
 
 #include <util/datetime/base.h>
+#include <util/generic/strbuf.h>
 
 namespace NKikimr::NHttpProxy {
 
@@ -13,5 +14,10 @@ struct THttpRequestContext;
 TException MapToException(NYdb::EStatus status, const TString& method, size_t issueCode);
 
 TString LogHttpRequestResponseCommonInfoString(const THttpRequestContext& httpContext, TInstant startTime, TStringBuf api, TStringBuf topicPath, TStringBuf method, TStringBuf userSid, int httpCode, TStringBuf httpResponseMessage);
+
+// host is the HTTP Host / :authority value. headers is the raw header blob.
+// tlsSecure is true when the connection to http_proxy itself is TLS.
+TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headers, bool tlsSecure);
+TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext);
 
 } // namespace NKikimr::NHttpProxy

--- a/ydb/services/sqs_topic/create_queue.cpp
+++ b/ydb/services/sqs_topic/create_queue.cpp
@@ -265,8 +265,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 .Fifo = QueueAttributes.FifoQueue,
             };
 
-            TString path = PackQueueUrlPath(queueUrl);
-            TString url = TStringBuilder() << GetEndpoint(Cfg()) << path;
+            TString url = MakeQueueUrl(queueUrl, Request_.get());
             result.set_queue_url(std::move(url));
 
             return ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ctx);

--- a/ydb/services/sqs_topic/get_queue_url.cpp
+++ b/ydb/services/sqs_topic/get_queue_url.cpp
@@ -143,8 +143,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 .Fifo = QueueName.EndsWith(".fifo"),
             };
 
-            TString path = PackQueueUrlPath(queueUrl);
-            TString url = TStringBuilder() << GetEndpoint(Cfg()) << path;
+            TString url = MakeQueueUrl(queueUrl, Request_.get());
             result.set_queue_url(std::move(url));
 
             return ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ctx);

--- a/ydb/services/sqs_topic/list_queues.cpp
+++ b/ydb/services/sqs_topic/list_queues.cpp
@@ -4,6 +4,7 @@
 #include "request.h"
 #include "utils.h"
 
+#include <ydb/library/persqueue/topic_parser/topic_parser.h>
 #include <ydb/core/http_proxy/events.h>
 #include <ydb/core/persqueue/public/list_topics/list_all_topics_actor.h>
 #include <ydb/core/persqueue/events/internal.h>
@@ -187,12 +188,10 @@ namespace NKikimr::NSqsTopic::V1 {
             const TRichQueueUrl queueUrl{
                 .Database = DatabaseName_,
                 .TopicPath = ToString(topicPath),
-                .Consumer = topicConsumer.Consumer,
+                .Consumer = NPersQueue::ConvertOldConsumerName(topicConsumer.Consumer, ctx),
                 .Fifo = topicConsumer.Fifo,
             };
-            TString path = PackQueueUrlPath(queueUrl);
-            TString url = TStringBuilder() << GetEndpoint(Cfg()) << path;
-            result.add_queue_urls(url);
+            result.add_queue_urls(MakeQueueUrl(queueUrl, Request_.get()));
         }
         return this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ctx);
     }

--- a/ydb/services/sqs_topic/queue_url/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/queue_url/ut/utils_ut.cpp
@@ -98,4 +98,22 @@ Y_UNIT_TEST_SUITE(SqsTopicQueueUrl) {
             MakeQueueUrlEndpoint("", "localhost", 2135, false),
             "http://localhost:2135");
     }
+
+    Y_UNIT_TEST(MakeQueueUrlFallbackOmitsZeroPort) {
+        TRichQueueUrl qu{
+            .Database = "/Root",
+            .TopicPath = "topic",
+            .Consumer = "consumer",
+            .Fifo = false,
+        };
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeQueueUrl(qu, "", "vla5-2135.example.net", 0, true),
+            "https://vla5-2135.example.net/v1/5//Root/5/topic/8/consumer");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeQueueUrlEndpoint("", "vla5-2135.example.net", 0, true),
+            "https://vla5-2135.example.net");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeQueueUrlEndpoint("", "localhost", 0, false),
+            "http://localhost");
+    }
 }

--- a/ydb/services/sqs_topic/queue_url/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/queue_url/ut/utils_ut.cpp
@@ -33,4 +33,69 @@ Y_UNIT_TEST_SUITE(SqsTopicQueueUrl) {
         UNIT_ASSERT_VALUES_EQUAL(result, "/v1/5//Root/10/topic/path/16/ydb_sqs_consumer.fifo");
         UNIT_ASSERT(*ParseQueueUrlPath(result) == qu);
     }
+
+    Y_UNIT_TEST(MakeQueueUrlPrefersRequestEndpoint) {
+        TRichQueueUrl qu{
+            .Database = "/Root",
+            .TopicPath = "topic",
+            .Consumer = "consumer",
+            .Fifo = false,
+        };
+        const TString url = MakeQueueUrl(
+            qu,
+            "https://lbkx.example.net:8443",
+            "node.example.net",
+            2135);
+        UNIT_ASSERT_VALUES_EQUAL(
+            url,
+            "https://lbkx.example.net:8443/v1/5//Root/5/topic/8/consumer");
+    }
+
+    Y_UNIT_TEST(MakeQueueUrlStripsTrailingSlashFromRequestEndpoint) {
+        TRichQueueUrl qu{
+            .Database = "/Root",
+            .TopicPath = "topic",
+            .Consumer = "consumer",
+            .Fifo = false,
+        };
+        const TString url = MakeQueueUrl(
+            qu,
+            "https://lbkx.example.net:8443/",
+            "node.example.net",
+            2135);
+        UNIT_ASSERT_VALUES_EQUAL(
+            url,
+            "https://lbkx.example.net:8443/v1/5//Root/5/topic/8/consumer");
+    }
+
+    Y_UNIT_TEST(MakeQueueUrlFallsBackToFqdnAndHttpProxyPort) {
+        TRichQueueUrl qu{
+            .Database = "/Root",
+            .TopicPath = "topic",
+            .Consumer = "consumer",
+            .Fifo = false,
+        };
+        const TString url = MakeQueueUrl(qu, "", "vla5-2135.example.net", 2135, true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            url,
+            "https://vla5-2135.example.net:2135/v1/5//Root/5/topic/8/consumer");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeQueueUrlEndpoint("", "vla5-2135.example.net", 2135, true),
+            "https://vla5-2135.example.net:2135");
+    }
+
+    Y_UNIT_TEST(MakeQueueUrlFallbackUsesHttpWhenNotSecure) {
+        TRichQueueUrl qu{
+            .Database = "/Root",
+            .TopicPath = "topic",
+            .Consumer = "consumer",
+            .Fifo = false,
+        };
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeQueueUrl(qu, "", "localhost", 2135, false),
+            "http://localhost:2135/v1/5//Root/5/topic/8/consumer");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeQueueUrlEndpoint("", "localhost", 2135, false),
+            "http://localhost:2135");
+    }
 }

--- a/ydb/services/sqs_topic/queue_url/utils.cpp
+++ b/ydb/services/sqs_topic/queue_url/utils.cpp
@@ -117,4 +117,19 @@ namespace NKikimr::NSqsTopic {
         }
         return result;
     }
+
+    TString MakeQueueUrlEndpoint(TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure) {
+        if (requestEndpoint) {
+            TString endpoint{requestEndpoint};
+            while (endpoint.EndsWith('/')) {
+                endpoint.pop_back();
+            }
+            return endpoint;
+        }
+        return TStringBuilder() << (secure ? "https://" : "http://") << fallbackHost << ":" << httpProxyPort;
+    }
+
+    TString MakeQueueUrl(const TRichQueueUrl& queueUrl, TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure) {
+        return MakeQueueUrlEndpoint(requestEndpoint, fallbackHost, httpProxyPort, secure) + PackQueueUrlPath(queueUrl);
+    }
 } // namespace NKikimr::NSqsTopic

--- a/ydb/services/sqs_topic/queue_url/utils.cpp
+++ b/ydb/services/sqs_topic/queue_url/utils.cpp
@@ -126,7 +126,12 @@ namespace NKikimr::NSqsTopic {
             }
             return endpoint;
         }
-        return TStringBuilder() << (secure ? "https://" : "http://") << fallbackHost << ":" << httpProxyPort;
+        TStringBuilder endpoint;
+        endpoint << (secure ? "https://" : "http://") << fallbackHost;
+        if (httpProxyPort != 0) {
+            endpoint << ":" << httpProxyPort;
+        }
+        return endpoint;
     }
 
     TString MakeQueueUrl(const TRichQueueUrl& queueUrl, TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure) {

--- a/ydb/services/sqs_topic/queue_url/utils.h
+++ b/ydb/services/sqs_topic/queue_url/utils.h
@@ -25,7 +25,8 @@ namespace NKikimr::NSqsTopic {
 
     // Public SQS QueueUrl prefix: scheme://host[:port] without a trailing slash.
     // If requestEndpoint is set (from the incoming HTTP request), it is used as-is.
-    // Otherwise scheme://fallbackHost:httpProxyPort, where scheme is https iff secure.
+    // Otherwise scheme://fallbackHost[:httpProxyPort], where scheme is https iff secure.
+    // Port 0 omits :port so the URL is not scheme://host:0.
     TString MakeQueueUrlEndpoint(TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure = true);
     TString MakeQueueUrl(const TRichQueueUrl& queueUrl, TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure = true);
 

--- a/ydb/services/sqs_topic/queue_url/utils.h
+++ b/ydb/services/sqs_topic/queue_url/utils.h
@@ -3,6 +3,7 @@
 #include <util/generic/strbuf.h>
 #include <util/generic/string.h>
 #include <util/stream/output.h>
+#include <util/system/types.h>
 
 #include <expected>
 
@@ -21,6 +22,12 @@ namespace NKikimr::NSqsTopic {
     std::expected<TRichQueueUrl, TString> ParseQueueUrlPath(const TStringBuf path);
 
     TString PackQueueUrlPath(const TRichQueueUrl& queueUrl);
+
+    // Public SQS QueueUrl prefix: scheme://host[:port] without a trailing slash.
+    // If requestEndpoint is set (from the incoming HTTP request), it is used as-is.
+    // Otherwise scheme://fallbackHost:httpProxyPort, where scheme is https iff secure.
+    TString MakeQueueUrlEndpoint(TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure = true);
+    TString MakeQueueUrl(const TRichQueueUrl& queueUrl, TStringBuf requestEndpoint, TStringBuf fallbackHost, ui16 httpProxyPort, bool secure = true);
 
     void WriteLengthDelimitedString(IOutputStream& os, TStringBuf value);
 } // namespace NKikimr::NSqsTopic

--- a/ydb/services/sqs_topic/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/ut/utils_ut.cpp
@@ -203,4 +203,15 @@ Y_UNIT_TEST_SUITE(SqsTopicMakeQueueUrl) {
             url,
             TStringBuilder() << "http://" << FQDNHostName() << ":2135/v1/5//Root/5/topic/8/consumer");
     }
+
+    Y_UNIT_TEST(FallsBackWithoutPortWhenHttpProxyConfigPortIsZero) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const TString url = CollectMakeQueueUrlWithoutRequestMetadata(runtime, 0, true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            url,
+            TStringBuilder() << "https://" << FQDNHostName() << "/v1/5//Root/5/topic/8/consumer");
+        UNIT_ASSERT(!url.Contains(":0"));
+    }
 }

--- a/ydb/services/sqs_topic/ut/utils_ut.cpp
+++ b/ydb/services/sqs_topic/ut/utils_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/services/sqs_topic/utils.h>
+#include <ydb/services/sqs_topic/queue_url/utils.h>
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/protos/pqconfig.pb.h>
@@ -7,6 +8,8 @@
 #include <ydb/library/actors/core/event_local.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/system/hostname.h>
 
 using namespace NKikimr::NSqsTopic;
 
@@ -20,6 +23,57 @@ namespace {
             {},
             {}
         });
+    }
+
+    struct TEvMakeQueueUrlResult
+        : public NActors::TEventLocal<TEvMakeQueueUrlResult, NActors::TEvents::ES_PRIVATE + 7422> {
+        TString QueueUrl;
+    };
+
+    class TMakeQueueUrlTestActor : public NActors::TActorBootstrapped<TMakeQueueUrlTestActor> {
+    public:
+        TMakeQueueUrlTestActor(NActors::TActorId edge, ui16 httpProxyPort, bool httpProxySecure)
+            : Edge_(edge)
+            , HttpProxyPort_(httpProxyPort)
+            , HttpProxySecure_(httpProxySecure)
+        {
+        }
+
+        void Bootstrap(const NActors::TActorContext& ctx) {
+            auto& httpProxyConfig = NKikimr::AppData(ctx)->HttpProxyConfig;
+            httpProxyConfig.SetPort(HttpProxyPort_);
+            httpProxyConfig.SetSecure(HttpProxySecure_);
+
+            const TRichQueueUrl queueUrl{
+                .Database = "/Root",
+                .TopicPath = "topic",
+                .Consumer = "consumer",
+                .Fifo = false,
+            };
+            auto* ev = new TEvMakeQueueUrlResult;
+            ev->QueueUrl = MakeQueueUrl(queueUrl, nullptr);
+            ctx.Send(Edge_, ev);
+            Die(ctx);
+        }
+
+    private:
+        NActors::TActorId Edge_;
+        ui16 HttpProxyPort_;
+        bool HttpProxySecure_;
+    };
+
+    TString CollectMakeQueueUrlWithoutRequestMetadata(
+        NKikimr::TTestActorRuntime& runtime,
+        ui16 httpProxyPort,
+        bool httpProxySecure)
+    {
+        const auto edge = runtime.AllocateEdgeActor();
+        runtime.Register(
+            new TMakeQueueUrlTestActor(edge, httpProxyPort, httpProxySecure),
+            0,
+            runtime.GetAppData().SystemPoolId);
+        auto ev = runtime.GrabEdgeEvent<TEvMakeQueueUrlResult>(edge);
+        return ev->Get()->QueueUrl;
     }
 
     TString GetLabelValue(
@@ -126,5 +180,27 @@ Y_UNIT_TEST_SUITE(SqsTopicMetricsLabels) {
         );
 
         UNIT_ASSERT_VALUES_EQUAL(GetLabelValue(labels, "consumer"), "account/dir--topic");
+    }
+}
+
+Y_UNIT_TEST_SUITE(SqsTopicMakeQueueUrl) {
+    Y_UNIT_TEST(FallsBackToHttpProxyConfigFromAppDataWhenRequestMetadataMissing) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const TString url = CollectMakeQueueUrlWithoutRequestMetadata(runtime, 8443, true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            url,
+            TStringBuilder() << "https://" << FQDNHostName() << ":8443/v1/5//Root/5/topic/8/consumer");
+    }
+
+    Y_UNIT_TEST(FallsBackToHttpWhenHttpProxyConfigIsNotSecure) {
+        NKikimr::TTestActorRuntime runtime(1, false);
+        InitRuntime(runtime);
+
+        const TString url = CollectMakeQueueUrlWithoutRequestMetadata(runtime, 2135, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            url,
+            TStringBuilder() << "http://" << FQDNHostName() << ":2135/v1/5//Root/5/topic/8/consumer");
     }
 }

--- a/ydb/services/sqs_topic/utils.cpp
+++ b/ydb/services/sqs_topic/utils.cpp
@@ -1,10 +1,11 @@
 #include "utils.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/grpc_services/base/iface.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/core/protos/http_config.pb.h>
+#include <ydb/services/sqs_topic/queue_url/utils.h>
 
 #include <library/cpp/digest/md5/md5.h>
 
@@ -31,17 +32,24 @@ namespace NKikimr::NSqsTopic {
         return result;
     }
 
-    TString GetEndpoint(const NKikimrConfig::TSqsConfig& config) {
-        const TString& endpoint = config.GetEndpoint();
-        if (endpoint) {
-            return endpoint;
-        } else {
-            return TStringBuilder() << "http://" << FQDNHostName() << ":" << config.GetHttpServerConfig().GetPort();
-        }
-    }
-
     const NKikimrConfig::TSqsConfig& Cfg() {
         return AppData()->SqsConfig;
+    }
+
+    TString MakeQueueUrl(const TRichQueueUrl& queueUrl, const NGRpcService::IRequestCtxBaseMtSafe* request) {
+        TString requestEndpoint;
+        if (request) {
+            if (const auto value = request->GetPeerMetaValues(TString{REQUEST_ENDPOINT_METADATA_KEY})) {
+                requestEndpoint = *value;
+            }
+        }
+        const auto& httpProxyConfig = AppData()->HttpProxyConfig;
+        return MakeQueueUrl(
+            queueUrl,
+            requestEndpoint,
+            FQDNHostName(),
+            static_cast<ui16>(httpProxyConfig.GetPort()),
+            httpProxyConfig.GetSecure());
     }
 
     TString GenerateMessageId(const TString& database, const TString& topicPath, const NPQ::NMLP::TMessageId& pos) {

--- a/ydb/services/sqs_topic/utils.h
+++ b/ydb/services/sqs_topic/utils.h
@@ -7,15 +7,19 @@ namespace NKikimrConfig {
     class TSqsConfig;
 } // namespace NKikimrConfig
 
-namespace NKikimr::NGrpcService {
-    class IRequestOpCtx;
-} // namespace NKikimr::NGrpcService
+namespace NKikimr::NGRpcService {
+    class IRequestCtxBaseMtSafe;
+} // namespace NKikimr::NGRpcService
 
 namespace NKikimr::NPQ::NMLP {
     struct TMessageId;
 } // namespace NKikimr::NPQ::NMLP
 
 namespace NKikimr::NSqsTopic {
+
+    struct TRichQueueUrl;
+
+    inline constexpr TStringBuf REQUEST_ENDPOINT_METADATA_KEY = "sqsRequestEndpoint";
 
     struct TQueueNameWithConsumer {
         TStringBuf QueueName;
@@ -26,7 +30,7 @@ namespace NKikimr::NSqsTopic {
 
     const NKikimrConfig::TSqsConfig& Cfg();
 
-    TString GetEndpoint(const NKikimrConfig::TSqsConfig& config);
+    TString MakeQueueUrl(const TRichQueueUrl& queueUrl, const NGRpcService::IRequestCtxBaseMtSafe* request);
 
     TString GenerateMessageId(const TString& database, const TString& topicPath, const NPQ::NMLP::TMessageId& pos);
 

--- a/ydb/tests/functional/sqs_topic/test_create_queue.py
+++ b/ydb/tests/functional/sqs_topic/test_create_queue.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import uuid
+from urllib.parse import urlsplit
 
 import botocore
 
@@ -212,3 +213,16 @@ class TestSqsTopicCreateQueue(KikimrSqsTopicTestBase):
                 pattern='InvalidParameterValue',
             ),
         )
+
+    def test_create_queue_uses_request_endpoint(self):
+        queue_name = self._make_queue_name('create_queue_uses_request_endpoint')
+        request_host = 'sqs-create-queue.test'
+
+        with self._boto_client_with_request_host(request_host) as (origin, client):
+            created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+
+        self._queue_url = created_url
+        created_path = urlsplit(created_url).path
+        assert_that(created_url, equal_to(origin + created_path))
+        assert_that(created_path.startswith('/v1/'), equal_to(True))
+        assert_that(created_url, contains_string(queue_name))

--- a/ydb/tests/functional/sqs_topic/test_get_queue_url.py
+++ b/ydb/tests/functional/sqs_topic/test_get_queue_url.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import uuid
+from urllib.parse import urlsplit
 
 import botocore
 
-from hamcrest import assert_that, equal_to, raises
+from hamcrest import assert_that, equal_to, is_not, raises
 
 from ydb.tests.library.sqs_topic.test_base import KikimrSqsTopicTestBase
 
@@ -134,3 +135,18 @@ class TestSqsTopicGetQueueUrl(KikimrSqsTopicTestBase):
                 pattern='InvalidParameterValue',
             ),
         )
+
+    def test_get_queue_url_uses_request_endpoint(self):
+        queue_name = self._make_queue_name('get_queue_url_uses_request_endpoint')
+        created_url = self._boto_client.create_queue(QueueName=queue_name)['QueueUrl']
+        self._queue_url = created_url
+
+        created_path = urlsplit(created_url).path
+        request_host = 'sqs-get-queue-url.test'
+
+        with self._boto_client_with_request_host(request_host) as (origin, client):
+            get_response = client.get_queue_url(QueueName=queue_name)
+            expected_queue_url = origin + created_path
+
+        assert_that(expected_queue_url, is_not(equal_to(created_url)))
+        assert_that(get_response['QueueUrl'], equal_to(expected_queue_url))

--- a/ydb/tests/functional/sqs_topic/test_list_queues.py
+++ b/ydb/tests/functional/sqs_topic/test_list_queues.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import uuid
+from urllib.parse import urlsplit
 
-from hamcrest import assert_that, has_item, not_none
+from hamcrest import assert_that, equal_to, has_item, is_not, not_none
 
 from ydb.tests.library.sqs_topic.test_base import KikimrSqsTopicTestBase
 
@@ -93,3 +94,19 @@ class TestSqsTopicListQueues(KikimrSqsTopicTestBase):
         assert_that(queue_urls, has_item(queue_url_2))
 
         self._boto_client.delete_queue(QueueUrl=queue_url_1)
+
+    def test_list_queues_uses_request_endpoint(self):
+        queue_name = self._make_queue_name('list_queues_uses_request_endpoint')
+        created_url = self._boto_client.create_queue(QueueName=queue_name)['QueueUrl']
+        self._queue_url = created_url
+
+        created_path = urlsplit(created_url).path
+        request_host = 'sqs-list-queues.test'
+
+        with self._boto_client_with_request_host(request_host) as (origin, client):
+            response = client.list_queues()
+            expected_queue_url = origin + created_path
+
+        queue_urls = response.get('QueueUrls', [])
+        assert_that(expected_queue_url, is_not(equal_to(created_url)))
+        assert_that(queue_urls, has_item(expected_queue_url))

--- a/ydb/tests/functional/sqs_topic/test_request_endpoint.py
+++ b/ydb/tests/functional/sqs_topic/test_request_endpoint.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from urllib.parse import urlsplit
+
+from hamcrest import assert_that, equal_to, has_length, not_none
+
+from ydb.tests.library.sqs_topic.test_base import KikimrSqsTopicTestBase
+
+
+class TestSqsTopicRequestEndpoint(KikimrSqsTopicTestBase):
+    def test_queue_lifecycle_uses_request_endpoint(self):
+        queue_name = self._make_queue_name('queue_lifecycle_uses_request_endpoint')
+        request_host = 'sqs-queue-lifecycle.test'
+        message_body = 'hello from custom request endpoint'
+
+        with self._boto_client_with_request_host(request_host) as (origin, client):
+            created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+            self._queue_url = created_url
+
+            created_path = urlsplit(created_url).path
+            assert_that(created_url, equal_to(origin + created_path))
+            assert_that(created_path.startswith('/v1/'), equal_to(True))
+
+            get_url = client.get_queue_url(QueueName=queue_name)['QueueUrl']
+            assert_that(get_url, equal_to(created_url))
+
+            send_response = client.send_message(
+                QueueUrl=created_url,
+                MessageBody=message_body,
+            )
+            assert_that(send_response['MessageId'], not_none())
+
+            receive_response = client.receive_message(
+                QueueUrl=created_url,
+                WaitTimeSeconds=20,
+                MaxNumberOfMessages=1,
+            )
+            messages = receive_response.get('Messages')
+            assert_that(messages, not_none())
+            assert_that(messages, has_length(1))
+            assert_that(messages[0]['Body'], equal_to(message_body))
+            assert_that(messages[0]['ReceiptHandle'], not_none())
+
+            client.delete_message(
+                QueueUrl=created_url,
+                ReceiptHandle=messages[0]['ReceiptHandle'],
+            )
+
+        assert_that(
+            self._get_consumer_uncommitted_messages_count(queue_name),
+            equal_to(0),
+        )

--- a/ydb/tests/functional/sqs_topic/test_request_endpoint.py
+++ b/ydb/tests/functional/sqs_topic/test_request_endpoint.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from urllib.parse import urlsplit
 
-from hamcrest import assert_that, equal_to, has_length, not_none
+from hamcrest import assert_that, equal_to, has_item, has_length, is_not, not_none
 
 from ydb.tests.library.sqs_topic.test_base import KikimrSqsTopicTestBase
 
@@ -50,3 +50,26 @@ class TestSqsTopicRequestEndpoint(KikimrSqsTopicTestBase):
             self._get_consumer_uncommitted_messages_count(queue_name),
             equal_to(0),
         )
+
+    def test_queue_urls_use_forwarded_host(self):
+        queue_name = self._make_queue_name('queue_urls_use_forwarded_host')
+        public_host = 'lbkx.example.net:8443'
+
+        with self._boto_client_with_forwarded_host(public_host) as (origin, client):
+            created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+            self._queue_url = created_url
+
+            created_path = urlsplit(created_url).path
+            assert_that(created_url, equal_to(origin + created_path))
+            assert_that(created_url.startswith('https://'), equal_to(True))
+
+            get_url = client.get_queue_url(QueueName=queue_name)['QueueUrl']
+            assert_that(get_url, equal_to(created_url))
+
+            listed = client.list_queues(QueueNamePrefix=queue_name).get('QueueUrls', [])
+            assert_that(listed, has_item(created_url))
+
+        default_url = self._boto_client.get_queue_url(QueueName=queue_name)['QueueUrl']
+        assert_that(default_url, is_not(equal_to(created_url)))
+        assert_that(urlsplit(default_url).path, equal_to(created_path))
+        assert_that(default_url.startswith('https://'), equal_to(False))

--- a/ydb/tests/functional/sqs_topic/ya.make
+++ b/ydb/tests/functional/sqs_topic/ya.make
@@ -15,6 +15,7 @@ TEST_SRCS(
     test_delete_message.py
     test_delete_message_batch.py
     test_list_queues.py
+    test_request_endpoint.py
     test_purge_queue.py
     test_add_permission.py
     test_remove_permission.py

--- a/ydb/tests/library/sqs_topic/test_base.py
+++ b/ydb/tests/library/sqs_topic/test_base.py
@@ -163,6 +163,24 @@ class KikimrSqsTopicTestBase(object):
         with resolve_hostname_as_localhost(request_host):
             yield origin, self._make_boto_client(endpoint_url='{}{}'.format(origin, self.database))
 
+    @contextmanager
+    def _boto_client_with_forwarded_host(self, public_host, proto='HTTPS, http'):
+        # Talk to the real backend Host (localhost:http_proxy_port) and inject balancer headers.
+        first_proto = proto.split(',', 1)[0].strip().lower()
+        public_origin = '{}://{}'.format(first_proto, public_host)
+        client = self._make_boto_client()
+
+        def add_forwarded_headers(request, **kwargs):
+            request.headers['X-Forwarded-Host'] = public_host
+            request.headers['X-Forwarded-Proto'] = proto
+
+        event_name = 'before-send.sqs.*'
+        client.meta.events.register(event_name, add_forwarded_headers)
+        try:
+            yield public_origin, client
+        finally:
+            client.meta.events.unregister(event_name, add_forwarded_headers)
+
     def _make_ydb_driver(self):
         node = self.cluster.nodes[1]
         config = ydb.DriverConfig(

--- a/ydb/tests/library/sqs_topic/test_base.py
+++ b/ydb/tests/library/sqs_topic/test_base.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import logging
+import socket
 import time
 import uuid
+from contextlib import contextmanager
 
 import boto3
 from hamcrest import assert_that, equal_to, has_item, has_length, not_none, raises
@@ -17,6 +19,31 @@ logger = logging.getLogger(__name__)
 DEFAULT_REGION = 'ru-central1'
 DEFAULT_SECURITY_TOKEN = 'root@builtin'
 DEFAULT_SQS_CONSUMER = 'ydb-sqs-consumer'
+
+
+@contextmanager
+def resolve_hostname_as_localhost(hostname):
+    # No /etc/hosts: remap a fake DNS name to the same address the cluster already uses.
+    original_getaddrinfo = socket.getaddrinfo
+    original_gethostbyname = socket.gethostbyname
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        if host == hostname:
+            host = 'localhost'
+        return original_getaddrinfo(host, port, *args, **kwargs)
+
+    def fake_gethostbyname(host):
+        if host == hostname:
+            host = 'localhost'
+        return original_gethostbyname(host)
+
+    socket.getaddrinfo = fake_getaddrinfo
+    socket.gethostbyname = fake_gethostbyname
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+        socket.gethostbyname = original_gethostbyname
 
 
 class KikimrSqsTopicTestBase(object):
@@ -119,16 +146,22 @@ class KikimrSqsTopicTestBase(object):
         )['QueueUrl']
         return queue_name
 
-    def _make_boto_client(self):
+    def _make_boto_client(self, endpoint_url=None):
         session = boto3.session.Session()
         return session.client(
             service_name='sqs',
             aws_access_key_id='unused',
             aws_secret_access_key='unused',
             aws_session_token=DEFAULT_SECURITY_TOKEN,
-            endpoint_url=self.sqs_endpoint,
+            endpoint_url=endpoint_url or self.sqs_endpoint,
             region_name=DEFAULT_REGION,
         )
+
+    @contextmanager
+    def _boto_client_with_request_host(self, request_host):
+        origin = 'http://{}:{}'.format(request_host, self.cluster.nodes[1].http_proxy_port)
+        with resolve_hostname_as_localhost(request_host):
+            yield origin, self._make_boto_client(endpoint_url='{}{}'.format(origin, self.database))
 
     def _make_ydb_driver(self):
         node = self.cluster.nodes[1]


### PR DESCRIPTION
### Changelog entry

Fix QueueUrl returned by SQS-over-topics CreateQueue, GetQueueUrl and ListQueues: use the client-facing HTTP origin (`Host` / `X-Forwarded-*`) instead of node FQDN and classic YMQ port 8771.

**Migration:** SQS-over-topics no longer uses `SqsConfig.Endpoint` (or YMQ `HttpServerConfig.Port`) when building QueueUrl. Fallback without HTTP origin is `scheme://FQDN[:HttpProxyConfig.Port]` with `scheme` from `HttpProxyConfig.Secure`. Classic YMQ is unchanged and still honors `SqsConfig.Endpoint`.

**Trust:** `http_proxy` is expected to sit behind a reverse proxy that sets/overwrites `X-Forwarded-Host` and `X-Forwarded-Proto`. Unknown proto values and host tokens containing `/`, `#` or `?` are ignored.

### Description for reviewers

**Problem**

For SQS-over-topics, `CreateQueue` / `GetQueueUrl` / `ListQueues` built QueueUrl via `GetEndpoint(SqsConfig)` → `http://<node FQDN>:8771/...`. Clients behind a balancer got URLs pointing at an internal node, not the endpoint they actually used (e.g. `https://lbkx.example.net:8443/...`).

Classic YMQ is unchanged.

**Solution**

1. **http_proxy** extracts public origin from the incoming HTTP request (`Host`, first `X-Forwarded-Host`, first `X-Forwarded-Proto`) and passes it to sqs_topic actors as LocalRpc metadata `sqsRequestEndpoint`.
   - Proto is allowlisted to `http`/`https` (unknown → connection TLS flag).
   - Host tokens with `/`, `#` or `?` are rejected; fall back to `Host`.
2. **sqs_topic** builds QueueUrl through shared `MakeQueueUrl()`:
   - if metadata is present → use request origin;
   - otherwise → `scheme://FQDN[:HttpProxyConfig.Port]` (`Port == 0` omits `:port`).
3. **ListQueues** also applies `ConvertOldConsumerName` so consumer path matches GetQueueUrl when `TopicsAreFirstClassCitizen=false`.
4. **AppData** exposes `HttpProxyConfig` for the fallback path.

**Tests**

Unit:
- `ydb/core/http_proxy/ut/utils_ut.cpp` — Host, TLS, X-Forwarded-*, proto allowlist, invalid forwarded host
- `ydb/services/sqs_topic/queue_url/ut/utils_ut.cpp` — request origin vs FQDN fallback, `Secure`, omit port 0
- `ydb/services/sqs_topic/ut/utils_ut.cpp` — actor fallback via AppData when origin metadata is missing

HTTP integration (`ydb/core/http_proxy/ut/sqs_topic_ut`):
- `TestGetQueueUrlUsesRequestHost` / `TestGetQueueUrlUsesForwardedHost`
- `TestCreateQueueUsesRequestHost` / `TestCreateQueueUsesForwardedHost`
- `TestListQueuesUsesForwardedHost`
- `TestListQueuesConvertsConsumerNameInFederation`

Functional boto3 (`ydb/tests/functional/sqs_topic`):
- `test_create_queue_uses_request_endpoint` / `test_get_queue_url_uses_request_endpoint` / `test_list_queues_uses_request_endpoint`
- `test_queue_lifecycle_uses_request_endpoint` (custom Host via DNS patch, no `/etc/hosts`)
- `test_queue_urls_use_forwarded_host` (real backend Host + injected `X-Forwarded-Host`/`Proto`)

**How to run**

```bash
./ya make --build relwithdebinfo -tA ydb/core/http_proxy/ut -F '*SqsRequestEndpoint*'
./ya make --build relwithdebinfo -tA ydb/core/http_proxy/ut -F '*Forwarded*'
./ya make --build relwithdebinfo -tA ydb/services/sqs_topic/queue_url/ut
./ya make --build relwithdebinfo -tA ydb/services/sqs_topic/ut -F '*MakeQueueUrl*'
./ya make --build relwithdebinfo -tA ydb/tests/functional/sqs_topic -F '*uses_request_endpoint*' -F '*use_forwarded_host*'
```