### PR TITLE
Fix Topic read balancer assignment for split/merge families

### DIFF
--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -158,15 +158,15 @@ void TPersQueueReadBalancer::InitDone(const TActorContext &ctx) {
         {"logPrefix", LogPrefix()},
         {"getInitLog", getInitLog()});
 
+    InitCompleted = true;
+
     for (auto &ev : UpdateEvents) {
         ctx.Send(ctx.SelfID, ev.Release());
     }
     UpdateEvents.clear();
 
-    for (auto &ev : RegisterEvents) {
-        ctx.Send(ctx.SelfID, ev.Release());
-    }
-    RegisterEvents.clear();
+    ReplayQueuedEvents(RegisterEvents, ctx);
+    ReplayQueuedEvents(InitBalancerEvents, ctx);
 
     GetStat(ctx);
 
@@ -837,9 +837,30 @@ void TPersQueueReadBalancer::UpdateActivePartitions() {
 // Balancing
 //
 
+// Finish/start/release are bound to a pipe and are stale after a PQRB restart.
+// Commit/status comes from the PQ tablet and must survive InitDone.
+void TPersQueueReadBalancer::EnqueueUntilInitDone(TAutoPtr<IEventHandle> ev) {
+    InitBalancerEvents.emplace_back(ev.Release());
+}
+
+void TPersQueueReadBalancer::ReplayQueuedEvents(std::deque<THolder<IEventHandle>>& events, const TActorContext& ctx) {
+    for (auto& ev : events) {
+        ctx.Send(IEventHandle::Forward(std::move(ev), ctx.SelfID).Release());
+    }
+    events.clear();
+}
+
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, const TActorContext& ctx) {
+    if (!InitCompleted) {
+        EnqueueUntilInitDone(ev.Release());
+        return;
+    }
     Balancer->Handle(ev, ctx);
     MLPBalancer->Handle(ev, ctx);
+}
+
+void TPersQueueReadBalancer::HandleOnInit(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, const TActorContext&) {
+    EnqueueUntilInitDone(ev.Release());
 }
 
 void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvReadingPartitionStartedRequest::TPtr& ev, const TActorContext& ctx) {
@@ -874,11 +895,15 @@ void TPersQueueReadBalancer::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& 
 
 void TPersQueueReadBalancer::HandleOnInit(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TActorContext&)
 {
-    RegisterEvents.push_back(ev->Release().Release());
+    RegisterEvents.emplace_back(ev.Release());
 }
 
 void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvRegisterReadSession::TPtr& ev, const TActorContext& ctx)
 {
+    if (!InitCompleted) {
+        RegisterEvents.emplace_back(ev.Release());
+        return;
+    }
     Balancer->Handle(ev, ctx);
 }
 
@@ -1155,6 +1180,10 @@ STFUNC(TPersQueueReadBalancer::StateInit) {
         HFunc(NSchemeShard::TEvSchemeShard::TEvSubDomainPathIdFound, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
         HFunc(TEvPersQueue::TEvGetPartitionsLocation, HandleOnInit);
+        IgnoreFunc(TEvPersQueue::TEvPartitionReleased);
+        IgnoreFunc(TEvPersQueue::TEvReadingPartitionStartedRequest);
+        IgnoreFunc(TEvPersQueue::TEvReadingPartitionFinishedRequest);
+        HFunc(TEvPQ::TEvReadingPartitionStatusRequest, HandleOnInit);
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         // MLP
         hFunc(TEvPQ::TEvMLPGetPartitionRequest, Handle);

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -837,7 +837,6 @@ void TPersQueueReadBalancer::UpdateActivePartitions() {
 // Balancing
 //
 
-// Finish/start/release are bound to a pipe and are stale after a PQRB restart.
 // Commit/status comes from the PQ tablet and must survive InitDone.
 void TPersQueueReadBalancer::EnqueueUntilInitDone(TAutoPtr<IEventHandle> ev) {
     InitBalancerEvents.emplace_back(ev.Release());
@@ -1180,6 +1179,7 @@ STFUNC(TPersQueueReadBalancer::StateInit) {
         HFunc(NSchemeShard::TEvSchemeShard::TEvSubDomainPathIdFound, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
         HFunc(TEvPersQueue::TEvGetPartitionsLocation, HandleOnInit);
+        // Finish/start/release are bound to a pipe and are stale after a PQRB restart.
         IgnoreFunc(TEvPersQueue::TEvPartitionReleased);
         IgnoreFunc(TEvPersQueue::TEvReadingPartitionStartedRequest);
         IgnoreFunc(TEvPersQueue::TEvReadingPartitionFinishedRequest);

--- a/ydb/core/persqueue/pqrb/read_balancer.h
+++ b/ydb/core/persqueue/pqrb/read_balancer.h
@@ -141,11 +141,15 @@ class TPersQueueReadBalancer : public TActor<TPersQueueReadBalancer>,
     void Handle(TEvPQ::TEvBalanceConsumer::TPtr& ev, const TActorContext& ctx); // from self
 
     void Handle(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, const TActorContext& ctx); // from Partition/PQ
+    void HandleOnInit(TEvPQ::TEvReadingPartitionStatusRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvReadingPartitionStartedRequest::TPtr& ev, const TActorContext& ctx); // from ReadSession
     void Handle(TEvPersQueue::TEvReadingPartitionFinishedRequest::TPtr& ev, const TActorContext& ctx); // from ReadSession
     void HandleOnInit(TEvPersQueue::TEvRegisterReadSession::TPtr &ev, const TActorContext& ctx); // from ReadSession
     void Handle(TEvPersQueue::TEvRegisterReadSession::TPtr &ev, const TActorContext& ctx); // from ReadSession
     void Handle(TEvPersQueue::TEvPartitionReleased::TPtr& ev, const TActorContext& ctx);  // from ReadSession
+
+    void EnqueueUntilInitDone(TAutoPtr<IEventHandle> ev);
+    void ReplayQueuedEvents(std::deque<THolder<IEventHandle>>& events, const TActorContext& ctx);
 
     void Handle(TEvTabletPipe::TEvServerConnected::TPtr& ev, const TActorContext&);
     void Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const TActorContext&);
@@ -285,8 +289,10 @@ private:
 
     ui64 StatsReportRound;
 
-    std::deque<TAutoPtr<TEvPersQueue::TEvRegisterReadSession>> RegisterEvents;
+    bool InitCompleted = false;
+    std::deque<THolder<IEventHandle>> RegisterEvents;
     std::deque<TAutoPtr<TEvPersQueue::TEvUpdateBalancerConfig>> UpdateEvents;
+    std::deque<THolder<IEventHandle>> InitBalancerEvents;
 
     static constexpr ui64 PARTITIONS_LOCATION_WAKEUP_TAG = 11;
     static constexpr TDuration PARTITIONS_LOCATION_WAKEUP_QUANTUM = TDuration::MilliSeconds(25);

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -898,6 +898,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
                 f->TargetStatus = family->TargetStatus;
                 f->Partitions.insert(f->Partitions.end(), members.begin(), members.end());
                 f->LastPipe = family->LastPipe;
+                f->RootPartitions.assign(f->Partitions.begin(), f->Partitions.end());
                 f->UpdatePartitionMapping(f->Partitions);
                 f->ClassifyPartitions();
                 if (locked) {
@@ -919,6 +920,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
 
             family->Partitions.clear();
             family->Partitions.push_back(partitionId);
+            family->RootPartitions = {partitionId};
 
             auto locked = family->LockedPartitions.contains(partitionId);
             family->LockedPartitions.clear();
@@ -975,7 +977,6 @@ std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lh
     }
     if ((lhs->IsActive() || lhs->IsReleasing()) && rhs->IsFree()) {
         lhs->AttachePartitions(rhs->Partitions, ctx);
-        lhs->RootPartitions.insert(lhs->RootPartitions.end(), rhs->Partitions.begin(), rhs->Partitions.end());
 
         rhs->Partitions.clear();
         rhs->Destroy();

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -412,15 +412,6 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
             "Cannot attach unreadable partition %u to family %lu", partitionId, Id);
     }
 
-    auto appendUniqueRoots = [&](const std::vector<ui32>& partitions) {
-        absl::flat_hash_set<ui32> seen(RootPartitions.begin(), RootPartitions.end());
-        for (auto partitionId : partitions) {
-            if (seen.insert(partitionId).second) {
-                RootPartitions.push_back(partitionId);
-            }
-        }
-    };
-
     if (IsActive()) {
         if (!Session) {
             YDB_LOG_CRIT("Attaching partitions to an active family without a session",
@@ -429,7 +420,7 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
         }
         if (!Session->AllPartitionsReadable(newPartitions)) {
             WantedPartitions.insert(newPartitions.begin(), newPartitions.end());
-            appendUniqueRoots(newPartitions);
+            AppendUniqueRoots(newPartitions);
             UpdateSpecialSessions();
             Release(ctx);
             return;
@@ -437,7 +428,7 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
 
         Partitions.insert(Partitions.end(), newPartitions.begin(), newPartitions.end());
         UpdatePartitionMapping(newPartitions);
-        appendUniqueRoots(newPartitions);
+        AppendUniqueRoots(newPartitions);
 
         for (auto partitionId : newPartitions) {
             LockPartition(partitionId, ctx);
@@ -447,13 +438,13 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
     } else if (IsFree()) {
         Partitions.insert(Partitions.end(), newPartitions.begin(), newPartitions.end());
         UpdatePartitionMapping(newPartitions);
-        appendUniqueRoots(newPartitions);
+        AppendUniqueRoots(newPartitions);
         for (auto partitionId : newPartitions) {
             WantedPartitions.erase(partitionId);
         }
     } else if (IsReleasing()) {
         WantedPartitions.insert(newPartitions.begin(), newPartitions.end());
-        appendUniqueRoots(newPartitions);
+        AppendUniqueRoots(newPartitions);
     }
 
     // Removing sessions wich can't read the family now
@@ -482,6 +473,9 @@ void TPartitionFamily::AttachReadyWantedPartitions(const TActorContext& ctx) {
         bool allParentsInFamily = true;
         for (auto* parent : node->DirectParents) {
             if (!parent) {
+                YDB_LOG_WARN("Partition graph has a null DirectParents pointer",
+                    {"logPrefix", LogPrefix()},
+                    {"partitionId", partitionId});
                 allParentsInFamily = false;
                 break;
             }
@@ -516,7 +510,16 @@ void TPartitionFamily::InactivatePartition(ui32 partitionId) {
     ChangePartitionCounters(-1, 1);
 }
 
- void TPartitionFamily::ChangePartitionCounters(ssize_t active, ssize_t inactive) {
+void TPartitionFamily::AppendUniqueRoots(const std::vector<ui32>& partitions) {
+    absl::flat_hash_set<ui32> seen(RootPartitions.begin(), RootPartitions.end());
+    for (auto partitionId : partitions) {
+        if (seen.insert(partitionId).second) {
+            RootPartitions.push_back(partitionId);
+        }
+    }
+}
+
+void TPartitionFamily::ChangePartitionCounters(ssize_t active, ssize_t inactive) {
     Y_VERIFY_DEBUG((ssize_t)ActivePartitionCount + active >= 0, "ActivePartitionCount: %lu, active: %ld", ActivePartitionCount, active);
     Y_VERIFY_DEBUG((ssize_t)InactivePartitionCount + inactive >= 0, "InactivePartitionCount: %lu, inactive: %ld", InactivePartitionCount, inactive);
 
@@ -542,7 +545,7 @@ void TPartitionFamily::Merge(TPartitionFamily* other) {
     UpdatePartitionMapping(other->Partitions);
     other->Partitions.clear();
 
-    RootPartitions.insert(RootPartitions.end(), other->RootPartitions.begin(), other->RootPartitions.end());
+    AppendUniqueRoots(other->RootPartitions);
     other->RootPartitions.clear();
 
     for (auto partitionId : Partitions) {
@@ -1084,7 +1087,12 @@ void TConsumer::AttachReadableDescendants(TPartitionFamily* family, const TActor
         });
     }
 
-    for (auto id : descendants) {
+    // Hash-set order is not stable. Sort so a chain (root → parent → grandchild)
+    // merges in a deterministic survivor family.
+    std::vector<ui32> ordered(descendants.begin(), descendants.end());
+    std::sort(ordered.begin(), ordered.end());
+
+    for (auto id : ordered) {
         auto* node = GetPartitionGraph().GetPartition(id);
         if (!node) {
             continue;
@@ -1094,6 +1102,9 @@ void TConsumer::AttachReadableDescendants(TPartitionFamily* family, const TActor
         if (node->DirectParents.size() > 1) {
             for (auto* parent : node->DirectParents) {
                 if (!parent) {
+                    YDB_LOG_WARN("Partition graph has a null DirectParents pointer",
+                        {"logPrefix", LogPrefix()},
+                        {"partitionId", id});
                     allParentsMerged = false;
                     continue;
                 }
@@ -1302,7 +1313,13 @@ bool TConsumer::IsReadable(ui32 partitionId) {
 
     auto parentsProcessed = [&](const auto& parents) {
         for (auto* parent : parents) {
-            if (!parent || !IsInactive(parent->Id)) {
+            if (!parent) {
+                YDB_LOG_WARN("Partition graph has a null parent pointer",
+                    {"logPrefix", LogPrefix()},
+                    {"partitionId", partitionId});
+                return false;
+            }
+            if (!IsInactive(parent->Id)) {
                 return false;
             }
         }

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -1377,7 +1377,10 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
                 if (allParentsMerged) {
                     auto* other = FindFamily(id);
                     if (other && other != family) {
-                        auto [f, _] = MergeFamilies(family, other, ctx);
+                        auto [f, v] = MergeFamilies(family, other, ctx);
+                        if (!v) {
+                            family->WantedPartitions.insert(id);
+                        }
                         family = f;
                     } else {
                         family->AttachePartitions({id}, ctx);
@@ -1424,6 +1427,10 @@ void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
 
     auto wasInactive = partition->IsInactive();
     if (partition->StartReading()) {
+        if (!ScalingSupport()) {
+            return;
+        }
+
         YDB_LOG_DEBUG("Reading of the partition was started by We stop reading from child partitions",
             {"logPrefix", LogPrefix()},
             {"partitionId", partitionId},
@@ -1436,21 +1443,18 @@ void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
 
         if (!family->IsLonely()) {
             BreakUpFamily(family, partitionId, false, ctx);
-            return;
-        }
-
-        if (wasInactive) {
+        } else if (wasInactive) {
             family->ActivatePartition(partitionId);
         }
 
-        // We releasing all children's partitions because we don't start reading the partition from EndOffset
-        GetPartitionGraph().Travers(partitionId, [&](ui32 partitionId) {
-            auto* partition = GetPartition(partitionId);
-            auto* f = FindFamily(partitionId);
+        // Stop reading children: the parent is being read again, so they are no longer readable.
+        GetPartitionGraph().Travers(partitionId, [&](ui32 childId) {
+            auto* child = GetPartition(childId);
+            auto* f = FindFamily(childId);
 
             if (f) {
-                if (partition && partition->Reset()) {
-                    f->ActivatePartition(partitionId);
+                if (child && child->Reset()) {
+                    f->ActivatePartition(childId);
                 }
                 DestroyFamily(f, ctx);
             }
@@ -1478,24 +1482,16 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
         return;
     }
 
-    auto* family = FindFamily(partitionId);
-    if (!family) {
-        YDB_LOG_DEBUG("Reading of the partition was finished by but the partition hasn't family",
+    auto* partitionPtr = GetPartition(partitionId);
+    if (!partitionPtr) {
+        YDB_LOG_DEBUG("Reading of the partition was finished by but the partition is unknown",
             {"logPrefix", LogPrefix()},
             {"partitionId", partitionId},
             {"consumerName", ConsumerName});
         return;
     }
 
-    if (!family->Session) {
-        YDB_LOG_DEBUG("Reading of the partition was finished by but the partition hasn't reading session",
-            {"logPrefix", LogPrefix()},
-            {"partitionId", partitionId},
-            {"consumerName", ConsumerName});
-        return;
-    }
-
-    auto& partition = Partitions[partitionId];
+    auto& partition = *partitionPtr;
 
     const bool wasInactive = partition.IsInactive();
     if (partition.SetFinishedState(r.GetScaleAwareSDK(), r.GetStartedReadingFromEndOffset()) || wasInactive) {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -267,24 +267,32 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 
             return true;
 
-        case ETargetStatus::Merge:
+        case ETargetStatus::Merge: {
             Status = EStatus::Free;
             AfterRelease();
 
+            TPartitionFamily* attachTo = this;
             auto it = Consumer.Families.find(MergeTo);
             if (it == Consumer.Families.end()) {
                 YDB_LOG_DEBUG("Has been released for merge but target family is not exists",
                     {"logPrefix", LogPrefix()});
-                return true;
-            }
-            auto* targetFamily = it->second.get();
-            if (targetFamily->CanAttach(Partitions) && targetFamily->CanAttach(WantedPartitions)) {
-                Consumer.MergeFamilies(targetFamily, this, ctx);
             } else {
-                WantedPartitions.clear();
+                auto* targetFamily = it->second.get();
+                if (targetFamily->CanAttach(Partitions) && targetFamily->CanAttach(WantedPartitions)) {
+                    attachTo = Consumer.MergeFamilies(targetFamily, this, ctx).first;
+                } else {
+                    WantedPartitions.clear();
+                    attachTo = targetFamily;
+                }
             }
+            // Parent families are in one place now, or this family remains after the
+            // target died with its session. Readable merge-children must be attached
+            // here: ProccessReadingFinished could not attach them while the merge was
+            // delayed on a release.
+            Consumer.AttachReadableDescendants(attachTo, ctx);
 
             return true;
+        }
     }
 }
 
@@ -320,6 +328,17 @@ void TPartitionFamily::AfterRelease() {
     }
 
     Partitions.clear();
+    {
+        absl::flat_hash_set<ui32> seen;
+        std::vector<ui32> uniqueRoots;
+        uniqueRoots.reserve(RootPartitions.size());
+        for (auto partitionId : RootPartitions) {
+            if (seen.insert(partitionId).second) {
+                uniqueRoots.push_back(partitionId);
+            }
+        }
+        RootPartitions = std::move(uniqueRoots);
+    }
     Partitions.insert(Partitions.end(), RootPartitions.begin(), RootPartitions.end());
 
     LockedPartitions.clear();
@@ -382,6 +401,15 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
     auto [activePartitionCount, inactivePartitionCount] = ClassifyPartitions(newPartitions);
     ChangePartitionCounters(activePartitionCount, inactivePartitionCount);
 
+    auto appendUniqueRoots = [&](const std::vector<ui32>& partitions) {
+        absl::flat_hash_set<ui32> seen(RootPartitions.begin(), RootPartitions.end());
+        for (auto partitionId : partitions) {
+            if (seen.insert(partitionId).second) {
+                RootPartitions.push_back(partitionId);
+            }
+        }
+    };
+
     if (IsActive()) {
         if (!Session) {
             YDB_LOG_CRIT("Attaching partitions to an active family without a session",
@@ -390,6 +418,7 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
         }
         if (!Session->AllPartitionsReadable(newPartitions)) {
             WantedPartitions.insert(newPartitions.begin(), newPartitions.end());
+            appendUniqueRoots(newPartitions);
             UpdateSpecialSessions();
             Release(ctx);
             return;
@@ -397,12 +426,23 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
 
         Partitions.insert(Partitions.end(), newPartitions.begin(), newPartitions.end());
         UpdatePartitionMapping(newPartitions);
+        appendUniqueRoots(newPartitions);
 
         for (auto partitionId : newPartitions) {
             LockPartition(partitionId, ctx);
             WantedPartitions.erase(partitionId);
         }
         LockedPartitions.insert(newPartitions.begin(), newPartitions.end());
+    } else if (IsFree()) {
+        Partitions.insert(Partitions.end(), newPartitions.begin(), newPartitions.end());
+        UpdatePartitionMapping(newPartitions);
+        appendUniqueRoots(newPartitions);
+        for (auto partitionId : newPartitions) {
+            WantedPartitions.erase(partitionId);
+        }
+    } else if (IsReleasing()) {
+        WantedPartitions.insert(newPartitions.begin(), newPartitions.end());
+        appendUniqueRoots(newPartitions);
     }
 
     // Removing sessions wich can't read the family now
@@ -413,6 +453,39 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
         } else {
             SpecialSessions.erase(it++);
         }
+    }
+}
+
+void TPartitionFamily::AttachReadyWantedPartitions(const TActorContext& ctx) {
+    if (WantedPartitions.empty()) {
+        return;
+    }
+
+    std::vector<ui32> ready;
+    ready.reserve(WantedPartitions.size());
+    for (auto partitionId : WantedPartitions) {
+        auto* node = Consumer.GetPartitionGraph().GetPartition(partitionId);
+        if (!node) {
+            continue;
+        }
+        bool allParentsInFamily = true;
+        for (auto* parent : node->DirectParents) {
+            if (!parent) {
+                allParentsInFamily = false;
+                break;
+            }
+            if (Consumer.FindFamily(parent->Id) != this) {
+                allParentsInFamily = false;
+                break;
+            }
+        }
+        if (allParentsInFamily) {
+            ready.push_back(partitionId);
+        }
+    }
+
+    if (!ready.empty()) {
+        AttachePartitions(ready, ctx);
     }
 }
 
@@ -892,6 +965,7 @@ std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lh
 
         lhs->Merge(rhs);
         rhs->Destroy();
+        lhs->AttachReadyWantedPartitions(ctx);
 
         return {lhs, true};
     }
@@ -905,6 +979,7 @@ std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lh
 
         rhs->Partitions.clear();
         rhs->Destroy();
+        lhs->AttachReadyWantedPartitions(ctx);
 
         return {lhs, true};
     }
@@ -949,6 +1024,103 @@ TPartitionFamily* TConsumer::FindFamily(ui32 partitionId) {
         return nullptr;
     }
     return it->second;
+}
+
+void TConsumer::AttachReadableDescendants(TPartitionFamily* family, const TActorContext& ctx) {
+    if (!family || AttachingDescendants) {
+        return;
+    }
+
+    struct TGuard {
+        bool& Flag;
+        explicit TGuard(bool& flag)
+            : Flag(flag)
+        {
+            Flag = true;
+        }
+        ~TGuard() {
+            Flag = false;
+        }
+    } guard(AttachingDescendants);
+
+    absl::flat_hash_set<ui32> roots;
+    roots.insert(family->RootPartitions.begin(), family->RootPartitions.end());
+    roots.insert(family->Partitions.begin(), family->Partitions.end());
+
+    bool needReleaseChildren = false;
+    for (auto partitionId : roots) {
+        auto* partition = GetPartition(partitionId);
+        if (partition && partition->NeedReleaseChildren()) {
+            needReleaseChildren = true;
+            break;
+        }
+    }
+
+    absl::flat_hash_set<ui32> descendants;
+    for (auto partitionId : roots) {
+        GetPartitionGraph().Travers(partitionId, [&](ui32 id) {
+            if (!IsReadable(id)) {
+                return false;
+            }
+            if (!roots.contains(id)) {
+                descendants.insert(id);
+            }
+            return true;
+        });
+    }
+
+    for (auto id : descendants) {
+        auto* node = GetPartitionGraph().GetPartition(id);
+        if (!node) {
+            continue;
+        }
+
+        bool allParentsMerged = true;
+        if (node->DirectParents.size() > 1) {
+            for (auto* parent : node->DirectParents) {
+                if (!parent) {
+                    allParentsMerged = false;
+                    continue;
+                }
+                auto* other = FindFamily(parent->Id);
+                if (!other) {
+                    allParentsMerged = false;
+                    continue;
+                }
+                if (other != family) {
+                    auto [f, ok] = MergeFamilies(family, other, ctx);
+                    family = f;
+                    allParentsMerged = allParentsMerged && ok;
+                }
+            }
+        }
+
+        if (!allParentsMerged) {
+            family->WantedPartitions.insert(id);
+            continue;
+        }
+
+        if (needReleaseChildren) {
+            std::array<ui32, 1> partitionIds{id};
+            if (!family->CanAttach(partitionIds)) {
+                continue;
+            }
+            auto* other = FindFamily(id);
+            if (other && other != family) {
+                auto [f, ok] = MergeFamilies(family, other, ctx);
+                family = f;
+                if (!ok) {
+                    family->WantedPartitions.insert(id);
+                }
+            } else {
+                family->AttachePartitions({id}, ctx);
+            }
+        } else if (!FindFamily(id)) {
+            CreateFamily({id}, ctx);
+        }
+    }
+
+    family->AttachReadyWantedPartitions(ctx);
 }
 
 void TConsumer::RegisterReadingSession(TSession* session, const TActorContext& ctx) {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -6,6 +6,8 @@
 
 #include <library/cpp/containers/absl/btree_set.h>
 
+#include <util/system/yassert.h>
+
 #include <algorithm>
 #include <array>
 
@@ -129,10 +131,6 @@ bool TPartitionFamily::IsLonely() const {
     return Partitions.size() == 1;
 }
 
-bool TPartitionFamily::HasActivePartitions() const {
-    return ActivePartitionCount;
-}
-
 const TString& TPartitionFamily::Topic() const {
     return Consumer.Topic();
 }
@@ -168,6 +166,8 @@ TString TPartitionFamily::LogPrefix() const {
 
 
 void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetStatus) {
+    Y_DEBUG_ABORT_UNLESS(IsActive(), "Releasing a family that is not active, family %lu", Id);
+    Y_DEBUG_ABORT_UNLESS(Session, "Releasing a family without a session, family %lu", Id);
     if (Status != EStatus::Active) {
         YDB_LOG_CRIT("Releasing the family that isn't active",
             {"logPrefix", LogPrefix()},
@@ -316,6 +316,8 @@ void TPartitionFamily::Destroy() {
         return;
     }
 
+    Y_DEBUG_ABORT_UNLESS(Consumer.DoomedGuardDepth > 0,
+        "Destroy family %zu without a doomed-family guard", Id);
     Consumer.DoomedFamilies.push_back(std::move(it->second));
     Consumer.Families.erase(it);
 }
@@ -351,6 +353,9 @@ void TPartitionFamily::AfterRelease() {
 }
 
 void TPartitionFamily::StartReading(TSession& session, const TActorContext& ctx) {
+    Y_DEBUG_ABORT_UNLESS(IsFree(), "StartReading requires a free family %lu", Id);
+    Y_DEBUG_ABORT_UNLESS(Consumer.Sessions.contains(session.Pipe),
+        "StartReading session is not registered, family %lu", Id);
     if (Status != EStatus::Free) {
         YDB_LOG_CRIT("Try start reading but the family status is",
             {"logPrefix", LogPrefix()},
@@ -401,6 +406,11 @@ void TPartitionFamily::AttachePartitions(const std::vector<ui32>& partitions, co
 
     auto [activePartitionCount, inactivePartitionCount] = ClassifyPartitions(newPartitions);
     ChangePartitionCounters(activePartitionCount, inactivePartitionCount);
+
+    for (auto partitionId : newPartitions) {
+        Y_DEBUG_ABORT_UNLESS(IsReadable(partitionId),
+            "Cannot attach unreadable partition %u to family %lu", partitionId, Id);
+    }
 
     auto appendUniqueRoots = [&](const std::vector<ui32>& partitions) {
         absl::flat_hash_set<ui32> seen(RootPartitions.begin(), RootPartitions.end());
@@ -641,9 +651,6 @@ std::pair<size_t, size_t> TPartitionFamily::ClassifyPartitions(const TPartitions
 }
 
 template
-std::pair<size_t, size_t> TPartitionFamily::ClassifyPartitions(const absl::btree_set<ui32>& partitions);
-
-template
 std::pair<size_t, size_t> TPartitionFamily::ClassifyPartitions(const std::vector<ui32>& partitions);
 
 void TPartitionFamily::UpdatePartitionMapping(const std::vector<ui32>& partitions) {
@@ -670,6 +677,10 @@ void TPartitionFamily::UpdateSpecialSessions() {
 }
 
 void TPartitionFamily::LockPartition(ui32 partitionId, const TActorContext& ctx) {
+    Y_DEBUG_ABORT_UNLESS(Session, "Lock partition %u without a session, family %lu", partitionId, Id);
+    Y_DEBUG_ABORT_UNLESS(IsActive(), "Lock partition %u from a non-active family %lu", partitionId, Id);
+    Y_DEBUG_ABORT_UNLESS(IsReadable(partitionId),
+        "Lock unreadable partition %u, family %lu", partitionId, Id);
     if (!Session) {
         YDB_LOG_CRIT("Lock partition without a session",
             {"logPrefix", LogPrefix()},
@@ -797,6 +808,7 @@ TPartitionFamily* TConsumer::CreateFamily(std::vector<ui32>&& partitions, const 
 }
 
 TPartitionFamily* TConsumer::CreateFamily(std::vector<ui32>&& partitions, TPartitionFamily::EStatus status, const TActorContext&) {
+    Y_DEBUG_ABORT_UNLESS(!partitions.empty(), "Cannot create an empty family, consumer %s", ConsumerName.data());
     auto id = ++NextFamilyId;
     auto [it, _] = Families.emplace(id, std::make_unique<TPartitionFamily>(*this, id, std::move(partitions)));
     auto* family = it->second.get();
@@ -958,6 +970,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
 }
 
 std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lhs, TPartitionFamily* rhs, const TActorContext& ctx) {
+    Y_DEBUG_ABORT_UNLESS(lhs && rhs, "MergeFamilies with a null family");
     AFL_ENSURE(lhs != rhs)
         ("lhs_id", lhs->Id)("rhs_id", rhs->Id)
         ("lhs_partitions", lhs->Partitions.size())("rhs_partitions", rhs->Partitions.size());
@@ -1378,13 +1391,15 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
                     auto* other = FindFamily(id);
                     if (other && other != family) {
                         auto [f, v] = MergeFamilies(family, other, ctx);
+                        family = f;
                         if (!v) {
                             family->WantedPartitions.insert(id);
                         }
-                        family = f;
                     } else {
                         family->AttachePartitions({id}, ctx);
                     }
+                } else {
+                    family->WantedPartitions.insert(id);
                 }
             } else {
                 YDB_LOG_DEBUG("Can't attache partition",
@@ -1520,6 +1535,123 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
     }
 }
 
+void TConsumer::AssertBalancingInvariants() {
+#ifdef NDEBUG
+    return;
+#endif
+
+    absl::flat_hash_set<TPartitionFamily*> liveFamilies;
+    absl::flat_hash_set<TSession*> liveSessions;
+    absl::flat_hash_map<TSession*, size_t> activeFamilies;
+    absl::flat_hash_map<TSession*, size_t> releasingFamilies;
+    absl::flat_hash_set<ui32> claimedPartitions;
+
+    liveFamilies.reserve(Families.size());
+    for (const auto& [id, family] : Families) {
+        Y_DEBUG_ABORT_UNLESS(family, "null family %zu", id);
+        liveFamilies.insert(family.get());
+    }
+    for (const auto& [pipe, session] : Sessions) {
+        Y_DEBUG_ABORT_UNLESS(session, "null session for pipe");
+        Y_DEBUG_ABORT_UNLESS(session->Pipe == pipe, "session pipe mismatch");
+        liveSessions.insert(session);
+    }
+
+    for (const auto& [id, family] : Families) {
+        Y_DEBUG_ABORT_UNLESS(family->Id == id, "family id mismatch %zu vs %zu", family->Id, id);
+
+        if (family->IsFree()) {
+            Y_DEBUG_ABORT_UNLESS(!family->Session, "free family %zu has a session", id);
+            Y_DEBUG_ABORT_UNLESS(family->LockedPartitions.empty(), "free family %zu has locked partitions", id);
+            auto uIt = UnreadableFamilies.find(id);
+            Y_DEBUG_ABORT_UNLESS(uIt != UnreadableFamilies.end() && uIt->second == family.get(),
+                "free family %zu is not in UnreadableFamilies", id);
+        } else {
+            Y_DEBUG_ABORT_UNLESS(family->Session, "active/releasing family %zu has no session", id);
+            Y_DEBUG_ABORT_UNLESS(liveSessions.contains(family->Session),
+                "family %zu session is not registered", id);
+            auto sit = family->Session->Families.find(family->Id);
+            Y_DEBUG_ABORT_UNLESS(sit != family->Session->Families.end() && sit->second == family.get(),
+                "session does not own family %zu", id);
+            if (family->IsActive()) {
+                ++activeFamilies[family->Session];
+            } else if (family->IsReleasing()) {
+                ++releasingFamilies[family->Session];
+            }
+        }
+
+        absl::flat_hash_set<ui32> uniquePartitions;
+        for (auto partitionId : family->Partitions) {
+            Y_DEBUG_ABORT_UNLESS(uniquePartitions.insert(partitionId).second,
+                "duplicate partition %u in family %zu", partitionId, id);
+            Y_DEBUG_ABORT_UNLESS(claimedPartitions.insert(partitionId).second,
+                "partition %u belongs to multiple families (family %zu)", partitionId, id);
+            auto mit = PartitionMapping.find(partitionId);
+            Y_DEBUG_ABORT_UNLESS(mit != PartitionMapping.end() && mit->second == family.get(),
+                "partition mapping mismatch for %u, family %zu", partitionId, id);
+        }
+
+        absl::flat_hash_set<ui32> uniqueRoots;
+        for (auto partitionId : family->RootPartitions) {
+            Y_DEBUG_ABORT_UNLESS(uniqueRoots.insert(partitionId).second,
+                "duplicate root partition %u in family %zu", partitionId, id);
+            Y_DEBUG_ABORT_UNLESS(uniquePartitions.contains(partitionId) || family->WantedPartitions.contains(partitionId),
+                "root partition %u is neither in Partitions nor WantedPartitions, family %zu", partitionId, id);
+        }
+
+        for (auto partitionId : family->LockedPartitions) {
+            Y_DEBUG_ABORT_UNLESS(uniquePartitions.contains(partitionId),
+                "locked partition %u is not in family %zu", partitionId, id);
+        }
+        if (family->IsActive()) {
+            Y_DEBUG_ABORT_UNLESS(family->LockedPartitions.size() == uniquePartitions.size(),
+                "active family %zu locked/partitions mismatch", id);
+        }
+
+        for (const auto& [pipe, session] : family->SpecialSessions) {
+            Y_DEBUG_ABORT_UNLESS(liveSessions.contains(session),
+                "stale special session in family %zu", id);
+            auto sIt = Sessions.find(pipe);
+            Y_DEBUG_ABORT_UNLESS(sIt != Sessions.end() && sIt->second == session,
+                "stale special session pipe in family %zu", id);
+        }
+    }
+
+    for (const auto& [partitionId, family] : PartitionMapping) {
+        Y_DEBUG_ABORT_UNLESS(liveFamilies.contains(family),
+            "mapping for partition %u points to a destroyed family", partitionId);
+        Y_DEBUG_ABORT_UNLESS(claimedPartitions.contains(partitionId),
+            "mapping for partition %u is not in any family partition list", partitionId);
+    }
+
+    for (const auto& [id, family] : UnreadableFamilies) {
+        Y_DEBUG_ABORT_UNLESS(liveFamilies.contains(family),
+            "unreadable family %zu is destroyed", id);
+        Y_DEBUG_ABORT_UNLESS(family->IsFree(), "unreadable family %zu is not free", id);
+        auto it = Families.find(id);
+        Y_DEBUG_ABORT_UNLESS(it != Families.end() && it->second.get() == family,
+            "unreadable family %zu is not in Families", id);
+    }
+
+    for (const auto& [_, session] : Sessions) {
+        Y_DEBUG_ABORT_UNLESS(activeFamilies[session] == session->ActiveFamilyCount,
+            "ActiveFamilyCount mismatch for session %s: actual %zu tracked %zu",
+            session->SessionName.data(), activeFamilies[session], session->ActiveFamilyCount);
+        Y_DEBUG_ABORT_UNLESS(releasingFamilies[session] == session->ReleasingFamilyCount,
+            "ReleasingFamilyCount mismatch for session %s: actual %zu tracked %zu",
+            session->SessionName.data(), releasingFamilies[session], session->ReleasingFamilyCount);
+        for (const auto& [familyId, family] : session->Families) {
+            Y_DEBUG_ABORT_UNLESS(liveFamilies.contains(family),
+                "session references a destroyed family %zu", familyId);
+            Y_DEBUG_ABORT_UNLESS(family->Session == session,
+                "session family back-pointer mismatch, family %zu", familyId);
+            auto it = Families.find(familyId);
+            Y_DEBUG_ABORT_UNLESS(it != Families.end() && it->second.get() == family,
+                "session references an unknown family %zu", familyId);
+        }
+    }
+}
+
 void TConsumer::ScheduleBalance(const TActorContext& ctx) {
     if (BalanceScheduled) {
         YDB_LOG_TRACE("Rebalancing already was scheduled",
@@ -1587,6 +1719,8 @@ size_t GetStatistics(const TFamilies& values, TPredicate predicate) {
 
 void TConsumer::Balance(const TActorContext& ctx) {
     TDoomedFamilyGuard doomed(*this);
+
+    AssertBalancingInvariants();
 
     YDB_LOG_DEBUG("Balancing",
         {"logPrefix", LogPrefix()},
@@ -1762,6 +1896,8 @@ void TConsumer::Balance(const TActorContext& ctx) {
     YDB_LOG_DEBUG("Balancing",
         {"logPrefix", LogPrefix()},
         {"duration", duration});
+
+    AssertBalancingInvariants();
 }
 
 void TConsumer::Release(ui32 partitionId, const TActorContext& ctx) {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -958,7 +958,10 @@ void TConsumer::RegisterReadingSession(TSession* session, const TActorContext& c
         }
 
         for (auto& partitionId : session->Partitions) {
-            if (!FindFamily(partitionId)) {
+            // A session that names a merge-child must not get it before all parents
+            // are processed: CreateFamily here would make the partition immediately
+            // balanceable.
+            if (!FindFamily(partitionId) && IsReadable(partitionId)) {
                 CreateFamily({partitionId}, ctx);
             }
         }
@@ -1048,14 +1051,24 @@ bool TConsumer::IsReadable(ui32 partitionId) {
         return false;
     }
 
-    if (Partitions.empty()) {
-        return node->DirectParents.empty();
-    }
-
-    for(auto* parent : node->AllParents) {
-        if (!IsInactive(parent->Id)) {
-            return false;
+    auto parentsProcessed = [&](const auto& parents) {
+        for (auto* parent : parents) {
+            if (!parent || !IsInactive(parent->Id)) {
+                return false;
+            }
         }
+        return true;
+    };
+
+    // DirectParents is the source of truth for a merge child. AllParents also
+    // covers grandparents (chained split/merge). An empty AllParents must not
+    // be treated as "no parents" — that used to make merge children readable
+    // immediately.
+    if (!parentsProcessed(node->DirectParents)) {
+        return false;
+    }
+    if (!parentsProcessed(node->AllParents)) {
+        return false;
     }
 
     return true;

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -264,6 +264,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 
             Status = EStatus::Free;
             AfterRelease();
+            AttachReadyWantedPartitions(ctx);
 
             return true;
 

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -202,7 +202,7 @@ void TPartitionFamily::Release(const TActorContext& ctx, ETargetStatus targetSta
     }
 }
 
-bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TActorContext& ctx) {
+bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId) {
     if (!Session || Session->Pipe != sender) {
         YDB_LOG_DEBUG("Try unlock the partition from other sender",
             {"logPrefix", LogPrefix()},
@@ -238,8 +238,6 @@ bool TPartitionFamily::Unlock(const TActorId& sender, ui32 partitionId, const TA
 
     --Session->ReleasingFamilyCount;
 
-    Reset(ctx);
-
     return true;
 }
 
@@ -257,7 +255,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
 
     switch (targetStatus) {
         case ETargetStatus::Destroy:
-            Destroy(ctx);
+            Destroy();
             return false;
 
         case ETargetStatus::Free:
@@ -290,7 +288,7 @@ bool TPartitionFamily::Reset(ETargetStatus targetStatus, const TActorContext& ct
     }
 }
 
-void TPartitionFamily::Destroy(const TActorContext&) {
+void TPartitionFamily::Destroy() {
     YDB_LOG_DEBUG("Destroyed",
         {"logPrefix", LogPrefix()});
 
@@ -303,7 +301,14 @@ void TPartitionFamily::Destroy(const TActorContext&) {
     }
     Consumer.UnreadableFamilies.erase(Id);
     Consumer.FamiliesRequireBalancing.erase(Id);
-    Consumer.Families.erase(Id);
+
+    auto it = Consumer.Families.find(Id);
+    if (it == Consumer.Families.end()) {
+        return;
+    }
+
+    Consumer.DoomedFamilies.push_back(std::move(it->second));
+    Consumer.Families.erase(it);
 }
 
 void TPartitionFamily::AfterRelease() {
@@ -501,7 +506,7 @@ bool TPartitionFamily::PossibleForBalance(TSession* session) {
     if (!session) {
         return false;
     }
-    if (!IsLonely()) {
+    if (Partitions.empty() || !IsLonely()) {
         return true;
     }
 
@@ -770,6 +775,8 @@ bool TConsumer::BreakUpFamily(ui32 partitionId, bool destroy, const TActorContex
 }
 
 bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool destroy, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     std::vector<TPartitionFamily*> newFamilies;
 
     if (!family->IsLonely()) {
@@ -884,7 +891,7 @@ std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lh
         lhs->IsReleasing() && rhs->IsReleasing() && lhs->Session == rhs->Session && lhs->TargetStatus == rhs->TargetStatus) {
 
         lhs->Merge(rhs);
-        rhs->Destroy(ctx);
+        rhs->Destroy();
 
         return {lhs, true};
     }
@@ -897,7 +904,7 @@ std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lh
         lhs->RootPartitions.insert(lhs->RootPartitions.end(), rhs->Partitions.begin(), rhs->Partitions.end());
 
         rhs->Partitions.clear();
-        rhs->Destroy(ctx);
+        rhs->Destroy();
 
         return {lhs, true};
     }
@@ -921,6 +928,8 @@ std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lh
 }
 
 void TConsumer::DestroyFamily(TPartitionFamily* family, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     switch(family->Status) {
         case TPartitionFamily::EStatus::Active:
             family->Release(ctx, TPartitionFamily::ETargetStatus::Destroy);
@@ -984,6 +993,8 @@ std::vector<TPartitionFamily*> Snapshot(const absl::flat_hash_map<size_t, std::u
 }
 
 void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     auto pipe = session->Pipe;
     Sessions.erase(session->Pipe);
     if (!session->WithGroups()) {
@@ -994,7 +1005,19 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
     }
 
     for (auto* family : Snapshot(Families)) {
+        auto live = Families.find(family->Id);
+        if (live == Families.end() || live->second.get() != family) {
+            continue;
+        }
+
         auto special = family->SpecialSessions.erase(pipe);
+        for (auto it = family->SpecialSessions.begin(); it != family->SpecialSessions.end();) {
+            if (it->second == session) {
+                family->SpecialSessions.erase(it++);
+            } else {
+                ++it;
+            }
+        }
 
         if (session == family->Session) {
             std::vector<ui32> roots;
@@ -1015,9 +1038,15 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
                 targetStatus = TPartitionFamily::ETargetStatus::Destroy;
             }
 
+            const size_t familyId = family->Id;
             if (family->Reset(targetStatus, ctx)) {
-                UnreadableFamilies[family->Id] = family;
-                FamiliesRequireBalancing.erase(family->Id);
+                auto it = Families.find(familyId);
+                if (it == Families.end()) {
+                    // Reset(Merge) may destroy this family by attaching it to the target.
+                    continue;
+                }
+                UnreadableFamilies[familyId] = it->second.get();
+                FamiliesRequireBalancing.erase(familyId);
             } else {
                 for (auto& r : roots) {
                     if (IsReadable(r)) {
@@ -1030,6 +1059,8 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
 }
 
 bool TConsumer::Unlock(const TActorId& sender, ui32 partitionId, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     auto* family = FindFamily(partitionId);
     if (!family) {
         YDB_LOG_CRIT("Unlocking the partition from unknown family",
@@ -1038,7 +1069,15 @@ bool TConsumer::Unlock(const TActorId& sender, ui32 partitionId, const TActorCon
         return false;
     }
 
-    return family->Unlock(sender, partitionId, ctx);
+    if (!family->Unlock(sender, partitionId)) {
+        return false;
+    }
+
+    // Reset may park this family in DoomedFamilies (Merge/Destroy). Drop it only
+    // after Unlock returns to TConsumer, so TPartitionFamily methods never
+    // continue on a destroyed this.
+    family->Reset(ctx);
+    return true;
 }
 
 bool TConsumer::IsReadable(ui32 partitionId) {
@@ -1095,6 +1134,8 @@ bool TConsumer::SetCommittedState(ui32 partitionId, ui32 generation, ui64 cookie
 }
 
 bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     if (!ScalingSupport()) {
         return false;
     }
@@ -1188,6 +1229,8 @@ bool TConsumer::ProccessReadingFinished(ui32 partitionId, bool wasInactive, cons
 }
 
 void TConsumer::StartReading(ui32 partitionId, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     if (!GetPartitionInfo(partitionId)) {
         YDB_LOG_NOTICE("Reading of the partition was started by but partition has been deleted",
             {"logPrefix", LogPrefix()},
@@ -1248,6 +1291,8 @@ TString GetSdkDebugString0(bool scaleAwareSDK) {
 }
 
 void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::TPtr& ev, const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     auto& r = ev->Get()->Record;
     auto partitionId = r.GetPartitionId();
 
@@ -1371,6 +1416,8 @@ size_t GetStatistics(const TFamilies& values, TPredicate predicate) {
 }
 
 void TConsumer::Balance(const TActorContext& ctx) {
+    TDoomedFamilyGuard doomed(*this);
+
     YDB_LOG_DEBUG("Balancing",
         {"logPrefix", LogPrefix()},
         {"sessions", Sessions.size()},
@@ -2006,7 +2053,8 @@ void TBalancer::Handle(TEvPersQueue::TEvGetReadSessionsInfo::TPtr& ev, const TAc
             pi->SetPartition(partitionId);
 
             auto* family = consumer->FindFamily(partitionId);
-            if (family && family->Session && family->LockedPartitions.contains(partitionId)) {
+            if (family && family->Session && consumer->Sessions.contains(family->Session->Pipe)
+                    && family->LockedPartitions.contains(partitionId)) {
                 auto* session = family->Session;
 
                 pi->SetClientNode(session->ClientNode);

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -1191,56 +1191,79 @@ void TConsumer::UnregisterReadingSession(TSession* session, const TActorContext&
         });
     }
 
-    for (auto* family : Snapshot(Families)) {
+    auto resetHeldFamily = [&](TPartitionFamily* family, bool special) {
         auto live = Families.find(family->Id);
         if (live == Families.end() || live->second.get() != family) {
-            continue;
+            return;
         }
 
-        auto special = family->SpecialSessions.erase(pipe);
-        for (auto it = family->SpecialSessions.begin(); it != family->SpecialSessions.end();) {
-            if (it->second == session) {
-                family->SpecialSessions.erase(it++);
-            } else {
-                ++it;
+        std::vector<ui32> roots;
+        roots.reserve(family->RootPartitions.size());
+        roots.insert(roots.end(), family->RootPartitions.begin(), family->RootPartitions.end());
+
+        TPartitionFamily::ETargetStatus targetStatus = family->TargetStatus;
+        if (special && family->SpecialSessions.empty()) {
+            for (auto& r : roots) {
+                if (!IsReadable(r)) {
+                    targetStatus = TPartitionFamily::ETargetStatus::Destroy;
+                    break;
+                }
             }
         }
 
-        if (session == family->Session) {
-            std::vector<ui32> roots;
-            roots.reserve(family->RootPartitions.size());
-            roots.insert(roots.end(), family->RootPartitions.begin(), family->RootPartitions.end());
+        if (!family->CanAttach(family->WantedPartitions)) {
+            targetStatus = TPartitionFamily::ETargetStatus::Destroy;
+        }
 
-            TPartitionFamily::ETargetStatus targetStatus = family->TargetStatus;
-            if (special && family->SpecialSessions.empty()) {
-                for (auto& r : roots) {
-                    if (!IsReadable(r)) {
-                        targetStatus = TPartitionFamily::ETargetStatus::Destroy;
-                        break;
-                    }
+        const size_t familyId = family->Id;
+        if (family->Reset(targetStatus, ctx)) {
+            auto it = Families.find(familyId);
+            if (it == Families.end()) {
+                // Reset(Merge) may destroy this family by attaching it to the target.
+                return;
+            }
+            UnreadableFamilies[familyId] = it->second.get();
+            FamiliesRequireBalancing.erase(familyId);
+        } else {
+            for (auto& r : roots) {
+                if (IsReadable(r)) {
+                    CreateFamily({r}, ctx);
+                }
+            }
+        }
+    };
+
+    std::vector<TPartitionFamily*> held;
+    held.reserve(session->Families.size());
+    for (auto& [_, family] : session->Families) {
+        held.push_back(family);
+    }
+
+    if (session->WithGroups()) {
+        // A preferred session may sit in SpecialSessions of families it is not
+        // currently reading. Scan those families only in this case.
+        for (auto* family : Snapshot(Families)) {
+            auto live = Families.find(family->Id);
+            if (live == Families.end() || live->second.get() != family) {
+                continue;
+            }
+
+            auto special = family->SpecialSessions.erase(pipe);
+            for (auto it = family->SpecialSessions.begin(); it != family->SpecialSessions.end();) {
+                if (it->second == session) {
+                    family->SpecialSessions.erase(it++);
+                } else {
+                    ++it;
                 }
             }
 
-            if (!family->CanAttach(family->WantedPartitions)) {
-                targetStatus = TPartitionFamily::ETargetStatus::Destroy;
+            if (session == family->Session) {
+                resetHeldFamily(family, special);
             }
-
-            const size_t familyId = family->Id;
-            if (family->Reset(targetStatus, ctx)) {
-                auto it = Families.find(familyId);
-                if (it == Families.end()) {
-                    // Reset(Merge) may destroy this family by attaching it to the target.
-                    continue;
-                }
-                UnreadableFamilies[familyId] = it->second.get();
-                FamiliesRequireBalancing.erase(familyId);
-            } else {
-                for (auto& r : roots) {
-                    if (IsReadable(r)) {
-                        CreateFamily({r}, ctx);
-                    }
-                }
-            }
+        }
+    } else {
+        for (auto* family : held) {
+            resetHeldFamily(family, false);
         }
     }
 }
@@ -1535,123 +1558,6 @@ void TConsumer::FinishReading(TEvPersQueue::TEvReadingPartitionFinishedRequest::
     }
 }
 
-void TConsumer::AssertBalancingInvariants() {
-#ifdef NDEBUG
-    return;
-#endif
-
-    absl::flat_hash_set<TPartitionFamily*> liveFamilies;
-    absl::flat_hash_set<TSession*> liveSessions;
-    absl::flat_hash_map<TSession*, size_t> activeFamilies;
-    absl::flat_hash_map<TSession*, size_t> releasingFamilies;
-    absl::flat_hash_set<ui32> claimedPartitions;
-
-    liveFamilies.reserve(Families.size());
-    for (const auto& [id, family] : Families) {
-        Y_DEBUG_ABORT_UNLESS(family, "null family %zu", id);
-        liveFamilies.insert(family.get());
-    }
-    for (const auto& [pipe, session] : Sessions) {
-        Y_DEBUG_ABORT_UNLESS(session, "null session for pipe");
-        Y_DEBUG_ABORT_UNLESS(session->Pipe == pipe, "session pipe mismatch");
-        liveSessions.insert(session);
-    }
-
-    for (const auto& [id, family] : Families) {
-        Y_DEBUG_ABORT_UNLESS(family->Id == id, "family id mismatch %zu vs %zu", family->Id, id);
-
-        if (family->IsFree()) {
-            Y_DEBUG_ABORT_UNLESS(!family->Session, "free family %zu has a session", id);
-            Y_DEBUG_ABORT_UNLESS(family->LockedPartitions.empty(), "free family %zu has locked partitions", id);
-            auto uIt = UnreadableFamilies.find(id);
-            Y_DEBUG_ABORT_UNLESS(uIt != UnreadableFamilies.end() && uIt->second == family.get(),
-                "free family %zu is not in UnreadableFamilies", id);
-        } else {
-            Y_DEBUG_ABORT_UNLESS(family->Session, "active/releasing family %zu has no session", id);
-            Y_DEBUG_ABORT_UNLESS(liveSessions.contains(family->Session),
-                "family %zu session is not registered", id);
-            auto sit = family->Session->Families.find(family->Id);
-            Y_DEBUG_ABORT_UNLESS(sit != family->Session->Families.end() && sit->second == family.get(),
-                "session does not own family %zu", id);
-            if (family->IsActive()) {
-                ++activeFamilies[family->Session];
-            } else if (family->IsReleasing()) {
-                ++releasingFamilies[family->Session];
-            }
-        }
-
-        absl::flat_hash_set<ui32> uniquePartitions;
-        for (auto partitionId : family->Partitions) {
-            Y_DEBUG_ABORT_UNLESS(uniquePartitions.insert(partitionId).second,
-                "duplicate partition %u in family %zu", partitionId, id);
-            Y_DEBUG_ABORT_UNLESS(claimedPartitions.insert(partitionId).second,
-                "partition %u belongs to multiple families (family %zu)", partitionId, id);
-            auto mit = PartitionMapping.find(partitionId);
-            Y_DEBUG_ABORT_UNLESS(mit != PartitionMapping.end() && mit->second == family.get(),
-                "partition mapping mismatch for %u, family %zu", partitionId, id);
-        }
-
-        absl::flat_hash_set<ui32> uniqueRoots;
-        for (auto partitionId : family->RootPartitions) {
-            Y_DEBUG_ABORT_UNLESS(uniqueRoots.insert(partitionId).second,
-                "duplicate root partition %u in family %zu", partitionId, id);
-            Y_DEBUG_ABORT_UNLESS(uniquePartitions.contains(partitionId) || family->WantedPartitions.contains(partitionId),
-                "root partition %u is neither in Partitions nor WantedPartitions, family %zu", partitionId, id);
-        }
-
-        for (auto partitionId : family->LockedPartitions) {
-            Y_DEBUG_ABORT_UNLESS(uniquePartitions.contains(partitionId),
-                "locked partition %u is not in family %zu", partitionId, id);
-        }
-        if (family->IsActive()) {
-            Y_DEBUG_ABORT_UNLESS(family->LockedPartitions.size() == uniquePartitions.size(),
-                "active family %zu locked/partitions mismatch", id);
-        }
-
-        for (const auto& [pipe, session] : family->SpecialSessions) {
-            Y_DEBUG_ABORT_UNLESS(liveSessions.contains(session),
-                "stale special session in family %zu", id);
-            auto sIt = Sessions.find(pipe);
-            Y_DEBUG_ABORT_UNLESS(sIt != Sessions.end() && sIt->second == session,
-                "stale special session pipe in family %zu", id);
-        }
-    }
-
-    for (const auto& [partitionId, family] : PartitionMapping) {
-        Y_DEBUG_ABORT_UNLESS(liveFamilies.contains(family),
-            "mapping for partition %u points to a destroyed family", partitionId);
-        Y_DEBUG_ABORT_UNLESS(claimedPartitions.contains(partitionId),
-            "mapping for partition %u is not in any family partition list", partitionId);
-    }
-
-    for (const auto& [id, family] : UnreadableFamilies) {
-        Y_DEBUG_ABORT_UNLESS(liveFamilies.contains(family),
-            "unreadable family %zu is destroyed", id);
-        Y_DEBUG_ABORT_UNLESS(family->IsFree(), "unreadable family %zu is not free", id);
-        auto it = Families.find(id);
-        Y_DEBUG_ABORT_UNLESS(it != Families.end() && it->second.get() == family,
-            "unreadable family %zu is not in Families", id);
-    }
-
-    for (const auto& [_, session] : Sessions) {
-        Y_DEBUG_ABORT_UNLESS(activeFamilies[session] == session->ActiveFamilyCount,
-            "ActiveFamilyCount mismatch for session %s: actual %zu tracked %zu",
-            session->SessionName.data(), activeFamilies[session], session->ActiveFamilyCount);
-        Y_DEBUG_ABORT_UNLESS(releasingFamilies[session] == session->ReleasingFamilyCount,
-            "ReleasingFamilyCount mismatch for session %s: actual %zu tracked %zu",
-            session->SessionName.data(), releasingFamilies[session], session->ReleasingFamilyCount);
-        for (const auto& [familyId, family] : session->Families) {
-            Y_DEBUG_ABORT_UNLESS(liveFamilies.contains(family),
-                "session references a destroyed family %zu", familyId);
-            Y_DEBUG_ABORT_UNLESS(family->Session == session,
-                "session family back-pointer mismatch, family %zu", familyId);
-            auto it = Families.find(familyId);
-            Y_DEBUG_ABORT_UNLESS(it != Families.end() && it->second.get() == family,
-                "session references an unknown family %zu", familyId);
-        }
-    }
-}
-
 void TConsumer::ScheduleBalance(const TActorContext& ctx) {
     if (BalanceScheduled) {
         YDB_LOG_TRACE("Rebalancing already was scheduled",
@@ -1719,8 +1625,6 @@ size_t GetStatistics(const TFamilies& values, TPredicate predicate) {
 
 void TConsumer::Balance(const TActorContext& ctx) {
     TDoomedFamilyGuard doomed(*this);
-
-    AssertBalancingInvariants();
 
     YDB_LOG_DEBUG("Balancing",
         {"logPrefix", LogPrefix()},
@@ -1896,8 +1800,6 @@ void TConsumer::Balance(const TActorContext& ctx) {
     YDB_LOG_DEBUG("Balancing",
         {"logPrefix", LogPrefix()},
         {"duration", duration});
-
-    AssertBalancingInvariants();
 }
 
 void TConsumer::Release(ui32 partitionId, const TActorContext& ctx) {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -6,6 +6,8 @@
 #include <library/cpp/containers/absl/flat_hash_map.h>
 #include <library/cpp/containers/absl/flat_hash_set.h>
 
+#include <vector>
+
 namespace NKikimr::NPQ::NApp {
 struct TNavigationBar;
 }
@@ -117,8 +119,8 @@ struct TPartitionFamily {
     // Releases all partitions of the family.
     void Release(const TActorContext& ctx, ETargetStatus targetStatus = ETargetStatus::Free);
     // Processes the signal from the reading session that the partition has been released.
-    // Return true if all partitions has been unlocked.
-    bool Unlock(const TActorId& sender, ui32 partitionId, const TActorContext& ctx);
+    // Return true if all partitions has been unlocked; the caller then Reset()s the family.
+    bool Unlock(const TActorId& sender, ui32 partitionId);
     // Processes the signal that the reading session has ended.
     bool Reset(const TActorContext& ctx);
     bool Reset(ETargetStatus targetStatus, const TActorContext& ctx);
@@ -140,7 +142,7 @@ struct TPartitionFamily {
     TString DebugStr() const;
 
 private:
-    void Destroy(const TActorContext& ctx);
+    void Destroy();
     void AfterRelease();
 
 private:
@@ -249,6 +251,28 @@ struct TConsumer {
 
 private:
     TString LogPrefix() const;
+
+    // Families.erase in Destroy() would free `this` while Unlock/Reset is still
+    // on the stack. Park the unique_ptr here and drop it when the outermost
+    // TConsumer call returns.
+    std::vector<std::unique_ptr<TPartitionFamily>> DoomedFamilies;
+    ui32 DoomedGuardDepth = 0;
+
+    struct TDoomedFamilyGuard {
+        TConsumer& C;
+        explicit TDoomedFamilyGuard(TConsumer& c)
+            : C(c)
+        {
+            ++C.DoomedGuardDepth;
+        }
+        ~TDoomedFamilyGuard() {
+            if (--C.DoomedGuardDepth == 0) {
+                C.DoomedFamilies.clear();
+            }
+        }
+        TDoomedFamilyGuard(const TDoomedFamilyGuard&) = delete;
+        TDoomedFamilyGuard& operator=(const TDoomedFamilyGuard&) = delete;
+    };
 };
 
 struct TSession {

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -253,8 +253,6 @@ struct TConsumer {
     bool ScalingSupport() const;
 
 private:
-    void AssertBalancingInvariants();
-
     TString LogPrefix() const;
     bool AttachingDescendants = false;
 

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -114,7 +114,6 @@ struct TPartitionFamily {
 
     bool IsCommon() const;
     bool IsLonely() const;
-    bool HasActivePartitions() const;
 
     // Releases all partitions of the family.
     void Release(const TActorContext& ctx, ETargetStatus targetStatus = ETargetStatus::Free);
@@ -254,6 +253,8 @@ struct TConsumer {
     bool ScalingSupport() const;
 
 private:
+    void AssertBalancingInvariants();
+
     TString LogPrefix() const;
     bool AttachingDescendants = false;
 

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -161,6 +161,7 @@ private:
     std::pair<size_t, size_t> ClassifyPartitions(const TPartitions& partitions);
     void UpdatePartitionMapping(const std::vector<ui32>& partitions);
     void UpdateSpecialSessions();
+    void AppendUniqueRoots(const std::vector<ui32>& partitions);
     void ChangePartitionCounters(ssize_t activeDiff, ssize_t inactiveDiff);
     void LockPartition(ui32 partitionId, const TActorContext& ctx);
     std::unique_ptr<TEvPersQueue::TEvReleasePartition> MakeEvReleasePartition(ui32 partitionId) const;

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.h
@@ -128,6 +128,7 @@ struct TPartitionFamily {
     void StartReading(TSession& session, const TActorContext& ctx);
     // Add partitions to the family.
     void AttachePartitions(const std::vector<ui32>& partitions, const TActorContext& ctx);
+    void AttachReadyWantedPartitions(const TActorContext& ctx);
     void Merge(TPartitionFamily* other);
 
     // The partition became active
@@ -229,6 +230,9 @@ struct TConsumer {
     std::pair<TPartitionFamily*, bool> MergeFamilies(TPartitionFamily* lhs, TPartitionFamily* rhs, const TActorContext& ctx);
     void DestroyFamily(TPartitionFamily* family, const TActorContext& ctx);
     TPartitionFamily* FindFamily(ui32 partitionId);
+    // After parents of a merged partition are processed, attach (or independently
+    // balance) readable descendants. Safe to call repeatedly.
+    void AttachReadableDescendants(TPartitionFamily* family, const TActorContext& ctx);
 
     void RegisterReadingSession(TSession* session, const TActorContext& ctx);
     void UnregisterReadingSession(TSession* session, const TActorContext& ctx);
@@ -251,6 +255,7 @@ struct TConsumer {
 
 private:
     TString LogPrefix() const;
+    bool AttachingDescendants = false;
 
     // Families.erase in Destroy() would free `this` while Unlock/Reset is still
     // on the stack. Park the unique_ptr here and drop it when the outermost

--- a/ydb/core/persqueue/pqrb/read_balancer__txinit.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__txinit.h
@@ -127,8 +127,7 @@ struct TPersQueueReadBalancer::TTxInit : public ITransaction {
 
     void Complete(const TActorContext& ctx) override {
         Self->SignalTabletActive(ctx);
-        if (Self->Inited)
-            Self->InitDone(ctx);
+        Self->InitDone(ctx);
     }
 };
 

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -766,6 +766,66 @@ Y_UNIT_TEST(PipeBreakOfTargetFamilyDuringRelease) {
     env.Finish("session-new", 1);
     env.AssertLocked(2, "session-new");
 }
+Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachMergeChild) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.Commit(0);
+    env.Commit(1);
+
+    env.RegisterSession("session-child", {3});
+    env.AssertLocked(2, "session-child");
+
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(2, "session-child");
+    UNIT_ASSERT_C(!env.SessionOf(1).empty(), "the other merge parent must stay assigned");
+}
+
+Y_UNIT_TEST(DelayedMergeThenCommitThenParentReleaseKeepsChildIndependent) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    auto pipeIt = env.Pipes.find(pending->Session);
+    UNIT_ASSERT(pipeIt != env.Pipes.end());
+    env.AckRelease(pipeIt->second, pending->Partition, pending->Session);
+    env.Pump();
+    env.AssertLocked(2);
+
+    env.Commit(0);
+    env.Commit(1);
+    env.RegisterSession("session-child", {3});
+    env.AssertLocked(2, "session-child");
+
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(2, "session-child");
+}
+
+Y_UNIT_TEST(CommitThenRebalanceKeepsMergeChildIndependent) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.Commit(1);
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(3, 2);
+}
 } // Y_UNIT_TEST_SUITE(TPqrbMergeBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbSplitBalancing) {
@@ -794,6 +854,80 @@ Y_UNIT_TEST(PreferredChildTakenAfterParentCommitted) {
     env.AssertLocked(1, "session-child");
 }
 
+Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachSplitChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.RegisterSession("session-child", {2});
+    env.AssertLocked(1, "session-child");
+
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(1, "session-child");
+    UNIT_ASSERT_C(!env.SessionOf(2).empty(), "the other split child must stay assigned");
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(2), env.SessionOf(0));
+}
+
+Y_UNIT_TEST(CommitThenRebalanceKeepsChildrenIndependent) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(3, 2);
+
+    const TString parentSession = env.SessionOf(0);
+    UNIT_ASSERT_C(!parentSession.empty(), "parent must stay assigned");
+    ui32 childrenWithParent = 0;
+    for (ui32 child : {1u, 2u}) {
+        const TString childSession = env.SessionOf(child);
+        UNIT_ASSERT_C(!childSession.empty(), "child " << child << " must stay assigned");
+        if (childSession == parentSession) {
+            ++childrenWithParent;
+        }
+    }
+    UNIT_ASSERT_C(childrenWithParent < 2,
+        "committed split children must not be glued back to the parent family on rebalance");
+}
+
+Y_UNIT_TEST(ScaleAwareFinishCommitThenSecondCommonSessionKeepsChildrenIndependent) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(3, 2);
+
+    const TString parentSession = env.SessionOf(0);
+    UNIT_ASSERT_C(!parentSession.empty(), "parent must stay assigned after rebalance");
+    absl::flat_hash_set<TString> childSessions;
+    ui32 childrenWithParent = 0;
+    for (ui32 child : {1u, 2u}) {
+        const TString childSession = env.SessionOf(child);
+        UNIT_ASSERT_C(!childSession.empty(), "child " << child << " must stay assigned");
+        childSessions.insert(childSession);
+        if (childSession == parentSession) {
+            ++childrenWithParent;
+        }
+    }
+    UNIT_ASSERT_C(childrenWithParent < 2,
+        "committed split children must stay in their own families, not glued back to the parent");
+    UNIT_ASSERT_C(childSessions.size() == 2 || childrenWithParent == 0,
+        "independent child families must be able to sit on a different session than the parent");
+}
 } // Y_UNIT_TEST_SUITE(TPqrbSplitBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants) {

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -634,6 +634,24 @@ Y_UNIT_TEST(PreferredChildDoesNotStealFromCommonParentSession) {
     env.AssertLocked(2, "session-0");
 }
 
+Y_UNIT_TEST(SessionClosedBeforeSecondParentFinished) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.Merge(0, 1);
+
+    const TString first = env.SessionOf(0);
+    env.Finish(first, 0);
+    env.AssertNotLocked(2);
+    env.CloseSession(first);
+    env.AssertNotLocked(2);
+
+    const TString remaining = env.SessionOf(1);
+    UNIT_ASSERT_C(!remaining.empty(), "surviving session must keep the other parent");
+    env.Finish(remaining, 1);
+    env.AssertLocked(2);
+}
 } // Y_UNIT_TEST_SUITE(TPqrbMergeBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbSplitBalancing) {
@@ -663,5 +681,35 @@ Y_UNIT_TEST(PreferredChildTakenAfterParentCommitted) {
 }
 
 } // Y_UNIT_TEST_SUITE(TPqrbSplitBalancing)
+
+Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants) {
+
+Y_UNIT_TEST(StaleFinishAfterPipeBreakIsIgnored) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    const auto pipe = env.Pipes["session-0"];
+    env.CloseSession("session-0");
+    env.InjectFinish(pipe, 0);
+    env.RegisterSession("session-new");
+    env.AssertNotLocked(1);
+    env.Finish("session-new", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(FinishThenImmediatePipeBreakKeepsConsumerIfOtherSessionAlive) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Split(0);
+    env.Finish(s0, 0, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+    env.CloseSession(s1);
+    env.AssertLocked(2);
+    env.AssertLocked(3);
+}
+
+} // Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants)
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -1,5 +1,19 @@
 #include "pqrb_ut_common.h"
 
+#include <optional>
+
+#include <util/generic/vector.h>
+
+#include <util/generic/utility.h>
+
+#include <ydb/core/testlib/actors/block_events.h>
+
+#include <ydb/core/persqueue/events/internal.h>
+
+#include <ydb/core/base/tablet_pipe.h>
+
+#include <ydb/core/base/tablet.h>
+
 #include <ydb/core/persqueue/pqrb/read_balancer__balancing.h>
 
 namespace NKikimr::NPQ {
@@ -217,5 +231,437 @@ Y_UNIT_TEST(BalancingUnsubscribeRemovesOnlyMatchingSubscription) {
 }
 
 } // Y_UNIT_TEST_SUITE(TPqrbBalancing)
+
+struct TScaleEnv {
+    TTestContext tc;
+    absl::flat_hash_map<TString, TActorId> Pipes;
+    absl::flat_hash_map<ui32, TString> LockedBy;
+    absl::flat_hash_map<ui32, TVector<ui32>> ParentPartitionIds;
+    absl::flat_hash_map<ui32, TVector<ui32>> ChildPartitionIds;
+    ui32 NextPartitionId = 0;
+    NKikimrPQ::TPQTabletConfig::TPartitionStrategyType PartitionStrategy =
+        NKikimrPQ::TPQTabletConfig::CAN_SPLIT_AND_MERGE;
+
+    explicit TScaleEnv(NKikimrPQ::TPQTabletConfig::TPartitionStrategyType strategy =
+        NKikimrPQ::TPQTabletConfig::CAN_SPLIT_AND_MERGE)
+        : PartitionStrategy(strategy)
+    {
+        tc.Prepare();
+        tc.Runtime->SetScheduledLimit(10000);
+        PQTabletPrepare({}, {}, tc);
+    }
+
+    void Publish() {
+        TBalancerUpdate update;
+        update.Strategy = PartitionStrategy;
+        update.NextPartitionId = NextPartitionId;
+        update.ParentPartitionIds = ParentPartitionIds;
+        update.ChildPartitionIds = ChildPartitionIds;
+        for (ui32 i = 0; i < NextPartitionId; ++i) {
+            update.Partitions.push_back({i, {tc.TabletId, i + 1}});
+        }
+        SendBalancerUpdate(tc, update);
+        Pump();
+    }
+
+    void CreateParents(ui32 count = 2) {
+        NextPartitionId = count;
+        Publish();
+    }
+
+    ui32 Merge(ui32 left, ui32 right) {
+        const ui32 child = NextPartitionId++;
+        ParentPartitionIds[child] = {left, right};
+        ChildPartitionIds[left].push_back(child);
+        ChildPartitionIds[right].push_back(child);
+        Publish();
+        return child;
+    }
+
+    std::pair<ui32, ui32> Split(ui32 parent) {
+        const ui32 left = NextPartitionId++;
+        const ui32 right = NextPartitionId++;
+        ParentPartitionIds[left] = {parent};
+        ParentPartitionIds[right] = {parent};
+        ChildPartitionIds[parent].push_back(left);
+        ChildPartitionIds[parent].push_back(right);
+        Publish();
+        return {left, right};
+    }
+
+    ui32 AddRoot() {
+        return NextPartitionId++, Publish(), NextPartitionId - 1;
+    }
+
+    TActorId RegisterSession(const TString& name, const TVector<ui32>& groups = {}, bool pump = true) {
+        auto pipe = RegisterReadSession(name, tc, groups);
+        Pipes[name] = pipe;
+        if (pump) {
+            Pump();
+        } else {
+            DispatchFor(tc, TDuration::MilliSeconds(50));
+        }
+        return pipe;
+    }
+
+    void Finish(const TString& session, ui32 partition, bool scaleAware = true, bool fromEnd = true, bool pump = true) {
+        auto it = Pipes.find(session);
+        UNIT_ASSERT_C(it != Pipes.end(), session);
+        tc.Runtime->SendToPipe(
+            tc.BalancerTabletId,
+            tc.Edge,
+            new TEvPersQueue::TEvReadingPartitionFinishedRequest(it->second, "user", partition, scaleAware, fromEnd),
+            0,
+            GetPipeConfigWithRetries(),
+            it->second
+        );
+        if (pump) {
+            Pump();
+        } else {
+            DispatchFor(tc, TDuration::MilliSeconds(50));
+        }
+    }
+
+    void StartReading(const TString& session, ui32 partition) {
+        auto it = Pipes.find(session);
+        UNIT_ASSERT_C(it != Pipes.end(), session);
+        tc.Runtime->SendToPipe(
+            tc.BalancerTabletId,
+            tc.Edge,
+            new TEvPersQueue::TEvReadingPartitionStartedRequest(it->second, "user", partition),
+            0,
+            GetPipeConfigWithRetries(),
+            it->second
+        );
+        Pump();
+    }
+
+    void Commit(ui32 partition, ui32 generation = 1, ui64 cookie = 1, bool pump = true) {
+        tc.Runtime->SendToPipe(
+            tc.BalancerTabletId,
+            tc.Edge,
+            new TEvPQ::TEvReadingPartitionStatusRequest("user", partition, generation, cookie),
+            0,
+            GetPipeConfigWithRetries()
+        );
+        if (pump) {
+            Pump();
+        } else {
+            DispatchFor(tc, TDuration::MilliSeconds(50));
+        }
+    }
+
+    void InjectFinish(const TActorId& pipe, ui32 partition, bool scaleAware = true, bool fromEnd = true) {
+        ForwardToTablet(
+            *tc.Runtime,
+            tc.BalancerTabletId,
+            tc.Edge,
+            new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe, "user", partition, scaleAware, fromEnd)
+        );
+        DispatchFor(tc, TDuration::MilliSeconds(50));
+    }
+
+    void InjectCommit(ui32 partition, ui32 generation = 1, ui64 cookie = 1) {
+        ForwardToTablet(
+            *tc.Runtime,
+            tc.BalancerTabletId,
+            tc.Edge,
+            new TEvPQ::TEvReadingPartitionStatusRequest("user", partition, generation, cookie)
+        );
+        DispatchFor(tc, TDuration::MilliSeconds(50));
+    }
+
+    void CloseSession(const TString& session) {
+        auto it = Pipes.find(session);
+        UNIT_ASSERT_C(it != Pipes.end(), session);
+        tc.Runtime->ClosePipe(it->second, tc.Edge, 0);
+        Pipes.erase(it);
+        for (auto jt = LockedBy.begin(); jt != LockedBy.end();) {
+            if (jt->second == session) {
+                LockedBy.erase(jt++);
+            } else {
+                ++jt;
+            }
+        }
+        Pump();
+    }
+
+    void AckRelease(const TActorId& pipe, ui32 partition, const TString& session) {
+        auto released = MakeHolder<TEvPersQueue::TEvPartitionReleased>();
+        released->Record.SetSession(session);
+        released->Record.SetPartition(partition);
+        released->Record.SetTopic("topic");
+        released->Record.SetClientId("user");
+        ActorIdToProto(pipe, released->Record.MutablePipeClient());
+        tc.Runtime->SendToPipe(
+            tc.BalancerTabletId,
+            tc.Edge,
+            released.Release(),
+            0,
+            GetPipeConfigWithRetries(),
+            pipe
+        );
+    }
+
+    void Pump(TDuration wait = TDuration::MilliSeconds(50)) {
+        DispatchFor(tc, wait);
+        for (;;) {
+            auto release = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvReleasePartition>(TDuration::MilliSeconds(5));
+            if (release) {
+                const ui32 partition = release->Record.GetGroup() - 1;
+                const TString session = release->Record.GetSession();
+                auto pipeIt = Pipes.find(session);
+                if (pipeIt == Pipes.end()) {
+                    LockedBy.erase(partition);
+                    continue;
+                }
+                AckRelease(pipeIt->second, partition, session);
+                LockedBy.erase(partition);
+                DispatchFor(tc, TDuration::MilliSeconds(10));
+                continue;
+            }
+            auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::MilliSeconds(5));
+            if (lock) {
+                const TString session = lock->Record.GetSession();
+                const ui32 partition = lock->Record.GetPartition();
+                if (Pipes.contains(session)) {
+                    LockedBy[partition] = session;
+                } else {
+                    LockedBy.erase(partition);
+                }
+                continue;
+            }
+            break;
+        }
+        DispatchFor(tc, wait);
+    }
+
+    struct TPendingRelease {
+        ui32 Partition = 0;
+        TString Session;
+    };
+
+    std::optional<TPendingRelease> WaitRelease(TDuration timeout = TDuration::Seconds(5)) {
+        DispatchFor(tc, TDuration::MilliSeconds(50));
+        auto release = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvReleasePartition>(timeout);
+        if (!release) {
+            return std::nullopt;
+        }
+        return TPendingRelease{
+            .Partition = release->Record.GetGroup() - 1,
+            .Session = release->Record.GetSession(),
+        };
+    }
+
+    std::pair<TString, TString> TwoSessionsOnParents() {
+        RegisterSession("session-0");
+        RegisterSession("session-1");
+        AssertLocked(0);
+        AssertLocked(1);
+        const TString a = SessionOf(0);
+        const TString b = SessionOf(1);
+        UNIT_ASSERT_VALUES_UNEQUAL(a, b);
+        return {a, b};
+    }
+
+    THolder<TEvPersQueue::TEvReadSessionsInfoResponse> SessionsInfo() {
+        auto sessions = MakeHolder<TEvPersQueue::TEvGetReadSessionsInfo>();
+        sessions->Record.SetClientId("user");
+        tc.Runtime->SendToPipe(tc.BalancerTabletId, tc.Edge, sessions.Release(), 0, GetPipeConfigWithRetries());
+        auto info = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvReadSessionsInfoResponse>(TDuration::Seconds(10));
+        UNIT_ASSERT(info);
+        return info;
+    }
+
+    TString SessionOf(ui32 partition) {
+        Pump(TDuration::MilliSeconds(10));
+        auto info = SessionsInfo();
+        for (const auto& pi : info->Record.GetPartitionInfo()) {
+            if (pi.GetPartition() == partition) {
+                return pi.GetSession();
+            }
+        }
+        return {};
+    }
+
+    void AssertLocked(ui32 partition, const TString& expectedSession = {}) {
+        Pump();
+        TString session;
+        if (auto it = LockedBy.find(partition); it != LockedBy.end()) {
+            session = it->second;
+        }
+        if (session.empty()) {
+            session = SessionOf(partition);
+        }
+        UNIT_ASSERT_C(!session.empty(), "partition " << partition << " must be locked");
+        if (!expectedSession.empty()) {
+            UNIT_ASSERT_VALUES_EQUAL_C(expectedSession, session, "partition " << partition);
+        }
+    }
+
+    void AssertNotLocked(ui32 partition) {
+        Pump();
+        UNIT_ASSERT_C(!LockedBy.contains(partition),
+            "partition " << partition << " must not be locked, session=" << LockedBy[partition]);
+        const TString session = SessionOf(partition);
+        UNIT_ASSERT_C(session.empty(), "partition " << partition << " must not be locked, session=" << session);
+    }
+
+    void AssertSameSession(const std::vector<ui32>& partitions) {
+        UNIT_ASSERT(!partitions.empty());
+        const TString session = SessionOf(partitions.front());
+        UNIT_ASSERT_C(!session.empty(), "partition " << partitions.front() << " must be locked");
+        for (auto partition : partitions) {
+            UNIT_ASSERT_VALUES_EQUAL_C(session, SessionOf(partition), "family must stay on one session");
+        }
+    }
+
+    void AssertEvenDistribution(ui32 partitionCount, ui32 sessionCount) {
+        Pump();
+        auto info = SessionsInfo();
+        absl::flat_hash_map<TString, ui32> counts;
+        absl::flat_hash_set<ui32> seen;
+        ui32 assigned = 0;
+        for (const auto& pi : info->Record.GetPartitionInfo()) {
+            if (pi.GetSession().empty()) {
+                continue;
+            }
+            UNIT_ASSERT_C(seen.insert(pi.GetPartition()).second,
+                "partition " << pi.GetPartition() << " listed twice in sessions info");
+            counts[pi.GetSession()]++;
+            ++assigned;
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(assigned, partitionCount, "every readable partition must be assigned");
+        UNIT_ASSERT_VALUES_EQUAL_C(counts.size(), sessionCount, "every session must get a share");
+        ui32 minCount = partitionCount;
+        ui32 maxCount = 0;
+        for (const auto& [session, count] : counts) {
+            Y_UNUSED(session);
+            minCount = Min(minCount, count);
+            maxCount = Max(maxCount, count);
+        }
+        UNIT_ASSERT_LE_C(maxCount - minCount, 1u,
+            "families must go to the least loaded sessions, counts=" << counts.size());
+    }
+
+    void SendToBalancerActor(const TActorId& actor, IEventBase* ev, const TActorId& sender) {
+        tc.Runtime->Send(new IEventHandle(actor, sender, ev), 0, true);
+    }
+
+    TActorId RebootBalancerAndHoldRestored(NActors::TBlockEvents<TEvTablet::TEvRestored>& restored) {
+        ForwardToTablet(*tc.Runtime, tc.BalancerTabletId, tc.Edge, new TEvents::TEvPoisonPill());
+        TDispatchOptions boot;
+        boot.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+        tc.Runtime->DispatchEvents(boot);
+        InvalidateTabletResolverCache(*tc.Runtime, tc.BalancerTabletId);
+
+        for (ui32 i = 0; i < 100 && restored.empty(); ++i) {
+            DispatchFor(tc, TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT_C(!restored.empty(), "PQRB TEvRestored must be held while the tablet is in StateInit");
+        LockedBy.clear();
+        Pipes.clear();
+        return restored.front()->GetRecipientRewrite();
+    }
+
+    TActorId InjectSessionDuringInit(const TActorId& pqrb, const TString& session) {
+        const TActorId pipe = tc.Runtime->AllocateEdgeActor();
+        SendToBalancerActor(
+            pqrb,
+            new TEvTabletPipe::TEvServerConnected(tc.BalancerTabletId, pipe, pipe),
+            pipe
+        );
+
+        auto request = MakeHolder<TEvPersQueue::TEvRegisterReadSession>();
+        request->Record.SetSession(session);
+        request->Record.SetClientId("user");
+        ActorIdToProto(pipe, request->Record.MutablePipeClient());
+        SendToBalancerActor(pqrb, request.Release(), tc.Edge);
+
+        Pipes[session] = pipe;
+        return pipe;
+    }
+};
+
+Y_UNIT_TEST_SUITE(TPqrbMergeBalancing) {
+
+Y_UNIT_TEST(ChildNotLockedUntilBothParentsFinished_OneSession) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+
+    env.Merge(0, 1);
+    env.AssertNotLocked(2);
+
+    env.Finish("session-0", 0);
+    env.AssertNotLocked(2);
+
+    env.Finish("session-0", 1);
+    env.AssertLocked(2, "session-0");
+    env.AssertSameSession({0, 1, 2});
+}
+
+Y_UNIT_TEST(PreferredPartitionsConflictDoesNotLockChildEarly) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0", {1});
+    env.RegisterSession("session-1", {2});
+    env.AssertLocked(0, "session-0");
+    env.AssertLocked(1, "session-1");
+
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-1", 1);
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-2", {3});
+    env.AssertLocked(2, "session-2");
+}
+
+Y_UNIT_TEST(PreferredChildDoesNotStealFromCommonParentSession) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.RegisterSession("session-child", {3});
+    env.AssertNotLocked(2);
+
+    env.Finish("session-0", 0);
+    env.AssertNotLocked(2);
+    env.Finish("session-0", 1);
+    env.AssertLocked(2, "session-0");
+}
+
+} // Y_UNIT_TEST_SUITE(TPqrbMergeBalancing)
+
+Y_UNIT_TEST_SUITE(TPqrbSplitBalancing) {
+
+Y_UNIT_TEST(PreferredChildNotLockedBeforeParentFinished) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.RegisterSession("session-child", {2});
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    env.Finish("session-0", 0);
+    env.AssertLocked(1, "session-0");
+    env.AssertLocked(2, "session-0");
+}
+
+Y_UNIT_TEST(PreferredChildTakenAfterParentCommitted) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.RegisterSession("session-child", {2});
+    env.Commit(0);
+    env.AssertLocked(1, "session-child");
+}
+
+} // Y_UNIT_TEST_SUITE(TPqrbSplitBalancing)
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -652,6 +652,120 @@ Y_UNIT_TEST(SessionClosedBeforeSecondParentFinished) {
     env.Finish(remaining, 1);
     env.AssertLocked(2);
 }
+Y_UNIT_TEST(ChildNotLockedUntilBothParentsFinished_TwoSessions) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(0), env.SessionOf(1));
+
+    env.Merge(0, 1);
+    env.AssertNotLocked(2);
+
+    const TString session0 = env.SessionOf(0);
+    env.Finish(session0, 0);
+    env.AssertNotLocked(2);
+
+    const TString session1 = env.SessionOf(1);
+    env.Finish(session1, 1);
+    env.AssertLocked(2);
+    env.AssertSameSession({0, 1, 2});
+}
+
+Y_UNIT_TEST(ResetMergeAttachesChildWhenTargetFamilyDied) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.Merge(0, 1);
+    env.RegisterSession("session-0", {1});
+    env.RegisterSession("session-1", {2, 3});
+    env.AssertLocked(0, "session-0");
+    env.AssertLocked(1, "session-1");
+    env.AssertNotLocked(2);
+
+    env.Finish("session-0", 0);
+    env.Finish("session-1", 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    const TString releasing = pending->Session;
+    const TString target = releasing == "session-0" ? "session-1" : "session-0";
+    UNIT_ASSERT_C(env.Pipes.contains(releasing), "releasing session must still be connected");
+
+    env.CloseSession(target);
+    env.RegisterSession("session-keep");
+
+    auto pipeIt = env.Pipes.find(releasing);
+    UNIT_ASSERT(pipeIt != env.Pipes.end());
+    env.AckRelease(pipeIt->second, pending->Partition, releasing);
+    env.Pump();
+
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(DelayedMergeDisconnectTargetBeforeUnlockLocksChild) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    const TString releasing = pending->Session;
+    const TString target = releasing == s0 ? s1 : s0;
+    UNIT_ASSERT_C(env.Pipes.contains(releasing), "releasing session must still be connected");
+
+    env.CloseSession(target);
+
+    auto pipeIt = env.Pipes.find(releasing);
+    UNIT_ASSERT(pipeIt != env.Pipes.end());
+    env.AckRelease(pipeIt->second, pending->Partition, releasing);
+    env.Pump();
+
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakDuringReleaseOfMergedFamily) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    env.CloseSession(pending->Session);
+
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakOfTargetFamilyDuringRelease) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    const TString target = pending->Session == s0 ? s1 : s0;
+    env.CloseSession(target);
+    env.CloseSession(pending->Session);
+
+    env.RegisterSession("session-new");
+    env.Finish("session-new", 0);
+    env.AssertNotLocked(2);
+    env.Finish("session-new", 1);
+    env.AssertLocked(2, "session-new");
+}
 } // Y_UNIT_TEST_SUITE(TPqrbMergeBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbSplitBalancing) {

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -1,20 +1,15 @@
 #include "pqrb_ut_common.h"
 
-#include <optional>
-
-#include <util/generic/vector.h>
-
-#include <util/generic/utility.h>
-
+#include <ydb/core/base/tablet.h>
+#include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/persqueue/events/internal.h>
+#include <ydb/core/persqueue/pqrb/read_balancer__balancing.h>
 #include <ydb/core/testlib/actors/block_events.h>
 
-#include <ydb/core/persqueue/events/internal.h>
+#include <util/generic/utility.h>
+#include <util/generic/vector.h>
 
-#include <ydb/core/base/tablet_pipe.h>
-
-#include <ydb/core/base/tablet.h>
-
-#include <ydb/core/persqueue/pqrb/read_balancer__balancing.h>
+#include <optional>
 
 namespace NKikimr::NPQ {
 
@@ -228,6 +223,123 @@ Y_UNIT_TEST(BalancingUnsubscribeRemovesOnlyMatchingSubscription) {
     );
     UNIT_ASSERT(afterUnsubscribeB);
     UNIT_ASSERT(afterUnsubscribeB->Get()->Record.GetStatus() == NKikimrPQ::TEvBalancingSubscribeNotify::BALANCING);
+}
+
+Y_UNIT_TEST(MessagesBeforeFirstConfigDoNotCrash) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto pipe = RegisterReadSession("session-0", tc);
+    DispatchFor(tc);
+
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe, "user", 0, true, true),
+        0,
+        GetPipeConfigWithRetries(),
+        pipe
+    );
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPQ::TEvReadingPartitionStatusRequest("user", 0, 1, 1),
+        0,
+        GetPipeConfigWithRetries()
+    );
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPersQueue::TEvReadingPartitionStartedRequest(pipe, "user", 0),
+        0,
+        GetPipeConfigWithRetries(),
+        pipe
+    );
+    auto released = MakeHolder<TEvPersQueue::TEvPartitionReleased>();
+    released->Record.SetSession("session-0");
+    released->Record.SetPartition(0);
+    released->Record.SetTopic("topic");
+    released->Record.SetClientId("user");
+    ActorIdToProto(pipe, released->Record.MutablePipeClient());
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        released.Release(),
+        0,
+        GetPipeConfigWithRetries(),
+        pipe
+    );
+
+    auto sessions = MakeHolder<TEvPersQueue::TEvGetReadSessionsInfo>();
+    sessions->Record.SetClientId("user");
+    tc.Runtime->SendToPipe(tc.BalancerTabletId, tc.Edge, sessions.Release(), 0, GetPipeConfigWithRetries());
+    auto info = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvReadSessionsInfoResponse>(TDuration::Seconds(10));
+    UNIT_ASSERT(info);
+
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {{0, {tc.TabletId, 1}}, {1, {tc.TabletId, 2}}},
+        .NextPartitionId = 2,
+    });
+    DispatchFor(tc, TDuration::MilliSeconds(200));
+
+    absl::flat_hash_set<TString> lockedSessions;
+    absl::flat_hash_set<ui32> locked;
+    for (;;) {
+        auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::MilliSeconds(200));
+        if (!lock) {
+            break;
+        }
+        locked.insert(lock->Record.GetPartition());
+        lockedSessions.insert(lock->Record.GetSession());
+    }
+    UNIT_ASSERT_C(!locked.empty(), "session registered before config must receive partitions after init");
+    UNIT_ASSERT(lockedSessions.contains("session-0"));
+}
+
+Y_UNIT_TEST(SessionRegisteredBeforeConfigGetsNewPartitions) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto pipe = RegisterReadSession("session-0", tc);
+    Y_UNUSED(pipe);
+    DispatchFor(tc);
+
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {{0, {tc.TabletId, 1}}},
+        .NextPartitionId = 1,
+    });
+
+    auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::Seconds(10));
+    UNIT_ASSERT(lock);
+    UNIT_ASSERT_VALUES_EQUAL(lock->Record.GetPartition(), 0u);
+    UNIT_ASSERT_VALUES_EQUAL(lock->Record.GetSession(), TString("session-0"));
+}
+
+Y_UNIT_TEST(PipeDisconnectBeforeFirstConfigDoNotCrash) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto pipe = RegisterReadSession("session-0", tc);
+    DispatchFor(tc);
+    tc.Runtime->ClosePipe(pipe, tc.Edge, 0);
+    DispatchFor(tc, TDuration::MilliSeconds(200));
+    while (tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::MilliSeconds(50))) {
+    }
+
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {{0, {tc.TabletId, 1}}},
+        .NextPartitionId = 1,
+    });
+    DispatchFor(tc);
+
+    auto pipe2 = RegisterReadSession("session-1", tc);
+    Y_UNUSED(pipe2);
+    auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::Seconds(10));
+    UNIT_ASSERT(lock);
+    UNIT_ASSERT_VALUES_EQUAL(lock->Record.GetSession(), TString("session-1"));
 }
 
 } // Y_UNIT_TEST_SUITE(TPqrbBalancing)
@@ -603,6 +715,134 @@ Y_UNIT_TEST(ChildNotLockedUntilBothParentsFinished_OneSession) {
     env.AssertSameSession({0, 1, 2});
 }
 
+Y_UNIT_TEST(ChildNotLockedUntilBothParentsFinished_TwoSessions) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(0), env.SessionOf(1));
+
+    env.Merge(0, 1);
+    env.AssertNotLocked(2);
+
+    const TString session0 = env.SessionOf(0);
+    env.Finish(session0, 0);
+    env.AssertNotLocked(2);
+
+    const TString session1 = env.SessionOf(1);
+    env.Finish(session1, 1);
+    env.AssertLocked(2);
+    env.AssertSameSession({0, 1, 2});
+}
+
+Y_UNIT_TEST(ChildLockedOnSameSessionWhenBothParentsWereTogether) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertLocked(2, "session-0");
+}
+
+Y_UNIT_TEST(ChildIndependentFamilyAfterBothParentsCommitted) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.Merge(0, 1);
+
+    env.Commit(0);
+    env.AssertNotLocked(2);
+    env.Commit(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(CommitThenRebalanceKeepsMergeChildIndependent) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.Commit(1);
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(3, 2);
+}
+
+Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachMergeChild) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.Commit(0);
+    env.Commit(1);
+
+    env.RegisterSession("session-child", {3});
+    env.AssertLocked(2, "session-child");
+
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(2, "session-child");
+    UNIT_ASSERT_C(!env.SessionOf(1).empty(), "the other merge parent must stay assigned");
+}
+
+Y_UNIT_TEST(DelayedMergeThenCommitThenParentReleaseKeepsChildIndependent) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    auto pipeIt = env.Pipes.find(pending->Session);
+    UNIT_ASSERT(pipeIt != env.Pipes.end());
+    env.AckRelease(pipeIt->second, pending->Partition, pending->Session);
+    env.Pump();
+    env.AssertLocked(2);
+
+    env.Commit(0);
+    env.Commit(1);
+    env.RegisterSession("session-child", {3});
+    env.AssertLocked(2, "session-child");
+
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(2, "session-child");
+}
+
+Y_UNIT_TEST(ChildNotLockedIfOnlyOneParentCommitted) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Commit(0);
+    env.AssertNotLocked(2);
+    env.Finish("session-0", 1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(OldSdkFinishedParentsAllowIndependentChild) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0, /*scaleAware=*/false, /*fromEnd=*/true);
+    env.AssertNotLocked(2);
+    env.Finish("session-0", 1, /*scaleAware=*/false, /*fromEnd=*/true);
+    env.AssertLocked(2);
+}
+
 Y_UNIT_TEST(PreferredPartitionsConflictDoesNotLockChildEarly) {
     TScaleEnv env;
     env.CreateParents(2);
@@ -634,6 +874,80 @@ Y_UNIT_TEST(PreferredChildDoesNotStealFromCommonParentSession) {
     env.AssertLocked(2, "session-0");
 }
 
+Y_UNIT_TEST(ThirdSessionDoesNotSplitUncommittedMergeFamily) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertSameSession({0, 1, 2});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 2});
+}
+
+Y_UNIT_TEST(UnaffectedPartitionBalancesIndependently) {
+    TScaleEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+
+    env.Finish("session-0", 0);
+    env.AssertNotLocked(3);
+    UNIT_ASSERT_C(!env.SessionOf(2).empty(), "unaffected partition 2 must stay readable");
+
+    env.Finish("session-0", 1);
+    env.AssertLocked(3);
+    UNIT_ASSERT_C(!env.SessionOf(2).empty(), "unaffected partition 2 must stay readable after merge");
+}
+
+Y_UNIT_TEST(ChainedMergeWaitsForAllAncestors) {
+    TScaleEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertLocked(3);
+
+    env.Merge(3, 2);
+    env.AssertNotLocked(4);
+    env.Finish("session-0", 3);
+    env.AssertNotLocked(4);
+    env.Finish("session-0", 2);
+    env.AssertLocked(4, "session-0");
+}
+
+Y_UNIT_TEST(SplitThenMergeChildrenWaitsForBothChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+
+    env.Merge(1, 2);
+    env.AssertNotLocked(3);
+    env.Finish(env.SessionOf(1), 1);
+    env.AssertNotLocked(3);
+    env.Finish(env.SessionOf(2), 2);
+    env.AssertLocked(3);
+}
+
+Y_UNIT_TEST(MergeAfterParentsAlreadyFinished) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.Merge(0, 1);
+    env.AssertLocked(2, "session-0");
+}
+
 Y_UNIT_TEST(SessionClosedBeforeSecondParentFinished) {
     TScaleEnv env;
     env.CreateParents(2);
@@ -652,26 +966,150 @@ Y_UNIT_TEST(SessionClosedBeforeSecondParentFinished) {
     env.Finish(remaining, 1);
     env.AssertLocked(2);
 }
-Y_UNIT_TEST(ChildNotLockedUntilBothParentsFinished_TwoSessions) {
+
+Y_UNIT_TEST(PipeBreakBeforeMergeConfig) {
     TScaleEnv env;
     env.CreateParents(2);
-    env.RegisterSession("session-0");
-    env.RegisterSession("session-1");
-    env.AssertLocked(0);
-    env.AssertLocked(1);
-    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(0), env.SessionOf(1));
+    auto [s0, s1] = env.TwoSessionsOnParents();
 
+    env.CloseSession(s0);
     env.Merge(0, 1);
     env.AssertNotLocked(2);
 
-    const TString session0 = env.SessionOf(0);
-    env.Finish(session0, 0);
+    env.RegisterSession("session-new");
+    env.Finish(env.SessionOf(0), 0);
+    env.Finish(env.SessionOf(1), 1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakAfterMergeBeforeParentsFinished) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
     env.AssertNotLocked(2);
 
-    const TString session1 = env.SessionOf(1);
-    env.Finish(session1, 1);
+    env.CloseSession(s0);
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-new");
+    env.Finish(env.SessionOf(0), 0);
+    env.AssertNotLocked(2);
+    env.Finish(env.SessionOf(1), 1);
     env.AssertLocked(2);
-    env.AssertSameSession({0, 1, 2});
+}
+
+Y_UNIT_TEST(PipeBreakOfUnreadParentAfterFirstFinished) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.AssertNotLocked(2);
+    env.CloseSession(s1);
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-new");
+    const TString remaining = env.SessionOf(1);
+    UNIT_ASSERT_C(!remaining.empty(), "unread parent must be taken by the new session");
+    env.Finish(remaining, 1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakDuringReleaseOfMergedFamily) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    env.CloseSession(pending->Session);
+
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakOfTargetFamilyDuringRelease) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    const TString target = pending->Session == s0 ? s1 : s0;
+    env.CloseSession(target);
+    env.CloseSession(pending->Session);
+
+    env.RegisterSession("session-new");
+    env.Finish("session-new", 0);
+    env.AssertNotLocked(2);
+    env.Finish("session-new", 1);
+    env.AssertLocked(2, "session-new");
+}
+
+Y_UNIT_TEST(PipeBreakAfterChildAttached) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+    env.Finish(s0, 0);
+    env.Finish(s1, 1);
+    env.AssertLocked(2);
+
+    const TString holder = env.SessionOf(2);
+    UNIT_ASSERT_C(!holder.empty(), "child must have a holder before the pipe break");
+    env.CloseSession(holder);
+
+    if (env.Pipes.empty()) {
+        env.RegisterSession("session-new");
+        env.AssertLocked(2, "session-new");
+    } else {
+        env.AssertLocked(2);
+    }
+}
+
+Y_UNIT_TEST(PipeBreakBothSessionsAfterMergeBeforeFinish) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+    env.AssertNotLocked(2);
+
+    env.CloseSession(s0);
+    env.CloseSession(s1);
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-new");
+    env.Finish("session-new", 0);
+    env.AssertNotLocked(2);
+    env.Finish("session-new", 1);
+    env.AssertLocked(2, "session-new");
+}
+
+Y_UNIT_TEST(PipeBreakSameSessionAfterFirstParentFinished) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.AssertNotLocked(2);
+
+    env.CloseSession("session-0");
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-new");
+    env.Finish("session-new", 0);
+    env.AssertNotLocked(2);
+    env.Finish("session-new", 1);
+    env.AssertLocked(2, "session-new");
 }
 
 Y_UNIT_TEST(ResetMergeAttachesChildWhenTargetFamilyDied) {
@@ -729,132 +1167,52 @@ Y_UNIT_TEST(DelayedMergeDisconnectTargetBeforeUnlockLocksChild) {
     env.AssertLocked(2);
 }
 
-Y_UNIT_TEST(PipeBreakDuringReleaseOfMergedFamily) {
-    TScaleEnv env;
-    env.CreateParents(2);
-    auto [s0, s1] = env.TwoSessionsOnParents();
-    env.Merge(0, 1);
-
-    env.Finish(s0, 0);
-    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
-
-    auto pending = env.WaitRelease();
-    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
-    env.CloseSession(pending->Session);
-
-    env.AssertLocked(2);
-}
-
-Y_UNIT_TEST(PipeBreakOfTargetFamilyDuringRelease) {
-    TScaleEnv env;
-    env.CreateParents(2);
-    auto [s0, s1] = env.TwoSessionsOnParents();
-    env.Merge(0, 1);
-
-    env.Finish(s0, 0);
-    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
-
-    auto pending = env.WaitRelease();
-    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
-    const TString target = pending->Session == s0 ? s1 : s0;
-    env.CloseSession(target);
-    env.CloseSession(pending->Session);
-
-    env.RegisterSession("session-new");
-    env.Finish("session-new", 0);
-    env.AssertNotLocked(2);
-    env.Finish("session-new", 1);
-    env.AssertLocked(2, "session-new");
-}
-Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachMergeChild) {
-    TScaleEnv env;
-    env.CreateParents(2);
-    env.RegisterSession("session-0");
-    env.Merge(0, 1);
-    env.Finish("session-0", 0);
-    env.Finish("session-0", 1);
-    env.Commit(0);
-    env.Commit(1);
-
-    env.RegisterSession("session-child", {3});
-    env.AssertLocked(2, "session-child");
-
-    env.RegisterSession("session-pref", {1});
-    env.AssertLocked(0, "session-pref");
-    env.AssertLocked(2, "session-child");
-    UNIT_ASSERT_C(!env.SessionOf(1).empty(), "the other merge parent must stay assigned");
-}
-
-Y_UNIT_TEST(DelayedMergeThenCommitThenParentReleaseKeepsChildIndependent) {
-    TScaleEnv env;
-    env.CreateParents(2);
-    auto [s0, s1] = env.TwoSessionsOnParents();
-    env.Merge(0, 1);
-
-    env.Finish(s0, 0);
-    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
-
-    auto pending = env.WaitRelease();
-    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
-    auto pipeIt = env.Pipes.find(pending->Session);
-    UNIT_ASSERT(pipeIt != env.Pipes.end());
-    env.AckRelease(pipeIt->second, pending->Partition, pending->Session);
-    env.Pump();
-    env.AssertLocked(2);
-
-    env.Commit(0);
-    env.Commit(1);
-    env.RegisterSession("session-child", {3});
-    env.AssertLocked(2, "session-child");
-
-    env.RegisterSession("session-pref", {1});
-    env.AssertLocked(0, "session-pref");
-    env.AssertLocked(2, "session-child");
-}
-
-Y_UNIT_TEST(CommitThenRebalanceKeepsMergeChildIndependent) {
-    TScaleEnv env;
-    env.CreateParents(2);
-    env.RegisterSession("session-0");
-    env.Merge(0, 1);
-    env.Finish("session-0", 0);
-    env.Finish("session-0", 1);
-    env.AssertSameSession({0, 1, 2});
-
-    env.Commit(0);
-    env.Commit(1);
-    env.RegisterSession("session-1");
-    env.AssertEvenDistribution(3, 2);
-}
 } // Y_UNIT_TEST_SUITE(TPqrbMergeBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbSplitBalancing) {
 
-Y_UNIT_TEST(PreferredChildNotLockedBeforeParentFinished) {
+Y_UNIT_TEST(ChildrenNotLockedUntilParentFinished) {
     TScaleEnv env;
     env.CreateParents(1);
     env.RegisterSession("session-0");
+    env.AssertLocked(0);
+
     env.Split(0);
-    env.RegisterSession("session-child", {2});
     env.AssertNotLocked(1);
     env.AssertNotLocked(2);
 
     env.Finish("session-0", 0);
     env.AssertLocked(1, "session-0");
     env.AssertLocked(2, "session-0");
+    env.AssertSameSession({0, 1, 2});
 }
 
-Y_UNIT_TEST(PreferredChildTakenAfterParentCommitted) {
+Y_UNIT_TEST(ThirdSessionDoesNotSplitUncommittedFamily) {
     TScaleEnv env;
     env.CreateParents(1);
     env.RegisterSession("session-0");
     env.Split(0);
-    env.RegisterSession("session-child", {2});
-    env.Commit(0);
-    env.AssertLocked(1, "session-child");
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 2});
 }
 
-Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachSplitChildren) {
+Y_UNIT_TEST(ChildrenIndependentAfterParentCommitted) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    env.Commit(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(CommitBreaksUpFamilySoSecondSessionCanTakeChild) {
     TScaleEnv env;
     env.CreateParents(1);
     env.RegisterSession("session-0");
@@ -864,39 +1222,8 @@ Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachSplitChildren) {
 
     env.Commit(0);
     env.RegisterSession("session-child", {2});
-    env.AssertLocked(1, "session-child");
-
-    env.RegisterSession("session-pref", {1});
-    env.AssertLocked(0, "session-pref");
     env.AssertLocked(1, "session-child");
     UNIT_ASSERT_C(!env.SessionOf(2).empty(), "the other split child must stay assigned");
-    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(2), env.SessionOf(0));
-}
-
-Y_UNIT_TEST(CommitThenRebalanceKeepsChildrenIndependent) {
-    TScaleEnv env;
-    env.CreateParents(1);
-    env.RegisterSession("session-0");
-    env.Split(0);
-    env.Finish("session-0", 0);
-    env.AssertSameSession({0, 1, 2});
-
-    env.Commit(0);
-    env.RegisterSession("session-1");
-    env.AssertEvenDistribution(3, 2);
-
-    const TString parentSession = env.SessionOf(0);
-    UNIT_ASSERT_C(!parentSession.empty(), "parent must stay assigned");
-    ui32 childrenWithParent = 0;
-    for (ui32 child : {1u, 2u}) {
-        const TString childSession = env.SessionOf(child);
-        UNIT_ASSERT_C(!childSession.empty(), "child " << child << " must stay assigned");
-        if (childSession == parentSession) {
-            ++childrenWithParent;
-        }
-    }
-    UNIT_ASSERT_C(childrenWithParent < 2,
-        "committed split children must not be glued back to the parent family on rebalance");
 }
 
 Y_UNIT_TEST(ScaleAwareFinishCommitThenSecondCommonSessionKeepsChildrenIndependent) {
@@ -928,6 +1255,28 @@ Y_UNIT_TEST(ScaleAwareFinishCommitThenSecondCommonSessionKeepsChildrenIndependen
     UNIT_ASSERT_C(childSessions.size() == 2 || childrenWithParent == 0,
         "independent child families must be able to sit on a different session than the parent");
 }
+
+Y_UNIT_TEST(FinishCommitThenCloseParentPipeKeepsChildrenOnOtherSession) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.Commit(0);
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(3, 2);
+
+    const TString parentSession = env.SessionOf(0);
+    UNIT_ASSERT_C(!parentSession.empty(), "parent must be locked before the pipe break");
+    UNIT_ASSERT_C(env.Pipes.contains(parentSession), parentSession);
+    env.CloseSession(parentSession);
+
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+    env.AssertLocked(0);
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(0), parentSession);
+}
+
 Y_UNIT_TEST(FinishParentWhileFamilyReleasingAttachesChildrenAfterUnlock) {
     TScaleEnv env;
     env.CreateParents(1);
@@ -954,6 +1303,52 @@ Y_UNIT_TEST(FinishParentWhileFamilyReleasingAttachesChildrenAfterUnlock) {
     env.AssertLocked(0);
     env.AssertSameSession({0, 1, 2});
 }
+
+Y_UNIT_TEST(CommitThenRebalanceKeepsChildrenIndependent) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(3, 2);
+
+    const TString parentSession = env.SessionOf(0);
+    UNIT_ASSERT_C(!parentSession.empty(), "parent must stay assigned");
+    ui32 childrenWithParent = 0;
+    for (ui32 child : {1u, 2u}) {
+        const TString childSession = env.SessionOf(child);
+        UNIT_ASSERT_C(!childSession.empty(), "child " << child << " must stay assigned");
+        if (childSession == parentSession) {
+            ++childrenWithParent;
+        }
+    }
+    UNIT_ASSERT_C(childrenWithParent < 2,
+        "committed split children must not be glued back to the parent family on rebalance");
+}
+
+Y_UNIT_TEST(CommitThenParentReleaseDoesNotReattachSplitChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.Commit(0);
+    env.RegisterSession("session-child", {2});
+    env.AssertLocked(1, "session-child");
+
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(1, "session-child");
+    UNIT_ASSERT_C(!env.SessionOf(2).empty(), "the other split child must stay assigned");
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(2), env.SessionOf(0));
+}
+
 Y_UNIT_TEST(RereadParentThenSecondSessionDoesNotReattachChildren) {
     TScaleEnv env;
     env.CreateParents(1);
@@ -967,6 +1362,93 @@ Y_UNIT_TEST(RereadParentThenSecondSessionDoesNotReattachChildren) {
     env.AssertLocked(0);
     env.AssertNotLocked(1);
     env.AssertNotLocked(2);
+}
+
+Y_UNIT_TEST(PreferredChildNotLockedBeforeParentFinished) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.RegisterSession("session-child", {2});
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    env.Finish("session-0", 0);
+    env.AssertLocked(1, "session-0");
+    env.AssertLocked(2, "session-0");
+}
+
+Y_UNIT_TEST(PreferredChildTakenAfterParentCommitted) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.RegisterSession("session-child", {2});
+    env.Commit(0);
+    env.AssertLocked(1, "session-child");
+}
+
+Y_UNIT_TEST(OldSdkFromEndAllowsIndependentChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0, /*scaleAware=*/false, /*fromEnd=*/true);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(OldSdkNotFromEndDoesNotLockChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0, /*scaleAware=*/false, /*fromEnd=*/false);
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+}
+
+Y_UNIT_TEST(UnaffectedPartitionStaysReadableDuringSplit) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    UNIT_ASSERT_C(!env.SessionOf(1).empty(), "unaffected partition 1 must stay readable");
+    env.AssertNotLocked(2);
+    env.AssertNotLocked(3);
+
+    env.Finish("session-0", 0);
+    env.AssertLocked(2);
+    env.AssertLocked(3);
+    UNIT_ASSERT_C(!env.SessionOf(1).empty(), "unaffected partition 1 must stay readable after split");
+}
+
+Y_UNIT_TEST(ChainedSplitWaitsForAncestors) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertNotLocked(1);
+    env.Finish("session-0", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+
+    env.Split(1);
+    env.AssertNotLocked(3);
+    env.AssertNotLocked(4);
+    env.Finish(env.SessionOf(1), 1);
+    env.AssertLocked(3);
+    env.AssertLocked(4);
+}
+
+Y_UNIT_TEST(SplitAfterParentAlreadyFinished) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Finish("session-0", 0);
+    env.Split(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
 }
 
 Y_UNIT_TEST(RereadParentAfterIndependentChildren) {
@@ -997,9 +1479,205 @@ Y_UNIT_TEST(RereadParentAfterScaleAwareChildren) {
     env.AssertNotLocked(2);
     env.AssertLocked(0, "session-0");
 }
+
+Y_UNIT_TEST(PipeBreakBeforeSplitConfig) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.CloseSession("session-0");
+
+    env.Split(0);
+    env.RegisterSession("session-new");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+    env.Finish("session-new", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakAfterSplitBeforeParentFinished) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertNotLocked(1);
+    env.CloseSession("session-0");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-new");
+    env.Finish("session-new", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakAfterChildrenAttached) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.Split(0);
+
+    const TString holder = env.SessionOf(0);
+    UNIT_ASSERT_C(!holder.empty(), "parent must be locked before finish");
+    env.Finish(holder, 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+
+    env.CloseSession(holder);
+    if (env.Pipes.empty()) {
+        env.RegisterSession("session-new");
+        env.Finish("session-new", 0);
+    }
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(PipeBreakAfterParentCommitted) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Commit(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+
+    env.CloseSession("session-0");
+    env.RegisterSession("session-new");
+    env.Commit(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
 } // Y_UNIT_TEST_SUITE(TPqrbSplitBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants) {
+
+Y_UNIT_TEST(EachPartitionLockedByExactlyOneSession) {
+    TScaleEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(4, 2);
+}
+
+Y_UNIT_TEST(FamiliesGoToLeastLoadedSessions) {
+    TScaleEnv env;
+    env.CreateParents(6);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.RegisterSession("session-2");
+    env.AssertEvenDistribution(6, 3);
+}
+
+Y_UNIT_TEST(UncommittedFamilyIsBalancedAsOneUnit) {
+    TScaleEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertSameSession({0, 1, 3});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 3});
+    UNIT_ASSERT_C(!env.SessionOf(2).empty(), "unaffected partition must stay assigned");
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(2), env.SessionOf(3));
+}
+
+Y_UNIT_TEST(ScaleAwareFinishNotFromEndGivesChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertNotLocked(1);
+    env.Finish("session-0", 0, /*scaleAware=*/true, /*fromEnd=*/false);
+    env.AssertLocked(1, "session-0");
+    env.AssertLocked(2, "session-0");
+}
+
+Y_UNIT_TEST(CommitOfUnreadableChildIsIgnored) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Commit(1);
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+    env.Finish("session-0", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(FinishThenCommitIsIdempotent) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.Commit(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(CommitThenFinishIsIdempotent) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Commit(0);
+    env.Finish("session-0", 0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(DoubleFinishDoesNotLoseChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 0);
+    env.AssertLocked(1, "session-0");
+    env.AssertLocked(2, "session-0");
+}
+
+Y_UNIT_TEST(FinishThenImmediatePipeBreakKeepsConsumerIfOtherSessionAlive) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Split(0);
+    env.Finish(s0, 0, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+    env.CloseSession(s1);
+    env.AssertLocked(2);
+    env.AssertLocked(3);
+}
+
+Y_UNIT_TEST(CommitThenImmediatePipeBreakOnLastSessionRequiresNewCommit) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Commit(0, 1, 1, /*pump=*/false);
+    env.CloseSession("session-0");
+    env.RegisterSession("session-new");
+    env.AssertNotLocked(1);
+    env.Commit(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(FinishAndCommitRaceThenPipeBreak) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+    env.Finish(s0, 0, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+    env.Commit(1, 1, 1, /*pump=*/false);
+    env.CloseSession(s0);
+    env.Finish(s1, 1);
+    env.AssertLocked(2);
+}
 
 Y_UNIT_TEST(StaleFinishAfterPipeBreakIsIgnored) {
     TScaleEnv env;
@@ -1016,15 +1694,90 @@ Y_UNIT_TEST(StaleFinishAfterPipeBreakIsIgnored) {
     env.AssertLocked(2);
 }
 
-Y_UNIT_TEST(FinishThenImmediatePipeBreakKeepsConsumerIfOtherSessionAlive) {
+Y_UNIT_TEST(StaleCommitAfterLastSessionGoneIsIgnoredUntilReconnect) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.CloseSession("session-0");
+    env.InjectCommit(0);
+    env.RegisterSession("session-new");
+    env.AssertNotLocked(1);
+    env.Commit(0);
+    env.AssertLocked(1);
+}
+
+Y_UNIT_TEST(NewRootPartitionGoesToLeastLoadedSession) {
     TScaleEnv env;
     env.CreateParents(2);
-    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(2, 2);
+
+    const ui32 added = env.AddRoot();
+    env.AssertLocked(added);
+    env.AssertEvenDistribution(3, 2);
+}
+
+Y_UNIT_TEST(NewRootPartitionWhileNoSessions) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    const ui32 added = env.AddRoot();
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(added);
+}
+
+Y_UNIT_TEST(NewRootPartitionDuringRebalanceRelease) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+
+    env.RegisterSession("session-1", {}, /*pump=*/false);
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second session must trigger a release");
+    const ui32 added = env.AddRoot();
+    env.Pump();
+    env.AssertLocked(added);
+    env.AssertEvenDistribution(3, 2);
+}
+
+Y_UNIT_TEST(NewRootPartitionThenImmediateSessionClose) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    const ui32 added = env.AddRoot();
+    env.CloseSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(added);
+}
+
+Y_UNIT_TEST(PreferredSessionGetsNewMatchingPartition) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0, "session-0");
+    const ui32 added = env.AddRoot();
+    UNIT_ASSERT_VALUES_EQUAL(added, 1u);
+    env.RegisterSession("session-pref", {2});
+    env.AssertLocked(1, "session-pref");
+    env.AssertLocked(0, "session-0");
+}
+
+Y_UNIT_TEST(NewPartitionAddedWhileParentFinishInFlight) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
     env.Split(0);
-    env.Finish(s0, 0, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
-    env.CloseSession(s1);
+    env.Finish("session-0", 0, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+    const ui32 added = env.AddRoot();
+    env.Pump();
+    env.AssertLocked(1);
     env.AssertLocked(2);
-    env.AssertLocked(3);
+    env.AssertLocked(added);
 }
 
 Y_UNIT_TEST(FinishDuringBalancerRestartIsIgnored) {
@@ -1135,6 +1888,7 @@ Y_UNIT_TEST(FinishThenDisconnectDuringBalancerRestartIsIgnored) {
     env.AssertNotLocked(1);
     env.AssertNotLocked(2);
 }
+
 } // Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants)
 
 struct TClassicEnv : TScaleEnv {
@@ -1145,6 +1899,150 @@ struct TClassicEnv : TScaleEnv {
 };
 
 Y_UNIT_TEST_SUITE(TPqrbClassicBalancing) {
+
+Y_UNIT_TEST(OneSessionGetsAllPartitions) {
+    TClassicEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.AssertEvenDistribution(4, 1);
+}
+
+Y_UNIT_TEST(TwoSessionsSplitEvenly) {
+    TClassicEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(4, 2);
+}
+
+Y_UNIT_TEST(ThreeSessionsSplitEvenly) {
+    TClassicEnv env;
+    env.CreateParents(6);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.RegisterSession("session-2");
+    env.AssertEvenDistribution(6, 3);
+}
+
+Y_UNIT_TEST(UnevenRemainderDiffersByAtMostOne) {
+    TClassicEnv env;
+    env.CreateParents(5);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(5, 2);
+}
+
+Y_UNIT_TEST(EachPartitionLockedByExactlyOneSession) {
+    TClassicEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(4, 2);
+    absl::flat_hash_set<TString> holders;
+    for (ui32 i = 0; i < 4; ++i) {
+        const TString session = env.SessionOf(i);
+        UNIT_ASSERT_C(!session.empty(), "partition " << i << " must be locked");
+        holders.insert(session);
+    }
+    UNIT_ASSERT_VALUES_EQUAL(holders.size(), 2u);
+}
+
+Y_UNIT_TEST(ClosingOneSessionReturnsPartitionsToTheOther) {
+    TClassicEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(4, 2);
+    env.CloseSession("session-1");
+    env.AssertEvenDistribution(4, 1);
+    env.AssertLocked(0, "session-0");
+    env.AssertLocked(1, "session-0");
+    env.AssertLocked(2, "session-0");
+    env.AssertLocked(3, "session-0");
+}
+
+Y_UNIT_TEST(ThreeSessionsThenOneLeavesRemainEven) {
+    TClassicEnv env;
+    env.CreateParents(6);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.RegisterSession("session-2");
+    env.AssertEvenDistribution(6, 3);
+    env.CloseSession("session-1");
+    env.AssertEvenDistribution(6, 2);
+}
+
+Y_UNIT_TEST(NewSessionAfterLastDisconnectGetsAllWithoutFinish) {
+    TClassicEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-0");
+    env.AssertEvenDistribution(3, 1);
+    env.CloseSession("session-0");
+    env.RegisterSession("session-new");
+    env.AssertEvenDistribution(3, 1);
+}
+
+Y_UNIT_TEST(PipeBreakDuringRebalanceDoesNotDropPartition) {
+    TClassicEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+
+    env.RegisterSession("session-1", {}, /*pump=*/false);
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second session must trigger a release");
+    env.CloseSession(pending->Session);
+    env.Pump();
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+}
+
+Y_UNIT_TEST(FinishDoesNotHideOrMovePartitions) {
+    TClassicEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(4, 2);
+
+    absl::flat_hash_map<ui32, TString> before;
+    for (ui32 i = 0; i < 4; ++i) {
+        before[i] = env.SessionOf(i);
+        env.Finish(before[i], i);
+    }
+    env.AssertEvenDistribution(4, 2);
+    for (ui32 i = 0; i < 4; ++i) {
+        UNIT_ASSERT_VALUES_EQUAL_C(before[i], env.SessionOf(i), "finish must not reassign partition " << i);
+    }
+}
+
+Y_UNIT_TEST(CommitDoesNotChangeAssignment) {
+    TClassicEnv env;
+    env.CreateParents(4);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(4, 2);
+
+    absl::flat_hash_map<ui32, TString> before;
+    for (ui32 i = 0; i < 4; ++i) {
+        before[i] = env.SessionOf(i);
+        env.Commit(i);
+    }
+    env.AssertEvenDistribution(4, 2);
+    for (ui32 i = 0; i < 4; ++i) {
+        UNIT_ASSERT_VALUES_EQUAL_C(before[i], env.SessionOf(i), "commit must not reassign partition " << i);
+    }
+}
+
+Y_UNIT_TEST(FinishThenStartReadingKeepsPartitionLocked) {
+    TClassicEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0, "session-0");
+    env.Finish("session-0", 0);
+    env.StartReading("session-0", 0);
+    env.AssertLocked(0, "session-0");
+}
 
 Y_UNIT_TEST(ParentLinksInConfigAreIgnoredWhenScalingDisabled) {
     TClassicEnv env;
@@ -1159,15 +2057,146 @@ Y_UNIT_TEST(ParentLinksInConfigAreIgnoredWhenScalingDisabled) {
     env.AssertLocked(2);
 }
 
-Y_UNIT_TEST(FinishThenStartReadingKeepsPartitionLocked) {
+Y_UNIT_TEST(PreferredSessionGetsRequestedPartition) {
+    TClassicEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-pref", {2});
+    env.AssertLocked(1, "session-pref");
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(0), TString("session-pref"));
+    UNIT_ASSERT_VALUES_UNEQUAL(env.SessionOf(2), TString("session-pref"));
+}
+
+Y_UNIT_TEST(PreferredAndCommonSessionsCoverAllPartitions) {
+    TClassicEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-common");
+    env.RegisterSession("session-pref", {1});
+    env.AssertLocked(0, "session-pref");
+    env.AssertLocked(1, "session-common");
+    env.AssertLocked(2, "session-common");
+}
+
+Y_UNIT_TEST(TwoPreferredSessionsTakeDisjointPartitions) {
+    TClassicEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-common");
+    env.RegisterSession("session-a", {1});
+    env.RegisterSession("session-b", {3});
+    env.AssertLocked(0, "session-a");
+    env.AssertLocked(2, "session-b");
+    env.AssertLocked(1, "session-common");
+}
+
+Y_UNIT_TEST(PreferredConflictDoesNotDoubleLock) {
+    TClassicEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-a", {1});
+    env.RegisterSession("session-b", {1});
+    env.AssertLocked(0);
+    const TString holder = env.SessionOf(0);
+    UNIT_ASSERT_C(holder == "session-a" || holder == "session-b", holder);
+    env.AssertEvenDistribution(1, 1);
+}
+
+Y_UNIT_TEST(PreferredUnknownGroupIsRejected) {
+    TClassicEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-bad", {5}, /*pump=*/false);
+    auto error = env.tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvError>(TDuration::Seconds(10));
+    UNIT_ASSERT(error);
+    env.Pump();
+    env.AssertEvenDistribution(2, 1);
+}
+
+Y_UNIT_TEST(PreferredSessionTakesMatchingPartitionAfterItAppears) {
     TClassicEnv env;
     env.CreateParents(1);
     env.RegisterSession("session-0");
     env.AssertLocked(0, "session-0");
-    env.Finish("session-0", 0);
-    env.StartReading("session-0", 0);
+    const ui32 added = env.AddRoot();
+    UNIT_ASSERT_VALUES_EQUAL(added, 1u);
+    env.RegisterSession("session-pref", {2});
+    env.AssertLocked(1, "session-pref");
     env.AssertLocked(0, "session-0");
 }
+
+Y_UNIT_TEST(NewPartitionGoesToLeastLoadedSession) {
+    TClassicEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(2, 2);
+    const ui32 added = env.AddRoot();
+    env.AssertLocked(added);
+    env.AssertEvenDistribution(3, 2);
+}
+
+Y_UNIT_TEST(NewPartitionWhileNoSessions) {
+    TClassicEnv env;
+    env.CreateParents(1);
+    const ui32 added = env.AddRoot();
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(added);
+}
+
+Y_UNIT_TEST(NewPartitionDuringRebalanceRelease) {
+    TClassicEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+
+    env.RegisterSession("session-1", {}, /*pump=*/false);
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second session must trigger a release");
+    const ui32 added = env.AddRoot();
+    env.Pump();
+    env.AssertLocked(added);
+    env.AssertEvenDistribution(3, 2);
+}
+
+Y_UNIT_TEST(StaleFinishAfterPipeBreakDoesNotAffectLocks) {
+    TClassicEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    const auto pipe = env.Pipes["session-0"];
+    env.CloseSession("session-0");
+    env.InjectFinish(pipe, 0);
+    env.RegisterSession("session-new");
+    env.AssertEvenDistribution(2, 1);
+}
+
+Y_UNIT_TEST(StaleReleaseAfterPipeBreakIsIgnored) {
+    TClassicEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0, "session-0");
+    const auto pipe = env.Pipes["session-0"];
+    env.CloseSession("session-0");
+    env.AckRelease(pipe, 0, "session-0");
+    DispatchFor(env.tc, TDuration::MilliSeconds(50));
+    env.RegisterSession("session-new");
+    env.AssertLocked(0, "session-new");
+}
+
+Y_UNIT_TEST(StaleFinishFromAliveOtherSessionDoesNotStealPartition) {
+    TClassicEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.RegisterSession("session-1");
+    env.AssertEvenDistribution(2, 2);
+    const TString holder0 = env.SessionOf(0);
+    const TString other = holder0 == "session-0" ? "session-1" : "session-0";
+    env.Finish(other, 0);
+    UNIT_ASSERT_VALUES_EQUAL(holder0, env.SessionOf(0));
+    env.AssertLocked(1);
+}
+
 } // Y_UNIT_TEST_SUITE(TPqrbClassicBalancing)
 
 } // namespace NKikimr::NPQ
+
+

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -928,6 +928,32 @@ Y_UNIT_TEST(ScaleAwareFinishCommitThenSecondCommonSessionKeepsChildrenIndependen
     UNIT_ASSERT_C(childSessions.size() == 2 || childrenWithParent == 0,
         "independent child families must be able to sit on a different session than the parent");
 }
+Y_UNIT_TEST(FinishParentWhileFamilyReleasingAttachesChildrenAfterUnlock) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertLocked(0, "session-0");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    env.RegisterSession("session-pref", {1}, /*pump=*/false);
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "preferred session must release the parent family");
+    UNIT_ASSERT_VALUES_EQUAL(pending->Partition, 0u);
+
+    env.Finish(pending->Session, 0, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pipeIt = env.Pipes.find(pending->Session);
+    UNIT_ASSERT(pipeIt != env.Pipes.end());
+    env.AckRelease(pipeIt->second, pending->Partition, pending->Session);
+    env.Pump();
+
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+    env.AssertLocked(0);
+    env.AssertSameSession({0, 1, 2});
+}
 } // Y_UNIT_TEST_SUITE(TPqrbSplitBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants) {

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -1027,6 +1027,114 @@ Y_UNIT_TEST(FinishThenImmediatePipeBreakKeepsConsumerIfOtherSessionAlive) {
     env.AssertLocked(3);
 }
 
+Y_UNIT_TEST(FinishDuringBalancerRestartIsIgnored) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertLocked(0, "session-0");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    NActors::TBlockEvents<TEvTablet::TEvRestored> restored(*env.tc.Runtime, [&](auto& ev) {
+        return ev->Get()->TabletID == env.tc.BalancerTabletId
+            && ev->GetRecipientRewrite() == ev->Get()->UserTabletActor;
+    });
+
+    const TActorId pqrb = env.RebootBalancerAndHoldRestored(restored);
+    const TActorId pipe = env.InjectSessionDuringInit(pqrb, "session-0");
+    env.SendToBalancerActor(
+        pqrb,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe, "user", 0, true, true),
+        env.tc.Edge
+    );
+    DispatchFor(env.tc);
+
+    restored.Unblock();
+    restored.Stop();
+    DispatchFor(env.tc, TDuration::MilliSeconds(200));
+
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    env.SendToBalancerActor(
+        pqrb,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe, "user", 0, true, true),
+        env.tc.Edge
+    );
+    DispatchFor(env.tc, TDuration::MilliSeconds(200));
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(CommitDuringBalancerRestartMakesChildrenReadable) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertLocked(0, "session-0");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    NActors::TBlockEvents<TEvTablet::TEvRestored> restored(*env.tc.Runtime, [&](auto& ev) {
+        return ev->Get()->TabletID == env.tc.BalancerTabletId
+            && ev->GetRecipientRewrite() == ev->Get()->UserTabletActor;
+    });
+
+    const TActorId pqrb = env.RebootBalancerAndHoldRestored(restored);
+    env.InjectSessionDuringInit(pqrb, "session-0");
+    env.SendToBalancerActor(
+        pqrb,
+        new TEvPQ::TEvReadingPartitionStatusRequest("user", 0, 1, 1),
+        env.tc.Edge
+    );
+    DispatchFor(env.tc);
+
+    restored.Unblock();
+    restored.Stop();
+    DispatchFor(env.tc, TDuration::MilliSeconds(200));
+
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(FinishThenDisconnectDuringBalancerRestartIsIgnored) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.AssertLocked(0, "session-0");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+
+    NActors::TBlockEvents<TEvTablet::TEvRestored> restored(*env.tc.Runtime, [&](auto& ev) {
+        return ev->Get()->TabletID == env.tc.BalancerTabletId
+            && ev->GetRecipientRewrite() == ev->Get()->UserTabletActor;
+    });
+
+    const TActorId pqrb = env.RebootBalancerAndHoldRestored(restored);
+    const TActorId pipe = env.InjectSessionDuringInit(pqrb, "session-0");
+    env.SendToBalancerActor(
+        pqrb,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe, "user", 0, true, true),
+        env.tc.Edge
+    );
+    env.SendToBalancerActor(
+        pqrb,
+        new TEvTabletPipe::TEvServerDisconnected(env.tc.BalancerTabletId, pipe, pipe),
+        pipe
+    );
+    DispatchFor(env.tc);
+
+    restored.Unblock();
+    restored.Stop();
+    DispatchFor(env.tc, TDuration::MilliSeconds(200));
+
+    env.RegisterSession("session-new");
+    env.AssertLocked(0, "session-new");
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+}
 } // Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants)
 
 struct TClassicEnv : TScaleEnv {

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -1167,6 +1167,73 @@ Y_UNIT_TEST(DelayedMergeDisconnectTargetBeforeUnlockLocksChild) {
     env.AssertLocked(2);
 }
 
+Y_UNIT_TEST(DisconnectAfterUncommittedMergeDoesNotDoubleLock) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertSameSession({0, 1, 2});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 2});
+
+    const TString holder = env.SessionOf(2);
+    env.CloseSession(holder);
+    env.AssertSameSession({0, 1, 2});
+    env.AssertEvenDistribution(3, 1);
+}
+
+Y_UNIT_TEST(DisconnectAfterDelayedMergeDoesNotDoubleLock) {
+    TScaleEnv env;
+    env.CreateParents(2);
+    auto [s0, s1] = env.TwoSessionsOnParents();
+    env.Merge(0, 1);
+
+    env.Finish(s0, 0);
+    env.Finish(s1, 1, /*scaleAware=*/true, /*fromEnd=*/true, /*pump=*/false);
+
+    auto pending = env.WaitRelease();
+    UNIT_ASSERT_C(pending, "second finished parent must trigger a family release to merge");
+    auto pipeIt = env.Pipes.find(pending->Session);
+    UNIT_ASSERT(pipeIt != env.Pipes.end());
+    env.AckRelease(pipeIt->second, pending->Partition, pending->Session);
+    env.Pump();
+    env.AssertLocked(2);
+
+    const TString holder = env.SessionOf(2);
+    UNIT_ASSERT_C(!holder.empty(), "merged child must stay assigned");
+    UNIT_ASSERT_C(env.Pipes.size() > 1, "a second session must keep the consumer alive");
+    env.CloseSession(holder);
+    env.AssertSameSession({0, 1, 2});
+    env.AssertEvenDistribution(3, 1);
+}
+
+Y_UNIT_TEST(ChainedMergeDescendantsStayTogetherThenReconnectOnce) {
+    TScaleEnv env;
+    env.CreateParents(3);
+    env.RegisterSession("session-0");
+    env.Merge(0, 1);
+    env.Finish("session-0", 0);
+    env.Finish("session-0", 1);
+    env.AssertLocked(3);
+
+    env.Merge(3, 2);
+    env.AssertNotLocked(4);
+    env.Finish("session-0", 3);
+    env.Finish("session-0", 2);
+    env.AssertSameSession({0, 1, 2, 3, 4});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 2, 3, 4});
+
+    const TString holder = env.SessionOf(4);
+    env.CloseSession(holder);
+    env.AssertSameSession({0, 1, 2, 3, 4});
+    env.AssertEvenDistribution(5, 1);
+}
+
 } // Y_UNIT_TEST_SUITE(TPqrbMergeBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbSplitBalancing) {
@@ -1439,6 +1506,45 @@ Y_UNIT_TEST(ChainedSplitWaitsForAncestors) {
     env.Finish(env.SessionOf(1), 1);
     env.AssertLocked(3);
     env.AssertLocked(4);
+}
+
+Y_UNIT_TEST(ChainedSplitDescendantsStayTogetherThenIndependentAfterCommit) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.Split(1);
+    env.Finish(env.SessionOf(1), 1);
+    env.AssertSameSession({0, 1, 2, 3, 4});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 2, 3, 4});
+
+    env.Commit(0);
+    env.Commit(1);
+    env.AssertEvenDistribution(5, 2);
+}
+
+Y_UNIT_TEST(DisconnectAfterSplitThenMergeDoesNotDoubleLock) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.Merge(1, 2);
+    env.Finish(env.SessionOf(1), 1);
+    env.Finish(env.SessionOf(2), 2);
+    env.AssertLocked(3);
+    env.AssertSameSession({0, 1, 2, 3});
+
+    env.RegisterSession("session-1");
+    env.AssertSameSession({0, 1, 2, 3});
+
+    const TString holder = env.SessionOf(3);
+    env.CloseSession(holder);
+    env.AssertSameSession({0, 1, 2, 3});
+    env.AssertEvenDistribution(4, 1);
 }
 
 Y_UNIT_TEST(SplitAfterParentAlreadyFinished) {

--- a/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_ut.cpp
@@ -954,6 +954,49 @@ Y_UNIT_TEST(FinishParentWhileFamilyReleasingAttachesChildrenAfterUnlock) {
     env.AssertLocked(0);
     env.AssertSameSession({0, 1, 2});
 }
+Y_UNIT_TEST(RereadParentThenSecondSessionDoesNotReattachChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.StartReading("session-0", 0);
+    env.RegisterSession("session-1");
+    env.AssertLocked(0);
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+}
+
+Y_UNIT_TEST(RereadParentAfterIndependentChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0, /*scaleAware=*/false, /*fromEnd=*/true);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+
+    env.StartReading("session-0", 0);
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+    env.AssertLocked(0, "session-0");
+}
+
+Y_UNIT_TEST(RereadParentAfterScaleAwareChildren) {
+    TScaleEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.Split(0);
+    env.Finish("session-0", 0);
+    env.AssertSameSession({0, 1, 2});
+
+    env.StartReading("session-0", 0);
+    env.AssertNotLocked(1);
+    env.AssertNotLocked(2);
+    env.AssertLocked(0, "session-0");
+}
 } // Y_UNIT_TEST_SUITE(TPqrbSplitBalancing)
 
 Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants) {
@@ -985,5 +1028,38 @@ Y_UNIT_TEST(FinishThenImmediatePipeBreakKeepsConsumerIfOtherSessionAlive) {
 }
 
 } // Y_UNIT_TEST_SUITE(TPqrbBalancingInvariants)
+
+struct TClassicEnv : TScaleEnv {
+    TClassicEnv()
+        : TScaleEnv(NKikimrPQ::TPQTabletConfig::DISABLED)
+    {
+    }
+};
+
+Y_UNIT_TEST_SUITE(TPqrbClassicBalancing) {
+
+Y_UNIT_TEST(ParentLinksInConfigAreIgnoredWhenScalingDisabled) {
+    TClassicEnv env;
+    env.NextPartitionId = 3;
+    env.ParentPartitionIds[1] = {0};
+    env.ParentPartitionIds[2] = {0};
+    env.ChildPartitionIds[0] = {1, 2};
+    env.Publish();
+    env.RegisterSession("session-0");
+    env.AssertLocked(0);
+    env.AssertLocked(1);
+    env.AssertLocked(2);
+}
+
+Y_UNIT_TEST(FinishThenStartReadingKeepsPartitionLocked) {
+    TClassicEnv env;
+    env.CreateParents(1);
+    env.RegisterSession("session-0");
+    env.AssertLocked(0, "session-0");
+    env.Finish("session-0", 0);
+    env.StartReading("session-0", 0);
+    env.AssertLocked(0, "session-0");
+}
+} // Y_UNIT_TEST_SUITE(TPqrbClassicBalancing)
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/sdk_balancing_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/sdk_balancing_ut.cpp
@@ -9,6 +9,10 @@
 #include <util/datetime/base.h>
 #include <util/stream/output.h>
 
+#include <memory>
+#include <set>
+#include <vector>
+
 namespace NKikimr {
 
 using namespace NYdb::NTopic;
@@ -154,6 +158,332 @@ Y_UNIT_TEST_SUITE(Balancing) {
 
     Y_UNIT_TEST(Balancing_ManyTopics_PQv1) {
         ManyTopics(SdkVersion::PQv1);
+    }
+
+ }
+
+void WaitEnded(const std::shared_ptr<ITestReadSession>& session, size_t count) {
+    for (size_t i = 0; i < 15; ++i) {
+        if (session->GetEndedPartitionEvents().size() >= count) {
+            return;
+        }
+        Sleep(TDuration::Seconds(1));
+    }
+    UNIT_ASSERT_VALUES_EQUAL_C(count, session->GetEndedPartitionEvents().size(),
+        "timed out waiting for ended partition events");
+}
+
+void WaitFamilyOnOneSession(
+    const std::shared_ptr<ITestReadSession>& first,
+    const std::shared_ptr<ITestReadSession>& second,
+    const std::set<size_t>& family,
+    const TString& message)
+{
+    std::set<size_t> p0;
+    std::set<size_t> p1;
+    for (size_t i = 0; i < 20; ++i) {
+        p0 = first->GetPartitions();
+        p1 = second->GetPartitions();
+        bool firstHasAll = true;
+        bool secondHasAll = true;
+        bool firstHasAny = false;
+        bool secondHasAny = false;
+        for (auto id : family) {
+            const bool inFirst = p0.contains(id);
+            const bool inSecond = p1.contains(id);
+            firstHasAll = firstHasAll && inFirst;
+            secondHasAll = secondHasAll && inSecond;
+            firstHasAny = firstHasAny || inFirst;
+            secondHasAny = secondHasAny || inSecond;
+        }
+        if ((firstHasAll && !secondHasAny) || (secondHasAll && !firstHasAny)) {
+            return;
+        }
+        Sleep(TDuration::Seconds(1));
+    }
+    UNIT_ASSERT_C(false, message << ", p0=" << p0 << " p1=" << p1);
+}
+
+Y_UNIT_TEST_SUITE(MergeBalancing) {
+
+    Y_UNIT_TEST(OneSession_ChildAfterBothParents) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 2, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        auto write1 = CreateWriteSession(client, "producer-1", 1);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+        UNIT_ASSERT(write1->Write(Msg("p1", 1)));
+
+        auto session = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 2,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session->WaitAndAssertPartitions({0, 1}, "Must read both parent partitions");
+        session->WaitAllMessages();
+
+        ui64 txId = 2001;
+        MergePartition(setup, ++txId, 0, 1);
+
+        WaitEnded(session, 2);
+        session->WaitAndAssertPartitions({0, 1, 2}, "ScaleAware session must get the merge child after both parents ended");
+        session->Close();
+        write0->Close(TDuration::Seconds(1));
+        write1->Close(TDuration::Seconds(1));
+    }
+
+    Y_UNIT_TEST(ThirdSessionDoesNotSplitUncommittedFamily) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 2, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        auto write1 = CreateWriteSession(client, "producer-1", 1);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+        UNIT_ASSERT(write1->Write(Msg("p1", 1)));
+
+        auto session0 = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 2,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session0->WaitAndAssertPartitions({0, 1}, "Must read parents");
+        session0->WaitAllMessages();
+
+        ui64 txId = 2004;
+        MergePartition(setup, ++txId, 0, 1);
+        WaitEnded(session0, 2);
+        session0->WaitAndAssertPartitions({0, 1, 2}, "Family must include merge child");
+        session0->Run();
+
+        auto session1 = CreateTestReadSession({
+            .Name = "Session-1",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        WaitFamilyOnOneSession(session0, session1, {0, 1, 2},
+            "Uncommitted merge family must stay on one session");
+
+        session0->Close();
+        session1->Close();
+        write0->Close(TDuration::Seconds(1));
+        write1->Close(TDuration::Seconds(1));
+    }
+
+    Y_UNIT_TEST(UnaffectedPartitionStaysReadable) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 3, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        auto write1 = CreateWriteSession(client, "producer-1", 1);
+        auto write2 = CreateWriteSession(client, "producer-2", 2);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+        UNIT_ASSERT(write1->Write(Msg("p1", 1)));
+        UNIT_ASSERT(write2->Write(Msg("p2", 1)));
+
+        auto session = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 3,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session->WaitAndAssertPartitions({0, 1, 2}, "All original partitions");
+        session->WaitAllMessages();
+
+        ui64 txId = 2006;
+        MergePartition(setup, ++txId, 0, 1);
+        UNIT_ASSERT_C(session->GetPartitions().contains(2), "Partition 2 must stay assigned during merge of 0 and 1");
+        WaitEnded(session, 2);
+        session->WaitAndAssertPartitions({0, 1, 2, 3}, "Unaffected partition 2 stays with the merge child");
+
+        session->Close();
+        write0->Close(TDuration::Seconds(1));
+        write1->Close(TDuration::Seconds(1));
+        write2->Close(TDuration::Seconds(1));
+    }
+
+    Y_UNIT_TEST(SplitThenMerge_ChildAfterBothSplitChildren) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 1, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+
+        auto session = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 1,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session->WaitAndAssertPartitions({0}, "root");
+        session->WaitAllMessages();
+
+        ui64 txId = 2007;
+        SplitPartition(setup, ++txId, 0, "a");
+        WaitEnded(session, 1);
+        session->Commit();
+        session->WaitAndAssertPartitions({0, 1, 2}, "split children");
+        session->Run();
+
+        MergePartition(setup, ++txId, 1, 2);
+        WaitEnded(session, 3);
+        session->WaitAndAssertPartitions({0, 1, 2, 3}, "merge child after both split children ended");
+
+        session->Close();
+        write0->Close(TDuration::Seconds(1));
+    }
+
+    Y_UNIT_TEST(PQv1_ChildAfterParentsFinished) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 2, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        auto write1 = CreateWriteSession(client, "producer-1", 1);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+        UNIT_ASSERT(write1->Write(Msg("p1", 1)));
+
+        auto session = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::PQv1,
+            .ExpectedMessagesCount = 2,
+            .AutoCommit = true,
+            .AutoPartitioningSupport = false,
+        });
+        session->WaitAndAssertPartitions({0, 1}, "PQv1 reads parents");
+        session->WaitAllMessages();
+
+        ui64 txId = 2008;
+        MergePartition(setup, ++txId, 0, 1);
+        Sleep(TDuration::Seconds(2));
+        auto partitions = session->GetPartitions();
+        UNIT_ASSERT_C(partitions.contains(2) || partitions.contains(0),
+            "PQv1 session must keep reading after merge, partitions=" << partitions);
+
+        session->Close();
+        write0->Close(TDuration::Seconds(1));
+        write1->Close(TDuration::Seconds(1));
+    }
+
+ }
+
+Y_UNIT_TEST_SUITE(SplitBalancing) {
+
+    Y_UNIT_TEST(OneSession_ChildrenAfterParent) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 1, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+
+        auto session = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 1,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session->WaitAndAssertPartitions({0}, "root");
+        session->WaitAllMessages();
+
+        ui64 txId = 3001;
+        SplitPartition(setup, ++txId, 0, "a");
+        WaitEnded(session, 1);
+        session->WaitAndAssertPartitions({0, 1, 2}, "ScaleAware session must get both split children after the parent ended");
+
+        session->Close();
+        write0->Close(TDuration::Seconds(1));
+    }
+
+    Y_UNIT_TEST(ThirdSessionDoesNotSplitUncommittedFamily) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 1, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+
+        auto session0 = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 1,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session0->WaitAndAssertPartitions({0}, "root");
+        session0->WaitAllMessages();
+
+        ui64 txId = 3002;
+        SplitPartition(setup, ++txId, 0, "a");
+        WaitEnded(session0, 1);
+        session0->WaitAndAssertPartitions({0, 1, 2}, "family includes split children");
+        session0->Run();
+
+        auto session1 = CreateTestReadSession({
+            .Name = "Session-1",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        WaitFamilyOnOneSession(session0, session1, {0, 1, 2},
+            "Uncommitted split family must stay on one session");
+
+        session0->Close();
+        session1->Close();
+        write0->Close(TDuration::Seconds(1));
+    }
+
+    Y_UNIT_TEST(UnaffectedPartitionStaysReadable) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 2, 100);
+        TTopicClient client = setup.MakeClient();
+
+        auto write0 = CreateWriteSession(client, "producer-0", 0);
+        auto write1 = CreateWriteSession(client, "producer-1", 1);
+        UNIT_ASSERT(write0->Write(Msg("p0", 1)));
+        UNIT_ASSERT(write1->Write(Msg("p1", 1)));
+
+        auto session = CreateTestReadSession({
+            .Name = "Session-0",
+            .Setup = setup,
+            .Sdk = SdkVersion::Topic,
+            .ExpectedMessagesCount = 2,
+            .AutoCommit = false,
+            .AutoPartitioningSupport = true,
+        });
+        session->WaitAndAssertPartitions({0, 1}, "both original partitions");
+        session->WaitAllMessages();
+
+        ui64 txId = 3003;
+        SplitPartition(setup, ++txId, 0, "a");
+        UNIT_ASSERT_C(session->GetPartitions().contains(1), "Partition 1 must stay assigned during split of 0");
+        WaitEnded(session, 1);
+        session->WaitAndAssertPartitions({0, 1, 2, 3}, "Unaffected partition 1 stays with the split children");
+
+        session->Close();
+        write0->Close(TDuration::Seconds(1));
+        write1->Close(TDuration::Seconds(1));
     }
 
  }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed Topic read balancer assignment after partition split and merge: children are no longer locked too early, uncommitted families stay on one session, committed children stay independent, and a balancer restart no longer drops commit status or applies stale finish/release.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Harden PQRB session balancing (`ydb/core/persqueue/pqrb`) for split/merge families, pipe disconnect, reread, and tablet restart. Each bug is a separate commit with tests that fail without the fix.

**Readable children and preferred sessions**
- `IsReadable` requires both `DirectParents` and `AllParents` inactive. An empty `AllParents` is not “no parents”.
- Preferred `CreateFamily` only for already readable partitions, so a session that names a merge/split child does not lock it before parents are processed.

**Lifetime / UAF**
- `Unlock` no longer `Reset`s the family while `this` is still on the stack.
- `Destroy` parks the `unique_ptr` in `DoomedFamilies`; `TDoomedFamilyGuard` drops it when the outermost `TConsumer` call returns.
- `UnregisterReadingSession` skips families already merged away and ignores sessions that are no longer registered.

**Delayed merge and wanted children**
- After `Reset(Merge)`, attach readable descendants even if the target family died with its session.
- Attach also updates `RootPartitions` and works for Free/Releasing families.
- `Reset(Free)` attaches ready `WantedPartitions` after `AfterRelease`, so finish during a steal does not leave children stuck.

**Committed children stay independent**
- `BreakUpFamily` shrinks leftover `RootPartitions` to the committed partition; new families copy roots from their members.
- Active+Free merge no longer double-inserts into `RootPartitions`, so a later parent steal does not glue children back.

**Reread and classic topics**
- `StartReading` always traverses children after breakup; do not return early and leave children locked.
- Skip the scale path when `ScalingSupport` is off (classic `DISABLED` topics).
- Finish updates `TPartition` even without a locked session.

**Balancer restart**
- Finish/start/release are pipe-bound and ignored in `StateInit`.
- Commit/status from the PQ tablet is queued until `InitDone`.
- `TTxInit::Complete` always calls `InitDone`. Register is replayed before commits.

**Debug and coverage**
- `Y_DEBUG_ABORT_UNLESS` on release/lock/create/merge/destroy; `AssertBalancingInvariants` after Balance/Unregister (`NDEBUG` no-ops in relwithdebinfo).
- Extra tablet and SDK tests for pipe-break stages, uncommitted family as one load unit, old SDK fromEnd, preferred vs common, classic balancing, stale finish/release.

## Test plan
- [x] `./ya make --build relwithdebinfo -tA ydb/core/persqueue/pqrb/ut` (151 GOOD)
- [x] Bug-specific tests fail on unfixed code (12 FAIL, 4 CRASH vs HEAD)