### PR TITLE
docs: correct Resource Broker restore queue limit

### DIFF
--- a/ydb/docs/en/core/reference/configuration/resource_broker_config.md
+++ b/ydb/docs/en/core/reference/configuration/resource_broker_config.md
@@ -11,7 +11,7 @@ Different types of activities (background operations, [TTL](../../concepts/ttl.m
 |---------------------------| --- | --- |----------------------------------------------------|
 | `queue_ttl`               | 2 | — | [TTL](../../concepts/ttl.md) data deletion operations.                |
 | `queue_backup`            | 2 | — | [Backup](../../devops/backup-and-recovery.md#s3) operations.                |
-| `queue_restore`           | 2 | — | [Restore from backup](../../devops/backup-and-recovery.md#s3) operations.     |
+| `queue_restore`           | 10 | — | [Restore from backup](../../devops/backup-and-recovery.md#s3) operations.     |
 | `queue_build_index`       | 10 | — | [Online secondary index creation](../../concepts/query_execution/secondary_indexes.md#index-add) operations.   |
 | `queue_cdc_initial_scan` | 4 | — | [Initial table scan](../../concepts/cdc.md#initial-scan) operations.             |
 

--- a/ydb/docs/ru/core/reference/configuration/resource_broker_config.md
+++ b/ydb/docs/ru/core/reference/configuration/resource_broker_config.md
@@ -11,7 +11,7 @@
 |---------------------------| --- | --- |----------------------------------------------------|
 | `queue_ttl`               | 2 | — | Операции удаления данных по [TTL](../../concepts/ttl.md).                |
 | `queue_backup`            | 2 | — | Операции [резервного копирования](../../devops/backup-and-recovery/index.md#s3).                |
-| `queue_restore`           | 2 | — | Операции [восстановления из резервной копии](../../devops/backup-and-recovery/index.md#s3).     |
+| `queue_restore`           | 10 | — | Операции [восстановления из резервной копии](../../devops/backup-and-recovery/index.md#s3).     |
 | `queue_build_index`       | 10 | — | Операции [онлайн-создания вторичного индекса](../../concepts/query_execution/secondary_indexes.md#index-add).   |
 | `queue_cdc_initial_scan` | 4 | — | [Первоначальное сканирование таблицы](../../concepts/cdc.md#initial-scan).             |
 


### PR DESCRIPTION
### Motivation

The documented concurrency limit for the Resource Broker `queue_restore` queue is outdated. The correct value is 10, while both RU and EN reference pages currently state 2.

The limit was changed by implementation commit `3e997dd6fcd430043c7f7dc8c23b336b13d26d75`, which is present starting from the 25.3 release line.

### Changes

- Change `queue_restore` from 2 to 10 in the RU configuration reference.
- Apply the same correction to the EN configuration reference.

### Verification

- RU and EN values remain synchronized.
- No paths, TOC entries, or public URLs are changed.
- `git diff --check` passes.

### Backport scope

Backport to `stable-25-3`, `stable-25-4`, `stable-26-1`, `stable-26-2`, and `stable-26-3`. Do not backport to `stable-25-1` or `stable-25-2`, because they do not contain the implementation change. Minor `stable-X-Y-Z` branches are outside the documentation backport scope.
