### PR TITLE
Parallel execution in SectorMap + jitter

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -96,6 +96,7 @@ TPDisk::TPDisk(std::shared_ptr<TPDiskCtx> pCtx, const TIntrusivePtr<TPDiskConfig
             SectorMapFirstSectorWriteRate = TControlWrapper(diskModeParams->FirstSectorWriteRate, 0, 100000ull * 1024 * 1024);
             SectorMapLastSectorWriteRate = TControlWrapper(diskModeParams->LastSectorWriteRate, 0, 100000ull * 1024 * 1024);
             SectorMapSeekSleepMicroSeconds = TControlWrapper(diskModeParams->SeekSleepMicroSeconds, 0, 100ul * 1000 * 1000);
+            SectorMapSeekSleepJitterMicroSeconds = TControlWrapper(diskModeParams->SeekSleepJitterMicroSeconds, 0, 100ul * 1000 * 1000);
         }
         auto failureProbs = Cfg->SectorMap->GetFailureProbabilities();
         if (failureProbs) {
@@ -3143,6 +3144,7 @@ bool TPDisk::Initialize() {
                     REGISTER_LOCAL_CONTROL(SectorMapFirstSectorWriteRate);
                     REGISTER_LOCAL_CONTROL(SectorMapLastSectorWriteRate);
                     REGISTER_LOCAL_CONTROL(SectorMapSeekSleepMicroSeconds);
+                    REGISTER_LOCAL_CONTROL(SectorMapSeekSleepJitterMicroSeconds);
 
                     LastSectorReadRateControlName = TStringBuilder() << "PDisk_" << PCtx->PDiskId << "_SectorMapLastSectorReadRate";
                     LastSectorWriteRateControlName = TStringBuilder() << "PDisk_" << PCtx->PDiskId << "_SectorMapLastSectorWriteRate";
@@ -4398,6 +4400,7 @@ void TPDisk::Update() {
             }
 
             diskModeParams->SeekSleepMicroSeconds.store(SectorMapSeekSleepMicroSeconds);
+            diskModeParams->SeekSleepJitterMicroSeconds.store(SectorMapSeekSleepJitterMicroSeconds);
         }
         auto failureProbs = Cfg->SectorMap->GetFailureProbabilities();
         if (failureProbs) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -137,6 +137,7 @@ public:
     TControlWrapper SectorMapFirstSectorWriteRate;
     TControlWrapper SectorMapLastSectorWriteRate;
     TControlWrapper SectorMapSeekSleepMicroSeconds;
+    TControlWrapper SectorMapSeekSleepJitterMicroSeconds;
     // used to store valid value in ICB if SectorMapFirstSector*Rate < SectorMapLastSector*Rate
     TString LastSectorReadRateControlName;
     TString LastSectorWriteRateControlName;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_sectormap.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_sectormap.cpp
@@ -6,6 +6,7 @@
 
 #include <ydb/core/blobstorage/crypto/default.h>
 #include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/library/pdisk_io/aio.h>
 
 #include <util/system/hp_timer.h>
 
@@ -96,5 +97,127 @@ Y_UNIT_TEST_SUITE(TSectorMapPerformance) {
     MAKE_TEST(SSD, 1960, 1000, Write, First);
 
 #undef MAKE_TEST
+
+    Y_UNIT_TEST(TestAsyncReadQueueDepthAndJitter) {
+        constexpr ui32 QueueDepth = 8;
+        constexpr ui32 OperationCount = 100;
+        constexpr ui64 SeekSleepUs = 10'000;
+        constexpr ui64 SeekSleepJitterUs = 10'000;
+        constexpr ui64 SectorSize = NPDisk::NSectorMap::SECTOR_SIZE;
+
+        struct TNoopCallback : NPDisk::ICallback {
+            void Exec(NPDisk::TAsyncIoOperationResult*) override {
+            }
+        };
+
+        struct TOperationState {
+            TInstant SubmittedAt;
+            TDuration Latency;
+        };
+
+        auto sectorMap = MakeIntrusive<NPDisk::TSectorMap>(SectorSize * 16, EDiskMode::DM_HDD);
+        auto diskModeParams = sectorMap->GetDiskModeParams();
+        UNIT_ASSERT(diskModeParams);
+        diskModeParams->SeekSleepMicroSeconds.store(SeekSleepUs);
+        diskModeParams->SeekSleepJitterMicroSeconds.store(SeekSleepJitterUs);
+        diskModeParams->FirstSectorReadRate.store(1ull << 40);
+        diskModeParams->LastSectorReadRate.store(1ull << 40);
+
+        auto io = NPDisk::CreateAsyncIoContextMap("SectorMapAsyncReadQueueDepthAndJitter", 1, sectorMap);
+        UNIT_ASSERT(io->Setup(QueueDepth, true) == NPDisk::EIoResult::Ok);
+
+        TNoopCallback callback;
+        TVector<TOperationState> states(OperationCount);
+        TVector<TString> buffers;
+        TVector<NPDisk::IAsyncIoOperation*> operations;
+        buffers.reserve(OperationCount);
+        operations.reserve(OperationCount);
+
+        for (ui32 idx = 0; idx < OperationCount; ++idx) {
+            buffers.emplace_back(TString::Uninitialized(SectorSize));
+            auto *op = io->CreateAsyncIoOperation(&states[idx], NPDisk::TReqId(NPDisk::TReqId::Test0, idx), nullptr);
+            io->PreparePRead(op, buffers.back().Detach(), SectorSize, 0);
+            operations.push_back(op);
+        }
+
+        auto submit = [&](ui32 idx) {
+            const TInstant submittedAt = TInstant::Now();
+            const auto result = io->Submit(operations[idx], &callback);
+            if (result == NPDisk::EIoResult::Ok) {
+                states[idx].SubmittedAt = submittedAt;
+            }
+            return result;
+        };
+
+        ui32 nextToSubmit = 0;
+        ui32 completed = 0;
+        ui32 inFlight = 0;
+        ui32 maxInFlight = 0;
+        TVector<TDuration> latencies;
+        latencies.reserve(OperationCount);
+
+        const TInstant startedAt = TInstant::Now();
+        for (; nextToSubmit < QueueDepth; ++nextToSubmit) {
+            UNIT_ASSERT(submit(nextToSubmit) == NPDisk::EIoResult::Ok);
+            maxInFlight = Max(maxInFlight, ++inFlight);
+        }
+        UNIT_ASSERT(submit(nextToSubmit) == NPDisk::EIoResult::TryAgain);
+
+        while (completed < OperationCount) {
+            NPDisk::TAsyncIoOperationResult events[QueueDepth];
+            const i64 eventCount = io->GetEvents(1, QueueDepth, events, TDuration::Seconds(5));
+            UNIT_ASSERT_C(eventCount > 0, "No SectorMap read completions received");
+
+            for (i64 idx = 0; idx < eventCount; ++idx) {
+                UNIT_ASSERT(events[idx].Result == NPDisk::EIoResult::Ok);
+                auto *state = static_cast<TOperationState*>(events[idx].Operation->GetCookie());
+                state->Latency = TInstant::Now() - state->SubmittedAt;
+                latencies.push_back(state->Latency);
+                io->DestroyAsyncIoOperation(events[idx].Operation);
+                --inFlight;
+                ++completed;
+            }
+
+            while (nextToSubmit < OperationCount && inFlight < QueueDepth) {
+                const auto result = submit(nextToSubmit);
+                if (result == NPDisk::EIoResult::TryAgain) {
+                    break;
+                }
+                UNIT_ASSERT(result == NPDisk::EIoResult::Ok);
+                ++nextToSubmit;
+                maxInFlight = Max(maxInFlight, ++inFlight);
+            }
+        }
+
+        const TDuration elapsed = TInstant::Now() - startedAt;
+        UNIT_ASSERT(io->Destroy() == NPDisk::EIoResult::Ok);
+
+        TDuration minLatency = TDuration::Max();
+        TDuration maxLatency = TDuration::Zero();
+        ui64 firstLatencyMs = 0;
+        bool hasFirstLatencyMs = false;
+        bool hasDifferentLatencyMs = false;
+        for (const TDuration latency : latencies) {
+            minLatency = Min(minLatency, latency);
+            maxLatency = Max(maxLatency, latency);
+            const ui64 latencyMs = latency.MilliSeconds();
+            if (!hasFirstLatencyMs) {
+                firstLatencyMs = latencyMs;
+                hasFirstLatencyMs = true;
+            } else if (firstLatencyMs != latencyMs) {
+                hasDifferentLatencyMs = true;
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(latencies.size(), OperationCount);
+        UNIT_ASSERT_VALUES_EQUAL(maxInFlight, QueueDepth);
+        UNIT_ASSERT_C(minLatency >= TDuration::MilliSeconds(8), "Expected base SectorMap read delay"
+                << " minLatency# " << minLatency << " maxLatency# " << maxLatency);
+        UNIT_ASSERT_C(hasDifferentLatencyMs, "Expected jitter to produce different read latencies"
+                << " minLatency# " << minLatency << " maxLatency# " << maxLatency);
+        UNIT_ASSERT_C(NSan::PlainOrUnderSanitizer(elapsed < TDuration::MilliSeconds(900), true),
+                "Expected 100 reads with QD# " << QueueDepth << " to finish faster than serial execution"
+                << " elapsed# " << elapsed << " minLatency# " << minLatency << " maxLatency# " << maxLatency);
+    }
 }
 }

--- a/ydb/library/pdisk_io/aio_map.cpp
+++ b/ydb/library/pdisk_io/aio_map.cpp
@@ -69,6 +69,35 @@ struct TAsyncIoOperationMap : IObjectInQueue, IAsyncIoOperation {
         return ReqId;
     }
 
+    TDuration GetDelay() {
+        switch (Type) {
+            case IAsyncIoOperation::EType::PRead:
+                return SectorMap.GetReadDelay(Size, Offset, PrevAsyncIoOperationIsInProgress, 0);
+            case IAsyncIoOperation::EType::PWrite:
+                return SectorMap.GetWriteDelay(Size, Offset, PrevAsyncIoOperationIsInProgress, 0);
+            default:
+                Y_FAIL_S("Unexpected op type# " << (i64)Type);
+        }
+    }
+
+    void ProcessNoThrottle() {
+        switch (Type) {
+            case IAsyncIoOperation::EType::PRead:
+                {
+                    IsFailed = !SectorMap.ReadNoThrottle((ui8*)Data, Size, Offset);
+                    break;
+                }
+            case IAsyncIoOperation::EType::PWrite:
+                {
+                    IsFailed = !SectorMap.WriteNoThrottle((ui8*)Data, Size, Offset);
+                    break;
+                }
+            default:
+                Y_FAIL_S("Unexpected op type# " << (i64)Type);
+        }
+        Complete();
+    }
+
     void Process(void*) override {
         switch (Type) {
             case IAsyncIoOperation::EType::PRead:
@@ -84,6 +113,10 @@ struct TAsyncIoOperationMap : IObjectInQueue, IAsyncIoOperation {
             default:
                 Y_FAIL_S("Unexpected op type# " << (i64)Type);
         }
+        Complete();
+    }
+
+    void Complete() {
         AsyncIoContext.OnAsyncIoOperationCompletion(this);
         CompleteQueue.Push(this);
     }
@@ -97,19 +130,20 @@ struct TAsyncIoOperationMap : IObjectInQueue, IAsyncIoOperation {
     }
 };
 
-class TRandomWaitThreadPool : public IThreadPool {
+class TDelayedThreadPool : public IThreadPool {
     TCountedQueueOneOne<TAsyncIoOperationMap*, 4 << 10> IncomingQueue;
     TMultiMap<TInstant, TAsyncIoOperationMap*> WaitQueue;
 
     TThread WorkThread;
     std::atomic<bool> StopFlag;
-    std::pair<TDuration, TDuration> WaitParams;
+    bool UseRandomWait = false;
+    std::pair<TDuration, TDuration> WaitParams = {TDuration::Zero(), TDuration::Zero()};
     TSpinLock DeadlineLock;
     TInstant LatestDeadline;
 
     ///////    Thread working part    /////
     static void *Proc(void* that) {
-        static_cast<TRandomWaitThreadPool*>(that)->Work();
+        static_cast<TDelayedThreadPool*>(that)->Work();
         return nullptr;
     }
 
@@ -121,11 +155,7 @@ class TRandomWaitThreadPool : public IThreadPool {
             for (TAtomicBase idx = 0; idx < size; ++idx) {
                 TAsyncIoOperationMap *op = IncomingQueue.Pop();
                 if (op) {
-                    if (op->Deadline <= now) {
-                        op->Process(nullptr);
-                    } else {
-                        WaitQueue.emplace(op->Deadline, op);
-                    }
+                    WaitQueue.emplace(op->Deadline, op);
                 } else {
                     receivedNullFromIncomingQueue = true;
                 }
@@ -138,7 +168,7 @@ class TRandomWaitThreadPool : public IThreadPool {
             auto it = WaitQueue.begin();
             while (it != WaitQueue.end() && it->first <= now) {
                 TAsyncIoOperationMap *op = it->second;
-                op->Process(nullptr);
+                op->ProcessNoThrottle();
                 auto curr = it;
                 ++it;
                 WaitQueue.erase(curr);
@@ -170,21 +200,26 @@ class TRandomWaitThreadPool : public IThreadPool {
         }
     }
 
-    ///////    Intefrace   /////
+    ///////    Interface   /////
     bool Add(IObjectInQueue *obj) override {
         if (StopFlag.load()) {
             return false;
         }
         auto op = static_cast<TAsyncIoOperationMap*>(obj);
-        const TDuration randomWaitAddend = WaitParams.first
-            + TDuration::MicroSeconds(RandomNumber<ui32>(WaitParams.second.MicroSeconds()));
         {
             TGuard<TSpinLock> guard(DeadlineLock);
-            const TInstant baseDeadline = Max(LatestDeadline, TInstant::Now());
-            op->Deadline = baseDeadline + randomWaitAddend;
-            LatestDeadline = op->Deadline;
+            TDuration delay = op->GetDelay();
+            if (UseRandomWait) {
+                delay += WaitParams.first + TDuration::MicroSeconds(RandomNumber<ui32>(WaitParams.second.MicroSeconds()));
+            }
+            const TInstant now = TInstant::Now();
+            const TInstant baseDeadline = UseRandomWait ? Max(LatestDeadline, now) : now;
+            op->Deadline = baseDeadline + delay;
+            if (UseRandomWait) {
+                LatestDeadline = op->Deadline;
+            }
+            IncomingQueue.Push(op);
         }
-        IncomingQueue.Push(op);
         return true;
     }
 
@@ -204,16 +239,25 @@ class TRandomWaitThreadPool : public IThreadPool {
 
 
 public:
-    TRandomWaitThreadPool(const std::pair<TDuration, TDuration>& waitParams)
+    TDelayedThreadPool()
         : WorkThread(TThread::TParams(Proc, this))
         , StopFlag(false)
+        , LatestDeadline(TInstant::Now())
+    {
+        WorkThread.Start();
+    }
+
+    TDelayedThreadPool(const std::pair<TDuration, TDuration>& waitParams)
+        : WorkThread(TThread::TParams(Proc, this))
+        , StopFlag(false)
+        , UseRandomWait(true)
         , WaitParams(waitParams)
         , LatestDeadline(TInstant::Now())
     {
         WorkThread.Start();
     }
 
-    ~TRandomWaitThreadPool(){
+    ~TDelayedThreadPool(){
     }
 };
 
@@ -359,7 +403,9 @@ public:
         }
         MaxEvents = maxEvents;
         if (SectorMap->ImitateRandomWait) {
-            Queue = new TRandomWaitThreadPool(*SectorMap->ImitateRandomWait);
+            Queue = new TDelayedThreadPool(*SectorMap->ImitateRandomWait);
+        } else if (SectorMap->GetDiskModeParams()) {
+            Queue = new TDelayedThreadPool();
         } else {
             Queue = new TThreadPool();
             Queue->Start(1, MaxEvents);

--- a/ydb/library/pdisk_io/aio_map.cpp
+++ b/ydb/library/pdisk_io/aio_map.cpp
@@ -2,6 +2,8 @@
 
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_countedqueueoneone.h>
 
+#include <library/cpp/deprecated/atomic/atomic.h>
+
 #include <util/random/random.h>
 #include <util/system/spinlock.h>
 #include <util/thread/pool.h>
@@ -138,6 +140,8 @@ class TDelayedThreadPool : public IThreadPool {
     std::atomic<bool> StopFlag;
     bool UseRandomWait = false;
     std::pair<TDuration, TDuration> WaitParams = {TDuration::Zero(), TDuration::Zero()};
+    ui64 MaxEvents = 0;
+    TAtomic InFlight = 0;
     TSpinLock DeadlineLock;
     TInstant LatestDeadline;
 
@@ -169,6 +173,7 @@ class TDelayedThreadPool : public IThreadPool {
             while (it != WaitQueue.end() && it->first <= now) {
                 TAsyncIoOperationMap *op = it->second;
                 op->ProcessNoThrottle();
+                ReleaseSlot();
                 auto curr = it;
                 ++it;
                 WaitQueue.erase(curr);
@@ -185,6 +190,7 @@ class TDelayedThreadPool : public IThreadPool {
     void Cleanup(bool receiveNull) {
         for (auto& op : WaitQueue) {
             delete op.second;
+            ReleaseSlot();
         }
         WaitQueue.clear();
         while (!receiveNull) {
@@ -193,6 +199,7 @@ class TDelayedThreadPool : public IThreadPool {
                 TAsyncIoOperationMap *op = IncomingQueue.Pop();
                 if (op) {
                     delete op;
+                    ReleaseSlot();
                 } else {
                     receiveNull = true;
                 }
@@ -205,6 +212,9 @@ class TDelayedThreadPool : public IThreadPool {
         if (StopFlag.load()) {
             return false;
         }
+        if (!AcquireSlot()) {
+            return false;
+        }
         auto op = static_cast<TAsyncIoOperationMap*>(obj);
         {
             TGuard<TSpinLock> guard(DeadlineLock);
@@ -213,14 +223,36 @@ class TDelayedThreadPool : public IThreadPool {
                 delay += WaitParams.first + TDuration::MicroSeconds(RandomNumber<ui32>(WaitParams.second.MicroSeconds()));
             }
             const TInstant now = TInstant::Now();
-            const TInstant baseDeadline = UseRandomWait ? Max(LatestDeadline, now) : now;
+            const bool serialize = UseRandomWait || !MaxEvents;
+            const TInstant baseDeadline = serialize ? Max(LatestDeadline, now) : now;
             op->Deadline = baseDeadline + delay;
-            if (UseRandomWait) {
+            if (serialize) {
                 LatestDeadline = op->Deadline;
             }
             IncomingQueue.Push(op);
         }
         return true;
+    }
+
+    bool AcquireSlot() {
+        if (!MaxEvents) {
+            return true;
+        }
+        for (;;) {
+            const ui64 inFlight = AtomicGet(InFlight);
+            if (inFlight >= MaxEvents) {
+                return false;
+            }
+            if (AtomicCas(&InFlight, inFlight + 1, inFlight)) {
+                return true;
+            }
+        }
+    }
+
+    void ReleaseSlot() {
+        if (MaxEvents) {
+            AtomicDecrement(InFlight);
+        }
     }
 
     size_t Size() const noexcept override {
@@ -239,19 +271,21 @@ class TDelayedThreadPool : public IThreadPool {
 
 
 public:
-    TDelayedThreadPool()
+    TDelayedThreadPool(ui64 maxEvents)
         : WorkThread(TThread::TParams(Proc, this))
         , StopFlag(false)
+        , MaxEvents(maxEvents)
         , LatestDeadline(TInstant::Now())
     {
         WorkThread.Start();
     }
 
-    TDelayedThreadPool(const std::pair<TDuration, TDuration>& waitParams)
+    TDelayedThreadPool(ui64 maxEvents, const std::pair<TDuration, TDuration>& waitParams)
         : WorkThread(TThread::TParams(Proc, this))
         , StopFlag(false)
         , UseRandomWait(true)
         , WaitParams(waitParams)
+        , MaxEvents(maxEvents)
         , LatestDeadline(TInstant::Now())
     {
         WorkThread.Start();
@@ -271,7 +305,7 @@ class TAsyncIoContextMap : public IAsyncIoContext {
     TPDiskDebugInfo PDiskInfo;
 
     TSpinLock SpinLock;
-    IAsyncIoOperation* LastOngoingAsyncIoOperation = nullptr;
+    ui64 OngoingAsyncIoOperationCount = 0;
     std::atomic<ui64> GlobalCounter = 0;
 
 public:
@@ -403,9 +437,9 @@ public:
         }
         MaxEvents = maxEvents;
         if (SectorMap->ImitateRandomWait) {
-            Queue = new TDelayedThreadPool(*SectorMap->ImitateRandomWait);
+            Queue = new TDelayedThreadPool(MaxEvents, *SectorMap->ImitateRandomWait);
         } else if (SectorMap->GetDiskModeParams()) {
-            Queue = new TDelayedThreadPool();
+            Queue = new TDelayedThreadPool(MaxEvents);
         } else {
             Queue = new TThreadPool();
             Queue->Start(1, MaxEvents);
@@ -417,15 +451,16 @@ public:
         op->SetCallback(callback);
         TAsyncIoOperationMap *operation = static_cast<TAsyncIoOperationMap*>(op);
 
+        bool isOk = false;
         {
             TGuard<TSpinLock> guard(SpinLock);
-            if (LastOngoingAsyncIoOperation != nullptr) {
-                operation->PrevAsyncIoOperationIsInProgress = true;
+            operation->PrevAsyncIoOperationIsInProgress = OngoingAsyncIoOperationCount != 0;
+            isOk = Queue->Add(operation);
+            if (isOk) {
+                ++OngoingAsyncIoOperationCount;
             }
-            LastOngoingAsyncIoOperation = operation;
         }
 
-        bool isOk = Queue->Add(operation);
         return isOk ? EIoResult::Ok : EIoResult::TryAgain;
     }
 
@@ -445,10 +480,10 @@ public:
     }
 
     void OnAsyncIoOperationCompletion(IAsyncIoOperation *op) override {
+        Y_UNUSED(op);
         TGuard<TSpinLock> guard(SpinLock);
-        if (LastOngoingAsyncIoOperation == op) {
-            LastOngoingAsyncIoOperation = nullptr;
-        }
+        Y_ABORT_UNLESS(OngoingAsyncIoOperationCount);
+        --OngoingAsyncIoOperationCount;
     }
 };
 

--- a/ydb/library/pdisk_io/sector_map.h
+++ b/ydb/library/pdisk_io/sector_map.h
@@ -111,6 +111,7 @@ class TSectorOperationThrottler {
 public:
     struct TDiskModeParams {
         std::atomic<ui64> SeekSleepMicroSeconds;
+        std::atomic<ui64> SeekSleepJitterMicroSeconds;
         std::atomic<ui64> FirstSectorReadRate;
         std::atomic<ui64> LastSectorReadRate;
         std::atomic<ui64> FirstSectorWriteRate;
@@ -129,6 +130,7 @@ public:
         EDeviceType deviceType = DiskModeToDeviceType(diskMode);
         const auto &devicePerformance = TDevicePerformanceParams::Get(deviceType);
         DiskModeParams.SeekSleepMicroSeconds = (devicePerformance.SeekTimeNs + 1000) / 1000 - 1;
+        DiskModeParams.SeekSleepJitterMicroSeconds = 0;
         DiskModeParams.FirstSectorReadRate = devicePerformance.FirstSectorReadBytesPerSec;
         DiskModeParams.LastSectorReadRate = devicePerformance.LastSectorReadBytesPerSec;
         DiskModeParams.FirstSectorWriteRate = devicePerformance.FirstSectorWriteBytesPerSec;
@@ -139,12 +141,20 @@ public:
     }
 
     void ThrottleRead(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs) {
-        ThrottleOperation(size, offset, prevOperationIsInProgress, operationTimeMs,
-                DiskModeParams.FirstSectorReadRate, DiskModeParams.LastSectorReadRate);
+        Sleep(GetReadDelay(size, offset, prevOperationIsInProgress, operationTimeMs));
     }
 
     void ThrottleWrite(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs) {
-        ThrottleOperation(size, offset, prevOperationIsInProgress, operationTimeMs,
+        Sleep(GetWriteDelay(size, offset, prevOperationIsInProgress, operationTimeMs));
+    }
+
+    TDuration GetReadDelay(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs) {
+        return GetOperationDelay(size, offset, prevOperationIsInProgress, operationTimeMs,
+                DiskModeParams.FirstSectorReadRate, DiskModeParams.LastSectorReadRate);
+    }
+
+    TDuration GetWriteDelay(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs) {
+        return GetOperationDelay(size, offset, prevOperationIsInProgress, operationTimeMs,
                 DiskModeParams.FirstSectorWriteRate, DiskModeParams.LastSectorWriteRate);
     }
 
@@ -153,21 +163,24 @@ public:
     }
 
 private:
-    /* throttle read/write operation */
-    void ThrottleOperation(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs,
+    /* calculate read/write operation delay */
+    TDuration GetOperationDelay(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs,
             ui64 firstSectorRate, ui64 lastSectorRate) {
         if (size == 0) {
-            return;
+            return TDuration::Zero();
         }
 
         ui64 beginSector = offset / NSectorMap::SECTOR_SIZE;
         ui64 endSector = (offset + size + NSectorMap::SECTOR_SIZE - 1) / NSectorMap::SECTOR_SIZE;
         ui64 midSector = (beginSector + endSector) / 2;
 
+        TDuration delay = TDuration::Zero();
         {
             TGuard<TMutex> guard(Mutex);
             if (beginSector != MostRecentlyUsedSector + 1 || !prevOperationIsInProgress) {
-                Sleep(TDuration::MicroSeconds(DiskModeParams.SeekSleepMicroSeconds));
+                const ui64 seekSleepJitterMicroSeconds = DiskModeParams.SeekSleepJitterMicroSeconds.load();
+                delay += TDuration::MicroSeconds(DiskModeParams.SeekSleepMicroSeconds.load()
+                        + (seekSleepJitterMicroSeconds ? RandomNumber<ui64>(seekSleepJitterMicroSeconds + 1) : 0));
             }
 
             MostRecentlyUsedSector = endSector - 1;
@@ -177,7 +190,8 @@ private:
 
         auto rateByMilliSeconds = rate / 1000;
         auto milliSecondsToWait = std::max(0., (double)size / rateByMilliSeconds - operationTimeMs);
-        Sleep(TDuration::MilliSeconds(milliSecondsToWait));
+        delay += TDuration::MilliSeconds(milliSecondsToWait);
+        return delay;
     }
 
     static double CalcRate(double firstSectorRate, double lastSectorRate, double sector, double lastSector) {
@@ -279,17 +293,27 @@ public:
         Write((ui8*)str.Detach(), bytes, 0);
     }
 
-    bool Read(ui8 *data, i64 size, ui64 offset, bool prevOperationIsInProgress = false) {
+    TDuration GetReadDelay(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs) {
+        if (SectorOperationThrottler.Get() != nullptr) {
+            return SectorOperationThrottler->GetReadDelay(size, offset, prevOperationIsInProgress, operationTimeMs);
+        }
+        return TDuration::Zero();
+    }
+
+    TDuration GetWriteDelay(i64 size, ui64 offset, bool prevOperationIsInProgress, double operationTimeMs) {
+        if (SectorOperationThrottler.Get() != nullptr) {
+            return SectorOperationThrottler->GetWriteDelay(size, offset, prevOperationIsInProgress, operationTimeMs);
+        }
+        return TDuration::Zero();
+    }
+
+    bool ReadNoThrottle(ui8 *data, i64 size, ui64 offset, bool callReadCallback = true) {
         Y_ABORT_UNLESS(size % NSectorMap::SECTOR_SIZE == 0);
         Y_ABORT_UNLESS(offset % NSectorMap::SECTOR_SIZE == 0);
 
         if (ShouldFailRead()) {
             return false;
         }
-
-        i64 dataSize = size;
-        ui64 dataOffset = offset;
-        THPTimer timer;
 
         TGuard<TTicketLock> guard(MapLock);
         for (; size > 0; size -= NSectorMap::SECTOR_SIZE) {
@@ -317,9 +341,22 @@ public:
             data += NSectorMap::SECTOR_SIZE;
         }
 
-        if (SectorOperationThrottler.Get() != nullptr) {
-            SectorOperationThrottler->ThrottleRead(dataSize, dataOffset, prevOperationIsInProgress, timer.Passed() * 1000);
+        if (callReadCallback && ReadCallback) {
+            ReadCallback();
         }
+        return true;
+    }
+
+    bool Read(ui8 *data, i64 size, ui64 offset, bool prevOperationIsInProgress = false) {
+        i64 dataSize = size;
+        ui64 dataOffset = offset;
+        THPTimer timer;
+
+        if (!ReadNoThrottle(data, size, offset, false)) {
+            return false;
+        }
+
+        Sleep(GetReadDelay(dataSize, dataOffset, prevOperationIsInProgress, timer.Passed() * 1000));
 
         if (ReadCallback) {
             ReadCallback();
@@ -327,9 +364,12 @@ public:
         return true;
     }
 
-    bool Write(const ui8 *data, i64 size, ui64 offset, bool prevOperationIsInProgress = false) {
+    bool WriteNoThrottle(const ui8 *data, i64 size, ui64 offset, bool *shouldThrottle = nullptr) {
         Y_ABORT_UNLESS(size % NSectorMap::SECTOR_SIZE == 0);
         Y_ABORT_UNLESS(offset % NSectorMap::SECTOR_SIZE == 0);
+        if (shouldThrottle) {
+            *shouldThrottle = false;
+        }
 
         if (ShouldFailWrite()) {
             return false;
@@ -337,10 +377,9 @@ public:
         if (ShouldSilentWriteFail()) {
             return true;
         }
-
-        i64 dataSize = size;
-        ui64 dataOffset = offset;
-        THPTimer timer;
+        if (shouldThrottle) {
+            *shouldThrottle = true;
+        }
 
         {
             TGuard<TTicketLock> guard(MapLock);
@@ -385,8 +424,20 @@ public:
             }
         }
 
-        if (SectorOperationThrottler.Get() != nullptr) {
-            SectorOperationThrottler->ThrottleWrite(dataSize, dataOffset, prevOperationIsInProgress, timer.Passed() * 1000);
+        return true;
+    }
+
+    bool Write(const ui8 *data, i64 size, ui64 offset, bool prevOperationIsInProgress = false) {
+        i64 dataSize = size;
+        ui64 dataOffset = offset;
+        bool shouldThrottle = false;
+        THPTimer timer;
+
+        if (!WriteNoThrottle(data, size, offset, &shouldThrottle)) {
+            return false;
+        }
+        if (shouldThrottle) {
+            Sleep(GetWriteDelay(dataSize, dataOffset, prevOperationIsInProgress, timer.Passed() * 1000));
         }
         return true;
     }


### PR DESCRIPTION
- **Parallel execution in SectorMap + jitter**
- **Test for SectorMap QD with jitter**

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

To initialise the SectorMap with delays emulation set the following in the storage config:

```
host_configs:
- drive:
  - path: SectorMap:1:64:HDD
    type: ROT
    pdisk_config:
      device_in_flight: 8
  host_config_id: 1
...
blob_storage_config:
  service_set:
    groups:
    - erasure_species: none
      rings:
      - fail_domains:
        - vdisk_locations:
          - node_id: 1
            path: SectorMap:1:64:HDD
            pdisk_category: ROT
            pdisk_config:
              device_in_flight: 8
```

Example script to run kv workload using the SectorMap with QD and jitter (if using Linux x86_64 local one-node YDB installation described here https://ydb.tech/docs/en/quickstart):

```
#!/usr/bin/env bash
set +e
echo Stopping the services...
./stop.sh
sleep 5
ls -l ~/ydbd/ydbd/bin/ydbd
./start.sh ram
sleep 5
ydb -e grpc://localhost:2136 -d /Root/test workload kv init
ydb -e grpc://localhost:2136 -d /Root/test workload kv run insert -t 100
echo -n Setting SleepTime...
curl -s -X POST -o /dev/null -w "%{http_code}\n" 'http://localhost:8765/actors/icb'   -d 'PDisk_1_SectorMapSeekSleepMicroSeconds=5000'
echo -n Setting jitter...
curl -s -X POST -o /dev/null -w "%{http_code}\n" 'http://localhost:8765/actors/icb'   -d 'PDisk_1_SectorMapSeekSleepJitterMicroSeconds=50000'
echo -n Invoking full compaction...
curl -sL -o /dev/null -w "%{http_code}\n" 'http://localhost:8765/actors/vdisks/vdisk000000001_000001000?type=dbmainpage&dbname=LogoBlobs&action=compact'
sleep 5
ydb -e grpc://localhost:2136 -d /Root/test workload kv run select
```