### PR TITLE
docs: clarify local-ydb Docker TLS configuration

### DIFF
--- a/ydb/docs/en/core/reference/docker/configuration.md
+++ b/ydb/docs/en/core/reference/docker/configuration.md
@@ -6,8 +6,8 @@
 
 | Name | Type | Default  | Description |
 | -- | -- | -- | -- |
-| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0` or `1` | `1` | Enable the `grpcs://` protocol (gRPC over TLS) |
-| [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_data` | Data path with TLS certificates for the `grpcs://` connection |
+| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0`, `1`, `false`, or `true` | `true` | Enable the `grpcs://` protocol (gRPC over TLS). Values `1` and `true` enable TLS; `0` and `false` disable it. |
+| [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_certs` | Directory with TLS certificates for the `grpcs://` connection. |
 | [`MON_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L170) | `int` | `8765` | HTTP port of [Embedded UI](../../reference/embedded-ui/index.md) |
 | [`GRPC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L174) | `int` | `2136` | gRPC port |
 | [`IC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L179) | `int` | `19001` | [Interconnect](../../concepts/glossary.md#interconnect) port |
@@ -23,3 +23,5 @@
 | [`YDB_ENABLE_COLUMN_TABLES`](https://GitHub.com/ydb-platform/ydb/blob/69a57074e4c259aea0bbb9a735c5ed821743629c/ydb/tests/library/harness/kikimr_config.py#L86) | `0` or `1` | `0` | Enables [column-oriented tables](../../concepts/datamodel/table.md#column-oriented-tables) |
 | [`YDB_PREINITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L14) | `string` | `/preinit.d` | Path to the [pre-init scripts](./init-scripts.md) directory |
 | [`YDB_INITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L13) | `string` | `/init.d` | Path to the [init scripts](./init-scripts.md) directory |
+
+When TLS is enabled, the directory specified by `YDB_GRPC_TLS_DATA_PATH` may contain a pre-generated `ca.pem`, `cert.pem`, and `key.pem`. If all three files are present, non-empty, and regular files, the container uses them without regenerating or overwriting them. If none of these files exist, the container generates a self-signed certificate set. A partial or invalid set causes startup to fail with an error.

--- a/ydb/docs/en/core/reference/docker/configuration.md
+++ b/ydb/docs/en/core/reference/docker/configuration.md
@@ -6,7 +6,7 @@
 
 | Name | Type | Default  | Description |
 | -- | -- | -- | -- |
-| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0`, `1`, `false`, or `true` | `true` | Enable the `grpcs://` protocol (gRPC over TLS). Values `1` and `true` enable TLS; `0` and `false` disable it. |
+| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0`, `1`, `false`, or `true` | `true` | Enable the `grpcs://` protocol (gRPC over TLS). |
 | [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_certs` | Directory with TLS certificates for the `grpcs://` connection. |
 | [`MON_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L170) | `int` | `8765` | HTTP port of [Embedded UI](../../reference/embedded-ui/index.md) |
 | [`GRPC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L174) | `int` | `2136` | gRPC port |
@@ -23,5 +23,3 @@
 | [`YDB_ENABLE_COLUMN_TABLES`](https://GitHub.com/ydb-platform/ydb/blob/69a57074e4c259aea0bbb9a735c5ed821743629c/ydb/tests/library/harness/kikimr_config.py#L86) | `0` or `1` | `0` | Enables [column-oriented tables](../../concepts/datamodel/table.md#column-oriented-tables) |
 | [`YDB_PREINITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L14) | `string` | `/preinit.d` | Path to the [pre-init scripts](./init-scripts.md) directory |
 | [`YDB_INITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L13) | `string` | `/init.d` | Path to the [init scripts](./init-scripts.md) directory |
-
-When TLS is enabled, the directory specified by `YDB_GRPC_TLS_DATA_PATH` may contain a pre-generated `ca.pem`, `cert.pem`, and `key.pem`. If all three files are present, non-empty, and regular files, the container uses them without regenerating or overwriting them. If none of these files exist, the container generates a self-signed certificate set. A partial or invalid set causes startup to fail with an error.

--- a/ydb/docs/ru/core/reference/docker/configuration.md
+++ b/ydb/docs/ru/core/reference/docker/configuration.md
@@ -6,8 +6,8 @@
 
 | Имя | Тип | Значение по умолчанию | Описание |
 | -- | -- | -- | -- |
-| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0` или `1` | `1` | Включает использование TLS для gRPC соединений. |
-| [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_data` | Путь до директории с TLS сертификатами для gRPC соединений. |
+| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0`, `1`, `false` или `true` | `true` | Включает использование TLS для gRPC-соединений. Значения `1` и `true` включают TLS, `0` и `false` выключают. |
+| [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_certs` | Путь к директории с TLS-сертификатами для gRPC-соединений. |
 | [`MON_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L170) | `int` | `8765` | HTTP-порт [встроенного веб-интерфейса {{ ydb-short-name }}](../../reference/embedded-ui/index.md). |
 | [`GRPC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L174) | `int` | `2136` | gRPC порт. |
 | [`IC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L179) | `int` | `19001` | Порт интерконнекта. |
@@ -24,3 +24,5 @@
 | [`YDB_PREINITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L14) | `string` | `/preinit.d` | Путь к директории [pre-init scripts](./init-scripts.md) |
 | [`YDB_INITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L13) | `string` | `/init.d` | Путь к директории [init scripts](./init-scripts.md) |
 | [`YDB_CHANNEL_BUFFER_SIZE`](https://github.com/ydb-platform/ydb/blob/26.1.1.1/ydb/tests/library/harness/kikimr_config.py#L545) | `string` | `8388608` | Размер канала передачи данных между компонентами обработки запроса. Значение по умолчанию (в байтах) в промышленном окружении [равно](https://github.com/ydb-platform/ydb/blob/26.1.1.1/ydb/tests/functional/serializable/ya.make#L3) `8 МиБ`, в тестовом — `256 КиБ`. |
+
+Если TLS включён, в директории `YDB_GRPC_TLS_DATA_PATH` можно заранее разместить файлы `ca.pem`, `cert.pem` и `key.pem`. Если присутствуют все три непустых обычных файла, контейнер использует их без повторной генерации и перезаписи. Если ни одного из этих файлов нет, контейнер генерирует самоподписанный комплект сертификатов. Частичный или некорректный комплект приводит к ошибке запуска.

--- a/ydb/docs/ru/core/reference/docker/configuration.md
+++ b/ydb/docs/ru/core/reference/docker/configuration.md
@@ -6,7 +6,7 @@
 
 | Имя | Тип | Значение по умолчанию | Описание |
 | -- | -- | -- | -- |
-| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0`, `1`, `false` или `true` | `true` | Включает использование TLS для gRPC-соединений. Значения `1` и `true` включают TLS, `0` и `false` выключают. |
+| [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0`, `1`, `false` или `true` | `true` | Включает использование TLS для gRPC-соединений. |
 | [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_certs` | Путь к директории с TLS-сертификатами для gRPC-соединений. |
 | [`MON_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L170) | `int` | `8765` | HTTP-порт [встроенного веб-интерфейса {{ ydb-short-name }}](../../reference/embedded-ui/index.md). |
 | [`GRPC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L174) | `int` | `2136` | gRPC порт. |
@@ -24,5 +24,3 @@
 | [`YDB_PREINITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L14) | `string` | `/preinit.d` | Путь к директории [pre-init scripts](./init-scripts.md) |
 | [`YDB_INITSCRIPTS_DIR`](https://github.com/ydb-platform/ydb/blob/e7065254821ac3093d8135a76145c9a09e3631e2/.github/docker/files/initialize_local_ydb#L13) | `string` | `/init.d` | Путь к директории [init scripts](./init-scripts.md) |
 | [`YDB_CHANNEL_BUFFER_SIZE`](https://github.com/ydb-platform/ydb/blob/26.1.1.1/ydb/tests/library/harness/kikimr_config.py#L545) | `string` | `8388608` | Размер канала передачи данных между компонентами обработки запроса. Значение по умолчанию (в байтах) в промышленном окружении [равно](https://github.com/ydb-platform/ydb/blob/26.1.1.1/ydb/tests/functional/serializable/ya.make#L3) `8 МиБ`, в тестовом — `256 КиБ`. |
-
-Если TLS включён, в директории `YDB_GRPC_TLS_DATA_PATH` можно заранее разместить файлы `ca.pem`, `cert.pem` и `key.pem`. Если присутствуют все три непустых обычных файла, контейнер использует их без повторной генерации и перезаписи. Если ни одного из этих файлов нет, контейнер генерирует самоподписанный комплект сертификатов. Частичный или некорректный комплект приводит к ошибке запуска.


### PR DESCRIPTION
### What

- Document `true`/`false` and `1`/`0` values for `YDB_GRPC_ENABLE_TLS`.
- Correct the default `YDB_GRPC_TLS_DATA_PATH` from `/ydb_data` to `/ydb_certs`.
- Document how complete, absent, and partial pre-generated certificate bundles are handled.
- Keep the English and Russian documentation in sync.

### Dependency

The documented support for pre-generated certificates and numeric TLS values is implemented by #50270. Merge #50270 before this PR.

### Validation

- `git diff --check`.