### PR TITLE
fix invalid assertion

### DIFF
--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federation_observer.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federation_observer.cpp
@@ -67,7 +67,8 @@ void TFederatedDbObserverImpl::RunFederationDiscoveryImpl() {
     // IAM token is not ready yet), which in turn calls OnFederationDiscovery that
     // tries to acquire Lock.  Holding Lock here would cause a spin-deadlock on
     // the single gRPC event-loop thread.
-    Y_ABORT_UNLESS(!Lock.IsLocked());
+    // TSpinLock::IsLocked cannot validate this caller contract because it also
+    // returns true when another thread owns Lock.
 
     NYdbGrpc::IQueueClientContextPtr ctx;
     {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Description for reviewers <!-- (optional) description for those who read this PR -->

The assertion is intended to verify that the current thread doesn't hold the lock, but for some reason checks if the lock is held at all.
The minimal fix is to remove this assertion entirely.

