### PR TITLE
PersQueue: do not convert legacy-looking topic names when FCC=true

### DIFF
--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -534,10 +534,10 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT(!ev->UsedSyncVersion);
     }
 
-    Y_UNIT_TEST(FccLegacyRt3UsesLbRoot) {
+    Y_UNIT_TEST(FccKeepsLiteralLegacyLookingName) {
         TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate& request, TNavigate::TEntry& entry) {
             UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
-            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/LbCommunal/account/topic");
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/rt3.dc1--account--topic");
             FillOkTopic(entry, /*balancerTabletId=*/15);
         });
         auto& appData = env.Runtime.GetAppData();
@@ -548,7 +548,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].RealPath, "/Root/LbCommunal/account/topic");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["rt3.dc1--account--topic"].RealPath, "/Root/rt3.dc1--account--topic");
     }
 
     Y_UNIT_TEST(MultipleOriginalsSameResolvedPath) {

--- a/ydb/core/persqueue/public/nameresolver/nameresolver.cpp
+++ b/ydb/core/persqueue/public/nameresolver/nameresolver.cpp
@@ -69,29 +69,10 @@ bool HasModernPathSeparator(TStringBuf topic) {
     return false;
 }
 
-bool IsLegacyStyleName(TStringBuf topic) {
-    // Modern paths use a single '/' separator (e.g. PQ/rt3.dc1--topic leaf under a dir).
-    // Short legacy may still contain accidental '//' (account--a//b) without a modern sep.
-    if (HasModernPathSeparator(topic)) {
-        return false;
-    }
-    if (topic.StartsWith("rt3.") || topic.Contains("--") || topic.Contains("@")) {
-        return true;
-    }
-    return !topic.Contains("/");
-}
-
 bool IsExplicitLegacyName(TStringBuf topic) {
     // Unlike bare names, these are never relative modern paths inside a user DB.
     return !HasModernPathSeparator(topic)
         && (topic.StartsWith("rt3.") || topic.Contains("--") || topic.Contains("@"));
-}
-
-// True when database is a strict child of lbRoot (e.g. Root/account1 under Root).
-bool IsDatabaseUnderLbRoot(TStringBuf databaseNorm, TStringBuf lbRoot) {
-    return !lbRoot.empty()
-        && databaseNorm != lbRoot
-        && IsPathPrefix(databaseNorm, lbRoot);
 }
 
 bool IsCleanRelativePath(TStringBuf path) {
@@ -401,19 +382,9 @@ std::expected<TResolvedName, TString> ResolveName(
     };
 
     if (!isFederation) {
-        if (!IsLegacyStyleName(topicName)) {
-            return wrap(JoinWithDatabase(database, databaseNorm, topicName));
-        }
-        auto parsed = TryParseLegacyToModernPath(topicName, localDc, dc);
-        if (!parsed) {
-            return std::unexpected(parsed.error());
-        }
-        // Bare name inside a user DB under LbRoot stays in that DB (CREATE TOPIC in tenant).
-        // Explicit legacy (rt3/--/@) and bare names outside LbRoot still join via LbRoot.
-        if (!IsExplicitLegacyName(topicName) && IsDatabaseUnderLbRoot(databaseNorm, lbRoot)) {
-            return wrap(JoinWithDatabase(database, databaseNorm, *parsed));
-        }
-        return wrap(JoinWithRoot(lbRoot, database, std::move(*parsed)));
+        // FCC: never interpret rt3. / -- / @ as a legacy name. A leaf like
+        // TestSchemeList--test-topic-1 is a literal topic under the database.
+        return wrap(JoinWithDatabase(database, databaseNorm, topicName));
     }
 
     // Federation mode.

--- a/ydb/core/persqueue/public/nameresolver/nameresolver.h
+++ b/ydb/core/persqueue/public/nameresolver/nameresolver.h
@@ -25,10 +25,8 @@ struct TResolvedName {
  *   - Otherwise: request database (absolute), or empty if request database is empty
  *
  * First-class citizen (FCC / non-federation) mode:
- *   Converts legacy-style names (rt3.*, short legacy with --/@, or bare name without '/').
- *   Modern paths with '/' are joined with database (full topic path).
- *   Bare names inside a user database under LbRoot stay under that database
- *   (not remapped to LbRoot); explicit legacy still joins via LbRoot.
+ *   Names are joined with the request database as-is. Legacy forms (rt3.*, --, @)
+ *   are not converted: a leaf like TestSchemeList--test-topic-1 is a literal name.
  *
  * Federation mode (!TopicsAreFirstClassCitizen):
  *   - Root-like database (empty, prefixes PQ Root, or prefixes LbUserDatabaseRoot):
@@ -50,17 +48,21 @@ struct TResolvedName {
  *
  * Examples (LbRoot = "/Root/LbCommunal", PQ Root = "/Root/PQ"):
  *
- *   // Without localDc/dc (defaults): local path, no -mirrored-from- suffix
- *   ResolveName(db, "rt3.dc1--account--topic")
- *     -> Path="/Root/LbCommunal/account/topic", NavigateDatabase=db  // FCC
- *   ResolveName("/Root", "account/topic")  // federation
+ *   // FCC: literal names under the request database (-- is not a path separator)
+ *   ResolveName(db, "TestSchemeList--test-topic-1")
+ *     -> Path=db+"/TestSchemeList--test-topic-1", NavigateDatabase=db
+ *   ResolveName(db, "account/topic")
+ *     -> Path=db+"/account/topic", NavigateDatabase=db
+ *
+ *   // Federation: without localDc/dc (defaults) — local path, no -mirrored-from- suffix
+ *   ResolveName("/Root", "account/topic")
  *     -> Path="/Root/LbCommunal/account/topic", NavigateDatabase="/Root/LbCommunal/account"
  *   ResolveName("/Root/LbCommunal/account", "dir/topic")
  *     -> Path="/Root/LbCommunal/account/dir/topic", NavigateDatabase="/Root/LbCommunal/account"
  *
- *   // With localDc (mirroring / DC-aware resolve)
- *   ResolveName(db, "rt3.dc1--account--topic", "dc1")
- *     -> Path="/Root/LbCommunal/account/topic", NavigateDatabase=db
+ *   // Federation: with localDc (mirroring / DC-aware resolve)
+ *   ResolveName("/Root", "rt3.dc1--account--topic", "dc1")
+ *     -> Path="/Root/LbCommunal/account/topic", NavigateDatabase="/Root/LbCommunal/account"
  *   ResolveName("/Root", "account/topic", "dc1", "dc2")
  *     -> Path="/Root/LbCommunal/account/topic-mirrored-from-dc2", NavigateDatabase="/Root/LbCommunal/account"
  */

--- a/ydb/core/persqueue/public/nameresolver/ut/nameresolver_ut.cpp
+++ b/ydb/core/persqueue/public/nameresolver/ut/nameresolver_ut.cpp
@@ -139,10 +139,17 @@ Y_UNIT_TEST_F(FederationUserDbAbsolutePathWithPqRootEqDomain, TNameResolverFixtu
     UNIT_ASSERT_VALUES_EQUAL(resolved.NavigateDatabase, "/Root/test_db");
 }
 
-Y_UNIT_TEST_F(FccLegacyKeepsRequestNavigateDatabase, TNameResolverFixture) {
-    // FCC: path may be under LbRoot, but SchemeCache DatabaseName stays the request DB.
+Y_UNIT_TEST_F(FccKeepsLiteralDashDashName, TNameResolverFixture) {
+    // Go SDK TestSchemeList uses t.Name(), which contains '--'. That is a legal FCC leaf.
+    const auto resolved = OkFull(ResolveName(TString{Database}, "TestSchemeList--test-topic-1"));
+    UNIT_ASSERT_VALUES_EQUAL(resolved.Path, "/Root/Db/TestSchemeList--test-topic-1");
+    UNIT_ASSERT_VALUES_EQUAL(resolved.NavigateDatabase, "/Root/Db");
+}
+
+Y_UNIT_TEST_F(FccLegacyLookingNameKeepsRequestDatabase, TNameResolverFixture) {
+    // FCC: SchemeCache DatabaseName stays the request DB; the name is not remapped to LbRoot.
     const auto resolved = OkFull(ResolveName(TString{Database}, "rt3.dc1--account--topic", "dc1"));
-    UNIT_ASSERT_VALUES_EQUAL(resolved.Path, "/Root/LbCommunal/account/topic");
+    UNIT_ASSERT_VALUES_EQUAL(resolved.Path, "/Root/Db/rt3.dc1--account--topic");
     UNIT_ASSERT_VALUES_EQUAL(resolved.NavigateDatabase, "/Root/Db");
 }
 
@@ -205,58 +212,58 @@ Y_UNIT_TEST_F(ModernPathNormalizedWithDatabase, TNameResolverFixture) {
         "/Root/Db/account/topic");
 }
 
-Y_UNIT_TEST_F(LocalRt3, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsLiteralRt3, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc1--account--topic", "dc1", "dc1")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/rt3.dc1--account--topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc1--account--topic", "dc1", "")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/rt3.dc1--account--topic");
 }
 
-Y_UNIT_TEST_F(RemoteRt3Mirrored, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsLiteralRemoteRt3, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc2--account--topic", "dc1", "dc2")),
-        "/Root/LbCommunal/account/topic-mirrored-from-dc2");
+        "/Root/Db/rt3.dc2--account--topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc2--account--topic", "dc1", "")),
-        "/Root/LbCommunal/account/topic-mirrored-from-dc2");
+        "/Root/Db/rt3.dc2--account--topic");
 }
 
-Y_UNIT_TEST_F(Rt3WithDirectories, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsLiteralRt3WithAt, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc1--account@dir--topic", "dc1", "")),
-        "/Root/LbCommunal/account/dir/topic");
+        "/Root/Db/rt3.dc1--account@dir--topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc2--account@dir--topic", "dc1", "")),
-        "/Root/LbCommunal/account/dir/topic-mirrored-from-dc2");
+        "/Root/Db/rt3.dc2--account@dir--topic");
 }
 
-Y_UNIT_TEST_F(ShortLegacyLocal, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsLiteralShortDashDash, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--topic", "dc1", "")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/account--topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account@dir--topic", "dc1", "")),
-        "/Root/LbCommunal/account/dir/topic");
+        "/Root/Db/account@dir--topic");
 }
 
-Y_UNIT_TEST_F(ShortLegacyForeignDcMirrored, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccIgnoresDcForLegacyLookingName, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--topic", "dc1", "dc2")),
-        "/Root/LbCommunal/account/topic-mirrored-from-dc2");
+        "/Root/Db/account--topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account@dir--topic", "dc1", "dc2")),
-        "/Root/LbCommunal/account/dir/topic-mirrored-from-dc2");
+        "/Root/Db/account@dir--topic");
 }
 
-Y_UNIT_TEST_F(BareTopic, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccBareTopicJoinsDatabase, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "topic", "dc1", "")),
-        "/Root/LbCommunal/topic");
+        "/Root/Db/topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "topic", "dc1", "dc2")),
-        "/Root/LbCommunal/topic-mirrored-from-dc2");
+        "/Root/Db/topic");
 }
 
 Y_UNIT_TEST_F(FccBareInUserDatabaseUnderLbRoot, TNameResolverFixture) {
@@ -267,102 +274,102 @@ Y_UNIT_TEST_F(FccBareInUserDatabaseUnderLbRoot, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(resolved.NavigateDatabase, "/Root/account1");
 }
 
-Y_UNIT_TEST_F(AtWithoutDashDashIsLegacy, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsLiteralAtName, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account@dir", "dc1", "")),
-        "/Root/LbCommunal/account@dir");
+        "/Root/Db/account@dir");
 }
 
-Y_UNIT_TEST_F(DcMismatchReturnsError, TNameResolverFixture) {
-    ExpectError(
-        ResolveName(TString{Database}, "rt3.dc1--account--topic", "dc1", "dc2"),
-        "DC specified both in topic name and separate option and they mismatch.");
+Y_UNIT_TEST_F(FccIgnoresRt3DcMismatch, TNameResolverFixture) {
+    UNIT_ASSERT_VALUES_EQUAL(
+        Ok(ResolveName(TString{Database}, "rt3.dc1--account--topic", "dc1", "dc2")),
+        "/Root/Db/rt3.dc1--account--topic");
 }
 
-Y_UNIT_TEST_F(ShortWithoutDcIsLocal, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsLiteralNamesWithoutDc, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--topic", "", "")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/account--topic");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "topic", "", "")),
-        "/Root/LbCommunal/topic");
+        "/Root/Db/topic");
 }
 
-Y_UNIT_TEST_F(MalformedRt3NoDashDash, TNameResolverFixture) {
-    ExpectError(
-        ResolveName(TString{Database}, "rt3.bad", "dc1", ""),
-        "Malformed legacy style topic name: contains 'rt3.', but no '--'.");
+Y_UNIT_TEST_F(FccKeepsMalformedRt3AsLiteral, TNameResolverFixture) {
+    UNIT_ASSERT_VALUES_EQUAL(
+        Ok(ResolveName(TString{Database}, "rt3.bad", "dc1", "")),
+        "/Root/Db/rt3.bad");
 }
 
-Y_UNIT_TEST_F(MalformedRt3EmptyDc, TNameResolverFixture) {
-    ExpectError(
-        ResolveName(TString{Database}, "rt3.--account--topic", "dc1", ""),
-        "Internal error: Could not determine DC for topic: rt3.--account--topic.");
+Y_UNIT_TEST_F(FccKeepsRt3EmptyDcAsLiteral, TNameResolverFixture) {
+    UNIT_ASSERT_VALUES_EQUAL(
+        Ok(ResolveName(TString{Database}, "rt3.--account--topic", "dc1", "")),
+        "/Root/Db/rt3.--account--topic");
 }
 
-Y_UNIT_TEST_F(MalformedRt3EmptyShort, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsRt3EmptyShortAsLiteral, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc1--", "dc1", "")),
-        "/Root/LbCommunal");
+        "/Root/Db/rt3.dc1--");
 }
 
-Y_UNIT_TEST_F(ShortDashDashConverted, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccKeepsTrailingDashDashAsLiteral, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--", "dc1", "")),
-        "/Root/LbCommunal/account");
+        "/Root/Db/account--");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "--topic", "dc1", "")),
-        "/Root/LbCommunal/topic");
+        "/Root/Db/--topic");
 }
 
-Y_UNIT_TEST_F(EmptyNameFccIsLegacyBare, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccEmptyNameJoinsDatabase, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "", "dc1", "")),
-        "/Root/LbCommunal");
+        "/Root/Db");
 }
 
-Y_UNIT_TEST_F(DoubleSlashInLegacyFccConverted, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccNormalizesDoubleSlashInLegacyLookingName, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--a//b", "dc1", "")),
-        "/Root/LbCommunal/account/a/b");
+        "/Root/Db/account--a/b");
 }
 
-Y_UNIT_TEST_F(LeadingSlashStripped, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccStripsLeadingSlashOnLiteralRt3, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "/rt3.dc1--account--topic", "dc1", "")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/rt3.dc1--account--topic");
 }
 
-Y_UNIT_TEST_F(MirrorSkippedWhenLocalDcEmpty, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccDoesNotMirrorLegacyLookingName, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc2--account--topic", "", "dc2")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/rt3.dc2--account--topic");
 }
 
-Y_UNIT_TEST_F(FallbackToDatabaseWhenLbRootEmpty, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccIgnoresEmptyLbRootForLiteralName, TNameResolverFixture) {
     SetLbRoot("");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc1--account--topic", "dc1", "")),
-        "/Root/Db/account/topic");
+        "/Root/Db/rt3.dc1--account--topic");
 }
 
-Y_UNIT_TEST_F(NoRootReturnsModernPathOnly, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccEmptyDatabaseKeepsRelativeLiteralName, TNameResolverFixture) {
     SetLbRoot("");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName("", "rt3.dc1--account--topic", "dc1", "")),
-        "account/topic");
+        "/rt3.dc1--account--topic");
 }
 
-Y_UNIT_TEST_F(DefaultDcParsesFromRt3Name, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccDefaultDcKeepsLiteralRt3, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc2--account--topic", "dc1")),
-        "/Root/LbCommunal/account/topic-mirrored-from-dc2");
+        "/Root/Db/rt3.dc2--account--topic");
 }
 
-Y_UNIT_TEST_F(DefaultDcShortUsesLocalDc, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccDefaultDcKeepsLiteralShortName, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--topic", "dc1")),
-        "/Root/LbCommunal/account/topic");
+        "/Root/Db/account--topic");
 }
 
 Y_UNIT_TEST_F(IsPathPrefixExactMatch, TNameResolverFixture) {
@@ -609,11 +616,11 @@ Y_UNIT_TEST_F(FccEmptyNameUncleanDatabaseUnderLbRoot, TNameResolverFixture) {
     UNIT_ASSERT_VALUES_EQUAL(resolved.NavigateDatabase, "/Root/account1");
 }
 
-Y_UNIT_TEST_F(JoinWithRootEmptyLbRootUncleanPath, TNameResolverFixture) {
+Y_UNIT_TEST_F(FccNormalizesDoubleSlashWithoutLegacyConvert, TNameResolverFixture) {
     SetLbRoot("");
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "account--a//b", "dc1", "")),
-        "/Root/Db/account/a/b");
+        "/Root/Db/account--a/b");
 }
 
 Y_UNIT_TEST_F(AbsoluteDatabaseUncleanRequestDatabase, TNameResolverFixture) {
@@ -661,6 +668,7 @@ Y_UNIT_TEST_F(FederationRootMirroredMalformedRejected, TNameResolverFixture) {
 }
 
 Y_UNIT_TEST_F(NavigateDatabaseEmptyWhenNoAccountTopicShape, TNameResolverFixture) {
+    SetFcc(false);
     // Path under LbRoot without account/topic shape → keep request database.
     const auto resolved = OkFull(ResolveName(TString{Database}, "rt3.dc1--", "dc1"));
     UNIT_ASSERT_VALUES_EQUAL(resolved.Path, "/Root/LbCommunal");
@@ -676,6 +684,7 @@ Y_UNIT_TEST_F(TryFederationAccountTargetCanonizesUncleanPath, TNameResolverFixtu
 }
 
 Y_UNIT_TEST_F(CorrectNameFalseUsesConvertOldTopicName, TNameResolverFixture) {
+    SetFcc(false);
     // CorrectName rejects empty producer between '--'; shortLegacy still converts.
     UNIT_ASSERT_VALUES_EQUAL(
         Ok(ResolveName(TString{Database}, "rt3.dc1----topic", "dc1", "")),

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -82,7 +82,7 @@ private:
 
         auto database = CanonizePath(Settings.Database);
         // Federation create still expects the original legacy name so ForFederation can
-        // extract DC/producer metadata. ResolveName is only for FCC (modern + legacy → path).
+        // extract DC/producer metadata. ResolveName is only for FCC (literal modern path).
         TString path;
         if (AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {
             auto resolved = NNameResolver::ResolveName(database, Settings.Strategy->GetTopicName());

--- a/ydb/core/persqueue/public/schema/create_topic_ut.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_ut.cpp
@@ -37,22 +37,68 @@ Y_UNIT_TEST(CreateTopicSuccess) {
         NKikimrPQ::TPQTabletConfig::EConsumerType_Name(::NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING));
 }
 
-Y_UNIT_TEST(CreateTopicLegacyName) {
+Y_UNIT_TEST(CreateTopicKeepsLiteralDashDashName) {
     auto setup = CreateSetup();
     auto& runtime = setup->GetRuntime();
     runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
 
-    const TString legacyName = "rt3.dc1--account--topic";
-    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(legacyName)), Ydb::StatusIds::SUCCESS);
+    const TString name = "TestSchemeList--test-topic-1";
+    const TString path = "/Root/" + name;
+    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(name)), Ydb::StatusIds::SUCCESS);
 
     auto edge = runtime.AllocateEdgeActor();
-    runtime.Register(NDescriber::CreateDescriberActor(edge, "/Root", {legacyName}));
+    runtime.Register(NDescriber::CreateDescriberActor(edge, "/Root", {name}));
     auto response = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
     UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1u);
-    const auto it = response->Topics.find(legacyName);
+    const auto it = response->Topics.find(name);
     UNIT_ASSERT(it != response->Topics.end());
     UNIT_ASSERT_VALUES_EQUAL(it->second.Status, NDescriber::EStatus::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(it->second.RealPath, "/Root/account/topic");
+    UNIT_ASSERT_VALUES_EQUAL(it->second.RealPath, path);
+
+    // "--" is not a path separator: the converted legacy path must not exist.
+    auto convertedEdge = runtime.AllocateEdgeActor();
+    runtime.Register(NDescriber::CreateDescriberActor(convertedEdge, "/Root", {TString("TestSchemeList/test-topic-1")}));
+    auto converted = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+    UNIT_ASSERT_VALUES_EQUAL(converted->Topics.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(converted->Topics.begin()->second.Status, NDescriber::EStatus::NOT_FOUND);
+}
+
+// https://github.com/ydb-platform/ydb/issues/50971
+// Go SDK TestSchemeList creates a topic named like t.Name() (contains "--") and
+// lists the database root. FCC must keep the leaf literal: no -- → / rewrite.
+Y_UNIT_TEST(CreateFccLegacyLookingNameListedAsLiteral) {
+    auto setup = CreateSetup("FccLegacyLookingSchemeList");
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+
+    const TVector<TString> names = {
+        "TestSchemeList--test-topic-1",
+        "rt3.dc1--account--topic",
+    };
+    for (const auto& name : names) {
+        AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(name)), Ydb::StatusIds::SUCCESS);
+    }
+
+    auto ls = setup->GetServer().AnnoyingClient->Ls("/Root");
+    UNIT_ASSERT(ls);
+    UNIT_ASSERT_VALUES_EQUAL(ls->Record.GetSchemeStatus(), NKikimrScheme::StatusSuccess);
+
+    auto findChild = [&](TStringBuf childName) -> const NKikimrSchemeOp::TDirEntry* {
+        for (const auto& child : ls->Record.GetPathDescription().GetChildren()) {
+            if (child.GetName() == childName) {
+                return &child;
+            }
+        }
+        return nullptr;
+    };
+
+    for (const auto& name : names) {
+        const auto* child = findChild(name);
+        UNIT_ASSERT_C(child, name);
+        UNIT_ASSERT_VALUES_EQUAL(child->GetPathType(), NKikimrSchemeOp::EPathTypePersQueueGroup);
+    }
+    UNIT_ASSERT(!findChild("TestSchemeList"));
+    UNIT_ASSERT(!findChild("account"));
 }
 
 Y_UNIT_TEST(CreateSharedConsumer) {

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/schema_ops_ut.cpp
@@ -596,46 +596,21 @@ Y_UNIT_TEST(NegativeReadSpeedRejected) {
     AssertStatus(result, Ydb::StatusIds::BAD_REQUEST, "partition_total_read_speed_bytes_per_second");
 }
 
-Y_UNIT_TEST(FccTopicNameFormatsCreateAndDescribeAliases) {
+Y_UNIT_TEST(FccKeepsLiteralDashDashTopicName) {
     auto setup = CreateSetup("PQv1NameFormatsFcc");
     auto& runtime = setup->GetRuntime();
 
-    MkDir(*setup, "/Root", "fcclegacy");
+    const TString name = "TestSchemeList--test-topic-1";
+    const TString path = "/Root/" + name;
+    CreateTopic(runtime, name);
+    AssertDescribeAliases(runtime, {name, path}, path);
+
     MkDir(*setup, "/Root", "fccmodern");
-    MkDir(*setup, "/Root", "fccshort");
-
-    CreateTopic(runtime, "rt3.dc1--fcclegacy--topic");
-    AssertDescribeAliases(
-        runtime,
-        {
-            "rt3.dc1--fcclegacy--topic",
-            "fcclegacy--topic",
-            "fcclegacy/topic",
-            "/Root/fcclegacy/topic",
-        },
-        "/Root/fcclegacy/topic");
-
     CreateTopic(runtime, "fccmodern/topic");
     AssertDescribeAliases(
         runtime,
-        {
-            "rt3.dc1--fccmodern--topic",
-            "fccmodern--topic",
-            "fccmodern/topic",
-            "/Root/fccmodern/topic",
-        },
+        {"fccmodern/topic", "/Root/fccmodern/topic"},
         "/Root/fccmodern/topic");
-
-    CreateTopic(runtime, "fccshort--topic");
-    AssertDescribeAliases(
-        runtime,
-        {
-            "rt3.dc1--fccshort--topic",
-            "fccshort--topic",
-            "fccshort/topic",
-            "/Root/fccshort/topic",
-        },
-        "/Root/fccshort/topic");
 }
 
 Y_UNIT_TEST(FederationTopicNameFormats) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -1533,40 +1533,33 @@ Y_UNIT_TEST(UnauthenticatedRejectedWhenRequired) {
     AssertStatus(result, Ydb::StatusIds::UNAUTHORIZED, "Unauthenticated access is forbidden");
 }
 
-Y_UNIT_TEST(FccTopicNameFormatsCreateAndDescribeAliases) {
+Y_UNIT_TEST(FccKeepsLiteralDashDashTopicName) {
     auto setup = CreateSetup("TopicNameFormatsFcc");
     auto& runtime = setup->GetRuntime();
 
-    MkDir(*setup, "/Root", "fcclegacy");
+    const TString name = "TestSchemeList--test-topic-1";
+    const TString path = "/Root/" + name;
+    CreateTopic(runtime, name);
+    AssertDescribeAliases(runtime, {name, path}, path);
+
+    auto ls = setup->GetServer().AnnoyingClient->Ls("/Root");
+    UNIT_ASSERT(ls);
+    bool listed = false;
+    for (const auto& child : ls->Record.GetPathDescription().GetChildren()) {
+        if (child.GetName() == name) {
+            listed = true;
+            UNIT_ASSERT_VALUES_EQUAL(child.GetPathType(), NKikimrSchemeOp::EPathTypePersQueueGroup);
+        }
+        UNIT_ASSERT_VALUES_UNEQUAL(child.GetName(), "TestSchemeList");
+    }
+    UNIT_ASSERT(listed);
+
     MkDir(*setup, "/Root", "fccmodern");
-    MkDir(*setup, "/Root", "fccshort");
-
-    const TVector<TString> legacyAliases = {
-        "rt3.dc1--fcclegacy--topic",
-        "fcclegacy--topic",
-        "fcclegacy/topic",
-        "/Root/fcclegacy/topic",
-    };
-    CreateTopic(runtime, "rt3.dc1--fcclegacy--topic");
-    AssertDescribeAliases(runtime, legacyAliases, "/Root/fcclegacy/topic");
-
-    const TVector<TString> modernAliases = {
-        "rt3.dc1--fccmodern--topic",
-        "fccmodern--topic",
-        "fccmodern/topic",
-        "/Root/fccmodern/topic",
-    };
     CreateTopic(runtime, "fccmodern/topic");
-    AssertDescribeAliases(runtime, modernAliases, "/Root/fccmodern/topic");
-
-    const TVector<TString> shortAliases = {
-        "rt3.dc1--fccshort--topic",
-        "fccshort--topic",
-        "fccshort/topic",
-        "/Root/fccshort/topic",
-    };
-    CreateTopic(runtime, "fccshort--topic");
-    AssertDescribeAliases(runtime, shortAliases, "/Root/fccshort/topic");
+    AssertDescribeAliases(
+        runtime,
+        {"fccmodern/topic", "/Root/fccmodern/topic"},
+        "/Root/fccmodern/topic");
 }
 
 Y_UNIT_TEST(FederationTopicNameFormats) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

With `TopicsAreFirstClassCitizen=true`, topic names that look like legacy forms (`--`, `rt3.*`, `@`) are no longer rewritten into paths. A name such as `TestSchemeList--test-topic-1` stays a single leaf under the database.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/50971

PR #49827 wired `ResolveName` into FCC Topic API create. Any leaf containing `--` without `/` was classified as short legacy `account--topic`, so `TestSchemeList--test-topic-1` became `TestSchemeList/test-topic-1`. `ListDirectory` of the database root then missed the topic.

This PR disables legacy conversion in FCC: `ResolveName` joins the name with the request database as-is. Federation mode (`FCC=false`) is unchanged.

Tests cover the Go SDK `TestSchemeList` case: create a `--` name, list `/Root`, and assert there is no rewritten directory.