### PR TITLE
[detailed-metrics] YQL control surface

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table.cpp
@@ -216,6 +216,7 @@ private:
                 FillPartitioningSettings(describeTableResult, tableDescription);
                 FillKeyBloomFilter(describeTableResult, tableDescription);
                 FillReadReplicasSettings(describeTableResult, tableDescription);
+                FillMetricsSettings(describeTableResult, tableDescription);
 
                 return ReplyWithResult(Ydb::StatusIds::SUCCESS, describeTableResult, ctx);
             }

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -318,6 +318,12 @@ bool ConvertCreateTableSettingsToProto(NYql::TKikimrTableMetadataPtr metadata, Y
         proto.mutable_storage_settings()->set_external_data_channels_count(*count);
     }
 
+    if (const auto level = metadata->TableSettings.MetricsLevel;
+        level && *level != Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
+              && *level != Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE) {
+        proto.mutable_metrics_settings()->set_metrics_level(*level);
+    }
+
     proto.set_temporary(metadata->Temporary);
 
     return true;

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -800,7 +800,13 @@ namespace {
                 YQL_ENSURE(result);
                 request->mutable_partitioning_settings()->mutable_auto_partitioning_settings()->set_strategy(strategy);
             } else if (name == "setMetricsLevel") {
-                auto metricsLevel = FromString<i32>(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
+                ui32 metricsLevel = 0;
+                TString error;
+                auto result = ParseTopicMetricsLevel(
+                        setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value(),
+                        metricsLevel, error
+                );
+                YQL_ENSURE(result, << error);
                 request->set_metrics_level(metricsLevel);
             } else if (name == "setContentBasedDeduplication") {
                 auto value = FromString<bool>(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
@@ -876,7 +882,13 @@ namespace {
                 YQL_ENSURE(result);
                 request->mutable_alter_partitioning_settings()->mutable_alter_auto_partitioning_settings()->set_set_strategy(strategy);
             } else if (name == "setMetricsLevel") {
-                auto metricsLevel = FromString<i32>(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
+                ui32 metricsLevel = 0;
+                TString error;
+                auto result = ParseTopicMetricsLevel(
+                        TString(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value()),
+                        metricsLevel, error
+                );
+                YQL_ENSURE(result, << error);
                 request->set_set_metrics_level(metricsLevel);
             } else if (name == "resetMetricsLevel") {
                 request->mutable_reset_metrics_level();
@@ -2489,6 +2501,29 @@ public:
                             ConvertTtlSettingsToProto(ttlSettings, *alterTableRequest.mutable_set_ttl_settings());
                         } else if (name == "resetTtlSettings") {
                             alterTableRequest.mutable_drop_ttl_settings();
+                        } else if (name == "setMetricsLevel" || name == "resetMetricsLevel") {
+                            if (!SessionCtx->Config().FeatureFlags.GetEnableDataShardDetailedMetrics()) {
+                                ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()),
+                                    TStringBuilder() << "METRICS_LEVEL is not supported: EnableDataShardDetailedMetrics is off"));
+                                return SyncError();
+                            }
+                            if (name == "resetMetricsLevel") {
+                                alterTableRequest.mutable_drop_metrics_settings();
+                            } else {
+                                auto raw = TString(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
+                                Ydb::Table::MetricsSettings::MetricsLevel level;
+                                TString error;
+                                if (!ParseMetricsLevel(raw, level, error)) {
+                                    ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()), error));
+                                    return SyncError();
+                                }
+                                if (level == Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
+                                    || level == Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED) {
+                                    alterTableRequest.mutable_drop_metrics_settings();
+                                } else {
+                                    alterTableRequest.mutable_set_metrics_settings()->set_metrics_level(level);
+                                }
+                            }
                         } else {
                             ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()),
                                 TStringBuilder() << "Unknown table profile setting: " << name));

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
@@ -178,7 +178,7 @@ bool TTableSettings::IsSet() const {
     return CompactionPolicy || PartitionBy || AutoPartitioningBySize || UniformPartitions || PartitionAtKeys
         || PartitionSizeMb || AutoPartitioningByLoad || MinPartitions || MaxPartitions || KeyBloomFilter
         || ReadReplicasSettings || TtlSettings || DataSourcePath || Location || ExternalSourceParameters
-        || StoreExternalBlobs || ExternalDataChannelsCount;
+        || StoreExternalBlobs || ExternalDataChannelsCount || MetricsLevel;
 }
 
 EYqlIssueCode YqlStatusFromYdbStatus(ui32 ydbStatus) {
@@ -340,6 +340,64 @@ void ConvertTtlSettingsToProto(const NYql::TTtlSettings& settings, Ydb::Table::T
             outTier->mutable_delete_();
         }
     }
+}
+
+bool ParseMetricsLevel(TStringBuf raw, Ydb::Table::MetricsSettings::MetricsLevel& out, TString& error) {
+    // one can set metrics level both by literal and by numeric value
+    // PUBLIC numerics drift from any other enum, so remap them here
+    static constexpr Ydb::Table::MetricsSettings::MetricsLevel numericLevels[] = {
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION,
+    };
+
+    const TString value = to_lower(TString(raw));
+    ui64 numericVal = 0;
+    // to use numericLevels array own offsets, rather than map
+    if (TryFromString<ui64>(value, numericVal)
+        && numericVal > 0
+        && numericVal <= std::size(numericLevels))
+    {
+        out = numericLevels[numericVal - 1];
+    } else if (value == "database") {
+        out = Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE;
+    } else if (value == "table") {
+        out = Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE;
+    } else if (value == "partition") {
+        out = Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION;
+    } else {
+        error = TStringBuilder() << "METRICS_LEVEL is invalid: " << raw;
+        return false;
+    }
+
+    return true;
+}
+
+// Ydb::Topic's metrics_level is a plain uint32 that flows verbatim to PQTabletConfig::MetricsLevel,
+// so unlike ParseMetricsLevel above, no remap is needed here: the numbers below are exactly
+// METRICS_LEVEL_{DISABLED,DATABASE,OBJECT,DETAILED} from ydb/core/persqueue/public/constants.h.
+// TODO: the RFC says level 0 (DISABLED) is supported by neither YDB nor LogBroker, but the topic
+// proto and today's metrics_level = 0 both allow it; rejecting DISABLED needs agreement with the
+// topic/LogBroker owners first, so it is accepted for now.
+bool ParseTopicMetricsLevel(TStringBuf raw, ui32& out, TString& error) {
+    const TString value = to_lower(TString(raw));
+    ui64 numericVal = 0;
+    if (TryFromString<ui64>(value, numericVal) && numericVal <= 3) {
+        out = static_cast<ui32>(numericVal);
+    } else if (value == "disabled") {
+        out = 0;
+    } else if (value == "database") {
+        out = 1;
+    } else if (value == "topic") {
+        out = 2;
+    } else if (value == "partition") {
+        out = 3;
+    } else {
+        error = TStringBuilder() << "METRICS_LEVEL is invalid: " << raw;
+        return false;
+    }
+
+    return true;
 }
 
 Ydb::FeatureFlag::Status GetFlagValue(const TMaybe<bool>& value) {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -536,6 +536,7 @@ struct TTableSettings {
     TMaybe<TString> PartitionByHashFunction;
     TMaybe<TString> StoreExternalBlobs;
     TMaybe<ui64> ExternalDataChannelsCount;
+    TMaybe<Ydb::Table::MetricsSettings::MetricsLevel> MetricsLevel;
 
     // These parameters are only used for external sources
     TMaybe<TString> DataSourcePath;
@@ -1747,6 +1748,8 @@ bool SetColumnType(const TTypeAnnotationNode* typeNode, bool notNull, Ydb::Type&
 bool ConvertReadReplicasSettingsToProto(const TString settings, Ydb::Table::ReadReplicasSettings& proto,
     Ydb::StatusIds::StatusCode& code, TString& error);
 void ConvertTtlSettingsToProto(const NYql::TTtlSettings& settings, Ydb::Table::TtlSettings& proto);
+bool ParseMetricsLevel(TStringBuf raw, Ydb::Table::MetricsSettings::MetricsLevel& out, TString& error);
+bool ParseTopicMetricsLevel(TStringBuf raw, ui32& out, TString& error);
 
 } // namespace NYql
 

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -2197,12 +2197,37 @@ private:
                 meta->TableSettings.ExternalDataChannelsCount = FromString<ui32>(
                     setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value()
                 );
+            } else if (name == "setMetricsLevel") {
+                if (!SessionCtx->Config().FeatureFlags.GetEnableDataShardDetailedMetrics()) {
+                    ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()),
+                        TStringBuilder() << "METRICS_LEVEL is not supported: EnableDataShardDetailedMetrics is off"));
+                    return TStatus::Error;
+                }
+                auto raw = TString(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
+                Ydb::Table::MetricsSettings::MetricsLevel level;
+                TString error;
+                if (!ParseMetricsLevel(raw, level, error)) {
+                    ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()), error));
+                    return TStatus::Error;
+                }
+                meta->TableSettings.MetricsLevel = level;
+            } else if (name == "resetMetricsLevel") {
+                ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()),
+                    "Can't reset METRICS_LEVEL"));
+                return TStatus::Error;
             } else {
                 ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()),
                     TStringBuilder() << "Unknown table profile setting: " << name));
                 return TStatus::Error;
             }
         }
+
+        if (meta->StoreType == EStoreType::Column && meta->TableSettings.MetricsLevel) {
+            ctx.AddError(TIssue(ctx.GetPosition(create.Pos()),
+                "METRICS_LEVEL is not supported for column tables"));
+            return TStatus::Error;
+        }
+
         return TStatus::Ok;
     }
 
@@ -2628,6 +2653,16 @@ private:
                             columnNames, table->Metadata->Columns, columnsPos, ctx)) {
                     return TStatus::Error;
                 }
+            } else if (name == "setTableSettings" && table->Metadata->IsOlap()) {
+                auto listNode = action.Value().Cast<TCoNameValueTupleList>();
+                for (const auto& setting : listNode) {
+                    auto settingName = setting.Name().Value();
+                    if (settingName == "setMetricsLevel" || settingName == "resetMetricsLevel") {
+                        ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()),
+                            "METRICS_LEVEL is not supported for column tables"));
+                        return TStatus::Error;
+                    }
+                }
             } else if (name != "setTableSettings"
                     && name != "addChangefeed"
                     && name != "dropChangefeed"
@@ -2697,6 +2732,22 @@ private:
         }
         return true;
     }
+    static bool CheckTopicMetricsLevel(const TCoNameValueTupleList& settings, TExprContext& ctx) {
+        for (const auto& setting : settings) {
+            auto name = setting.Name().Value();
+            if (name != "setMetricsLevel") {
+                continue;
+            }
+            ui32 value = 0;
+            TString error;
+            if (!ParseTopicMetricsLevel(setting.Value().Cast<TCoDataCtor>().Literal().template Cast<TCoAtom>().Value(), value, error)) {
+                ctx.AddError(TIssue(ctx.GetPosition(setting.Name().Pos()), error));
+                return false;
+            }
+        }
+        return true;
+    }
+
     static bool CheckConsumerSettings(const TCoNameValueTupleList& settings, TExprContext& ctx) {
         for (const auto& setting : settings) {
             const auto name = setting.Name().Value();
@@ -2729,6 +2780,9 @@ private:
 
     virtual TStatus HandleCreateTopic(TKiCreateTopic node, TExprContext& ctx) override {
         if (!CheckTopicSettings(node.Settings(), ctx)) {
+            return TStatus::Error;
+        }
+        if (!CheckTopicMetricsLevel(node.TopicSettings(), ctx)) {
             return TStatus::Error;
         }
 
@@ -2805,6 +2859,9 @@ private:
 
     virtual TStatus HandleAlterTopic(TKiAlterTopic node, TExprContext& ctx) override {
         if (!CheckTopicSettings(node.Settings(), ctx)) {
+            return TStatus::Error;
+        }
+        if (!CheckTopicMetricsLevel(node.TopicSettings(), ctx)) {
             return TStatus::Error;
         }
        THashSet<TString> allConsumers;

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -626,6 +626,345 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
     }
 
+    Y_UNIT_TEST(TableMetricsLevelCreatePartition) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTable` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = "PARTITION");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto describe = session.DescribeTable("/Root/MetricsTable").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+        const auto metrics = describe.GetTableDescription().GetMetricsSettings();
+        UNIT_ASSERT(metrics.has_value());
+        UNIT_ASSERT(metrics->GetMetricsLevel() == TMetricsSettings::EMetricsLevel::Partition);
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelCreateNumeric) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTable` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = 2);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto describe = session.DescribeTable("/Root/MetricsTable").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+        const auto metrics = describe.GetTableDescription().GetMetricsSettings();
+        UNIT_ASSERT(metrics.has_value());
+        UNIT_ASSERT(metrics->GetMetricsLevel() == TMetricsSettings::EMetricsLevel::Table);
+
+        auto resultSuffixed = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTableSuffixed` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = 2u);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(resultSuffixed.GetStatus(), EStatus::SUCCESS, resultSuffixed.GetIssues().ToString());
+
+        auto describeSuffixed = session.DescribeTable("/Root/MetricsTableSuffixed").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describeSuffixed.GetStatus(), EStatus::SUCCESS, describeSuffixed.GetIssues().ToString());
+        const auto metricsSuffixed = describeSuffixed.GetTableDescription().GetMetricsSettings();
+        UNIT_ASSERT(metricsSuffixed.has_value());
+        UNIT_ASSERT(metricsSuffixed->GetMetricsLevel() == TMetricsSettings::EMetricsLevel::Table);
+
+        auto resultDatabase = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTableNumericDatabase` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = 1);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(resultDatabase.GetStatus(), EStatus::SUCCESS, resultDatabase.GetIssues().ToString());
+
+        auto describeDatabase = session.DescribeTable("/Root/MetricsTableNumericDatabase").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describeDatabase.GetStatus(), EStatus::SUCCESS, describeDatabase.GetIssues().ToString());
+        UNIT_ASSERT(!describeDatabase.GetTableDescription().GetMetricsSettings().has_value());
+
+        // 3 is the top of the numeric range: PARTITION must be reachable numerically,
+        // not only by literal.
+        auto resultPartition = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTableNumericPartition` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = 3);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(resultPartition.GetStatus(), EStatus::SUCCESS, resultPartition.GetIssues().ToString());
+
+        auto describePartition = session.DescribeTable("/Root/MetricsTableNumericPartition").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describePartition.GetStatus(), EStatus::SUCCESS, describePartition.GetIssues().ToString());
+        const auto metricsPartition = describePartition.GetTableDescription().GetMetricsSettings();
+        UNIT_ASSERT(metricsPartition.has_value());
+        UNIT_ASSERT(metricsPartition->GetMetricsLevel() == TMetricsSettings::EMetricsLevel::Partition);
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelCreateLowerCase) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTable` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (metrics_level = "table");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto describe = session.DescribeTable("/Root/MetricsTable").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+        const auto metrics = describe.GetTableDescription().GetMetricsSettings();
+        UNIT_ASSERT(metrics.has_value());
+        UNIT_ASSERT(metrics->GetMetricsLevel() == TMetricsSettings::EMetricsLevel::Table);
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelAlterSetAndReset) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto create = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTable` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            );
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(create.GetStatus(), EStatus::SUCCESS, create.GetIssues().ToString());
+
+        // ALTER TABLE whose only action is METRICS_LEVEL must succeed
+        // (regression check for GetAlterOperationKinds).
+        auto alterSet = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/MetricsTable` SET (METRICS_LEVEL = "PARTITION");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(alterSet.GetStatus(), EStatus::SUCCESS, alterSet.GetIssues().ToString());
+
+        {
+            auto describe = session.DescribeTable("/Root/MetricsTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            const auto metrics = describe.GetTableDescription().GetMetricsSettings();
+            UNIT_ASSERT(metrics.has_value());
+            UNIT_ASSERT(metrics->GetMetricsLevel() == TMetricsSettings::EMetricsLevel::Partition);
+        }
+
+        auto alterReset = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/MetricsTable` RESET (METRICS_LEVEL);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(alterReset.GetStatus(), EStatus::SUCCESS, alterReset.GetIssues().ToString());
+
+        {
+            auto describe = session.DescribeTable("/Root/MetricsTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            UNIT_ASSERT(!describe.GetTableDescription().GetMetricsSettings().has_value());
+        }
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelAlterSetDatabase) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto create = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsTable` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            );
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(create.GetStatus(), EStatus::SUCCESS, create.GetIssues().ToString());
+
+        // DATABASE has no dedicated SchemeShard enum value: it clears the setting,
+        // same as RESET.
+        auto alter = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/MetricsTable` SET (METRICS_LEVEL = "DATABASE");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(alter.GetStatus(), EStatus::SUCCESS, alter.GetIssues().ToString());
+
+        auto describe = session.DescribeTable("/Root/MetricsTable").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+        UNIT_ASSERT(!describe.GetTableDescription().GetMetricsSettings().has_value());
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelInvalidValue) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // Unknown name: reaches ParseMetricsLevel and is rejected there.
+        auto badSymbol = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsBadSymbol` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = "NOPE");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(badSymbol.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(badSymbol.GetIssues().ToString(),
+            "METRICS_LEVEL is invalid: NOPE");
+
+        auto badNumeric = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsBadNumeric` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = 9);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(badNumeric.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(badNumeric.GetIssues().ToString(),
+            "METRICS_LEVEL is invalid: 9");
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelDisabledRejected) {
+        // DISABLED is not part of the accepted set at the SQL layer, neither by
+        // literal nor by its spec number 0.
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto createSymbolic = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsDisabledSymbolic` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = "DISABLED");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(createSymbolic.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(createSymbolic.GetIssues().ToString(),
+            "METRICS_LEVEL is invalid: DISABLED");
+
+        auto createNumeric = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsDisabledNumeric` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = 0);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(createNumeric.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(createNumeric.GetIssues().ToString(),
+            "METRICS_LEVEL is invalid: 0");
+
+        auto create = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsDisabledAlter` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = "TABLE");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(create.GetStatus(), EStatus::SUCCESS, create.GetIssues().ToString());
+
+        auto alter = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/MetricsDisabledAlter` SET (METRICS_LEVEL = "DISABLED");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(alter.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(alter.GetIssues().ToString(),
+            "METRICS_LEVEL is invalid: DISABLED");
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelFeatureFlagOff) {
+        // EnableDataShardDetailedMetrics defaults to false.
+        // CREATE is rejected in type annotation, ALTER/RESET in exec: the two paths
+        // word the tail differently, so the assertions match only the shared prefix.
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto create = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsFlagOff` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (METRICS_LEVEL = "TABLE");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(create.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(create.GetIssues().ToString(),
+            "METRICS_LEVEL is not supported: EnableDataShardDetailedMetrics");
+
+        auto createNoMetrics = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsFlagOff` (
+                Key Uint64,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            );
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(createNoMetrics.GetStatus(), EStatus::SUCCESS, createNoMetrics.GetIssues().ToString());
+
+        auto alter = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/MetricsFlagOff` SET (METRICS_LEVEL = "TABLE");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(alter.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(alter.GetIssues().ToString(),
+            "METRICS_LEVEL is not supported: EnableDataShardDetailedMetrics");
+
+        auto reset = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `/Root/MetricsFlagOff` RESET (METRICS_LEVEL);
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(reset.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(reset.GetIssues().ToString(),
+            "METRICS_LEVEL is not supported: EnableDataShardDetailedMetrics");
+    }
+
+    Y_UNIT_TEST(TableMetricsLevelColumnTableRejected) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/MetricsColumnTable` (
+                Key Uint64 NOT NULL,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            )
+            WITH (STORE = COLUMN, METRICS_LEVEL = "TABLE");
+        )").ExtractValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "METRICS_LEVEL is not supported for column tables");
+    }
+
+
     Y_UNIT_TEST(ColumnTableMultiColumnStatisticsWithoutWithMeansAllTypes) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableColumnStatistics(true);
@@ -12628,6 +12967,30 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             const auto query = R"(
                 --!syntax_v1
+                ALTER TOPIC `/Root/topic` SET (metrics_level = "TOPIC")
+            )";
+            const auto result = executeQuery(query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                --!syntax_v1
+                ALTER TOPIC `/Root/topic` SET (metrics_level = "PARTITION")
+            )";
+            const auto result = executeQuery(query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                --!syntax_v1
+                ALTER TOPIC `/Root/topic` SET (metrics_level = "database")
+            )";
+            const auto result = executeQuery(query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                --!syntax_v1
                 CREATE TOPIC `/Root/topic1` (
                     CONSUMER cs WITH (type='streaming', keep_messages_order=true)
                 )
@@ -12871,6 +13234,9 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
         // bad
         {
+            // Empty string is screened by the translator, so the message comes from there
+            // rather than from ParseTopicMetricsLevel. Asserted on the same substring the
+            // pre-existing test used, which the translator's wording still contains.
             const auto query = R"(
                 --!syntax_v1
                 CREATE TOPIC `/Root/topic` WITH (metrics_level = "")
@@ -12878,6 +13244,15 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             const auto result = executeQuery(query);
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "METRICS_LEVEL value should be an integer", result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                --!syntax_v1
+                CREATE TOPIC `/Root/topic` WITH (metrics_level = "NOPE")
+            )";
+            const auto result = executeQuery(query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "METRICS_LEVEL is invalid: NOPE", result.GetIssues().ToString());
         }
     }
 

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -16,6 +16,7 @@
 #include <ydb/core/protos/kqp_physical.pb.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/protos/sys_view_types.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/scheme/protos/type_info.pb.h>
 #include <ydb/core/scheme/scheme_pathid.h>
@@ -66,7 +67,9 @@ THashSet<EAlterOperationKind> GetAlterOperationKinds(const Ydb::Table::AlterTabl
         req->has_alter_partitioning_settings() ||
         req->set_key_bloom_filter() != Ydb::FeatureFlag::STATUS_UNSPECIFIED ||
         req->has_set_read_replicas_settings() ||
-        req->add_statistics_size() || req->drop_statistics_size())
+        req->add_statistics_size() || req->drop_statistics_size() ||
+        req->metrics_settings_action_case() !=
+            Ydb::Table::AlterTableRequest::METRICS_SETTINGS_ACTION_NOT_SET)
     {
         ops.emplace(EAlterOperationKind::Common);
     }
@@ -2811,6 +2814,27 @@ void FillReadReplicasSettings(Ydb::Table::CreateTableRequest& out,
 void FillReadReplicasSettings(Ydb::Table::GlobalIndexSettings& out,
     const NKikimrSchemeOp::TTableDescription& in) {
     FillReadReplicasSettingsImpl(out, in);
+}
+
+void FillMetricsSettings(Ydb::Table::DescribeTableResult& out,
+        const NKikimrSchemeOp::TTableDescription& in) {
+    if (!in.HasDetailedMetricsSettings() || !in.GetDetailedMetricsSettings().HasConfigured()) {
+        return;
+    }
+
+    switch (in.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel()) {
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled:
+        out.mutable_metrics_settings()->set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED);
+        break;
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable:
+        out.mutable_metrics_settings()->set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE);
+        break;
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition:
+        out.mutable_metrics_settings()->set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION);
+        break;
+    default:
+        break;
+    }
 }
 
 bool FillTableDescription(NKikimrSchemeOp::TModifyScheme& out,

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -184,6 +184,10 @@ void FillReadReplicasSettings(Ydb::Table::CreateTableRequest& out,
 void FillReadReplicasSettings(Ydb::Table::GlobalIndexSettings& out,
     const NKikimrSchemeOp::TTableDescription& in);
 
+// out
+void FillMetricsSettings(Ydb::Table::DescribeTableResult& out,
+    const NKikimrSchemeOp::TTableDescription& in);
+
 // in
 bool FillTableDescription(NKikimrSchemeOp::TModifyScheme& out,
     const Ydb::Table::CreateTableRequest& in, const TTableProfiles& profiles,

--- a/ydb/core/ydb_convert/table_settings.cpp
+++ b/ydb/core/ydb_convert/table_settings.cpp
@@ -4,6 +4,7 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/follower_group.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 
 #include <ydb/library/conclusion/status.h>
 
@@ -30,6 +31,27 @@ namespace {
             return proto.partition_at_keys().split_points().size() + 1;
         default:
             return defaultMinPartitions;
+        }
+    }
+
+    void FillDetailedMetricsSettings(NKikimrSchemeOp::TTableDetailedMetricsSettings& out,
+        Ydb::Table::MetricsSettings::MetricsLevel level)
+    {
+        switch (level) {
+        case Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED:
+            out.MutableConfigured()->SetMetricsLevel(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled);
+            break;
+        case Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE:
+            out.MutableConfigured()->SetMetricsLevel(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable);
+            break;
+        case Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION:
+            out.MutableConfigured()->SetMetricsLevel(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition);
+            break;
+        case Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE:
+        case Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED:
+        default:
+            out.MutableNotConfigured();
+            break;
         }
     }
 }
@@ -238,6 +260,10 @@ bool FillCreateTableSettingsDesc(NKikimrSchemeOp::TTableDescription& tableDesc,
         }
     }
 
+    if (proto.has_metrics_settings()) {
+        FillDetailedMetricsSettings(*tableDesc.MutableDetailedMetricsSettings(), proto.metrics_settings().metrics_level());
+    }
+
     tableDesc.SetTemporary(proto.Gettemporary());
 
     return true;
@@ -289,7 +315,13 @@ bool FillCreateTableSettingsDesc(NKikimrSchemeOp::TColumnTableDescription& table
         error = "Storage settings are not supported";
         return false;
     }
-    
+
+    if (proto.has_metrics_settings()) {
+        code = Ydb::StatusIds::BAD_REQUEST;
+        error = "Metrics settings are not supported";
+        return false;
+    }
+
     tableDesc.SetTemporary(proto.temporary());
 
     return true;
@@ -440,6 +472,14 @@ bool FillAlterTableSettingsDesc(NKikimrSchemeOp::TTableDescription& tableDesc,
         }
     } else if (proto.has_drop_ttl_settings()) {
         tableDesc.MutableTTLSettings()->MutableDisabled();
+    }
+
+    if (proto.has_set_metrics_settings()) {
+        FillDetailedMetricsSettings(*tableDesc.MutableDetailedMetricsSettings(), proto.set_metrics_settings().metrics_level());
+        changed = true;
+    } else if (proto.has_drop_metrics_settings()) {
+        tableDesc.MutableDetailedMetricsSettings()->MutableNotConfigured();
+        changed = true;
     }
 
     if (!changed && !hadPartitionConfig) {


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

Public surface for detailed metrics support: YQL ALTER and table describe
Only DATABASE/TABLE/PARTITION levels are surfaced meaning DB-defined (which in turn can be DISABLED/TABLE/PARTITION), table (table reports its own datashard metrics), partition (table reports its own datashard metrics for each tablet and each follower tablet)

https://nda.ya.ru/t/VWak_dXn7oNoEu — is available for details