### PR TITLE
Fix VPatch quorum handling for Mirror3dc

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -447,6 +447,7 @@ struct TBlobStorageGroupPatchParameters {
     };
 
     bool UseVPatch = false;
+    bool EnableVPatchForTesting = false;
 };
 IActor* CreateBlobStorageGroupPatchRequest(TBlobStorageGroupPatchParameters params);
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -118,6 +118,7 @@ class TBlobStorageGroupPatchRequest : public TBlobStorageGroupRequestActor {
     TBlobStorageGroupInfo::TVDiskIds VDisks;
 
     bool UseVPatch = false;
+    bool EnableVPatchForTesting = false;
     bool IsGoodPatchedBlobId = false;
     bool IsAllowedErasure = false;
     bool IsSecured = false;
@@ -170,6 +171,7 @@ public:
         , Deadline(params.Common.Event->Deadline)
         , Orbit(std::move(params.Common.Event->Orbit))
         , UseVPatch(params.UseVPatch)
+        , EnableVPatchForTesting(params.EnableVPatchForTesting)
     {}
 
     void ReplyAndDie(NKikimrProto::EReplyStatus status) override {
@@ -447,11 +449,14 @@ public:
             return;
         }
 
-        Y_ABORT_UNLESS(subgroupIdx < 32);
-        SuccessfulVPatchResultsMask |= ui32{1} << subgroupIdx;
-        const bool hasQuorum = Info->Type.GetErasure() == TErasureType::ErasureMirror3dc
-            ? NVPatch::HasMirror3dcQuorum(*Info, SuccessfulVPatchResultsMask)
-            : ReceivedResults == Info->Type.TotalPartCount();
+        bool hasQuorum;
+        if (Info->Type.GetErasure() == TErasureType::ErasureMirror3dc) {
+            Y_ABORT_UNLESS(subgroupIdx < 32);
+            SuccessfulVPatchResultsMask |= ui32{1} << subgroupIdx;
+            hasQuorum = NVPatch::HasMirror3dcQuorum(*Info, SuccessfulVPatchResultsMask);
+        } else {
+            hasQuorum = ReceivedResults == Info->Type.TotalPartCount();
+        }
         if (hasQuorum) {
             YDB_LOG_PATCH_LOG(PRI_DEBUG, "Got successful quorum, make own success response",
                 {"marker", "BPPA25"});
@@ -958,7 +963,8 @@ public:
         IsAllowedErasure = Info->Type.ErasureFamily() == TErasureType::ErasureParityBlock
                 || Info->Type.GetErasure() == TErasureType::ErasureNone
                 || Info->Type.GetErasure() == TErasureType::ErasureMirror3dc;
-        if (false && IsGoodPatchedBlobId && IsAllowedErasure && UseVPatch && OriginalGroupId == Info->GroupID && !IsSecured) {
+        if (EnableVPatchForTesting && IsGoodPatchedBlobId && IsAllowedErasure && UseVPatch
+                && OriginalGroupId == Info->GroupID && !IsSecured) {
             YDB_LOG_PATCH_LOG(PRI_DEBUG, "Start VPatch strategy from bootstrap",
                 {"marker", "BPPA03"});
             StartVPatch();

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -29,10 +29,8 @@ bool HasMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 successfulSubgro
 
 ui32 SelectMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 availableSubgroupMask) {
     for (ui32 diskCount = 3; diskCount <= 4; ++diskCount) {
-        for (ui32 candidate = availableSubgroupMask; candidate;
-                candidate = (candidate - 1) & availableSubgroupMask) {
-            if (static_cast<ui32>(std::popcount(candidate)) == diskCount
-                    && HasMirror3dcQuorum(info, candidate)) {
+        for (ui32 candidate = availableSubgroupMask; candidate; candidate = (candidate - 1) & availableSubgroupMask) {
+            if (static_cast<ui32>(std::popcount(candidate)) == diskCount && HasMirror3dcQuorum(info, candidate)) {
                 return candidate;
             }
         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -6,6 +6,8 @@
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_partlayout.h>
 #include <ydb/core/util/stlog.h>
 
+#include <bit>
+
 #include <util/generic/ymath.h>
 #include <util/system/datetime.h>
 #include <util/system/hp_timer.h>
@@ -23,6 +25,19 @@ bool HasMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 successfulSubgro
     const auto successful = TBlobStorageGroupInfo::TSubgroupVDisks::CreateFromMask(
         &info.GetTopology(), successfulSubgroupMask);
     return info.GetQuorumChecker().CheckQuorumForSubgroup(successful);
+}
+
+ui32 SelectMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 availableSubgroupMask) {
+    for (ui32 diskCount = 3; diskCount <= 4; ++diskCount) {
+        for (ui32 candidate = availableSubgroupMask; candidate;
+                candidate = (candidate - 1) & availableSubgroupMask) {
+            if (static_cast<ui32>(std::popcount(candidate)) == diskCount
+                    && HasMirror3dcQuorum(info, candidate)) {
+                return candidate;
+            }
+        }
+    }
+    return 0;
 }
 
 } // namespace NVPatch
@@ -780,27 +795,35 @@ public:
         YDB_LOG_PATCH_LOG(PRI_DEBUG, "Continue VPatch {mirror-3-dc}",
             {"marker", "BPPA10"});
         TStackVec<TPartPlacement, TypicalPartsInBlob> placements;
-        ui32 subgroupMask = 0;
+        ui32 availableSubgroupMask = 0;
         for (const TPartPlacement& placement : FoundParts) {
             Y_ABORT_UNLESS(placement.VDiskIdxInSubgroup < 32);
+            availableSubgroupMask |= ui32{1} << placement.VDiskIdxInSubgroup;
+        }
+
+        const ui32 selectedSubgroupMask = NVPatch::SelectMirror3dcQuorum(*Info, availableSubgroupMask);
+        ui32 pendingSubgroupMask = selectedSubgroupMask;
+        for (const TPartPlacement& placement : FoundParts) {
             const ui32 bit = ui32{1} << placement.VDiskIdxInSubgroup;
-            if (!(subgroupMask & bit)) {
-                subgroupMask |= bit;
+            if (pendingSubgroupMask & bit) {
+                pendingSubgroupMask &= ~bit;
                 placements.push_back(placement);
-                if (NVPatch::HasMirror3dcQuorum(*Info, subgroupMask)) {
-                    SentVPatchDiff += placements.size();
-                    SendDiffs(placements);
-                    YDB_LOG_PATCH_LOG(PRI_DEBUG, "Found quorum {mirror-3-dc}",
-                        {"marker", "BPPA14"},
-                        {"SubgroupMask", subgroupMask},
-                        {"PlacementCount", placements.size()});
-                    return true;
-                }
             }
+        }
+        if (selectedSubgroupMask) {
+            Y_ABORT_UNLESS(!pendingSubgroupMask);
+            SentVPatchDiff += placements.size();
+            SendDiffs(placements);
+            YDB_LOG_PATCH_LOG(PRI_DEBUG, "Found quorum {mirror-3-dc}",
+                {"marker", "BPPA14"},
+                {"AvailableSubgroupMask", availableSubgroupMask},
+                {"SelectedSubgroupMask", selectedSubgroupMask},
+                {"PlacementCount", placements.size()});
+            return true;
         }
         YDB_LOG_PATCH_LOG(PRI_DEBUG, "Didn't find quorum {mirror-3-dc}",
             {"marker", "BPPA13"},
-            {"SubgroupMask", subgroupMask});
+            {"AvailableSubgroupMask", availableSubgroupMask});
         return false;
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -1,5 +1,6 @@
 #include "dsproxy.h"
 #include "dsproxy_mon.h"
+#include "dsproxy_patch.h"
 #include "root_cause.h"
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_partlayout.h>
@@ -14,6 +15,17 @@
 LWTRACE_USING(BLOBSTORAGE_PROVIDER);
 
 namespace NKikimr {
+
+namespace NVPatch {
+
+bool HasMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 successfulSubgroupMask) {
+    Y_ABORT_UNLESS(info.Type.GetErasure() == TErasureType::ErasureMirror3dc);
+    const auto successful = TBlobStorageGroupInfo::TSubgroupVDisks::CreateFromMask(
+        &info.GetTopology(), successfulSubgroupMask);
+    return info.GetQuorumChecker().CheckQuorumForSubgroup(successful);
+}
+
+} // namespace NVPatch
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // PATCH request
@@ -82,6 +94,7 @@ class TBlobStorageGroupPatchRequest : public TBlobStorageGroupRequestActor {
     ui32 ErrorResponses = 0;
     ui32 SentVPatchDiff = 0;
     ui32 ReceivedResults = 0;
+    ui32 SuccessfulVPatchResultsMask = 0;
 
     TStackVec<TPartPlacement, TypicalMaxPartsCount> FoundParts;
     TStackVec<bool, TypicalDisksInSubring> ReceivedResponseFlags;
@@ -421,38 +434,30 @@ public:
             return;
         }
 
-        if (ReceivedResults == Info->Type.TotalPartCount()) {
-            YDB_LOG_PATCH_LOG(PRI_DEBUG, "Got all succesful responses, make own success response",
+        Y_ABORT_UNLESS(subgroupIdx < 32);
+        SuccessfulVPatchResultsMask |= ui32{1} << subgroupIdx;
+        const bool hasQuorum = Info->Type.GetErasure() == TErasureType::ErasureMirror3dc
+            ? NVPatch::HasMirror3dcQuorum(*Info, SuccessfulVPatchResultsMask)
+            : ReceivedResults == Info->Type.TotalPartCount();
+        if (hasQuorum) {
+            YDB_LOG_PATCH_LOG(PRI_DEBUG, "Got successful quorum, make own success response",
                 {"marker", "BPPA25"});
             ReplyAndDie(NKikimrProto::OK);
         }
     }
 
     bool VerifyPartPlacementForMirror3dc() const {
-        constexpr ui32 DCCount = 3;
-        constexpr ui32 VDiskByDC = 3;
-        ui32 countByDC[DCCount] = {0, 0, 0};
-
-        for (auto &[subgroupIdx, partId] : FoundParts) {
-            countByDC[subgroupIdx / VDiskByDC]++;
+        ui32 subgroupMask = 0;
+        for (const TPartPlacement& placement : FoundParts) {
+            Y_ABORT_UNLESS(placement.VDiskIdxInSubgroup < 32);
+            subgroupMask |= ui32{1} << placement.VDiskIdxInSubgroup;
         }
-
-        if (countByDC[0] && countByDC[1] && countByDC[2]) {
-            YDB_LOG_PATCH_LOG(PRI_DEBUG, "VerifyPartPlacement {mirror-3-dc} found all 3 disks",
-                {"marker", "BPPA22"});
-            return true;
-        }
-
-        ui32 x2Count = 0;
-        for (ui32 dcIdx = 0; dcIdx < DCCount; ++dcIdx) {
-            if (countByDC[dcIdx] >= 2) {
-                x2Count++;
-            }
-        }
+        const bool hasQuorum = NVPatch::HasMirror3dcQuorum(*Info, subgroupMask);
         YDB_LOG_PATCH_LOG(PRI_DEBUG, "VerifyPartPlacement {mirror-3-dc}",
             {"marker", "BPPA00"},
-            {"X2Count", x2Count});
-        return x2Count >= 2;
+            {"SubgroupMask", subgroupMask},
+            {"HasQuorum", hasQuorum});
+        return hasQuorum;
     }
 
     bool VerifyPartPlacement() const {
@@ -774,56 +779,29 @@ public:
     bool ContinueVPatchForMirror3dc() {
         YDB_LOG_PATCH_LOG(PRI_DEBUG, "Continue VPatch {mirror-3-dc}",
             {"marker", "BPPA10"});
-        constexpr ui32 DCCount = 3;
-        constexpr ui32 VDiskByDC = 3;
-        ui32 countByDC[DCCount] = {0, 0, 0};
-        TPartPlacement diskByDC[DCCount][VDiskByDC];
-
-        for (auto &[subgroupIdx, partId] : FoundParts) {
-            ui32 dc = subgroupIdx / VDiskByDC;
-            ui32 idx = countByDC[dc];
-            diskByDC[dc][idx] = TPartPlacement{subgroupIdx, partId};
-            countByDC[dc]++;
-        }
-
-        if (countByDC[0] && countByDC[1] && countByDC[2]) {
-            YDB_LOG_PATCH_LOG(PRI_DEBUG, "Found disks {mirror-3-dc} on each dc",
-                {"marker", "BPPA11"},
-                {"DiskFromFirstDC", diskByDC[0][0].ToString()},
-                {"DiskFromSecondDC", diskByDC[0][0].ToString()},
-                {"DiskFromThirdDC", diskByDC[2][0].ToString()});
-            SendDiffs({diskByDC[0][0], diskByDC[1][0], diskByDC[2][0]});
-            return true;
-        }
-        YDB_LOG_PATCH_LOG(PRI_DEBUG, "Didn't find disks {mirror-3-dc} on each dc",
-            {"marker", "BPPA12"});
-
-        ui32 x2Count = 0;
-        for (ui32 dcIdx = 0; dcIdx < DCCount; ++dcIdx) {
-            if (countByDC[dcIdx] >= 2) {
-                x2Count++;
-            }
-        }
-        if (x2Count < 2) {
-            YDB_LOG_PATCH_LOG(PRI_DEBUG, "Didn't find disks {mirror-3-dc}",
-                {"marker", "BPPA13"});
-            return false;
-        }
         TStackVec<TPartPlacement, TypicalPartsInBlob> placements;
-        for (ui32 dcIdx = 0; dcIdx < DCCount; ++dcIdx) {
-            if (countByDC[dcIdx] >= 2) {
-                placements.push_back(diskByDC[dcIdx][0]);
-                placements.push_back(diskByDC[dcIdx][1]);
+        ui32 subgroupMask = 0;
+        for (const TPartPlacement& placement : FoundParts) {
+            Y_ABORT_UNLESS(placement.VDiskIdxInSubgroup < 32);
+            const ui32 bit = ui32{1} << placement.VDiskIdxInSubgroup;
+            if (!(subgroupMask & bit)) {
+                subgroupMask |= bit;
+                placements.push_back(placement);
+                if (NVPatch::HasMirror3dcQuorum(*Info, subgroupMask)) {
+                    SentVPatchDiff += placements.size();
+                    SendDiffs(placements);
+                    YDB_LOG_PATCH_LOG(PRI_DEBUG, "Found quorum {mirror-3-dc}",
+                        {"marker", "BPPA14"},
+                        {"SubgroupMask", subgroupMask},
+                        {"PlacementCount", placements.size()});
+                    return true;
+                }
             }
         }
-        SendDiffs(placements);
-        YDB_LOG_PATCH_LOG(PRI_DEBUG, "Found disks {mirror-3-dc} x2 mode",
-            {"marker", "BPPA14"},
-            {"FirstDiskFromFirstDC", placements[0]},
-            {"SecondDiskFromFirstDC", placements[1]},
-            {"FirstDiskFromSecondDC", placements[2]},
-            {"SecondDiskFromSecondDC", placements[3]});
-        return true;
+        YDB_LOG_PATCH_LOG(PRI_DEBUG, "Didn't find quorum {mirror-3-dc}",
+            {"marker", "BPPA13"},
+            {"SubgroupMask", subgroupMask});
+        return false;
     }
 
     bool ContinueVPatch() {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
+
+namespace NKikimr::NVPatch {
+
+bool HasMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 successfulSubgroupMask);
+
+} // namespace NKikimr::NVPatch

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.h
@@ -5,5 +5,6 @@
 namespace NKikimr::NVPatch {
 
 bool HasMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 successfulSubgroupMask);
+ui32 SelectMirror3dcQuorum(const TBlobStorageGroupInfo& info, ui32 availableSubgroupMask);
 
 } // namespace NKikimr::NVPatch

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_env_mock_ut.h
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_env_mock_ut.h
@@ -203,7 +203,8 @@ struct TDSProxyEnv {
                 }));
     }
 
-    std::unique_ptr<IActor> CreatePatchRequestActor(TEvBlobStorage::TEvPatch::TPtr &ev, bool useVPatch = false) {
+    std::unique_ptr<IActor> CreatePatchRequestActor(TEvBlobStorage::TEvPatch::TPtr &ev, bool useVPatch = false,
+            bool enableVPatchForTesting = false) {
         return std::unique_ptr<IActor>(CreateBlobStorageGroupPatchRequest(
             TBlobStorageGroupPatchParameters{
                 .Common = {
@@ -219,7 +220,8 @@ struct TDSProxyEnv {
                     .Event = ev->Get(),
                     .ExecutionRelay = ev->Get()->ExecutionRelay
                 },
-                .UseVPatch = useVPatch
+                .UseVPatch = useVPatch,
+                .EnableVPatchForTesting = enableVPatchForTesting,
             }));
     }
 };

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/util/stlog.h>
 #include <ydb/core/base/blobstorage_common.h>
 
+#include <bit>
 #include <cstring>
 
 namespace NKikimr {
@@ -22,6 +23,25 @@ Y_UNIT_TEST_SUITE(TVPatchMirror3dcQuorumTest) {
         UNIT_ASSERT(NVPatch::HasMirror3dcQuorum(info, 0b000011011)); // 2+2
         UNIT_ASSERT(!NVPatch::HasMirror3dcQuorum(info, 0b000001011)); // 2+1
         UNIT_ASSERT(!NVPatch::HasMirror3dcQuorum(info, 0b001001001)); // one realm only
+    }
+
+    Y_UNIT_TEST(PrefersOneReplicaFromEachRealm) {
+        const TBlobStorageGroupInfo info(TErasureType::ErasureMirror3dc, 1, 3, 3);
+
+        const ui32 selected = NVPatch::SelectMirror3dcQuorum(info, 0b000011111); // 2+2+1 available
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<ui32>(std::popcount(selected)), 3);
+        UNIT_ASSERT(NVPatch::HasMirror3dcQuorum(info, selected));
+    }
+
+    Y_UNIT_TEST(FallsBackToTwoByTwo) {
+        const TBlobStorageGroupInfo info(TErasureType::ErasureMirror3dc, 1, 3, 3);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NVPatch::SelectMirror3dcQuorum(info, 0b000011011),
+            0b000011011); // 2+2 available
+        UNIT_ASSERT_VALUES_EQUAL(
+            NVPatch::SelectMirror3dcQuorum(info, 0b000001011),
+            0); // only 2+1 available
     }
 }
 

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
@@ -9,7 +9,6 @@
 #include <ydb/core/util/stlog.h>
 #include <ydb/core/base/blobstorage_common.h>
 
-#include <bit>
 #include <cstring>
 
 namespace NKikimr {
@@ -28,9 +27,10 @@ Y_UNIT_TEST_SUITE(TVPatchMirror3dcQuorumTest) {
     Y_UNIT_TEST(PrefersOneReplicaFromEachRealm) {
         const TBlobStorageGroupInfo info(TErasureType::ErasureMirror3dc, 1, 3, 3);
 
-        const ui32 selected = NVPatch::SelectMirror3dcQuorum(info, 0b000011111); // 2+2+1 available
-        UNIT_ASSERT_VALUES_EQUAL(static_cast<ui32>(std::popcount(selected)), 3);
-        UNIT_ASSERT(NVPatch::HasMirror3dcQuorum(info, selected));
+        // Realm 0: bits 0, 3; realm 1: bits 1, 4; realm 2: bit 2.
+        constexpr ui32 available = 0b000011111; // 2+2+1
+        constexpr ui32 expected = 0b000011100; // bits 2, 3, 4: 1+1+1
+        UNIT_ASSERT_VALUES_EQUAL(NVPatch::SelectMirror3dcQuorum(info, available), expected);
     }
 
     Y_UNIT_TEST(FallsBackToTwoByTwo) {

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
@@ -649,6 +649,149 @@ void SetLogPriorities(TTestBasicRuntime &runtime) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TMirror3dcVPatchActorTest {
+    struct TDiffEvents {
+        ui32 SelectedMask = 0;
+        ui32 ForceEndMask = 0;
+        TVector<TEvBlobStorage::TEvVPatchDiff::TPtr> Selected;
+    };
+
+    TTestArgs Args;
+    TTestBasicRuntime Runtime{1, false};
+    TDSProxyEnv Env;
+    TActorId PatchActorId;
+
+    void SendFoundParts(ui32 availableMask) {
+        for (ui32 vdiskIdx = 0; vdiskIdx < Args.GType.BlobSubgroupSize(); ++vdiskIdx) {
+            auto start = Runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVPatchStart>({Env.VDisks[vdiskIdx]});
+            auto& record = start->Get()->Record;
+            UNIT_ASSERT(record.HasCookie());
+            const ui32 subgroupIdx = record.GetCookie();
+            UNIT_ASSERT(subgroupIdx < 32);
+
+            const TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
+            UNIT_ASSERT_VALUES_EQUAL(Env.Info->GetIdxInSubgroup(vdisk, Args.OriginalId.Hash()), subgroupIdx);
+
+            auto foundParts = std::make_unique<TEvBlobStorage::TEvVPatchFoundParts>(NKikimrProto::OK,
+                Args.OriginalId, Args.PatchedId, vdisk, record.GetCookie(), Runtime.GetCurrentTime(), "", &record,
+                nullptr, nullptr, nullptr, 0);
+            if (availableMask & ui32{1} << subgroupIdx) {
+                foundParts->AddPart(subgroupIdx % 3 + 1);
+            }
+            SendByHandle(Runtime, start, std::move(foundParts));
+        }
+    }
+
+    TDiffEvents CollectDiffEvents(ui32 availableMask) {
+        TDiffEvents result;
+        for (ui32 vdiskIdx = 0; vdiskIdx < Args.GType.BlobSubgroupSize(); ++vdiskIdx) {
+            const auto [_, subgroupIdx] = TVDiskPointer::GetVDiskIdx(vdiskIdx).GetIndecies(Env, Args.OriginalId.Hash());
+            const ui32 bit = ui32{1} << subgroupIdx;
+            if (!(availableMask & bit)) {
+                continue;
+            }
+
+            auto diff = Runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVPatchDiff>({Env.VDisks[vdiskIdx]});
+            UNIT_ASSERT(diff->Get()->Record.HasCookie());
+            UNIT_ASSERT_VALUES_EQUAL(diff->Get()->Record.GetCookie(), subgroupIdx);
+            if (diff->Get()->IsForceEnd()) {
+                result.ForceEndMask |= bit;
+            } else {
+                result.SelectedMask |= bit;
+                result.Selected.push_back(std::move(diff));
+            }
+        }
+        return result;
+    }
+
+    void SendResult(const TEvBlobStorage::TEvVPatchDiff::TPtr& diff, NKikimrProto::EReplyStatus status) {
+        auto& record = diff->Get()->Record;
+        const TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
+        auto result = std::make_unique<TEvBlobStorage::TEvVPatchResult>(status, Args.OriginalId, Args.PatchedId,
+            vdisk, record.GetCookie(), Runtime.GetCurrentTime(), &record, nullptr, nullptr, nullptr, 0);
+        result->SetStatusFlagsAndFreeSpace(Args.StatusFlags, Args.ApproximateFreeSpaceShare);
+        SendByHandle(Runtime, diff, std::move(result));
+    }
+
+public:
+    TMirror3dcVPatchActorTest() {
+        Args.MakeDefault(TErasureType::ErasureMirror3dc);
+        SetLogPriorities(Runtime);
+        SetupRuntime(Runtime);
+        Env.Configure(Runtime, Args.GType, Args.CurrentGroupId, 0, TBlobStorageGroupInfo::EEM_NONE);
+    }
+
+    TDiffEvents Start(ui32 availableMask) {
+        auto patch = CreatePatch(Runtime, Env, Args);
+        auto patchActor = Env.CreatePatchRequestActor(patch, true, true);
+        PatchActorId = Runtime.Register(patchActor.release(), 0, 0, TMailboxType::Simple, 0, Env.FakeProxyActorId);
+
+        SendFoundParts(availableMask);
+        return CollectDiffEvents(availableMask);
+    }
+
+    void CompleteSuccessfully(const TDiffEvents& events) {
+        UNIT_ASSERT(!events.Selected.empty());
+        for (ui32 i = 0; i < events.Selected.size(); ++i) {
+            SendResult(events.Selected[i], NKikimrProto::OK);
+            if (i + 1 != events.Selected.size()) {
+                TDispatchOptions options;
+                options.FinalEvents.emplace_back(TEvBlobStorage::TEvVPatchResult::EventType);
+                Runtime.DispatchEvents(options);
+                UNIT_ASSERT(Runtime.FindActor(PatchActorId));
+            }
+        }
+        ReceivePatchResult(Runtime, Args, NKikimrProto::OK);
+        UNIT_ASSERT(!Runtime.FindActor(PatchActorId));
+    }
+
+    void FailAndFallback(const TDiffEvents& events) {
+        UNIT_ASSERT(!events.Selected.empty());
+        SendResult(events.Selected.front(), NKikimrProto::ERROR);
+        ConductFallbackPatch(Runtime, Args);
+    }
+
+    void CompleteFallback() {
+        ConductFallbackPatch(Runtime, Args);
+    }
+};
+
+Y_UNIT_TEST_SUITE(TVPatchMirror3dcActorTest) {
+    Y_UNIT_TEST(SelectsOneReplicaFromEachRealm) {
+        TMirror3dcVPatchActorTest test;
+        const auto events = test.Start(0b000000111); // 1+1+1
+        UNIT_ASSERT_VALUES_EQUAL(events.SelectedMask, 0b000000111);
+        UNIT_ASSERT_VALUES_EQUAL(events.ForceEndMask, 0);
+        test.CompleteSuccessfully(events);
+    }
+
+    Y_UNIT_TEST(SelectsTwoReplicasFromTwoRealms) {
+        TMirror3dcVPatchActorTest test;
+        const auto events = test.Start(0b000011011); // 2+2
+        UNIT_ASSERT_VALUES_EQUAL(events.SelectedMask, 0b000011011);
+        UNIT_ASSERT_VALUES_EQUAL(events.ForceEndMask, 0);
+        test.CompleteSuccessfully(events);
+    }
+
+    Y_UNIT_TEST(FallsBackWithoutQuorum) {
+        TMirror3dcVPatchActorTest test;
+        const auto events = test.Start(0b000001011); // 2+1
+        UNIT_ASSERT_VALUES_EQUAL(events.SelectedMask, 0);
+        UNIT_ASSERT_VALUES_EQUAL(events.ForceEndMask, 0b000001011);
+        test.CompleteFallback();
+    }
+
+    Y_UNIT_TEST(FallsBackOnSelectedVDiskError) {
+        TMirror3dcVPatchActorTest test;
+        const auto events = test.Start(0b000011111); // 2+2+1
+        UNIT_ASSERT_VALUES_EQUAL(events.SelectedMask, 0b000011100); // 1+1+1
+        UNIT_ASSERT_VALUES_EQUAL(events.ForceEndMask, 0b000000011);
+        test.FailAndFallback(events);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 Y_UNIT_TEST_SUITE(TDSProxyPatchTest) {
 
 template <typename ECase>

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_patch_ut.cpp
@@ -4,6 +4,7 @@
 #include "dsproxy_test_state_ut.h"
 #include "dsproxy_vdisk_mock_ut.h"
 
+#include <ydb/core/blobstorage/dsproxy/dsproxy_patch.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_partlayout.h>
 #include <ydb/core/util/stlog.h>
 #include <ydb/core/base/blobstorage_common.h>
@@ -12,6 +13,17 @@
 
 namespace NKikimr {
 namespace NDSProxyPatchTest {
+
+Y_UNIT_TEST_SUITE(TVPatchMirror3dcQuorumTest) {
+    Y_UNIT_TEST(UsesTopologyAwareQuorum) {
+        const TBlobStorageGroupInfo info(TErasureType::ErasureMirror3dc, 1, 3, 3);
+
+        UNIT_ASSERT(NVPatch::HasMirror3dcQuorum(info, 0b000000111)); // 1+1+1
+        UNIT_ASSERT(NVPatch::HasMirror3dcQuorum(info, 0b000011011)); // 2+2
+        UNIT_ASSERT(!NVPatch::HasMirror3dcQuorum(info, 0b000001011)); // 2+1
+        UNIT_ASSERT(!NVPatch::HasMirror3dcQuorum(info, 0b001001001)); // one realm only
+    }
+}
 
 struct TVDiskPointer {
     ui32 VDiskIdx;

--- a/ydb/core/blobstorage/dsproxy/ya.make
+++ b/ydb/core/blobstorage/dsproxy/ya.make
@@ -33,6 +33,7 @@ SRCS(
     dsproxy_nodemonactor.cpp
     dsproxy_nodemonactor.h
     dsproxy_patch.cpp
+    dsproxy_patch.h
     dsproxy_put.cpp
     dsproxy_put_impl.cpp
     dsproxy_put_impl.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed VPatch quorum handling for Mirror3dc groups.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Uses the topology quorum checker when selecting replicas and completing a patch, preferring one replica from each realm before falling back to two replicas in two realms.