### PR TITLE
[NBS-7572] Batch persisting VChunkConfig changes and Ahead-behind fields changes

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -301,7 +301,7 @@ size_t TBaseFixture::ReplyUpdateRequests()
 {
     auto requests = std::move(PartitionDirectService->UpdateConfigRequests);
     for (auto& r: requests) {
-        r.Promise.SetValue();
+        r.Promise.SetValue(EPersistResult::Success);
     }
     return requests.size();
 }
@@ -311,7 +311,7 @@ size_t TBaseFixture::ReplyUpdateDirtyMapStateRequests()
     auto requests =
         std::move(PartitionDirectService->UpdateDirtyMapStateRequests);
     for (auto& r: requests) {
-        r.Promise.SetValue();
+        r.Promise.SetValue(EPersistResult::Success);
     }
     return requests.size();
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/delete_partition.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/delete_partition.cpp
@@ -256,7 +256,21 @@ void TPartitionActor::HandleUpdateVChunkConfigDuringDelete(
         LogTitle.GetWithTime().c_str(),
         ev->Get()->VChunkConfig.DebugPrint().c_str());
 
-    ev->Get()->UpdateCompleted.SetValue();
+    ev->Get()->UpdateCompleted.SetValue(EPersistResult::Cancelled);
+}
+
+void TPartitionActor::HandleUpdateDirtyMapStateDuringDelete(
+    const TEvPartitionDirectPrivate::TEvUpdateDirtyMapState::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        NKikimrServices::NBS_PARTITION,
+        "%s Drop UpdateDirtyMapState during delete: vchunk %u",
+        LogTitle.GetWithTime().c_str(),
+        ev->Get()->VChunkIndex);
+
+    ev->Get()->UpdateCompleted.SetValue(EPersistResult::Cancelled);
 }
 
 // Ignore fast path service shutdown during delete
@@ -331,6 +345,9 @@ STFUNC(TPartitionActor::StateDelete)
         HFunc(
             TEvPartitionDirectPrivate::TEvUpdateVChunkConfig,
             HandleUpdateVChunkConfigDuringDelete);
+        HFunc(
+            TEvPartitionDirectPrivate::TEvUpdateDirtyMapState,
+            HandleUpdateDirtyMapStateDuringDelete);
         // Ignore fast path service shutdown during delete
         HFunc(
             TEvPartitionDirectPrivate::TEvFastPathServiceShutdown,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -248,7 +248,7 @@ size_t TDBGFixture::ReplyUpdateRequests()
 {
     auto requests = std::move(Service->UpdateConfigRequests);
     for (auto& r: requests) {
-        r.Promise.SetValue();
+        r.Promise.SetValue(EPersistResult::Success);
     }
     return requests.size();
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -399,7 +399,7 @@ void TFastPathService::ScheduleAfterDelay(
         std::move(callback));
 }
 
-NThreading::TFuture<void> TFastPathService::UpdateVChunkConfig(
+TPersistResultFuture TFastPathService::UpdateVChunkConfig(
     const TVChunkConfig& cfg)
 {
     auto event =
@@ -409,7 +409,7 @@ NThreading::TFuture<void> TFastPathService::UpdateVChunkConfig(
     return result;
 }
 
-NThreading::TFuture<void> TFastPathService::UpdateDirtyMapState(
+TPersistResultFuture TFastPathService::UpdateDirtyMapState(
     ui32 vChunkIndex,
     TDirtyMapStateProto state)
 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -121,10 +121,9 @@ public:
         TDuration delay,
         NYdb::NBS::TCallback callback) override;
 
-    NThreading::TFuture<void> UpdateVChunkConfig(
-        const TVChunkConfig& cfg) override;
+    TPersistResultFuture UpdateVChunkConfig(const TVChunkConfig& cfg) override;
 
-    NThreading::TFuture<void> UpdateDirtyMapState(
+    TPersistResultFuture UpdateDirtyMapState(
         ui32 vChunkIndex,
         TDirtyMapStateProto state) override;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "partition_direct_service.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
@@ -121,7 +123,7 @@ struct TTxPartition
         struct TUpdateConfigRequest
         {
             TVChunkConfig VChunkConfig;
-            NThreading::TPromise<void> UpdateCompleted;
+            TPersistResultPromise UpdateCompleted;
         };
 
         using TUpdateConfigRequests = TVector<TUpdateConfigRequest>;
@@ -147,7 +149,7 @@ struct TTxPartition
         {
             ui32 VChunkIndex;
             TDirtyMapStateProto State;
-            NThreading::TPromise<void> UpdateCompleted;
+            TPersistResultPromise UpdateCompleted;
         };
 
         using TUpdateStateRequests = TVector<TUpdateStateRequest>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -139,17 +139,19 @@ struct TTxPartition
     //
     struct TUpdateDirtyMapState
     {
-        const ui32 VChunkIndex;
-        const TDirtyMapStateProto State;
-        NThreading::TPromise<void> UpdateCompleted;
+        struct TUpdateStateRequest
+        {
+            ui32 VChunkIndex;
+            TDirtyMapStateProto State;
+            NThreading::TPromise<void> UpdateCompleted;
+        };
 
-        TUpdateDirtyMapState(
-            ui32 vChunkIndex,
-            TDirtyMapStateProto state,
-            NThreading::TPromise<void> updateCompleted)
-            : VChunkIndex(vChunkIndex)
-            , State(std::move(state))
-            , UpdateCompleted(std::move(updateCompleted))
+        using TUpdateStateRequests = TVector<TUpdateStateRequest>;
+
+        TUpdateStateRequests UpdateStateRequests;
+
+        explicit TUpdateDirtyMapState(TUpdateStateRequests updateStateRequests)
+            : UpdateStateRequests(std::move(updateStateRequests))
         {}
 
         void Clear()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -118,14 +118,18 @@ struct TTxPartition
     //
     struct TUpdateVChunkConfig
     {
-        const TVChunkConfig VChunkConfig;
-        NThreading::TPromise<void> UpdateCompleted;
+        struct TUpdateConfigRequest
+        {
+            TVChunkConfig VChunkConfig;
+            NThreading::TPromise<void> UpdateCompleted;
+        };
 
-        explicit TUpdateVChunkConfig(
-            TVChunkConfig vChunkConfig,
-            NThreading::TPromise<void> updateCompleted)
-            : VChunkConfig(std::move(vChunkConfig))
-            , UpdateCompleted(std::move(updateCompleted))
+        using TUpdateConfigRequests = TVector<TUpdateConfigRequest>;
+
+        TUpdateConfigRequests UpdateConfigRequests;
+
+        explicit TUpdateVChunkConfig(TUpdateConfigRequests updateConfigRequests)
+            : UpdateConfigRequests(std::move(updateConfigRequests))
         {}
 
         void Clear()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
@@ -17,7 +17,13 @@ bool TPartitionActor::PrepareUpdateDirtyMapState(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(tx);
-    Y_UNUSED(args);
+
+    Y_DEBUG_ABORT_UNLESS(ExecutingUpdateDirtyMapStatePromises.empty());
+    ExecutingUpdateDirtyMapStatePromises.reserve(
+        args.UpdateStateRequests.size());
+    for (const auto& request: args.UpdateStateRequests) {
+        ExecutingUpdateDirtyMapStatePromises.push_back(request.UpdateCompleted);
+    }
 
     return true;
 }
@@ -40,15 +46,16 @@ void TPartitionActor::CompleteUpdateDirtyMapState(
     TTxPartition::TUpdateDirtyMapState& args)
 {
     for (auto& request: args.UpdateStateRequests) {
-        request.UpdateCompleted.SetValue();
+        request.UpdateCompleted.TrySetValue(EPersistResult::Success);
     }
+    ExecutingUpdateDirtyMapStatePromises.clear();
     ExecutingUpdateDirtyMapState = false;
 
     if (!PendingUpdateDirtyMapStateRequests.empty()) {
         LOG_INFO(
             ctx,
             NKikimrServices::NBS_PARTITION,
-            "%s Execute pending UpdateDirtyMapStateRequests %lu",
+            "%s Execute pending UpdateDirtyMapStateRequests %zu",
             LogTitle.GetWithTime().c_str(),
             PendingUpdateDirtyMapStateRequests.size());
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatedirtymapstate.cpp
@@ -30,16 +30,34 @@ void TPartitionActor::ExecuteUpdateDirtyMapState(
     Y_UNUSED(ctx);
 
     TPartitionDatabase db(tx.DB);
-    db.StoreDirtyMapState(args.VChunkIndex, args.State);
+    for (const auto& request: args.UpdateStateRequests) {
+        db.StoreDirtyMapState(request.VChunkIndex, request.State);
+    }
 }
 
 void TPartitionActor::CompleteUpdateDirtyMapState(
     const TActorContext& ctx,
     TTxPartition::TUpdateDirtyMapState& args)
 {
-    Y_UNUSED(ctx);
+    for (auto& request: args.UpdateStateRequests) {
+        request.UpdateCompleted.SetValue();
+    }
+    ExecutingUpdateDirtyMapState = false;
 
-    args.UpdateCompleted.SetValue();
+    if (!PendingUpdateDirtyMapStateRequests.empty()) {
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Execute pending UpdateDirtyMapStateRequests %lu",
+            LogTitle.GetWithTime().c_str(),
+            PendingUpdateDirtyMapStateRequests.size());
+
+        ExecutingUpdateDirtyMapState = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateDirtyMapState>(
+                std::move(PendingUpdateDirtyMapStateRequests)));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
@@ -30,16 +30,34 @@ void TPartitionActor::ExecuteUpdateVChunkConfig(
     Y_UNUSED(ctx);
 
     TPartitionDatabase db(tx.DB);
-    db.StoreVChunkConfig(args.VChunkConfig);
+    for (const auto& request: args.UpdateConfigRequests) {
+        db.StoreVChunkConfig(request.VChunkConfig);
+    }
 }
 
 void TPartitionActor::CompleteUpdateVChunkConfig(
     const TActorContext& ctx,
     TTxPartition::TUpdateVChunkConfig& args)
 {
-    Y_UNUSED(ctx);
+    for (auto& request: args.UpdateConfigRequests) {
+        request.UpdateCompleted.SetValue();
+    }
+    ExecutingUpdateVChunkConfig = false;
 
-    args.UpdateCompleted.SetValue();
+    if (!PendingUpdateVChunkConfigRequests.empty()) {
+        LOG_INFO(
+            ctx,
+            NKikimrServices::NBS_PARTITION,
+            "%s Execute pending UpdateVChunkConfigRequests %lu",
+            LogTitle.GetWithTime().c_str(),
+            PendingUpdateVChunkConfigRequests.size());
+
+        ExecutingUpdateVChunkConfig = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateVChunkConfig>(
+                std::move(PendingUpdateVChunkConfigRequests)));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
@@ -17,7 +17,13 @@ bool TPartitionActor::PrepareUpdateVChunkConfig(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(tx);
-    Y_UNUSED(args);
+
+    Y_DEBUG_ABORT_UNLESS(ExecutingUpdateVChunkConfigPromises.empty());
+    ExecutingUpdateVChunkConfigPromises.reserve(
+        args.UpdateConfigRequests.size());
+    for (const auto& request: args.UpdateConfigRequests) {
+        ExecutingUpdateVChunkConfigPromises.push_back(request.UpdateCompleted);
+    }
 
     return true;
 }
@@ -40,15 +46,16 @@ void TPartitionActor::CompleteUpdateVChunkConfig(
     TTxPartition::TUpdateVChunkConfig& args)
 {
     for (auto& request: args.UpdateConfigRequests) {
-        request.UpdateCompleted.SetValue();
+        request.UpdateCompleted.TrySetValue(EPersistResult::Success);
     }
+    ExecutingUpdateVChunkConfigPromises.clear();
     ExecutingUpdateVChunkConfig = false;
 
     if (!PendingUpdateVChunkConfigRequests.empty()) {
         LOG_INFO(
             ctx,
             NKikimrServices::NBS_PARTITION,
-            "%s Execute pending UpdateVChunkConfigRequests %lu",
+            "%s Execute pending UpdateVChunkConfigRequests %zu",
             LogTitle.GetWithTime().c_str(),
             PendingUpdateVChunkConfigRequests.size());
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -698,15 +698,26 @@ void TPartitionActor::HandleUpdateVChunkConfig(
     LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
-        "%s Handle UpdateVChunkConfig %s",
+        "%s Handle UpdateVChunkConfig %s %s",
         LogTitle.GetWithTime().c_str(),
-        msg->VChunkConfig.DebugPrint().c_str());
+        msg->VChunkConfig.DebugPrint().c_str(),
+        ExecutingUpdateVChunkConfig ? "later" : "now");
 
-    ExecuteTx(
-        ctx,
-        CreateTx<TUpdateVChunkConfig>(
-            std::move(msg->VChunkConfig),
-            std::move(msg->UpdateCompleted)));
+    if (ExecutingUpdateVChunkConfig) {
+        PendingUpdateVChunkConfigRequests.push_back(
+            {.VChunkConfig = std::move(msg->VChunkConfig),
+             .UpdateCompleted = std::move(msg->UpdateCompleted)});
+    } else {
+        Y_DEBUG_ABORT_UNLESS(PendingUpdateVChunkConfigRequests.empty());
+
+        ExecutingUpdateVChunkConfig = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateVChunkConfig>(
+                TTxPartition::TUpdateVChunkConfig::TUpdateConfigRequests{
+                    {.VChunkConfig = std::move(msg->VChunkConfig),
+                     .UpdateCompleted = std::move(msg->UpdateCompleted)}}));
+    }
 }
 
 void TPartitionActor::HandleUpdateDirtyMapState(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -148,9 +148,46 @@ void TPartitionActor::CleanupResources(const TActorContext& ctx)
 
     GetNbsService()->VhostServer->DetachStorage(GetSocketPath());
 
+    // It is assumed that the transaction to the local database is always
+    // successful. If the Tablet finishes its work, then it is necessary to
+    // respond to all pending requests so that there are no leakage resources.
+    // We will do this after the initiator of the request is stopped.
+    auto failUpdateRequests =
+        [executingConfigPromises =
+             std::move(ExecutingUpdateVChunkConfigPromises),
+         pendingConfigRequests = std::move(PendingUpdateVChunkConfigRequests),
+         executingDirtyMapPromises =
+             std::move(ExecutingUpdateDirtyMapStatePromises),
+         pendingDirtyMapRequests =
+             std::move(PendingUpdateDirtyMapStateRequests)]() mutable
+    {
+        for (auto& promise: executingConfigPromises) {
+            promise.TrySetValue(EPersistResult::Cancelled);
+        }
+        for (auto& req: pendingConfigRequests) {
+            req.UpdateCompleted.TrySetValue(EPersistResult::Cancelled);
+        }
+
+        for (auto& promise: executingDirtyMapPromises) {
+            promise.TrySetValue(EPersistResult::Cancelled);
+        }
+        for (auto& req: pendingDirtyMapRequests) {
+            req.UpdateCompleted.TrySetValue(EPersistResult::Cancelled);
+        }
+    };
+
     if (FastPathService) {
-        FastPathService->Stop();
+        auto onStop = FastPathService->Stop();
+        onStop.Subscribe(
+            [failUpdateRequests = std::move(failUpdateRequests)](
+                const NThreading::TFuture<void>& stopFuture) mutable
+            {
+                Y_UNUSED(stopFuture);
+                failUpdateRequests();
+            });
         FastPathService.reset();
+    } else {
+        failUpdateRequests();
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -718,16 +718,28 @@ void TPartitionActor::HandleUpdateDirtyMapState(
     LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
-        "%s Handle UpdateDirtyMapState vchunk %u",
+        "%s Handle UpdateDirtyMapState vchunk %u %s",
         LogTitle.GetWithTime().c_str(),
-        msg->VChunkIndex);
+        msg->VChunkIndex,
+        ExecutingUpdateDirtyMapState ? "later" : "now");
 
-    ExecuteTx(
-        ctx,
-        CreateTx<TUpdateDirtyMapState>(
-            msg->VChunkIndex,
-            std::move(msg->State),
-            std::move(msg->UpdateCompleted)));
+    if (ExecutingUpdateDirtyMapState) {
+        PendingUpdateDirtyMapStateRequests.push_back(
+            {.VChunkIndex = msg->VChunkIndex,
+             .State = std::move(msg->State),
+             .UpdateCompleted = std::move(msg->UpdateCompleted)});
+    } else {
+        Y_DEBUG_ABORT_UNLESS(PendingUpdateDirtyMapStateRequests.empty());
+
+        ExecutingUpdateDirtyMapState = true;
+        ExecuteTx(
+            ctx,
+            CreateTx<TUpdateDirtyMapState>(
+                TTxPartition::TUpdateDirtyMapState::TUpdateStateRequests{
+                    {.VChunkIndex = msg->VChunkIndex,
+                     .State = std::move(msg->State),
+                     .UpdateCompleted = std::move(msg->UpdateCompleted)}}));
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -80,6 +80,11 @@ private:
     // At most one add-host runs at a time across the whole partition.
     std::optional<TAddHostInFlight> AddHostInFlight;
 
+    // Batch persisting of vchunk configs.
+    bool ExecutingUpdateVChunkConfig = false;
+    TTxPartition::TUpdateVChunkConfig::TUpdateConfigRequests
+        PendingUpdateVChunkConfigRequests;
+
     // Batch persisting of ahead and behind fields.
     bool ExecutingUpdateDirtyMapState = false;
     TTxPartition::TUpdateDirtyMapState::TUpdateStateRequests

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -82,11 +82,13 @@ private:
 
     // Batch persisting of vchunk configs.
     bool ExecutingUpdateVChunkConfig = false;
+    TVector<TPersistResultPromise> ExecutingUpdateVChunkConfigPromises;
     TTxPartition::TUpdateVChunkConfig::TUpdateConfigRequests
         PendingUpdateVChunkConfigRequests;
 
     // Batch persisting of ahead and behind fields.
     bool ExecutingUpdateDirtyMapState = false;
+    TVector<TPersistResultPromise> ExecutingUpdateDirtyMapStatePromises;
     TTxPartition::TUpdateDirtyMapState::TUpdateStateRequests
         PendingUpdateDirtyMapStateRequests;
 
@@ -236,6 +238,10 @@ private:
 
     void HandleUpdateVChunkConfigDuringDelete(
         const TEvPartitionDirectPrivate::TEvUpdateVChunkConfig::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUpdateDirtyMapStateDuringDelete(
+        const TEvPartitionDirectPrivate::TEvUpdateDirtyMapState::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleFastPathServiceShutdownDuringDelete(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -80,6 +80,11 @@ private:
     // At most one add-host runs at a time across the whole partition.
     std::optional<TAddHostInFlight> AddHostInFlight;
 
+    // Batch persisting of ahead and behind fields.
+    bool ExecutingUpdateDirtyMapState = false;
+    TTxPartition::TUpdateDirtyMapState::TUpdateStateRequests
+        PendingUpdateDirtyMapStateRequests;
+
 public:
     TPartitionActor(
         const NActors::TActorId& tablet,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "partition_direct_service.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/public.h>
@@ -48,7 +50,8 @@ struct TEvPartitionDirectPrivate
               TEventLocal<TEvUpdateVChunkConfig, EvUpdateVChunkConfig>
     {
         TVChunkConfig VChunkConfig;
-        NThreading::TPromise<void> UpdateCompleted = NThreading::NewPromise();
+        TPersistResultPromise UpdateCompleted =
+            NThreading::NewPromise<EPersistResult>();
 
         explicit TEvUpdateVChunkConfig(TVChunkConfig cfg)
             : VChunkConfig(std::move(cfg))
@@ -61,7 +64,8 @@ struct TEvPartitionDirectPrivate
     {
         ui32 VChunkIndex;
         TDirtyMapStateProto State;
-        NThreading::TPromise<void> UpdateCompleted = NThreading::NewPromise();
+        TPersistResultPromise UpdateCompleted =
+            NThreading::NewPromise<EPersistResult>();
 
         TEvUpdateDirtyMapState(ui32 vChunkIndex, TDirtyMapStateProto state)
             : VChunkIndex(vChunkIndex)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
@@ -19,6 +19,18 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Result of an asynchronous request to persist partition state.
+// Cancelled means the partition stopped before it could confirm completion.
+enum class EPersistResult
+{
+    Success,
+    Cancelled,
+};
+using TPersistResultFuture = NThreading::TFuture<EPersistResult>;
+using TPersistResultPromise = NThreading::TPromise<EPersistResult>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct IPartitionDirectService
 {
     virtual ~IPartitionDirectService() = default;
@@ -32,12 +44,12 @@ struct IPartitionDirectService
 
     // Asynchronously persists the given vchunk config to the partition's
     // local DB. Caller must ensure cfg.IsValid().
-    virtual NThreading::TFuture<void> UpdateVChunkConfig(
+    virtual TPersistResultFuture UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) = 0;
 
     // Asynchronously persists the given TDirtyMapStateProto to the partition's
     // local DB.
-    virtual NThreading::TFuture<void> UpdateDirtyMapState(
+    virtual TPersistResultFuture UpdateDirtyMapState(
         ui32 vChunkIndex,
         TDirtyMapStateProto state) = 0;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
@@ -24,14 +24,14 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
     struct TUpdateConfigRequest
     {
         NStorage::NPartitionDirect::TVChunkConfig Config;
-        NThreading::TPromise<void> Promise;
+        TPersistResultPromise Promise;
     };
 
     struct TUpdateDirtyMapStateRequest
     {
         ui32 VChunkIndex = 0;
         TDirtyMapStateProto Proto;
-        NThreading::TPromise<void> Promise;
+        TPersistResultPromise Promise;
     };
 
     explicit TPartitionDirectServiceMock(bool dropScheduledCallbacks = false)
@@ -64,21 +64,23 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
         executor->ExecuteSimple(std::move(callback));
     }
 
-    NThreading::TFuture<void> UpdateVChunkConfig(
+    TPersistResultFuture UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) override
     {
-        UpdateConfigRequests.emplace_back(cfg, NThreading::NewPromise());
+        UpdateConfigRequests.emplace_back(
+            cfg,
+            NThreading::NewPromise<EPersistResult>());
         return UpdateConfigRequests.back().Promise.GetFuture();
     }
 
-    NThreading::TFuture<void> UpdateDirtyMapState(
+    TPersistResultFuture UpdateDirtyMapState(
         ui32 vChunkIndex,
         TDirtyMapStateProto state) override
     {
         UpdateDirtyMapStateRequests.emplace_back(TUpdateDirtyMapStateRequest{
             .VChunkIndex = vChunkIndex,
             .Proto = std::move(state),
-            .Promise = NThreading::NewPromise()});
+            .Promise = NThreading::NewPromise<EPersistResult>()});
         return UpdateDirtyMapStateRequests.back().Promise.GetFuture();
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -191,7 +191,7 @@ ui64 CreatePartitionTablet(
     return PartitionTabletId;
 }
 
-NThreading::TFuture<void> SendVChunkConfigUpdate(
+TPersistResultFuture SendVChunkConfigUpdate(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
     ui32 vChunkIndex)
@@ -221,7 +221,7 @@ NThreading::TFuture<void> SendVChunkConfigUpdate(
     return future;
 }
 
-NThreading::TFuture<void> SendDirtyMapStateUpdate(
+TPersistResultFuture SendDirtyMapStateUpdate(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
     ui32 vChunkIndex,
@@ -1089,7 +1089,7 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
         UNIT_ASSERT(!first.HasValue());
 
-        TVector<NThreading::TFuture<void>> batched;
+        TVector<TPersistResultFuture> batched;
         batched.push_back(SendDirtyMapStateUpdate(env, partition, 1, 2));
         batched.push_back(SendDirtyMapStateUpdate(env, partition, 2, 3));
         batched.push_back(SendDirtyMapStateUpdate(env, partition, 3, 4));
@@ -1109,6 +1109,7 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         // stay unresolved until the common commit completes.
         UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
         UNIT_ASSERT(first.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, first.GetValue());
         for (const auto& future: batched) {
             UNIT_ASSERT(!future.HasValue());
         }
@@ -1118,6 +1119,9 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
         for (const auto& future: batched) {
             UNIT_ASSERT(future.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                EPersistResult::Success,
+                future.GetValue());
         }
 
         // Completion of a batch resets the in-flight state: a later update
@@ -1130,6 +1134,7 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         releaseCommit(2);
         env.Sim(TDuration::Seconds(1));
         UNIT_ASSERT(next.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, next.GetValue());
 
         runtime->FilterFunction = {};
     }
@@ -1178,7 +1183,7 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
         UNIT_ASSERT(!first.HasValue());
 
-        TVector<NThreading::TFuture<void>> batched;
+        TVector<TPersistResultFuture> batched;
         batched.push_back(SendVChunkConfigUpdate(env, partition, 1));
         batched.push_back(SendVChunkConfigUpdate(env, partition, 2));
         batched.push_back(SendVChunkConfigUpdate(env, partition, 3));
@@ -1194,6 +1199,7 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
 
         UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
         UNIT_ASSERT(first.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, first.GetValue());
         for (const auto& future: batched) {
             UNIT_ASSERT(!future.HasValue());
         }
@@ -1203,6 +1209,9 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
         for (const auto& future: batched) {
             UNIT_ASSERT(future.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                EPersistResult::Success,
+                future.GetValue());
         }
 
         auto next = SendVChunkConfigUpdate(env, partition, 4);
@@ -1213,6 +1222,89 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         releaseCommit(2);
         env.Sim(TDuration::Seconds(1));
         UNIT_ASSERT(next.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(EPersistResult::Success, next.GetValue());
+    }
+
+    Y_UNIT_TEST(ShouldFailStateUpdatesWhenPartitionStops)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        TActorId bootstrapperId;
+        const ui64 partition =
+            CreatePartitionTablet(env, 32768, &bootstrapperId);
+
+        TVector<std::unique_ptr<IEventHandle>> blockedCommitResults;
+        bool bootstrapperDeathObserved = false;
+        runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == TEvTablet::TEvCommitResult::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvCommitResult>();
+                if (msg->TabletID == partition) {
+                    blockedCommitResults.push_back(std::move(ev));
+                    return false;
+                }
+            }
+
+            if (ev->GetTypeRewrite() == TEvTablet::TEvTabletDead::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvTabletDead>();
+                if (msg->TabletID == partition &&
+                    ev->GetRecipientRewrite() == bootstrapperId)
+                {
+                    bootstrapperDeathObserved = true;
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto executingConfig = SendVChunkConfigUpdate(env, partition, 0);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommitResults.size());
+
+        auto pendingConfig = SendVChunkConfigUpdate(env, partition, 1);
+        auto executingDirtyMap = SendDirtyMapStateUpdate(env, partition, 0, 1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommitResults.size());
+
+        auto pendingDirtyMap = SendDirtyMapStateUpdate(env, partition, 1, 2);
+        env.Sim(TDuration::Seconds(1));
+
+        UNIT_ASSERT(!executingConfig.HasValue());
+        UNIT_ASSERT(!pendingConfig.HasValue());
+        UNIT_ASSERT(!executingDirtyMap.HasValue());
+        UNIT_ASSERT(!pendingDirtyMap.HasValue());
+
+        const TActorId sender = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+        runtime->SendToPipe(
+            partition,
+            sender,
+            new TEvPartitionDirectPrivate::TEvPoison("test shutdown"),
+            0,
+            TTestActorSystem::GetPipeConfigWithRetries());
+        runtime->DestroyActor(sender);
+
+        env.Sim(TDuration::Seconds(10));
+
+        UNIT_ASSERT(bootstrapperDeathObserved);
+        for (const auto& future:
+             {executingConfig,
+              pendingConfig,
+              executingDirtyMap,
+              pendingDirtyMap})
+        {
+            UNIT_ASSERT(future.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                EPersistResult::Cancelled,
+                future.GetValue());
+        }
     }
 
     Y_UNIT_TEST(BasicWriteReadPBufferReplication)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -191,6 +191,36 @@ ui64 CreatePartitionTablet(
     return PartitionTabletId;
 }
 
+NThreading::TFuture<void> SendVChunkConfigUpdate(
+    TEnvironmentSetup& env,
+    ui64 partitionTabletId,
+    ui32 vChunkIndex)
+{
+    auto config = TVChunkConfig::MakeDefault(
+        vChunkIndex,
+        DirectBlockGroupHostCount,
+        DefaultPrimaryCount);
+
+    auto request =
+        std::make_unique<TEvPartitionDirectPrivate::TEvUpdateVChunkConfig>(
+            std::move(config));
+    auto future = request->UpdateCompleted.GetFuture();
+
+    const TActorId sender = env.Runtime->AllocateEdgeActor(
+        env.Settings.ControllerNodeId,
+        __FILE__,
+        __LINE__);
+    env.Runtime->SendToPipe(
+        partitionTabletId,
+        sender,
+        request.release(),
+        0,
+        TTestActorSystem::GetPipeConfigWithRetries());
+    env.Runtime->DestroyActor(sender);
+
+    return future;
+}
+
 NThreading::TFuture<void> SendDirtyMapStateUpdate(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
@@ -1102,6 +1132,87 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT(next.HasValue());
 
         runtime->FilterFunction = {};
+    }
+
+    Y_UNIT_TEST(ShouldBatchVChunkConfigUpdates)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        const ui64 partition = CreatePartitionTablet(env);
+
+        TVector<std::unique_ptr<IEventHandle>> blockedCommits;
+        THashSet<ui32> releasedCommitSteps;
+        runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == TEvTablet::TEvCommit::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvCommit>();
+                if (msg->TabletID == partition &&
+                    !releasedCommitSteps.contains(msg->Step))
+                {
+                    blockedCommits.push_back(std::move(ev));
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto releaseCommit = [&](size_t index)
+        {
+            UNIT_ASSERT_C(
+                index < blockedCommits.size() && blockedCommits[index],
+                "commit is not blocked");
+            auto* msg = blockedCommits[index]->Get<TEvTablet::TEvCommit>();
+            releasedCommitSteps.insert(msg->Step);
+            runtime->Send(
+                std::move(blockedCommits[index]),
+                env.Settings.ControllerNodeId);
+        };
+
+        auto first = SendVChunkConfigUpdate(env, partition, 0);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        UNIT_ASSERT(!first.HasValue());
+
+        TVector<NThreading::TFuture<void>> batched;
+        batched.push_back(SendVChunkConfigUpdate(env, partition, 1));
+        batched.push_back(SendVChunkConfigUpdate(env, partition, 2));
+        batched.push_back(SendVChunkConfigUpdate(env, partition, 3));
+        env.Sim(TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(0);
+        env.Sim(TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        UNIT_ASSERT(first.HasValue());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(future.HasValue());
+        }
+
+        auto next = SendVChunkConfigUpdate(env, partition, 4);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(3u, blockedCommits.size());
+        UNIT_ASSERT(!next.HasValue());
+
+        releaseCommit(2);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT(next.HasValue());
     }
 
     Y_UNIT_TEST(BasicWriteReadPBufferReplication)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -191,6 +191,36 @@ ui64 CreatePartitionTablet(
     return PartitionTabletId;
 }
 
+NThreading::TFuture<void> SendDirtyMapStateUpdate(
+    TEnvironmentSetup& env,
+    ui64 partitionTabletId,
+    ui32 vChunkIndex,
+    ui32 stateGeneration)
+{
+    TDirtyMapStateProto state;
+    state.SetStateGeneration(stateGeneration);
+
+    auto request =
+        std::make_unique<TEvPartitionDirectPrivate::TEvUpdateDirtyMapState>(
+            vChunkIndex,
+            std::move(state));
+    auto future = request->UpdateCompleted.GetFuture();
+
+    const TActorId sender = env.Runtime->AllocateEdgeActor(
+        env.Settings.ControllerNodeId,
+        __FILE__,
+        __LINE__);
+    env.Runtime->SendToPipe(
+        partitionTabletId,
+        sender,
+        request.release(),
+        0,
+        TTestActorSystem::GetPipeConfigWithRetries());
+    env.Runtime->DestroyActor(sender);
+
+    return future;
+}
+
 NProto::TError DeletePartition(
     TEnvironmentSetup& env,
     ui64 partitionTabletId,
@@ -983,6 +1013,95 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
 
         // The replay re-sent the BSController allocation request.
         UNIT_ASSERT_VALUES_EQUAL(2u, addHostRequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldBatchDirtyMapStateUpdates)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        const ui64 partition = CreatePartitionTablet(env);
+
+        TVector<std::unique_ptr<IEventHandle>> blockedCommits;
+        THashSet<ui32> releasedCommitSteps;
+        runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev)
+        {
+            if (ev->GetTypeRewrite() == TEvTablet::TEvCommit::EventType) {
+                auto* msg = ev->Get<TEvTablet::TEvCommit>();
+                if (msg->TabletID == partition &&
+                    !releasedCommitSteps.contains(msg->Step))
+                {
+                    blockedCommits.push_back(std::move(ev));
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto releaseCommit = [&](size_t index)
+        {
+            UNIT_ASSERT_C(
+                index < blockedCommits.size() && blockedCommits[index],
+                "commit is not blocked");
+            auto* msg = blockedCommits[index]->Get<TEvTablet::TEvCommit>();
+            releasedCommitSteps.insert(msg->Step);
+            runtime->Send(
+                std::move(blockedCommits[index]),
+                env.Settings.ControllerNodeId);
+        };
+
+        auto first = SendDirtyMapStateUpdate(env, partition, 0, 1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        UNIT_ASSERT(!first.HasValue());
+
+        TVector<NThreading::TFuture<void>> batched;
+        batched.push_back(SendDirtyMapStateUpdate(env, partition, 1, 2));
+        batched.push_back(SendDirtyMapStateUpdate(env, partition, 2, 3));
+        batched.push_back(SendDirtyMapStateUpdate(env, partition, 3, 4));
+        env.Sim(TDuration::Seconds(1));
+
+        // While the first transaction is in flight, the remaining updates do
+        // not start their own transactions.
+        UNIT_ASSERT_VALUES_EQUAL(1u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(0);
+        env.Sim(TDuration::Seconds(1));
+
+        // All pending updates are persisted by one transaction. Its promises
+        // stay unresolved until the common commit completes.
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        UNIT_ASSERT(first.HasValue());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        releaseCommit(1);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(2u, blockedCommits.size());
+        for (const auto& future: batched) {
+            UNIT_ASSERT(future.HasValue());
+        }
+
+        // Completion of a batch resets the in-flight state: a later update
+        // starts and completes a new transaction normally.
+        auto next = SendDirtyMapStateUpdate(env, partition, 4, 5);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(3u, blockedCommits.size());
+        UNIT_ASSERT(!next.HasValue());
+
+        releaseCommit(2);
+        env.Sim(TDuration::Seconds(1));
+        UNIT_ASSERT(next.HasValue());
+
+        runtime->FilterFunction = {};
     }
 
     Y_UNIT_TEST(BasicWriteReadPBufferReplication)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -863,9 +863,11 @@ void TVChunk::DoPersistDirtyMap()
         [weakSelf = weak_from_this(),
          executor = Executor,
          stateGeneration]   //
-        (const TFuture<void>& f) mutable
+        (const TPersistResultFuture& f) mutable
         {
-            Y_UNUSED(f);
+            if (f.GetValue() != EPersistResult::Success) {
+                return;
+            }
             executor->ExecuteSimple(
                 [weakSelf = std::move(weakSelf), stateGeneration]()
                 {
@@ -1013,10 +1015,11 @@ void TVChunk::PersistNextPendingConfig()
         PartitionDirectService->UpdateVChunkConfig(pending.Config);
     onPersisted.Subscribe(
         [weakSelf = weak_from_this(), executor = Executor]   //
-        (const TFuture<void>& f)
+        (const TPersistResultFuture& f) mutable
         {
-            Y_UNUSED(f);
-
+            if (f.GetValue() != EPersistResult::Success) {
+                return;
+            }
             executor->ExecuteSimple(
                 [weakSelf = std::move(weakSelf)]()
                 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 GENERATE_ENUM_SERIALIZATION(ddisk_data_copier.h)
 GENERATE_ENUM_SERIALIZATION(direct_block_group_impl.h)
+GENERATE_ENUM_SERIALIZATION(partition_direct_service.h)
 
 SRCS(
     ddisk_data_copier.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. Batch persisting of ahead and behind dirty map fields
2. Batch persisting of VChunkConfig

### Description for reviewers <!-- (optional) description for those who read this PR -->
