### PR TITLE
Honor RFC 7239 Forwarded and X-Forwarded-Port in SQS-over-topics QueueUrl

### DIFF
--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -13,6 +13,131 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
         UNIT_ASSERT_VALUES_EQUAL(MakeSqsRequestEndpoint("", "X-Forwarded-Proto: https\r\n", false), "");
     }
 
+    Y_UNIT_TEST(ForwardedHeaderPresenceMatrix) {
+        struct TCase {
+            const char* Name;
+            TStringBuf Host;
+            TStringBuf Headers;
+            bool Tls;
+            TStringBuf Expected;
+        };
+
+        const TCase cases[] = {
+            // No headers at all
+            {"empty", "", "", false, ""},
+            {"empty_tls", "", "", true, ""},
+
+            // Host only
+            {"host_port", "backend.internal:8771", "", false, "http://backend.internal:8771"},
+            {"host_port_tls", "backend.internal:8771", "", true, "https://backend.internal:8771"},
+            {"host", "backend.internal", "", false, "http://backend.internal"},
+            {"host_tls", "backend.internal", "", true, "https://backend.internal"},
+
+            // Only X-Forwarded-Host
+            {"xfh", "backend.internal:8771",
+             "X-Forwarded-Host: example.com\r\n", false, "http://example.com"},
+            {"xfh_port", "backend.internal:8771",
+             "X-Forwarded-Host: example.com:8080\r\n", false, "http://example.com:8080"},
+            {"xfh_empty_host", "",
+             "X-Forwarded-Host: example.com\r\n", false, "http://example.com"},
+            {"xfh_port_empty_host", "",
+             "X-Forwarded-Host: example.com:8080\r\n", false, "http://example.com:8080"},
+
+            // Only X-Forwarded-Port
+            {"xfp_overrides_host_port", "backend.internal:8771",
+             "X-Forwarded-Port: 8443\r\n", false, "http://backend.internal:8443"},
+            {"xfp_on_host", "backend.internal",
+             "X-Forwarded-Port: 8443\r\n", false, "http://backend.internal:8443"},
+            {"xfp_empty_host", "",
+             "X-Forwarded-Port: 8443\r\n", false, ""},
+
+            // Only X-Forwarded-Proto
+            {"xproto_https", "backend.internal:8771",
+             "X-Forwarded-Proto: https\r\n", false, "https://backend.internal:8771"},
+            {"xproto_https_host", "backend.internal",
+             "X-Forwarded-Proto: https\r\n", false, "https://backend.internal"},
+            {"xproto_http_overrides_tls", "backend.internal:8771",
+             "X-Forwarded-Proto: http\r\n", true, "http://backend.internal:8771"},
+            {"xproto_empty_host", "",
+             "X-Forwarded-Proto: https\r\n", false, ""},
+
+            // X-Forwarded-Host + X-Forwarded-Port
+            {"xfh_xfp", "backend.internal:8771",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Port: 8443\r\n",
+             false, "http://example.com:8443"},
+            {"xfh_port_xfp", "backend.internal:8771",
+             "X-Forwarded-Host: example.com:8080\r\n"
+             "X-Forwarded-Port: 8443\r\n",
+             false, "http://example.com:8443"},
+            {"xfh_xfp_empty_host", "",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Port: 8443\r\n",
+             false, "http://example.com:8443"},
+
+            // X-Forwarded-Host + X-Forwarded-Proto
+            {"xfh_xproto", "backend.internal:8771",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com"},
+            {"xfh_port_xproto", "backend.internal:8771",
+             "X-Forwarded-Host: example.com:8080\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com:8080"},
+            {"xfh_xproto_empty_host", "",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com"},
+
+            // X-Forwarded-Port + X-Forwarded-Proto
+            {"xfp_xproto", "backend.internal:8771",
+             "X-Forwarded-Port: 8443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://backend.internal:8443"},
+            {"xfp_xproto_host", "backend.internal",
+             "X-Forwarded-Port: 8443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://backend.internal:8443"},
+            {"xfp_default_https", "backend.internal",
+             "X-Forwarded-Port: 443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://backend.internal"},
+            {"xfp_xproto_empty_host", "",
+             "X-Forwarded-Port: 8443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, ""},
+
+            // All three
+            {"all", "backend.internal:8771",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Port: 8443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com:8443"},
+            {"all_xfh_port_overridden", "backend.internal:8771",
+             "X-Forwarded-Host: example.com:8080\r\n"
+             "X-Forwarded-Port: 8443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com:8443"},
+            {"all_default_https_port", "backend.internal:8771",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Port: 443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com"},
+            {"all_empty_host", "",
+             "X-Forwarded-Host: example.com\r\n"
+             "X-Forwarded-Port: 8443\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com:8443"},
+        };
+
+        for (const auto& c : cases) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                MakeSqsRequestEndpoint(c.Host, c.Headers, c.Tls),
+                c.Expected,
+                c.Name);
+        }
+    }
+
     Y_UNIT_TEST(UsesHostAndPlainHttp) {
         UNIT_ASSERT_VALUES_EQUAL(
             MakeSqsRequestEndpoint("sqs.ydb.test:8443", "", false),
@@ -49,6 +174,112 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
                 "X-Forwarded-Proto: https\r\n",
                 false),
             "https://example.com:8080");
+    }
+
+    Y_UNIT_TEST(PrefersForwardedPortOverHostPort) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Port: 9090\r\n",
+                false),
+            "http://example.com:9090");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Port: 8443\r\n"
+                "X-Forwarded-Proto: https\r\n",
+                false),
+            "https://example.com:8443");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com\r\n"
+                "X-Forwarded-Port: 8080\r\n",
+                false),
+            "http://example.com:8080");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Port: 8443\r\n",
+                false),
+            "http://backend.internal:8443");
+    }
+
+    Y_UNIT_TEST(TakesFirstForwardedPortToken) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Port: 8443, 8771\r\n",
+                false),
+            "http://example.com:8443");
+    }
+
+    Y_UNIT_TEST(IgnoresInvalidForwardedPortAndUsesHostPort) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Port: abc\r\n",
+                false),
+            "http://example.com:8080");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Port: 0\r\n",
+                false),
+            "http://example.com:8080");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Port: 65536\r\n",
+                false),
+            "http://example.com:8080");
+    }
+
+    Y_UNIT_TEST(UsesDefaultPortFromProtoWhenNoPortSpecified) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com\r\n"
+                "X-Forwarded-Proto: https\r\n",
+                false),
+            "https://example.com");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com\r\n"
+                "X-Forwarded-Proto: http\r\n",
+                false),
+            "http://example.com");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com\r\n"
+                "X-Forwarded-Port: 443\r\n"
+                "X-Forwarded-Proto: https\r\n",
+                false),
+            "https://example.com");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com\r\n"
+                "X-Forwarded-Port: 80\r\n"
+                "X-Forwarded-Proto: http\r\n",
+                false),
+            "http://example.com");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com\r\n"
+                "X-Forwarded-Port: 443\r\n"
+                "X-Forwarded-Proto: http\r\n",
+                false),
+            "http://example.com:443");
     }
 
     Y_UNIT_TEST(TakesFirstForwardedTokenAndLowercasesProto) {
@@ -113,5 +344,22 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
         UNIT_ASSERT_VALUES_EQUAL(
             MakeSqsRequestEndpoint(request->Host, request->Headers, tlsSecure),
             "https://lbkx.example.net:8443");
+    }
+
+    Y_UNIT_TEST(ParsedHttpRequestPrefersForwardedPort) {
+        auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        endpoint->Secure = false;
+        const TString raw =
+            "POST / HTTP/1.1\r\n"
+            "Host: vla5-2135.lbkx.example.net:8771\r\n"
+            "X-Forwarded-Host: example.com:8080\r\n"
+            "X-Forwarded-Port: 8443\r\n"
+            "X-Forwarded-Proto: https\r\n"
+            "\r\n";
+        auto request = MakeIntrusive<NHttp::THttpIncomingRequest>(
+            raw, endpoint, NHttp::THttpConfig::SocketAddressType{});
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(request->Host, request->Headers, false),
+            "https://example.com:8443");
     }
 }

--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -138,6 +138,145 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
         }
     }
 
+    Y_UNIT_TEST(Rfc7239ForwardedPresenceMatrix) {
+        struct TCase {
+            const char* Name;
+            TStringBuf Host;
+            TStringBuf Headers;
+            bool Tls;
+            TStringBuf Expected;
+        };
+
+        const TCase cases[] = {
+            // No Forwarded header
+            {"no_forwarded", "backend.internal:8771", "", false, "http://backend.internal:8771"},
+
+            // Only host=
+            {"host", "backend.internal:8771",
+             "Forwarded: host=example.com\r\n", false, "http://example.com"},
+            {"host_port_quoted", "backend.internal:8771",
+             "Forwarded: host=\"example.com:8080\"\r\n", false, "http://example.com:8080"},
+            {"host_port_unquoted", "backend.internal:8771",
+             "Forwarded: host=example.com:8080\r\n", false, "http://example.com:8080"},
+            {"host_empty_request_host", "",
+             "Forwarded: host=example.com\r\n", false, "http://example.com"},
+
+            // Only proto=
+            {"proto_https", "backend.internal:8771",
+             "Forwarded: proto=https\r\n", false, "https://backend.internal:8771"},
+            {"proto_http_overrides_tls", "backend.internal:8771",
+             "Forwarded: proto=http\r\n", true, "http://backend.internal:8771"},
+            {"proto_empty_request_host", "",
+             "Forwarded: proto=https\r\n", false, ""},
+
+            // host= + proto=
+            {"host_proto", "backend.internal:8771",
+             "Forwarded: host=example.com;proto=https\r\n", false, "https://example.com"},
+            {"host_port_proto", "backend.internal:8771",
+             "Forwarded: host=\"example.com:8080\";proto=https\r\n", false, "https://example.com:8080"},
+            {"proto_then_host", "backend.internal:8771",
+             "Forwarded: proto=https;host=example.com\r\n", false, "https://example.com"},
+            {"host_proto_empty_request_host", "",
+             "Forwarded: host=example.com;proto=https\r\n", false, "https://example.com"},
+
+            // for= / by= ignored
+            {"for_by_ignored", "backend.internal:8771",
+             "Forwarded: for=192.0.2.43;by=203.0.113.60;host=example.com;proto=https\r\n",
+             false, "https://example.com"},
+
+            // RFC 7.5 chain: first element has only for=, host/proto on a later element
+            {"rfc_example_chain", "backend.internal:8771",
+             "Forwarded: for=192.0.2.43, for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com\r\n",
+             false, "http://example.com"},
+
+            // First host=/proto= wins
+            {"first_element_wins", "backend.internal:8771",
+             "Forwarded: host=first.example;proto=http, host=second.example;proto=https\r\n",
+             false, "http://first.example"},
+
+            // Quoted proto, case-insensitive names
+            {"quoted_proto_case", "backend.internal:8771",
+             "Forwarded: Host=example.com;PROTO=\"HTTPS\"\r\n", false, "https://example.com"},
+
+            // Whitespace around tokens
+            {"ows", "backend.internal:8771",
+             "Forwarded: for=192.0.2.43; host=\"example.com:8080\"; proto=https\r\n",
+             false, "https://example.com:8080"},
+
+            // IPv6 host must be quoted
+            {"ipv6_host_port", "backend.internal:8771",
+             "Forwarded: host=\"[2001:db8:cafe::17]:8080\";proto=https\r\n",
+             false, "https://[2001:db8:cafe::17]:8080"},
+
+            // Multiple Forwarded header fields (RFC 7.1)
+            {"split_headers", "backend.internal:8771",
+             "Forwarded: for=192.0.2.43\r\n"
+             "Forwarded: host=example.com;proto=https\r\n",
+             false, "https://example.com"},
+
+            // Invalid host falls back to X-Forwarded-Host / Host
+            {"invalid_host_fallback_xfh", "backend.internal:8771",
+             "Forwarded: host=evil.com/phishing\r\n"
+             "X-Forwarded-Host: example.com\r\n",
+             false, "http://example.com"},
+            {"invalid_host_fallback_host", "backend.internal:8771",
+             "Forwarded: host=evil.com/phishing\r\n",
+             false, "http://backend.internal:8771"},
+
+            // Unknown proto falls back to X-Forwarded-Proto / TLS
+            {"unknown_proto_fallback_xfp", "backend.internal:8771",
+             "Forwarded: host=example.com;proto=ftp\r\n"
+             "X-Forwarded-Proto: https\r\n",
+             false, "https://example.com"},
+
+            // Forwarded overrides X-Forwarded-*
+            {"overrides_xfh", "backend.internal:8771",
+             "Forwarded: host=rfc.example\r\n"
+             "X-Forwarded-Host: xfh.example\r\n",
+             false, "http://rfc.example"},
+            {"overrides_xproto", "backend.internal:8771",
+             "Forwarded: host=example.com;proto=https\r\n"
+             "X-Forwarded-Proto: http\r\n",
+             false, "https://example.com"},
+
+            // X-Forwarded-Port still wins over port in Forwarded host
+            {"xfp_overrides_rfc_host_port", "backend.internal:8771",
+             "Forwarded: host=\"example.com:8080\";proto=https\r\n"
+             "X-Forwarded-Port: 8443\r\n",
+             false, "https://example.com:8443"},
+
+            // Forwarded host without port + X-Forwarded-Port
+            {"rfc_host_xfp", "backend.internal:8771",
+             "Forwarded: host=example.com\r\n"
+             "X-Forwarded-Port: 8080\r\n",
+             false, "http://example.com:8080"},
+
+            // Default ports omitted
+            {"default_https_omitted", "backend.internal:8771",
+             "Forwarded: host=example.com;proto=https\r\n",
+             false, "https://example.com"},
+            {"explicit_443_omitted", "backend.internal:8771",
+             "Forwarded: host=\"example.com:443\";proto=https\r\n",
+             false, "https://example.com"},
+        };
+
+        for (const auto& c : cases) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                MakeSqsRequestEndpoint(c.Host, c.Headers, c.Tls),
+                c.Expected,
+                c.Name);
+        }
+    }
+
+    Y_UNIT_TEST(Rfc7239ForwardedFullString) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "Forwarded: for=192.0.2.60;host=\"mysite.com:8080\";proto=http;by=8.8.8.8\r\n",
+                false),
+            "http://mysite.com:8080");
+    }
+
     Y_UNIT_TEST(UsesHostAndPlainHttp) {
         UNIT_ASSERT_VALUES_EQUAL(
             MakeSqsRequestEndpoint("sqs.ydb.test:8443", "", false),
@@ -361,5 +500,22 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
         UNIT_ASSERT_VALUES_EQUAL(
             MakeSqsRequestEndpoint(request->Host, request->Headers, false),
             "https://example.com:8443");
+    }
+
+    Y_UNIT_TEST(ParsedHttpRequestRfc7239Forwarded) {
+        auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        endpoint->Secure = false;
+        const TString raw =
+            "POST / HTTP/1.1\r\n"
+            "Host: vla5-2135.lbkx.example.net:8771\r\n"
+            "Forwarded: for=192.0.2.43, for=198.51.100.17;host=\"lbkx.example.net:8443\";proto=https\r\n"
+            "X-Forwarded-Host: ignored.example\r\n"
+            "X-Forwarded-Proto: http\r\n"
+            "\r\n";
+        auto request = MakeIntrusive<NHttp::THttpIncomingRequest>(
+            raw, endpoint, NHttp::THttpConfig::SocketAddressType{});
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(request->Host, request->Headers, false),
+            "https://lbkx.example.net:8443");
     }
 }

--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -35,6 +35,22 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
             "https://lbkx.example.net:8443");
     }
 
+    Y_UNIT_TEST(AcceptsForwardedHostWithDomainAndNonStandardPort) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n",
+                false),
+            "http://example.com:8080");
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeSqsRequestEndpoint(
+                "backend.internal:8771",
+                "X-Forwarded-Host: example.com:8080\r\n"
+                "X-Forwarded-Proto: https\r\n",
+                false),
+            "https://example.com:8080");
+    }
+
     Y_UNIT_TEST(TakesFirstForwardedTokenAndLowercasesProto) {
         UNIT_ASSERT_VALUES_EQUAL(
             MakeSqsRequestEndpoint(

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -3,6 +3,7 @@
 #include "http_req.h"
 
 #include <library/cpp/string_utils/url/url.h>
+#include <ydb/library/http/rfc7239_forwarded.h>
 
 #include <util/generic/maybe.h>
 #include <util/string/ascii.h>
@@ -110,112 +111,7 @@ bool IsValidRequestHost(TStringBuf host) {
     return !host.empty() && host.find_first_of("/?#") == TStringBuf::npos;
 }
 
-void SkipOws(TStringBuf& s) {
-    while (!s.empty() && (s[0] == ' ' || s[0] == '\t')) {
-        s = s.SubStr(1);
-    }
-}
-
-bool IsHttpTchar(char c) {
-    return IsAsciiAlnum(c)
-        || c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\''
-        || c == '*' || c == '+' || c == '-' || c == '.' || c == '^' || c == '_'
-        || c == '`' || c == '|' || c == '~';
-}
-
-bool ParseHttpToken(TStringBuf& s, TStringBuf& token) {
-    size_t n = 0;
-    while (n < s.size() && IsHttpTchar(s[n])) {
-        ++n;
-    }
-    if (n == 0) {
-        return false;
-    }
-    token = s.SubStr(0, n);
-    s = s.SubStr(n);
-    return true;
-}
-
-bool ParseHttpQuotedString(TStringBuf& s, TString& value) {
-    if (s.empty() || s[0] != '"') {
-        return false;
-    }
-    s = s.SubStr(1);
-    value.clear();
-    while (!s.empty()) {
-        const char c = s[0];
-        s = s.SubStr(1);
-        if (c == '"') {
-            return true;
-        }
-        if (c == '\\') {
-            if (s.empty()) {
-                return false;
-            }
-            value.push_back(s[0]);
-            s = s.SubStr(1);
-            continue;
-        }
-        value.push_back(c);
-    }
-    return false;
-}
-
-bool ParseForwardedPairValue(TStringBuf& s, TString& value) {
-    SkipOws(s);
-    if (!s.empty() && s[0] == '"') {
-        return ParseHttpQuotedString(s, value);
-    }
-    size_t n = 0;
-    while (n < s.size() && s[n] != ';' && s[n] != ',') {
-        ++n;
-    }
-    value = TString{StripString(s.SubStr(0, n))};
-    s = s.SubStr(n);
-    return !value.empty();
-}
-
-// RFC 7239: first valid host= / proto= left to right. Port is part of host (Host ABNF).
-void ParseRfc7239Forwarded(TStringBuf header, TString& host, TString& proto) {
-    host.clear();
-    proto.clear();
-    TStringBuf s = header;
-    while (!s.empty()) {
-        SkipOws(s);
-        if (s.empty()) {
-            break;
-        }
-        if (s[0] == ',' || s[0] == ';') {
-            s = s.SubStr(1);
-            continue;
-        }
-        TStringBuf name;
-        if (!ParseHttpToken(s, name)) {
-            while (!s.empty() && s[0] != ';' && s[0] != ',') {
-                s = s.SubStr(1);
-            }
-            continue;
-        }
-        SkipOws(s);
-        if (s.empty() || s[0] != '=') {
-            continue;
-        }
-        s = s.SubStr(1);
-        TString value;
-        if (!ParseForwardedPairValue(s, value)) {
-            continue;
-        }
-        if (host.empty() && AsciiEqualsIgnoreCase(name, "host") && IsValidRequestHost(value)) {
-            host = std::move(value);
-        } else if (proto.empty() && AsciiEqualsIgnoreCase(name, "proto")) {
-            if (TString normalized = NormalizeForwardedProto(value); !normalized.empty()) {
-                proto = std::move(normalized);
-            }
-        }
-    }
-}
-
-TString JoinForwardedHeaderValues(const NHttp::THeaders& headers) {
+TString JoinForwardedHeaderValues(const ::NHttp::THeaders& headers) {
     TStringBuilder out;
     const auto range = headers.Headers.equal_range("forwarded");
     for (auto it = range.first; it != range.second; ++it) {
@@ -265,30 +161,35 @@ TString FormatSqsEndpoint(TStringBuf scheme, TStringBuf hostname, TMaybe<ui16> p
 } // namespace
 
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tlsSecure) {
-    const NHttp::THeaders headers(headersBlob);
-    TString rfcHost;
-    TString rfcProto;
-    ParseRfc7239Forwarded(JoinForwardedHeaderValues(headers), rfcHost, rfcProto);
+    const ::NHttp::THeaders headers(headersBlob);
+    const auto forwarded = ::NKikimr::NHttp::ParseRfc7239Forwarded(JoinForwardedHeaderValues(headers));
 
-    if (IsValidRequestHost(rfcHost)) {
-        host = rfcHost;
-    } else if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host"));
-               IsValidRequestHost(forwardedHost))
-    {
-        host = forwardedHost;
+    TStringBuf hostname;
+    TMaybe<ui16> hostPort;
+    if (!forwarded.Host.empty()) {
+        hostname = forwarded.Host;
+        hostPort = forwarded.Port;
+    } else {
+        TStringBuf chosen = host;
+        if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host"));
+            IsValidRequestHost(forwardedHost))
+        {
+            chosen = forwardedHost;
+        }
+        if (!IsValidRequestHost(chosen)) {
+            return {};
+        }
+        const auto split = SplitHostAndPort(chosen);
+        hostname = split.first;
+        hostPort = split.second;
     }
-    if (!IsValidRequestHost(host)) {
-        return {};
-    }
-
-    const auto [hostname, hostPort] = SplitHostAndPort(host);
     if (!IsValidRequestHost(hostname)) {
         return {};
     }
 
     TString scheme = tlsSecure ? "https" : "http";
-    if (!rfcProto.empty()) {
-        scheme = rfcProto;
+    if (forwarded.Proto == "http" || forwarded.Proto == "https") {
+        scheme = forwarded.Proto;
     } else if (TStringBuf proto = headers.Get("x-forwarded-proto"); !proto.empty()) {
         if (TString normalized = NormalizeForwardedProto(proto); !normalized.empty()) {
             scheme = std::move(normalized);

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -2,6 +2,9 @@
 
 #include "http_req.h"
 
+#include <library/cpp/string_utils/url/url.h>
+
+#include <util/generic/maybe.h>
 #include <util/string/ascii.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
@@ -224,56 +227,37 @@ TString JoinForwardedHeaderValues(const NHttp::THeaders& headers) {
     return out;
 }
 
-bool TryParseTcpPort(TStringBuf value, ui16& port) {
+TMaybe<ui16> TryParseTcpPort(TStringBuf value) {
     ui16 parsed = 0;
     if (!TryFromString(value, parsed) || parsed == 0) {
-        return false;
+        return Nothing();
     }
-    port = parsed;
-    return true;
+    return parsed;
 }
 
-void SplitHostAndPort(TStringBuf host, TStringBuf& hostname, bool& hasPort, ui16& port) {
-    hostname = host;
-    hasPort = false;
-    port = 0;
-    if (host.empty()) {
-        return;
+std::pair<TStringBuf, TMaybe<ui16>> SplitHostAndPort(TStringBuf host) {
+    TStringBuf scheme;
+    TStringBuf hostname;
+    ui16 port = 0;
+    if (TryGetSchemeHostAndPort(host, scheme, hostname, port)) {
+        return {hostname, port != 0 ? TMaybe<ui16>(port) : Nothing()};
     }
-    if (host[0] == '[') {
-        const size_t close = host.find(']');
-        if (close == TStringBuf::npos) {
-            return;
-        }
-        hostname = host.SubStr(0, close + 1);
-        const TStringBuf rest = host.SubStr(close + 1);
-        if (!rest.empty() && rest[0] == ':') {
-            ui16 parsed = 0;
-            if (TryParseTcpPort(rest.SubStr(1), parsed)) {
-                hasPort = true;
-                port = parsed;
-            }
-        }
-        return;
+
+    TStringBuf hostAndPort = GetHostAndPort(host);
+    TStringBuf hostOnly;
+    TStringBuf portStr;
+    if (hostAndPort && hostAndPort.back() != ']' && hostAndPort.TryRSplit(':', hostOnly, portStr)) {
+        return {hostOnly, Nothing()};
     }
-    const size_t colon = host.find(':');
-    if (colon == TStringBuf::npos || host.find(':', colon + 1) != TStringBuf::npos) {
-        return;
-    }
-    hostname = host.SubStr(0, colon);
-    ui16 parsed = 0;
-    if (TryParseTcpPort(host.SubStr(colon + 1), parsed)) {
-        hasPort = true;
-        port = parsed;
-    }
+    return {hostAndPort ? hostAndPort : host, Nothing()};
 }
 
-TString FormatSqsEndpoint(TStringBuf scheme, TStringBuf hostname, bool hasPort, ui16 port) {
+TString FormatSqsEndpoint(TStringBuf scheme, TStringBuf hostname, TMaybe<ui16> port) {
     const ui16 defaultPort = scheme == "https" ? 443 : 80;
     TStringBuilder result;
     result << scheme << "://" << hostname;
-    if (hasPort && port != defaultPort) {
-        result << ':' << port;
+    if (port && *port != defaultPort) {
+        result << ':' << *port;
     }
     return result;
 }
@@ -297,10 +281,7 @@ TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tls
         return {};
     }
 
-    TStringBuf hostname;
-    bool hostHasPort = false;
-    ui16 hostPort = 0;
-    SplitHostAndPort(host, hostname, hostHasPort, hostPort);
+    const auto [hostname, hostPort] = SplitHostAndPort(host);
     if (!IsValidRequestHost(hostname)) {
         return {};
     }
@@ -314,17 +295,12 @@ TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tls
         }
     }
 
-    bool hasPort = false;
-    ui16 port = 0;
-    if (ui16 forwardedPort = 0; TryParseTcpPort(FirstForwardedValue(headers.Get("x-forwarded-port")), forwardedPort)) {
-        hasPort = true;
-        port = forwardedPort;
-    } else if (hostHasPort) {
-        hasPort = true;
+    TMaybe<ui16> port = TryParseTcpPort(FirstForwardedValue(headers.Get("x-forwarded-port")));
+    if (!port) {
         port = hostPort;
     }
 
-    return FormatSqsEndpoint(scheme, hostname, hasPort, port);
+    return FormatSqsEndpoint(scheme, hostname, port);
 }
 
 TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext) {

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -4,6 +4,7 @@
 
 #include <util/string/ascii.h>
 #include <util/string/builder.h>
+#include <util/string/cast.h>
 #include <util/string/strip.h>
 
 namespace NKikimr::NHttpProxy {
@@ -106,6 +107,60 @@ bool IsValidRequestHost(TStringBuf host) {
     return !host.empty() && host.find_first_of("/?#") == TStringBuf::npos;
 }
 
+bool TryParseTcpPort(TStringBuf value, ui16& port) {
+    ui16 parsed = 0;
+    if (!TryFromString(value, parsed) || parsed == 0) {
+        return false;
+    }
+    port = parsed;
+    return true;
+}
+
+void SplitHostAndPort(TStringBuf host, TStringBuf& hostname, bool& hasPort, ui16& port) {
+    hostname = host;
+    hasPort = false;
+    port = 0;
+    if (host.empty()) {
+        return;
+    }
+    if (host[0] == '[') {
+        const size_t close = host.find(']');
+        if (close == TStringBuf::npos) {
+            return;
+        }
+        hostname = host.SubStr(0, close + 1);
+        const TStringBuf rest = host.SubStr(close + 1);
+        if (!rest.empty() && rest[0] == ':') {
+            ui16 parsed = 0;
+            if (TryParseTcpPort(rest.SubStr(1), parsed)) {
+                hasPort = true;
+                port = parsed;
+            }
+        }
+        return;
+    }
+    const size_t colon = host.find(':');
+    if (colon == TStringBuf::npos || host.find(':', colon + 1) != TStringBuf::npos) {
+        return;
+    }
+    hostname = host.SubStr(0, colon);
+    ui16 parsed = 0;
+    if (TryParseTcpPort(host.SubStr(colon + 1), parsed)) {
+        hasPort = true;
+        port = parsed;
+    }
+}
+
+TString FormatSqsEndpoint(TStringBuf scheme, TStringBuf hostname, bool hasPort, ui16 port) {
+    const ui16 defaultPort = scheme == "https" ? 443 : 80;
+    TStringBuilder result;
+    result << scheme << "://" << hostname;
+    if (hasPort && port != defaultPort) {
+        result << ':' << port;
+    }
+    return result;
+}
+
 } // namespace
 
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tlsSecure) {
@@ -118,13 +173,33 @@ TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tls
     if (!IsValidRequestHost(host)) {
         return {};
     }
+
+    TStringBuf hostname;
+    bool hostHasPort = false;
+    ui16 hostPort = 0;
+    SplitHostAndPort(host, hostname, hostHasPort, hostPort);
+    if (!IsValidRequestHost(hostname)) {
+        return {};
+    }
+
     TString scheme = tlsSecure ? "https" : "http";
     if (TStringBuf proto = headers.Get("x-forwarded-proto"); !proto.empty()) {
         if (TString normalized = NormalizeForwardedProto(proto); !normalized.empty()) {
             scheme = std::move(normalized);
         }
     }
-    return TStringBuilder() << scheme << "://" << host;
+
+    bool hasPort = false;
+    ui16 port = 0;
+    if (ui16 forwardedPort = 0; TryParseTcpPort(FirstForwardedValue(headers.Get("x-forwarded-port")), forwardedPort)) {
+        hasPort = true;
+        port = forwardedPort;
+    } else if (hostHasPort) {
+        hasPort = true;
+        port = hostPort;
+    }
+
+    return FormatSqsEndpoint(scheme, hostname, hasPort, port);
 }
 
 TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext) {

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -101,10 +101,127 @@ TString NormalizeForwardedProto(TStringBuf proto) {
     return scheme;
 }
 
-// Host / X-Forwarded-Host must be host[:port] (or [ipv6]:port). Reject path, query and fragment
-// so they cannot leak into QueueUrl as https://evil.com/phishing#/v1/...
+// Host / X-Forwarded-Host / Forwarded host= must be host[:port] (or [ipv6]:port).
+// Reject path, query and fragment so they cannot leak into QueueUrl as https://evil.com/phishing#/v1/...
 bool IsValidRequestHost(TStringBuf host) {
     return !host.empty() && host.find_first_of("/?#") == TStringBuf::npos;
+}
+
+void SkipOws(TStringBuf& s) {
+    while (!s.empty() && (s[0] == ' ' || s[0] == '\t')) {
+        s = s.SubStr(1);
+    }
+}
+
+bool IsHttpTchar(char c) {
+    return IsAsciiAlnum(c)
+        || c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\''
+        || c == '*' || c == '+' || c == '-' || c == '.' || c == '^' || c == '_'
+        || c == '`' || c == '|' || c == '~';
+}
+
+bool ParseHttpToken(TStringBuf& s, TStringBuf& token) {
+    size_t n = 0;
+    while (n < s.size() && IsHttpTchar(s[n])) {
+        ++n;
+    }
+    if (n == 0) {
+        return false;
+    }
+    token = s.SubStr(0, n);
+    s = s.SubStr(n);
+    return true;
+}
+
+bool ParseHttpQuotedString(TStringBuf& s, TString& value) {
+    if (s.empty() || s[0] != '"') {
+        return false;
+    }
+    s = s.SubStr(1);
+    value.clear();
+    while (!s.empty()) {
+        const char c = s[0];
+        s = s.SubStr(1);
+        if (c == '"') {
+            return true;
+        }
+        if (c == '\\') {
+            if (s.empty()) {
+                return false;
+            }
+            value.push_back(s[0]);
+            s = s.SubStr(1);
+            continue;
+        }
+        value.push_back(c);
+    }
+    return false;
+}
+
+bool ParseForwardedPairValue(TStringBuf& s, TString& value) {
+    SkipOws(s);
+    if (!s.empty() && s[0] == '"') {
+        return ParseHttpQuotedString(s, value);
+    }
+    size_t n = 0;
+    while (n < s.size() && s[n] != ';' && s[n] != ',') {
+        ++n;
+    }
+    value = TString{StripString(s.SubStr(0, n))};
+    s = s.SubStr(n);
+    return !value.empty();
+}
+
+// RFC 7239: first valid host= / proto= left to right. Port is part of host (Host ABNF).
+void ParseRfc7239Forwarded(TStringBuf header, TString& host, TString& proto) {
+    host.clear();
+    proto.clear();
+    TStringBuf s = header;
+    while (!s.empty()) {
+        SkipOws(s);
+        if (s.empty()) {
+            break;
+        }
+        if (s[0] == ',' || s[0] == ';') {
+            s = s.SubStr(1);
+            continue;
+        }
+        TStringBuf name;
+        if (!ParseHttpToken(s, name)) {
+            while (!s.empty() && s[0] != ';' && s[0] != ',') {
+                s = s.SubStr(1);
+            }
+            continue;
+        }
+        SkipOws(s);
+        if (s.empty() || s[0] != '=') {
+            continue;
+        }
+        s = s.SubStr(1);
+        TString value;
+        if (!ParseForwardedPairValue(s, value)) {
+            continue;
+        }
+        if (host.empty() && AsciiEqualsIgnoreCase(name, "host") && IsValidRequestHost(value)) {
+            host = std::move(value);
+        } else if (proto.empty() && AsciiEqualsIgnoreCase(name, "proto")) {
+            if (TString normalized = NormalizeForwardedProto(value); !normalized.empty()) {
+                proto = std::move(normalized);
+            }
+        }
+    }
+}
+
+TString JoinForwardedHeaderValues(const NHttp::THeaders& headers) {
+    TStringBuilder out;
+    const auto range = headers.Headers.equal_range("forwarded");
+    for (auto it = range.first; it != range.second; ++it) {
+        if (!out.empty()) {
+            out << ", ";
+        }
+        out << it->second;
+    }
+    return out;
 }
 
 bool TryParseTcpPort(TStringBuf value, ui16& port) {
@@ -165,8 +282,14 @@ TString FormatSqsEndpoint(TStringBuf scheme, TStringBuf hostname, bool hasPort, 
 
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tlsSecure) {
     const NHttp::THeaders headers(headersBlob);
-    if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host"));
-        IsValidRequestHost(forwardedHost))
+    TString rfcHost;
+    TString rfcProto;
+    ParseRfc7239Forwarded(JoinForwardedHeaderValues(headers), rfcHost, rfcProto);
+
+    if (IsValidRequestHost(rfcHost)) {
+        host = rfcHost;
+    } else if (TStringBuf forwardedHost = FirstForwardedValue(headers.Get("x-forwarded-host"));
+               IsValidRequestHost(forwardedHost))
     {
         host = forwardedHost;
     }
@@ -183,7 +306,9 @@ TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headersBlob, bool tls
     }
 
     TString scheme = tlsSecure ? "https" : "http";
-    if (TStringBuf proto = headers.Get("x-forwarded-proto"); !proto.empty()) {
+    if (!rfcProto.empty()) {
+        scheme = rfcProto;
+    } else if (TStringBuf proto = headers.Get("x-forwarded-proto"); !proto.empty()) {
         if (TString normalized = NormalizeForwardedProto(proto); !normalized.empty()) {
             scheme = std::move(normalized);
         }

--- a/ydb/core/http_proxy/utils.h
+++ b/ydb/core/http_proxy/utils.h
@@ -17,10 +17,12 @@ TString LogHttpRequestResponseCommonInfoString(const THttpRequestContext& httpCo
 
 // host is the HTTP Host / :authority value. headers is the raw header blob.
 // tlsSecure is true when the connection to http_proxy itself is TLS.
-// Prefers the first X-Forwarded-Host token when it is a host[:port] without '/', '#' or '?';
-// otherwise uses host. Unknown X-Forwarded-Proto values fall back to tlsSecure.
-// Port, highest wins: valid X-Forwarded-Port, then port in the chosen host, else the
-// scheme default (80/http, 443/https). Default ports are omitted from the URL.
+// Origin, highest wins per field:
+//   host: RFC 7239 Forwarded host= (first valid, left to right), else first X-Forwarded-Host
+//         token that is host[:port] without '/', '#' or '?', else Host.
+//   proto: Forwarded proto=, else X-Forwarded-Proto; unknown values fall back to tlsSecure.
+//   port: valid X-Forwarded-Port, then port in the chosen host, else the scheme default
+//         (80/http, 443/https). Default ports are omitted from the URL.
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headers, bool tlsSecure);
 TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext);
 

--- a/ydb/core/http_proxy/utils.h
+++ b/ydb/core/http_proxy/utils.h
@@ -19,6 +19,8 @@ TString LogHttpRequestResponseCommonInfoString(const THttpRequestContext& httpCo
 // tlsSecure is true when the connection to http_proxy itself is TLS.
 // Prefers the first X-Forwarded-Host token when it is a host[:port] without '/', '#' or '?';
 // otherwise uses host. Unknown X-Forwarded-Proto values fall back to tlsSecure.
+// Port, highest wins: valid X-Forwarded-Port, then port in the chosen host, else the
+// scheme default (80/http, 443/https). Default ports are omitted from the URL.
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headers, bool tlsSecure);
 TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext);
 

--- a/ydb/core/http_proxy/ya.make
+++ b/ydb/core/http_proxy/ya.make
@@ -49,6 +49,7 @@ PEERDIR(
     contrib/libs/grpc
     contrib/restricted/nlohmann_json
     library/cpp/string_utils/url
+    ydb/library/http
     ydb/library/actors/http
     ydb/library/actors/core
     ydb/library/grpc/actor_client

--- a/ydb/core/http_proxy/ya.make
+++ b/ydb/core/http_proxy/ya.make
@@ -48,6 +48,7 @@ SRCS(
 PEERDIR(
     contrib/libs/grpc
     contrib/restricted/nlohmann_json
+    library/cpp/string_utils/url
     ydb/library/actors/http
     ydb/library/actors/core
     ydb/library/grpc/actor_client

--- a/ydb/library/http/rfc7239_forwarded.cpp
+++ b/ydb/library/http/rfc7239_forwarded.cpp
@@ -1,0 +1,162 @@
+#include "rfc7239_forwarded.h"
+
+#include <library/cpp/string_utils/url/url.h>
+
+#include <util/string/ascii.h>
+#include <util/string/cast.h>
+#include <util/string/strip.h>
+
+#include <utility>
+
+namespace NKikimr::NHttp {
+namespace {
+
+void SkipOws(TStringBuf& s) {
+    while (!s.empty() && (s[0] == ' ' || s[0] == '\t')) {
+        s = s.SubStr(1);
+    }
+}
+
+bool IsHttpTchar(char c) {
+    return IsAsciiAlnum(c)
+        || c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\''
+        || c == '*' || c == '+' || c == '-' || c == '.' || c == '^' || c == '_'
+        || c == '`' || c == '|' || c == '~';
+}
+
+bool ParseHttpToken(TStringBuf& s, TStringBuf& token) {
+    size_t n = 0;
+    while (n < s.size() && IsHttpTchar(s[n])) {
+        ++n;
+    }
+    if (n == 0) {
+        return false;
+    }
+    token = s.SubStr(0, n);
+    s = s.SubStr(n);
+    return true;
+}
+
+// RFC 7230 quoted-string / quoted-pair.
+bool ParseHttpQuotedString(TStringBuf& s, TString& value) {
+    if (s.empty() || s[0] != '"') {
+        return false;
+    }
+    s = s.SubStr(1);
+    value.clear();
+    while (!s.empty()) {
+        const char c = s[0];
+        s = s.SubStr(1);
+        if (c == '"') {
+            return true;
+        }
+        if (c == '\\') {
+            if (s.empty()) {
+                return false;
+            }
+            value.push_back(s[0]);
+            s = s.SubStr(1);
+            continue;
+        }
+        value.push_back(c);
+    }
+    return false;
+}
+
+// RFC 7239: value = token / quoted-string. Unquoted host:port and node:port are
+// accepted too: ":" is not tchar, so the ABNF requires quotes, but Host / node
+// values commonly appear unquoted.
+bool ParseForwardedPairValue(TStringBuf& s, TString& value) {
+    SkipOws(s);
+    if (ParseHttpQuotedString(s, value)) {
+        return !value.empty();
+    }
+    size_t n = 0;
+    while (n < s.size() && s[n] != ';' && s[n] != ',') {
+        ++n;
+    }
+    value = TString{StripString(s.SubStr(0, n))};
+    s = s.SubStr(n);
+    return !value.empty();
+}
+
+bool IsValidRequestHost(TStringBuf host) {
+    return !host.empty() && host.find_first_of("/?#") == TStringBuf::npos;
+}
+
+std::pair<TStringBuf, TMaybe<ui16>> SplitHostAndPort(TStringBuf host) {
+    TStringBuf scheme;
+    TStringBuf hostname;
+    ui16 port = 0;
+    if (TryGetSchemeHostAndPort(host, scheme, hostname, port)) {
+        return {hostname, port != 0 ? TMaybe<ui16>(port) : Nothing()};
+    }
+
+    // Port is present but not a ui16. RFC 7230 Host is uri-host [ ":" port ]; keep uri-host.
+    TStringBuf hostOnly;
+    TStringBuf unusedPort;
+    host.TryRSplit(':', hostOnly, unusedPort);
+    return {hostOnly, Nothing()};
+}
+
+TString ToLowerAscii(TStringBuf s) {
+    TString out;
+    out.reserve(s.size());
+    for (char c : s) {
+        out.push_back(AsciiToLower(c));
+    }
+    return out;
+}
+
+} // namespace
+
+TRfc7239Forwarded ParseRfc7239Forwarded(TStringBuf header) {
+    TRfc7239Forwarded result;
+    TStringBuf s = header;
+    while (!s.empty()) {
+        SkipOws(s);
+        if (s.empty()) {
+            break;
+        }
+        if (s[0] == ',' || s[0] == ';') {
+            s = s.SubStr(1);
+            continue;
+        }
+
+        TStringBuf name;
+        if (!ParseHttpToken(s, name)) {
+            while (!s.empty() && s[0] != ';' && s[0] != ',') {
+                s = s.SubStr(1);
+            }
+            continue;
+        }
+
+        SkipOws(s);
+        if (s.empty() || s[0] != '=') {
+            continue;
+        }
+        s = s.SubStr(1);
+
+        TString value;
+        if (!ParseForwardedPairValue(s, value)) {
+            continue;
+        }
+
+        if (result.Host.empty() && AsciiEqualsIgnoreCase(name, "host") && IsValidRequestHost(value)) {
+            auto [hostname, port] = SplitHostAndPort(value);
+            if (IsValidRequestHost(hostname)) {
+                result.Host = TString{hostname};
+                result.Port = port;
+            }
+        } else if (result.Proto.empty() && AsciiEqualsIgnoreCase(name, "proto")) {
+            result.Proto = ToLowerAscii(value);
+        } else if (result.For.empty() && AsciiEqualsIgnoreCase(name, "for")) {
+            result.For = std::move(value);
+        } else if (result.By.empty() && AsciiEqualsIgnoreCase(name, "by")) {
+            result.By = std::move(value);
+        }
+    }
+    return result;
+}
+
+} // namespace NKikimr::NHttp

--- a/ydb/library/http/rfc7239_forwarded.h
+++ b/ydb/library/http/rfc7239_forwarded.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <util/generic/maybe.h>
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
+
+namespace NKikimr::NHttp {
+
+// First occurrence of each RFC 7239 parameter, left to right (Section 4).
+// Port is taken from host= (Host ABNF: uri-host [ ":" port ]); there is no port= parameter.
+struct TRfc7239Forwarded {
+    TString Host;
+    TMaybe<ui16> Port;
+    TString Proto;
+    TString For;
+    TString By;
+};
+
+TRfc7239Forwarded ParseRfc7239Forwarded(TStringBuf header);
+
+} // namespace NKikimr::NHttp

--- a/ydb/library/http/ut/rfc7239_forwarded_ut.cpp
+++ b/ydb/library/http/ut/rfc7239_forwarded_ut.cpp
@@ -1,0 +1,322 @@
+#include <ydb/library/http/rfc7239_forwarded.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/maybe.h>
+
+using namespace NKikimr::NHttp;
+
+namespace {
+
+void AssertParsed(
+    TStringBuf name,
+    TStringBuf header,
+    TStringBuf host,
+    TMaybe<ui16> port,
+    TStringBuf proto,
+    TStringBuf forNode,
+    TStringBuf by)
+{
+    const auto got = ParseRfc7239Forwarded(header);
+    UNIT_ASSERT_VALUES_EQUAL_C(got.Host, host, name);
+    UNIT_ASSERT_VALUES_EQUAL_C(got.Port.Defined(), port.Defined(), name);
+    if (port) {
+        UNIT_ASSERT_VALUES_EQUAL_C(*got.Port, *port, name);
+    }
+    UNIT_ASSERT_VALUES_EQUAL_C(got.Proto, proto, name);
+    UNIT_ASSERT_VALUES_EQUAL_C(got.For, forNode, name);
+    UNIT_ASSERT_VALUES_EQUAL_C(got.By, by, name);
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(Rfc7239Forwarded) {
+    Y_UNIT_TEST(Empty) {
+        AssertParsed("empty", "", "", Nothing(), "", "", "");
+        AssertParsed("ows", "  \t  ", "", Nothing(), "", "", "");
+        AssertParsed("empty_pairs", ";,;;,", "", Nothing(), "", "", "");
+    }
+
+    Y_UNIT_TEST(RfcSection4Examples) {
+        AssertParsed(
+            "obfuscated_for",
+            "for=\"_gazonk\"",
+            "", Nothing(), "", "_gazonk", "");
+        AssertParsed(
+            "ipv6_for_port",
+            "For=\"[2001:db8:cafe::17]:4711\"",
+            "", Nothing(), "", "[2001:db8:cafe::17]:4711", "");
+        AssertParsed(
+            "for_proto_by",
+            "for=192.0.2.60;proto=http;by=203.0.113.43",
+            "", Nothing(), "http", "192.0.2.60", "203.0.113.43");
+        AssertParsed(
+            "for_list",
+            "for=192.0.2.43, for=198.51.100.17",
+            "", Nothing(), "", "192.0.2.43", "");
+    }
+
+    Y_UNIT_TEST(RfcSection6Identifiers) {
+        AssertParsed(
+            "ipv4_for_port",
+            "for=\"192.0.2.43:47011\"",
+            "", Nothing(), "", "192.0.2.43:47011", "");
+        AssertParsed(
+            "unknown",
+            "for=unknown",
+            "", Nothing(), "", "unknown", "");
+        AssertParsed(
+            "unknown_port",
+            "for=\"unknown:1234\"",
+            "", Nothing(), "", "unknown:1234", "");
+        AssertParsed(
+            "obf_list",
+            "for=_hidden, for=_SEVKISEK",
+            "", Nothing(), "", "_hidden", "");
+    }
+
+    Y_UNIT_TEST(RfcSection71EquivalentLists) {
+        const TStringBuf expectedFor = "192.0.2.43";
+        AssertParsed(
+            "compact",
+            "for=192.0.2.43,for=\"[2001:db8:cafe::17]\",for=unknown",
+            "", Nothing(), "", expectedFor, "");
+        AssertParsed(
+            "spaced",
+            "for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown",
+            "", Nothing(), "", expectedFor, "");
+        AssertParsed(
+            "joined_fields",
+            "for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown",
+            "", Nothing(), "", expectedFor, "");
+    }
+
+    Y_UNIT_TEST(HostAndPort) {
+        AssertParsed(
+            "host",
+            "host=example.com",
+            "example.com", Nothing(), "", "", "");
+        AssertParsed(
+            "host_port_quoted",
+            "host=\"example.com:8080\"",
+            "example.com", ui16{8080}, "", "", "");
+        AssertParsed(
+            "host_port_unquoted",
+            "host=example.com:8080",
+            "example.com", ui16{8080}, "", "", "");
+        AssertParsed(
+            "default_looking_port",
+            "host=\"example.com:443\";proto=https",
+            "example.com", ui16{443}, "https", "", "");
+        AssertParsed(
+            "ipv6_host_port",
+            "host=\"[2001:db8:cafe::17]:8080\"",
+            "[2001:db8:cafe::17]", ui16{8080}, "", "", "");
+        AssertParsed(
+            "ipv6_host",
+            "host=\"[2001:db8:cafe::17]\"",
+            "[2001:db8:cafe::17]", Nothing(), "", "", "");
+    }
+
+    Y_UNIT_TEST(FullElement) {
+        AssertParsed(
+            "full",
+            "for=192.0.2.60;host=\"mysite.com:8080\";proto=http;by=8.8.8.8",
+            "mysite.com", ui16{8080}, "http", "192.0.2.60", "8.8.8.8");
+        AssertParsed(
+            "proto_then_host",
+            "proto=https;host=example.com;for=192.0.2.43;by=203.0.113.60",
+            "example.com", Nothing(), "https", "192.0.2.43", "203.0.113.60");
+    }
+
+    Y_UNIT_TEST(FirstOccurrenceWins) {
+        AssertParsed(
+            "first_of_each",
+            "for=192.0.2.43, for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com",
+            "example.com", Nothing(), "http", "192.0.2.43", "203.0.113.60");
+        AssertParsed(
+            "later_params_ignored",
+            "host=first.example;proto=http, host=second.example;proto=https;for=10.0.0.1;by=10.0.0.2",
+            "first.example", Nothing(), "http", "10.0.0.1", "10.0.0.2");
+        AssertParsed(
+            "duplicate_in_element",
+            "host=first.example;host=second.example;proto=http;proto=https",
+            "first.example", Nothing(), "http", "", "");
+    }
+
+    Y_UNIT_TEST(CaseInsensitiveNamesAndProto) {
+        AssertParsed(
+            "mixed_case",
+            "Host=example.com;PROTO=\"HTTPS\";For=192.0.2.60;BY=203.0.113.43",
+            "example.com", Nothing(), "https", "192.0.2.60", "203.0.113.43");
+    }
+
+    Y_UNIT_TEST(QuotedStringUnescape) {
+        AssertParsed(
+            "escaped_quote",
+            R"(host="example\".com")",
+            "example\".com", Nothing(), "", "", "");
+        AssertParsed(
+            "escaped_backslash",
+            R"(for="foo\\bar")",
+            "", Nothing(), "", R"(foo\bar)", "");
+    }
+
+    Y_UNIT_TEST(OptionalWhitespace) {
+        AssertParsed(
+            "ows",
+            "for=192.0.2.43; host=\"example.com:8080\"; proto=https ; by=203.0.113.43",
+            "example.com", ui16{8080}, "https", "192.0.2.43", "203.0.113.43");
+        AssertParsed(
+            "ows_around_equals",
+            "host = example.com ; proto = HTTP",
+            "example.com", Nothing(), "http", "", "");
+    }
+
+    Y_UNIT_TEST(InvalidHostSkipped) {
+        AssertParsed(
+            "path",
+            "host=evil.com/phishing;host=example.com",
+            "example.com", Nothing(), "", "", "");
+        AssertParsed(
+            "query",
+            "host=evil.com?next=1",
+            "", Nothing(), "", "", "");
+        AssertParsed(
+            "fragment",
+            "host=evil.com#x",
+            "", Nothing(), "", "", "");
+        AssertParsed(
+            "invalid_then_valid",
+            "host=evil.com/phishing, host=example.com:8080",
+            "example.com", ui16{8080}, "", "", "");
+    }
+
+    Y_UNIT_TEST(InvalidPortDropped) {
+        AssertParsed(
+            "non_numeric_port",
+            "host=example.com:abc",
+            "example.com", Nothing(), "", "", "");
+        AssertParsed(
+            "port_zero",
+            "host=\"example.com:0\"",
+            "example.com", Nothing(), "", "", "");
+        AssertParsed(
+            "port_overflow",
+            "host=example.com:65536",
+            "example.com", Nothing(), "", "", "");
+    }
+
+    Y_UNIT_TEST(ProtoNotOnlyHttp) {
+        AssertParsed(
+            "ftp",
+            "proto=ftp;host=example.com",
+            "example.com", Nothing(), "ftp", "", "");
+        AssertParsed(
+            "quoted_mixed",
+            "proto=\"HTTP\"",
+            "", Nothing(), "http", "", "");
+    }
+
+    Y_UNIT_TEST(ExtensionsIgnored) {
+        AssertParsed(
+            "secret",
+            "for=192.0.2.43;secret=foo;host=example.com;proto=https",
+            "example.com", Nothing(), "https", "192.0.2.43", "");
+    }
+
+    Y_UNIT_TEST(MalformedPairsSkipped) {
+        AssertParsed(
+            "missing_value",
+            "host=;proto=https;host=example.com",
+            "example.com", Nothing(), "https", "", "");
+        AssertParsed(
+            "token_without_equals",
+            "host example.com;proto=https",
+            "", Nothing(), "https", "", "");
+        AssertParsed(
+            "unclosed_quote",
+            "host=\"example.com;proto=https",
+            "", Nothing(), "", "", "");
+        AssertParsed(
+            "empty_quoted",
+            "for=\"\";host=example.com",
+            "example.com", Nothing(), "", "", "");
+        AssertParsed(
+            "name_without_equals_at_eof",
+            "host=example.com;proto",
+            "example.com", Nothing(), "", "", "");
+    }
+
+    Y_UNIT_TEST(InvalidTokenNameSkipped) {
+        // forwarded-pair = token "=" value; token is 1*tchar (RFC 7230).
+        AssertParsed(
+            "at_then_valid",
+            "@foo=bar;host=example.com",
+            "example.com", Nothing(), "", "", "");
+        AssertParsed(
+            "between_list_elements",
+            "for=192.0.2.43, [not-a-token], host=example.com",
+            "example.com", Nothing(), "", "192.0.2.43", "");
+        AssertParsed(
+            "no_list_delimiter",
+            ":::not-a-pair",
+            "", Nothing(), "", "", "");
+    }
+
+    Y_UNIT_TEST(DanglingQuotedPair) {
+        // RFC 7230 quoted-pair is "\" CHAR; a trailing backslash is invalid.
+        AssertParsed(
+            "backslash_at_eof",
+            "for=\"abc\\",
+            "", Nothing(), "", "", "");
+        AssertParsed(
+            "backslash_at_eof_then_host",
+            "for=\"abc\\;host=example.com",
+            "", Nothing(), "", "", "");
+    }
+
+    Y_UNIT_TEST(Rfc75ExampleUsage) {
+        AssertParsed(
+            "second_proxy",
+            "for=192.0.2.43, for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com",
+            "example.com", Nothing(), "http", "192.0.2.43", "203.0.113.60");
+    }
+
+    Y_UNIT_TEST(ByAndObfuscatedPort) {
+        AssertParsed(
+            "by_obfuscated",
+            "by=\"_hidden\"",
+            "", Nothing(), "", "", "_hidden");
+        AssertParsed(
+            "by_unknown",
+            "by=unknown",
+            "", Nothing(), "", "", "unknown");
+        AssertParsed(
+            "by_ipv6_port",
+            "by=\"[2001:db8:cafe::17]:47011\"",
+            "", Nothing(), "", "", "[2001:db8:cafe::17]:47011");
+        AssertParsed(
+            "obfport",
+            "for=\"_hidden:_obf1\"",
+            "", Nothing(), "", "_hidden:_obf1", "");
+    }
+
+    Y_UNIT_TEST(Ipv4Host) {
+        AssertParsed(
+            "v4",
+            "host=192.0.2.1",
+            "192.0.2.1", Nothing(), "", "", "");
+        AssertParsed(
+            "v4_port",
+            "host=\"192.0.2.1:8080\"",
+            "192.0.2.1", ui16{8080}, "", "", "");
+    }
+
+    Y_UNIT_TEST(EmptyUriHostRejected) {
+        // RFC 7230 Host = uri-host [ ":" port ]; empty uri-host is not a Host.
+        AssertParsed(
+            "port_only",
+            "host=\":8080\";host=example.com",
+            "example.com", Nothing(), "", "", "");
+    }
+}

--- a/ydb/library/http/ut/ya.make
+++ b/ydb/library/http/ut/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(ydb/library/http)
+
+SIZE(SMALL)
+
+SRCS(
+    rfc7239_forwarded_ut.cpp
+)
+
+END()

--- a/ydb/library/http/ya.make
+++ b/ydb/library/http/ya.make
@@ -1,0 +1,15 @@
+LIBRARY()
+
+SRCS(
+    rfc7239_forwarded.cpp
+)
+
+PEERDIR(
+    library/cpp/string_utils/url
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/library/ya.make
+++ b/ydb/library/ya.make
@@ -17,6 +17,7 @@ RECURSE(
     fyamlcpp
     global_plugins
     grpc
+    http
     http_proxy
     intersection_tree
     json_index

--- a/ydb/tests/functional/sqs_topic/test_request_endpoint.py
+++ b/ydb/tests/functional/sqs_topic/test_request_endpoint.py
@@ -73,3 +73,21 @@ class TestSqsTopicRequestEndpoint(KikimrSqsTopicTestBase):
         assert_that(default_url, is_not(equal_to(created_url)))
         assert_that(urlsplit(default_url).path, equal_to(created_path))
         assert_that(default_url.startswith('https://'), equal_to(False))
+
+    def test_forwarded_host_accepts_domain_with_port(self):
+        queue_name = self._make_queue_name('forwarded_host_domain_with_port')
+        public_host = 'example.com:8080'
+
+        with self._boto_client_with_forwarded_host(public_host, proto='http') as (origin, client):
+            created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+            self._queue_url = created_url
+
+            created_path = urlsplit(created_url).path
+            assert_that(created_url, equal_to(origin + created_path))
+            assert_that(created_url, equal_to('http://example.com:8080' + created_path))
+
+            get_url = client.get_queue_url(QueueName=queue_name)['QueueUrl']
+            assert_that(get_url, equal_to(created_url))
+
+            listed = client.list_queues(QueueNamePrefix=queue_name).get('QueueUrls', [])
+            assert_that(listed, has_item(created_url))

--- a/ydb/tests/functional/sqs_topic/test_request_endpoint.py
+++ b/ydb/tests/functional/sqs_topic/test_request_endpoint.py
@@ -91,3 +91,67 @@ class TestSqsTopicRequestEndpoint(KikimrSqsTopicTestBase):
 
             listed = client.list_queues(QueueNamePrefix=queue_name).get('QueueUrls', [])
             assert_that(listed, has_item(created_url))
+
+    def test_queue_urls_use_rfc_forwarded(self):
+        queue_name = self._make_queue_name('queue_urls_use_rfc_forwarded')
+        public_host = 'lbkx.example.net:8443'
+
+        with self._boto_client_with_rfc_forwarded(public_host, proto='https') as (origin, client):
+            created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+            self._queue_url = created_url
+
+            created_path = urlsplit(created_url).path
+            assert_that(created_url, equal_to(origin + created_path))
+            assert_that(created_url, equal_to('https://lbkx.example.net:8443' + created_path))
+
+            get_url = client.get_queue_url(QueueName=queue_name)['QueueUrl']
+            assert_that(get_url, equal_to(created_url))
+
+            listed = client.list_queues(QueueNamePrefix=queue_name).get('QueueUrls', [])
+            assert_that(listed, has_item(created_url))
+
+        default_url = self._boto_client.get_queue_url(QueueName=queue_name)['QueueUrl']
+        assert_that(default_url, is_not(equal_to(created_url)))
+        assert_that(urlsplit(default_url).path, equal_to(created_path))
+
+    def test_rfc_forwarded_host_with_port(self):
+        queue_name = self._make_queue_name('rfc_forwarded_host_with_port')
+        public_host = 'example.com:8080'
+
+        with self._boto_client_with_rfc_forwarded(public_host, proto='http') as (origin, client):
+            created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+            self._queue_url = created_url
+
+            created_path = urlsplit(created_url).path
+            assert_that(created_url, equal_to(origin + created_path))
+            assert_that(created_url, equal_to('http://example.com:8080' + created_path))
+
+            get_url = client.get_queue_url(QueueName=queue_name)['QueueUrl']
+            assert_that(get_url, equal_to(created_url))
+
+            listed = client.list_queues(QueueNamePrefix=queue_name).get('QueueUrls', [])
+            assert_that(listed, has_item(created_url))
+
+    def test_rfc_forwarded_overrides_x_forwarded(self):
+        queue_name = self._make_queue_name('rfc_forwarded_overrides_x_forwarded')
+        public_host = 'rfc.example.net:8443'
+
+        with self._boto_client_with_rfc_forwarded(public_host, proto='https') as (origin, client):
+            def add_x_forwarded(request, **kwargs):
+                request.headers['X-Forwarded-Host'] = 'xfh.example.net:9090'
+                request.headers['X-Forwarded-Proto'] = 'http'
+
+            event_name = 'before-send.sqs.*'
+            client.meta.events.register(event_name, add_x_forwarded)
+            try:
+                created_url = client.create_queue(QueueName=queue_name)['QueueUrl']
+                self._queue_url = created_url
+
+                created_path = urlsplit(created_url).path
+                assert_that(created_url, equal_to(origin + created_path))
+                assert_that(created_url, equal_to('https://rfc.example.net:8443' + created_path))
+
+                get_url = client.get_queue_url(QueueName=queue_name)['QueueUrl']
+                assert_that(get_url, equal_to(created_url))
+            finally:
+                client.meta.events.unregister(event_name, add_x_forwarded)

--- a/ydb/tests/library/sqs_topic/test_base.py
+++ b/ydb/tests/library/sqs_topic/test_base.py
@@ -181,6 +181,27 @@ class KikimrSqsTopicTestBase(object):
         finally:
             client.meta.events.unregister(event_name, add_forwarded_headers)
 
+    @contextmanager
+    def _boto_client_with_rfc_forwarded(self, public_host, proto='https'):
+        first_proto = proto.split(',', 1)[0].strip().lower()
+        if ':' in public_host or public_host.startswith('['):
+            host_param = '"{}"'.format(public_host)
+        else:
+            host_param = public_host
+        forwarded = 'for=192.0.2.43;host={};proto={}'.format(host_param, first_proto)
+        public_origin = '{}://{}'.format(first_proto, public_host)
+        client = self._make_boto_client()
+
+        def add_forwarded_header(request, **kwargs):
+            request.headers['Forwarded'] = forwarded
+
+        event_name = 'before-send.sqs.*'
+        client.meta.events.register(event_name, add_forwarded_header)
+        try:
+            yield public_origin, client
+        finally:
+            client.meta.events.unregister(event_name, add_forwarded_header)
+
     def _make_ydb_driver(self):
         node = self.cluster.nodes[1]
         config = ydb.DriverConfig(


### PR DESCRIPTION
### Changelog entry

Build SQS-over-topics QueueUrl from RFC 7239 `Forwarded` (`host=`, `proto=`) and `X-Forwarded-Port`, and keep a non-standard port from `X-Forwarded-Host` (for example `example.com:8080`).

### Description for reviewers

QueueUrl origin now follows proxy-header rules, highest wins per field:

1. **host** — first valid RFC 7239 `Forwarded host=` (left to right), else first `X-Forwarded-Host` token, else `Host`.
2. **proto** — `Forwarded proto=`, else `X-Forwarded-Proto`; unknown values fall back to connection TLS.
3. **port** — valid `X-Forwarded-Port`, else port in the chosen host, else the scheme default (`80`/`http`, `443`/`https`). Default ports are omitted from the URL.

RFC 7239 has no separate `port=` parameter: port is part of `host=` (`host="mysite.com:8080"`). `for=` and `by=` are ignored for QueueUrl. Invalid host tokens (`/`, `#`, `?`) fall back to `X-Forwarded-Host` / `Host`.

**Tests**

- UT `SqsRequestEndpoint`: header-presence matrices for `X-Forwarded-*` and `Forwarded`, full string `Forwarded: for=192.0.2.60;host="mysite.com:8080";proto=http;by=8.8.8.8` → `http://mysite.com:8080`, parsed HTTP request.
- boto3 (`ydb/tests/functional/sqs_topic`): CreateQueue / GetQueueUrl / ListQueues with `host:port`, RFC `Forwarded`, and `Forwarded` overriding `X-Forwarded-*`.
