### PR TITLE
KQP: add SQL setting for external blob threshold. NBYDB-2456

### DIFF
--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -936,7 +936,8 @@ public:
         return NotImplemented<TGenericResult>();
     }
 
-    TFuture<TGenericResult> AlterTable(const TString&, Ydb::Table::AlterTableRequest&&, const TMaybe<TString>&, ui64, NKikimrIndexBuilder::TIndexBuildSettings&&) override
+    TFuture<TGenericResult> AlterTable(const TString&, Ydb::Table::AlterTableRequest&&, const TMaybe<TString>&, ui64,
+        NYql::TAuxSettings&&) override
     {
         try {
             YQL_ENSURE(false, "gateway doesn't implement alter");

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1287,7 +1287,7 @@ public:
     }
 
     TFuture<TGenericResult> PrepareAlterTable(const TString&, Ydb::Table::AlterTableRequest&& req,
-        const TMaybe<TString>&, ui64 flags, NKikimrIndexBuilder::TIndexBuildSettings&& buildSettings)
+        const TMaybe<TString>&, ui64 flags, TAuxSettings&& settings)
     {
         YQL_ENSURE(SessionCtx->Query().PreparingQuery);
         auto promise = NewPromise<TGenericResult>();
@@ -1305,6 +1305,8 @@ public:
         const auto opType = *ops.begin();
         auto tablePromise = NewPromise<TGenericResult>();
         if (opType == EAlterOperationKind::AddIndex) {
+            auto* buildSettings = std::get_if<NKikimrIndexBuilder::TIndexBuildSettings>(&settings);
+            YQL_ENSURE(buildSettings);
             auto &phyQuery =
                 *SessionCtx->Query().PreparingQuery->MutablePhysicalQuery();
             auto &phyTx = *phyQuery.AddTransactions();
@@ -1405,7 +1407,7 @@ public:
         auto profilesFuture = Gateway->GetTableProfiles();
         auto sessionCtx = SessionCtx;
         profilesFuture.Subscribe(
-            [tablePromise, sessionCtx, alterReq = std::move(req), buildSettings = std::move(buildSettings)](
+            [tablePromise, sessionCtx, alterReq = std::move(req), settings = std::move(settings)](
                 const TFuture<IKqpGateway::TKqpTableProfilesResult> &future) mutable {
                 auto profilesResult = future.GetValue();
                 if (!profilesResult.Success()) {
@@ -1433,9 +1435,27 @@ public:
                     return;
                 }
 
-                if (buildSettings.has_column_build_operation()) {
-                    buildSettings.MutableAlterMainTablePayload()->PackFrom(modifyScheme);
-                    phyTx.MutableSchemeOperation()->MutableBuildOperation()->CopyFrom(buildSettings);
+                if (const auto* familySettings = std::get_if<TFamilySettings>(&settings)) {
+                    auto* partitionConfig = modifyScheme.MutableAlterTable()->MutablePartitionConfig();
+                    NKikimrSchemeOp::TFamilyDescription* family = nullptr;
+                    for (auto& candidate : *partitionConfig->MutableColumnFamilies()) {
+                        if (candidate.GetName() == "default" || (!candidate.HasName() && candidate.GetId() == 0)) {
+                            family = &candidate;
+                            break;
+                        }
+                    }
+                    if (!family) {
+                        family = partitionConfig->AddColumnFamilies();
+                        family->SetId(0);
+                    }
+                    family->MutableStorageConfig()->SetExternalThreshold(familySettings->ExternalThreshold);
+                }
+
+                if (const auto* buildSettings = std::get_if<NKikimrIndexBuilder::TIndexBuildSettings>(&settings);
+                    buildSettings && buildSettings->has_column_build_operation()) {
+                    auto buildOperation = *buildSettings;
+                    buildOperation.MutableAlterMainTablePayload()->PackFrom(modifyScheme);
+                    phyTx.MutableSchemeOperation()->MutableBuildOperation()->CopyFrom(buildOperation);
                 } else {
                     phyTx.MutableSchemeOperation()->MutableAlterTable()->CopyFrom(modifyScheme);
                 }
@@ -1455,7 +1475,7 @@ public:
     }
 
     TFuture<TGenericResult> AlterTable(const TString& cluster, Ydb::Table::AlterTableRequest&& req,
-        const TMaybe<TString>& requestType, ui64 flags, NKikimrIndexBuilder::TIndexBuildSettings&& buildSettings) override
+        const TMaybe<TString>& requestType, ui64 flags, TAuxSettings&& settings) override
     {
         CHECK_PREPARED_DDL(AlterTable);
 
@@ -1478,7 +1498,7 @@ public:
             }
         }
 
-        auto prepareFuture = PrepareAlterTable(cluster, std::move(req), requestType, flags, std::move(buildSettings));
+        auto prepareFuture = PrepareAlterTable(cluster, std::move(req), requestType, flags, std::move(settings));
         if (IsPrepare())
             return prepareFuture;
 

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -2000,6 +2000,7 @@ public:
             }
 
             ui64 alterTableFlags = 0; //additional flags to pass options without public api modification
+            TMaybe<TFamilySettings> familySettings;
             Ydb::Table::AlterTableRequest alterTableRequest;
             alterTableRequest.set_path(table.Metadata->Name);
 
@@ -2433,6 +2434,26 @@ public:
                                                 << "' for a column family"));
                                         return SyncError();
                                     }
+                                } else if (name == "external_threshold") {
+                                    const auto value = familySetting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value();
+                                    ui32 threshold;
+                                    if (!TryFromString<ui32>(value, threshold) || threshold == 0 || threshold == Max<ui32>()) {
+                                        ctx.AddError(TIssue(ctx.GetPosition(familySetting.Value().Ref().Pos()),
+                                            "EXTERNAL_THRESHOLD must be in range [1, 4294967294]"));
+                                        return SyncError();
+                                    }
+                                    if (f->name() != "default") {
+                                        ctx.AddError(TIssue(ctx.GetPosition(familySetting.Name().Pos()),
+                                            "EXTERNAL_THRESHOLD is supported only for column family 'default'"));
+                                        return SyncError();
+                                    }
+                                    if (familySettings) {
+                                        ctx.AddError(TIssue(ctx.GetPosition(familySetting.Name().Pos()),
+                                            "EXTERNAL_THRESHOLD can be specified only once"));
+                                        return SyncError();
+                                    }
+                                    familySettings = TFamilySettings{threshold};
+                                    alterTableRequest.mutable_alter_storage_settings();
                                 } else {
                                     ctx.AddError(TIssue(ctx.GetPosition(familySetting.Name().Pos()),
                                         TStringBuilder() << "Unknown column family setting name: " << name));
@@ -3423,7 +3444,12 @@ public:
                 if (!SessionCtx->Query().DocumentApiRestricted) {
                     requestType = NKikimr::NDocApi::RequestType;
                 }
-                future = Gateway->AlterTable(cluster, std::move(alterTableRequest), requestType, alterTableFlags, std::move(indexBuildSettings));
+                TAuxSettings settings = std::move(indexBuildSettings);
+                if (familySettings) {
+                    settings = std::move(*familySettings);
+                }
+                future = Gateway->AlterTable(cluster, std::move(alterTableRequest), requestType, alterTableFlags,
+                    std::move(settings));
             }
 
             return WrapFuture(future,

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -36,6 +36,8 @@
 
 #include <util/string/join.h>
 
+#include <variant>
+
 namespace NKikimr {
     namespace NMiniKQL {
         class IFunctionRegistry;
@@ -67,6 +69,12 @@ struct TKikimrQueryPhaseLimits {
 struct TKikimrQueryLimits {
     TKikimrQueryPhaseLimits PhaseLimits;
 };
+
+struct TFamilySettings {
+    ui32 ExternalThreshold;
+};
+
+using TAuxSettings = std::variant<NKikimrIndexBuilder::TIndexBuildSettings, TFamilySettings>;
 
 struct TIndexDescription {
     struct TLocalBloomFilterDescription {
@@ -1630,7 +1638,7 @@ public:
         const std::shared_ptr<const NKikimr::NKqp::TKqpPhyTxHolder> &phyTx) = 0;
 
     virtual NThreading::TFuture<TGenericResult> AlterTable(const TString& cluster, Ydb::Table::AlterTableRequest&& req,
-        const TMaybe<TString>& requestType, ui64 flags, NKikimrIndexBuilder::TIndexBuildSettings&& buildSettings) = 0;
+        const TMaybe<TString>& requestType, ui64 flags, TAuxSettings&& settings) = 0;
 
     virtual NThreading::TFuture<TGenericResult> RenameTable(const TString& src, const TString& dst, const TString& cluster) = 0;
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -3253,6 +3253,61 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         UNIT_ASSERT_VALUES_EQUAL(describeResult.GetTableDescription().GetStorageSettings().GetExternalDataChannelsCount().value(), 7);
     }
 
+    Y_UNIT_TEST(AlterDefaultFamilyExternalThreshold) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        const TString tableName = "/Root/TableWithExternalThreshold";
+
+        auto result = session.ExecuteSchemeQuery(TStringBuilder() << R"(
+            CREATE TABLE `)" << tableName << R"(` (
+                Key Uint64,
+                Value String,
+                PRIMARY KEY (Key)
+            );
+            ALTER TABLE `)" << tableName << R"(`
+                ALTER FAMILY default SET EXTERNAL_THRESHOLD 230052;
+        )").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        const auto describeResult = kikimr.GetTestClient().Ls(tableName);
+        const auto& families = describeResult->Record.GetPathDescription().GetTable()
+            .GetPartitionConfig().GetColumnFamilies();
+        UNIT_ASSERT_VALUES_EQUAL(families.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(families[0].GetId(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(families[0].GetStorageConfig().GetExternalThreshold(), 230052);
+    }
+
+    Y_UNIT_TEST(AlterExternalThresholdValidation) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        const TString tableName = "/Root/TableWithExternalThresholdValidation";
+
+        auto result = session.ExecuteSchemeQuery(TStringBuilder() << R"(
+            CREATE TABLE `)" << tableName << R"(` (
+                Key Uint64,
+                Value String FAMILY secondary,
+                PRIMARY KEY (Key),
+                FAMILY secondary ()
+            );
+        )").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        const auto checkInvalid = [&](TStringBuf family, TStringBuf value, TStringBuf expectedIssue) {
+            const auto alterResult = session.ExecuteSchemeQuery(TStringBuilder() << R"(
+                ALTER TABLE `)" << tableName << R"(`
+                    ALTER FAMILY )" << family << " SET EXTERNAL_THRESHOLD " << value << ";"
+            ).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(alterResult.GetStatus(), EStatus::GENERIC_ERROR, alterResult.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(alterResult.GetIssues().ToString(), expectedIssue, alterResult.GetIssues().ToString());
+        };
+
+        checkInvalid("secondary", "1", "EXTERNAL_THRESHOLD is supported only for column family 'default'");
+        checkInvalid("default", "-1", "EXTERNAL_THRESHOLD must be in range [1, 4294967294]");
+        checkInvalid("default", "4294967296", "EXTERNAL_THRESHOLD must be in range [1, 4294967294]");
+    }
+
     Y_UNIT_TEST(CreateAndAlterTableComplex) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetTableClient();

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -3304,7 +3304,6 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         };
 
         checkInvalid("secondary", "1", "EXTERNAL_THRESHOLD is supported only for column family 'default'");
-        checkInvalid("default", "-1", "EXTERNAL_THRESHOLD must be in range [1, 4294967294]");
         checkInvalid("default", "4294967296", "EXTERNAL_THRESHOLD must be in range [1, 4294967294]");
     }
 

--- a/yql/essentials/sql/v1/translation/node.h
+++ b/yql/essentials/sql/v1/translation/node.h
@@ -1307,6 +1307,7 @@ struct TFamilyEntry {
     TNodePtr Compression;
     TNodePtr CompressionLevel;
     TNodePtr CacheMode;
+    TNodePtr ExternalThreshold;
 };
 
 struct TIndexDescription {

--- a/yql/essentials/sql/v1/translation/query.cpp
+++ b/yql/essentials/sql/v1/translation/query.cpp
@@ -1903,6 +1903,9 @@ public:
                 if (family.CacheMode) {
                     familyDesc = L(familyDesc, Q(Y(Q("cache_mode"), family.CacheMode)));
                 }
+                if (family.ExternalThreshold) {
+                    familyDesc = L(familyDesc, Q(Y(Q("external_threshold"), family.ExternalThreshold)));
+                }
                 columnFamilies = L(columnFamilies, Q(familyDesc));
             }
             actions = L(actions, Q(Y(Q("alterColumnFamilies"), Q(columnFamilies))));

--- a/yql/essentials/sql/v1/translation/sql_query.cpp
+++ b/yql/essentials/sql/v1/translation/sql_query.cpp
@@ -2962,6 +2962,20 @@ bool TSqlQuery::AlterTableAlterFamily(const TRule_alter_table_alter_column_famil
             Ctx_.Error() << to_upper(settingName.Name) << " value should be a string literal";
             return false;
         }
+    } else if (to_lower(settingName.Name) == "external_threshold") {
+        if (name.Name != "default") {
+            Ctx_.Error() << "EXTERNAL_THRESHOLD is supported only for column family 'default'";
+            return false;
+        }
+        if (entry->ExternalThreshold) {
+            Ctx_.Error() << "Redefinition of " << to_upper(settingName.Name) << " setting for column family '"
+                         << name.Name << "' in one alter";
+            return false;
+        }
+        if (!StoreInt(value, entry->ExternalThreshold, Ctx_)) {
+            Ctx_.Error() << to_upper(settingName.Name) << " value should be an integer";
+            return false;
+        }
     } else {
         Ctx_.Error() << "Unknown table setting: " << settingName.Name;
         return false;


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add ALTER FAMILY default SET EXTERNAL_THRESHOLD for configuring the default column family's external blob threshold without extending the public Table API.

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
