### PR TITLE
Datashard: fix read-your-writes bugs in Snapshot Isolation

### DIFF
--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -1020,7 +1020,7 @@ NTable::ITransactionMapPtr TDataShardUserDb::GetReadTxMap(const TTableId& tableI
         VolatileTxId && !VolatileCommitTxIds.empty() ||
         // We need tx map when current lock has uncommitted changes
         LockTxId && Self.SysLocksTable().HasCurrentWriteLock(tableId) ||
-        // In SnapshotIsolatiom mode we need tx map to see changes committed by our
+        // In SnapshotIsolation mode we need tx map to see changes committed by our
         // own locks earlier in this EvWrite (immediate commit path). Those deltas
         // remain in the localdb under their original LockTxId; without a TxMap entry
         // they are only visible at MvccVersion, which may be newer than SnapshotVersion.

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -561,7 +561,7 @@ void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId) {
             // Update TxMap to include the new commit
             auto it = TxMaps.find(tableId.PathId);
             if (it != TxMaps.end()) {
-                it->second->Add(lockId, MvccVersion);
+                it->second->Add(lockId, TRowVersion::Min());
             }
         }
         // Note for AI agents: we don't add lockId to CommittedTxIds because
@@ -584,7 +584,7 @@ void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId) {
 
 void TDataShardUserDb::AddCommitTxId(const TTableId& tableId, ui64 txId) {
     auto* dynamicTxMap = static_cast<NTable::TDynamicTransactionMap*>(GetReadTxMap(tableId).Get());
-    dynamicTxMap->Add(txId, MvccVersion);
+    dynamicTxMap->Add(txId, TRowVersion::Min());
 }
 
 class TLockedReadTxObserver: public NTable::ITransactionObserver {
@@ -996,7 +996,7 @@ ui64 TDataShardUserDb::GetWriteTxId(const TTableId& tableId) {
             // Update TxMap to include the new commit
             auto it = TxMaps.find(tableId.PathId);
             if (it != TxMaps.end()) {
-                it->second->Add(VolatileTxId, MvccVersion);
+                it->second->Add(VolatileTxId, TRowVersion::Min());
             }
         }
         // Note for AI agents: we don't add VolatileTxId to CommittedTxIds
@@ -1019,7 +1019,13 @@ NTable::ITransactionMapPtr TDataShardUserDb::GetReadTxMap(const TTableId& tableI
         // We need tx map to see committed volatile tx changes
         VolatileTxId && !VolatileCommitTxIds.empty() ||
         // We need tx map when current lock has uncommitted changes
-        LockTxId && Self.SysLocksTable().HasCurrentWriteLock(tableId)
+        LockTxId && Self.SysLocksTable().HasCurrentWriteLock(tableId) ||
+        // In SnapshotIsolatiom mode we need tx map to see changes committed by our
+        // own locks earlier in this EvWrite (immediate commit path). Those deltas
+        // remain in the localdb under their original LockTxId; without a TxMap entry
+        // they are only visible at MvccVersion, which may be newer than SnapshotVersion.
+        // Mapping them to TRowVersion::Min() makes them visible at any snapshot.
+        LockMode == ELockMode::OptimisticSnapshotIsolation && !CommittedTxIds.empty()
     );
 
     if (!needTxMap) {
@@ -1034,9 +1040,18 @@ NTable::ITransactionMapPtr TDataShardUserDb::GetReadTxMap(const TTableId& tableI
             // Uncommitted changes are visible in all possible snapshots
             txMap->Add(LockTxId, TRowVersion::Min());
         } else if (VolatileTxId) {
-            // We want committed volatile changes to be visible at the write version
+            // Own volatile commit-time writes must be visible at any snapshot,
+            // same as LockTxId.
             for (ui64 commitTxId : VolatileCommitTxIds) {
-                txMap->Add(commitTxId, MvccVersion);
+                txMap->Add(commitTxId, TRowVersion::Min());
+            }
+        }
+        if (LockMode == ELockMode::OptimisticSnapshotIsolation) {
+            // Make immediately committed lock changes visible at any snapshot.
+            // This allows commit-time writes (e.g. DELETE in the same EvWrite as the
+            // lock commit) to see rows committed by the lock via RowExists checks.
+            for (ui64 txId : CommittedTxIds) {
+                txMap->Add(txId, TRowVersion::Min());
             }
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_snapshot_isolation.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot_isolation.cpp
@@ -1275,7 +1275,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.back().GetCounter(), ui64(TSysTables::TLocksTable::TLock::ErrorBroken));
     }
 
-    Y_UNIT_TEST(DeleteInsertSameRowOnCommit) {
+    Y_UNIT_TEST_TWIN(DeleteInsertSameRowImmediateCommit, StandaloneDelete) {
         TPortManager pm;
         NKikimrConfig::TAppConfig app;
         TServerSettings serverSettings(pm.GetPort(2134));
@@ -1310,13 +1310,27 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             tx1.ReadKey(tableId, shards.at(0), 2),
             "");
 
-        // Try deleting the row, inserting it, and committing in a single EvWrite
-        UNIT_ASSERT_VALUES_EQUAL(
-            tx1.WriteCommit(
-                tableId, shards.at(0),
-                TOperation::Delete(1),
-                TOperation::Insert(1, 1002)),
-            "OK");
+        if (StandaloneDelete) {
+            // delete the row with an immediate write
+            UNIT_ASSERT_VALUES_EQUAL(
+                tx1.Write(tableId, shards.at(0), TOperation::Delete(1)),
+                "OK");
+
+            // Try inserting a different value for the same key and committing in a single EvWrite
+            UNIT_ASSERT_VALUES_EQUAL(
+                tx1.WriteCommit(
+                    tableId, shards.at(0),
+                    TOperation::Insert(1, 1002)),
+                "OK");
+        } else {
+            // Try deleting the row, inserting it, and committing in a single EvWrite
+            UNIT_ASSERT_VALUES_EQUAL(
+                tx1.WriteCommit(
+                    tableId, shards.at(0),
+                    TOperation::Delete(1),
+                    TOperation::Insert(1, 1002)),
+                "OK");
+        }
 
         // We should observe effects from tx1
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1326,7 +1340,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             "{ items { int32_value: 1 } items { int32_value: 1002 } }");
     }
 
-Y_UNIT_TEST(DeleteInsertSameRowUncommittedChanges) {
+    Y_UNIT_TEST_TWIN(DeleteInsertSameRowDistributedCommit, StandaloneDelete) {
         TPortManager pm;
         NKikimrConfig::TAppConfig app;
         TServerSettings serverSettings(pm.GetPort(2134));
@@ -1341,18 +1355,20 @@ Y_UNIT_TEST(DeleteInsertSameRowUncommittedChanges) {
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSchemeExec(runtime, R"(
                 CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10))
             )"),
             "SUCCESS"
         );
 
         ExecSQL(server, sender, R"(
             UPSERT INTO `/Root/table` (key, value) VALUES (1, 1001);
+            UPSERT INTO `/Root/table` (key, value) VALUES (11, 1101);
         )");
 
         const auto tableId = ResolveTableId(server, sender, "/Root/table");
         UNIT_ASSERT(tableId);
         const auto shards = GetTableShards(server, sender, "/Root/table");
-        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
         TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
@@ -1361,25 +1377,51 @@ Y_UNIT_TEST(DeleteInsertSameRowUncommittedChanges) {
             tx1.ReadKey(tableId, shards.at(0), 2),
             "");
 
-        // delete the row with an immediate write
-        UNIT_ASSERT_VALUES_EQUAL(
-            tx1.Write(tableId, shards.at(0), TOperation::Delete(1)),
-            "OK"
-        );
 
-        // Try inserting a different value for the same key and committing in a single EvWrite
-        UNIT_ASSERT_VALUES_EQUAL(
-            tx1.WriteCommit(
-                tableId, shards.at(0),
-                TOperation::Insert(1, 1002)),
-            "OK");
+        if (StandaloneDelete) {
+            // delete the rows with immediate writes
+            UNIT_ASSERT_VALUES_EQUAL(
+                tx1.Write(tableId, shards.at(0), TOperation::Delete(1)),
+                "OK");
+            UNIT_ASSERT_VALUES_EQUAL(
+                tx1.Write(tableId, shards.at(1), TOperation::Delete(11)),
+                "OK");
+
+            // Now insert new values for the same key and commit with a distributed commit
+            tx1.InitCommit(shards);
+            auto write1 = tx1.PrepareCommit(
+                    tableId, shards.at(0),
+                    TOperation::Insert(1, 1002));
+            auto write2 = tx1.PrepareCommit(
+                    tableId, shards.at(1),
+                    TOperation::Insert(11, 1102));
+            tx1.SendPlan();
+
+            UNIT_ASSERT_VALUES_EQUAL(write1.NextString(), "OK");
+            UNIT_ASSERT_VALUES_EQUAL(write2.NextString(), "OK");
+        } else {
+            tx1.InitCommit(shards);
+            auto write1 = tx1.PrepareCommit(
+                    tableId, shards.at(0),
+                    TOperation::Delete(1),
+                    TOperation::Insert(1, 1002));
+            auto write2 = tx1.PrepareCommit(
+                    tableId, shards.at(1),
+                    TOperation::Delete(11),
+                    TOperation::Insert(11, 1102));
+            tx1.SendPlan();
+
+            UNIT_ASSERT_VALUES_EQUAL(write1.NextString(), "OK");
+            UNIT_ASSERT_VALUES_EQUAL(write2.NextString(), "OK");
+        }
 
         // We should observe effects from tx1
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSimpleExec(runtime, R"(
                 SELECT key, value FROM `/Root/table` ORDER BY key;
             )"),
-            "{ items { int32_value: 1 } items { int32_value: 1002 } }");
+            "{ items { int32_value: 1 } items { int32_value: 1002 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 1102 } }");
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation)

--- a/ydb/core/tx/datashard/datashard_ut_snapshot_isolation.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot_isolation.cpp
@@ -1275,6 +1275,113 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.back().GetCounter(), ui64(TSysTables::TLocksTable::TLock::ErrorBroken));
     }
 
+    Y_UNIT_TEST(DeleteInsertSameRowOnCommit) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES (1, 1001);
+        )");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        UNIT_ASSERT(tableId);
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
+
+        // establish the snapshot
+        UNIT_ASSERT_VALUES_EQUAL(
+            tx1.ReadKey(tableId, shards.at(0), 2),
+            "");
+
+        // Try deleting the row, inserting it, and committing in a single EvWrite
+        UNIT_ASSERT_VALUES_EQUAL(
+            tx1.WriteCommit(
+                tableId, shards.at(0),
+                TOperation::Delete(1),
+                TOperation::Insert(1, 1002)),
+            "OK");
+
+        // We should observe effects from tx1
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 1002 } }");
+    }
+
+Y_UNIT_TEST(DeleteInsertSameRowUncommittedChanges) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES (1, 1001);
+        )");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        UNIT_ASSERT(tableId);
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
+
+        // establish the snapshot
+        UNIT_ASSERT_VALUES_EQUAL(
+            tx1.ReadKey(tableId, shards.at(0), 2),
+            "");
+
+        // delete the row with an immediate write
+        UNIT_ASSERT_VALUES_EQUAL(
+            tx1.Write(tableId, shards.at(0), TOperation::Delete(1)),
+            "OK"
+        );
+
+        // Try inserting a different value for the same key and committing in a single EvWrite
+        UNIT_ASSERT_VALUES_EQUAL(
+            tx1.WriteCommit(
+                tableId, shards.at(0),
+                TOperation::Insert(1, 1002)),
+            "OK");
+
+        // We should observe effects from tx1
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 1002 } }");
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
@@ -29,18 +29,41 @@ NLongTxService::TLockHandle MakeLockHandle(TTestActorRuntime& runtime, ui64 lock
 }
 
 void TWriteOperation::ApplyTo(const TTableId& tableId, NEvents::TDataEvents::TEvWrite* req) {
-    TVector<TCell> cells;
-    cells.reserve(Rows.size() * 2);
-    for (const auto& row : Rows) {
-        cells.push_back(TCell::Make(row.Key));
-        cells.push_back(TCell::Make(row.Value));
+    switch (Type) {
+    case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT:
+    case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT: {
+        TVector<TCell> cells;
+        cells.reserve(Rows.size() * 2);
+        for (const auto& row : Rows) {
+            cells.push_back(TCell::Make(row.Key));
+            cells.push_back(TCell::Make(row.Value));
+        }
+
+        TSerializedCellMatrix matrix(cells, Rows.size(), 2);
+        TString blobData = matrix.ReleaseBuffer();
+
+        ui64 payloadIndex = NKikimr::NEvWrite::TPayloadWriter<NKikimr::NEvents::TDataEvents::TEvWrite>(*req).AddDataToPayload(std::move(blobData));
+        req->AddOperation(Type, tableId, { 1, 2 }, payloadIndex, NKikimrDataEvents::FORMAT_CELLVEC);
+
+        break;
     }
+    case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_DELETE: {
+        TVector<TCell> cells;
+        cells.reserve(Rows.size());
+        for (const auto& row : Rows) {
+            cells.push_back(TCell::Make(row.Key));
+        }
 
-    TSerializedCellMatrix matrix(cells, Rows.size(), 2);
-    TString blobData = matrix.ReleaseBuffer();
+        TSerializedCellMatrix matrix(cells, Rows.size(), 1);
+        TString blobData = matrix.ReleaseBuffer();
 
-    ui64 payloadIndex = NKikimr::NEvWrite::TPayloadWriter<NKikimr::NEvents::TDataEvents::TEvWrite>(*req).AddDataToPayload(std::move(blobData));
-    req->AddOperation(Type, tableId, { 1, 2 }, payloadIndex, NKikimrDataEvents::FORMAT_CELLVEC);
+        ui64 payloadIndex = NKikimr::NEvWrite::TPayloadWriter<NKikimr::NEvents::TDataEvents::TEvWrite>(*req).AddDataToPayload(std::move(blobData));
+        req->AddOperation(Type, tableId, { 1 }, payloadIndex, NKikimrDataEvents::FORMAT_CELLVEC);
+        break;
+    }
+    default:
+        Y_ENSURE(false, "Unexpected op type: " << Type);
+    }
 }
 
 TTransactionState::TTransactionState(TTestActorRuntime& runtime, NKikimrDataEvents::ELockMode lockMode)

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -45,6 +45,17 @@ struct TWriteOperation {
             std::move(rows),
         };
     }
+
+    static TWriteOperation Delete(i32 key) {
+        return Delete({ { key, 0 } } );
+    }
+
+    static TWriteOperation Delete(TVector<TKeyValue> rows) {
+        return TWriteOperation{
+            NKikimrDataEvents::TEvWrite::TOperation::OPERATION_DELETE,
+            std::move(rows),
+        };
+    }
 };
 
 class TTransactionState {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

В snapshot isolation была проблема с read-your-writes из-за того, что операции в коммитящем EvWrite не видят результаты предыдущих операций и коммитов в том же EvWrite (изменения коммитятся в MvccVersion, а читаются в SnapshotVersion). Пофиксил, заменив версию собственных изменений в TxMap с MvccVersion на TRowVersion::Min() - так они будут всегда видны.