### PR TITLE
duplicates manager race has been fixed

### DIFF
--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.h
@@ -80,9 +80,8 @@ public:
     void RegisterActors(const NCommon::ISourcesConstructor& sources);
     void UnregisterActors();
 
-    NActors::TActorId GetDuplicatesManagerVerified() const {
+    NActors::TActorId GetDuplicatesManager() const {
         TGuard<TSpinLock> g(DuplicatesManagerLock);
-        AFL_VERIFY(DuplicatesManager);
         return DuplicatesManager;
     }
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.h
@@ -412,11 +412,14 @@ public:
 
     void StartFetchingDuplicateFilter(std::shared_ptr<NDuplicateFiltering::IFilterSubscriber>&& subscriber) {
         auto context = std::static_pointer_cast<TSpecialReadContext>(GetContext());
-        if (!context->IsActive()) {
+        const auto duplicatesManager = context->GetDuplicatesManager();
+        if (!duplicatesManager) {
+            // Scan abort raced with this step: UnregisterActors already dropped the manager.
+            AFL_VERIFY(!context->IsActive());
             return;
         }
         NActors::TActivationContext::AsActorContext().Send(
-            context->GetDuplicatesManagerVerified(), new NDuplicateFiltering::TEvRequestFilter(*this, std::move(subscriber)));
+            duplicatesManager, new NDuplicateFiltering::TEvRequestFilter(*this, std::move(subscriber)));
     }
 
     std::optional<ui64> GetPortionIdOptional() const override {

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/context.h
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/context.h
@@ -80,9 +80,8 @@ public:
     void RegisterActors(const NCommon::ISourcesConstructor& sources);
     void UnregisterActors();
 
-    NActors::TActorId GetDuplicatesManagerVerified() const {
+    NActors::TActorId GetDuplicatesManager() const {
         TGuard<TSpinLock> g(DuplicatesManagerLock);
-        AFL_VERIFY(DuplicatesManager);
         return DuplicatesManager;
     }
 

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/source.h
@@ -412,11 +412,14 @@ public:
 
     void StartFetchingDuplicateFilter(std::shared_ptr<NDuplicateFiltering::IFilterSubscriber>&& subscriber) {
         auto context = std::static_pointer_cast<TSpecialReadContext>(GetContext());
-        if (!context->IsActive()) {
+        const auto duplicatesManager = context->GetDuplicatesManager();
+        if (!duplicatesManager) {
+            // Scan abort raced with this step: UnregisterActors already dropped the manager.
+            AFL_VERIFY(!context->IsActive());
             return;
         }
         NActors::TActivationContext::AsActorContext().Send(
-            context->GetDuplicatesManagerVerified(), new NDuplicateFiltering::TEvRequestFilter(*this, std::move(subscriber)));
+            duplicatesManager, new NDuplicateFiltering::TEvRequestFilter(*this, std::move(subscriber)));
     }
 
     std::optional<ui64> GetPortionIdOptional() const override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/pull/23147/changes - предыдущий фикс не помог, здесь важно что `IsActive` может быть сброшен перед тем как вызвали `GetDuplicatesManagerVerified`. Поэтому здесь в начале получаем ActorId, а потом в него отпоавляем event. И это безопасно с точки зрения AS, если актор был разрушен, то event не долетит до него
