### PR TITLE
[NBS-7517] Copy blocks throttling

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/config/config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/config/config.cpp
@@ -47,6 +47,7 @@ TStorageConfig::TStorageConfig(
     xxx(PBufferCleanupLsnStep,              ui64,     3000                    )\
     xxx(UseDirectSessionTransport,          bool,     false                   )\
     xxx(EnableChecksums,                    bool,     true                    )\
+    xxx(CopyRangeBandwidthMbs,              ui32,     200                     )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RO
 // clang-format on

--- a/ydb/core/nbs/cloud/blockstore/config/config.h
+++ b/ydb/core/nbs/cloud/blockstore/config/config.h
@@ -42,6 +42,7 @@ public:
     [[nodiscard]] ui64 GetPBufferCleanupLsnStep() const;
     [[nodiscard]] bool GetUseDirectSessionTransport() const;
     [[nodiscard]] bool GetEnableChecksums() const;
+    [[nodiscard]] ui32 GetCopyRangeBandwidthMbs() const;
 
     [[nodiscard]] TString Dump() const;
 

--- a/ydb/core/nbs/cloud/blockstore/config/config_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/config/config_ut.cpp
@@ -28,6 +28,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(4u, config.GetVhostThreadsCount());
         UNIT_ASSERT_VALUES_EQUAL(4u, config.GetVhostQueuesCount());
         UNIT_ASSERT(config.GetEnableChecksums());
+        UNIT_ASSERT_VALUES_EQUAL(200, config.GetCopyRangeBandwidthMbs());
     }
 
     Y_UNIT_TEST(ShouldUseExplicitProtoValuesWhenSet)
@@ -41,8 +42,9 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         proto.SetVhostThreadsCount(12);
         proto.SetVhostQueuesCount(16);
         proto.SetEnableChecksums(false);
+        proto.SetCopyRangeBandwidthMbs(100);
 
-        TStorageConfig config{std::move(proto)};
+        TStorageConfig config{proto};
 
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(42),
@@ -56,6 +58,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(12u, config.GetVhostThreadsCount());
         UNIT_ASSERT_VALUES_EQUAL(16u, config.GetVhostQueuesCount());
         UNIT_ASSERT(!config.GetEnableChecksums());
+        UNIT_ASSERT_VALUES_EQUAL(100u, config.GetCopyRangeBandwidthMbs());
     }
 
     Y_UNIT_TEST(ShouldApplyDefaultsForPartialProto)
@@ -63,7 +66,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         NProto::TStorageServiceConfig proto;
         proto.SetStripeSize(2048);
 
-        TStorageConfig config{std::move(proto)};
+        TStorageConfig config{proto};
 
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MicroSeconds(1000),
@@ -76,6 +79,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(134217728, config.GetVChunkSize());
         UNIT_ASSERT_VALUES_EQUAL(4u, config.GetVhostThreadsCount());
         UNIT_ASSERT_VALUES_EQUAL(4u, config.GetVhostQueuesCount());
+        UNIT_ASSERT_VALUES_EQUAL(200, config.GetCopyRangeBandwidthMbs());
     }
 
     Y_UNIT_TEST(ShouldAcceptOnlyVhostThreadsCountAndKeepOtherDefaults)
@@ -83,7 +87,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         NProto::TStorageServiceConfig proto;
         proto.SetVhostThreadsCount(8);
 
-        TStorageConfig config{std::move(proto)};
+        TStorageConfig config{proto};
 
         UNIT_ASSERT_VALUES_EQUAL(8u, config.GetVhostThreadsCount());
         // VhostQueuesCount must fall back to its default when not set.
@@ -95,7 +99,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         NProto::TStorageServiceConfig proto;
         proto.SetVhostQueuesCount(2);
 
-        TStorageConfig config{std::move(proto)};
+        TStorageConfig config{proto};
 
         UNIT_ASSERT_VALUES_EQUAL(2u, config.GetVhostQueuesCount());
         // VhostThreadsCount must fall back to its default when not set.

--- a/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
+++ b/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
@@ -156,4 +156,8 @@ message TStorageServiceConfig
     // Defaults to true. When false, NBS does not calculate or attach per-block
     // checksums and DDisk/PersistentBuffer ignore checksum machinery.
     optional bool EnableChecksums = 32;
+
+    // Maximum aggregate bandwidth in megabytes per second for copying ranges
+    // within a DirectBlockGroup. 0 disables throttling.
+    optional uint32 CopyRangeBandwidthMbs = 33;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/service/trace_service.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/model/disk_description.h>
 
+#include <ydb/core/nbs/cloud/storage/core/libs/common/format.h>
 #include <ydb/core/nbs/cloud/storage/core/libs/common/future_helper.h>
 
 #include <ydb/library/actors/core/log.h>
@@ -184,21 +185,51 @@ void TDDiskDataCopier::StartCopyRange()
             break;
     }
 
+    auto timeWaitBeforeExecution = DirectBlockGroup->TakeCopyRangeBudget(
+        freshRange->Size() * VolumeConfig->BlockSize);
     auto hint = DirtyMap->BeginRangeSync(Destination, *freshRange);
     hint.ReadyToStart.Subscribe(
-        [weakSelf = weak_from_this(), syncId = hint.SyncId, range = hint.Range](
-            const TFuture<void>& f)
+        [weakSelf = weak_from_this(),
+         syncId = hint.SyncId,
+         range = hint.Range,
+         willStartAt = TInstant::Now() + timeWaitBeforeExecution]   //
+        (const TFuture<void>& f) mutable
         {
             Y_UNUSED(f);
 
             if (auto self = weakSelf.lock()) {
-                self->CopyRange(syncId, range);
+                self->CopyRange(willStartAt - TInstant::Now(), syncId, range);
             }
         });
 }
 
-void TDDiskDataCopier::CopyRange(ui64 syncId, TBlockRange64 range)
+void TDDiskDataCopier::CopyRange(
+    TDuration timeWaitBeforeExecution,
+    ui64 syncId,
+    TBlockRange64 range)
 {
+    if (timeWaitBeforeExecution) {
+        LOG_DEBUG(
+            *ActorSystem,
+            NKikimrServices::NBS_PARTITION,
+            "%s %lu %s Schedule copy range %s",
+            LogTitle.GetWithTime().c_str(),
+            syncId,
+            range.Print().c_str(),
+            FormatDuration(timeWaitBeforeExecution).c_str());
+
+        DirectBlockGroup->Schedule(
+            timeWaitBeforeExecution,
+            [weakSelf = weak_from_this(), syncId, range]()
+            {
+                if (auto self = weakSelf.lock()) {
+                    self->CopyRange({}, syncId, range);
+                }
+            });
+
+        return;
+    }
+
     LOG_DEBUG(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
@@ -59,7 +59,10 @@ private:
     std::optional<TBlockRange64> GetFreshRange() const;
     NWilson::TSpan CreateSpan(TBlockRange64 range) const;
     void StartCopyRange();
-    void CopyRange(ui64 syncId, TBlockRange64 range);
+    void CopyRange(
+        TDuration timeWaitBeforeExecution,
+        ui64 syncId,
+        TBlockRange64 range);
     void OnRangeRead(
         TCopyRangeRequestStatePtr copyRangeState,
         const IReadRequestExecutor::TResponse& response);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -219,6 +219,11 @@ public:
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) = 0;
 
+    // Reserves byteCount from this DirectBlockGroup's aggregate range-copy
+    // bandwidth budget. Returns the delay before the operation may start;
+    // zero means it may start immediately or throttling is disabled.
+    virtual TDuration TakeCopyRangeBudget(ui64 byteCount) = 0;
+
     // Translate host index to NodeId.
     [[nodiscard]] virtual ui32 GetNodeId(THostIndex host) const = 0;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -219,9 +219,9 @@ public:
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) = 0;
 
-    // Reserves byteCount from this DirectBlockGroup's aggregate range-copy
-    // bandwidth budget. Returns the delay before the operation may start;
-    // zero means it may start immediately or throttling is disabled.
+    // Reserves byteCount from the disk-wide range-copy bandwidth budget shared
+    // by all DirectBlockGroups. Returns the delay before the operation may
+    // start. Zero means it may start immediately or throttling is disabled.
     virtual TDuration TakeCopyRangeBudget(ui64 byteCount) = 0;
 
     // Translate host index to NodeId.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -222,7 +222,7 @@ public:
     // Reserves byteCount from the disk-wide range-copy bandwidth budget shared
     // by all DirectBlockGroups. Returns the delay before the operation may
     // start. Zero means it may start immediately or throttling is disabled.
-    virtual TDuration TakeCopyRangeBudget(ui64 byteCount) = 0;
+    [[nodiscard]] virtual TDuration TakeCopyRangeBudget(ui64 byteCount) = 0;
 
     // Translate host index to NodeId.
     [[nodiscard]] virtual ui32 GetNodeId(THostIndex host) const = 0;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -224,6 +224,15 @@ TDirectBlockGroup::TDirectBlockGroup(
     Y_ASSERT(pbufferIds.size() == ddisksIds.size());
     Y_ASSERT(pbufferIds.size() >= DirectBlockGroupHostCount);
 
+    const ui64 copyRangeBandwidth =
+        StorageConfig->GetCopyRangeBandwidthMbs() * 1_MB;
+    if (copyRangeBandwidth) {
+        CopyRangeBucket.emplace(
+            ActorSystem->Timestamp(),
+            copyRangeBandwidth,
+            copyRangeBandwidth);
+    }
+
     for (THostIndex host = 0; host < ddisksIds.size(); ++host) {
         AddDDiskAndPBufferConnection(host, ddisksIds[host], pbufferIds[host]);
     }
@@ -1330,6 +1339,17 @@ void TDirectBlockGroup::OnAddHostResult(
 
     DoEstablishConnection(newHostIndex, EConnectionType::DDisk);
     DoEstablishConnection(newHostIndex, EConnectionType::PBuffer);
+}
+
+TDuration TDirectBlockGroup::TakeCopyRangeBudget(ui64 byteCount)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    if (!CopyRangeBucket) {
+        return {};
+    }
+
+    return CopyRangeBucket->Register(ActorSystem->Timestamp(), byteCount);
 }
 
 ui32 TDirectBlockGroup::GetNodeId(THostIndex host) const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -224,15 +224,6 @@ TDirectBlockGroup::TDirectBlockGroup(
     Y_ASSERT(pbufferIds.size() == ddisksIds.size());
     Y_ASSERT(pbufferIds.size() >= DirectBlockGroupHostCount);
 
-    const ui64 copyRangeBandwidth =
-        StorageConfig->GetCopyRangeBandwidthMbs() * 1_MB;
-    if (copyRangeBandwidth) {
-        CopyRangeBucket.emplace(
-            ActorSystem->Timestamp(),
-            copyRangeBandwidth,
-            copyRangeBandwidth);
-    }
-
     for (THostIndex host = 0; host < ddisksIds.size(); ++host) {
         AddDDiskAndPBufferConnection(host, ddisksIds[host], pbufferIds[host]);
     }
@@ -1345,11 +1336,7 @@ TDuration TDirectBlockGroup::TakeCopyRangeBudget(ui64 byteCount)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
-    if (!CopyRangeBucket) {
-        return {};
-    }
-
-    return CopyRangeBucket->Register(ActorSystem->Timestamp(), byteCount);
+    return Service->TakeVolumeCopyRangeBudget(byteCount);
 }
 
 ui32 TDirectBlockGroup::GetNodeId(THostIndex host) const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -17,7 +17,6 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ddisk_helpers.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/error_utils.h>
 #include <ydb/core/nbs/cloud/storage/core/libs/common/scheduler.h>
@@ -288,7 +287,6 @@ private:
     TVector<TVChunkWeakPtr> VChunks;
     TOracle Oracle;
     TDirectBlockGroupCounters Counters;
-    std::optional<TSimpleLeakyBucket> CopyRangeBucket;
 
     bool BlockedGenerationDetected = false;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -17,6 +17,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ddisk_helpers.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/error_utils.h>
 #include <ydb/core/nbs/cloud/storage/core/libs/common/scheduler.h>
@@ -146,6 +147,8 @@ public:
         THostIndex newHostIndex,
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) override;
+
+    TDuration TakeCopyRangeBudget(ui64 byteCount) override;
 
     ui32 GetNodeId(THostIndex host) const override;
 
@@ -285,6 +288,7 @@ private:
     TVector<TVChunkWeakPtr> VChunks;
     TOracle Oracle;
     TDirectBlockGroupCounters Counters;
+    std::optional<TSimpleLeakyBucket> CopyRangeBucket;
 
     bool BlockedGenerationDetected = false;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -76,69 +76,31 @@ NWilson::TTraceId CreateTraceId()
         NWilson::TTraceId::MAX_TIME_TO_LIVE);
 }
 
-TStorageConfigPtr MakeStorageConfig(ui64 copyRangeBandwidthMbs)
-{
-    NProto::TStorageServiceConfig config;
-    config.SetCopyRangeBandwidthMbs(copyRangeBandwidthMbs);
-    return std::make_shared<TStorageConfig>(std::move(config));
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
 {
-    Y_UNIT_TEST_F(ShouldNotThrottleCopyRangeWhenDisabled, TDBGFixture)
+    Y_UNIT_TEST_F(ShouldDelegateCopyRangeBudgetToService, TDBGFixture)
     {
         auto executor = MakeExecutor();
         auto dbg = MakeDirectBlockGroup(
             executor,
             std::make_unique<TStorageTransportMock>());
 
-        const auto delay =
-            RunOnExecutor(
-                executor,
-                [dbg] { return dbg->TakeCopyRangeBudget(CopyRangeSize); })
-                .GetValue(WaitTimeout);
+        auto initialReady = RunAndGetInitialReady(dbg);
+        WaitReady(executor, initialReady);
 
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), delay);
-    }
+        Service->CopyRangeBudgetDelay = TDuration::MilliSeconds(250);
+        const auto delay = RunOnExecutor(
+                               executor,
+                               [dbg] { return dbg->TakeCopyRangeBudget(2_MB); })
+                               .GetValue(WaitTimeout);
 
-    Y_UNIT_TEST_F(ShouldThrottleCopyRangeAndRefillBudget, TDBGFixture)
-    {
-        constexpr ui64 copyRangeBandwidthMbs = 2;
-
-        auto executor = MakeExecutor();
-        auto dbg = MakeDirectBlockGroup(
-            executor,
-            std::make_unique<TStorageTransportMock>(),
-            0,
-            MakeStorageConfig(copyRangeBandwidthMbs));
-
-        auto takeBudget = [&]
-        {
-            return RunOnExecutor(
-                       executor,
-                       [dbg]
-                       { return dbg->TakeCopyRangeBudget(CopyRangeSize); })
-                .GetValue(WaitTimeout);
-        };
-
-        // The initial budget allows one second of bandwidth to start
-        // immediately: two 1 MB ranges at 2 MB/s.
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
-
-        // The third range creates a 1 MB debt at 2 MB/s.
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(500), takeBudget());
-
-        // Refill is capped at one second of bandwidth, so idle time does not
-        // accumulate a larger burst.
-        Runtime->AdvanceCurrentTime(TDuration::Seconds(10));
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(500), takeBudget());
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(250), delay);
+        UNIT_ASSERT_VALUES_EQUAL(1u, Service->CopyRangeBudgetRequestCount);
+        UNIT_ASSERT_VALUES_EQUAL(2_MB, Service->LastCopyRangeBudgetByteCount);
     }
 
     // The initial-ready signal fires exactly once, only after the locked

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -76,12 +76,71 @@ NWilson::TTraceId CreateTraceId()
         NWilson::TTraceId::MAX_TIME_TO_LIVE);
 }
 
+TStorageConfigPtr MakeStorageConfig(ui64 copyRangeBandwidthMbs)
+{
+    NProto::TStorageServiceConfig config;
+    config.SetCopyRangeBandwidthMbs(copyRangeBandwidthMbs);
+    return std::make_shared<TStorageConfig>(std::move(config));
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
 {
+    Y_UNIT_TEST_F(ShouldNotThrottleCopyRangeWhenDisabled, TDBGFixture)
+    {
+        auto executor = MakeExecutor();
+        auto dbg = MakeDirectBlockGroup(
+            executor,
+            std::make_unique<TStorageTransportMock>());
+
+        const auto delay =
+            RunOnExecutor(
+                executor,
+                [dbg] { return dbg->TakeCopyRangeBudget(CopyRangeSize); })
+                .GetValue(WaitTimeout);
+
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), delay);
+    }
+
+    Y_UNIT_TEST_F(ShouldThrottleCopyRangeAndRefillBudget, TDBGFixture)
+    {
+        constexpr ui64 copyRangeBandwidthMbs = 2;
+
+        auto executor = MakeExecutor();
+        auto dbg = MakeDirectBlockGroup(
+            executor,
+            std::make_unique<TStorageTransportMock>(),
+            0,
+            MakeStorageConfig(copyRangeBandwidthMbs));
+
+        auto takeBudget = [&]
+        {
+            return RunOnExecutor(
+                       executor,
+                       [dbg]
+                       { return dbg->TakeCopyRangeBudget(CopyRangeSize); })
+                .GetValue(WaitTimeout);
+        };
+
+        // The initial budget allows one second of bandwidth to start
+        // immediately: two 1 MB ranges at 2 MB/s.
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
+
+        // The third range creates a 1 MB debt at 2 MB/s.
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(500), takeBudget());
+
+        // Refill is capped at one second of bandwidth, so idle time does not
+        // accumulate a larger burst.
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), takeBudget());
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(500), takeBudget());
+    }
+
     // The initial-ready signal fires exactly once, only after the locked
     // quorum (3 of 5 DDisk sessions and PBuffers) is reached.
     Y_UNIT_TEST_F(ShouldSignalInitialReadyOnceLockedQuorumReached, TDBGFixture)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -199,6 +199,10 @@ TDirectBlockGroupMock::TDirectBlockGroupMock()
     {
         Y_ABORT_UNLESS(false, "Should set OnAddHostResultHandler");
     };
+    TakeCopyRangeBudgetHandler = [](ui64)
+    {
+        return TDuration::Zero();
+    };
 }
 
 void TDirectBlockGroupMock::Register(TVChunkWeakPtr vChunk)
@@ -390,6 +394,11 @@ void TDirectBlockGroupMock::OnAddHostResult(
         newHostIndex,
         std::move(ddiskId),
         std::move(pbufferId));
+}
+
+TDuration TDirectBlockGroupMock::TakeCopyRangeBudget(ui64 byteCount)
+{
+    return TakeCopyRangeBudgetHandler(byteCount);
 }
 
 ui32 TDirectBlockGroupMock::GetNodeId(THostIndex host) const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -145,6 +145,8 @@ public:
         THostIndex newHostIndex,
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId)>;
+    using TTakeCopyRangeBudgetHandler =
+        std::function<TDuration(ui64 byteCount)>;
 
     TExecutorPtr Executor;
     TOracleMock Oracle;
@@ -160,6 +162,7 @@ public:
     TListPBuffersHandler ListPBuffersHandler;
     TDBGDumpHandler DumpHandler;
     TOnAddHostResultHandler OnAddHostResultHandler;
+    TTakeCopyRangeBudgetHandler TakeCopyRangeBudgetHandler;
 
     TVector<TVChunkWeakPtr> VChunks;
 
@@ -249,6 +252,8 @@ public:
         THostIndex newHostIndex,
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) override;
+
+    TDuration TakeCopyRangeBudget(ui64 byteCount) override;
 
     ui32 GetNodeId(THostIndex host) const override;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -155,11 +155,17 @@ TDBGFixture::MakeDirectBlockGroup(
     std::unique_ptr<NStorage::NTransport::IStorageTransport> transport,
     const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
     const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
-    size_t directBlockGroupIndex) const
+    size_t directBlockGroupIndex,
+    TStorageConfigPtr storageConfig) const
 {
+    if (!storageConfig) {
+        storageConfig =
+            std::make_shared<TStorageConfig>(NProto::TStorageServiceConfig());
+    }
+
     return std::make_shared<TDirectBlockGroup>(
         Runtime->GetActorSystem(0),
-        std::make_shared<TStorageConfig>(NProto::TStorageServiceConfig()),
+        std::move(storageConfig),
         executor,
         DiskDescription,
         directBlockGroupIndex,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -155,17 +155,11 @@ TDBGFixture::MakeDirectBlockGroup(
     std::unique_ptr<NStorage::NTransport::IStorageTransport> transport,
     const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
     const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
-    size_t directBlockGroupIndex,
-    TStorageConfigPtr storageConfig) const
+    size_t directBlockGroupIndex) const
 {
-    if (!storageConfig) {
-        storageConfig =
-            std::make_shared<TStorageConfig>(NProto::TStorageServiceConfig());
-    }
-
     return std::make_shared<TDirectBlockGroup>(
         Runtime->GetActorSystem(0),
-        std::move(storageConfig),
+        std::make_shared<TStorageConfig>(NProto::TStorageServiceConfig()),
         executor,
         DiskDescription,
         directBlockGroupIndex,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
@@ -85,16 +85,14 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
         std::unique_ptr<NTransport::IStorageTransport> transport,
         const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
         const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
-        size_t directBlockGroupIndex = 0,
-        TStorageConfigPtr storageConfig = nullptr) const;
+        size_t directBlockGroupIndex = 0) const;
 
     template <typename TTransport>
         requires std::derived_from<TTransport, NTransport::IStorageTransport>
     [[nodiscard]] std::shared_ptr<TDirectBlockGroup> MakeDirectBlockGroup(
         const TExecutorPtr& executor,
         std::unique_ptr<TTransport> transport,
-        size_t directBlockGroupIndex = 0,
-        TStorageConfigPtr storageConfig = nullptr) const
+        size_t directBlockGroupIndex = 0) const
     {
         auto ddisks = transport->GetDDiskIds();
         auto pbuffers = transport->GetPBufferIds();
@@ -104,8 +102,7 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
             std::move(transport),
             ddisks,
             pbuffers,
-            directBlockGroupIndex,
-            std::move(storageConfig));
+            directBlockGroupIndex);
     }
 
     // Interleaves the simulated runtime and the coroutine executor: dispatches

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
@@ -85,14 +85,16 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
         std::unique_ptr<NTransport::IStorageTransport> transport,
         const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
         const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
-        size_t directBlockGroupIndex = 0) const;
+        size_t directBlockGroupIndex = 0,
+        TStorageConfigPtr storageConfig = nullptr) const;
 
     template <typename TTransport>
         requires std::derived_from<TTransport, NTransport::IStorageTransport>
     [[nodiscard]] std::shared_ptr<TDirectBlockGroup> MakeDirectBlockGroup(
         const TExecutorPtr& executor,
         std::unique_ptr<TTransport> transport,
-        size_t directBlockGroupIndex = 0) const
+        size_t directBlockGroupIndex = 0,
+        TStorageConfigPtr storageConfig = nullptr) const
     {
         auto ddisks = transport->GetDDiskIds();
         auto pbuffers = transport->GetPBufferIds();
@@ -102,7 +104,8 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
             std::move(transport),
             ddisks,
             pbuffers,
-            directBlockGroupIndex);
+            directBlockGroupIndex,
+            std::move(storageConfig));
     }
 
     // Interleaves the simulated runtime and the coroutine executor: dispatches

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -174,6 +174,15 @@ TFastPathService::TFastPathService(
           .BlocksPerStripe = StorageConfig->GetStripeSize() / blockSize,
           .VChunkSize = StorageConfig->GetVChunkSize()}))
 {
+    const ui64 copyRangeBandwidth =
+        StorageConfig->GetCopyRangeBandwidthMbs() * 1_MB;
+    if (copyRangeBandwidth) {
+        CopyRangeBucket.emplace(
+            ActorSystem->Timestamp(),
+            copyRangeBandwidth,
+            copyRangeBandwidth);
+    }
+
     LOG_INFO(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,
@@ -461,6 +470,16 @@ bool TFastPathService::TryAdvancePBufferBarrier(
         return true;
     }
     return false;
+}
+
+TDuration TFastPathService::TakeVolumeCopyRangeBudget(ui64 byteCount)
+{
+    if (!CopyRangeBucket) {
+        return {};
+    }
+
+    auto guard = Guard(CopyRangeBucketLock);
+    return CopyRangeBucket->Register(ActorSystem->Timestamp(), byteCount);
 }
 
 TFastPathServiceInfo TFastPathService::GetMonInfo() const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -15,6 +15,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/public.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/public.h>
 
@@ -66,6 +67,9 @@ private:
 
     TAdaptiveLock PBufferBarrierLock;
     TMap<NKikimr::NBsController::TDDiskId, ui64> LastSentBarrierByPBuffer;
+
+    TAdaptiveLock CopyRangeBucketLock;
+    std::optional<TSimpleLeakyBucket> CopyRangeBucket;
 
 public:
     TFastPathService(
@@ -136,6 +140,8 @@ public:
     bool TryAdvancePBufferBarrier(
         const NKikimr::NBsController::TDDiskId& pbufferDDiskId,
         ui64 lsn) override;
+
+    TDuration TakeVolumeCopyRangeBudget(ui64 byteCount) override;
 
     // Read-only info for the monitoring UI.
     [[nodiscard]] TFastPathServiceInfo GetMonInfo() const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service_ut.cpp
@@ -1,0 +1,130 @@
+#include "fast_path_service.h"
+
+#include <ydb/core/nbs/cloud/blockstore/config/config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
+
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/base/counters.h>
+#include <ydb/core/testlib/actors/test_runtime.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <algorithm>
+#include <thread>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    std::unique_ptr<NActors::TTestActorRuntime> Runtime;
+    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters{
+        new NMonitoring::TDynamicCounters()};
+
+    void SetUp(NUnitTest::TTestContext& context) override
+    {
+        Y_UNUSED(context);
+
+        Runtime = std::make_unique<NActors::TTestActorRuntime>();
+        Runtime->Initialize(NActors::TTestActorRuntime::TEgg{
+            .App0 = new NKikimr::
+                TAppData(0, 0, 0, 0, {}, nullptr, nullptr, nullptr, nullptr),
+            .Opaque = nullptr,
+            .KeyConfigGenerator = nullptr,
+            .Icb = {},
+            .Dcb = {}});
+    }
+
+    std::shared_ptr<TFastPathService> MakeService(
+        ui64 copyRangeBandwidthMbs) const
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetCopyRangeBandwidthMbs(copyRangeBandwidthMbs);
+
+        return std::make_shared<TFastPathService>(
+            Runtime->GetActorSystem(0),
+            NActors::TActorId(),
+            TDiskDescription{
+                .DiskId = "disk-id",
+                .TabletId = 100,
+                .Generation = 1},
+            0,
+            DefaultBlockSize,
+            TVector<IDirectBlockGroupPtr>{},
+            TVChunkConfigs{},
+            TDirtyMapStateProtos{},
+            std::make_shared<TStorageConfig>(std::move(storageServiceConfig)),
+            nullptr,
+            nullptr,
+            Counters);
+    }
+
+    static TVector<TDuration> TakeBudgetConcurrently(
+        const std::shared_ptr<TFastPathService>& service,
+        size_t requestCount)
+    {
+        TVector<TDuration> delays(requestCount);
+        TVector<std::thread> threads;
+        threads.reserve(requestCount);
+
+        for (size_t i = 0; i < requestCount; ++i) {
+            threads.emplace_back(
+                [&, i] {
+                    delays[i] =
+                        service->TakeVolumeCopyRangeBudget(CopyRangeSize);
+                });
+        }
+        for (auto& thread: threads) {
+            thread.join();
+        }
+
+        std::sort(delays.begin(), delays.end());
+        return delays;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TFastPathServiceTest)
+{
+    Y_UNIT_TEST_F(ShouldNotThrottleCopyRangeWhenDisabled, TFixture)
+    {
+        auto service = MakeService(0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            service->TakeVolumeCopyRangeBudget(CopyRangeSize));
+    }
+
+    Y_UNIT_TEST_F(ShouldShareCopyRangeBudgetAcrossThreads, TFixture)
+    {
+        auto service = MakeService(2);
+
+        const auto checkBudget = [&]
+        {
+            const auto delays = TakeBudgetConcurrently(service, 4);
+            UNIT_ASSERT_VALUES_EQUAL(4u, delays.size());
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), delays[0]);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), delays[1]);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(500), delays[2]);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(1), delays[3]);
+        };
+
+        // A 2 MB/s bucket allows a 2 MB initial burst shared by all callers.
+        checkBudget();
+
+        // The maximum accumulated budget remains one second of bandwidth.
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+        checkBudget();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
@@ -78,6 +78,11 @@ struct IPartitionDirectService
     virtual bool TryAdvancePBufferBarrier(
         const NKikimr::NBsController::TDDiskId& pbufferDDiskId,
         ui64 lsn) = 0;
+
+    // Reserves byteCount from the disk-wide range-copy bandwidth budget.
+    // Returns the delay before the operation may start. Zero means it may start
+    // immediately or throttling is disabled. Called from DBG executor threads.
+    virtual TDuration TakeVolumeCopyRangeBudget(ui64 byteCount) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
@@ -44,6 +44,9 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
     ui64 LsnGenerator = 0;
     size_t BlockedGenerationCount = 0;
     TString LastBlockedReason;
+    size_t CopyRangeBudgetRequestCount = 0;
+    ui64 LastCopyRangeBudgetByteCount = 0;
+    TDuration CopyRangeBudgetDelay;
     TVector<TUpdateConfigRequest> UpdateConfigRequests;
     TVector<TUpdateDirtyMapStateRequest> UpdateDirtyMapStateRequests;
 
@@ -109,6 +112,13 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
         Y_UNUSED(pbufferDDiskId);
         Y_UNUSED(lsn);
         return true;
+    }
+
+    TDuration TakeVolumeCopyRangeBudget(ui64 byteCount) override
+    {
+        ++CopyRangeBudgetRequestCount;
+        LastCopyRangeBudgetByteCount = byteCount;
+        return CopyRangeBudgetDelay;
     }
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ut/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     direct_block_group_test_fixture.cpp
     direct_session_registry_ut.cpp
     erase_request_ut.cpp
+    fast_path_service_ut.cpp
     flush_request_ut.cpp
     ic_direct_storage_transport_ut.cpp
     read_request_ut.cpp

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -46,6 +46,7 @@ PEERDIR(
     ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page
     ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos
     ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport
+    ydb/core/nbs/cloud/blockstore/libs/throttling
     ydb/core/nbs/cloud/storage/core/libs/coroutine
 
     ydb/core/protos

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.cpp
@@ -1,0 +1,54 @@
+#include "simple_leaky_bucket.h"
+
+#include <algorithm>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+constexpr TDuration MinWaitTime = TDuration::MicroSeconds(5);
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSimpleLeakyBucket::TSimpleLeakyBucket(
+    TInstant ts,
+    double rate,
+    double initialBudget)
+    : Rate(rate)
+    , MaxBudget(initialBudget)
+    , BonusBudget(Rate * MinWaitTime.SecondsFloat())
+    , Budget(initialBudget)
+    , LastUpdateTs(ts)
+{}
+
+TDuration TSimpleLeakyBucket::Register(TInstant ts, double valueToSpent)
+{
+    Y_DEBUG_ABORT_UNLESS(valueToSpent > 0);
+
+    const TDuration timePassed = ts - LastUpdateTs;
+    if (timePassed) {
+        Budget = std::min(Budget + Rate * timePassed.SecondsFloat(), MaxBudget);
+    }
+    LastUpdateTs = ts;
+
+    if (Budget + BonusBudget >= valueToSpent) {
+        Budget -= valueToSpent;
+        return {};
+    }
+
+    Budget -= valueToSpent;
+    return TDuration::Seconds(-Budget / Rate);
+}
+
+double TSimpleLeakyBucket::GetBudget() const
+{
+    return Budget;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.cpp
@@ -20,28 +20,28 @@ TSimpleLeakyBucket::TSimpleLeakyBucket(
     double initialBudget)
     : Rate(rate)
     , MaxBudget(initialBudget)
-    , BonusBudget(Rate * MinWaitTime.SecondsFloat())
+    , MinDelayedBudget(-Rate * MinWaitTime.SecondsFloat())
     , Budget(initialBudget)
     , LastUpdateTs(ts)
-{}
-
-TDuration TSimpleLeakyBucket::Register(TInstant ts, double valueToSpent)
 {
-    Y_DEBUG_ABORT_UNLESS(valueToSpent > 0);
+    Y_ABORT_UNLESS(Rate > 0);
+    Y_ABORT_UNLESS(MinDelayedBudget < 0);
+}
+
+TDuration TSimpleLeakyBucket::Register(TInstant ts, double valueToSpend)
+{
+    Y_DEBUG_ABORT_UNLESS(valueToSpend > 0);
 
     const TDuration timePassed = ts - LastUpdateTs;
     if (timePassed) {
-        Budget = std::min(Budget + Rate * timePassed.SecondsFloat(), MaxBudget);
+        Budget = Min(Budget + Rate * timePassed.SecondsFloat(), MaxBudget);
     }
+
     LastUpdateTs = ts;
+    Budget -= valueToSpend;
 
-    if (Budget + BonusBudget >= valueToSpent) {
-        Budget -= valueToSpent;
-        return {};
-    }
-
-    Budget -= valueToSpent;
-    return TDuration::Seconds(-Budget / Rate);
+    return Budget >= MinDelayedBudget ? TDuration()
+                                      : TDuration::Seconds(-Budget / Rate);
 }
 
 double TSimpleLeakyBucket::GetBudget() const

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h
@@ -19,7 +19,7 @@ public:
     TSimpleLeakyBucket(TInstant ts, double rate, double initialBudget);
 
     // Returns the time to wait before executing the registered operation.
-    [[nodiscard]] TDuration Register(TInstant ts, double valueToSpent);
+    [[nodiscard]] TDuration Register(TInstant ts, double valueToSpend);
 
     // Returns the budget at the last update. The value may be negative.
     [[nodiscard]] double GetBudget() const;
@@ -30,7 +30,7 @@ private:
 
     // Extra budget used to suppress very short waits. The operation may execute
     // immediately, but the corresponding debt is retained in the budget.
-    const double BonusBudget;
+    const double MinDelayedBudget;
 
     double Budget = 0;   // accumulated budget
     TInstant LastUpdateTs;

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <util/datetime/base.h>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A budget-based rate limiter with a bounded positive balance.
+//
+// The budget is replenished at a fixed rate and capped at initialBudget, which
+// is also the starting balance. Register immediately reserves the operation's
+// cost. If this creates a debt, it returns the time needed to repay that debt
+// before the operation can be executed. Timestamps passed to Register must be
+// nondecreasing and the refill rate must be positive.
+class TSimpleLeakyBucket
+{
+public:
+    TSimpleLeakyBucket(TInstant ts, double rate, double initialBudget);
+
+    // Returns the time to wait before executing the registered operation.
+    [[nodiscard]] TDuration Register(TInstant ts, double valueToSpent);
+
+    // Returns the budget at the last update. The value may be negative.
+    [[nodiscard]] double GetBudget() const;
+
+private:
+    const double Rate;        // budget refill rate per second
+    const double MaxBudget;   // maximum accumulated budget
+
+    // Extra budget used to suppress very short waits. The operation may execute
+    // immediately, but the corresponding debt is retained in the budget.
+    const double BonusBudget;
+
+    double Budget = 0;   // accumulated budget
+    TInstant LastUpdateTs;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket_ut.cpp
@@ -38,6 +38,32 @@ Y_UNIT_TEST_SUITE(TSimpleLeakyBucketTest)
             bucket.Register(start + TDuration::Seconds(3), 10));
         UNIT_ASSERT_DOUBLES_EQUAL(20, bucket.GetBudget(), 1e-10);
     }
+
+    Y_UNIT_TEST(ShouldReturnTimeRequiredToRepayDebt)
+    {
+        const TInstant start = TInstant::Seconds(1);
+        TSimpleLeakyBucket bucket(start, 10, 100);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Seconds(2),
+            bucket.Register(start, 120));
+        UNIT_ASSERT_DOUBLES_EQUAL(-20, bucket.GetBudget(), 1e-10);
+    }
+
+    Y_UNIT_TEST(ShouldSuppressShortWaitAndRetainDebt)
+    {
+        const TInstant start = TInstant::Seconds(1);
+        TSimpleLeakyBucket bucket(start, 1'000'000, 10);
+
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), bucket.Register(start, 10));
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), bucket.Register(start, 5));
+        UNIT_ASSERT_DOUBLES_EQUAL(-5, bucket.GetBudget(), 1e-10);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MicroSeconds(6),
+            bucket.Register(start, 1));
+        UNIT_ASSERT_DOUBLES_EQUAL(-6, bucket.GetBudget(), 1e-10);
+    }
 }
 
 }   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/simple_leaky_bucket_ut.cpp
@@ -1,0 +1,43 @@
+#include "simple_leaky_bucket.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TSimpleLeakyBucketTest)
+{
+    Y_UNIT_TEST(ShouldNotAccumulateBudgetAboveInitialBudget)
+    {
+        const TInstant start = TInstant::Seconds(1);
+        TSimpleLeakyBucket bucket(start, 10, 100);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            bucket.Register(start, 100));
+        UNIT_ASSERT_DOUBLES_EQUAL(0, bucket.GetBudget(), 1e-10);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            bucket.Register(start + TDuration::Seconds(100), 10));
+        UNIT_ASSERT_DOUBLES_EQUAL(90, bucket.GetBudget(), 1e-10);
+    }
+
+    Y_UNIT_TEST(ShouldAccumulateBudgetBelowLimit)
+    {
+        const TInstant start = TInstant::Seconds(1);
+        TSimpleLeakyBucket bucket(start, 10, 100);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            bucket.Register(start, 100));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            bucket.Register(start + TDuration::Seconds(3), 10));
+        UNIT_ASSERT_DOUBLES_EQUAL(20, bucket.GetBudget(), 1e-10);
+    }
+}
+
+}   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/ut/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/ut/ya.make
@@ -1,0 +1,12 @@
+UNITTEST_FOR(ydb/core/nbs/cloud/blockstore/libs/throttling)
+
+INCLUDE(${ARCADIA_ROOT}/ydb/core/nbs/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    simple_leaky_bucket_ut.cpp
+)
+
+PEERDIR(
+)
+
+END()

--- a/ydb/core/nbs/cloud/blockstore/libs/throttling/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/throttling/ya.make
@@ -1,0 +1,15 @@
+LIBRARY()
+
+SRCS(
+    simple_leaky_bucket.cpp
+    simple_leaky_bucket.h
+)
+
+PEERDIR(
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/nbs/cloud/blockstore/libs/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/ya.make
@@ -4,5 +4,6 @@ RECURSE(
     kikimr
     service
     storage
+    throttling
     vhost
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add disk-wide throttling for background DDisk range copying using a shared leaky-bucket budget.

### Description for reviewers <!-- (optional) description for those who read this PR -->

