### PR TITLE
Reshaped .sys/query_sessions for Workload Manager

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -95,7 +95,7 @@ public:
         State.store(state, std::memory_order_release);
     }
 
-    void SetPoolId(TString poolId, TString classifiedBy) override {
+    void SetPoolContext(TString poolId, TString classifiedBy) override {
         TGuard<TAdaptiveLock> guard(PoolIdLock);
         PoolId = std::move(poolId);
         ClassifiedBy = std::move(classifiedBy);

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -95,11 +95,12 @@ public:
         State.store(state, std::memory_order_release);
     }
 
-    void SetPoolId(TString poolId) override {
+    void SetPoolId(TString poolId, TString classifiedBy) override {
         TGuard<TAdaptiveLock> guard(PoolIdLock);
         PoolId = std::move(poolId);
+        ClassifiedBy = std::move(classifiedBy);
     }
-    
+
     EState GetState() const {
         return State.load(std::memory_order_acquire);
     }
@@ -117,12 +118,18 @@ public:
         return PoolId;
     }
 
+    TString GetClassifiedBy() const {
+        TGuard<TAdaptiveLock> guard(PoolIdLock);
+        return ClassifiedBy;
+    }
+
     void Clean() {
         EnterTimeUs.store(0, std::memory_order_release);
         ExitTimeUs.store(0, std::memory_order_release);
         {
             TGuard<TAdaptiveLock> guard(PoolIdLock);
             PoolId.clear();
+            ClassifiedBy.clear();
         }
         State.store(EState::NONE, std::memory_order_release);
     }
@@ -134,6 +141,7 @@ private:
 
     mutable TAdaptiveLock PoolIdLock;
     TString PoolId;
+    TString ClassifiedBy;
 };
 
 template<typename TValue>
@@ -258,6 +266,7 @@ public:
         auto curNow = TInstant::Now();
         const_cast<TKqpSessionInfo*>(sessionInfo)->QueryStartAt = TInstant::Zero();
         const_cast<TKqpSessionInfo*>(sessionInfo)->StateChangeAt = curNow;
+        const_cast<TKqpSessionInfo*>(sessionInfo)->WmState->Clean();
     }
 
     TKqpSessionInfo* Create(const TString& sessionId, const TActorId& workerId,

--- a/ydb/core/kqp/proxy_service/kqp_session_info.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_session_info.cpp
@@ -2,6 +2,8 @@
 
 #include <ydb/core/sys_view/common/registry.h>
 
+#include <util/generic/algorithm.h>
+
 namespace NKikimr::NKqp {
 
 using VSessions = NKikimr::NSysView::Schema::QuerySessions;
@@ -13,7 +15,7 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
     // internally consistent even if a WM callback races with serialization.
     using EWmState = NWorkloadManager::ISessionUpdater::EState;
     const auto wmState = WmState->GetState();
-    const bool isInWmQueue = (wmState == EWmState::PENDING || wmState == EWmState::DELAYED);
+    const bool isInWmQueue = EqualToOneOf(wmState, EWmState::PENDING, EWmState::DELAYED);
     const bool wmExited = (wmState == EWmState::EXITED);
 
     if (fieldsMap.NeedField(VSessions::SessionId::ColumnId)) {  // 1
@@ -25,8 +27,12 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
             proto->SetState("QUEUED");
         } else {
             switch(State) {
-                case TKqpSessionInfo::ESessionState::IDLE:      proto->SetState("IDLE"); break;
-                case TKqpSessionInfo::ESessionState::EXECUTING: proto->SetState("EXECUTING"); break;
+                case TKqpSessionInfo::ESessionState::IDLE:
+                    proto->SetState("IDLE"); 
+                    break;
+                case TKqpSessionInfo::ESessionState::EXECUTING:
+                    proto->SetState("EXECUTING");
+                    break;
             }
         }
     }
@@ -69,14 +75,12 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
         proto->SetSessionStartAt(SessionStartedAt.MicroSeconds());
     }
 
-    // QueryStartAt is left unset (NULL) while the session is IDLE or queued.
-    if (fieldsMap.NeedField(VSessions::QueryStartAt::ColumnId)
-        && State == ESessionState::EXECUTING
-        && !isInWmQueue) { // 12
-        if (wmExited) {
-            proto->SetQueryStartAt(WmState->GetExitTime().MicroSeconds());
-        } else {
-            proto->SetQueryStartAt(QueryStartAt.MicroSeconds());
+    if (fieldsMap.NeedField(VSessions::QueryStartAt::ColumnId)) { // 12
+        // QueryStartAt is left unset (NULL) while the session is IDLE or queued.
+        if (State == ESessionState::EXECUTING && !isInWmQueue) {
+            proto->SetQueryStartAt(wmExited
+                ? WmState->GetExitTime().MicroSeconds()
+                : QueryStartAt.MicroSeconds());
         }
     }
 

--- a/ydb/core/kqp/proxy_service/kqp_session_info.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_session_info.cpp
@@ -69,8 +69,10 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
         proto->SetSessionStartAt(SessionStartedAt.MicroSeconds());
     }
 
-    // QueryStartAt is left unset (NULL) while the request is queued.
-    if (fieldsMap.NeedField(VSessions::QueryStartAt::ColumnId) && !isInWmQueue) { // 12
+    // QueryStartAt is left unset (NULL) while the session is IDLE or queued.
+    if (fieldsMap.NeedField(VSessions::QueryStartAt::ColumnId)
+        && State == ESessionState::EXECUTING
+        && !isInWmQueue) { // 12
         if (wmExited) {
             proto->SetQueryStartAt(WmState->GetExitTime().MicroSeconds());
         } else {

--- a/ydb/core/kqp/proxy_service/kqp_session_info.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_session_info.cpp
@@ -9,19 +9,24 @@ using VSessions = NKikimr::NSysView::Schema::QuerySessions;
 constexpr size_t QUERY_TEXT_LIMIT = 10_KB;
 
 void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFieldsMap& fieldsMap) const {
+    // Snapshot the WM state once so State/StateChangeAt/QueryStartAt stay
+    // internally consistent even if a WM callback races with serialization.
+    using EWmState = NWorkloadManager::ISessionUpdater::EState;
+    const auto wmState = WmState->GetState();
+    const bool isInWmQueue = (wmState == EWmState::PENDING || wmState == EWmState::DELAYED);
+    const bool wmExited = (wmState == EWmState::EXITED);
+
     if (fieldsMap.NeedField(VSessions::SessionId::ColumnId)) {  // 1
         proto->SetSessionId(SessionId);
     }
 
     if (fieldsMap.NeedField(VSessions::State::ColumnId)) {  // 3
-        switch(State) {
-            case TKqpSessionInfo::ESessionState::IDLE: {
-                proto->SetState("IDLE");
-                break;
-            }
-            case TKqpSessionInfo::ESessionState::EXECUTING: {
-                proto->SetState("EXECUTING");
-                break;
+        if (isInWmQueue) {
+            proto->SetState("QUEUED");
+        } else {
+            switch(State) {
+                case TKqpSessionInfo::ESessionState::IDLE:      proto->SetState("IDLE"); break;
+                case TKqpSessionInfo::ESessionState::EXECUTING: proto->SetState("EXECUTING"); break;
             }
         }
     }
@@ -64,12 +69,23 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
         proto->SetSessionStartAt(SessionStartedAt.MicroSeconds());
     }
 
-    if (fieldsMap.NeedField(VSessions::QueryStartAt::ColumnId)) { // 12
-        proto->SetQueryStartAt(QueryStartAt.MicroSeconds());
+    // QueryStartAt is left unset (NULL) while the request is queued.
+    if (fieldsMap.NeedField(VSessions::QueryStartAt::ColumnId) && !isInWmQueue) { // 12
+        if (wmExited) {
+            proto->SetQueryStartAt(WmState->GetExitTime().MicroSeconds());
+        } else {
+            proto->SetQueryStartAt(QueryStartAt.MicroSeconds());
+        }
     }
 
     if (fieldsMap.NeedField(VSessions::StateChangeAt::ColumnId)) { // 13
-        proto->SetStateChangeAt(StateChangeAt.MicroSeconds());
+        if (isInWmQueue) {
+            proto->SetStateChangeAt(WmState->GetEnterTime().MicroSeconds());
+        } else if (wmExited) {
+            proto->SetStateChangeAt(WmState->GetExitTime().MicroSeconds());
+        } else {
+            proto->SetStateChangeAt(StateChangeAt.MicroSeconds());
+        }
     }
 
     if (fieldsMap.NeedField(VSessions::UserSID::ColumnId)) {  // 14
@@ -77,50 +93,25 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
     }
 
     if (fieldsMap.NeedField(VSessions::WmPoolId::ColumnId)) { // 17
-        if (WmState) {
-            proto->SetWmPoolId(WmState->GetPoolId());
+        auto poolId = WmState->GetPoolId();
+        if (!poolId.empty()) {
+            proto->SetWmPoolId(std::move(poolId));
         }
     }
 
-    if (fieldsMap.NeedField(VSessions::WmState::ColumnId)) { // 18
-        if (WmState) {
-            using EWmState = NWorkloadManager::ISessionUpdater::EState;
-            switch(WmState->GetState()) {
-                case EWmState::NONE: {
-                    proto->SetWmState("NONE");
-                    break;
-                }
-                case EWmState::PENDING: {
-                    proto->SetWmState("PENDING");
-                    break;
-                }
-                case EWmState::DELAYED: {
-                    proto->SetWmState("DELAYED");
-                    break;
-                }
-                case EWmState::EXITED: {
-                    proto->SetWmState("EXITED");
-                    break;
-                }
-            }
-        }
-    }
-
-    if (fieldsMap.NeedField(VSessions::WmEnterTime::ColumnId)) { // 19
-        if (WmState) {
-            proto->SetWmEnterTime(WmState->GetEnterTime().MicroSeconds());
-        }
-    }
-
-    if (fieldsMap.NeedField(VSessions::WmExitTime::ColumnId)) { // 20
-        if (WmState) {
-            proto->SetWmExitTime(WmState->GetExitTime().MicroSeconds());
-        }
-    }
+    // Columns 18/19/20 (WmState/WmEnterTime/WmExitTime) are deprecated and
+    // always NULL; proto fields are kept reserved for a future removal.
 
     if (fieldsMap.NeedField(VSessions::TraceId::ColumnId)) { // 21
         if (State == TKqpSessionInfo::EXECUTING && !TraceId.empty()) {
             proto->SetTraceId(TraceId);
+        }
+    }
+
+    if (fieldsMap.NeedField(VSessions::WmClassifiedBy::ColumnId)) { // 22
+        auto classifiedBy = WmState->GetClassifiedBy();
+        if (!classifiedBy.empty()) {
+            proto->SetWmClassifiedBy(std::move(classifiedBy));
         }
     }
 }

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -597,7 +597,7 @@ public:
     void NotifyWmClassification(const TString& poolId,
                                 const NWorkloadManager::TResolver& resolver = NWorkloadManager::TResolver::Default()) {
         if (auto updater = QueryState->RequestEv->GetWmSessionUpdater()) {
-            updater->SetPoolId(poolId, resolver.ToSysViewString());
+            updater->SetPoolContext(poolId, resolver.ToSysViewString());
         }
     }
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -616,6 +616,9 @@ public:
                     {"traceId", TraceId()});
 
                 QueryState->UserRequestContext->PoolId = s.PoolId;
+                if (auto updater = QueryState->RequestEv->GetWmSessionUpdater()) {
+                    updater->SetPoolId(s.PoolId, s.Resolver.ToSysViewString());
+                }
                 if (s.SkipAdmission) {
                     QueryState->UserRequestContext->PoolConfig = s.PoolConfig;
                     return std::nullopt;
@@ -1060,6 +1063,9 @@ public:
                     {"skipAdmission", r.SkipAdmission},
                     {"traceId", TraceId()});
                 QueryState->UserRequestContext->PoolId = r.PoolId;
+                if (auto updater = QueryState->RequestEv->GetWmSessionUpdater()) {
+                    updater->SetPoolId(r.PoolId, r.Resolver.ToSysViewString());
+                }
                 if (r.SkipAdmission) {
                     QueryState->UserRequestContext->PoolConfig = r.PoolConfig;
                     return std::nullopt;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -594,6 +594,13 @@ public:
         CompileQuery();
     }
 
+    void NotifyWmClassification(const TString& poolId,
+                                const NWorkloadManager::TResolver& resolver = NWorkloadManager::TResolver::Default()) {
+        if (auto updater = QueryState->RequestEv->GetWmSessionUpdater()) {
+            updater->SetPoolId(poolId, resolver.ToSysViewString());
+        }
+    }
+
     bool WmPreCompileClassify() {
         auto classifier = QueryState->QueryClassifier;
 
@@ -616,9 +623,7 @@ public:
                     {"traceId", TraceId()});
 
                 QueryState->UserRequestContext->PoolId = s.PoolId;
-                if (auto updater = QueryState->RequestEv->GetWmSessionUpdater()) {
-                    updater->SetPoolId(s.PoolId, s.Resolver.ToSysViewString());
-                }
+                NotifyWmClassification(s.PoolId, s.Resolver);
                 if (s.SkipAdmission) {
                     QueryState->UserRequestContext->PoolConfig = s.PoolConfig;
                     return std::nullopt;
@@ -640,6 +645,7 @@ public:
                     {"logPrefix", LogPrefix()},
                     {"traceId", TraceId()});
                 QueryState->UserRequestContext->PoolId = NResourcePool::DEFAULT_POOL_ID;
+                NotifyWmClassification(NResourcePool::DEFAULT_POOL_ID);
                 return std::nullopt;
             },
             [this](const NWorkloadManager::IQueryClassifier::TPendingCompilation&) -> TError {
@@ -1063,9 +1069,7 @@ public:
                     {"skipAdmission", r.SkipAdmission},
                     {"traceId", TraceId()});
                 QueryState->UserRequestContext->PoolId = r.PoolId;
-                if (auto updater = QueryState->RequestEv->GetWmSessionUpdater()) {
-                    updater->SetPoolId(r.PoolId, r.Resolver.ToSysViewString());
-                }
+                NotifyWmClassification(r.PoolId, r.Resolver);
                 if (r.SkipAdmission) {
                     QueryState->UserRequestContext->PoolConfig = r.PoolConfig;
                     return std::nullopt;
@@ -1079,6 +1083,7 @@ public:
                     {"marker", "KQPSA"},
                     {"logPrefix", LogPrefix()},
                     {"traceId", TraceId()});
+                NotifyWmClassification(NResourcePool::DEFAULT_POOL_ID);
                 return std::nullopt;
             },
             [this](const NWorkloadManager::IQueryClassifier::TReject& r) -> TError {

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -410,6 +410,7 @@ message TSessionInfo {
     optional int64 WmEnterTime = 19;
     optional int64 WmExitTime = 20;
     optional string TraceId = 21;
+    // Description of how the query was classified into WmPoolId
     optional string WmClassifiedBy = 22;
 }
 

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -410,6 +410,7 @@ message TSessionInfo {
     optional int64 WmEnterTime = 19;
     optional int64 WmExitTime = 20;
     optional string TraceId = 21;
+    optional string WmClassifiedBy = 22;
 }
 
 message TEvListSessionsRequest {

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -601,6 +601,7 @@ struct Schema : NIceDb::Schema {
         struct WmEnterTime        : Column<19, NScheme::NTypeIds::Timestamp> {};
         struct WmExitTime         : Column<20, NScheme::NTypeIds::Timestamp> {};
         struct TraceId            : Column<21, NScheme::NTypeIds::Utf8> {};
+        struct WmClassifiedBy     : Column<22, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<SessionId>;
         using TColumns = TableColumns<
@@ -622,7 +623,8 @@ struct Schema : NIceDb::Schema {
             WmState,
             WmEnterTime,
             WmExitTime,
-            TraceId>;
+            TraceId,
+            WmClassifiedBy>;
     };
 
     struct PrimaryIndexPortionStats : Table<14> {

--- a/ydb/core/sys_view/sessions/sessions.cpp
+++ b/ydb/core/sys_view/sessions/sessions.cpp
@@ -91,23 +91,20 @@ public:
             }});
 
             insert({TSchema::WmPoolId::ColumnId, [] (const TNodeInfo& info, ui32) {   // 17
-                return TCell(info.GetWmPoolId().data(), info.GetWmPoolId().size());
+                return info.HasWmPoolId() ? TCell(info.GetWmPoolId().data(), info.GetWmPoolId().size()) : TCell();
             }});
 
-            insert({TSchema::WmState::ColumnId, [] (const TNodeInfo& info, ui32) {   // 18
-                return TCell(info.GetWmState().data(), info.GetWmState().size());
-            }});
-
-            insert({TSchema::WmEnterTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 19
-                return info.GetWmEnterTime() ? TCell::Make<ui64>(info.GetWmEnterTime()) : TCell();
-            }});
-
-            insert({TSchema::WmExitTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 20
-                return info.GetWmExitTime() ? TCell::Make<ui64>(info.GetWmExitTime()) : TCell();
-            }});
+            // Columns 18/19/20 are deprecated and always NULL, reserved for a future removal.
+            insert({TSchema::WmState::ColumnId,     [] (const TNodeInfo&, ui32) { return TCell(); }});  // 18
+            insert({TSchema::WmEnterTime::ColumnId, [] (const TNodeInfo&, ui32) { return TCell(); }});  // 19
+            insert({TSchema::WmExitTime::ColumnId,  [] (const TNodeInfo&, ui32) { return TCell(); }});  // 20
 
             insert({TSchema::TraceId::ColumnId, [] (const TNodeInfo& info, ui32) {  // 21
                 return info.HasTraceId() ? TCell(info.GetTraceId().data(), info.GetTraceId().size()) : TCell();
+            }});
+
+            insert({TSchema::WmClassifiedBy::ColumnId, [] (const TNodeInfo& info, ui32) {  // 22
+                return info.HasWmClassifiedBy() ? TCell(info.GetWmClassifiedBy().data(), info.GetWmClassifiedBy().size()) : TCell();
             }});
         }
     };

--- a/ydb/services/workload_manager/actors/pool_handlers_actors.cpp
+++ b/ydb/services/workload_manager/actors/pool_handlers_actors.cpp
@@ -216,10 +216,6 @@ private:
         TRequest* request = &LocalSessions.insert({sessionId, TRequest(workerActorId, sessionId, requestText, wmSessionUpdater)}).first->second;
         Counters.LocalDelayedRequests->Inc();
 
-        if (wmSessionUpdater) {
-            wmSessionUpdater->SetPoolId(PoolId);
-        }
-
         UpdatePoolConfig(ev->Get()->PoolConfig);
         UpdateSchemeboardSubscription(ev->Get()->PathId);
         OnScheduleRequest(request);

--- a/ydb/services/workload_manager/common/resolver.h
+++ b/ydb/services/workload_manager/common/resolver.h
@@ -18,7 +18,7 @@ struct TResolver {
     };
 
     EType Type;
-    TString Name;  // classifier rank/name for EType::Classifier; empty otherwise
+    TString Name;  // classifier name for EType::Classifier; empty otherwise
 
     static TResolver Direct()              { return {EType::Direct, {}}; }
     static TResolver Default()             { return {EType::Default, {}}; }
@@ -29,7 +29,7 @@ struct TResolver {
     TString ToSysViewString() const {
         switch (Type) {
             case EType::Direct:        return "USER";
-            case EType::Classifier:    return Name;
+            case EType::Classifier:    return TString("CLASSIFIER: ") + Name;
             case EType::Default:       return "NONE";
             case EType::SharedReading: return "SHARED_READING";
         }
@@ -40,7 +40,7 @@ struct TResolver {
     TString ToLogString() const {
         switch (Type) {
             case EType::Direct:        return "User request";
-            case EType::Classifier:    return TString("Classifier with rank: ") + Name;
+            case EType::Classifier:    return TString("Classifier: ") + Name;
             case EType::Default:       return "Default";
             case EType::SharedReading: return "ResourcePoolForSharedReading";
         }

--- a/ydb/services/workload_manager/common/resolver.h
+++ b/ydb/services/workload_manager/common/resolver.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NKikimr::NWorkloadManager {
+
+///
+/// Explains how a query was routed to its resource pool. Feeds the
+/// `WmClassifiedBy` sys view column and error/log messages built by the
+/// classifier.
+///
+struct TResolver {
+    enum class EType {
+        Direct,          // user set PoolId in the request
+        Classifier,      // a classifier rule matched
+        Default,         // no rule matched, fell through to default pool
+        SharedReading,   // system-forced pool for shared-reading streaming queries
+    };
+
+    EType Type;
+    TString Name;  // classifier rank/name for EType::Classifier; empty otherwise
+
+    static TResolver Direct()              { return {EType::Direct, {}}; }
+    static TResolver Default()             { return {EType::Default, {}}; }
+    static TResolver SharedReading()       { return {EType::SharedReading, {}}; }
+    static TResolver Classifier(TString n) { return {EType::Classifier, std::move(n)}; }
+
+    // Value emitted into the `WmClassifiedBy` sys view column.
+    TString ToSysViewString() const {
+        switch (Type) {
+            case EType::Direct:        return "USER";
+            case EType::Classifier:    return Name;
+            case EType::Default:       return "NONE";
+            case EType::SharedReading: return "SHARED_READING";
+        }
+    }
+
+    // Human-readable label for error messages and logs. Kept stable so existing
+    // classifier tests and user-visible error text do not change.
+    TString ToLogString() const {
+        switch (Type) {
+            case EType::Direct:        return "User request";
+            case EType::Classifier:    return TString("Classifier with rank: ") + Name;
+            case EType::Default:       return "Default";
+            case EType::SharedReading: return "ResourcePoolForSharedReading";
+        }
+    }
+};
+
+} // namespace NKikimr::NWorkloadManager

--- a/ydb/services/workload_manager/query_classifier.cpp
+++ b/ydb/services/workload_manager/query_classifier.cpp
@@ -68,7 +68,7 @@ public:
                 return *PreClassifyResult;
             }
 
-            if (TryResolve(settings, PreClassifyResult)) {
+            if (TryResolve(value, PreClassifyResult)) {
                 return *PreClassifyResult;
             }
         }
@@ -138,7 +138,7 @@ public:
                 return *PostClassifyResult;
             }
 
-            if (TryResolve(settings, PostClassifyResult)) {
+            if (TryResolve(it->second, PostClassifyResult)) {
                 return *PostClassifyResult;
             }
         }
@@ -262,10 +262,11 @@ private:
     }
 
     template<typename TStore>
-    bool TryResolve(const NResourcePool::TClassifierSettings& classifier, TStore& store) {
+    bool TryResolve(const TResourcePoolClassifierConfig& config, TStore& store) {
+        const auto& classifier = config.GetClassifierSettings();
         Y_ABORT_UNLESS(classifier.ResourcePool.has_value(),
             "ResourcePool must be set for non-Reject classifiers");
-        return TryResolve(*classifier.ResourcePool, store, TResolver::Classifier(ToString(classifier.Rank)));
+        return TryResolve(*classifier.ResourcePool, store, TResolver::Classifier(config.GetName()));
     }
 
     static TReject MakeRejectFromClassifier(const TResourcePoolClassifierConfig& config) {
@@ -274,7 +275,7 @@ private:
         return TReject{
             .Code = Ydb::StatusIds::PRECONDITION_FAILED,
             .Message = TStringBuilder() << "Request is rejected by classifier '" << name << "' (rank=" << rank << ")",
-            .Resolver = TResolver::Classifier(ToString(rank)).ToLogString(),
+            .Resolver = TResolver::Classifier(name).ToLogString(),
         };
     }
 

--- a/ydb/services/workload_manager/query_classifier.cpp
+++ b/ydb/services/workload_manager/query_classifier.cpp
@@ -8,9 +8,6 @@
 
 namespace NKikimr::NWorkloadManager {
 
-inline constexpr char RESOLVER_IS_USER[] = "User request";
-inline constexpr char DEFAULT_RESOLVER[] = "Default";
-
 class TQueryClassifier : public IQueryClassifier {
 public:
     TQueryClassifier(TResourcePoolMapPtr resourcePoolMap,
@@ -37,13 +34,13 @@ public:
 
         // User requested an explicit pool
         if (Context.PoolId) {
-            TryResolve(Context.PoolId, PreClassifyResult, RESOLVER_IS_USER);
+            TryResolve(Context.PoolId, PreClassifyResult, TResolver::Direct());
             return *PreClassifyResult;
         }
 
         // If no classification, use default pool
         if (!ClassifierView) {
-            TryResolve(NResourcePool::DEFAULT_POOL_ID, PreClassifyResult, DEFAULT_RESOLVER);
+            TryResolve(NResourcePool::DEFAULT_POOL_ID, PreClassifyResult, TResolver::Default());
             return *PreClassifyResult;
         }
 
@@ -77,7 +74,7 @@ public:
         }
 
         // No suitable classification, use default pool
-        TryResolve(NResourcePool::DEFAULT_POOL_ID, PreClassifyResult, DEFAULT_RESOLVER);
+        TryResolve(NResourcePool::DEFAULT_POOL_ID, PreClassifyResult, TResolver::Default());
         return *PreClassifyResult;
     }
 
@@ -88,7 +85,7 @@ public:
 
         if (userRequestContext.IsStreamingQuery && ResourcePoolForSharedReading.has_value()) {
             if (UsesSharedReading(preparedQuery.GetPhysicalQuery())) {
-                static constexpr auto resolver = "ResourcePoolForSharedReading";
+                const auto resolver = TResolver::SharedReading();
                 if (Context.PoolId && Context.PoolId != *ResourcePoolForSharedReading) {
                     PostClassifyResult = TReject{
                         .Code = Ydb::StatusIds::PRECONDITION_FAILED,
@@ -96,8 +93,8 @@ public:
                             << "Explicit resource pool '" << Context.PoolId
                             << "' conflicts with required pool for shared reading '"
                             << *ResourcePoolForSharedReading << "'"
-                            << ", resolved by: " << resolver,
-                        .Resolver = resolver,
+                            << ", resolved by: " << resolver.ToLogString(),
+                        .Resolver = resolver.ToLogString(),
                     };
                     return *PostClassifyResult;
                 }
@@ -111,12 +108,12 @@ public:
 
             // No shared reading — apply the original user pool, if any.
             if (Context.PoolId) {
-                TryResolve(Context.PoolId, PostClassifyResult, RESOLVER_IS_USER);
+                TryResolve(Context.PoolId, PostClassifyResult, TResolver::Direct());
                 return *PostClassifyResult;
             }
 
             if (!ClassifierView) {
-                TryResolve(NResourcePool::DEFAULT_POOL_ID, PostClassifyResult, DEFAULT_RESOLVER);
+                TryResolve(NResourcePool::DEFAULT_POOL_ID, PostClassifyResult, TResolver::Default());
                 return *PostClassifyResult;
             }
         }
@@ -147,7 +144,7 @@ public:
         }
 
         // No suitable classification, use default pool
-        TryResolve(NResourcePool::DEFAULT_POOL_ID, PostClassifyResult, DEFAULT_RESOLVER);
+        TryResolve(NResourcePool::DEFAULT_POOL_ID, PostClassifyResult, TResolver::Default());
         return *PostClassifyResult;
     }
 
@@ -268,7 +265,7 @@ private:
     bool TryResolve(const NResourcePool::TClassifierSettings& classifier, TStore& store) {
         Y_ABORT_UNLESS(classifier.ResourcePool.has_value(),
             "ResourcePool must be set for non-Reject classifiers");
-        return TryResolve(*classifier.ResourcePool, store, TStringBuilder() << "Classifier with rank: " << classifier.Rank);
+        return TryResolve(*classifier.ResourcePool, store, TResolver::Classifier(ToString(classifier.Rank)));
     }
 
     static TReject MakeRejectFromClassifier(const TResourcePoolClassifierConfig& config) {
@@ -277,7 +274,7 @@ private:
         return TReject{
             .Code = Ydb::StatusIds::PRECONDITION_FAILED,
             .Message = TStringBuilder() << "Request is rejected by classifier '" << name << "' (rank=" << rank << ")",
-            .Resolver = TStringBuilder() << "Classifier with rank: " << rank,
+            .Resolver = TResolver::Classifier(ToString(rank)).ToLogString(),
         };
     }
 
@@ -295,7 +292,7 @@ private:
     ///     preserved for accounting/observability.
     ///
     template<typename TStore>
-    bool TryResolve(const TString& poolId, TStore& store, const TString& resolver, bool mandatoryPool = false) {
+    bool TryResolve(const TString& poolId, TStore& store, TResolver resolver, bool mandatoryPool = false) {
         const auto* poolInfo = FindPool(poolId);
 
         if (!poolInfo) {
@@ -304,12 +301,12 @@ private:
                     .Code = Ydb::StatusIds::NOT_FOUND,
                     .Message = TStringBuilder()
                         << "Resource pool: " << poolId << " not found"
-                        << ", resolved by: " << resolver,
-                    .Resolver = resolver,
+                        << ", resolved by: " << resolver.ToLogString(),
+                    .Resolver = resolver.ToLogString(),
                 };
                 return true;
             }
-            store = TResolvedPoolId{.PoolId = poolId, .Resolver = resolver};
+            store = TResolvedPoolId{.PoolId = poolId, .Resolver = std::move(resolver)};
             return false;
         }
 
@@ -318,8 +315,8 @@ private:
                 .Code = Ydb::StatusIds::NOT_FOUND,
                 .Message = TStringBuilder()
                     << "Resource pool: " << poolId << " not found or you don't have describe permissions"
-                    << ", resolved by: " << resolver,
-                .Resolver = resolver
+                    << ", resolved by: " << resolver.ToLogString(),
+                .Resolver = resolver.ToLogString()
             };
             return false;
         }
@@ -329,23 +326,23 @@ private:
                 .Code = Ydb::StatusIds::UNAUTHORIZED,
                 .Message = TStringBuilder()
                     << "No access permissions for resource pool: " << poolId
-                    << ", resolved by: " << resolver,
-                .Resolver = resolver
+                    << ", resolved by: " << resolver.ToLogString(),
+                .Resolver = resolver.ToLogString()
             };
             return false;
         }
 
         if (!poolInfo->Config.IsWorkloadServiceRequired() && !mandatoryPool) {
-            store = TBypass{.Resolver = resolver};
+            store = TBypass{.Resolver = resolver.ToLogString()};
         } else if (!poolInfo->Config.IsAdmissionRequired()) {
             store = TResolvedPoolId{
                 .PoolId = poolId,
-                .Resolver = resolver,
+                .Resolver = std::move(resolver),
                 .SkipAdmission = true,
                 .PoolConfig = poolInfo->Config,
             };
         } else {
-            store = TResolvedPoolId{.PoolId = poolId, .Resolver = resolver};
+            store = TResolvedPoolId{.PoolId = poolId, .Resolver = std::move(resolver)};
         }
 
         return true;

--- a/ydb/services/workload_manager/query_classifier.h
+++ b/ydb/services/workload_manager/query_classifier.h
@@ -4,6 +4,7 @@
 #include <ydb/core/kqp/query_data/kqp_prepared_query.h>
 #include <ydb/core/resource_pools/resource_pool_classifier_settings.h>
 #include <ydb/services/workload_manager/common/helpers.h>
+#include <ydb/services/workload_manager/common/resolver.h>
 #include <ydb/services/workload_manager/metadata_subscription/resource_pool_classifier/snapshot.h>
 #include <ydb/library/aclib/aclib.h>
 
@@ -46,7 +47,7 @@ public:
 
     struct TResolvedPoolId {
         TString PoolId;
-        TString Resolver;
+        TResolver Resolver;
         // If true, session actor should apply PoolConfig directly and skip WMS admission actor.
         // Used when the pool has per-node caps (TotalCpu/TotalMemory) but no admission gating.
         bool SkipAdmission = false;

--- a/ydb/services/workload_manager/session_updater.h
+++ b/ydb/services/workload_manager/session_updater.h
@@ -21,7 +21,7 @@ public:
     virtual ~ISessionUpdater() = default;
 
     virtual void SetRequestState(EState state, TInstant timestamp) = 0;
-    virtual void SetPoolId(TString poolId, TString classifiedBy) = 0;
+    virtual void SetPoolContext(TString poolId, TString classifiedBy) = 0;
 };
 
 } // namespace NKikimr::NWorkloadManager

--- a/ydb/services/workload_manager/session_updater.h
+++ b/ydb/services/workload_manager/session_updater.h
@@ -21,7 +21,7 @@ public:
     virtual ~ISessionUpdater() = default;
 
     virtual void SetRequestState(EState state, TInstant timestamp) = 0;
-    virtual void SetPoolId(TString poolId) = 0;
+    virtual void SetPoolId(TString poolId, TString classifiedBy) = 0;
 };
 
 } // namespace NKikimr::NWorkloadManager

--- a/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
@@ -435,6 +435,43 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
     }
 
     ///
+    /// RFC C3.2: request routed by a classifier match must show
+    /// WmClassifiedBy = "CLASSIFIER: <name>".
+    ///
+    Y_UNIT_TEST(TestStateExecutingClassifiedByClassifier) {
+        using namespace NYdb::NTable;
+        TQuerySessionTestFixture f("my_pool", ISessionUpdater::EXITED);
+
+        const TString classifierId = "my_pool_classifier";
+        auto ddl = f.GetYdb()->ExecuteQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL CLASSIFIER )" << classifierId << R"( WITH (
+                RESOURCE_POOL="my_pool",
+                RANK=20
+            );
+        )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_EQUAL_C(ddl.GetStatus(), NYdb::EStatus::SUCCESS, ddl.GetIssues().ToString());
+        f.GetYdb()->WaitForClassifierPropagation();
+
+        const TString& query = TSampleQueries::TSelect42::Query;
+        TActorId edge = f.SetupInterceptor(query);
+        auto& runtime = *f.GetYdb()->GetRuntime();
+
+        auto session = f.GetYdb()->GetTableClient().CreateSession().GetValueSync().GetSession();
+        auto future = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx());
+        auto ev = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edge);
+
+        TQuerySessionReader reader(f.GetYdb());
+        reader.FetchAll(query);
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].State, "EXECUTING");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, TString("CLASSIFIER: ") + classifierId);
+
+        runtime.Send(new IEventHandle(ev->Sender, edge, ev->Release().Release()));
+        UNIT_ASSERT(future.GetValueSync().IsSuccess());
+    }
+
+    ///
     /// RFC C1: after the query finishes the session goes IDLE — Query is cleared,
     /// WmPoolId / WmClassifiedBy / QueryStartAt must all be NULL.
     ///

--- a/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
@@ -33,8 +33,8 @@ public:
         Inner->SetRequestState(state, timestamp);
     }
 
-    void SetPoolId(TString poolId, TString classifiedBy) override {
-        Inner->SetPoolId(std::move(poolId), std::move(classifiedBy));
+    void SetPoolContext(TString poolId, TString classifiedBy) override {
+        Inner->SetPoolContext(std::move(poolId), std::move(classifiedBy));
     }
 
 private:
@@ -377,6 +377,10 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, "USER");
         UNIT_ASSERT(reader[0].StateChangeAt);
         UNIT_ASSERT(!reader[0].QueryStartAt);
+        // Deprecated columns must stay NULL even while the request is DELAYED.
+        UNIT_ASSERT(!reader[0].WmState);
+        UNIT_ASSERT(!reader[0].WmEnterTime);
+        UNIT_ASSERT(!reader[0].WmExitTime);
 
         runtime.Send(new IEventHandle(evHanging->Sender, edgeHanging, evHanging->Release().Release()));
         auto evDelayed = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edgeDelayed);
@@ -456,7 +460,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
 
     ///
     /// RFC C4: with ResourcePools disabled the classifier is never invoked, so
-    /// SetPoolId is never called — WmPoolId / WmClassifiedBy stay NULL for the
+    /// SetPoolContext is never called — WmPoolId / WmClassifiedBy stay NULL for the
     /// whole session lifecycle. State can still be IDLE or EXECUTING.
     ///
     Y_UNIT_TEST(TestStateWmDisabled) {

--- a/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
@@ -33,8 +33,8 @@ public:
         Inner->SetRequestState(state, timestamp);
     }
 
-    void SetPoolId(TString poolId) override {
-        Inner->SetPoolId(poolId);
+    void SetPoolId(TString poolId, TString classifiedBy) override {
+        Inner->SetPoolId(std::move(poolId), std::move(classifiedBy));
     }
 
 private:
@@ -177,9 +177,14 @@ private:
 class TQuerySessionReader {
 public:
     struct Row {
-        std::optional<std::string> WmPoolId;
-        std::optional<std::string> WmState;
         std::optional<std::string> SessionId;
+        std::optional<std::string> State;
+        std::optional<std::string> WmPoolId;
+        std::optional<std::string> WmClassifiedBy;
+        std::optional<TInstant> StateChangeAt;
+        std::optional<TInstant> QueryStartAt;
+        // Deprecated columns kept in the read for regression assertions.
+        std::optional<std::string> WmState;
         std::optional<TInstant> WmEnterTime;
         std::optional<TInstant> WmExitTime;
     };
@@ -190,16 +195,26 @@ public:
     {}
 
     void FetchAll(const TString& query) {
+        Fetch(TStringBuilder() << "Query = '" << query << "'");
+    }
+
+    void FetchBySessionId(const TString& sessionId) {
+        Fetch(TStringBuilder() << "SessionId = '" << sessionId << "'");
+    }
+
+private:
+    void Fetch(const TString& predicate) {
         using namespace fmt::literals;
 
         Results.clear();
         TString q = fmt::format(R"(
-            SELECT SessionId, WmPoolId, WmState, WmEnterTime, WmExitTime
+            SELECT SessionId, State, WmPoolId, WmClassifiedBy, StateChangeAt, QueryStartAt,
+                   WmState, WmEnterTime, WmExitTime
             FROM `.sys/query_sessions`
-            WHERE State = 'EXECUTING' and Query = '{query}'
-            ORDER By WmState
+            WHERE {predicate}
+            ORDER BY SessionId
         )",
-            "query"_a = query
+            "predicate"_a = predicate
         );
 
         auto result = Ydb->ExecuteQuery(q, TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
@@ -209,22 +224,21 @@ public:
         auto parser = std::make_unique<NYdb::TResultSetParser>(rs);
 
         while (parser->TryNextRow()) {
-            auto wmState = parser->ColumnParser("WmState").GetOptionalUtf8();
-            auto wmPoolId = parser->ColumnParser("WmPoolId").GetOptionalUtf8();
-            auto sessionId = parser->ColumnParser("SessionId").GetOptionalUtf8();
-            auto wmEnterTime = parser->ColumnParser("WmEnterTime").GetOptionalTimestamp();
-            auto wmExitTime = parser->ColumnParser("WmExitTime").GetOptionalTimestamp();
-
             Results.push_back(Row{
-                .WmPoolId = wmPoolId,
-                .WmState = wmState,
-                .SessionId = sessionId,
-                .WmEnterTime = wmEnterTime,
-                .WmExitTime = wmExitTime
+                .SessionId       = parser->ColumnParser("SessionId").GetOptionalUtf8(),
+                .State           = parser->ColumnParser("State").GetOptionalUtf8(),
+                .WmPoolId        = parser->ColumnParser("WmPoolId").GetOptionalUtf8(),
+                .WmClassifiedBy  = parser->ColumnParser("WmClassifiedBy").GetOptionalUtf8(),
+                .StateChangeAt   = parser->ColumnParser("StateChangeAt").GetOptionalTimestamp(),
+                .QueryStartAt    = parser->ColumnParser("QueryStartAt").GetOptionalTimestamp(),
+                .WmState         = parser->ColumnParser("WmState").GetOptionalUtf8(),
+                .WmEnterTime     = parser->ColumnParser("WmEnterTime").GetOptionalTimestamp(),
+                .WmExitTime      = parser->ColumnParser("WmExitTime").GetOptionalTimestamp(),
             });
         }
     }
 
+public:
     Row operator[](size_t index) const {
         Y_ENSURE(index < Results.size());
         return Results[index];
@@ -295,9 +309,8 @@ private:
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
     ///
-    /// Executes a query and processes all WM states up to the specified final state.
-    /// It captures session data from .sys/query_sessions by 'parking' the request
-    /// in the interceptor actor, ensuring a race-free read before actual SQL execution starts.
+    /// Executes a query in a user-supplied pool, freezing WM at `state` so the
+    /// session row can be observed at that step of the queue lifecycle.
     ///
     TQuerySessionReader ReadQuerySessionAfterState(ISessionUpdater::EState state) {
         TQuerySessionTestFixture f("my_pool", state);
@@ -307,14 +320,11 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         auto future = f.GetYdb()->ExecuteQueryAsync(query, myPool);
         auto runtime = f.GetYdb()->GetRuntime();
 
-        // Stop a request before a real execution to prevent read races from a .sys/query_sessions
-        // The request is now 'parked' in the interceptor actor
         auto ev = runtime->GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edge);
 
         TQuerySessionReader reader(f.GetYdb());
         reader.FetchAll(query);
 
-        // Continue a request execution by sending the event back to the interceptor
         runtime->Send(new IEventHandle(ev->Sender, edge, ev->Release().Release()));
 
         auto result = future.GetResult();
@@ -323,46 +333,27 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         return reader;
     }
 
-    Y_UNIT_TEST(TestWmStateNone) {  
-        auto reader = ReadQuerySessionAfterState(ISessionUpdater::NONE);
-
-        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "NONE");
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
-        UNIT_ASSERT(!reader[0].WmEnterTime);
-        UNIT_ASSERT(!reader[0].WmExitTime);
-    }
-
-    Y_UNIT_TEST(TestWmStatePending) {
+    ///
+    /// RFC C2: request parked in the local pending queue.
+    /// Displayed State must be QUEUED; QueryStartAt is NULL until execution starts.
+    ///
+    Y_UNIT_TEST(TestStateQueuedPending) {
         auto reader = ReadQuerySessionAfterState(ISessionUpdater::PENDING);
 
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "PENDING");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].State, "QUEUED");
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
-        UNIT_ASSERT(reader[0].WmEnterTime);
-        UNIT_ASSERT(!reader[0].WmExitTime);
-    }
-
-    Y_UNIT_TEST(TestWmStateExited) {
-        auto reader = ReadQuerySessionAfterState(ISessionUpdater::EXITED);
-
-        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "EXITED");
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
-        UNIT_ASSERT(reader[0].WmEnterTime);
-        UNIT_ASSERT(reader[0].WmExitTime);
-        UNIT_ASSERT(*reader[0].WmEnterTime < *reader[0].WmExitTime);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, "USER");
+        UNIT_ASSERT(reader[0].StateChangeAt);
+        UNIT_ASSERT(!reader[0].QueryStartAt);
     }
 
     ///
-    /// Verifies the full lifecycle of a queued request within a Resource Pool.
-    /// The test simulates a pool limit exhaustion (limit=1), forcing the second
-    /// query into a 'DELAYED' state. It then ensures that once the first query
-    /// is released, the second one correctly transitions to 'EXITED' state,
-    /// preserving its original 'WmEnterTime' and recording a valid 'WmExitTime'.
+    /// RFC C2: request parked in the delayed_requests table.
+    /// Collapses to the same displayed State = QUEUED as PENDING.
     ///
-    Y_UNIT_TEST(TestWmStateDelayedToExited) {
-        TQuerySessionTestFixture f("my_pool", ISessionUpdater::EXITED, /*limit=*/1);
+    Y_UNIT_TEST(TestStateQueuedDelayed) {
+        TQuerySessionTestFixture f("my_pool", ISessionUpdater::DELAYED, /*limit=*/1);
         auto myPool = TQueryRunnerSettings().PoolId("my_pool");
         auto& runtime = *f.GetYdb()->GetRuntime();
 
@@ -372,39 +363,23 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         TActorId edgeHanging = f.SetupInterceptor(qHanging);
         TActorId edgeDelayed = f.SetupInterceptor(qDelayed);
 
-        // Stop a first request before a real execution to fill limits
         auto hangingRequest = f.GetYdb()->ExecuteQueryAsync(qHanging, myPool);
         auto evHanging = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edgeHanging);
-        
-        // Run a second request which has to be placed in a Delayed Queue
-        auto delayedRequest = f.GetYdb()->ExecuteQueryAsync(qDelayed, myPool);
 
-        // Wait for condition
+        auto delayedRequest = f.GetYdb()->ExecuteQueryAsync(qDelayed, myPool);
         f.GetYdb()->WaitPoolState({.DelayedRequests = 1, .RunningRequests = 1});
 
         TQuerySessionReader reader(f.GetYdb());
         reader.FetchAll(qDelayed);
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "DELAYED");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].State, "QUEUED");
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
-        UNIT_ASSERT(reader[0].WmEnterTime);
-        UNIT_ASSERT(!reader[0].WmExitTime);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, "USER");
+        UNIT_ASSERT(reader[0].StateChangeAt);
+        UNIT_ASSERT(!reader[0].QueryStartAt);
 
-        // Continue the first request and wait for the second request to be about to execute
         runtime.Send(new IEventHandle(evHanging->Sender, edgeHanging, evHanging->Release().Release()));
         auto evDelayed = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edgeDelayed);
- 
-        TQuerySessionReader reader2(f.GetYdb());
-        reader2.FetchAll(qDelayed);
-        UNIT_ASSERT_VALUES_EQUAL(reader2.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmState, "EXITED");
-        UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmPoolId, "my_pool");
-        UNIT_ASSERT(reader2[0].WmEnterTime);
-        UNIT_ASSERT(reader2[0].WmExitTime);
-        UNIT_ASSERT(*reader2[0].WmEnterTime < *reader2[0].WmExitTime);
-        UNIT_ASSERT_VALUES_EQUAL(*reader[0].WmEnterTime, *reader2[0].WmEnterTime);
-
-        // Continue the second request
         runtime.Send(new IEventHandle(evDelayed->Sender, edgeDelayed, evDelayed->Release().Release()));
 
         hangingRequest.GetResult();
@@ -412,58 +387,108 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
     }
 
     ///
-    /// Verifies that session metadata and Workload Manager (WM) state are correctly
-    /// cleaned up and reset when a KQP session is reused for a new query.
-    /// The test ensures that reusing a session via TableClient properly invokes
-    /// WmState->Clean(), resetting timestamps and states in the .sys/query_sessions table.
+    /// RFC C3: after the request leaves the queue, displayed State is EXECUTING
+    /// and StateChangeAt / QueryStartAt both equal the queue-exit time.
     ///
-    Y_UNIT_TEST(TestWmStateCleanupOnSessionReuse) {
-        using namespace NYdb::NTable;
+    Y_UNIT_TEST(TestStateExecutingAfterQueue) {
+        auto reader = ReadQuerySessionAfterState(ISessionUpdater::EXITED);
 
-        // We use PENDING state because AttachQueryText calls Clean() before placing request into pool
-        TQuerySessionTestFixture f(NResourcePool::DEFAULT_POOL_ID, ISessionUpdater::PENDING);
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].State, "EXECUTING");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, "USER");
+        UNIT_ASSERT(reader[0].StateChangeAt);
+        UNIT_ASSERT(reader[0].QueryStartAt);
+        UNIT_ASSERT_VALUES_EQUAL(*reader[0].StateChangeAt, *reader[0].QueryStartAt);
+    }
+
+    ///
+    /// RFC C3.1: request that hits the default pool through the classifier fallback
+    /// must show WmClassifiedBy = "NONE".
+    ///
+    Y_UNIT_TEST(TestStateExecutingDefaultPool) {
+        TQuerySessionTestFixture f(NResourcePool::DEFAULT_POOL_ID, ISessionUpdater::EXITED);
+        const TString& query = TSampleQueries::TSelect42::Query;
+        TActorId edge = f.SetupInterceptor(query);
         auto& runtime = *f.GetYdb()->GetRuntime();
 
+        auto future = f.GetYdb()->ExecuteQueryAsync(query);  // no explicit pool -> default
+        auto ev = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edge);
+
+        TQuerySessionReader reader(f.GetYdb());
+        reader.FetchAll(query);
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].State, "EXECUTING");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, NResourcePool::DEFAULT_POOL_ID);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, "NONE");
+
+        runtime.Send(new IEventHandle(ev->Sender, edge, ev->Release().Release()));
+        TSampleQueries::TSelect42::CheckResult(future.GetResult());
+    }
+
+    ///
+    /// RFC C1: after the query finishes the session goes IDLE — Query is cleared,
+    /// WmPoolId / WmClassifiedBy / QueryStartAt must all be NULL.
+    ///
+    Y_UNIT_TEST(TestStateIdle) {
+        using namespace NYdb::NTable;
+        TQuerySessionTestFixture f("my_pool", ISessionUpdater::EXITED);
         auto db = f.GetYdb()->GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
-        auto sessionId = session.GetId();
+        const auto sessionId = session.GetId();
 
-        // Execute the first query
-        const TString qFirst = "SELECT 11;";
-        TActorId edge1 = f.SetupInterceptor(qFirst);
-        auto future1 = session.ExecuteDataQuery(qFirst, TTxControl::BeginTx().CommitTx());
-        auto ev1 = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edge1);
-        
+        auto res = session.ExecuteDataQuery(TSampleQueries::TSelect42::Query,
+                                            TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT(res.IsSuccess());
+
         TQuerySessionReader reader(f.GetYdb());
-        reader.FetchAll(qFirst);
+        reader.FetchBySessionId(sessionId);
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].SessionId, sessionId);
-        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "PENDING");
-        UNIT_ASSERT(reader[0].WmEnterTime);
-        UNIT_ASSERT(!reader[0].WmExitTime);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].State, "IDLE");
+        UNIT_ASSERT(!reader[0].WmPoolId);
+        UNIT_ASSERT(!reader[0].WmClassifiedBy);
+        UNIT_ASSERT(!reader[0].QueryStartAt);
+    }
 
-        // Resume and wait for the first query to finish
-        runtime.Send(new IEventHandle(ev1->Sender, edge1, ev1->Release().Release()));
-        UNIT_ASSERT(future1.GetValueSync().IsSuccess());
+    ///
+    /// RFC C4: with ResourcePools disabled the classifier is never invoked, so
+    /// SetPoolId is never called — WmPoolId / WmClassifiedBy stay NULL for the
+    /// whole session lifecycle. State can still be IDLE or EXECUTING.
+    ///
+    Y_UNIT_TEST(TestStateWmDisabled) {
+        using namespace NYdb::NTable;
+        auto ydb = TYdbSetupSettings()
+            .NodeCount(1)
+            .EnableResourcePools(false)
+            .EnableStreamingQueries(false)
+            .Create();
 
-        // Execute the second query in the same session
-        const TString qSecond = "SELECT 12;";
-        TActorId edge2 = f.SetupInterceptor(qSecond);
-        auto future2 = session.ExecuteDataQuery(qSecond, TTxControl::BeginTx().CommitTx());
-        auto ev2 = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edge2);
+        auto session = ydb->GetTableClient().CreateSession().GetValueSync().GetSession();
+        const auto sessionId = session.GetId();
 
-        TQuerySessionReader reader2(f.GetYdb());
-        reader2.FetchAll(qSecond);
-        UNIT_ASSERT_VALUES_EQUAL(reader2.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(reader2[0].SessionId, sessionId);
-        UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmState, "PENDING");
-        UNIT_ASSERT(reader2[0].WmEnterTime);
-        UNIT_ASSERT(!reader2[0].WmExitTime);
-        UNIT_ASSERT(*reader[0].WmEnterTime < *reader2[0].WmEnterTime);
-        
-        // Resume and wait for the second query to finish
-        runtime.Send(new IEventHandle(ev2->Sender, edge2, ev2->Release().Release()));
-        UNIT_ASSERT(future2.GetValueSync().IsSuccess());
+        auto res = session.ExecuteDataQuery(TSampleQueries::TSelect42::Query,
+                                            TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT(res.IsSuccess());
+
+        TQuerySessionReader reader(ydb);
+        reader.FetchBySessionId(sessionId);
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT(!reader[0].WmPoolId);
+        UNIT_ASSERT(!reader[0].WmClassifiedBy);
+    }
+
+    ///
+    /// RFC: WmState / WmEnterTime / WmExitTime are deprecated and MUST always be NULL,
+    /// regardless of the actual queue state.
+    ///
+    Y_UNIT_TEST(TestDeprecatedColumnsAlwaysNull) {
+        for (auto state : {ISessionUpdater::NONE, ISessionUpdater::PENDING, ISessionUpdater::EXITED}) {
+            auto reader = ReadQuerySessionAfterState(state);
+            UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+            UNIT_ASSERT_C(!reader[0].WmState,     "WmState must be NULL for state=" << state);
+            UNIT_ASSERT_C(!reader[0].WmEnterTime, "WmEnterTime must be NULL for state=" << state);
+            UNIT_ASSERT_C(!reader[0].WmExitTime,  "WmExitTime must be NULL for state=" << state);
+        }
     }
 }
 

--- a/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
@@ -194,16 +194,16 @@ public:
         : Ydb(ydb)
     {}
 
-    void FetchAll(const TString& query) {
+    void FetchAll(TStringBuf query) {
         Fetch(TStringBuilder() << "Query = '" << query << "'");
     }
 
-    void FetchBySessionId(const TString& sessionId) {
+    void FetchBySessionId(TStringBuf sessionId) {
         Fetch(TStringBuilder() << "SessionId = '" << sessionId << "'");
     }
 
 private:
-    void Fetch(const TString& predicate) {
+    void Fetch(TStringBuf predicate) {
         using namespace fmt::literals;
 
         Results.clear();
@@ -404,15 +404,19 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
 
     ///
     /// RFC C3.1: request that hits the default pool through the classifier fallback
-    /// must show WmClassifiedBy = "NONE".
+    /// must show WmClassifiedBy = "NONE". Uses TableClient because IYdbSetup's
+    /// runner always attaches a PoolId to the request; TableClient sends no
+    /// PoolId, letting the classifier reach its Default branch.
     ///
     Y_UNIT_TEST(TestStateExecutingDefaultPool) {
+        using namespace NYdb::NTable;
         TQuerySessionTestFixture f(NResourcePool::DEFAULT_POOL_ID, ISessionUpdater::EXITED);
         const TString& query = TSampleQueries::TSelect42::Query;
         TActorId edge = f.SetupInterceptor(query);
         auto& runtime = *f.GetYdb()->GetRuntime();
 
-        auto future = f.GetYdb()->ExecuteQueryAsync(query);  // no explicit pool -> default
+        auto session = f.GetYdb()->GetTableClient().CreateSession().GetValueSync().GetSession();
+        auto future = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx());
         auto ev = runtime.GrabEdgeEvent<NWorkloadManager::TEvContinueRequest>(edge);
 
         TQuerySessionReader reader(f.GetYdb());
@@ -423,7 +427,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmClassifiedBy, "NONE");
 
         runtime.Send(new IEventHandle(ev->Sender, edge, ev->Release().Release()));
-        TSampleQueries::TSelect42::CheckResult(future.GetResult());
+        UNIT_ASSERT(future.GetValueSync().IsSuccess());
     }
 
     ///
@@ -485,9 +489,9 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         for (auto state : {ISessionUpdater::NONE, ISessionUpdater::PENDING, ISessionUpdater::EXITED}) {
             auto reader = ReadQuerySessionAfterState(state);
             UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
-            UNIT_ASSERT_C(!reader[0].WmState,     "WmState must be NULL for state=" << state);
-            UNIT_ASSERT_C(!reader[0].WmEnterTime, "WmEnterTime must be NULL for state=" << state);
-            UNIT_ASSERT_C(!reader[0].WmExitTime,  "WmExitTime must be NULL for state=" << state);
+            UNIT_ASSERT_C(!reader[0].WmState,     "WmState must be NULL for state=" << ui32(state));
+            UNIT_ASSERT_C(!reader[0].WmEnterTime, "WmEnterTime must be NULL for state=" << ui32(state));
+            UNIT_ASSERT_C(!reader[0].WmExitTime,  "WmExitTime must be NULL for state=" << ui32(state));
         }
     }
 }

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -992,6 +992,10 @@
       {
         "name": "TraceId",
         "type": "Utf8?"
+      },
+      {
+        "name": "WmClassifiedBy",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -564,6 +564,10 @@
       {
         "name": "TraceId",
         "type": "Utf8?"
+      },
+      {
+        "name": "WmClassifiedBy",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reshaped `.sys/query_sessions` for Workload Manager states (see ydb-platform/ydb-rfc#299)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implementation of RFC https://github.com/ydb-platform/ydb-rfc/pull/299.

See the RFC for the schema change, semantics of `WmClassifiedBy`, the new `QUEUED` display state, and the deprecation of `WmState` / `WmEnterTime` / `WmExitTime`.
