### PR TITLE
Avoid O(n^2) CmdWrite scans when the mirrorer packs a write request.

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -59,14 +59,6 @@ ui64 GetLogicalMessageCount(const TPersQueueReadEvent::TDataReceivedEvent::TComp
     return GetBatchInfo(message).LogicalMessageCount;
 }
 
-ui64 GetWriteRequestEndOffset(const NKikimrClient::TPersQueuePartitionRequest& request) {
-    ui64 offset = request.GetCmdWriteOffset();
-    for (const auto& cmd : request.GetCmdWrite()) {
-        offset += cmd.GetLogicalMessageCount();
-    }
-    return offset;
-}
-
 } // namespace
 
 TMirrorer::TMirrorer(
@@ -140,10 +132,11 @@ void TMirrorer::Handle(TEvents::TEvPoisonPill::TPtr&, const TActorContext& ctx) 
     Die(ctx);
 }
 
-bool TMirrorer::AddToWriteRequest(
+bool AppendToWriteRequest(
     NKikimrClient::TPersQueuePartitionRequest& request,
     TPersQueueReadEvent::TDataReceivedEvent::TCompressedMessage& message,
-    bool& incorrectRequest
+    bool& incorrectRequest,
+    ui64& nextOffset
 ) {
     if (!request.HasCmdWriteOffset()) {
         if (request.CmdWriteSize() > 0) {
@@ -151,8 +144,9 @@ bool TMirrorer::AddToWriteRequest(
             return false;
         }
         request.SetCmdWriteOffset(message.GetOffset());
+        nextOffset = message.GetOffset();
     }
-    if (GetWriteRequestEndOffset(request) != message.GetOffset()) {
+    if (nextOffset != message.GetOffset()) {
         return false;
     }
 
@@ -175,11 +169,23 @@ bool TMirrorer::AddToWriteRequest(
     write->SetUncompressedSize(message.GetUncompressedSize());
 
     const auto batchInfo = GetBatchInfo(message);
+    ui64 logicalMessageCount = 1;
     if (batchInfo.LogicalMessageCount > 1) {
-        write->SetLogicalMessageCount(batchInfo.LogicalMessageCount);
+        logicalMessageCount = batchInfo.LogicalMessageCount;
+        write->SetLogicalMessageCount(logicalMessageCount);
         write->SetMaxSeqNo(*batchInfo.MaxSeqNo);
     }
+    nextOffset += logicalMessageCount;
     return true;
+}
+
+bool TMirrorer::AddToWriteRequest(
+    NKikimrClient::TPersQueuePartitionRequest& request,
+    TPersQueueReadEvent::TDataReceivedEvent::TCompressedMessage& message,
+    bool& incorrectRequest,
+    ui64& nextOffset
+) {
+    return AppendToWriteRequest(request, message, incorrectRequest, nextOffset);
 }
 
 void TMirrorer::ProcessError(const TActorContext& ctx, const TString& msg) {
@@ -423,7 +429,8 @@ void TMirrorer::TryToWrite(const TActorContext& ctx) {
     req->SetCookie(WRITE_REQUEST_COOKIE);
 
     bool incorrectRequest = false;
-    while (!Queue.empty() && AddToWriteRequest(*req, Queue.front(), incorrectRequest)) {
+    ui64 nextOffset = 0;
+    while (!Queue.empty() && AddToWriteRequest(*req, Queue.front(), incorrectRequest, nextOffset)) {
         WriteInFlight.emplace_back(std::move(Queue.front()));
         Queue.pop_front();
     }

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
@@ -93,7 +93,8 @@ private:
     bool AddToWriteRequest(
         NKikimrClient::TPersQueuePartitionRequest& request,
         NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TCompressedMessage& message,
-        bool& incorrectRequest
+        bool& incorrectRequest,
+        ui64& nextOffset
     );
     void ProcessError(const TActorContext& ctx, const TString& msg);
     void ProcessError(const TActorContext& ctx, const TString& msg, const NKikimrClient::TResponse& response);
@@ -197,6 +198,13 @@ private:
     ui64 ReadFuturesInFlight = 0;
     TInstant LastReadEventTime;
 };
+
+bool AppendToWriteRequest(
+    NKikimrClient::TPersQueuePartitionRequest& request,
+    NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TCompressedMessage& message,
+    bool& incorrectRequest,
+    ui64& nextOffset
+);
 
 }// NPQ
 }// NKikimr

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -8,9 +8,13 @@
 
 #include <ydb/public/api/grpc/ydb_topic_v1.grpc.pb.h>
 
+#include <ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/size_literals.h>
+
+#include <deque>
 
 namespace NKikimr::NPersQueueTests {
 
@@ -395,6 +399,63 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
 
             expectedOffset += messageCount;
         }
+    }
+
+    Y_UNIT_TEST(StopsPackingOnOffsetGap) {
+        using TCompressedMessage = NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TCompressedMessage;
+        using TMessageInformation = NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessageInformation;
+
+        auto makeMessage = [](ui64 offset, ui64 seqNo) {
+            auto meta = MakeIntrusive<NYdb::NTopic::TWriteSessionMeta>();
+            auto messageMeta = MakeIntrusive<NYdb::NTopic::TMessageMeta>();
+            const TString data = "payload";
+            TMessageInformation info(
+                offset,
+                "producer",
+                seqNo,
+                TInstant::MilliSeconds(1000),
+                TInstant::MilliSeconds(2000),
+                meta,
+                messageMeta,
+                data.size(),
+                "producer"
+            );
+            return TCompressedMessage(NYdb::NTopic::ECodec::RAW, data, std::move(info), nullptr);
+        };
+
+        auto fillWriteRequest = [](NKikimrClient::TPersQueuePartitionRequest& request, std::deque<TCompressedMessage>& queue) {
+            bool incorrectRequest = false;
+            ui64 nextOffset = 0;
+            size_t packed = 0;
+            while (!queue.empty() && NPQ::AppendToWriteRequest(request, queue.front(), incorrectRequest, nextOffset)) {
+                queue.pop_front();
+                ++packed;
+            }
+            UNIT_ASSERT(!incorrectRequest);
+            return packed;
+        };
+
+        std::deque<TCompressedMessage> queue;
+        queue.push_back(makeMessage(0, 1));
+        queue.push_back(makeMessage(1, 2));
+        queue.push_back(makeMessage(3, 3));
+
+        NKikimrClient::TPersQueuePartitionRequest prefix;
+        UNIT_ASSERT_VALUES_EQUAL(fillWriteRequest(prefix, queue), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(prefix.GetCmdWriteOffset(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(prefix.CmdWriteSize(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(prefix.GetCmdWrite(0).GetSeqNo(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(prefix.GetCmdWrite(1).GetSeqNo(), 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(queue.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(queue.front().GetOffset(), 3u);
+
+        NKikimrClient::TPersQueuePartitionRequest rest;
+        UNIT_ASSERT_VALUES_EQUAL(fillWriteRequest(rest, queue), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(rest.GetCmdWriteOffset(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(rest.CmdWriteSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(rest.GetCmdWrite(0).GetSeqNo(), 3);
+        UNIT_ASSERT(queue.empty());
     }
 
     Y_UNIT_TEST(ValidStartStream) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed high CPU usage in mirrored topics when ingesting a large number of small messages.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Since LOGBROKER-10406 (#43924) `AddToWriteRequest` recomputed the batch end offset by summing `LogicalMessageCount` over every already packed `CmdWrite`. That is correct for kafka batches, where one `CmdWrite` can span several offsets, but it is quadratic in the number of messages. With a 16 MB in-flight queue of small records this showed up as high CPU in `TMirrorer::AddToWriteRequest`.

Keep a running `nextOffset` instead: initialize it from the first message and advance it by the logical count of each packed `CmdWrite`. Continuity is still checked, so an offset hole still stops packing and the remaining queue goes into the next request. Cover that hole with `StopsPackingOnOffsetGap`.