### PR TITLE
[SPI-AI] Improve Ticket Parser error logging

### DIFF
--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -2046,7 +2046,7 @@ protected:
             record.SetErrorRefreshTime(this, now);
             CounterTicketsErrorsRetryable->Inc();
             BLOG_W("Failed to process ticket " << record.GetMaskedTicket()
-                << " (" << record.PeerName << "): retryable error '" << error.Message  << ' ' << errorLogMessage << "'");
+                << " (" << record.PeerName << "): retryable error '" << error.Message << errorLogMessage << "'");
             if (record.RefreshRetryableErrorImmediately) {
                 record.RefreshRetryableErrorImmediately = false;
                 GetDerived()->CanRefreshTicket(key, record);
@@ -2059,7 +2059,7 @@ protected:
             record.SetOkRefreshTime(this, now);
             CounterTicketsErrorsPermanent->Inc();
             BLOG_W("Failed to process ticket " << record.GetMaskedTicket()
-                << " (" << record.PeerName << "): non-retryable error '" << error.Message << ' ' << errorLogMessage << "'");
+                << " (" << record.PeerName << "): non-retryable error '" << error.Message << errorLogMessage << "'");
         }
         CounterTicketsErrors->Inc();
         record.IsLowRequestPriority = true;

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -2046,7 +2046,7 @@ protected:
             record.SetErrorRefreshTime(this, now);
             CounterTicketsErrorsRetryable->Inc();
             BLOG_W("Failed to process ticket " << record.GetMaskedTicket()
-                << " (" << record.PeerName << "): retryable error '" << error.Message << errorLogMessage << "'");
+                << " (" << record.PeerName << "): retryable error '" << error.Message  << ' ' << errorLogMessage << "'");
             if (record.RefreshRetryableErrorImmediately) {
                 record.RefreshRetryableErrorImmediately = false;
                 GetDerived()->CanRefreshTicket(key, record);
@@ -2059,7 +2059,7 @@ protected:
             record.SetOkRefreshTime(this, now);
             CounterTicketsErrorsPermanent->Inc();
             BLOG_W("Failed to process ticket " << record.GetMaskedTicket()
-                << " (" << record.PeerName << "): non-retryable error '" << error.Message << errorLogMessage << "'");
+                << " (" << record.PeerName << "): non-retryable error '" << error.Message << ' ' << errorLogMessage << "'");
         }
         CounterTicketsErrors->Inc();
         record.IsLowRequestPriority = true;

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -948,7 +948,7 @@ private:
                             SetError(key, record, {.Message = "Login state is not available yet", .Retryable = false});
                             CounterTicketsLogin->Inc();
                             BLOG_TRACE("CanInitLoginToken, database " << database
-                                << ", login state is not available yet, cannot deffer token (" << MaskTicket(record.Ticket) << ")");
+                                << ", login state is not available yet, cannot defer token (" << MaskTicket(record.Ticket) << ")");
                             return true;
                         }
                     } else {
@@ -956,7 +956,7 @@ private:
                         DeferredLoginTokens.insert(std::make_pair(database, std::make_pair(TlsActivationContext->Now() + TDuration::Seconds(NUM_SECONDS_TO_WAIT_FOR_SECURITY_STATE_UPDATE), std::unordered_set<TString>({key}))));
                     }
                     BLOG_TRACE("CanInitLoginToken, database " << database
-                        << ", login state is not available yet, deffer token (" << MaskTicket(record.Ticket) << ")");
+                        << ", login state is not available yet, defer token (" << MaskTicket(record.Ticket) << ")");
                     return true;
                 }
                 BLOG_TRACE("CanInitLoginToken, database " << database << ", A6 error");
@@ -1044,7 +1044,7 @@ private:
     void Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
         if (!NSecurity::IsGoodPeernameFormat(ev->Get()->PeerName)) {
             CounterWrongPeernameFormat->Inc();
-            BLOG_WARN("Ticket " << MaskTicket(ev->Get()->Ticket) << ": invalid peer name format: " << ev->Get()->PeerName.Quote()
+            BLOG_W("Ticket " << MaskTicket(ev->Get()->Ticket) << ": invalid peer name format: " << ev->Get()->PeerName.Quote()
                 << " for DB: " << ev->Get()->Database.Quote());
 
             if (AppData()->FeatureFlags.GetEnableTicketParserErrorBasedOnPeernameFormat()) {
@@ -1252,7 +1252,7 @@ private:
 
     void Handle(TEvExternalIdpProvider::TEvAuthenticateResponse::TPtr& ev) {
         TEvExternalIdpProvider::TEvAuthenticateResponse* response = ev->Get();
-        BLOG_DEBUG("Received TEvAuthenticateResponse from ExternalIdp for ticket "
+        BLOG_D("Received TEvAuthenticateResponse from ExternalIdp for ticket "
             << MaskTicket(response->Key) << " with status " << response->Status);
         auto& userTokens = GetDerived()->GetUserTokens();
         auto it = userTokens.find(response->Key);
@@ -1271,7 +1271,7 @@ private:
                 groups.emplace_back(group + domain);
             }
             record.ExpireTime = response->ExpiresAt;
-            BLOG_DEBUG("Ticket " << record.GetMaskedTicket() << " authenticated by ExternalIdp"
+            BLOG_D("Ticket " << record.GetMaskedTicket() << " authenticated by ExternalIdp"
                 << " as " << response->User << domain
                 << " with " << groups.size() << " group(s)");
             SetToken(key, record, new NACLib::TUserToken({
@@ -1355,7 +1355,7 @@ private:
         for (auto& [permissionName, permissionRecord] : record.Permissions) {
             permissionRecord.Subject.clear();
             permissionRecord.Error = {.Message = errorMessage, .Retryable = isRetryableError};
-            BLOG_WARN("Ticket " << record.GetMaskedTicket() << " permission " << permissionName
+            BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << permissionName
                 << " now has a " << (isRetryableError ? "retryable" : "permanent")  << " error \"" << errorMessage << "\""
                 << " retryable: " << isRetryableError);
         }
@@ -1405,7 +1405,7 @@ private:
                         const auto checkIt = request->Request.checks().find(resultKey);
                         if (checkIt == request->Request.checks().end()) {
                             SetAccessServiceBulkAuthorizeError(key, record, TStringBuilder() << "Internal error: unknown result key: " << resultKey, false);
-                            BLOG_ERROR("Internal error: unknown result key: " << resultKey << " for ticket " << record.GetMaskedTicket());
+                            BLOG_W("Internal error: unknown result key: " << resultKey << " for ticket " << record.GetMaskedTicket());
                             processingError = true;
                             break;
                         }
@@ -1456,7 +1456,7 @@ private:
                                 permissionRecord.Error = {.Message = errorMessage, .Retryable = false};
                             }
                         } else {
-                            BLOG_ERROR("Received response for unknown permission " << permissionName << " for ticket " << record.GetMaskedTicket());
+                            BLOG_W("Received response for unknown permission " << permissionName << " for ticket " << record.GetMaskedTicket());
                         }
                     }
                     if (!processingError) {
@@ -1475,7 +1475,7 @@ private:
                                 }
                                 return std::move(b);
                             };
-                            BLOG_ERROR("Received response with not all permissions. Absent permissions: " << printAbsentPermissions());
+                            BLOG_W("Received response with not all permissions. Absent permissions: " << printAbsentPermissions());
                             SetAccessServiceBulkAuthorizeError(key, record, TStringBuilder() << "Internal error: not all permissions in authorize response", false);
                         } else if (permissionDeniedCount < examinedPermissions.size() && !hasRequiredPermissionFailed) {
                             record.TokenType = TDerived::ETokenType::NebiusAccessService;
@@ -1540,7 +1540,7 @@ private:
                             permissionDeniedCount++;
                             auto& permissionDeniedRecord = permissionDeniedIt->second;
                             permissionDeniedRecord.Subject.clear();
-                            BLOG_NOTICE("Ticket " << record.GetMaskedTicket() << " permission " << result.permission()
+                            BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << result.permission()
                                 << " access denied for subject \"" << record.Subject << "\"");
                             TStringBuilder errorMessage;
                             if (permissionDeniedRecord.IsRequired()) {
@@ -1556,7 +1556,7 @@ private:
                             errorMessage << permissionDeniedError;
                             permissionDeniedRecord.Error = {.Message = errorMessage, .Retryable = false};
                         } else {
-                            BLOG_ERROR("Received response for unknown permission " << result.permission() << " for ticket " << record.GetMaskedTicket());
+                            BLOG_W("Received response for unknown permission " << result.permission() << " for ticket " << record.GetMaskedTicket());
                         }
                     }
                     if (permissionDeniedCount < examinedPermissions.size() && !hasRequiredPermissionFailed && subjectNameErrorMessage.empty()) {
@@ -1611,15 +1611,15 @@ private:
                     itPermission->second.Error = {.Message = TString{response->Status.Msg}, .Retryable = retryable};
                     if (itPermission->second.Subject.empty() || !retryable) {
                         itPermission->second.Subject.clear();
-                        BLOG_ERROR("Ticket " << record.GetMaskedTicket() << " permission " << permission
+                        BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << permission
                             << " now has a permanent error \"" << itPermission->second.Error << "\" " << " retryable:" << retryable);
                     } else if (retryable) {
-                        BLOG_ERROR("Ticket " << record.GetMaskedTicket() << " permission " << permission
+                        BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << permission
                             << " now has a retryable error \"" << response->Status.Msg << "\"");
                     }
                 }
             } else {
-                BLOG_ERROR("Received response for unknown permission " << permission << " for ticket " << record.GetMaskedTicket());
+                BLOG_W("Received response for unknown permission " << permission << " for ticket " << record.GetMaskedTicket());
             }
             if (--record.ResponsesLeft == 0) {
                 ui32 permissionsOk = 0;
@@ -1688,7 +1688,7 @@ private:
     void Handle(TEvTicketParser::TEvUpdateLoginSecurityState::TPtr& ev) {
         auto& loginProvider = LoginProviders[ev->Get()->SecurityState.GetAudience()];
         loginProvider.UpdateSecurityState(ev->Get()->SecurityState);
-        BLOG_DEBUG("Updated state for " << loginProvider.Audience << " keys " << GetLoginProviderKeys(loginProvider));
+        BLOG_D("Updated state for " << loginProvider.Audience << " keys " << GetLoginProviderKeys(loginProvider));
 
         auto it = DeferredLoginTokens.find(loginProvider.Audience);
         if (it != DeferredLoginTokens.end()) {
@@ -1730,12 +1730,12 @@ private:
             }
             auto& record = it->second;
             if ((record.ExpireTime > now) && (record.AccessTime + GetLifeTime() > now)) {
-                BLOG_DEBUG("Refreshing ticket " << record.GetMaskedTicket());
+                BLOG_D("Refreshing ticket " << record.GetMaskedTicket());
                 if (!RefreshTicket(key, record)) {
                     RefreshQueue.push({key, record.RefreshTime});
                 }
             } else {
-                BLOG_NOTICE("Expired ticket " << record.GetMaskedTicket());
+                BLOG_D("Expired ticket " << record.GetMaskedTicket());
                 if (!record.AuthorizeRequests.empty()) {
                     record.Error = {.Message = "Timed out", .Retryable = true};
                     Respond(record);
@@ -2027,7 +2027,7 @@ protected:
         } else {
             CounterTicketsHighPriorityBuildTime->Collect(ticketBuildTime);
         }
-        BLOG_DEBUG("Ticket " << record.GetMaskedTicket()
+        BLOG_D("Ticket " << record.GetMaskedTicket()
             << " (" << record.PeerName << ") has now valid token of " << record.Subject);
         record.IsLowRequestPriority = true;
         RefreshQueue.push({.Key = key, .RefreshTime = record.RefreshTime});
@@ -2045,7 +2045,7 @@ protected:
             record.ExpireTime = GetDerived()->GetExpireTime(record, now);
             record.SetErrorRefreshTime(this, now);
             CounterTicketsErrorsRetryable->Inc();
-            BLOG_WARN("Ticket " << record.GetMaskedTicket()
+            BLOG_W("Ticket " << record.GetMaskedTicket()
                 << " (" << record.PeerName << ") has now retryable error message '" << error.Message << errorLogMessage << "'");
             if (record.RefreshRetryableErrorImmediately) {
                 record.RefreshRetryableErrorImmediately = false;
@@ -2058,7 +2058,7 @@ protected:
             record.UnsetToken();
             record.SetOkRefreshTime(this, now);
             CounterTicketsErrorsPermanent->Inc();
-            BLOG_WARN("Ticket " << record.GetMaskedTicket()
+            BLOG_W("Ticket " << record.GetMaskedTicket()
                 << " (" << record.PeerName << ") has now permanent error message '" << error.Message << errorLogMessage << "'");
         }
         CounterTicketsErrors->Inc();
@@ -2421,7 +2421,7 @@ protected:
         }
 
         if (Config.HasExternalIdpConfig()) {
-            BLOG_DEBUG("External IdP authentication is enabled");
+            BLOG_D("External IdP authentication is enabled");
             ExternalIdpProvider = Register(
                 CreateExternalIdpProvider(Config.GetExternalIdpConfig(), {}),
                 TMailboxType::HTSwap, AppData()->UserPoolId);

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -520,7 +520,8 @@ private:
         };
 
         for (const auto& [permissionName, permissionRecord] : record.Permissions) {
-            BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " asking for AccessServiceAuthorization" << (useV2 ? "V2" : "V1") << "(" << permissionName << ")");
+            BLOG_TRACE("Ticket " << record.GetMaskedTicket()
+                << " asking for AccessServiceAuthorization" << (useV2 ? "V2" : "V1") << "(" << permissionName << ")");
             record.ResponsesLeft++;
 
             if (useV2) {
@@ -593,7 +594,7 @@ private:
     template <typename TTokenRecord>
     void AccessServiceAuthenticate(const TString& key, TTokenRecord& record) const {
         const bool useV2 = AppData()->FeatureFlags.GetEnableAccessServiceV2Interface();
-        BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " asking for AccessServiceAuthentication" << (useV2 ? "V2" : "V1") << ")");
+        BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " asking for AccessServiceAuthentication" << (useV2 ? "V2" : "V1"));
 
         if (useV2) {
             auto request = CreateAccessServiceRequest<TEvAccessServiceAuthenticateRequestV2>(key, record);
@@ -619,7 +620,8 @@ private:
         const bool useNebius = static_cast<bool>(NebiusAccessServiceValidator);
         const bool useV2 = !useNebius && AppData()->FeatureFlags.GetEnableAccessServiceV2Interface();
 
-        BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " asking for AccessServiceAuthentication" << (useNebius ? "V1(Nebius)" : (useV2 ? "V2" : "V1")) << ")");
+        BLOG_TRACE("Ticket " << record.GetMaskedTicket()
+            << " asking for AccessServiceAuthentication" << (useNebius ? "V1(Nebius)" : (useV2 ? "V2" : "V1")));
         record.ResponsesLeft++;
 
         if (useNebius) {
@@ -945,14 +947,16 @@ private:
                         } else {
                             SetError(key, record, {.Message = "Login state is not available yet", .Retryable = false});
                             CounterTicketsLogin->Inc();
-                            BLOG_TRACE("CanInitLoginToken, database " << database << ", login state is not available yet, cannot deffer token (" << MaskTicket(record.Ticket) << ")");
+                            BLOG_TRACE("CanInitLoginToken, database " << database
+                                << ", login state is not available yet, cannot deffer token (" << MaskTicket(record.Ticket) << ")");
                             return true;
                         }
                     } else {
                         static const ui64 NUM_SECONDS_TO_WAIT_FOR_SECURITY_STATE_UPDATE = std::max(RefreshPeriod.Seconds(), static_cast<TDuration::TValue>(2));
                         DeferredLoginTokens.insert(std::make_pair(database, std::make_pair(TlsActivationContext->Now() + TDuration::Seconds(NUM_SECONDS_TO_WAIT_FOR_SECURITY_STATE_UPDATE), std::unordered_set<TString>({key}))));
                     }
-                    BLOG_TRACE("CanInitLoginToken, database " << database << ", login state is not available yet, deffer token (" << MaskTicket(record.Ticket) << ")");
+                    BLOG_TRACE("CanInitLoginToken, database " << database
+                        << ", login state is not available yet, deffer token (" << MaskTicket(record.Ticket) << ")");
                     return true;
                 }
                 BLOG_TRACE("CanInitLoginToken, database " << database << ", A6 error");
@@ -1040,9 +1044,8 @@ private:
     void Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
         if (!NSecurity::IsGoodPeernameFormat(ev->Get()->PeerName)) {
             CounterWrongPeernameFormat->Inc();
-            BLOG_W("Ticket " << MaskTicket(ev->Get()->Ticket) <<
-                   ": invalid peer name format: " << ev->Get()->PeerName.Quote() <<
-                   " for DB: " << ev->Get()->Database.Quote());
+            BLOG_WARN("Ticket " << MaskTicket(ev->Get()->Ticket) << ": invalid peer name format: " << ev->Get()->PeerName.Quote()
+                << " for DB: " << ev->Get()->Database.Quote());
 
             if (AppData()->FeatureFlags.GetEnableTicketParserErrorBasedOnPeernameFormat()) {
                 TEvTicketParser::TError error;
@@ -1168,8 +1171,7 @@ private:
         switch (record.SubjectType) {
         case TPermissionRecord::TTypeCase::USER_ACCOUNT_TYPE:
             if (UserAccountService) {
-                BLOG_TRACE("Ticket " << record.GetMaskedTicket()
-                            << " asking for UserAccount(" << record.Subject << ")");
+                BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " asking for UserAccount(" << record.Subject << ")");
                 THolder<TEvAccessServiceGetUserAccountRequest> request = MakeHolder<TEvAccessServiceGetUserAccountRequest>(key);
                 request->Token = record.Ticket;
                 request->Request.set_user_account_id(TString(TStringBuf(record.Subject).NextTok('@')));
@@ -1180,8 +1182,7 @@ private:
             break;
         case TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_TYPE:
             if (ServiceAccountService) {
-                BLOG_TRACE("Ticket " << record.GetMaskedTicket()
-                            << " asking for ServiceAccount(" << record.Subject << ")");
+                BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " asking for ServiceAccount(" << record.Subject << ")");
                 THolder<TEvAccessServiceGetServiceAccountRequest> request = MakeHolder<TEvAccessServiceGetServiceAccountRequest>(key);
                 request->Token = record.Ticket;
                 request->Request.set_service_account_id(TString(TStringBuf(record.Subject).NextTok('@')));
@@ -1251,7 +1252,7 @@ private:
 
     void Handle(TEvExternalIdpProvider::TEvAuthenticateResponse::TPtr& ev) {
         TEvExternalIdpProvider::TEvAuthenticateResponse* response = ev->Get();
-        BLOG_D("Received TEvAuthenticateResponse from ExternalIdp for ticket "
+        BLOG_DEBUG("Received TEvAuthenticateResponse from ExternalIdp for ticket "
             << MaskTicket(response->Key) << " with status " << response->Status);
         auto& userTokens = GetDerived()->GetUserTokens();
         auto it = userTokens.find(response->Key);
@@ -1270,7 +1271,7 @@ private:
                 groups.emplace_back(group + domain);
             }
             record.ExpireTime = response->ExpiresAt;
-            BLOG_D("Ticket " << record.GetMaskedTicket() << " authenticated by ExternalIdp"
+            BLOG_DEBUG("Ticket " << record.GetMaskedTicket() << " authenticated by ExternalIdp"
                 << " as " << response->User << domain
                 << " with " << groups.size() << " group(s)");
             SetToken(key, record, new NACLib::TUserToken({
@@ -1354,10 +1355,9 @@ private:
         for (auto& [permissionName, permissionRecord] : record.Permissions) {
             permissionRecord.Subject.clear();
             permissionRecord.Error = {.Message = errorMessage, .Retryable = isRetryableError};
-            BLOG_TRACE("Ticket " << record.GetMaskedTicket()
-                                << " permission " << permissionName
-                                << " now has a " << (isRetryableError ? "retryable" : "permanent")  << " error \"" << errorMessage << "\""
-                                << " retryable: " << isRetryableError);
+            BLOG_WARN("Ticket " << record.GetMaskedTicket() << " permission " << permissionName
+                << " now has a " << (isRetryableError ? "retryable" : "permanent")  << " error \"" << errorMessage << "\""
+                << " retryable: " << isRetryableError);
         }
         SetError(key, record, {.Message = errorMessage, .Retryable = isRetryableError});
     }
@@ -1382,9 +1382,7 @@ private:
         auto& userTokens = GetDerived()->GetUserTokens();
         auto itToken = userTokens.find(key);
         if (itToken == userTokens.end()) {
-            BLOG_ERROR("Ticket(key) "
-                        << MaskTicket(key)
-                        << " has expired during permission check");
+            BLOG_ERROR("Ticket(key) " << MaskTicket(key) << " has expired during permission check");
         } else {
             auto& record = itToken->second;
             --record.ResponsesLeft;
@@ -1407,7 +1405,7 @@ private:
                         const auto checkIt = request->Request.checks().find(resultKey);
                         if (checkIt == request->Request.checks().end()) {
                             SetAccessServiceBulkAuthorizeError(key, record, TStringBuilder() << "Internal error: unknown result key: " << resultKey, false);
-                            BLOG_W("Internal error: unknown result key: " << resultKey << " for ticket " << record.GetMaskedTicket());
+                            BLOG_ERROR("Internal error: unknown result key: " << resultKey << " for ticket " << record.GetMaskedTicket());
                             processingError = true;
                             break;
                         }
@@ -1439,7 +1437,8 @@ private:
                             if (result.resultcode() != nebius::iam::v1::AuthorizeResult::OK) {
                                 permissionDeniedCount++;
                                 permissionRecord.Subject.clear();
-                                BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << permissionName << " access denied for subject \"" << (record.Subject ? record.Subject : "<not resolved>") << "\"");
+                                BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << permissionName
+                                    << " access denied for subject \"" << (record.Subject ? record.Subject : "<not resolved>") << "\"");
                                 TStringBuilder errorMessage;
                                 if (permissionRecord.IsRequired()) {
                                     hasRequiredPermissionFailed = true;
@@ -1457,7 +1456,7 @@ private:
                                 permissionRecord.Error = {.Message = errorMessage, .Retryable = false};
                             }
                         } else {
-                            BLOG_W("Received response for unknown permission " << permissionName << " for ticket " << record.GetMaskedTicket());
+                            BLOG_ERROR("Received response for unknown permission " << permissionName << " for ticket " << record.GetMaskedTicket());
                         }
                     }
                     if (!processingError) {
@@ -1476,7 +1475,7 @@ private:
                                 }
                                 return std::move(b);
                             };
-                            BLOG_W("Received response with not all permissions. Absent permissions: " << printAbsentPermissions());
+                            BLOG_ERROR("Received response with not all permissions. Absent permissions: " << printAbsentPermissions());
                             SetAccessServiceBulkAuthorizeError(key, record, TStringBuilder() << "Internal error: not all permissions in authorize response", false);
                         } else if (permissionDeniedCount < examinedPermissions.size() && !hasRequiredPermissionFailed) {
                             record.TokenType = TDerived::ETokenType::NebiusAccessService;
@@ -1510,9 +1509,7 @@ private:
         auto& userTokens = GetDerived()->GetUserTokens();
         auto itToken = userTokens.find(key);
         if (itToken == userTokens.end()) {
-            BLOG_ERROR("Ticket(key) "
-                        << MaskTicket(key)
-                        << " has expired during permission check");
+            BLOG_ERROR("Ticket(key) " << MaskTicket(key) << " has expired during permission check");
         } else {
             auto& record = itToken->second;
             --record.ResponsesLeft;
@@ -1543,7 +1540,8 @@ private:
                             permissionDeniedCount++;
                             auto& permissionDeniedRecord = permissionDeniedIt->second;
                             permissionDeniedRecord.Subject.clear();
-                            BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << result.permission() << " access denied for subject \"" << record.Subject << "\"");
+                            BLOG_NOTICE("Ticket " << record.GetMaskedTicket() << " permission " << result.permission()
+                                << " access denied for subject \"" << record.Subject << "\"");
                             TStringBuilder errorMessage;
                             if (permissionDeniedRecord.IsRequired()) {
                                 hasRequiredPermissionFailed = true;
@@ -1558,7 +1556,7 @@ private:
                             errorMessage << permissionDeniedError;
                             permissionDeniedRecord.Error = {.Message = errorMessage, .Retryable = false};
                         } else {
-                            BLOG_W("Received response for unknown permission " << result.permission() << " for ticket " << record.GetMaskedTicket());
+                            BLOG_ERROR("Received response for unknown permission " << result.permission() << " for ticket " << record.GetMaskedTicket());
                         }
                     }
                     if (permissionDeniedCount < examinedPermissions.size() && !hasRequiredPermissionFailed && subjectNameErrorMessage.empty()) {
@@ -1590,9 +1588,7 @@ private:
         auto& userTokens = GetDerived()->GetUserTokens();
         auto itToken = userTokens.find(key);
         if (itToken == userTokens.end()) {
-            BLOG_ERROR("Ticket(key) "
-                        << MaskTicket(key)
-                        << " has expired during permission check");
+            BLOG_ERROR("Ticket(key) " << MaskTicket(key) << " has expired during permission check");
         } else {
             auto& record = itToken->second;
             TString permission = request->Request.permission();
@@ -1607,40 +1603,23 @@ private:
                             record.Subject = itPermission->second.Subject;
                             record.SubjectType = itPermission->second.SubjectType;
                         }
-                        BLOG_TRACE("Ticket "
-                                    << record.GetMaskedTicket()
-                                    << " permission "
-                                    << permission
-                                    << " now has a valid subject \""
-                                    << record.Subject
-                                    << "\"");
+                        BLOG_TRACE("Ticket " << record.GetMaskedTicket() << " permission " << permission
+                            << " now has a valid subject \"" << record.Subject << "\"");
                     }
                 } else {
                     bool retryable = IsRetryableGrpcError(response->Status);
                     itPermission->second.Error = {.Message = TString{response->Status.Msg}, .Retryable = retryable};
                     if (itPermission->second.Subject.empty() || !retryable) {
                         itPermission->second.Subject.clear();
-                        BLOG_TRACE("Ticket "
-                                    << record.GetMaskedTicket()
-                                    << " permission "
-                                    << permission
-                                    << " now has a permanent error \""
-                                    << itPermission->second.Error
-                                    << "\" "
-                                    << " retryable:"
-                                    << retryable);
+                        BLOG_ERROR("Ticket " << record.GetMaskedTicket() << " permission " << permission
+                            << " now has a permanent error \"" << itPermission->second.Error << "\" " << " retryable:" << retryable);
                     } else if (retryable) {
-                        BLOG_TRACE("Ticket "
-                                    << record.GetMaskedTicket()
-                                    << " permission "
-                                    << permission
-                                    << " now has a retryable error \""
-                                    << response->Status.Msg
-                                    << "\"");
+                        BLOG_ERROR("Ticket " << record.GetMaskedTicket() << " permission " << permission
+                            << " now has a retryable error \"" << response->Status.Msg << "\"");
                     }
                 }
             } else {
-                BLOG_W("Received response for unknown permission " << permission << " for ticket " << record.GetMaskedTicket());
+                BLOG_ERROR("Received response for unknown permission " << permission << " for ticket " << record.GetMaskedTicket());
             }
             if (--record.ResponsesLeft == 0) {
                 ui32 permissionsOk = 0;
@@ -1709,7 +1688,7 @@ private:
     void Handle(TEvTicketParser::TEvUpdateLoginSecurityState::TPtr& ev) {
         auto& loginProvider = LoginProviders[ev->Get()->SecurityState.GetAudience()];
         loginProvider.UpdateSecurityState(ev->Get()->SecurityState);
-        BLOG_D("Updated state for " << loginProvider.Audience << " keys " << GetLoginProviderKeys(loginProvider));
+        BLOG_DEBUG("Updated state for " << loginProvider.Audience << " keys " << GetLoginProviderKeys(loginProvider));
 
         auto it = DeferredLoginTokens.find(loginProvider.Audience);
         if (it != DeferredLoginTokens.end()) {
@@ -1751,12 +1730,12 @@ private:
             }
             auto& record = it->second;
             if ((record.ExpireTime > now) && (record.AccessTime + GetLifeTime() > now)) {
-                BLOG_D("Refreshing ticket " << record.GetMaskedTicket());
+                BLOG_DEBUG("Refreshing ticket " << record.GetMaskedTicket());
                 if (!RefreshTicket(key, record)) {
                     RefreshQueue.push({key, record.RefreshTime});
                 }
             } else {
-                BLOG_D("Expired ticket " << record.GetMaskedTicket());
+                BLOG_NOTICE("Expired ticket " << record.GetMaskedTicket());
                 if (!record.AuthorizeRequests.empty()) {
                     record.Error = {.Message = "Timed out", .Retryable = true};
                     Respond(record);
@@ -2048,8 +2027,8 @@ protected:
         } else {
             CounterTicketsHighPriorityBuildTime->Collect(ticketBuildTime);
         }
-        BLOG_D("Ticket " << record.GetMaskedTicket() << " ("
-                    << record.PeerName << ") has now valid token of " << record.Subject);
+        BLOG_DEBUG("Ticket " << record.GetMaskedTicket()
+            << " (" << record.PeerName << ") has now valid token of " << record.Subject);
         record.IsLowRequestPriority = true;
         RefreshQueue.push({.Key = key, .RefreshTime = record.RefreshTime});
     }
@@ -2066,8 +2045,8 @@ protected:
             record.ExpireTime = GetDerived()->GetExpireTime(record, now);
             record.SetErrorRefreshTime(this, now);
             CounterTicketsErrorsRetryable->Inc();
-            BLOG_D("Ticket " << record.GetMaskedTicket() << " ("
-                        << record.PeerName << ") has now retryable error message '" << error.Message << errorLogMessage << "'");
+            BLOG_WARN("Ticket " << record.GetMaskedTicket()
+                << " (" << record.PeerName << ") has now retryable error message '" << error.Message << errorLogMessage << "'");
             if (record.RefreshRetryableErrorImmediately) {
                 record.RefreshRetryableErrorImmediately = false;
                 GetDerived()->CanRefreshTicket(key, record);
@@ -2079,8 +2058,8 @@ protected:
             record.UnsetToken();
             record.SetOkRefreshTime(this, now);
             CounterTicketsErrorsPermanent->Inc();
-            BLOG_D("Ticket " << record.GetMaskedTicket() << " ("
-                        << record.PeerName << ") has now permanent error message '" << error.Message << errorLogMessage << "'");
+            BLOG_WARN("Ticket " << record.GetMaskedTicket()
+                << " (" << record.PeerName << ") has now permanent error message '" << error.Message << errorLogMessage << "'");
         }
         CounterTicketsErrors->Inc();
         record.IsLowRequestPriority = true;
@@ -2442,7 +2421,7 @@ protected:
         }
 
         if (Config.HasExternalIdpConfig()) {
-            BLOG_D("External IdP authentication is enabled");
+            BLOG_DEBUG("External IdP authentication is enabled");
             ExternalIdpProvider = Register(
                 CreateExternalIdpProvider(Config.GetExternalIdpConfig(), {}),
                 TMailboxType::HTSwap, AppData()->UserPoolId);
@@ -2602,6 +2581,11 @@ void TTicketParserImpl<TDerived>::Handle(TEvTokenManager::TEvUpdateToken::TPtr& 
         << ", Token# " << MaskTicket(ev->Get()->Token));
     if (ev->Get()->Status.Code == TEvTokenManager::TStatus::ECode::SUCCESS) {
         ServiceTokens[ev->Get()->Id] = ev->Get()->Token;
+    } else {
+        BLOG_ERROR("Failed to update service token: id# " << ev->Get()->Id
+            << ", Status.code# " << convertStatusCode(ev->Get()->Status.Code)
+            << ", Status.Msg# " << ev->Get()->Status.Message
+            << ", Token# " << MaskTicket(ev->Get()->Token));
     }
 }
 

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -2045,8 +2045,8 @@ protected:
             record.ExpireTime = GetDerived()->GetExpireTime(record, now);
             record.SetErrorRefreshTime(this, now);
             CounterTicketsErrorsRetryable->Inc();
-            BLOG_W("Ticket " << record.GetMaskedTicket()
-                << " (" << record.PeerName << ") has now retryable error message '" << error.Message << errorLogMessage << "'");
+            BLOG_W("Failed to process ticket " << record.GetMaskedTicket()
+                << " (" << record.PeerName << "): retryable error '" << error.Message << errorLogMessage << "'");
             if (record.RefreshRetryableErrorImmediately) {
                 record.RefreshRetryableErrorImmediately = false;
                 GetDerived()->CanRefreshTicket(key, record);
@@ -2058,8 +2058,8 @@ protected:
             record.UnsetToken();
             record.SetOkRefreshTime(this, now);
             CounterTicketsErrorsPermanent->Inc();
-            BLOG_W("Ticket " << record.GetMaskedTicket()
-                << " (" << record.PeerName << ") has now permanent error message '" << error.Message << errorLogMessage << "'");
+            BLOG_W("Failed to process ticket " << record.GetMaskedTicket()
+                << " (" << record.PeerName << "): non-retryable error '" << error.Message << errorLogMessage << "'");
         }
         CounterTicketsErrors->Inc();
         record.IsLowRequestPriority = true;

--- a/ydb/core/security/ticket_parser_log.h
+++ b/ydb/core/security/ticket_parser_log.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#if defined BLOG_D || defined BLOG_I || defined BLOG_ERROR || defined BLOG_TRACE
+#if defined BLOG_ERROR || defined BLOG_WARN || defined BLOG_NOTICE || defined BLOG_DEBUG || defined BLOG_TRACE
 #error log macro definition clash
 #endif
 
-#define BLOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
-#define BLOG_TRACE(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
 #define BLOG_ERROR(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
-#define BLOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_WARN(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_NOTICE(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_DEBUG(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_TRACE(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)

--- a/ydb/core/security/ticket_parser_log.h
+++ b/ydb/core/security/ticket_parser_log.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#if defined BLOG_ERROR || defined BLOG_WARN || defined BLOG_NOTICE || defined BLOG_DEBUG || defined BLOG_TRACE
+#if defined BLOG_D || defined BLOG_I || defined BLOG_ERROR || defined BLOG_TRACE
 #error log macro definition clash
 #endif
 
-#define BLOG_ERROR(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
-#define BLOG_WARN(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
-#define BLOG_NOTICE(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
-#define BLOG_DEBUG(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
 #define BLOG_TRACE(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_ERROR(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)
+#define BLOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, stream)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improve operational visibility of Ticket Parser failures without changing authentication behavior.

- Raise retryable and permanent ticket-processing failures from debug to warning level.
- Add explicit error logging for failed service-token updates.
- Keep ticket and token material masked in all new and updated log messages.

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://nda.ya.ru/t/fdkWHWwo7oEKSR
