### PR TITLE
Fix flaky Producer_SessionClosedDueToUserError: return ProducerClosed when closed due to error

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
@@ -2187,8 +2187,10 @@ void TProducer::HandleClientMessage(TMessageInfo&& message) {
 void TProducer::HandleClientFlush(NThreading::TPromise<TFlushResult> promise) {
     if (Closed.load() || MessagesWorker->InFlightMessages.empty()) {
         auto sessionClosedEvent = EventsWorker->GetSessionClosedEvent();
+        bool isClosedDueToError = sessionClosedEvent &&
+            sessionClosedEvent->GetStatus() != EStatus::SUCCESS;
         FlushPromises.push_back(std::make_pair(std::move(promise), TFlushResult{
-            .Status = EFlushStatus::Success,
+            .Status = isClosedDueToError ? EFlushStatus::ProducerClosed : EFlushStatus::Success,
             .LastWrittenSeqNo = LastWrittenSeqNo.load(),
             .ClosedDescription = sessionClosedEvent ? std::make_optional(TCloseDescription(*sessionClosedEvent)) : std::nullopt,
         }));
@@ -2419,8 +2421,10 @@ TWriteStats TProducer::GetWriteStats() {
 NThreading::TFuture<TFlushResult> TProducer::Flush() {
     if (Closed.load()) {
         auto sessionClosedEvent = EventsWorker->GetSessionClosedEvent();
+        bool isClosedDueToError = sessionClosedEvent &&
+            sessionClosedEvent->GetStatus() != EStatus::SUCCESS;
         return NThreading::MakeFuture(TFlushResult{
-            .Status = EFlushStatus::Success,
+            .Status = isClosedDueToError ? EFlushStatus::ProducerClosed : EFlushStatus::Success,
             .LastWrittenSeqNo = LastWrittenSeqNo.load(),
             .ClosedDescription = sessionClosedEvent ? std::make_optional(TCloseDescription(*sessionClosedEvent)) : std::nullopt,
         });


### PR DESCRIPTION
## Problem

The test `BasicUsage::Producer_SessionClosedDueToUserError` was flaky — it could FAIL or TIMEOUT.

## Root cause

When a sub-session fatally closes (e.g. `BAD_REQUEST` on `seq_no=0`) **before** `Flush()` is called, the fast path in `TProducer::Flush()` and `TProducer::HandleClientFlush()` returned `EFlushStatus::Success` with a filled `ClosedDescription` instead of `EFlushStatus::ProducerClosed`.

This caused `IsClosed()` to return `false`, making the test assertion fail intermittently — depending on whether the sub-session closed before or after the `Flush()` call (a race condition).

## Fix

In both `Flush()` and `HandleClientFlush()`, when `Closed==true`, check if the `SessionClosedEvent` has a non-SUCCESS status. If so, return `EFlushStatus::ProducerClosed` instead of `EFlushStatus::Success`.

This is consistent with `SetClosedStatusToFlushPromises()` (producer.cpp:1383), which handles the slow path (flush promise already attached to an in-flight message) and correctly returns `ProducerClosed`.

## Testing

Verified with `--test-retries 200` — the FAIL mode no longer reproduces.

Refs: LOGBROKER-10615, Issue #50613