### PR TITLE
local-ydb: reuse mounted gRPC TLS data

### DIFF
--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -261,8 +261,12 @@ def default_users():
     return {user: password}
 
 
+def parse_grpc_tls_enable(value):
+    return (value or '').strip().lower() in ('1', 'true')
+
+
 def enable_tls():
-    return os.getenv('YDB_GRPC_ENABLE_TLS', '').strip().lower() in ('1', 'true')
+    return parse_grpc_tls_enable(os.getenv('YDB_GRPC_ENABLE_TLS'))
 
 
 def is_tiny_mode():
@@ -312,8 +316,8 @@ def has_any_grpc_tls_data_file(tls_data_path):
     return any(os.path.lexists(os.path.join(tls_data_path, filename)) for filename in GRPC_TLS_DATA_FILES)
 
 
-def should_generate_grpc_tls_data():
-    return not has_any_grpc_tls_data_file(os.getenv('YDB_GRPC_TLS_DATA_PATH'))
+def should_generate_grpc_tls_data(tls_data_path):
+    return not has_any_grpc_tls_data_file(tls_data_path)
 
 
 def pq_client_service_types(arguments):
@@ -391,7 +395,7 @@ def deploy(arguments):
         optionals.update({'grpc_ssl_enable': enable_tls()})
         optionals.update(
             {
-                'generate_grpc_tls_data': should_generate_grpc_tls_data()
+                'generate_grpc_tls_data': should_generate_grpc_tls_data(os.getenv('YDB_GRPC_TLS_DATA_PATH'))
             }
         )
     pdisk_store_path = arguments.ydb_working_dir if arguments.ydb_working_dir else None

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -16,7 +16,7 @@ import yatest
 
 from yql.essentials.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
-from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_config import GRPC_TLS_DATA_FILES, KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.harness.daemon import Daemon
 from ydb.tests.library.harness.util import LogLevels
@@ -262,7 +262,7 @@ def default_users():
 
 
 def enable_tls():
-    return os.getenv('YDB_GRPC_ENABLE_TLS') == 'true'
+    return os.getenv('YDB_GRPC_ENABLE_TLS', '').strip().lower() in ('1', 'true')
 
 
 def is_tiny_mode():
@@ -304,6 +304,12 @@ def generic_connector_config():
 def grpc_tls_data_path(arguments):
     default_store = arguments.ydb_working_dir if arguments.ydb_working_dir else None
     return os.getenv('YDB_GRPC_TLS_DATA_PATH', default_store)
+
+
+def has_any_grpc_tls_data_file(tls_data_path):
+    if not tls_data_path:
+        return False
+    return any(os.path.lexists(os.path.join(tls_data_path, filename)) for filename in GRPC_TLS_DATA_FILES)
 
 
 def pq_client_service_types(arguments):
@@ -376,8 +382,16 @@ def deploy(arguments):
 
     optionals = {}
     if enable_tls():
-        optionals.update({'grpc_tls_data_path': grpc_tls_data_path(arguments)})
+        tls_data_path = grpc_tls_data_path(arguments)
+        optionals.update({'grpc_tls_data_path': tls_data_path})
         optionals.update({'grpc_ssl_enable': enable_tls()})
+        optionals.update(
+            {
+                'generate_grpc_tls_data': not has_any_grpc_tls_data_file(
+                    os.getenv('YDB_GRPC_TLS_DATA_PATH')
+                )
+            }
+        )
     pdisk_store_path = arguments.ydb_working_dir if arguments.ydb_working_dir else None
 
     enable_feature_flags = arguments.enabled_feature_flags.copy()  # type: typing.List[str]
@@ -440,12 +454,10 @@ def deploy(arguments):
         target_config = os.path.join(configs_path, "config.yaml")
         action = resolve_deploy_config_action(config_path, target_config)
         if action == 'copy':
-            self.write_tls_data()
             shutil.copyfile(config_path, target_config)
             return
         if action == 'preserve':
             logger.info('Preserving existing config at %s', target_config)
-            self.write_tls_data()
             return
 
         original_write_proto_configs(configs_path)

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -312,6 +312,10 @@ def has_any_grpc_tls_data_file(tls_data_path):
     return any(os.path.lexists(os.path.join(tls_data_path, filename)) for filename in GRPC_TLS_DATA_FILES)
 
 
+def should_generate_grpc_tls_data():
+    return not has_any_grpc_tls_data_file(os.getenv('YDB_GRPC_TLS_DATA_PATH'))
+
+
 def pq_client_service_types(arguments):
     items = getattr(arguments, 'pq_client_service_types', None)
     if not items:
@@ -387,9 +391,7 @@ def deploy(arguments):
         optionals.update({'grpc_ssl_enable': enable_tls()})
         optionals.update(
             {
-                'generate_grpc_tls_data': not has_any_grpc_tls_data_file(
-                    os.getenv('YDB_GRPC_TLS_DATA_PATH')
-                )
+                'generate_grpc_tls_data': should_generate_grpc_tls_data()
             }
         )
     pdisk_store_path = arguments.ydb_working_dir if arguments.ydb_working_dir else None

--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -3,8 +3,8 @@ import tempfile
 import unittest
 
 from ydb.public.tools.lib.cmds import (
-    enable_tls,
     generic_connector_config,
+    parse_grpc_tls_enable,
     resolve_deploy_config_action,
     same_config_path,
     should_generate_grpc_tls_data,
@@ -88,34 +88,27 @@ def test_same_config_path_resolves_symlinks():
         assert resolve_deploy_config_action(link, target) == 'preserve'
 
 
-def test_enable_tls_accepts_documented_values(monkeypatch):
-    monkeypatch.delenv('YDB_GRPC_ENABLE_TLS', raising=False)
-    assert enable_tls() is False
-
+def test_parse_grpc_tls_enable_accepts_documented_values():
     for value in ('1', 'true', ' TRUE '):
-        monkeypatch.setenv('YDB_GRPC_ENABLE_TLS', value)
-        assert enable_tls() is True
+        assert parse_grpc_tls_enable(value) is True
 
-    for value in ('0', 'false', 'yes', ''):
-        monkeypatch.setenv('YDB_GRPC_ENABLE_TLS', value)
-        assert enable_tls() is False
+    for value in (None, '0', 'false', 'yes', ''):
+        assert parse_grpc_tls_enable(value) is False
 
 
-def test_should_generate_grpc_tls_data_uses_explicit_path(monkeypatch):
-    monkeypatch.delenv('YDB_GRPC_TLS_DATA_PATH', raising=False)
-    assert should_generate_grpc_tls_data() is True
+def test_should_generate_grpc_tls_data_uses_explicit_path():
+    assert should_generate_grpc_tls_data(None) is True
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        monkeypatch.setenv('YDB_GRPC_TLS_DATA_PATH', tmpdir)
-        assert should_generate_grpc_tls_data() is True
+        assert should_generate_grpc_tls_data(tmpdir) is True
 
         with open(os.path.join(tmpdir, 'unrelated.pem'), 'w'):
             pass
-        assert should_generate_grpc_tls_data() is True
+        assert should_generate_grpc_tls_data(tmpdir) is True
 
         for filename in ('ca.pem', 'cert.pem', 'key.pem'):
             path = os.path.join(tmpdir, filename)
             with open(path, 'w'):
                 pass
-            assert should_generate_grpc_tls_data() is False
+            assert should_generate_grpc_tls_data(tmpdir) is False
             os.unlink(path)

--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -3,9 +3,11 @@ import tempfile
 import unittest
 
 from ydb.public.tools.lib.cmds import (
+    enable_tls,
     generic_connector_config,
     resolve_deploy_config_action,
     same_config_path,
+    should_generate_grpc_tls_data,
     should_preserve_existing_config,
 )
 from yql.essentials.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
@@ -84,3 +86,36 @@ def test_same_config_path_resolves_symlinks():
             raise unittest.SkipTest('symlinks not supported on this filesystem')
         assert same_config_path(link, target) is True
         assert resolve_deploy_config_action(link, target) == 'preserve'
+
+
+def test_enable_tls_accepts_documented_values(monkeypatch):
+    monkeypatch.delenv('YDB_GRPC_ENABLE_TLS', raising=False)
+    assert enable_tls() is False
+
+    for value in ('1', 'true', ' TRUE '):
+        monkeypatch.setenv('YDB_GRPC_ENABLE_TLS', value)
+        assert enable_tls() is True
+
+    for value in ('0', 'false', 'yes', ''):
+        monkeypatch.setenv('YDB_GRPC_ENABLE_TLS', value)
+        assert enable_tls() is False
+
+
+def test_should_generate_grpc_tls_data_uses_explicit_path(monkeypatch):
+    monkeypatch.delenv('YDB_GRPC_TLS_DATA_PATH', raising=False)
+    assert should_generate_grpc_tls_data() is True
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv('YDB_GRPC_TLS_DATA_PATH', tmpdir)
+        assert should_generate_grpc_tls_data() is True
+
+        with open(os.path.join(tmpdir, 'unrelated.pem'), 'w'):
+            pass
+        assert should_generate_grpc_tls_data() is True
+
+        for filename in ('ca.pem', 'cert.pem', 'key.pem'):
+            path = os.path.join(tmpdir, filename)
+            with open(path, 'w'):
+                pass
+            assert should_generate_grpc_tls_data() is False
+            os.unlink(path)


### PR DESCRIPTION
## Summary

- accept both `true` and the documented numeric value `1` for `YDB_GRPC_ENABLE_TLS`
- detect certificate files in an explicitly configured `YDB_GRPC_TLS_DATA_PATH`
- request existing-certificate mode from `KikimrConfigGenerator` and rely on the harness to validate partial or empty bundles
- remove calls to the obsolete deferred `write_tls_data` hook

## Tests

Focused unit tests verify:

- unset, numeric, textual, case-insensitive, and invalid `YDB_GRPC_ENABLE_TLS` values
- generation for an unset or empty explicit TLS path
- ignoring unrelated files
- selecting reuse when any one of `ca.pem`, `cert.pem`, or `key.pem` exists, including an empty partial bundle that the harness must reject instead of overwriting

The tests call pure decision functions with explicit values and use a real temporary directory. They do not use `monkeypatch` and do not mock `open` or `deploy`.

## Scope

#50270 has been merged into `main` and provides the corresponding test-harness support. This PR changes only the CLI implementation and its focused unit tests:

- `ydb/public/tools/lib/cmds/__init__.py`
- `ydb/public/tools/lib/cmds/ut/test.py`

Docker acceptance coverage is in #50594.

Local `git diff --check` and Python syntax checks pass. The branch is based directly on current `main`.
