### PR TITLE
Сделал учет ImmedateControlOptions в сравнении конфигов

### DIFF
--- a/ydb/tests/library/compatibility/configs/comparator/__main__.py
+++ b/ydb/tests/library/compatibility/configs/comparator/__main__.py
@@ -20,6 +20,11 @@ class FieldInfo:
     def __init__(self, field: dict):
         self.id = field.get('id')
         self.value = field.get('default-value')
+        # Immediate controls (TImmediateControlsConfig) also carry the allowed
+        # range taken from the (ControlOptions) field option. Absent for
+        # everything else.
+        self.min_value = field.get('min-value')
+        self.max_value = field.get('max-value')
 
 
 class FieldIdent:
@@ -36,6 +41,24 @@ def _get_value_string(value: FieldInfo) -> str:
     if isinstance(value.value, list):
         return '[]'
     return str(value.value)
+
+
+def _describe_range_narrowing(old: FieldInfo, new: FieldInfo) -> str:
+    """Describes narrowing of the allowed [min, max] range, if any.
+
+    A bound that is missing in the older version is not compared: the range was
+    not specified back then, so there is nothing to narrow. The same holds for a
+    bound that has disappeared in the newer version - dropping a bound widens
+    the range rather than narrows it.
+    """
+    narrowed = []
+    if old.min_value is not None and new.min_value is not None and new.min_value > old.min_value:
+        narrowed.append(f'min {old.min_value} -> {new.min_value}')
+    if old.max_value is not None and new.max_value is not None and new.max_value < old.max_value:
+        narrowed.append(f'max {old.max_value} -> {new.max_value}')
+    if not narrowed:
+        return ''
+    return 'range narrowed ' + ', '.join(narrowed)
 
 
 class FieldResolution:
@@ -120,8 +143,15 @@ class Differ:
                     return Resolution.INFO, 'FF switched on'
                 else:
                     return Resolution.ERROR, 'FF switched off'
-            return Resolution.WARNING, f'value changed {old.value} -> {new.value}'
-        return Resolution.OK, value_str
+            resolution, message = Resolution.WARNING, f'value changed {old.value} -> {new.value}'
+        else:
+            resolution, message = Resolution.OK, value_str
+        narrowing = _describe_range_narrowing(old, new)
+        if narrowing:
+            if resolution.value < Resolution.WARNING.value:
+                resolution = Resolution.WARNING
+            message = f'{message}, {narrowing}' if message else narrowing
+        return resolution, message
 
     def compare(self):
         for ident, values in self.fields:
@@ -252,7 +282,7 @@ function showBranches(event) {
 <li><span style="background-color: #dddddd;font-weight:bold">Серый</span> - значение задано и не изменялось, в том числе пустое.</li>
 <li><span style="background-color: #aaffaa;font-weight:bold">Зеленый</span> - безопасное изменение, такое как добавление нового поля или включение Feature flag.</li>
 <li><span style="background-color: #ffffaa;font-weight:bold">Желтый</span> - изменение, которое может вызвать изменение поведения,
-но не должно быть критичным, например изменение значения по умолчанию.</li>
+но не должно быть критичным, например изменение значения по умолчанию или сужение допустимого диапазона immediate control.</li>
 <li><span style="background-color: #ffaaaa;font-weight:bold">Красный</span> - опасное изменение,
 которое может все сломать: удаление полей, изменение их типа или id (в протобуфе), выключение Feature flag итд.</li>
 </ul>
@@ -268,7 +298,8 @@ The color indicates the criticality of the changes in the neighboring branches:
 <li><span style="font-weight:bold">White</span> means that the field is completely absent in this version of the configuration.</li>
 <li><span style="background-color: #dddddd;font-weight:bold">Grey</span> - the value is set and has not changed, including the empty one.</li>
 <li><span style="background-color: #aaffaa;font-weight:bold">Green</span> - a safe change, such as adding a new field or enabling the Feature flag.</li>
-<li><span style="background-color: #ffffaa;font-weight:bold">Yellow</span> - a change that may cause a change in behavior, but should not be critical, such as changing the default value.</li>
+<li><span style="background-color: #ffffaa;font-weight:bold">Yellow</span> - a change that may cause a change in behavior, but should not be critical,
+such as changing the default value or narrowing the allowed range of an immediate control.</li>
 <li><span style="background-color: #ffaaaa;font-weight:bold">Red</span> - A dangerous change that can break everything:
 removing fields, changing their type or id (in protobuf), disabling the Feature flag etc.</li>
 </ul>

--- a/ydb/tests/library/compatibility/configs/dump/dumper/main.cpp
+++ b/ydb/tests/library/compatibility/configs/dump/dumper/main.cpp
@@ -71,6 +71,30 @@ NJson::TJsonValue GetRepeatedFieldValue(const FieldDescriptor& field, const TSet
     }
 }
 
+// Immediate controls (TImmediateControlsConfig) keep their real runtime default,
+// as well as the allowed range, in the (ControlOptions) field option rather than
+// in the protobuf default value: the control board code generator
+// (ydb/core/control/lib/generated/codegen/main.cpp) builds every TControl from
+// these options. Without this the dump reports 0 for all of them.
+// Returns true if the default value has been taken from the options.
+bool PrintImmediateControlOptions(const FieldDescriptor& field, NJson::TJsonValue& json) {
+    if (!field.options().HasExtension(NKikimrConfig::ControlOptions)) {
+        return false;
+    }
+    const auto& controlOptions = field.options().GetExtension(NKikimrConfig::ControlOptions);
+    if (controlOptions.HasMinValue()) {
+        json["min-value"] = controlOptions.GetMinValue();
+    }
+    if (controlOptions.HasMaxValue()) {
+        json["max-value"] = controlOptions.GetMaxValue();
+    }
+    if (!controlOptions.HasDefaultValue()) {
+        return false;
+    }
+    json["default-value"] = controlOptions.GetDefaultValue();
+    return true;
+}
+
 void PrintSingleField(const Message& proto,
                      const TSet<TString>& printedMessages,
                      const FieldDescriptor& field,
@@ -78,7 +102,9 @@ void PrintSingleField(const Message& proto,
         Y_ABORT_UNLESS(!field.is_repeated(), "field is repeated.");
         json[key]["id"] = field.number();
         json[key]["file"] = field.file()->name();
-        PrintSingleFieldValue(proto, printedMessages, field, json[key]["default-value"]);
+        if (!PrintImmediateControlOptions(field, json[key])) {
+            PrintSingleFieldValue(proto, printedMessages, field, json[key]["default-value"]);
+        }
 }
 
 void PrintRepeatedField(const FieldDescriptor& field, const TSet<TString>& printedMessages,


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/37761

Теперь если заданы ImmedateControlOptions для какого-то поля, то значение по умолчанию берется оттуда.

Также добавлена проверка диапазона доступных значений, его сужение - WARNING.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
