### PR TITLE
Move solomon_runner from yql/essentials to ydb

### DIFF
--- a/ydb/library/yql/tools/solomon_emulator/testing/conftest.py
+++ b/ydb/library/yql/tools/solomon_emulator/testing/conftest.py
@@ -1,0 +1,6 @@
+try:
+    from ydb.library.yql.tools.solomon_emulator.testing.solomon_runner import solomon_emulator
+except ImportError:
+    solomon_emulator = None
+
+assert solomon_emulator is solomon_emulator

--- a/ydb/library/yql/tools/solomon_emulator/testing/solomon_runner.py
+++ b/ydb/library/yql/tools/solomon_emulator/testing/solomon_runner.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+import requests
+
+
+class SolomonWrapper(object):
+    def __init__(self, url, http_endpoint, grpc_endpoint):
+        self._url = url
+        self._endpoint = http_endpoint
+        self._grpc_endpoint = grpc_endpoint
+        self.table_prefix = ""
+
+    def is_valid(self):
+        return self._url is not None
+
+    def cleanup(self):
+        res = requests.post(self._url + "/cleanup")
+        res.raise_for_status()
+
+    def get_metrics(self):
+        res = requests.get(self._url + "/metrics/get?project=my_project&cluster=my_cluster&service=my_service")
+        res.raise_for_status()
+        return res.text
+
+    def prepare_program(self, program, program_file, res_dir, lang='sql'):
+        return program, program_file
+
+    @property
+    def url(self):
+        return self._url
+
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    @property
+    def grpc_endpoint(self):
+        return self._grpc_endpoint
+
+
+@pytest.fixture(scope='module')
+def solomon_emulator(request):
+    solomon_url = os.environ.get("SOLOMON_HTTP_URL")
+    solomon_endpoint = os.environ.get("SOLOMON_HTTP_ENDPOINT")
+    solomon_grpc_endpoint = os.environ.get("SOLOMON_GRPC_ENDPOINT")
+    return SolomonWrapper(solomon_url, solomon_endpoint, solomon_grpc_endpoint)

--- a/ydb/library/yql/tools/solomon_emulator/testing/ya.make
+++ b/ydb/library/yql/tools/solomon_emulator/testing/ya.make
@@ -1,0 +1,16 @@
+PY23_LIBRARY()
+
+PY_SRCS(
+    solomon_runner.py
+)
+
+PY_SRCS(
+    NAMESPACE ydb_library_yql_tools_solomon_emulator_testing
+    conftest.py
+)
+
+PEERDIR(
+    contrib/python/requests
+)
+
+END()

--- a/ydb/library/yql/tools/solomon_emulator/ya.make
+++ b/ydb/library/yql/tools/solomon_emulator/ya.make
@@ -3,4 +3,5 @@ RECURSE(
     client
     lib
     recipe
+    testing
 )

--- a/ydb/tests/fq/solomon/test.py
+++ b/ydb/tests/fq/solomon/test.py
@@ -39,7 +39,7 @@ def pytest_generate_tests(metafunc):
     return pytest_generate_tests_for_run(metafunc, suites=['solomon'], data_path=DATA_PATH)
 
 
-def test(suite, case, cfg, solomon):
+def test(suite, case, cfg, solomon_emulator):
     config = get_config(suite, case, cfg, data_path=DATA_PATH)
 
     prov = 'solomon'

--- a/ydb/tests/fq/solomon/ya.make
+++ b/ydb/tests/fq/solomon/ya.make
@@ -24,6 +24,7 @@ DATA(
 INCLUDE(${ARCADIA_ROOT}/ydb/library/yql/tools/solomon_emulator/recipe/recipe.inc)
 
 PEERDIR(
+    ydb/library/yql/tools/solomon_emulator/testing
     ydb/tests/fq/tools
     yql/essentials/tests/common/test_framework
 )


### PR DESCRIPTION
solomon_runner.py belonged to the generic yql/essentials/tests/common/test_framework but is only relevant to the Solomon emulator. Moved it next to the emulator and registered the solomon_emulator pytest fixture via the Arcadia conftest-plugin mechanism. Renamed the fixture to avoid conflict with the existing solomon fixture in test_framework.