### PR TITLE
Bump ydbdoc-review action to v0.2.2

### DIFF
--- a/.github/workflows/ydbdoc-continue.yml
+++ b/.github/workflows/ydbdoc-continue.yml
@@ -43,7 +43,7 @@ jobs:
           echo "YDBDOC_YDB_SA_KEY_FILE=$RUNNER_TEMP/ydb-sa.json" >> "$GITHUB_ENV"
 
       - name: Continue translation with operator feedback
-        uses: ydb-platform/ydbdoc-review@v0.1.0
+        uses: ydb-platform/ydbdoc-review@v0.2.2
         with:
           mode: continue
           repo: ${{ github.repository }}

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -35,7 +35,7 @@ jobs:
           git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
 
       - name: Documentation translation review
-        uses: ydb-platform/ydbdoc-review@v0.1.0
+        uses: ydb-platform/ydbdoc-review@v0.2.2
         with:
           repo: ${{ github.repository }}
           pr: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -33,7 +33,7 @@ jobs:
           git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
 
       - name: Verify translation PR
-        uses: ydb-platform/ydbdoc-review@v0.1.0
+        uses: ydb-platform/ydbdoc-review@v0.2.2
         with:
           mode: verify
           repo: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Bump `ydbdoc-review` from `@v0.1.0` to `@v0.2.2` in doc_translate, doc_verify, and doc_continue workflows.
- v0.2.2 fixes over-scoped translation for localized RU deltas (#50839): preserve EN when href/fence/autotitle changes already satisfied.

## Test plan
- [ ] Merge and re-run `doc_translate` on merged source PR #50839
- [ ] Confirm minimal/no-op EN diff on new translation PR