### PR TITLE
topic: surface DescribeTopic error in Producer instead of misleading "Topic has no partitions"

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
@@ -1649,13 +1649,19 @@ TProducer::TProducer(
 
     TDescribeTopicSettings describeTopicSettings;
     auto topicConfig = DescribeTopicWithRetries(client.get(), settings.Path_, describeTopicSettings, DbDriverState, LogPrefix());
+    if (!topicConfig.IsSuccess()) {
+        ythrow TContractViolation(TStringBuilder()
+            << "Failed to describe topic '" << settings.Path_ << "': " << topicConfig.GetStatus()
+            << ", " << topicConfig.GetIssues().ToOneLineString()
+            << " (check that the topic path and the database are correct)");
+    }
     auto partitions = topicConfig.GetTopicDescription().GetPartitions();
     std::sort(partitions.begin(), partitions.end(), [](const auto& a, const auto& b) -> bool {
         return a.GetPartitionId() < b.GetPartitionId();
     });
 
     if (partitions.empty()) {
-        ythrow TContractViolation("Topic has no partitions");
+        ythrow TContractViolation(TStringBuilder() << "Topic '" << settings.Path_ << "' has no partitions");
     }
 
     auto partitionChooserStrategy = settings.PartitionChooserStrategy_;


### PR DESCRIPTION
## Problem

When a `TWriteSession`/Producer is created with a wrong topic path or a wrong database, `DescribeTopic` fails (e.g. `SCHEME_ERROR`, path not found). However, the Producer ignored the result status: it took `topicConfig.GetTopicDescription().GetPartitions()` (empty on a failed describe) and threw `TContractViolation("Topic has no partitions")`.

This masks the real cause — the misleading "Topic has no partitions" is reported even when the actual error is that the path/database does not exist.

## Change

In `producer.cpp`, after `DescribeTopicWithRetries`, check `IsSuccess()` first and rethrow with the real status and issues (plus a hint to verify the path/database). The empty-partitions message now also includes the topic path.

Before:
```
Topic has no partitions
```
After (wrong path/database):
```
Failed to describe topic '<path>': SCHEME_ERROR, <issues> (check that the topic path and the database are correct)
```
