### PR TITLE
docs: align parent maintenance TOCs

### DIFF
--- a/ydb/docs/en/core/maintenance/toc_i.yaml
+++ b/ydb/docs/en/core/maintenance/toc_i.yaml
@@ -1,6 +1,6 @@
 items:
 - name: Backups
-  href: backup_and_recovery.md
+  href: ../devops/backup-and-recovery/index.md
 - name: Diagnostics
   include: { mode: link, path: ../troubleshooting/toc_p.yaml }
 - name: Cluster maintenance
@@ -12,6 +12,6 @@ items:
   - name: Changing an actor system's configuration
     href: manual/change_actorsystem_configs.md
   - name: Maintenance without downtime
-    href: manual/maintenance-without-downtime.md
+    href: ../devops/concepts/maintenance-without-downtime.md
   - name: Updating configurations via CMS
     href: manual/cms.md

--- a/ydb/docs/redirects.yaml
+++ b/ydb/docs/redirects.yaml
@@ -126,6 +126,8 @@ common:
     to: /devops/configuration-management/configuration-v1/dynamic-config-volatile-config.md
   - from: /maintenance/manual/cms.md
     to: /devops/configuration-management/configuration-v1/cms.md
+  - from: /maintenance/manual/maintenance-without-downtime.md
+    to: /devops/concepts/maintenance-without-downtime.md
   - from: /devops/manual/upgrade.md
     to: /devops/deployment-options/manual/update-executable.md
   - from: /devops/manual/backup-and-recovery.md

--- a/ydb/docs/ru/core/maintenance/toc_i.yaml
+++ b/ydb/docs/ru/core/maintenance/toc_i.yaml
@@ -1,7 +1,17 @@
 items:
+- name: Резервное копирование
+  href: ../devops/backup-and-recovery/index.md
 - name: Диагностика
   include: { mode: link, path: ../troubleshooting/toc_p.yaml }
 - name: Обслуживание кластера
   items:
   - name: "{{ ydb-ui-name }}"
     include: { mode: link, path: ../reference/ydb-ui/toc_p.yaml }
+  - name: Управление дисковой подсистемой кластера
+    include: { mode: link, path: manual/toc_p.yaml }
+  - name: Изменение конфигурации актор-системы
+    href: ../devops/configuration-management/configuration-v1/change_actorsystem_configs.md
+  - name: Обслуживание без простоя
+    href: ../devops/concepts/maintenance-without-downtime.md
+  - name: Изменение конфигураций через CMS
+    href: ../devops/configuration-management/configuration-v1/cms.md


### PR DESCRIPTION
### Motivation

The RU and EN parent maintenance TOCs describe the same documentation section but currently expose different subsections. The EN Backups and Maintenance without downtime entries also point to legacy locations instead of their canonical pages.

### Changes

- Retarget the EN Backups entry to `devops/backup-and-recovery/index.md`.
- Retarget the EN Maintenance without downtime entry to `devops/concepts/maintenance-without-downtime.md`.
- Add a redirect from the retired `/maintenance/manual/maintenance-without-downtime.md` URL to the canonical page.
- Add the corresponding Backups, disk-subsystem, actor-system configuration, maintenance-without-downtime, and CMS entries to the RU parent TOC.
- Preserve the `{{ ydb-ui-name }}` entry added to RU `main`; it is not changed by this PR.

### Safety proof

- Every added or retargeted page exists and is reachable from its canonical section TOC.
- The old Maintenance without downtime URL continues to resolve through the new common redirect.
- No page is deleted in this PR.
- The branch is rebased onto the current `main`.
- `git diff --check` passes.

### Merge dependency

PRs #50850 and #50851 retarget the remaining EN actor-system and CMS entries. Merge them before this PR, then rebase this PR once more so the final RU and EN parent structures can be reviewed together without overlapping edits.
