### PR TITLE
docs: add virtual group decommissioning to EN overview

### DIFF
--- a/ydb/docs/en/core/maintenance/manual/index.md
+++ b/ydb/docs/en/core/maintenance/manual/index.md
@@ -14,6 +14,7 @@ Main topics:
 * [{#T}](scrubbing.md)
 * [{#T}](disk_end_space.md)
 * [{#T}](../../devops/deployment-options/manual/decommissioning.md)
+* [{#T}](virtual_storage_groups_decommit.md)
 * [{#T}](failure_model.md)
 * [{#T}](node_restarting.md)
 * [{#T}](dynamic-config.md)


### PR DESCRIPTION
### Motivation

`virtual_storage_groups_decommit.md` is already reachable from both RU and EN maintenance TOCs and is listed in the RU maintenance overview. The EN overview omits it, so the overview pages are asymmetric and EN readers do not see this operation in the section summary.

### Changes

- Add the existing `virtual_storage_groups_decommit.md` article to the EN maintenance overview.
- No files or TOC entries are moved or deleted.

### Safety proof

- The target page exists and is already reachable through the EN maintenance TOC.
- This PR changes only one overview link.
- The branch is rebased onto the current `main`.
- `git diff --check` passes.
