### PR TITLE
Implement prefixed fulltext index with relevance support (compact only)

### DIFF
--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -2160,6 +2160,7 @@ private:
     // sub-tables for the relevance variant).
     void FillFulltextIndexSettings(size_t index, const TIndexDescription& indexDescription, const TKikimrTableMetadataPtr& implTable, NKikimrKqp::TKqpTableSinkIndexSettings* indexSettings, THashMap<TString, THashSet<TString>>& tablesMap,
             const TKikimrTableMetadataPtr& tableMeta, const TVector<TStringBuf>& columns, const TVector<TStringBuf>& lookupColumns) {
+        YQL_ENSURE(indexDescription.KeyColumns.size() > 0);
         if (indexDescription.Type == TIndexDescription::EType::GlobalFulltextCompact) {
             indexSettings->SetIndexType(NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompact);
             *indexSettings->MutableFulltextSettings() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexDescription.SpecializedIndexDescription).GetSettings();
@@ -2189,8 +2190,14 @@ private:
             }
             FillTableId(*statsTable, *indexSettings->MutableStatsTable());
             FillTablesMap(statsTable->Name, tablesMap);
-            for (const auto& columnName: {NTableIndex::NFulltext::IdColumn,
-                NTableIndex::NFulltext::DocCountColumn, NTableIndex::NFulltext::SumDocLengthColumn}) {
+            TVector<TString> statsCols = {indexDescription.KeyColumns.begin(),
+                indexDescription.KeyColumns.end()-1};
+            if (!statsCols.size()) {
+                statsCols.push_back(NTableIndex::NFulltext::IdColumn);
+            }
+            statsCols.push_back(NTableIndex::NFulltext::DocCountColumn);
+            statsCols.push_back(NTableIndex::NFulltext::SumDocLengthColumn);
+            for (const auto& columnName: statsCols) {
                 const auto& columnMeta = statsTable->Columns.at(columnName);
                 FillColumnProto(columnName, &columnMeta, indexSettings->AddStatsColumns());
                 tablesMap[statsTable->Name].emplace(columnName);
@@ -2214,7 +2221,7 @@ private:
         }
 
         FillTablesMap(implTable->Name, tablesMap);
-        for (size_t i = 0; i+1 < indexDescription.KeyColumns.size(); i++) {
+        for (size_t i = 0; i < indexDescription.KeyColumns.size()-1; i++) {
             // Add prefix columns
             const auto& columnName = indexDescription.KeyColumns[i];
             const auto& columnMeta = implTable->Columns.at(columnName);

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -1651,6 +1651,7 @@ public:
  */
 class TStatsTableReader : public TTableReader<TStatsTableReader> {
     NKqpProto::EKqpFullTextIndexType IndexType;
+    TConstArrayRef<TCell> PrefixCells;
 public:
     TStatsTableReader(const NKqpProto::EKqpFullTextIndexType& indexType,
         const TIntrusivePtr<TKqpCounters>& counters,
@@ -1662,9 +1663,11 @@ public:
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
-        const TVector<i32>& resultColumnIds)
+        const TVector<i32>& resultColumnIds,
+        TConstArrayRef<TCell> prefixCells)
         : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , IndexType(indexType)
+        , PrefixCells(prefixCells)
     {}
 
     static TIntrusivePtr<TStatsTableReader> FromSettings(
@@ -1672,7 +1675,8 @@ public:
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
         const NKikimrKqp::TKqpFullTextSourceSettings* settings,
-        bool withRelevance)
+        bool withRelevance,
+        TConstArrayRef<TCell> prefixCells)
     {
         if (!withRelevance) {
             return nullptr;
@@ -1696,7 +1700,6 @@ public:
         NScheme::TTypeInfo sumDocLengthColumnType;
 
         for (const auto& column : columns) {
-
             if (column.GetName() == DocCountColumn) {
                 statsColumnIndex = column.GetId();
                 statsColumnType = NScheme::TypeInfoFromProto(
@@ -1728,7 +1731,7 @@ public:
             settings->GetIndexType(), counters,
             FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
                 settings->GetDatabase(), settings->GetPoolId(),
-                keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
+                keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds, prefixCells);
     }
 
     ui64 GetDocCount(const TConstArrayRef<TCell>& row) const {
@@ -1742,19 +1745,11 @@ public:
     }
 
     std::pair<ui64, std::unique_ptr<TEvDataShard::TEvRead>> GetTotalStatsRequest(ui64 readId) {
-        TCell tokenCell = TCell::Make<ui32>(0);
-        std::vector <TCell> fromCells;
-        fromCells.insert(fromCells.begin(), tokenCell);
-
-        TCell maxCell = TCell::Make<ui32>(std::numeric_limits<ui32>::max());
-        std::vector <TCell> toCells;
-        toCells.insert(toCells.begin(), maxCell);
-
-        bool fromInclusive = true;
-        bool toInclusive = false;
-        auto tcellVector = TTableRange(fromCells, fromInclusive, toCells, toInclusive);
-
-        auto partitioning = GetRangePartitioning(tcellVector);
+        TVector<TCell> zero = {TCell::Make<ui32>(0)};
+        TTableRange rng = PrefixCells.size()
+            ? TTableRange(PrefixCells, true, PrefixCells, true)
+            : TTableRange(zero, true, zero, true);
+        auto partitioning = GetRangePartitioning(rng);
         YQL_ENSURE(partitioning.size() == 1);
         auto [shardId, range] = partitioning[0];
         return std::make_pair(shardId, GetReadRequest(readId, range));
@@ -2476,6 +2471,10 @@ private:
     ui64 DocCount = 0;
     ui64 SumDocLength = 0;
 
+    // Leading prefix key values of the posting table (a per-query binding; empty for a non-prefixed
+    // index). Owned here for the source's lifetime and referenced by each per-token read.
+    TOwnedCellVec PrefixCells;
+
     // Table readers -- one per involved table.  Null readers indicate that the
     // table is not needed (e.g., docs/stats are null for plain indexes).
     TIntrusivePtr<TMainTableReader> MainTableReader;
@@ -2483,10 +2482,6 @@ private:
     TIntrusivePtr<TDocsTableReader> DocsTableReader;
     TIntrusivePtr<TStatsTableReader> StatsTableReader;
     TIntrusivePtr<TUniqueIndexReader> UniqueIndexReader;  // Resolves __ydb_row_id -> PK via unique secondary index
-
-    // Leading prefix key values of the posting table (a per-query binding; empty for a non-prefixed
-    // index). Owned here for the source's lifetime and referenced by each per-token read.
-    TOwnedCellVec PrefixCells;
 
     // True when the fulltext index uses __ydb_row_id as the synthetic doc_id, and the
     // primary key must be resolved through UniqueIndexReader before main-table reads.
@@ -2883,12 +2878,12 @@ public:
         , LogPrefix(TStringBuilder() << "TxId: " << txId << ", task: " << taskId << ", CA Id " << computeActorId << ". ")
         , SchemeCacheRequestTimeout(SCHEME_CACHE_REQUEST_TIMEOUT)
         , PipeCacheId(NKikimr::MakePipePerNodeCacheID(false))
+        , PrefixCells(TIndexTableImplReader::ParsePrefixCells(Settings))
         , MainTableReader(TMainTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings))
         , IndexTableReader(TIndexTableImplReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance()))
         , DocsTableReader(TDocsTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance()))
-        , StatsTableReader(TStatsTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance()))
+        , StatsTableReader(TStatsTableReader::FromSettings(Counters, Snapshot, LogPrefix, Settings, MainTableReader->GetWithRelevance(), PrefixCells))
         , UniqueIndexReader(TUniqueIndexReader::FromSettings(Counters, Snapshot, LogPrefix, Settings))
-        , PrefixCells(TIndexTableImplReader::ParsePrefixCells(Settings))
         , UseRowIdAsDocId(UniqueIndexReader != nullptr)
         , ReadsState(Counters, LogPrefix)
         , DocsReadingQueue(this->SelfId(), ReadsState)

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -3892,7 +3892,9 @@ public:
                     writeInfo.Actors.at(indexSettings.StatsTableId.PathId).WriteActor->Open(
                         writeCookie,
                         NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT_INCREMENT,
-                        {indexSettings.StatsColumns.at(0)},
+                        // key is zero id or prefix, 2 data columns
+                        TVector<NKikimrKqp::TKqpColumnMetadataProto>(indexSettings.StatsColumns.begin(),
+                            indexSettings.StatsColumns.end() - 2),
                         indexSettings.StatsColumns,
                         0,
                         settings.Priority);

--- a/ydb/core/kqp/runtime/kqp_write_table.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_table.cpp
@@ -1077,6 +1077,11 @@ private:
 
 template<class TDocId>
 class TFulltextTokenizeProjection : public IFulltextTokenizeProjection {
+    struct TPrefixBuffer {
+        ui64 DocCount = 0;
+        ui64 TotalDocLength = 0;
+        THashMap<TString, THashMap<ui64, ui32>> Tokens;
+    };
 public:
     TFulltextTokenizeProjection(
         TConstArrayRef<NScheme::TTypeInfo> columnTypes,
@@ -1096,7 +1101,7 @@ public:
         , RowBatcher(PrefixSize + 5, std::nullopt, Alloc)
         , DocsBatcher(Added ? 2 + DataColumnCount : 1, std::nullopt, Alloc)
         , DictBatcher(2, std::nullopt, Alloc)
-        , StatsBatcher(3, std::nullopt, Alloc) {
+        , StatsBatcher(PrefixSize ? 2 + PrefixSize : 3, std::nullopt, Alloc) {
         AFL_ENSURE(Indexes.size() == columnTypes.size());
         // Settings/Analyzers are required for fulltext indexes, but not for json
         AFL_ENSURE(settings.columns_size() == 1 ||
@@ -1132,14 +1137,14 @@ public:
             default:
                 YQL_ENSURE(false, "Invalid FulltextAnalyzeActor input column type: " << TextTypeId);
         }
-        auto& prefixTokens = TokenLists[TSerializedCellVec::Serialize(prefixCells)];
+        auto& prefix = PrefixBuffers[TSerializedCellVec::Serialize(prefixCells)];
         ui32 docLength = 0;
         for (auto& token: tokens) {
-            prefixTokens[token][docId]++;
+            prefix.Tokens[token][docId]++;
             docLength++;
         }
-        DocCount++;
-        TotalDocLength += docLength;
+        prefix.DocCount++;
+        prefix.TotalDocLength += docLength;
         if (WithFreq) {
             // indexImplDocsTable columns: document ID, __ydb_length, data columns
             TVector<TCell> docsCells(Added ? 2 + DataColumnCount : 1);
@@ -1155,26 +1160,18 @@ public:
     }
 
     IDataBatchPtr Flush() override {
-        for (auto& [prefix, prefixTokens]: TokenLists) {
+        for (auto& [prefix, prefixTokens]: PrefixBuffers) {
             FlushPrefix(prefix, prefixTokens);
         }
-        TokenLists.clear();
-        if (WithFreq) {
-            // indexImplStatsTable columns: __ydb_id (always ui32 0), __ydb_doc_count, __ydb_total_doc_length
-            TVector<TCell> statsCells(3);
-            statsCells[0] = TCell::Make((ui32)0);
-            statsCells[1] = TCell::Make(Added ? DocCount : -DocCount);
-            statsCells[2] = TCell::Make(Added ? TotalDocLength : -TotalDocLength);
-            StatsBatcher.AddRow(statsCells);
-        }
+        PrefixBuffers.clear();
         auto result = RowBatcher.Flush(true);
         YQL_ENSURE(RowBatcher.IsEmpty());
         return result;
     }
 
-    void FlushPrefix(const TString& prefix, const THashMap<TString, THashMap<ui64, ui32>>& tokenLists) {
+    void FlushPrefix(const TString& prefix, const TPrefixBuffer& prefixBuffer) {
         TVector<TStringBuf> sortedTokens;
-        for (const auto& [token, docFreqs]: tokenLists) {
+        for (const auto& [token, docFreqs]: prefixBuffer.Tokens) {
             sortedTokens.push_back(token);
         }
         std::sort(sortedTokens.begin(), sortedTokens.end());
@@ -1189,7 +1186,7 @@ public:
         TVector<TCell> dictCells(2);
         NFulltext::TDeltaWriter wr;
         for (const auto& token: sortedTokens) {
-            const auto& docFreqs = tokenLists.at(token);
+            const auto& docFreqs = prefixBuffer.Tokens.at(token);
             TVector<ui64> docIds;
             ui64 totalFreq = 0;
             for (const auto& [docId, freq]: docFreqs) {
@@ -1220,6 +1217,21 @@ public:
                 DictBatcher.AddRow(dictCells);
             }
         }
+        if (WithFreq) {
+            // indexImplStatsTable columns: __ydb_id (always ui32 0) or key prefix,
+            // __ydb_doc_count, __ydb_total_doc_length
+            TVector<TCell> statsCells(PrefixSize ? 2 + PrefixSize : 3);
+            if (!PrefixSize) {
+                statsCells[0] = TCell::Make((ui32)0);
+            } else {
+                for (size_t i = 0; i < PrefixSize; i++) {
+                    statsCells[i] = prefixCells.GetCells().at(i);
+                }
+            }
+            statsCells[PrefixSize ? 0 + PrefixSize : 1] = TCell::Make(Added ? prefixBuffer.DocCount : -prefixBuffer.DocCount);
+            statsCells[PrefixSize ? 1 + PrefixSize : 2] = TCell::Make(Added ? prefixBuffer.TotalDocLength : -prefixBuffer.TotalDocLength);
+            StatsBatcher.AddRow(statsCells);
+        }
     }
 
     IDataBatchPtr FlushDocs() override {
@@ -1249,12 +1261,10 @@ private:
     ui32 DataColumnCount = 0;
     ui32 PrefixSize = 0;
     NScheme::TTypeId TextTypeId = 0;
-    ui64 TotalDocLength = 0;
-    ui64 DocCount = 0;
     bool WithFreq = false;
     bool Added = false;
     Ydb::Table::FulltextIndexSettings::Analyzers Analyzers;
-    THashMap<TString, THashMap<TString, THashMap<ui64, ui32>>> TokenLists;
+    THashMap<TString, TPrefixBuffer> PrefixBuffers;
     TVector<ui32> Indexes;
     std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     TRowsBatcher RowBatcher;

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_search_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_search_ut.cpp
@@ -905,43 +905,57 @@ Y_UNIT_TEST_QUAD(SelectWithFulltextRelevance, UTF8, EnableIndexStreamWrite) {
     }
 }
 
-Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
+void DoTestLuceneRelevanceComparison(bool Compact, bool AfterBuild, bool Prefixed) {
     auto kikimr = Compact ? KikimrWithCompact() : Kikimr();
     auto db = kikimr.GetQueryClient();
 
     // Create table with fulltext index using relevance layout
-    TString createQuery = R"sql(
+    TString createQuery = Sprintf(R"sql(
         CREATE TABLE `/Root/Texts` (
             Key Uint64,
+            %s
             Text String,
             PRIMARY KEY (Key)
         );
-    )sql";
+    )sql", Prefixed ? "UserId Uint64," : "");
     auto result = db.ExecuteQuery(createQuery, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
     auto ins = [&]() {
         // Insert exact documents from Lucene test
-        TString insertQuery = R"sql(
-            UPSERT INTO `/Root/Texts` (Key, Text) VALUES
-                (0, "the quick brown fox jumps over the lazy dog"),
-                (1, "quick quick fox"),
-                (2, "lazy dog sleeps"),
-                (3, "brown bear eats honey"),
-                (4, "xylophone music is rare")
-        )sql";
+        TString insertQuery = Prefixed
+            ? R"sql(
+                UPSERT INTO `/Root/Texts` (Key, UserId, Text) VALUES
+                    (0, 100, "the quick brown fox jumps over the lazy dog"),
+                    (1, 100, "quick quick fox"),
+                    (2, 100, "lazy dog sleeps"),
+                    (3, 100, "brown bear eats honey"),
+                    (4, 100, "xylophone music is rare"),
+                    (5, 200, "a slow brown fox is better than the quick dog"),
+                    (6, 200, "the lazy sheep"),
+                    (7, 300, "drop bear eats humans"),
+                    (8, 400, "piano music")
+            )sql"
+            : R"sql(
+                UPSERT INTO `/Root/Texts` (Key, Text) VALUES
+                    (0, "the quick brown fox jumps over the lazy dog"),
+                    (1, "quick quick fox"),
+                    (2, "lazy dog sleeps"),
+                    (3, "brown bear eats honey"),
+                    (4, "xylophone music is rare")
+            )sql";
         result = db.ExecuteQuery(insertQuery, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
     };
 
     auto createIdx = [&]() {
         // Add fulltext index with relevance
-        TString indexQuery = R"sql(
+        TString indexQuery = Sprintf(R"sql(
             ALTER TABLE `/Root/Texts` ADD INDEX fulltext_idx
                 GLOBAL USING fulltext_relevance
-                ON (Text)
+                ON (%sText)
                 WITH (tokenizer=standard, use_filter_lowercase=true)
-        )sql";
+        )sql", Prefixed ? "UserId, " : "");
         result = db.ExecuteQuery(indexQuery, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
     };
@@ -977,40 +991,47 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
         }}
     };
 
+    auto pfx = [&](TString query) {
+        if (Prefixed) {
+            SubstGlobal(query, "WHERE FulltextScore", "WHERE UserId=100 AND FulltextScore");
+        }
+        return query;
+    };
+
     DoValidateRelevanceQuery(db,
-        R"sql(
+        pfx(R"sql(
             SELECT Key, FulltextScore(Text, "%s", "or" as DefaultOperator, "1" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "%s", "or" as DefaultOperator, "1" as MinimumShouldMatch) > 0
             ORDER BY Relevance DESC
-        )sql",
+        )sql"),
         testCases);
 
     DoValidateRelevanceQuery(db,
-        R"sql(
+        pfx(R"sql(
             SELECT Key, FulltextScore(Text, "%s", "or" as DefaultOperator, "50%" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "%s", "or" as DefaultOperator, "50%" as MinimumShouldMatch) > 0
             ORDER BY Relevance DESC
-        )sql",
+        )sql"),
         testCases);
 
     DoValidateRelevanceQuery(db,
-        R"sql(
+        pfx(R"sql(
             SELECT Key, FulltextScore(Text, "%s", "or" as DefaultOperator, "-1" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "%s", "or" as DefaultOperator, "-1" as MinimumShouldMatch) > 0
             ORDER BY Relevance DESC
-        )sql",
+        )sql"),
         testCases);
 
     DoValidateRelevanceQuery(db,
-        R"sql(
+        pfx(R"sql(
             SELECT Key, FulltextScore(Text, "%s", "or" as DefaultOperator, "-100" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "%s", "or" as DefaultOperator, "-100" as MinimumShouldMatch) > 0
             ORDER BY Relevance DESC
-        )sql",
+        )sql"),
         testCases);
 
     std::vector<std::pair<std::string, std::vector<std::pair<ui64, double>>>> andTestCases = {
@@ -1034,25 +1055,25 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     };
 
     DoValidateRelevanceQuery(db,
-        R"sql(
+        pfx(R"sql(
             SELECT Key, FulltextScore(Text, "%s", "and" as DefaultOperator) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "%s", "and" as DefaultOperator) > 0
             ORDER BY Relevance DESC
-        )sql",
+        )sql"),
         andTestCases);
 
     DoValidateRelevanceQuery(db,
-        R"sql(
+        pfx(R"sql(
             SELECT Key, FulltextScore(Text, "%s", "or" as DefaultOperator, "100" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "%s", "or" as DefaultOperator, "100" as MinimumShouldMatch) > 0
             ORDER BY Relevance DESC
-        )sql",
+        )sql"),
         andTestCases);
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "and" as DefaultOperator, "1" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "and" as DefaultOperator, "1" as MinimumShouldMatch) > 0
@@ -1066,7 +1087,7 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     }
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "some" as DefaultOperator, "1" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "some" as DefaultOperator, "1" as MinimumShouldMatch) > 0
@@ -1080,7 +1101,7 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     }
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "or" as DefaultOperator, "101%" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "or" as DefaultOperator, "101%" as MinimumShouldMatch) > 0
@@ -1094,7 +1115,7 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     }
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "or" as DefaultOperator, "-1%" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "or" as DefaultOperator, "-1%" as MinimumShouldMatch) > 0
@@ -1108,7 +1129,7 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     }
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "or" as DefaultOperator, "0%" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "or" as DefaultOperator, "0%" as MinimumShouldMatch) > 0
@@ -1122,7 +1143,7 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     }
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "or" as DefaultOperator, "non_numeric%" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "or" as DefaultOperator, "non_numeric%" as MinimumShouldMatch) > 0
@@ -1136,7 +1157,7 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
     }
 
     {
-        TString query = Sprintf(R"sql(
+        TString query = pfx(R"sql(
             SELECT Key, FulltextScore(Text, "quick fox", "or" as DefaultOperator, "non_numeric" as MinimumShouldMatch) as Relevance
             FROM `/Root/Texts` VIEW `fulltext_idx`
             WHERE FulltextScore(Text, "quick fox", "or" as DefaultOperator, "non_numeric" as MinimumShouldMatch) > 0
@@ -1148,6 +1169,14 @@ Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "MinimumShouldMatch is incorrect. Invalid value: `non_numeric`. Should be a number");
     }
+}
+
+Y_UNIT_TEST_QUAD(LuceneRelevanceComparison, Compact, AfterBuild) {
+    DoTestLuceneRelevanceComparison(Compact, AfterBuild, false);
+}
+
+Y_UNIT_TEST_TWIN(LuceneRelevanceComparisonPrefixed, AfterBuild) {
+    DoTestLuceneRelevanceComparison(true, AfterBuild, true);
 }
 
 // `+term` required-term syntax: every match must contain all `+` terms, and
@@ -3798,11 +3827,11 @@ Y_UNIT_TEST(CreatePrefixedFulltextIndexOnPrimaryKey) {
     UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "must not be a primary key column");
 }
 
-/*
 Y_UNIT_TEST(SelectWithFulltextRelevancePrefixed) {
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableFulltextIndex(true);
     featureFlags.SetEnableFulltextIndexPrefix(true);
+    featureFlags.SetEnableCompactFulltextIndex(true);
     auto kikimr = Kikimr(std::move(featureFlags));
     auto db = kikimr.GetQueryClient();
 
@@ -3812,11 +3841,7 @@ Y_UNIT_TEST(SelectWithFulltextRelevancePrefixed) {
                 Key Uint64,
                 UserId Uint64,
                 Text Utf8,
-                PRIMARY KEY (Key),
-                INDEX fulltext_idx
-                    GLOBAL USING fulltext_relevance
-                    ON (UserId, Text)
-                    WITH (tokenizer=standard, use_filter_lowercase=true)
+                PRIMARY KEY (Key)
             );
         )sql";
         auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -3831,6 +3856,17 @@ Y_UNIT_TEST(SelectWithFulltextRelevancePrefixed) {
                 (3, 200, "cats love milk"),
                 (4, 200, "birds love to fly")
         )sql";
+        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    {
+        TString query = Sprintf(R"sql(
+            ALTER TABLE `/Root/Docs` ADD INDEX fulltext_idx
+                GLOBAL USING fulltext_relevance
+                ON (UserId, Text)
+                WITH (tokenizer=standard, use_filter_lowercase=true)
+        )sql");
         auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
     }
@@ -3856,6 +3892,7 @@ Y_UNIT_TEST(SelectWithFulltextMatchMultiPrefixReversedOrder) {
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableFulltextIndex(true);
     featureFlags.SetEnableFulltextIndexPrefix(true);
+    featureFlags.SetEnableCompactFulltextIndex(true);
     auto kikimr = Kikimr(std::move(featureFlags));
     auto db = kikimr.GetQueryClient();
 
@@ -3909,7 +3946,6 @@ Y_UNIT_TEST(SelectWithFulltextMatchMultiPrefixReversedOrder) {
         WHERE Region = 10 AND UserId = 200 AND FulltextScore(Text, "cats") > 0 ORDER BY Key;
     )sql"));
 }
-*/
 
 Y_UNIT_TEST(SelectWithFulltextMatchPrefixedBuild) {
     // Exercises the index-build scan path (ALTER ADD INDEX over populated data) with prefix columns.
@@ -4234,51 +4270,166 @@ Y_UNIT_TEST_TWIN(SelectWithFulltextMatchPrefixedMultiColumnTyped, Compact) {
         WHERE Tenant = "acme" AND UserId = 100 AND FulltextMatch(Text, "cats") ORDER BY Key;)sql"));
 }
 
-Y_UNIT_TEST_TWIN(PrefixedRelevanceRejected, Compact) {
-    // Prefixed indexes with relevance are not supported yet: aggregation of the corpus-global dictionary
-    // is not implemented. The combination must be rejected.
-    auto kikimr = Compact ? KikimrPrefixCompact() : KikimrPrefix();
+Y_UNIT_TEST(SelectWithFulltextRelevancePrefixedPerPrefixStats) {
+    // Prefixed relevance index: BM25 statistics (DocCount, SumDocLength, document frequency) must be
+    // aggregated per prefix, not corpus-globally. The same document text under two prefixes scores
+    // differently because each prefix is its own corpus. Built via ALTER ADD INDEX so the plain and
+    // compact (delta-segment) formats share the same build path (compact has no online write maintenance).
+    auto kikimr = KikimrPrefixCompact();
     auto db = kikimr.GetQueryClient();
 
-    {
-        TString query = R"sql(
-            CREATE TABLE `/Root/Docs` (
-                Key Uint64,
-                UserId Uint64,
-                Text Utf8,
-                PRIMARY KEY (Key),
-                INDEX fulltext_idx GLOBAL USING fulltext_relevance ON (UserId, Text)
-                    WITH (tokenizer=standard, use_filter_lowercase=true)
-            );
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_C(result.GetStatus() != EStatus::SUCCESS, result.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Prefixed fulltext indexes with relevance are not supported");
-    }
+    auto exec = [&](const TString& q) {
+        auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(r.GetStatus(), EStatus::SUCCESS, r.GetIssues().ToString());
+    };
 
-    {
-        TString query = R"sql(
-            CREATE TABLE `/Root/Docs` (
-                Key Uint64,
-                UserId Uint64,
-                Text Utf8,
-                PRIMARY KEY (Key)
-            );
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-    }
+    exec(R"sql(
+        CREATE TABLE `/Root/Docs` (Key Uint64, UserId Uint64, Text Utf8, PRIMARY KEY (Key));
+    )sql");
+    exec(R"sql(
+        UPSERT INTO `/Root/Docs` (Key, UserId, Text) VALUES
+            (1, 100, "cats"),
+            (2, 100, "dogs run"),
+            (3, 200, "cats");
+    )sql");
+    exec(R"sql(
+        ALTER TABLE `/Root/Docs` ADD INDEX fulltext_idx
+            GLOBAL USING fulltext_relevance ON (UserId, Text)
+            WITH (tokenizer=standard, use_filter_lowercase=true);
+    )sql");
 
-    {
-        TString query = R"sql(
-            ALTER TABLE `/Root/Docs` ADD INDEX fulltext_idx GLOBAL USING fulltext_relevance
-            ON (UserId, Text)
-            WITH (tokenizer=standard, use_filter_lowercase=true)
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_C(result.GetStatus() != EStatus::SUCCESS, result.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Prefixed fulltext indexes with relevance are not supported");
-    }
+    // Prefix 100 corpus: N=2, SumDocLength=1+2=3, avgdl=1.5, df("cats")=1.
+    //   IDF = ln((2-1+0.5)/(1+0.5)+1) = ln(2); doc 1 |d|=1, tf=1
+    //   score = ln(2) * 1/(1 + 1.2*(1-0.75+0.75*1/1.5)) = 0.36481431
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{1, 0.36481431}}}});
+
+    // Prefix 200 corpus: N=1, SumDocLength=1, avgdl=1.0, df("cats")=1.
+    //   IDF = ln((1-1+0.5)/(1+0.5)+1) = ln(4/3); doc 3 |d|=1, tf=1
+    //   score = ln(4/3) * 1/(1 + 1.2*(1-0.75+0.75*1/1.0)) = 0.13076458
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 200 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{3, 0.13076458}}}});
+
+    // A term present only in one prefix must not leak into another prefix's results.
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 200 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"dogs", {}}});
+}
+
+Y_UNIT_TEST(SelectWithFulltextRelevancePrefixedWriteMaintenance) {
+    // Online write maintenance for a prefixed relevance index must keep the per-prefix BM25 statistics
+    // (DocCount / SumDocLength) in sync. INSERT / UPDATE / DELETE on one prefix change that prefix's
+    // scores while other prefixes stay isolated. Plain format only: compact relevance is build-only.
+    auto kikimr = KikimrPrefixCompact();
+    auto db = kikimr.GetQueryClient();
+
+    auto exec = [&](const TString& q) {
+        auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(r.GetStatus(), EStatus::SUCCESS, r.GetIssues().ToString());
+    };
+
+    exec(R"sql(
+        CREATE TABLE `/Root/Docs` (Key Uint64, UserId Uint64, Text Utf8, PRIMARY KEY (Key));
+    )sql");
+    exec(R"sql(
+        UPSERT INTO `/Root/Docs` (Key, UserId, Text) VALUES
+            (1, 100, "cats"),
+            (3, 200, "cats");
+    )sql");
+    exec(R"sql(
+        ALTER TABLE `/Root/Docs` ADD INDEX fulltext_idx
+            GLOBAL USING fulltext_relevance ON (UserId, Text)
+            WITH (tokenizer=standard, use_filter_lowercase=true);
+    )sql");
+
+    // Baseline: one "cats" doc per prefix. N=1, SumDocLength=1, avgdl=1, df("cats")=1.
+    //   IDF = ln(4/3); score = ln(4/3) * 1/(1 + 1.2) = 0.13076458
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{1, 0.13076458}}}});
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 200 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{3, 0.13076458}}}});
+
+    // INSERT a second doc into prefix 100: N goes 1 -> 2, so "cats" idf changes, and "dogs" appears.
+    exec(R"sql(INSERT INTO `/Root/Docs` (Key, UserId, Text) VALUES (2, 100, "dogs");)sql");
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{1, 0.31506690}}}});  // IDF = ln(2); score = ln(2) / 2.2
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"dogs", {{2, 0.31506690}}}});
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 200 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{3, 0.13076458}}}});  // prefix 200 untouched
+
+    // UPDATE doc 1's text: "cats" is dropped, "birds" appears; prefix stats stay N=2.
+    exec(R"sql(UPDATE `/Root/Docs` SET Text = "birds" WHERE Key = 1;)sql");
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {}}});
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"birds", {{1, 0.31506690}}}});
+
+    // DELETE doc 1: prefix 100 loses its "birds" doc; prefix 200 stays intact.
+    exec(R"sql(DELETE FROM `/Root/Docs` WHERE Key = 1;)sql");
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 100 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"birds", {}}});
+    DoValidateRelevanceQuery(db,
+        R"sql(
+            SELECT Key, FulltextScore(Text, "%s") as Relevance FROM `/Root/Docs` VIEW `fulltext_idx`
+            WHERE UserId = 200 AND FulltextScore(Text, "%s") > 0
+            ORDER BY Relevance DESC
+        )sql",
+        {{"cats", {{3, 0.13076458}}}});
 }
 
 // Creates an integer-PK table with an inline prefixed fulltext index (online write maintenance path),
@@ -4309,10 +4460,10 @@ static void SetupPrefixedDocs(NYdb::NQuery::TQueryClient& db, bool covered = fal
     )sql", covered ? "fulltext_relevance" : "fulltext_plain", covered ? "COVER (Data)" : ""));
 }
 
-Y_UNIT_TEST_TWIN(PrefixedInsert, Compact) {
+void DoTestPrefixedInsert(bool Compact, bool Covered) {
     auto kikimr = Compact ? KikimrPrefixCompact() : KikimrPrefix();
     auto db = kikimr.GetQueryClient();
-    SetupPrefixedDocs(db, false);
+    SetupPrefixedDocs(db, Covered);
 
     auto exec = [&](const TString& q) {
         auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -4333,17 +4484,29 @@ Y_UNIT_TEST_TWIN(PrefixedInsert, Compact) {
     CompareYson("[[[2u];[\"milk data\"]]]", selectKeys(R"sql(
         SELECT Key, Data FROM `/Root/Docs` VIEW `fulltext_idx`
         WHERE UserId = 200 AND FulltextMatch(Text, "cats") ORDER BY Key;)sql"));
-    if (0) {
+    if (Covered) {
         CompareYson("[[[1u];[\"play data\"]];[[2u];[\"milk data\"]];[[3u];[\"fast data\"]]]", selectKeys(R"sql(
             SELECT Key, Data FROM `/Root/Docs/fulltext_idx/indexImplDocsTable`
             ORDER BY Key;)sql"));
     }
 }
 
-Y_UNIT_TEST_TWIN(PrefixedUpsert, Compact) {
+Y_UNIT_TEST(PrefixedInsert) {
+    DoTestPrefixedInsert(false, false);
+}
+
+Y_UNIT_TEST(PrefixedInsertCompact) {
+    DoTestPrefixedInsert(true, false);
+}
+
+Y_UNIT_TEST(PrefixedInsertCovered) {
+    DoTestPrefixedInsert(true, true);
+}
+
+void DoTestPrefixedUpsert(bool Compact, bool Covered) {
     auto kikimr = Compact ? KikimrPrefixCompact() : KikimrPrefix();
     auto db = kikimr.GetQueryClient();
-    SetupPrefixedDocs(db, false);
+    SetupPrefixedDocs(db, Covered);
 
     auto exec = [&](const TString& q) {
         auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -4372,17 +4535,29 @@ Y_UNIT_TEST_TWIN(PrefixedUpsert, Compact) {
     CompareYson("[[[2u];[\"milk data\"]]]", selectKeys(R"sql(
         SELECT Key, Data FROM `/Root/Docs` VIEW `fulltext_idx`
         WHERE UserId = 200 AND FulltextMatch(Text, "cats") ORDER BY Key;)sql"));
-    if (0) {
+    if (Covered) {
         CompareYson("[[[1u];[\"sing data\"]];[[2u];[\"milk data\"]];[[3u];[\"sleep data\"]]]", selectKeys(R"sql(
             SELECT Key, Data FROM `/Root/Docs/fulltext_idx/indexImplDocsTable`
             ORDER BY Key;)sql"));
     }
 }
 
-Y_UNIT_TEST_TWIN(PrefixedUpdate, Compact) {
+Y_UNIT_TEST(PrefixedUpsert) {
+    DoTestPrefixedUpsert(false, false);
+}
+
+Y_UNIT_TEST(PrefixedUpsertCompact) {
+    DoTestPrefixedUpsert(true, false);
+}
+
+Y_UNIT_TEST(PrefixedUpsertCovered) {
+    DoTestPrefixedUpsert(true, true);
+}
+
+void DoTestPrefixedUpdate(bool Compact, bool Covered) {
     auto kikimr = Compact ? KikimrPrefixCompact() : KikimrPrefix();
     auto db = kikimr.GetQueryClient();
-    SetupPrefixedDocs(db, false);
+    SetupPrefixedDocs(db, Covered);
 
     auto exec = [&](const TString& q) {
         auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -4409,17 +4584,29 @@ Y_UNIT_TEST_TWIN(PrefixedUpdate, Compact) {
     CompareYson("[[[2u];[\"love data\"]]]", selectKeys(R"sql(
         SELECT Key, Data FROM `/Root/Docs` VIEW `fulltext_idx`
         WHERE UserId = 200 AND FulltextMatch(Text, "cats") ORDER BY Key;)sql"));
-    if (0) {
+    if (Covered) {
         CompareYson("[[[1u];[\"play data\"]];[[2u];[\"love data\"]]]", selectKeys(R"sql(
             SELECT Key, Data FROM `/Root/Docs/fulltext_idx/indexImplDocsTable`
             ORDER BY Key;)sql"));
     }
 }
 
-Y_UNIT_TEST_TWIN(PrefixedReplace, Compact) {
+Y_UNIT_TEST(PrefixedUpdate) {
+    DoTestPrefixedUpdate(false, false);
+}
+
+Y_UNIT_TEST(PrefixedUpdateCompact) {
+    DoTestPrefixedUpdate(true, false);
+}
+
+Y_UNIT_TEST(PrefixedUpdateCovered) {
+    DoTestPrefixedUpdate(true, true);
+}
+
+void DoTestPrefixedReplace(bool Compact, bool Covered) {
     auto kikimr = Compact ? KikimrPrefixCompact() : KikimrPrefix();
     auto db = kikimr.GetQueryClient();
-    SetupPrefixedDocs(db, false);
+    SetupPrefixedDocs(db, Covered);
 
     auto exec = [&](const TString& q) {
         auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -4447,11 +4634,75 @@ Y_UNIT_TEST_TWIN(PrefixedReplace, Compact) {
     CompareYson("[[[2u];[\"milk data\"]]]", selectKeys(R"sql(
         SELECT Key, Data FROM `/Root/Docs` VIEW `fulltext_idx`
         WHERE UserId = 200 AND FulltextMatch(Text, "cats") ORDER BY Key;)sql"));
-    if (0) {
+    if (Covered) {
         CompareYson("[[[1u];[\"sing data\"]];[[2u];[\"milk data\"]];[[3u];[\"fast data\"]]]", selectKeys(R"sql(
             SELECT Key, Data FROM `/Root/Docs/fulltext_idx/indexImplDocsTable`
             ORDER BY Key;)sql"));
     }
+}
+
+Y_UNIT_TEST(PrefixedReplace) {
+    DoTestPrefixedReplace(false, false);
+}
+
+Y_UNIT_TEST(PrefixedReplaceCompact) {
+    DoTestPrefixedReplace(true, false);
+}
+
+Y_UNIT_TEST(PrefixedReplaceCovered) {
+    DoTestPrefixedReplace(true, true);
+}
+
+Y_UNIT_TEST(PrefixedRelevanceStatsEmptyDoc) {
+    auto kikimr = KikimrPrefixCompact();
+    auto db = kikimr.GetQueryClient();
+
+    auto exec = [&](const TString& q) {
+        auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(r.GetStatus(), EStatus::SUCCESS, r.GetIssues().ToString());
+    };
+    auto selectKeys = [&](const TString& q) {
+        auto r = db.ExecuteQuery(q, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(r.GetStatus(), EStatus::SUCCESS, r.GetIssues().ToString());
+        return NYdb::FormatResultSetYson(r.GetResultSet(0));
+    };
+
+    exec(R"sql(
+        CREATE TABLE `/Root/Docs` (
+            Key Uint64,
+            UserId Uint64,
+            Text Utf8,
+            Data Utf8,
+            PRIMARY KEY (Key)
+        );
+    )sql");
+    exec(R"sql(
+        UPSERT INTO `/Root/Docs` (Key, UserId, Text, Data) VALUES
+            (1, 100, "cats love to play", "play data"),
+            (2, 100, "", "empty doc data"),
+            (3, 200, "cats love milk", "milk data");
+    )sql");
+    exec(R"sql(
+        ALTER TABLE `/Root/Docs` ADD INDEX fulltext_idx GLOBAL USING fulltext_relevance
+        ON (UserId, Text)
+        WITH (tokenizer=standard, use_filter_lowercase=true)
+    )sql");
+
+    CompareYson("[[[100u];2u;4u]]", selectKeys(R"sql(
+        SELECT * FROM `/Root/Docs/fulltext_idx/indexImplStatsTable` WHERE UserId = 100
+    )sql"));
+
+    exec(R"sql(UPDATE `/Root/Docs` SET Text="cat" WHERE Key=1;)sql");
+
+    CompareYson("[[[100u];2u;1u]]", selectKeys(R"sql(
+        SELECT * FROM `/Root/Docs/fulltext_idx/indexImplStatsTable` WHERE UserId = 100
+    )sql"));
+
+    exec(R"sql(DELETE FROM `/Root/Docs` WHERE Key=2;)sql");
+
+    CompareYson("[[[100u];1u;1u]]", selectKeys(R"sql(
+        SELECT * FROM `/Root/Docs/fulltext_idx/indexImplStatsTable` WHERE UserId = 100
+    )sql"));
 }
 
 Y_UNIT_TEST_TWIN(SelectWithFulltextMatchPrefixedRowIdComplexKey, Compact) {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2143,6 +2143,10 @@ message TEvBuildFulltextDictRequest {
     // [prefix..., __ydb_token, __ydb_max_id, __ydb_generation]; the dict scan must skip these
     // to locate the token and to group/compact segments per (prefix, token).
     repeated string PrefixColumns = 18;
+    // Statistics table is required for prefixed indexes with relevance
+    optional string StatsTableName = 19;
+    optional bool SkipFirstPrefix = 20;
+    optional bool SkipLastPrefix = 21;
 }
 
 message TEvBuildFulltextDictResponse {
@@ -2164,6 +2168,14 @@ message TEvBuildFulltextDictResponse {
     optional uint64 FirstTokenRows = 10;
     optional string LastToken = 11;
     optional uint64 LastTokenRows = 12;
+
+    // First and last prefix document statistics if skipped in the scan
+    optional string FirstPrefix = 13;
+    optional uint64 FirstPrefixDocCount = 14;
+    optional uint64 FirstPrefixSumDocLength = 15;
+    optional string LastPrefix = 16;
+    optional uint64 LastPrefixDocCount = 17;
+    optional uint64 LastPrefixSumDocLength = 18;
 }
 
 message TEvCdcStreamScanRequest {

--- a/ydb/core/tx/datashard/build_index/fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext.cpp
@@ -387,6 +387,11 @@ public:
         } else {
             tokens = Analyze(row.Get(0).AsBuf(), TextAnalyzers);
         }
+        const ui32 docTokens = tokens.size();
+        if (PrefixColumns.size()) {
+            // Add an empty token to count documents in prefix
+            tokens.emplace_back();
+        }
         if (Compact) {
             Y_ENSURE(key.size() == 1);
             ui64 docId;
@@ -403,6 +408,11 @@ public:
                 if (i < tokens.size() - 1 && tokens[i] == tokens[i + 1]) {
                     freq++;
                     continue;
+                }
+                if (tokens[i].empty()) {
+                    // Empty token's frequency is the document's total length + 1 (to support length == 0),
+                    // used to calculate per-prefix document statistics
+                    freq = docTokens + 1;
                 }
                 TString bucketKey = MakeCompactBucketKey(prefixCells, tokens[i]);
                 auto& state = TokenBuf[bucketKey];
@@ -441,7 +451,7 @@ public:
                 FlushAllTokens();
             }
             if (Request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance) {
-                UploadDocRow(key, row, tokens.size());
+                UploadDocRow(key, row, docTokens);
             }
         } else if (Request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance) {
             LastProcessedKey = TSerializedCellVec(key);
@@ -450,7 +460,7 @@ public:
             // safe across the asymmetrically-filling posting and docs buffers.
             Uploader.SetCurrentSourceKey(LastProcessedKey);
             UploadFulltextRelevance(prefixCells, docIdKey, tokens);
-            UploadDocRow(docIdKey, row, tokens.size());
+            UploadDocRow(docIdKey, row, docTokens);
         } else {
             LastProcessedKey = TSerializedCellVec(key);
             Uploader.SetCurrentSourceKey(LastProcessedKey);

--- a/ydb/core/tx/datashard/build_index/fulltext_dict.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext_dict.cpp
@@ -26,10 +26,12 @@ using namespace NTableIndex::NFulltext;
 using namespace NKikimr::NFulltext;
 
 /*
- * TBuildFulltextDictScan aggregates rows from the fulltext posting table and does two things:
+ * TBuildFulltextDictScan aggregates rows from the fulltext posting table and does 3 things:
  * 1) calculates token frequencies, i.e. the number of documents containing each token.
+ *    (optional, unused in new versions because DictTable is removed).
  * 2) compacts fulltext segments generated during initial build process for compact index formats
  *    (FulltextCompact/FulltextCompactRelevance/JsonCompact).
+ * 3) calculates per-prefix document counts and total lengths.
  *
  * For simple index formats:
  * - This scan takes the indexImplTable and writes output to indexImplDictTable (optionally).
@@ -45,10 +47,13 @@ using namespace NKikimr::NFulltext;
  *
  * Request:
  * - The client sends TEvBuildFulltextDictRequest with:
+ *   - Index type
+ *   - Prefix columns
  *   - Name of the target dictionary table
  *   - Name of the target compacted posting table
- *   - Index type
+ *   - Name of the target stats table
  *   - SkipFirstToken, SkipLastToken
+ *   - SkipFirstPrefix, SkipLastPrefix (for stats)
  *
  * Execution Flow:
  * - TBuildFulltextDictScan scans the whole input shard
@@ -83,6 +88,7 @@ protected:
     bool Signed = false;
 
     TBufferData* DictBuf = nullptr;
+    TBufferData* StatsBuf = nullptr;
     TBufferData* PostingBuf = nullptr;
 
     bool SkipFirstToken = false;
@@ -92,11 +98,21 @@ protected:
     ui64 FirstTokenRows = 0;
     ui64 LastTokenRows = 0;
 
+    bool SkipFirstPrefix = false;
+    bool SkipLastPrefix = false;
+    TString FirstPrefix;
+    TString LastPrefix;
+    ui64 FirstPrefixDocCount = 0;
+    ui64 LastPrefixDocCount = 0;
+    ui64 FirstPrefixSumDocLength = 0;
+    ui64 LastPrefixSumDocLength = 0;
+
     // Number of leading prefix key columns in the posting table key [prefix..., token, max_id, gen].
     // Zero for non-prefixed indexes. Used to locate the token and to group segments per (prefix, token).
     ui32 NumPrefixColumns = 0;
     // Current group's key cells [prefix..., token] and its serialized form for group boundary detection.
     TOwnedCellVec LastGroupKey;
+    TString FirstGroupKeySerialized;
     TString LastGroupKeySerialized;
 
     bool WithFreq = false;
@@ -129,6 +145,8 @@ public:
         , Uploader(request.GetDatabaseName(), request.GetScanSettings())
         , SkipFirstToken(request.GetSkipFirstToken())
         , SkipLastToken(request.GetSkipLastToken())
+        , SkipFirstPrefix(request.GetSkipFirstPrefix())
+        , SkipLastPrefix(request.GetSkipLastPrefix())
         , ScanSettings(request.GetScanSettings())
         , ResponseActorId(responseActorId)
         , Response(std::move(response))
@@ -158,6 +176,26 @@ public:
                 uploadTypes->emplace_back(FreqColumn, type);
             }
             DictBuf = Uploader.AddDestination(request.GetDictTableName(), uploadTypes);
+        }
+
+        if (request.GetStatsTableName())
+        {
+            // Pre-prefix document count and total length stats
+            auto uploadTypes = std::make_shared<NTxProxy::TUploadTypes>();
+            for (const auto& prefixColumn : request.GetPrefixColumns()) {
+                addType(uploadTypes, prefixColumn);
+            }
+            {
+                Ydb::Type type;
+                type.set_type_id(DocCountType);
+                uploadTypes->emplace_back(DocCountColumn, type);
+            }
+            {
+                Ydb::Type type;
+                type.set_type_id(DocCountType);
+                uploadTypes->emplace_back(SumDocLengthColumn, type);
+            }
+            StatsBuf = Uploader.AddDestination(request.GetStatsTableName(), uploadTypes);
         }
 
         if (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextCompact ||
@@ -195,8 +233,11 @@ public:
             }
 
             auto tags = GetAllTags(table);
-            ScanTags.push_back(tags.at("__ydb_added"));
-            ScanTags.push_back(tags.at("__ydb_segment"));
+            ScanTags.push_back(tags.at(AddedColumn));
+            ScanTags.push_back(tags.at(SegmentColumn));
+        } else if (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance) {
+            auto tags = GetAllTags(table);
+            ScanTags.push_back(tags.at(FreqColumn));
         }
     }
 
@@ -225,10 +266,17 @@ public:
         record.MutableMeteringStats()->SetReadBytes(ReadBytes);
         record.MutableMeteringStats()->SetCpuTimeUs(Driver->GetTotalCpuTimeUs());
 
-        record.SetFirstToken(FirstToken);
-        record.SetLastToken(LastToken);
+        record.SetFirstToken(NumPrefixColumns > 0 ? FirstGroupKeySerialized : FirstToken);
+        record.SetLastToken(NumPrefixColumns > 0 ? LastGroupKeySerialized : LastToken);
         record.SetFirstTokenRows(FirstTokenRows);
         record.SetLastTokenRows(LastTokenRows);
+
+        record.SetFirstPrefix(FirstPrefix);
+        record.SetLastPrefix(LastPrefix);
+        record.SetFirstPrefixDocCount(FirstPrefixDocCount);
+        record.SetLastPrefixDocCount(LastPrefixDocCount);
+        record.SetFirstPrefixSumDocLength(FirstPrefixSumDocLength);
+        record.SetLastPrefixSumDocLength(LastPrefixSumDocLength);
 
         Uploader.Finish(record, status);
 
@@ -305,6 +353,9 @@ public:
         if (LastTokenRows > 0) {
             FinishToken(true);
         }
+        if (LastPrefixDocCount > 0) {
+            FinishPrefix(true);
+        }
 
         // call Seek to wait uploads
         return EScan::Reset;
@@ -368,11 +419,40 @@ protected:
     {
         return TStringBuilder() << "TBuildFulltextDictScan TabletId: " << TabletId << " Id: " << BuildId
             << " SkipFirstToken: " << SkipFirstToken << " SkipLastToken: " << SkipLastToken
+            << " SkipFirstPrefix: " << SkipFirstPrefix << " SkipLastPrefix: " << SkipLastPrefix
             << " " << Uploader.Debug();
     }
 
     void Feed(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
+        if (!key[NumPrefixColumns].Size()) {
+            // Empty token is only used to count per-prefix document statistics
+            if (!StatsBuf) {
+                return;
+            }
+            auto curPrefix = TSerializedCellVec::Serialize(key.Slice(0, NumPrefixColumns));
+            if (LastPrefix != curPrefix) {
+                if (LastPrefixDocCount > 0) {
+                    FinishPrefix(false);
+                }
+                LastPrefix = curPrefix;
+            }
+            if (!PostingBuf) {
+                LastPrefixDocCount++;
+                LastPrefixSumDocLength += row[0].AsValue<TTokenCount>();
+            } else {
+                Y_ENSURE(row[0].AsValue<bool>());
+                TConstArrayRef<ui8> inBuf((ui8*)row[1].AsBuf().data(), row[1].AsBuf().size());
+                TDeltaReader rdr(inBuf, WithFreq, Signed);
+                ui64 docId = 0;
+                ui32 freq = 0;
+                while (rdr.Read(docId, freq)) {
+                    LastPrefixDocCount++;
+                    LastPrefixSumDocLength += freq - 1;
+                }
+            }
+            return;
+        }
         // Segments are grouped and compacted per (prefix..., token). The token sits at
         // key[NumPrefixColumns]; the prefix cells precede it. With prefix columns as the leading
         // sort key, the same token may appear under different prefixes (non-adjacent), so the group
@@ -438,6 +518,7 @@ protected:
         }
         if (SkipFirstToken && !FirstToken) {
             FirstToken = LastToken;
+            FirstGroupKeySerialized = LastGroupKeySerialized;
             FirstTokenRows = LastTokenRows;
         } else if (DictBuf) {
             TVector<TCell> pk = {TCell(LastToken)};
@@ -448,6 +529,28 @@ protected:
         LastGroupKey = TOwnedCellVec();
         LastGroupKeySerialized.clear();
         LastTokenRows = 0;
+    }
+
+    void FinishPrefix(bool last)
+    {
+        if (last && SkipLastPrefix) {
+            return;
+        }
+        if (SkipFirstPrefix && FirstPrefixDocCount == 0) {
+            FirstPrefix = LastPrefix;
+            FirstPrefixDocCount = LastPrefixDocCount;
+            FirstPrefixSumDocLength = LastPrefixSumDocLength;
+        } else if (LastPrefixDocCount > 0) {
+            TSerializedCellVec uploadKey(LastPrefix);
+            TVector<TCell> uploadValue = {
+                TCell::Make(LastPrefixDocCount),
+                TCell::Make(LastPrefixSumDocLength),
+            };
+            StatsBuf->AddRow(uploadKey.GetCells(), uploadValue);
+        }
+        LastPrefix.clear();
+        LastPrefixDocCount = 0;
+        LastPrefixSumDocLength = 0;
     }
 };
 
@@ -565,6 +668,15 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildFulltextDictRequest::TPtr& ev,
             if (request.GetPostingTableName()) {
                 badRequest(TStringBuilder() << "Output posting table name is set for a non-compact index");
             }
+        }
+
+        bool requiresStats = request.PrefixColumnsSize() > 0 &&
+            (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance ||
+            request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance);
+        if (requiresStats && !request.GetStatsTableName()) {
+            badRequest(TStringBuilder() << "Empty output statistics table name");
+        } else if (!requiresStats && request.GetStatsTableName()) {
+            badRequest(TStringBuilder() << "Output statistics table name is set for a non-prefixed-relevance index");
         }
 
         if (request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance) {

--- a/ydb/core/tx/datashard/build_index/ut/ut_fulltext_dict.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_fulltext_dict.cpp
@@ -22,6 +22,7 @@ static const TString kDatabaseName = "/Root";
 static const TString kIndexTable = "/Root/table-index";
 static const TString kDictTable = "/Root/table-dict";
 static const TString kCompactTable = "/Root/table-compact";
+static const TString kStatsTable = "/Root/table-stats";
 
 Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextDictScan) {
 
@@ -129,6 +130,67 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextDictScan) {
         CreateShardedTable(server, sender, "/Root", "table-dict", options);
     }
 
+    // Posting table for a prefixed relevance index: key is [prefix..., __ydb_token, <doc_id>],
+    // value is __ydb_freq. The empty __ydb_token row carries the document length in __ydb_freq.
+    void CreatePrefixedIndexTable(Tests::TServer::TPtr server, TActorId sender) {
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {"UserId", "Uint64", true, true},
+            {TokenColumn, "String", true, true},
+            {"key", "Uint32", true, true},
+            {FreqColumn, TokenCountTypeName, false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-index", options);
+    }
+
+    // Compact posting table for a prefixed index: key is [prefix..., __ydb_token, __ydb_generation,
+    // __ydb_max_id], value is [__ydb_added, __ydb_segment].
+    void CreatePrefixedCompactTable(Tests::TServer::TPtr server, TActorId sender, const char* name, const char* keyType = "Uint64") {
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {"UserId", "Uint64", true, true},
+            {TokenColumn, "String", true, true},
+            {GenColumn, "Uint64", true, true},
+            {MaxIdColumn, keyType, true, true},
+            {AddedColumn, "Bool", false, true},
+            {SegmentColumn, "String", false, true},
+        });
+        CreateShardedTable(server, sender, "/Root", name, options);
+    }
+
+    // Per-prefix statistics table: key is [prefix...], value is [__ydb_doc_count, __ydb_sum_doc_length].
+    void CreateStatsTable(Tests::TServer::TPtr server, TActorId sender) {
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {"UserId", "Uint64", true, true},
+            {DocCountColumn, DocCountTypeName, false, false},
+            {SumDocLengthColumn, DocCountTypeName, false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-stats", options);
+    }
+
+    void FillPrefixedIndexTable(Tests::TServer::TPtr server, TActorId sender) {
+        ExecSQL(server, sender, Sprintf(R"(
+            UPSERT INTO `/Root/table-index` (UserId, %s, key, %s) VALUES
+                (100, "", 1, 1),
+                (100, "", 2, 2),
+                (100, "cats", 1, 1),
+                (100, "dogs", 2, 1),
+                (100, "run", 2, 1),
+                (200, "", 3, 1),
+                (200, "cats", 3, 1)
+        )", TokenColumn, FreqColumn));
+    }
+
     void Setup(Tests::TServer::TPtr server, TActorId sender) {
         server->GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
         server->GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
@@ -191,6 +253,16 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextDictScan) {
             request.SetPostingTableName("abc");
             request.ClearDictTableName();
         }, "[ { <main>: Error: Output posting table name is set for a non-compact index } { <main>: Error: Empty output dictionary table name } ]");
+
+        // A prefixed relevance index requires a statistics table.
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextDictRequest& request) {
+            request.AddPrefixColumns("UserId");
+        }, "{ <main>: Error: Empty output statistics table name }");
+
+        // A non-prefixed relevance index must not set a statistics table.
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextDictRequest& request) {
+            request.SetStatsTableName("abc");
+        }, "{ <main>: Error: Output statistics table name is set for a non-prefixed-relevance index }");
     }
 
     Y_UNIT_TEST_QUAD(Build, SkipFirst, SkipLast) {
@@ -235,6 +307,109 @@ __ydb_token = red, __ydb_freq = 2
         Cerr << index << Endl;
 
         UNIT_ASSERT_VALUES_EQUAL(index, expected);
+    }
+
+    Y_UNIT_TEST_QUAD(BuildPrefixedStats, SkipFirst, SkipLast) {
+        // Per-prefix document statistics aggregation: the empty __ydb_token posting rows carry each
+        // document's length, and the dict scan aggregates them into [prefix -> DocCount, SumDocLength]
+        // rows in the stats table. SkipFirst/SkipLast mirror the cross-shard boundary handling of the
+        // token-level dict scan.
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto sender = server->GetRuntime()->AllocateEdgeActor();
+
+        server->GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        server->GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        CreatePrefixedIndexTable(server, sender);
+        FillPrefixedIndexTable(server, sender);
+        CreateDictTable(server, sender);
+        CreateStatsTable(server, sender);
+
+        auto reply = DoBuild(server, sender, [](auto& request){
+            request.AddPrefixColumns("UserId");
+            request.SetStatsTableName(kStatsTable);
+            request.SetSkipFirstPrefix(SkipFirst);
+            request.SetSkipLastPrefix(SkipLast);
+        });
+        auto& record = reply->Get()->Record;
+
+        TString expected;
+        if (SkipFirst) {
+            UNIT_ASSERT_EQUAL(record.GetFirstPrefixDocCount(), 2);
+            UNIT_ASSERT_EQUAL(record.GetFirstPrefixSumDocLength(), 3);
+        } else {
+            expected += "UserId = 100, __ydb_doc_count = 2, __ydb_sum_doc_length = 3\n";
+        }
+
+        if (SkipLast) {
+            UNIT_ASSERT_EQUAL(record.GetLastPrefixDocCount(), 1);
+            UNIT_ASSERT_EQUAL(record.GetLastPrefixSumDocLength(), 1);
+        } else {
+            expected += "UserId = 200, __ydb_doc_count = 1, __ydb_sum_doc_length = 1\n";
+        }
+
+        auto stats = ReadShardedTable(server, kStatsTable);
+        Cerr << "Stats:" << Endl;
+        Cerr << stats << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(stats, expected);
+    }
+
+    Y_UNIT_TEST(BuildPrefixedStatsCompact) {
+        // Same as BuildPrefixedStats but for the compact (delta-segment) relevance format. Per-prefix
+        // stats are aggregated by decoding the empty-token delta segment, which stores (doc_id, length)
+        // pairs for every document in the prefix.
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto sender = server->GetRuntime()->AllocateEdgeActor();
+
+        server->GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        server->GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        CreatePrefixedCompactTable(server, sender, "table-index");
+        CreatePrefixedCompactTable(server, sender, "table-compact");
+        CreateStatsTable(server, sender);
+
+        // Empty-token segments: prefix 100 has docs (1, len=1) and (2, len=2) encoded as \x41\x02\x41\x03;
+        // prefix 200 has doc (3, len=1) encoded as \x43\x02.
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table-index` (UserId, __ydb_token, __ydb_generation, __ydb_max_id, __ydb_added, __ydb_segment) VALUES
+                (100, "", 1, 2, true, "\x41\x02\x41\x03"),
+                (100, "cats", 1, 1, true, "\x01"),
+                (100, "dogs", 1, 2, true, "\x02"),
+                (100, "run", 1, 2, true, "\x02"),
+                (200, "", 1, 3, true, "\x43\x02"),
+                (200, "cats", 1, 3, true, "\x03")
+        )");
+
+        auto reply = DoBuild(server, sender, [](auto& request){
+            request.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance);
+            request.ClearDictTableName();
+            request.AddPrefixColumns("UserId");
+            request.SetPostingTableName(kCompactTable);
+            request.SetStatsTableName(kStatsTable);
+        });
+
+        TString expected = R"(UserId = 100, __ydb_doc_count = 2, __ydb_sum_doc_length = 3
+UserId = 200, __ydb_doc_count = 1, __ydb_sum_doc_length = 1
+)";
+
+        auto stats = ReadShardedTable(server, kStatsTable);
+        Cerr << "Stats:" << Endl;
+        Cerr << stats << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(stats, expected);
     }
 
     void DoTestCompact(bool WithRelevance, const char* keyType) {

--- a/ydb/core/tx/schemeshard/index/build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index.cpp
@@ -336,7 +336,13 @@ void TSchemeShard::PersistBuildIndexShardStatusFulltext(NIceDb::TNiceDb& db, TIn
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstToken>(shardStatus.FirstToken),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastToken>(shardStatus.LastToken),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstTokenRows>(shardStatus.FirstTokenRows),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastTokenRows>(shardStatus.LastTokenRows)
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastTokenRows>(shardStatus.LastTokenRows),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstPrefix>(shardStatus.FirstPrefix),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstPrefixDocCount>(shardStatus.FirstPrefixDocCount),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstPrefixSumDocLength>(shardStatus.FirstPrefixSumDocLength),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastPrefix>(shardStatus.LastPrefix),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastPrefixDocCount>(shardStatus.LastPrefixDocCount),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastPrefixSumDocLength>(shardStatus.LastPrefixSumDocLength)
     );
 }
 
@@ -366,7 +372,13 @@ void TSchemeShard::PersistBuildIndexShardStatusReset(NIceDb::TNiceDb& db, TIndex
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstToken>(""),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastToken>(""),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstTokenRows>(0),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastTokenRows>(0)
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastTokenRows>(0),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstPrefix>(""),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstPrefixDocCount>(0),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::FirstPrefixSumDocLength>(0),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastPrefix>(""),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastPrefixDocCount>(0),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::LastPrefixSumDocLength>(0)
     );
 }
 

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -1578,20 +1578,35 @@ private:
             ev->Record.SetDictTableName(path.PathString());
         }
 
+        const auto& shardStatus = buildInfo.Shards.at(shardIdx);
+
         // Fulltext index columns are [prefix..., text]; all but the last are prefix key columns.
         // The dict scan needs them to skip prefix cells and compact segments per (prefix, token).
+        ui32 prefixColumnCount = 0;
         if (buildInfo.IndexColumns.size() > 1) {
+            prefixColumnCount = buildInfo.IndexColumns.size() - 1;
             for (size_t i = 0; i + 1 < buildInfo.IndexColumns.size(); ++i) {
                 ev->Record.AddPrefixColumns(buildInfo.IndexColumns[i]);
             }
+            if (buildInfo.IsBuildFulltextRelevance()) {
+                auto path = GetBuildPath(Self, buildInfo, NTableIndex::NFulltext::StatsTable);
+                ev->Record.SetStatsTableName(path.PathString());
+                if (shardStatus.Range.From.GetCells().size() > prefixColumnCount) {
+                    // Range start is possibly split in the middle of a prefix
+                    ev->Record.SetSkipFirstPrefix(true);
+                }
+                if (shardStatus.Range.To.GetCells().size() > prefixColumnCount) {
+                    // Range end is possibly split in the middle of a prefix
+                    ev->Record.SetSkipLastPrefix(true);
+                }
+            }
         }
 
-        const auto& shardStatus = buildInfo.Shards.at(shardIdx);
-        if (shardStatus.Range.From.GetCells().size() > 1) {
+        if (shardStatus.Range.From.GetCells().size() > prefixColumnCount + 1) {
             // Range start is possibly split in the middle of a token
             ev->Record.SetSkipFirstToken(true);
         }
-        if (shardStatus.Range.To.GetCells().size() > 1) {
+        if (shardStatus.Range.To.GetCells().size() > prefixColumnCount + 1) {
             // Range end is possibly split in the middle of a token
             ev->Record.SetSkipLastToken(true);
         }
@@ -1643,10 +1658,16 @@ private:
             }
         }
 
+        ui32 prefixColumns = buildInfo.IndexColumns.size() - 1;
         TVector<std::pair<TSerializedCellVec, TSerializedCellVec>> uploadRows;
         for (auto& [token, docCount]: borders) {
-            uploadRows.emplace_back(TSerializedCellVec{TVector<TCell>{TCell(token)}},
-                TSerializedCellVec{TVector<TCell>{TCell::Make(docCount)}});
+            if (prefixColumns > 0) {
+                uploadRows.emplace_back(TSerializedCellVec(token),
+                    TSerializedCellVec{TVector<TCell>{TCell::Make(docCount)}});
+            } else {
+                uploadRows.emplace_back(TSerializedCellVec{TVector<TCell>{TCell(token)}},
+                    TSerializedCellVec{TVector<TCell>{TCell::Make(docCount)}});
+            }
         }
 
         auto mainTablePath = TPath::Init(buildInfo.TablePathId, Self);
@@ -1672,7 +1693,61 @@ private:
 
         TActivationContext::AsActorContext().MakeFor(Self->SelfId()).Register(actor);
 
-        LOG_N("TTxBuildProgress: TUploadFulltextStats: " << buildInfo);
+        LOG_N("TTxBuildProgress: TUploadFulltextBorders: " << buildInfo);
+    }
+
+    struct TDocStats {
+        NTableIndex::NFulltext::TDocCount DocCount = 0;
+        NTableIndex::NFulltext::TDocCount SumDocLength = 0;
+    };
+
+    void SendUploadFulltextPrefixBordersRequest(TIndexBuildInfo& buildInfo) {
+        TMap<TString, TDocStats> borders;
+        for (auto& [shardIdx, shardStatus]: buildInfo.Shards) {
+            if (shardStatus.FirstPrefixDocCount) {
+                auto& b = borders[shardStatus.FirstPrefix];
+                b.DocCount += shardStatus.FirstPrefixDocCount;
+                b.SumDocLength += shardStatus.FirstPrefixSumDocLength;
+            }
+            if (shardStatus.LastPrefixDocCount) {
+                auto& b = borders[shardStatus.LastPrefix];
+                b.DocCount += shardStatus.LastPrefixDocCount;
+                b.SumDocLength += shardStatus.LastPrefixSumDocLength;
+            }
+        }
+
+        TVector<std::pair<TSerializedCellVec, TSerializedCellVec>> uploadRows;
+        for (auto& [prefix, stat]: borders) {
+            uploadRows.emplace_back(TSerializedCellVec(prefix),
+                TSerializedCellVec{TVector<TCell>{TCell::Make(stat.DocCount), TCell::Make(stat.SumDocLength)}});
+        }
+
+        auto mainTablePath = TPath::Init(buildInfo.TablePathId, Self);
+        const auto& mainTableInfo = Self->Tables.at(mainTablePath->PathId);
+
+        auto types = std::make_shared<NTxProxy::TUploadTypes>();
+        TColumnTypes baseColumnTypes;
+        TString error;
+        Y_ENSURE(ExtractTypes(mainTableInfo, baseColumnTypes, error), error);
+        Y_ENSURE(buildInfo.IndexColumns.size() > 1);
+        for (size_t i = 0; i < buildInfo.IndexColumns.size() - 1; i++) {
+            Ydb::Type type;
+            NScheme::ProtoFromTypeInfo(baseColumnTypes.at(buildInfo.IndexColumns[i]), type);
+            types->emplace_back(buildInfo.IndexColumns[i], type);
+        }
+
+        Ydb::Type type;
+        type.set_type_id(NTableIndex::NFulltext::DocCountType);
+        types->emplace_back(NTableIndex::NFulltext::DocCountColumn, type);
+        types->emplace_back(NTableIndex::NFulltext::SumDocLengthColumn, type);
+
+        auto path = GetBuildPath(Self, buildInfo, NTableIndex::NFulltext::StatsTable);
+        auto actor = new TUploadSampleK(CanonizePath(Self->RootPathElements), path.PathString(),
+            buildInfo.ScanSettings, Self->SelfId(), BuildId, types, std::move(uploadRows));
+
+        TActivationContext::AsActorContext().MakeFor(Self->SelfId()).Register(actor);
+
+        LOG_N("TTxBuildProgress: TUploadFulltextPrefixBorders: " << buildInfo);
     }
 
     void ClearAfterFill(const TActorContext& ctx, TIndexBuildInfo& buildInfo) {
@@ -2408,7 +2483,44 @@ private:
         return true;
     }
 
+    void ChangeToFulltextDictionary(TTransactionContext& txc, TIndexBuildInfo& buildInfo) {
+        ClearDoneShards(txc, buildInfo);
+        NIceDb::TNiceDb db{txc.DB};
+        buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexDictionary;
+        Self->PersistBuildIndexState(db, buildInfo);
+        Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+        ChangeState(BuildId, TIndexBuildInfo::EState::LockBuild);
+        Progress(BuildId);
+    }
+
+    void ChangeToFulltextDone(TTransactionContext& txc, TIndexBuildInfo& buildInfo) {
+        ClearDoneShards(txc, buildInfo);
+        NIceDb::TNiceDb db{txc.DB};
+        buildInfo.SubState = TIndexBuildInfo::ESubState::None;
+        Self->PersistBuildIndexState(db, buildInfo);
+        Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+    }
+
     bool FillFulltextIndex(TTransactionContext& txc, TIndexBuildInfo& buildInfo) {
+        // SubState flow:
+        // ("None" = "Posting")
+        // - GlobalFulltextPlain / GlobalJson:
+        //   None -> END
+        // - GlobalFulltextRelevance:
+        //   None -> Stats -> Dict -> Borders -> END
+        // - GlobalFulltextCompact / GlobalJsonCompact:
+        //   None -> Dict -> END
+        // - rowid GlobalFulltextCompact / rowid GlobalJsonCompact:
+        //   RowIdSrc -> None -> Dict -> END
+        // - GlobalFulltextCompactRelevance:
+        //   None -> Stats -> Dict -> END
+        // - rowid GlobalFulltextCompactRelevance:
+        //   RowIdSrc -> None -> Stats -> Dict -> END
+        // - prefixed GlobalFulltextCompactRelevance:
+        //   None -> Dict -> PrefixBorders -> END
+        // - prefixed rowid GlobalFulltextCompactRelevance:
+        //   RowIdSrc -> None -> Dict -> PrefixBorders -> END
+
         bool done = false;
 
         switch (buildInfo.SubState) {
@@ -2435,7 +2547,7 @@ private:
             }
             break;
         case TIndexBuildInfo::ESubState::None:
-            // Stage 1 for FulltextRelevance - build "posting" table (token-documents)
+            // Build "posting" table (token-documents)
             LOG_D("FillFulltextIndex Posting");
             if (NoShardsAdded(buildInfo)) {
                 AddAllShards(buildInfo);
@@ -2444,27 +2556,21 @@ private:
                 buildInfo.DoneShards.size() == buildInfo.Shards.size();
             if (done) {
                 LOG_D("FillFulltextIndex Posting Done");
-                if (buildInfo.IsBuildFulltextRelevance()) {
+                if (buildInfo.IsBuildFulltextRelevance() && !buildInfo.IsBuildFulltextPrefixedRelevance()) {
                     NIceDb::TNiceDb db{txc.DB};
                     buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
                     buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexStats;
                     Self->PersistBuildIndexState(db, buildInfo);
                     Progress(BuildId);
                     done = false;
-                } else if (buildInfo.IsBuildFulltextCompact()) {
-                    ClearDoneShards(txc, buildInfo);
-                    NIceDb::TNiceDb db{txc.DB};
-                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexDictionary;
-                    Self->PersistBuildIndexState(db, buildInfo);
-                    Self->PersistBuildIndexShardStatusReset(db, buildInfo);
-                    ChangeState(BuildId, TIndexBuildInfo::EState::LockBuild);
-                    Progress(BuildId);
+                } else if (buildInfo.IsBuildFulltextCompact() || buildInfo.IsBuildFulltextPrefixedRelevance()) {
+                    ChangeToFulltextDictionary(txc, buildInfo);
                     done = false;
                 }
             }
             break;
         case TIndexBuildInfo::ESubState::FulltextIndexStats:
-            // Stage 2 for FulltextRelevance/FulltextCompactRelevance - build statistics table (DocCount & TotalDocLength)
+            // Non-prefixed with relevance - index statistics table (DocCount & TotalDocLength)
             if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Collect) {
                 LOG_D("FillFulltextIndex SendUploadStats " << buildInfo.DebugString());
                 buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Upload;
@@ -2472,18 +2578,13 @@ private:
                 Progress(BuildId);
             } else if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Done) {
                 LOG_D("FillFulltextIndex UploadStats Done " << buildInfo.DebugString());
-                ClearDoneShards(txc, buildInfo);
-                NIceDb::TNiceDb db{txc.DB};
-                buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexDictionary;
-                Self->PersistBuildIndexState(db, buildInfo);
-                Self->PersistBuildIndexShardStatusReset(db, buildInfo);
-                ChangeState(BuildId, TIndexBuildInfo::EState::LockBuild);
-                Progress(BuildId);
+                ChangeToFulltextDictionary(txc, buildInfo);
             }
             break;
         case TIndexBuildInfo::ESubState::FulltextIndexDictionary:
-            // Stage 3 for FulltextRelevance - build dictionary table
-            // And/or stage 2 for FulltextCompact - compact token table
+            // FulltextRelevance - build dictionary table
+            // FulltextCompact - compact token table
+            // Prefixed with relevance - per-prefix statistics table
             LOG_D("FillFulltextIndex Dictionary");
             if (NoShardsAdded(buildInfo)) {
                 AddAllShards(buildInfo);
@@ -2497,6 +2598,10 @@ private:
                     buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
                     buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexBorders;
                     done = false;
+                } else if (buildInfo.IsBuildFulltextPrefixedRelevance()) {
+                    buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexPrefixBorders;
+                    done = false;
                 } else {
                     buildInfo.SubState = TIndexBuildInfo::ESubState::None;
                     Self->PersistBuildIndexShardStatusReset(db, buildInfo);
@@ -2507,7 +2612,7 @@ private:
             }
             break;
         case TIndexBuildInfo::ESubState::FulltextIndexBorders:
-            // Stage 4 for FulltextRelevance - fill border values for dictionary
+            // FulltextRelevance - aggregate border values for token dictionary
             if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Collect) {
                 LOG_D("FillFulltextIndex SendUploadBorders " << buildInfo.DebugString());
                 buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Upload;
@@ -2515,11 +2620,28 @@ private:
                 Progress(BuildId);
             } else if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Done) {
                 LOG_D("FillFulltextIndex UploadBorders Done " << buildInfo.DebugString());
-                ClearDoneShards(txc, buildInfo);
-                NIceDb::TNiceDb db{txc.DB};
-                buildInfo.SubState = TIndexBuildInfo::ESubState::None;
-                Self->PersistBuildIndexState(db, buildInfo);
-                Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+                if (buildInfo.IsBuildFulltextPrefixedRelevance()) {
+                    buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexPrefixBorders;
+                    NIceDb::TNiceDb db{txc.DB};
+                    Self->PersistBuildIndexState(db, buildInfo);
+                    Progress(BuildId);
+                } else {
+                    ChangeToFulltextDone(txc, buildInfo);
+                    done = true;
+                }
+            }
+            break;
+        case TIndexBuildInfo::ESubState::FulltextIndexPrefixBorders:
+            // Prefixed with relevance - aggregate border values for per-prefix statistics
+            if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Collect) {
+                LOG_D("FillFulltextIndex SendUploadPrefixBorders " << buildInfo.DebugString());
+                buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Upload;
+                SendUploadFulltextPrefixBordersRequest(buildInfo);
+                Progress(BuildId);
+            } else if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Done) {
+                LOG_D("FillFulltextIndex UploadPrefixBorders Done " << buildInfo.DebugString());
+                ChangeToFulltextDone(txc, buildInfo);
                 done = true;
             }
             break;
@@ -3856,7 +3978,8 @@ struct TSchemeShard::TIndexBuilder::TTxReplyFulltextDict: public TTxShardReply<T
     void HandleDone(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) override {
         const auto& record = Response->Get()->Record;
 
-        if (record.GetFirstTokenRows() || record.GetLastTokenRows()) {
+        if (record.GetFirstTokenRows() || record.GetLastTokenRows() ||
+            record.GetFirstPrefixDocCount() || record.GetLastPrefixDocCount()) {
             TTabletId shardId = TTabletId(record.GetTabletId());
             TShardIdx shardIdx = Self->GetShardIdx(shardId);
             TIndexBuildShardStatus& shardStatus = buildInfo.Shards.at(shardIdx);
@@ -3865,6 +3988,13 @@ struct TSchemeShard::TIndexBuilder::TTxReplyFulltextDict: public TTxShardReply<T
             shardStatus.FirstTokenRows = record.GetFirstTokenRows();
             shardStatus.LastToken = record.GetLastToken();
             shardStatus.LastTokenRows = record.GetLastTokenRows();
+
+            shardStatus.FirstPrefix = record.GetFirstPrefix();
+            shardStatus.FirstPrefixDocCount = record.GetFirstPrefixDocCount();
+            shardStatus.FirstPrefixSumDocLength = record.GetFirstPrefixSumDocLength();
+            shardStatus.LastPrefix = record.GetLastPrefix();
+            shardStatus.LastPrefixDocCount = record.GetLastPrefixDocCount();
+            shardStatus.LastPrefixSumDocLength = record.GetLastPrefixSumDocLength();
 
             Self->PersistBuildIndexShardStatusFulltext(db, BuildId, shardIdx, shardStatus);
         }

--- a/ydb/core/tx/schemeshard/index/index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/index/index_build_info.cpp
@@ -364,6 +364,7 @@ bool TIndexBuildInfo::IsValidSubState(ESubState value)
         case ESubState::FulltextIndexDictionary:
         case ESubState::FulltextIndexBorders:
         case ESubState::FulltextRowIdSrc:
+        case ESubState::FulltextIndexPrefixBorders:
             return true;
     }
     return false;

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -20,6 +20,13 @@ struct TIndexBuildShardStatus {
     NTableIndex::NFulltext::TDocCount FirstTokenRows = 0;
     NTableIndex::NFulltext::TDocCount LastTokenRows = 0;
 
+    TString FirstPrefix;
+    NTableIndex::NFulltext::TDocCount FirstPrefixDocCount = 0;
+    NTableIndex::NFulltext::TDocCount FirstPrefixSumDocLength = 0;
+    TString LastPrefix;
+    NTableIndex::NFulltext::TDocCount LastPrefixDocCount = 0;
+    NTableIndex::NFulltext::TDocCount LastPrefixSumDocLength = 0;
+
     NKikimrIndexBuilder::EBuildStatus Status = NKikimrIndexBuilder::EBuildStatus::INVALID;
 
     Ydb::StatusIds::StatusCode UploadStatus = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
@@ -114,6 +121,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         // Compact rowid-mode prepass: build the transient "row-id source" table (main re-keyed by the
         // dense seq) that the posting scan then reads so doc ids arrive ascending and densely packed.
         FulltextRowIdSrc = 203,
+        FulltextIndexPrefixBorders = 204,
     };
 
     struct TColumnBuildInfo {
@@ -789,6 +797,13 @@ public:
         shardStatus.FirstTokenRows = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::FirstTokenRows>();
         shardStatus.LastToken = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::LastToken>();
         shardStatus.LastTokenRows = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::LastTokenRows>();
+
+        shardStatus.FirstPrefix = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::FirstPrefix>();
+        shardStatus.FirstPrefixDocCount = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::FirstPrefixDocCount>();
+        shardStatus.FirstPrefixSumDocLength = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::FirstPrefixSumDocLength>();
+        shardStatus.LastPrefix = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::LastPrefix>();
+        shardStatus.LastPrefixDocCount = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::LastPrefixDocCount>();
+        shardStatus.LastPrefixSumDocLength = row.template GetValueOrDefault<Schema::IndexBuildShardStatus::LastPrefixSumDocLength>();
     }
 
     bool IsCancellationRequested() const {
@@ -824,6 +839,10 @@ public:
         return BuildKind == EBuildKind::BuildFulltext && (
             IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance ||
             IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance);
+    }
+
+    bool IsBuildFulltextPrefixedRelevance() const {
+        return IsBuildFulltextRelevance() && IndexColumns.size() > 1;
     }
 
     bool IsBuildFulltextCompact() const {

--- a/ydb/core/tx/schemeshard/index/index_utils.cpp
+++ b/ydb/core/tx/schemeshard/index/index_utils.cpp
@@ -734,20 +734,29 @@ auto CalcFulltextDictImplTableDescImpl(
 auto CalcFulltextStatsImplTableDescImpl(
     const auto& baseTable,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const TVector<TString>& prefixColumns)
 {
     auto tableColumns = ExtractInfo(baseTable);
 
     NKikimrSchemeOp::TTableDescription implTableDesc;
     implTableDesc.SetName(NTableIndex::NFulltext::StatsTable);
     SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
-    {
+
+    if (prefixColumns.size()) {
+        // Key is prefix
+        const THashSet<TString> prefixColumnsSet{prefixColumns.begin(), prefixColumns.end()};
+        FillIndexImplTableColumns(GetColumns(baseTable), prefixColumns, prefixColumnsSet, implTableDesc);
+    } else {
+        // Key is a single unused uint32 __ydb_id column always equal to 0
         auto col = implTableDesc.AddColumns();
         col->SetName(NFulltext::IdColumn);
         col->SetType("Uint32");
         col->SetTypeId(Ydb::Type::UINT32);
         col->SetNotNull(true);
+        implTableDesc.AddKeyColumnNames(NFulltext::IdColumn);
     }
+
     {
         auto col = implTableDesc.AddColumns();
         col->SetName(NFulltext::DocCountColumn);
@@ -762,7 +771,6 @@ auto CalcFulltextStatsImplTableDescImpl(
         col->SetTypeId(NFulltext::DocCountType);
         col->SetNotNull(true);
     }
-    implTableDesc.AddKeyColumnNames(NFulltext::IdColumn);
 
     implTableDesc.SetSystemColumnNamesAllowed(true);
 
@@ -999,17 +1007,19 @@ NKikimrSchemeOp::TTableDescription CalcFulltextDictImplTableDesc(
 NKikimrSchemeOp::TTableDescription CalcFulltextStatsImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const TVector<TString>& prefixColumns)
 {
-    return CalcFulltextStatsImplTableDescImpl(baseTableInfo, baseTablePartitionConfig, indexTableDesc);
+    return CalcFulltextStatsImplTableDescImpl(baseTableInfo, baseTablePartitionConfig, indexTableDesc, prefixColumns);
 }
 
 NKikimrSchemeOp::TTableDescription CalcFulltextStatsImplTableDesc(
     const NKikimrSchemeOp::TTableDescription& baseTableDescr,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const TVector<TString>& prefixColumns)
 {
-    return CalcFulltextStatsImplTableDescImpl(baseTableDescr, baseTablePartitionConfig, indexTableDesc);
+    return CalcFulltextStatsImplTableDescImpl(baseTableDescr, baseTablePartitionConfig, indexTableDesc, prefixColumns);
 }
 
 bool ExtractTypes(const NKikimrSchemeOp::TTableDescription& baseTableDescr, TColumnTypes& columnTypes, TString& explain) {

--- a/ydb/core/tx/schemeshard/index/index_utils.h
+++ b/ydb/core/tx/schemeshard/index/index_utils.h
@@ -167,12 +167,14 @@ NKikimrSchemeOp::TTableDescription CalcFulltextDictImplTableDesc(
 NKikimrSchemeOp::TTableDescription CalcFulltextStatsImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const TVector<TString>& prefixColumns);
 
 NKikimrSchemeOp::TTableDescription CalcFulltextStatsImplTableDesc(
     const NKikimrSchemeOp::TTableDescription& baseTableDescr,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const TVector<TString>& prefixColumns);
 
 TTableColumns ExtractInfo(const NSchemeShard::TTableInfo::TPtr& tableInfo);
 TTableColumns ExtractInfo(const NKikimrSchemeOp::TTableDescription& tableDesc);
@@ -306,10 +308,11 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
                 return false;
             }
 
-            if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance ||
-                indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance) {
+            if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance) {
+                // Old prefixed fulltext_relevance index requires updating stats in kqp/effects,
+                // but it's not implemented and won't be because the index type is EOL.
                 status = NKikimrScheme::EStatus::StatusInvalidParameter;
-                error = "Prefixed fulltext indexes with relevance are not supported";
+                error = "Only compact prefixed fulltext indexes with relevance are supported";
                 return false;
             }
 

--- a/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
@@ -300,9 +300,9 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 indexTableDesc = indexDesc.GetIndexImplTableDescriptions(0);
             }
 
+            auto prefixColumns = NTableIndex::GetFulltextPrefixColumns(indexDesc.GetKeyColumnNames());
             auto implTableDesc = CalcFulltextCompactImplTableDesc(tableInfo, tableInfo->PartitionConfig(),
-                indexTableDesc, &indexDesc.GetFulltextIndexDescription(), indexType,
-                NTableIndex::GetFulltextPrefixColumns(indexDesc.GetKeyColumnNames()), false);
+                indexTableDesc, &indexDesc.GetFulltextIndexDescription(), indexType, prefixColumns, false);
             implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
             result.push_back(createImplTable(std::move(implTableDesc),
                 THashSet<TString>{NTableIndex::NFulltext::GenSequence}));
@@ -320,7 +320,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance) {
                 const THashSet<TString> indexDataColumns{indexDesc.GetDataColumnNames().begin(), indexDesc.GetDataColumnNames().end()};
                 result.push_back(createImplTable(CalcFulltextDocsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns, docsTableDesc, indexDesc.GetFulltextIndexDescription())));
-                result.push_back(createImplTable(CalcFulltextStatsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), statsTableDesc)));
+                result.push_back(createImplTable(CalcFulltextStatsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), statsTableDesc, prefixColumns)));
             }
             break;
         }
@@ -347,14 +347,14 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 indexTableDesc = indexDesc.GetIndexImplTableDescriptions(NTableIndex::NFulltext::PostingTablePosition);
             }
             const THashSet<TString> indexDataColumns{indexDesc.GetDataColumnNames().begin(), indexDesc.GetDataColumnNames().end()};
+            auto prefixColumns = NTableIndex::GetFulltextPrefixColumns(indexDesc.GetKeyColumnNames());
             auto implTableDesc = CalcFulltextImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns,
-                indexTableDesc, indexDesc.GetFulltextIndexDescription(), indexType,
-                NTableIndex::GetFulltextPrefixColumns(indexDesc.GetKeyColumnNames()));
+                indexTableDesc, indexDesc.GetFulltextIndexDescription(), indexType, prefixColumns);
             implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
             result.push_back(createImplTable(std::move(implTableDesc)));
             result.push_back(createImplTable(CalcFulltextDocsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns, docsTableDesc, indexDesc.GetFulltextIndexDescription())));
             result.push_back(createImplTable(CalcFulltextDictImplTableDesc(tableInfo, tableInfo->PartitionConfig(), dictTableDesc, indexDesc.GetFulltextIndexDescription())));
-            result.push_back(createImplTable(CalcFulltextStatsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), statsTableDesc)));
+            result.push_back(createImplTable(CalcFulltextStatsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), statsTableDesc, prefixColumns)));
             break;
         }
         default:

--- a/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
@@ -503,10 +503,10 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     userIndexDesc = indexDescription.GetIndexImplTableDescriptions(0);
                 }
 
+                auto prefixColumns = NTableIndex::GetFulltextPrefixColumns(indexDescription.GetKeyColumnNames());
                 result.push_back(createIndexImplTable(CalcFulltextCompactImplTableDesc(
                     baseTableDescription, baseTableDescription.GetPartitionConfig(),
-                    userIndexDesc, &indexDescription.GetFulltextIndexDescription(), indexType,
-                        NTableIndex::GetFulltextPrefixColumns(indexDescription.GetKeyColumnNames()), false),
+                    userIndexDesc, &indexDescription.GetFulltextIndexDescription(), indexType, prefixColumns, false),
                     THashSet<TString>{NTableIndex::NFulltext::GenSequence}));
 
                 // Create the sequence
@@ -525,7 +525,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance) {
                     const THashSet<TString> indexDataColumns{indexDescription.GetDataColumnNames().begin(), indexDescription.GetDataColumnNames().end()};
                     result.push_back(createIndexImplTable(CalcFulltextDocsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), indexDataColumns, docsTableDesc, indexDescription.GetFulltextIndexDescription())));
-                    result.push_back(createIndexImplTable(CalcFulltextStatsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), statsTableDesc)));
+                    result.push_back(createIndexImplTable(CalcFulltextStatsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), statsTableDesc, prefixColumns)));
                 }
                 break;
             }
@@ -550,12 +550,12 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     userIndexDesc = indexDescription.GetIndexImplTableDescriptions(NTableIndex::NFulltext::PostingTablePosition);
                 }
                 const THashSet<TString> indexDataColumns{indexDescription.GetDataColumnNames().begin(), indexDescription.GetDataColumnNames().end()};
+                auto prefixColumns = NTableIndex::GetFulltextPrefixColumns(indexDescription.GetKeyColumnNames());
                 result.push_back(createIndexImplTable(CalcFulltextImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
-                    indexDataColumns, userIndexDesc, indexDescription.GetFulltextIndexDescription(), indexType,
-                    NTableIndex::GetFulltextPrefixColumns(indexDescription.GetKeyColumnNames()))));
+                    indexDataColumns, userIndexDesc, indexDescription.GetFulltextIndexDescription(), indexType, prefixColumns)));
                 result.push_back(createIndexImplTable(CalcFulltextDocsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), indexDataColumns, docsTableDesc, indexDescription.GetFulltextIndexDescription())));
                 result.push_back(createIndexImplTable(CalcFulltextDictImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), dictTableDesc, indexDescription.GetFulltextIndexDescription())));
-                result.push_back(createIndexImplTable(CalcFulltextStatsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), statsTableDesc)));
+                result.push_back(createIndexImplTable(CalcFulltextStatsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), statsTableDesc, prefixColumns)));
                 break;
             }
             default:

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1646,6 +1646,14 @@ struct Schema : NIceDb::Schema {
         struct FirstTokenRows : Column<18, NScheme::NTypeIds::Uint64> {};
         struct LastTokenRows : Column<19, NScheme::NTypeIds::Uint64> {};
 
+        // For prefixed fulltext_relevance indexes
+        struct FirstPrefix : Column<20, NScheme::NTypeIds::String> {};
+        struct FirstPrefixDocCount : Column<21, NScheme::NTypeIds::Uint64> {};
+        struct FirstPrefixSumDocLength : Column<22, NScheme::NTypeIds::Uint64> {};
+        struct LastPrefix : Column<23, NScheme::NTypeIds::String> {};
+        struct LastPrefixDocCount : Column<24, NScheme::NTypeIds::Uint64> {};
+        struct LastPrefixSumDocLength : Column<25, NScheme::NTypeIds::Uint64> {};
+
         using TKey = TableKey<Id, OwnerShardIdx, LocalShardIdx>;
         using TColumns = TableColumns<
             Id,
@@ -1666,7 +1674,13 @@ struct Schema : NIceDb::Schema {
             FirstToken,
             LastToken,
             FirstTokenRows,
-            LastTokenRows
+            LastTokenRows,
+            FirstPrefix,
+            FirstPrefixDocCount,
+            FirstPrefixSumDocLength,
+            LastPrefix,
+            LastPrefixDocCount,
+            LastPrefixSumDocLength
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
@@ -235,7 +235,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
         return index;
     }
 
-    /*
     // Regression test for the crash at build_index__progress.cpp SendUploadFulltextBordersRequest:
     // building a *prefixed* relevance index (e.g. ALTER TABLE ... ADD INDEX ... ON (lang, text))
     // hit `Y_ENSURE(buildInfo.IndexColumns.size() == 1)` because IndexColumns is [lang, text].
@@ -243,6 +242,8 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         runtime.GetAppData().FeatureFlags.SetEnableFulltextIndexPrefix(true);
+        runtime.GetAppData().FeatureFlags.SetEnableCompactFulltextIndex(true);
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
         ui64 txId = 100;
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
@@ -268,7 +269,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
             NLs::PathExist,
         });
     }
-    */
 
     Y_UNIT_TEST(DropTableWithFlatRelevance) {
         TTestBasicRuntime runtime;

--- a/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_fulltext_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_fulltext_index_build_reboots.cpp
@@ -118,4 +118,114 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTestReboots) {
             }
         });
     }
+
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(Prefixed, 4 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
+        // speed up the test:
+        // only check scheme shard reboots
+        t.TabletIds.clear();
+        t.TabletIds.push_back(t.SchemeShardTabletId);
+        // white list some more events
+        t.NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
+        t.NoRebootEventTypes.insert(TSchemeBoardEvents::EvUpdateAck);
+        t.NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletionRegistered);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerDisconnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerConnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientConnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientDestroyed);
+        t.NoRebootEventTypes.insert(TEvDataShard::EvBuildIndexProgressResponse);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            runtime.GetAppData().FeatureFlags.SetEnableCompactFulltextIndex(true);
+            RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "texts"
+                    Columns { Name: "id" Type: "Uint64" }
+                    Columns { Name: "user" Type: "Uint64" }
+                    Columns { Name: "text" Type: "String" }
+                    Columns { Name: "data" Type: "String" }
+                    KeyColumnNames: [ "id" ]
+                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 6 } } } }
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                TVector<TCell> cells = {
+                    TCell::Make((ui64)1), TCell::Make((ui64)100), TCell(TStringBuf("green apple")), TCell(TStringBuf("one")),
+                    TCell::Make((ui64)2), TCell::Make((ui64)100), TCell(TStringBuf("red apple and blue apple")), TCell(TStringBuf("two")),
+                    TCell::Make((ui64)3), TCell::Make((ui64)100), TCell(TStringBuf("yellow apple")), TCell(TStringBuf("three")),
+                    TCell::Make((ui64)4), TCell::Make((ui64)200), TCell(TStringBuf("red car")), TCell(TStringBuf("four")),
+                    TCell::Make((ui64)5), TCell::Make((ui64)200), TCell(TStringBuf("cat eats mice every day")), TCell(TStringBuf("five")),
+                };
+                WriteOp(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/texts",
+                    0, NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT,
+                    {1, 2, 3, 4}, TSerializedCellMatrix(cells, 5, 4), true);
+
+                cells = {
+                    TCell::Make((ui64)6), TCell::Make((ui64)100), TCell(TStringBuf("dogs eat mice but sometimes mice flee")), TCell(TStringBuf("six")),
+                    TCell::Make((ui64)7), TCell::Make((ui64)100), TCell(TStringBuf("dog eats mice and cats")), TCell(TStringBuf("seven")),
+                    TCell::Make((ui64)8), TCell::Make((ui64)100), TCell(TStringBuf("dogs like bones and mice")), TCell(TStringBuf("eight")),
+                    TCell::Make((ui64)9), TCell::Make((ui64)200), TCell(TStringBuf("foxes eat mice too")), TCell(TStringBuf("nine")),
+                    TCell::Make((ui64)10), TCell::Make((ui64)200), TCell(TStringBuf("everyone eats mice")), TCell(TStringBuf("ten")),
+                };
+                WriteOp(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/texts",
+                    1, NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT,
+                    {1, 2, 3, 4}, TSerializedCellMatrix(cells, 5, 4), true);
+            }
+
+            const ui64 buildIndexId = ++t.TxId;
+            {
+                auto indexColumns = TVector<TString>{"user", "text"};
+                auto sender = runtime.AllocateEdgeActor();
+                auto request = CreateBuildIndexRequest(buildIndexId, "/MyRoot", "/MyRoot/texts", TBuildIndexConfig{
+                    "index1", NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance, indexColumns, {"data"}, {}
+                });
+                auto& fulltext = *request->Record.MutableSettings()->mutable_index()->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings();
+                auto& analyzers = *fulltext.add_columns()->mutable_analyzers();
+                fulltext.mutable_columns()->at(0).set_column("text");
+                analyzers.set_tokenizer(Ydb::Table::FulltextIndexSettings::WHITESPACE);
+                // with too many scan events, the test works infinite time
+                request->Record.MutableSettings()->MutableScanSettings()->Clear();
+                ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, request);
+            }
+
+            t.TestEnv->TestWaitNotification(runtime, buildIndexId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto descr = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+                UNIT_ASSERT_VALUES_EQUAL((ui64)descr.GetIndexBuild().GetState(), (ui64)Ydb::Table::IndexBuildState::STATE_DONE);
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/texts"),
+                    {NLs::PathExist, NLs::IndexesCount(1)});
+                const TString indexPath = "/MyRoot/texts/index1";
+                TestDescribeResult(DescribePath(runtime, indexPath, true, true, true),
+                    {NLs::PathExist, NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::ImplTable, true, true, true), {NLs::PathExist});
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::NFulltext::DocsTable, true, true, true), {NLs::PathExist});
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + NTableIndex::NFulltext::StatsTable, true, true, true), {NLs::PathExist});
+
+                // Check row counts in index tables
+                {
+                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/texts/index1/" + TString(NTableIndex::ImplTable));
+                    Cerr << "... posting table contains " << rows << " rows" << Endl;
+                    UNIT_ASSERT_VALUES_EQUAL(rows, 28);
+                }
+
+                {
+                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/texts/index1/" + TString(NTableIndex::NFulltext::DocsTable));
+                    Cerr << "... document table contains " << rows << " rows" << Endl;
+                    UNIT_ASSERT_VALUES_EQUAL(rows, 10);
+                }
+
+                {
+                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/texts/index1/" + TString(NTableIndex::NFulltext::StatsTable));
+                    Cerr << "... statistics table contains " << rows << " rows" << Endl;
+                    UNIT_ASSERT_VALUES_EQUAL(rows, 2);
+                }
+            }
+        });
+    }
 }

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -5829,6 +5829,36 @@
                 "ColumnId": 19,
                 "ColumnName": "LastTokenRows",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 20,
+                "ColumnName": "FirstPrefix",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 21,
+                "ColumnName": "FirstPrefixDocCount",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 22,
+                "ColumnName": "FirstPrefixSumDocLength",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 23,
+                "ColumnName": "LastPrefix",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 24,
+                "ColumnName": "LastPrefixDocCount",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 25,
+                "ColumnName": "LastPrefixSumDocLength",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -5853,7 +5883,13 @@
                     16,
                     17,
                     18,
-                    19
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Description for reviewers

Некомпактный не поддерживается, потому что его всё равно закапывать. Поддержать не так сложно, но для этого нужен ещё кусок обработки Stats в kqp/opt/physical/effects и ещё пришлось бы доудалить Dict (а он не выпилен из некомпактных полнотекстовых).