### PR TITLE
Fix IProducer::Flush reporting Success after a fatal session close

### DIFF
--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Added `IWriteSession::Flush` to asynchronously wait until all previously accepted topic writes are acknowledged.
 
+* Fixed `IProducer::Flush` reporting Success instead of ProducerClosed when the producer was already closed due to a non-retryable error.
+
 * Fixed query parameters with incomplete types being sent to the server; the parameter builder now reports the error locally.
 
 * Added the initial process-wide SDK runtime infrastructure. Driver cancellation and callback accounting are now isolated per driver, without changing public APIs or resource-sharing behavior.

--- a/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
@@ -2184,13 +2184,28 @@ void TProducer::HandleClientMessage(TMessageInfo&& message) {
     MessagesWorker->AddMessage(std::move(message));
 }
 
+TFlushResult TProducer::MakeFlushResultOnClosed() {
+    auto sessionClosedEvent = EventsWorker->GetSessionClosedEvent();
+    const bool closedDueToError = sessionClosedEvent &&
+        sessionClosedEvent->GetStatus() != EStatus::SUCCESS;
+    return TFlushResult{
+        .Status = closedDueToError ? EFlushStatus::ProducerClosed : EFlushStatus::Success,
+        .LastWrittenSeqNo = LastWrittenSeqNo.load(),
+        .ClosedDescription = sessionClosedEvent ? std::make_optional(TCloseDescription(*sessionClosedEvent)) : std::nullopt,
+    };
+}
+
 void TProducer::HandleClientFlush(NThreading::TPromise<TFlushResult> promise) {
-    if (Closed.load() || MessagesWorker->InFlightMessages.empty()) {
-        auto sessionClosedEvent = EventsWorker->GetSessionClosedEvent();
+    if (Closed.load()) {
+        FlushPromises.push_back(std::make_pair(std::move(promise), MakeFlushResultOnClosed()));
+        return;
+    }
+
+    if (MessagesWorker->InFlightMessages.empty()) {
         FlushPromises.push_back(std::make_pair(std::move(promise), TFlushResult{
             .Status = EFlushStatus::Success,
             .LastWrittenSeqNo = LastWrittenSeqNo.load(),
-            .ClosedDescription = sessionClosedEvent ? std::make_optional(TCloseDescription(*sessionClosedEvent)) : std::nullopt,
+            .ClosedDescription = std::nullopt,
         }));
         return;
     }
@@ -2418,12 +2433,7 @@ TWriteStats TProducer::GetWriteStats() {
 
 NThreading::TFuture<TFlushResult> TProducer::Flush() {
     if (Closed.load()) {
-        auto sessionClosedEvent = EventsWorker->GetSessionClosedEvent();
-        return NThreading::MakeFuture(TFlushResult{
-            .Status = EFlushStatus::Success,
-            .LastWrittenSeqNo = LastWrittenSeqNo.load(),
-            .ClosedDescription = sessionClosedEvent ? std::make_optional(TCloseDescription(*sessionClosedEvent)) : std::nullopt,
-        });
+        return NThreading::MakeFuture(MakeFlushResultOnClosed());
     }
 
     auto promise = NThreading::NewPromise<TFlushResult>();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/producer.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/producer.h
@@ -425,6 +425,7 @@ private:
     void DrainClientRequests();
     void HandleClientMessage(TMessageInfo&& message);
     void HandleClientFlush(NThreading::TPromise<TFlushResult> promise);
+    TFlushResult MakeFlushResultOnClosed();
 
     TWriteResult WriteInternal(TWriteMessage& message, bool checkMemory);
     TWriteResult WriteToExplicitPartition(

--- a/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
@@ -1224,6 +1224,11 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         auto flushResult = session->Flush().GetValueSync();
         UNIT_ASSERT_C(flushResult.IsClosed(), "Failed to flush producer");
         UNIT_ASSERT_C(flushResult.ClosedDescription->GetStatus() == EStatus::BAD_REQUEST, "Status is not BAD_REQUEST");
+        // Flush after the producer is already closed must still report ProducerClosed,
+        // not Success (the historical race in issue #50613).
+        auto flushAfterClose = session->Flush().GetValueSync();
+        UNIT_ASSERT_C(flushAfterClose.IsClosed(), "Flush after close must report ProducerClosed");
+        UNIT_ASSERT_C(flushAfterClose.ClosedDescription->GetStatus() == EStatus::BAD_REQUEST, "Status is not BAD_REQUEST");
         UNIT_ASSERT_C(session->Close(TDuration::Seconds(10)).IsAlreadyClosed(), "Failed to close producer");
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed `IProducer::Flush` reporting Success instead of ProducerClosed when the producer was already closed due to a non-retryable error.

### Description for reviewers <!-- (optional) description for those who read this PR -->

`BasicUsage.Producer_SessionClosedDueToUserError` writes `SeqNo(0)`, the server closes the write session with `BAD_REQUEST`, and the test expects `Flush()` to return `ProducerClosed`.

If that close finished before `Flush()` was called, `Closed` was already true and `Flush()` / `HandleClientFlush` returned `Success`. That is the flake muted in #50613.

Report `ProducerClosed` (with the close description) when the producer is already shut down by a non-SUCCESS status. A second `Flush()` after close covers that path without relying on the race.

**Test**
- [x] `./ya make --build relwithdebinfo -DUSER_CXXFLAGS=-Werror -tA ydb/public/sdk/cpp/src/client/topic/ut/with_direct_read_ut -F '*Producer_SessionClosedDueToUserError*' --test-retries 5`