### PR TITLE
Make TDynamicFunctionRegistry thread-safe with immutable snapshots

### DIFF
--- a/ydb/core/kqp/common/dynamic_function_registry.cpp
+++ b/ydb/core/kqp/common/dynamic_function_registry.cpp
@@ -8,6 +8,7 @@
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 #include <util/system/dynlib.h>
+#include <util/system/rwlock.h>
 
 #include <utility>
 
@@ -109,6 +110,8 @@ public:
     {
     }
 
+    //! Caller must hold rhs.Lock_ (shared or exclusive), or rhs must be unused by
+    //! other threads. Lock_ itself is not copied (default-constructed).
     TDynamicFunctionRegistry(const TDynamicFunctionRegistry& rhs)
         : IDynamicFunctionRegistry()
         , Builtins_(rhs.Builtins_)
@@ -130,6 +133,8 @@ public:
         const TString& customUdfPrefix = {},
         THashSet<TString>* modules = nullptr) override
     {
+        TWriteGuard guard(Lock_);
+
         TUdfLibraryPtr lib;
 
         auto libIt = LoadedLibraries_.find(libraryPath);
@@ -208,6 +213,8 @@ public:
         const TStringBuf& moduleName,
         NUdf::TUniquePtr<NUdf::IUdfModule> module) override
     {
+        TWriteGuard guard(Lock_);
+
         TString libraryPathStr(libraryPath);
         // Track the path for RemoveModule cleanup; multiple in-memory modules may
         // share one synthetic path (unlike LoadUdfs which opens a real .so once).
@@ -223,6 +230,8 @@ public:
     }
 
     void RemoveModule(const TStringBuf& moduleName) override {
+        TWriteGuard guard(Lock_);
+
         // Only UdfModules_ / LoadedLibraries_. SystemModulePaths_ is a separate
         // catalog and must survive unload so FindUdfPath can still resolve it.
         auto it = UdfModules_.find(TString(moduleName));
@@ -245,6 +254,7 @@ public:
     }
 
     void SetSystemModulePaths(const TUdfModulePathsMap& paths) override {
+        TWriteGuard guard(Lock_);
         SystemModulePaths_ = paths;
     }
 
@@ -269,58 +279,64 @@ public:
     {
         TStringBuf moduleName;
         TStringBuf funcName;
-        if (name.TrySplit(MODULE_NAME_DELIMITER, moduleName, funcName)) {
-            auto it = UdfModules_.find(moduleName);
-            if (it != UdfModules_.end()) {
-                TFunctionTypeInfoBuilder typeInfoBuilder(langver, runtimeSettings, env, typeInfoHelper, moduleName,
-                                                         (flags & NUdf::IUdfModule::TFlags::TypesOnly) ? nullptr : countersProvider, pos,
-                                                         secureParamsProvider, logProvider);
-                const auto& module = *it->second.Impl;
-                module.BuildFunctionTypeInfo(
-                    funcName, userType, typeConfig, flags, typeInfoBuilder);
-
-                if (typeInfoBuilder.HasError()) {
-                    return TStatus::Error()
-                           << "Module: " << moduleName
-                           << ", function: " << funcName
-                           << ", error: " << typeInfoBuilder.GetError();
-                }
-
-                try {
-                    typeInfoBuilder.Build(funcInfo);
-                } catch (yexception& e) {
-                    return TStatus::Error()
-                           << "Module: " << moduleName
-                           << ", function: " << funcName
-                           << ", error: " << e.what();
-                }
-
-                if ((flags & NUdf::IRegistrator::TFlags::TypesOnly) &&
-                    !funcInfo->FunctionType)
-                {
-                    return TStatus::Error()
-                           << "Module: " << moduleName
-                           << ", function: " << funcName
-                           << ", function not found";
-                }
-
-                if (funcInfo->ModuleIRUniqID) {
-                    funcInfo->ModuleIRUniqID.prepend(moduleName);
-                }
-
-                return TStatus::Ok();
-            }
-
+        if (!name.TrySplit(MODULE_NAME_DELIMITER, moduleName, funcName)) {
             return TStatus::Error()
-                   << "Module " << moduleName << " is not registered";
+                   << "Function name must be in <module>.<func_name> scheme. "
+                   << "But get " << name;
         }
 
-        return TStatus::Error()
-               << "Function name must be in <module>.<func_name> scheme. "
-               << "But get " << name;
+        std::shared_ptr<NUdf::IUdfModule> module;
+        {
+            TReadGuard guard(Lock_);
+            auto it = UdfModules_.find(moduleName);
+            if (it == UdfModules_.end()) {
+                return TStatus::Error()
+                       << "Module " << moduleName << " is not registered";
+            }
+            module = it->second.Impl;
+        }
+
+        TFunctionTypeInfoBuilder typeInfoBuilder(langver, runtimeSettings, env, typeInfoHelper, moduleName,
+                                                 (flags & NUdf::IUdfModule::TFlags::TypesOnly) ? nullptr : countersProvider, pos,
+                                                 secureParamsProvider, logProvider);
+        module->BuildFunctionTypeInfo(
+            funcName, userType, typeConfig, flags, typeInfoBuilder);
+
+        if (typeInfoBuilder.HasError()) {
+            return TStatus::Error()
+                   << "Module: " << moduleName
+                   << ", function: " << funcName
+                   << ", error: " << typeInfoBuilder.GetError();
+        }
+
+        try {
+            typeInfoBuilder.Build(funcInfo);
+        } catch (yexception& e) {
+            return TStatus::Error()
+                   << "Module: " << moduleName
+                   << ", function: " << funcName
+                   << ", error: " << e.what();
+        }
+
+        if ((flags & NUdf::IRegistrator::TFlags::TypesOnly) &&
+            !funcInfo->FunctionType)
+        {
+            return TStatus::Error()
+                   << "Module: " << moduleName
+                   << ", function: " << funcName
+                   << ", function not found";
+        }
+
+        if (funcInfo->ModuleIRUniqID) {
+            funcInfo->ModuleIRUniqID.prepend(moduleName);
+        }
+
+        return TStatus::Ok();
     }
 
     TMaybe<TString> FindUdfPath(const TStringBuf& moduleName) const override {
+        TReadGuard guard(Lock_);
+
         if (const TUdfModule* udf = UdfModules_.FindPtr(moduleName)) {
             return udf->LibraryPath;
         }
@@ -333,10 +349,13 @@ public:
     }
 
     bool IsLoadedUdfModule(const TStringBuf& moduleName) const override {
+        TReadGuard guard(Lock_);
         return UdfModules_.contains(moduleName);
     }
 
     THashSet<TString> GetAllModuleNames() const override {
+        TReadGuard guard(Lock_);
+
         THashSet<TString> names;
         names.reserve(UdfModules_.size());
         for (const auto& module : UdfModules_) {
@@ -373,15 +392,22 @@ public:
             }
         } sink;
 
-        const auto it = UdfModules_.find(moduleName);
-        if (UdfModules_.cend() == it) {
-            return TFunctionsMap();
+        std::shared_ptr<NUdf::IUdfModule> module;
+        {
+            TReadGuard guard(Lock_);
+            const auto it = UdfModules_.find(moduleName);
+            if (UdfModules_.cend() == it) {
+                return TFunctionsMap();
+            }
+            module = it->second.Impl;
         }
-        it->second.Impl->GetAllFunctions(sink);
+
+        module->GetAllFunctions(sink);
         return sink.Functions;
     }
 
     bool SupportsSizedAllocators() const override {
+        TReadGuard guard(Lock_);
         return SupportsSizedAllocators_;
     }
 
@@ -390,22 +416,33 @@ public:
     }
 
     void CleanupModulesOnTerminate() const override {
-        for (const auto& module : UdfModules_) {
-            module.second.Impl->CleanupOnTerminate();
+        TVector<std::shared_ptr<NUdf::IUdfModule>> modules;
+        {
+            TReadGuard guard(Lock_);
+            modules.reserve(UdfModules_.size());
+            for (const auto& module : UdfModules_) {
+                modules.push_back(module.second.Impl);
+            }
+        }
+        for (const auto& module : modules) {
+            module->CleanupOnTerminate();
         }
     }
 
     TIntrusivePtr<IMutableFunctionRegistry> Clone() const override {
+        TReadGuard guard(Lock_);
         return new TDynamicFunctionRegistry(*this);
     }
 
     void SetBackTraceCallback(NUdf::TBackTraceCallback callback) override {
+        TWriteGuard guard(Lock_);
         BackTraceCallback_ = callback;
     }
 
 private:
     const IBuiltinFunctionRegistry::TPtr Builtins_;
 
+    mutable TRWMutex Lock_;
     THashMap<TString, TUdfLibraryPtr> LoadedLibraries_;
     TUdfModulesMap UdfModules_;
     TUdfModulePathsMap SystemModulePaths_;

--- a/ydb/core/kqp/common/dynamic_function_registry.cpp
+++ b/ydb/core/kqp/common/dynamic_function_registry.cpp
@@ -546,9 +546,15 @@ private:
         }
     }
 
+    //! Erase only if no in-flight LoadUdfs still holds the shared_ptr; otherwise a
+    //! concurrent Acquire would insert a second mutex for the same path and break
+    //! per-path serialization.
     void ReleaseNativePathLoadMutex(const TString& libraryPath) {
         with_lock (PathLoadMutexesLock_) {
-            PathLoadMutexes_.erase(libraryPath);
+            auto it = PathLoadMutexes_.find(libraryPath);
+            if (it != PathLoadMutexes_.end() && it->second.use_count() == 1) {
+                PathLoadMutexes_.erase(it);
+            }
         }
     }
 

--- a/ydb/core/kqp/common/dynamic_function_registry.cpp
+++ b/ydb/core/kqp/common/dynamic_function_registry.cpp
@@ -4,12 +4,18 @@
 #include <yql/essentials/minikql/mkql_utils.h>
 #include <yql/essentials/public/udf/udf_static_registry.h>
 
+#include <library/cpp/threading/hot_swap/hot_swap.h>
+
 #include <util/folder/path.h>
+#include <util/generic/hash.h>
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 #include <util/system/dynlib.h>
-#include <util/system/rwlock.h>
+#include <util/system/guard.h>
+#include <util/system/mutex.h>
+#include <util/system/spinlock.h>
 
+#include <atomic>
 #include <utility>
 
 namespace NKikimr::NKqp {
@@ -38,6 +44,22 @@ class TDynamicFunctionRegistry: public IDynamicFunctionRegistry {
         TDynamicLibrary Lib;
     };
     using TUdfLibraryPtr = TIntrusivePtr<TUdfLibrary>;
+
+    struct TSnapshot: public TAtomicRefCount<TSnapshot> {
+        THashMap<TString, TUdfLibraryPtr> LoadedLibraries;
+        TUdfModulesMap UdfModules;
+        TUdfModulePathsMap SystemModulePaths;
+
+        TSnapshot() = default;
+
+        TSnapshot(const TSnapshot& other)
+            : LoadedLibraries(other.LoadedLibraries)
+            , UdfModules(other.UdfModules)
+            , SystemModulePaths(other.SystemModulePaths)
+        {
+        }
+    };
+    using TSnapshotPtr = TIntrusivePtr<TSnapshot>;
 
     class TUdfModuleLoader: public NUdf::IRegistrator {
     public:
@@ -107,20 +129,21 @@ class TDynamicFunctionRegistry: public IDynamicFunctionRegistry {
 public:
     explicit TDynamicFunctionRegistry(IBuiltinFunctionRegistry::TPtr builtins)
         : Builtins_(std::move(builtins))
+        , State_(MakeIntrusive<TSnapshot>())
     {
     }
 
-    //! Caller must hold rhs.Lock_ (shared or exclusive), or rhs must be unused by
-    //! other threads. Lock_ itself is not copied (default-constructed).
+    //! Snapshot is copied; WriterMutex_ / LoadMutex_ are not shared with rhs.
     TDynamicFunctionRegistry(const TDynamicFunctionRegistry& rhs)
         : IDynamicFunctionRegistry()
         , Builtins_(rhs.Builtins_)
-        , LoadedLibraries_(rhs.LoadedLibraries_)
-        , UdfModules_(rhs.UdfModules_)
-        , SystemModulePaths_(rhs.SystemModulePaths_)
-        , BackTraceCallback_(rhs.BackTraceCallback_)
-        , SupportsSizedAllocators_(rhs.SupportsSizedAllocators_)
+        , State_(MakeIntrusive<TSnapshot>(*rhs.State_.AtomicLoad()))
+        , SupportsSizedAllocators_(
+              rhs.SupportsSizedAllocators_.load(std::memory_order_relaxed))
     {
+        with_lock (rhs.WriterMutex_) {
+            BackTraceCallback_ = rhs.BackTraceCallback_;
+        }
     }
 
     void AllowUdfPatch() override {
@@ -133,13 +156,28 @@ public:
         const TString& customUdfPrefix = {},
         THashSet<TString>* modules = nullptr) override
     {
-        TWriteGuard guard(Lock_);
+        // Serialize unsafe .so entry points; readers stay on wait-free snapshots.
+        // Lock order: LoadMutex_ -> WriterMutex_ (never reverse).
+        TGuard<TMutex> loadGuard(LoadMutex_);
 
         TUdfLibraryPtr lib;
+        NUdf::TBackTraceCallback backTraceCallback = nullptr;
+        bool needOpen = false;
+        {
+            auto snap = State_.AtomicLoad();
+            auto libIt = snap->LoadedLibraries.find(libraryPath);
+            if (libIt != snap->LoadedLibraries.end() && libIt->second) {
+                lib = libIt->second;
+            } else {
+                needOpen = true;
+                with_lock (WriterMutex_) {
+                    backTraceCallback = BackTraceCallback_;
+                }
+            }
+        }
 
-        auto libIt = LoadedLibraries_.find(libraryPath);
-        if (libIt == LoadedLibraries_.end()) {
-            lib = MakeIntrusive<TUdfLibrary>();
+        if (needOpen) {
+            auto opened = MakeIntrusive<TUdfLibrary>();
 #ifdef _win32_
             ui32 loadFlags = 0;
 #else
@@ -151,11 +189,11 @@ public:
                 absPath = JoinPaths(TFsPath::Cwd().PathSplit(), absPathSplit);
             }
 
-            lib->Lib.Open(absPath.data(), loadFlags);
-            lib->Lib.SetUnloadable(false);
+            opened->Lib.Open(absPath.data(), loadFlags);
+            opened->Lib.SetUnloadable(false);
 
             auto abiVersionFunc = reinterpret_cast<NUdf::TAbiVersionFunctionPtr>(
-                lib->Lib.SymOptional(AbiVersionFuncName));
+                opened->Lib.SymOptional(AbiVersionFuncName));
             if (!abiVersionFunc) {
                 return;
             }
@@ -168,40 +206,70 @@ public:
                                                                   << "; try to re-compile library using "
                                                                   << "YQL_ABI_VERSION(" << UDF_ABI_VERSION_MAJOR
                                                                   << " " << UDF_ABI_VERSION_MINOR << " 0) macro in ya.make");
-            lib->AbiVersion = version;
-            if (version < NUdf::MakeAbiVersion(2, 8, 0)) {
-                SupportsSizedAllocators_ = false;
-            }
+            opened->AbiVersion = version;
 
 #if defined(_win_) || defined(_darwin_)
-            auto bindSymbolsFunc = reinterpret_cast<NUdf::TBindSymbolsFunctionPtr>(lib->Lib.Sym(BindSymbolsFuncName));
+            auto bindSymbolsFunc = reinterpret_cast<NUdf::TBindSymbolsFunctionPtr>(
+                opened->Lib.Sym(BindSymbolsFuncName));
             bindSymbolsFunc(NUdf::GetStaticSymbols());
 #endif
 
-            if (BackTraceCallback_) {
-                auto setter = reinterpret_cast<NUdf::TSetBackTraceCallbackPtr>(lib->Lib.SymOptional(SetBackTraceCallbackName));
+            if (backTraceCallback) {
+                auto setter = reinterpret_cast<NUdf::TSetBackTraceCallbackPtr>(
+                    opened->Lib.SymOptional(SetBackTraceCallbackName));
                 if (setter) {
-                    setter(BackTraceCallback_);
+                    setter(backTraceCallback);
                 }
             }
 
-            libIt = LoadedLibraries_.insert({libraryPath, lib}).first;
-        } else {
-            lib = libIt->second;
+            with_lock (WriterMutex_) {
+                auto next = MakeIntrusive<TSnapshot>(*State_.AtomicLoad());
+                auto& slot = next->LoadedLibraries[libraryPath];
+                if (!slot) {
+                    slot = opened;
+                }
+                lib = slot;
+                State_.AtomicStore(next);
+            }
         }
+
+        Y_ENSURE(lib, "UDF library handle missing for " << libraryPath);
 
         auto registerFunc = reinterpret_cast<NUdf::TRegisterFunctionPtr>(
             lib->Lib.Sym(RegisterFuncName));
 
+        TUdfModulesMap staging;
         THashSet<TString> newModules;
         TUdfModuleLoader loader(
-            UdfModules_,
+            staging,
             &newModules,
             libraryPath,
             remmapings,
             lib->AbiVersion, customUdfPrefix);
         registerFunc(loader, flags);
         Y_ENSURE(!loader.HasError(), loader.GetError());
+
+        with_lock (WriterMutex_) {
+            auto next = MakeIntrusive<TSnapshot>(*State_.AtomicLoad());
+            for (const auto& [name, module] : staging) {
+                Y_UNUSED(module);
+                if (const TUdfModule* oldModule = next->UdfModules.FindPtr(name)) {
+                    ythrow yexception()
+                        << "UDF module duplication: name " << name
+                        << ", already loaded from " << oldModule->LibraryPath
+                        << ", trying to load from " << libraryPath;
+                }
+            }
+            for (auto& [name, module] : staging) {
+                next->UdfModules.emplace(name, std::move(module));
+            }
+            // Ensure library slot exists even if open raced with a placeholder.
+            auto& slot = next->LoadedLibraries[libraryPath];
+            if (!slot) {
+                slot = lib;
+            }
+            State_.AtomicStore(next);
+        }
 
         if (modules) {
             *modules = std::move(newModules);
@@ -213,49 +281,72 @@ public:
         const TStringBuf& moduleName,
         NUdf::TUniquePtr<NUdf::IUdfModule> module) override
     {
-        TWriteGuard guard(Lock_);
-
         TString libraryPathStr(libraryPath);
-        // Track the path for RemoveModule cleanup; multiple in-memory modules may
-        // share one synthetic path (unlike LoadUdfs which opens a real .so once).
-        LoadedLibraries_.emplace(libraryPathStr, nullptr);
-
         TUdfModuleRemappings remappings;
+        TUdfModulesMap staging;
         TUdfModuleLoader loader(
-            UdfModules_, /*newModules=*/nullptr, libraryPathStr,
+            staging, /*newModules=*/nullptr, libraryPathStr,
             remappings, NUdf::CurrentAbiVersion());
         loader.AddModule(moduleName, std::move(module));
-
         Y_ENSURE(!loader.HasError(), loader.GetError());
+
+        with_lock (WriterMutex_) {
+            auto next = MakeIntrusive<TSnapshot>(*State_.AtomicLoad());
+            // Track path for RemoveModule cleanup; multiple in-memory modules may
+            // share one synthetic path (unlike LoadUdfs which opens a real .so once).
+            next->LoadedLibraries.emplace(libraryPathStr, nullptr);
+            for (const auto& [name, staged] : staging) {
+                Y_UNUSED(staged);
+                if (const TUdfModule* oldModule = next->UdfModules.FindPtr(name)) {
+                    ythrow yexception()
+                        << "UDF module duplication: name " << name
+                        << ", already loaded from " << oldModule->LibraryPath
+                        << ", trying to load from " << libraryPathStr;
+                }
+            }
+            for (auto& [name, staged] : staging) {
+                next->UdfModules.emplace(name, std::move(staged));
+            }
+            State_.AtomicStore(next);
+        }
     }
 
     void RemoveModule(const TStringBuf& moduleName) override {
-        TWriteGuard guard(Lock_);
-
-        // Only UdfModules_ / LoadedLibraries_. SystemModulePaths_ is a separate
-        // catalog and must survive unload so FindUdfPath can still resolve it.
-        auto it = UdfModules_.find(TString(moduleName));
-        if (it == UdfModules_.end()) {
-            return;
-        }
-        const TString libraryPath = it->second.LibraryPath;
-        UdfModules_.erase(it);
-        bool pathStillUsed = false;
-        for (const auto& [name, module] : UdfModules_) {
-            Y_UNUSED(name);
-            if (module.LibraryPath == libraryPath) {
-                pathStillUsed = true;
-                break;
+        with_lock (WriterMutex_) {
+            auto cur = State_.AtomicLoad();
+            auto it = cur->UdfModules.find(TString(moduleName));
+            if (it == cur->UdfModules.end()) {
+                return;
             }
-        }
-        if (!pathStillUsed) {
-            LoadedLibraries_.erase(libraryPath);
+
+            auto next = MakeIntrusive<TSnapshot>(*cur);
+            it = next->UdfModules.find(TString(moduleName));
+            Y_ABORT_UNLESS(it != next->UdfModules.end());
+            const TString libraryPath = it->second.LibraryPath;
+            next->UdfModules.erase(it);
+
+            // SystemModulePaths is a separate catalog and must survive unload.
+            bool pathStillUsed = false;
+            for (const auto& [name, module] : next->UdfModules) {
+                Y_UNUSED(name);
+                if (module.LibraryPath == libraryPath) {
+                    pathStillUsed = true;
+                    break;
+                }
+            }
+            if (!pathStillUsed) {
+                next->LoadedLibraries.erase(libraryPath);
+            }
+            State_.AtomicStore(next);
         }
     }
 
     void SetSystemModulePaths(const TUdfModulePathsMap& paths) override {
-        TWriteGuard guard(Lock_);
-        SystemModulePaths_ = paths;
+        with_lock (WriterMutex_) {
+            auto next = MakeIntrusive<TSnapshot>(*State_.AtomicLoad());
+            next->SystemModulePaths = paths;
+            State_.AtomicStore(next);
+        }
     }
 
     const IBuiltinFunctionRegistry::TPtr& GetBuiltins() const override {
@@ -287,9 +378,9 @@ public:
 
         std::shared_ptr<NUdf::IUdfModule> module;
         {
-            TReadGuard guard(Lock_);
-            auto it = UdfModules_.find(moduleName);
-            if (it == UdfModules_.end()) {
+            auto snap = State_.AtomicLoad();
+            auto it = snap->UdfModules.find(moduleName);
+            if (it == snap->UdfModules.end()) {
                 return TStatus::Error()
                        << "Module " << moduleName << " is not registered";
             }
@@ -335,13 +426,13 @@ public:
     }
 
     TMaybe<TString> FindUdfPath(const TStringBuf& moduleName) const override {
-        TReadGuard guard(Lock_);
+        auto snap = State_.AtomicLoad();
 
-        if (const TUdfModule* udf = UdfModules_.FindPtr(moduleName)) {
+        if (const TUdfModule* udf = snap->UdfModules.FindPtr(moduleName)) {
             return udf->LibraryPath;
         }
 
-        if (const TString* path = SystemModulePaths_.FindPtr(moduleName)) {
+        if (const TString* path = snap->SystemModulePaths.FindPtr(moduleName)) {
             return *path;
         }
 
@@ -349,16 +440,14 @@ public:
     }
 
     bool IsLoadedUdfModule(const TStringBuf& moduleName) const override {
-        TReadGuard guard(Lock_);
-        return UdfModules_.contains(moduleName);
+        return State_.AtomicLoad()->UdfModules.contains(moduleName);
     }
 
     THashSet<TString> GetAllModuleNames() const override {
-        TReadGuard guard(Lock_);
-
+        auto snap = State_.AtomicLoad();
         THashSet<TString> names;
-        names.reserve(UdfModules_.size());
-        for (const auto& module : UdfModules_) {
+        names.reserve(snap->UdfModules.size());
+        for (const auto& module : snap->UdfModules) {
             names.insert(module.first);
         }
         return names;
@@ -394,9 +483,9 @@ public:
 
         std::shared_ptr<NUdf::IUdfModule> module;
         {
-            TReadGuard guard(Lock_);
-            const auto it = UdfModules_.find(moduleName);
-            if (UdfModules_.cend() == it) {
+            auto snap = State_.AtomicLoad();
+            const auto it = snap->UdfModules.find(moduleName);
+            if (snap->UdfModules.cend() == it) {
                 return TFunctionsMap();
             }
             module = it->second.Impl;
@@ -407,8 +496,7 @@ public:
     }
 
     bool SupportsSizedAllocators() const override {
-        TReadGuard guard(Lock_);
-        return SupportsSizedAllocators_;
+        return SupportsSizedAllocators_.load(std::memory_order_relaxed);
     }
 
     void PrintInfoTo(IOutputStream& out) const override {
@@ -418,9 +506,9 @@ public:
     void CleanupModulesOnTerminate() const override {
         TVector<std::shared_ptr<NUdf::IUdfModule>> modules;
         {
-            TReadGuard guard(Lock_);
-            modules.reserve(UdfModules_.size());
-            for (const auto& module : UdfModules_) {
+            auto snap = State_.AtomicLoad();
+            modules.reserve(snap->UdfModules.size());
+            for (const auto& module : snap->UdfModules) {
                 modules.push_back(module.second.Impl);
             }
         }
@@ -430,24 +518,23 @@ public:
     }
 
     TIntrusivePtr<IMutableFunctionRegistry> Clone() const override {
-        TReadGuard guard(Lock_);
         return new TDynamicFunctionRegistry(*this);
     }
 
     void SetBackTraceCallback(NUdf::TBackTraceCallback callback) override {
-        TWriteGuard guard(Lock_);
-        BackTraceCallback_ = callback;
+        with_lock (WriterMutex_) {
+            BackTraceCallback_ = callback;
+        }
     }
 
 private:
     const IBuiltinFunctionRegistry::TPtr Builtins_;
 
-    mutable TRWMutex Lock_;
-    THashMap<TString, TUdfLibraryPtr> LoadedLibraries_;
-    TUdfModulesMap UdfModules_;
-    TUdfModulePathsMap SystemModulePaths_;
+    THotSwap<TSnapshot> State_;
+    mutable TAdaptiveLock WriterMutex_;
+    TMutex LoadMutex_;
     NUdf::TBackTraceCallback BackTraceCallback_ = nullptr;
-    bool SupportsSizedAllocators_ = true;
+    std::atomic<bool> SupportsSizedAllocators_{true};
 };
 
 } // namespace

--- a/ydb/core/kqp/common/dynamic_function_registry.cpp
+++ b/ydb/core/kqp/common/dynamic_function_registry.cpp
@@ -15,7 +15,7 @@
 #include <util/system/mutex.h>
 #include <util/system/spinlock.h>
 
-#include <atomic>
+#include <memory>
 #include <utility>
 
 namespace NKikimr::NKqp {
@@ -49,6 +49,8 @@ class TDynamicFunctionRegistry: public IDynamicFunctionRegistry {
         THashMap<TString, TUdfLibraryPtr> LoadedLibraries;
         TUdfModulesMap UdfModules;
         TUdfModulePathsMap SystemModulePaths;
+        NUdf::TBackTraceCallback BackTraceCallback = nullptr;
+        bool SupportsSizedAllocators = true;
 
         TSnapshot() = default;
 
@@ -56,6 +58,8 @@ class TDynamicFunctionRegistry: public IDynamicFunctionRegistry {
             : LoadedLibraries(other.LoadedLibraries)
             , UdfModules(other.UdfModules)
             , SystemModulePaths(other.SystemModulePaths)
+            , BackTraceCallback(other.BackTraceCallback)
+            , SupportsSizedAllocators(other.SupportsSizedAllocators)
         {
         }
     };
@@ -133,17 +137,12 @@ public:
     {
     }
 
-    //! Snapshot is copied; WriterMutex_ / LoadMutex_ are not shared with rhs.
+    //! Snapshot is copied; WriterMutex_ / per-path load mutexes are not shared with rhs.
     TDynamicFunctionRegistry(const TDynamicFunctionRegistry& rhs)
         : IDynamicFunctionRegistry()
         , Builtins_(rhs.Builtins_)
         , State_(MakeIntrusive<TSnapshot>(*rhs.State_.AtomicLoad()))
-        , SupportsSizedAllocators_(
-              rhs.SupportsSizedAllocators_.load(std::memory_order_relaxed))
     {
-        with_lock (rhs.WriterMutex_) {
-            BackTraceCallback_ = rhs.BackTraceCallback_;
-        }
     }
 
     void AllowUdfPatch() override {
@@ -156,9 +155,11 @@ public:
         const TString& customUdfPrefix = {},
         THashSet<TString>* modules = nullptr) override
     {
-        // Serialize unsafe .so entry points; readers stay on wait-free snapshots.
-        // Lock order: LoadMutex_ -> WriterMutex_ (never reverse).
-        TGuard<TMutex> loadGuard(LoadMutex_);
+        // Native .so only (WASM uses AddModule and never enters here).
+        // Per-path mutex: same libraryPath serializes dlopen/Register; different
+        // paths load in parallel. Lock order: path load mutex -> WriterMutex_.
+        auto pathLoadMutex = AcquireNativePathLoadMutex(libraryPath);
+        TGuard<TMutex> loadGuard(*pathLoadMutex);
 
         TUdfLibraryPtr lib;
         NUdf::TBackTraceCallback backTraceCallback = nullptr;
@@ -170,9 +171,7 @@ public:
                 lib = libIt->second;
             } else {
                 needOpen = true;
-                with_lock (WriterMutex_) {
-                    backTraceCallback = BackTraceCallback_;
-                }
+                backTraceCallback = snap->BackTraceCallback;
             }
         }
 
@@ -312,6 +311,7 @@ public:
     }
 
     void RemoveModule(const TStringBuf& moduleName) override {
+        TMaybe<TString> droppedLibraryPath;
         with_lock (WriterMutex_) {
             auto cur = State_.AtomicLoad();
             auto it = cur->UdfModules.find(TString(moduleName));
@@ -336,8 +336,13 @@ public:
             }
             if (!pathStillUsed) {
                 next->LoadedLibraries.erase(libraryPath);
+                droppedLibraryPath = libraryPath;
             }
             State_.AtomicStore(next);
+        }
+        // Drop per-path load mutex after publish (lock order: never under WriterMutex_).
+        if (droppedLibraryPath) {
+            ReleaseNativePathLoadMutex(*droppedLibraryPath);
         }
     }
 
@@ -496,7 +501,7 @@ public:
     }
 
     bool SupportsSizedAllocators() const override {
-        return SupportsSizedAllocators_.load(std::memory_order_relaxed);
+        return State_.AtomicLoad()->SupportsSizedAllocators;
     }
 
     void PrintInfoTo(IOutputStream& out) const override {
@@ -523,18 +528,36 @@ public:
 
     void SetBackTraceCallback(NUdf::TBackTraceCallback callback) override {
         with_lock (WriterMutex_) {
-            BackTraceCallback_ = callback;
+            auto next = MakeIntrusive<TSnapshot>(*State_.AtomicLoad());
+            next->BackTraceCallback = callback;
+            State_.AtomicStore(next);
         }
     }
 
 private:
+    //! Per libraryPath mutex for native LoadUdfs (dlopen/Register). WASM uses AddModule.
+    std::shared_ptr<TMutex> AcquireNativePathLoadMutex(const TString& libraryPath) {
+        with_lock (PathLoadMutexesLock_) {
+            auto& slot = PathLoadMutexes_[libraryPath];
+            if (!slot) {
+                slot = std::make_shared<TMutex>();
+            }
+            return slot;
+        }
+    }
+
+    void ReleaseNativePathLoadMutex(const TString& libraryPath) {
+        with_lock (PathLoadMutexesLock_) {
+            PathLoadMutexes_.erase(libraryPath);
+        }
+    }
+
     const IBuiltinFunctionRegistry::TPtr Builtins_;
 
     THotSwap<TSnapshot> State_;
     mutable TAdaptiveLock WriterMutex_;
-    TMutex LoadMutex_;
-    NUdf::TBackTraceCallback BackTraceCallback_ = nullptr;
-    std::atomic<bool> SupportsSizedAllocators_{true};
+    TAdaptiveLock PathLoadMutexesLock_;
+    THashMap<TString, std::shared_ptr<TMutex>> PathLoadMutexes_;
 };
 
 } // namespace

--- a/ydb/core/kqp/common/dynamic_function_registry.h
+++ b/ydb/core/kqp/common/dynamic_function_registry.h
@@ -4,6 +4,16 @@
 
 namespace NKikimr::NKqp {
 
+//! Thread-safe mutable UDF registry with RemoveModule.
+//!
+//! Contract for a single instance:
+//! - All methods may be called concurrently from multiple threads.
+//! - Mutations (LoadUdfs / AddModule / RemoveModule / Set*) are serialized.
+//! - Concurrent Find* / Get* during RemoveModule either observe the module
+//!   (and keep it alive via shared_ptr for the duration of the module call)
+//!   or get "not registered" — never use-after-free.
+//! - Clone() takes a consistent snapshot under a shared lock; the clone is
+//!   independent of the source.
 class IDynamicFunctionRegistry: public NMiniKQL::IMutableFunctionRegistry {
 public:
     using TPtr = TIntrusivePtr<IDynamicFunctionRegistry>;
@@ -17,6 +27,7 @@ public:
 
 //! Creates a dynamic registry (full mutable UDF registry + RemoveModule).
 //! Returned as IMutableFunctionRegistry; cast to IDynamicFunctionRegistry for RemoveModule.
+//! The returned instance is thread-safe (see IDynamicFunctionRegistry).
 TIntrusivePtr<NMiniKQL::IMutableFunctionRegistry> CreateDynamicFunctionRegistry(
     NMiniKQL::IBuiltinFunctionRegistry::TPtr&& builtins);
 

--- a/ydb/core/kqp/common/dynamic_function_registry.h
+++ b/ydb/core/kqp/common/dynamic_function_registry.h
@@ -4,23 +4,27 @@
 
 namespace NKikimr::NKqp {
 
-//! Thread-safe mutable UDF registry with RemoveModule.
+//! Hot-mutable UDF registry with RemoveModule (WASM / dynamic load).
 //!
-//! Contract for a single instance:
-//! - All methods may be called concurrently from multiple threads.
-//! - Mutations (LoadUdfs / AddModule / RemoveModule / Set*) are serialized.
-//! - Concurrent Find* / Get* during RemoveModule either observe the module
-//!   (and keep it alive via shared_ptr for the duration of the module call)
-//!   or get "not registered" — never use-after-free.
-//! - Clone() takes a consistent snapshot under a shared lock; the clone is
-//!   independent of the source.
+//! Concurrency model (actor-friendly):
+//! - Readers (Find* / Get* / IsLoaded*) are wait-free via an immutable snapshot
+//!   (THotSwap): no registry lock is held across module callbacks.
+//! - Mutations (AddModule / RemoveModule / Set* / committing LoadUdfs) publish a
+//!   new snapshot under a short writer lock (COW). Concurrent mutations from
+//!   multiple threads/actors are supported; writers briefly serialize on publish.
+//! - After RemoveModule publishes, new lookups do not observe the module
+//!   (no phantom re-fetch). An in-flight call that already held shared_ptr may
+//!   still finish — never use-after-free.
+//! - LoadUdfs runs dlopen / Register under a separate load mutex (not on the
+//!   reader path); do not hold actor mailboxes across that work when possible.
+//! - Clone() copies the current snapshot; module Impl pointers are shared.
 class IDynamicFunctionRegistry: public NMiniKQL::IMutableFunctionRegistry {
 public:
     using TPtr = TIntrusivePtr<IDynamicFunctionRegistry>;
 
     //! Unloads a dynamically registered module by YQL module name. No-op if missing.
-    //! Drops the LoadedLibraries_ entry when no modules from that path remain.
-    //! Does not modify SystemModulePaths_: FindUdfPath may still return a system
+    //! Drops the LoadedLibraries entry when no modules from that path remain.
+    //! Does not modify SystemModulePaths: FindUdfPath may still return a system
     //! catalog path after unload (same as for never-loaded system modules).
     virtual void RemoveModule(const TStringBuf& moduleName) = 0;
 };

--- a/ydb/core/kqp/common/dynamic_function_registry.h
+++ b/ydb/core/kqp/common/dynamic_function_registry.h
@@ -15,9 +15,14 @@ namespace NKikimr::NKqp {
 //! - After RemoveModule publishes, new lookups do not observe the module
 //!   (no phantom re-fetch). An in-flight call that already held shared_ptr may
 //!   still finish — never use-after-free.
-//! - LoadUdfs runs dlopen / Register under a separate load mutex (not on the
-//!   reader path); do not hold actor mailboxes across that work when possible.
-//! - Clone() copies the current snapshot; module Impl pointers are shared.
+//! - LoadUdfs is for native .so modules only (WASM registers via AddModule).
+//!   Per libraryPath it serializes dlopen / Register so the same .so is not
+//!   opened/registered concurrently; different paths do not block each other.
+//!   Prefer not holding an actor mailbox across that work when possible.
+//! - Clone() copies the current snapshot (including BackTraceCallback /
+//!   SupportsSizedAllocators); module Impl pointers are shared.
+//! - Native per-path load mutexes are dropped when the last module for that
+//!   libraryPath is removed.
 class IDynamicFunctionRegistry: public NMiniKQL::IMutableFunctionRegistry {
 public:
     using TPtr = TIntrusivePtr<IDynamicFunctionRegistry>;

--- a/ydb/core/kqp/common/ut/dynamic_function_registry_ut.cpp
+++ b/ydb/core/kqp/common/ut/dynamic_function_registry_ut.cpp
@@ -13,6 +13,9 @@
 
 #include <util/stream/str.h>
 
+#include <atomic>
+#include <thread>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 using namespace NKikimr;
@@ -318,6 +321,124 @@ Y_UNIT_TEST(PrintInfoToDoesNotCrash) {
     auto registry = MakeRegistry();
     TStringStream out;
     registry->PrintInfoTo(out);
+}
+
+Y_UNIT_TEST(ConcurrentLookupDuringRemove) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule("Bar"));
+
+    std::atomic<bool> stop{false};
+    std::atomic<ui64> lookups{0};
+    std::atomic<ui64> errors{0};
+    constexpr size_t readerCount = 8;
+
+    TVector<std::thread> readers;
+    readers.reserve(readerCount);
+    for (size_t i = 0; i < readerCount; ++i) {
+        readers.emplace_back([&] {
+            TScopedAlloc alloc(__LOCATION__);
+            TTypeEnvironment env(alloc);
+            NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+            auto runtimeSettings = NYql::MakeRuntimeSettings();
+
+            while (!stop.load(std::memory_order_relaxed)) {
+                TFunctionTypeInfo funcInfo;
+                auto status = LookupTypeInfo(
+                    *registry, env, typeInfoHelper, *runtimeSettings, "Foo.Bar", &funcInfo);
+                lookups.fetch_add(1, std::memory_order_relaxed);
+                if (!status.IsOk()) {
+                    errors.fetch_add(1, std::memory_order_relaxed);
+                }
+                Y_UNUSED(registry->IsLoadedUdfModule("Foo"));
+            }
+        });
+    }
+
+    // Let readers warm up, then unload under concurrent lookups.
+    while (lookups.load(std::memory_order_relaxed) < 100) {
+        std::this_thread::yield();
+    }
+    Dyn(registry.Get())->RemoveModule("Foo");
+    stop.store(true, std::memory_order_relaxed);
+
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT_GT(lookups.load(), 0u);
+    // After remove some lookups may fail; before remove they must have succeeded.
+    // We only require no crash / use-after-free (survived joins).
+    Y_UNUSED(errors);
+}
+
+Y_UNIT_TEST(ConcurrentAddAndLookup) {
+    auto registry = MakeRegistry();
+    constexpr size_t moduleCount = 32;
+    constexpr size_t writerCount = 4;
+    constexpr size_t readerCount = 4;
+
+    std::atomic<size_t> nextIndex{0};
+    std::atomic<bool> writersDone{false};
+
+    TVector<std::thread> writers;
+    writers.reserve(writerCount);
+    for (size_t w = 0; w < writerCount; ++w) {
+        writers.emplace_back([&] {
+            for (;;) {
+                const size_t i = nextIndex.fetch_add(1, std::memory_order_relaxed);
+                if (i >= moduleCount) {
+                    break;
+                }
+                const TString name = TStringBuilder() << "Mod" << i;
+                registry->AddModule(
+                    TStringBuilder() << "/lib/" << i,
+                    name,
+                    new TStubUdfModule("Func"));
+            }
+        });
+    }
+
+    TVector<std::thread> readers;
+    readers.reserve(readerCount);
+    for (size_t r = 0; r < readerCount; ++r) {
+        readers.emplace_back([&] {
+            TScopedAlloc alloc(__LOCATION__);
+            TTypeEnvironment env(alloc);
+            NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+            auto runtimeSettings = NYql::MakeRuntimeSettings();
+
+            while (!writersDone.load(std::memory_order_acquire)) {
+                for (size_t i = 0; i < moduleCount; ++i) {
+                    const TString name = TStringBuilder() << "Mod" << i;
+                    if (registry->IsLoadedUdfModule(name)) {
+                        TFunctionTypeInfo funcInfo;
+                        auto status = LookupTypeInfo(
+                            *registry, env, typeInfoHelper, *runtimeSettings,
+                            TStringBuilder() << name << ".Func", &funcInfo);
+                        UNIT_ASSERT_C(status.IsOk(), status.GetError());
+                    }
+                }
+            }
+        });
+    }
+
+    for (auto& t : writers) {
+        t.join();
+    }
+    writersDone.store(true, std::memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(registry->GetAllModuleNames().size(), moduleCount);
+    for (size_t i = 0; i < moduleCount; ++i) {
+        const TString name = TStringBuilder() << "Mod" << i;
+        UNIT_ASSERT(registry->IsLoadedUdfModule(name));
+        UNIT_ASSERT_VALUES_EQUAL(
+            *registry->FindUdfPath(name),
+            TStringBuilder() << "/lib/" << i);
+    }
 }
 
 } // Y_UNIT_TEST_SUITE(TDynamicFunctionRegistryTest)

--- a/ydb/core/kqp/common/ut/dynamic_function_registry_ut.cpp
+++ b/ydb/core/kqp/common/ut/dynamic_function_registry_ut.cpp
@@ -73,6 +73,49 @@ private:
     ui32* CleanupCounter_;
 };
 
+//! Blocks inside BuildFunctionTypeInfo until Release_ is set (for remove-during-call tests).
+class TBlockingUdfModule: public NUdf::IUdfModule {
+public:
+    TBlockingUdfModule(
+        std::atomic<bool>& entered,
+        std::atomic<bool>& release,
+        TString functionName = "Bar")
+        : Entered_(entered)
+        , Release_(release)
+        , FunctionName_(std::move(functionName))
+    {
+    }
+
+    void GetAllFunctions(NUdf::IFunctionsSink& sink) const override {
+        sink.Add(FunctionName_);
+    }
+
+    void BuildFunctionTypeInfo(
+        const NUdf::TStringRef& name,
+        NUdf::TType* /*userType*/,
+        const NUdf::TStringRef& /*typeConfig*/,
+        ui32 /*flags*/,
+        NUdf::IFunctionTypeInfoBuilder& builder) const override
+    {
+        if (name != NUdf::TStringRef(FunctionName_)) {
+            return;
+        }
+        Entered_.store(true, std::memory_order_release);
+        while (!Release_.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        builder.SimpleSignature<i32(i32)>();
+    }
+
+    void CleanupOnTerminate() const override {
+    }
+
+private:
+    std::atomic<bool>& Entered_;
+    std::atomic<bool>& Release_;
+    const TString FunctionName_;
+};
+
 TIntrusivePtr<IMutableFunctionRegistry> MakeRegistry() {
     auto registry = CreateDynamicFunctionRegistry(CreateBuiltinRegistry());
     UNIT_ASSERT(AsDynamicFunctionRegistry(registry.Get()));
@@ -324,67 +367,81 @@ Y_UNIT_TEST(PrintInfoToDoesNotCrash) {
 }
 
 Y_UNIT_TEST(ConcurrentLookupDuringRemove) {
+    // Force RemoveModule while BuildFunctionTypeInfo is in-flight so the
+    // shared_ptr lifetime path is actually exercised (not just completed lookups).
+    std::atomic<bool> entered{false};
+    std::atomic<bool> release{false};
+
     auto registry = MakeRegistry();
-    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule("Bar"));
+    registry->AddModule(
+        "/lib/foo",
+        "Foo",
+        new TBlockingUdfModule(entered, release, "Bar"));
 
-    std::atomic<bool> stop{false};
-    std::atomic<ui64> lookups{0};
-    std::atomic<ui64> errors{0};
-    constexpr size_t readerCount = 8;
+    std::atomic<bool> lookupOk{false};
+    std::thread lookupThread([&] {
+        TScopedAlloc alloc(__LOCATION__);
+        TTypeEnvironment env(alloc);
+        NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+        auto runtimeSettings = NYql::MakeRuntimeSettings();
 
-    TVector<std::thread> readers;
-    readers.reserve(readerCount);
-    for (size_t i = 0; i < readerCount; ++i) {
-        readers.emplace_back([&] {
-            TScopedAlloc alloc(__LOCATION__);
-            TTypeEnvironment env(alloc);
-            NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
-            auto runtimeSettings = NYql::MakeRuntimeSettings();
+        TFunctionTypeInfo funcInfo;
+        auto status = LookupTypeInfo(
+            *registry, env, typeInfoHelper, *runtimeSettings, "Foo.Bar", &funcInfo);
+        lookupOk.store(status.IsOk() && funcInfo.FunctionType != nullptr,
+                       std::memory_order_relaxed);
+    });
 
-            while (!stop.load(std::memory_order_relaxed)) {
-                TFunctionTypeInfo funcInfo;
-                auto status = LookupTypeInfo(
-                    *registry, env, typeInfoHelper, *runtimeSettings, "Foo.Bar", &funcInfo);
-                lookups.fetch_add(1, std::memory_order_relaxed);
-                if (!status.IsOk()) {
-                    errors.fetch_add(1, std::memory_order_relaxed);
-                }
-                Y_UNUSED(registry->IsLoadedUdfModule("Foo"));
-            }
-        });
-    }
-
-    // Let readers warm up, then unload under concurrent lookups.
-    while (lookups.load(std::memory_order_relaxed) < 100) {
+    while (!entered.load(std::memory_order_acquire)) {
         std::this_thread::yield();
     }
-    Dyn(registry.Get())->RemoveModule("Foo");
-    stop.store(true, std::memory_order_relaxed);
 
-    for (auto& t : readers) {
-        t.join();
+    Dyn(registry.Get())->RemoveModule("Foo");
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Foo"));
+
+    // No phantom: new lookup after publish must not see the removed module.
+    {
+        TScopedAlloc alloc(__LOCATION__);
+        TTypeEnvironment env(alloc);
+        NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+        auto runtimeSettings = NYql::MakeRuntimeSettings();
+        TFunctionTypeInfo funcInfo;
+        auto status = LookupTypeInfo(
+            *registry, env, typeInfoHelper, *runtimeSettings, "Foo.Bar", &funcInfo);
+        UNIT_ASSERT(!status.IsOk());
     }
 
-    UNIT_ASSERT(!registry->IsLoadedUdfModule("Foo"));
-    UNIT_ASSERT_GT(lookups.load(), 0u);
-    // After remove some lookups may fail; before remove they must have succeeded.
-    // We only require no crash / use-after-free (survived joins).
-    Y_UNUSED(errors);
+    release.store(true, std::memory_order_release);
+    lookupThread.join();
+
+    UNIT_ASSERT(lookupOk.load(std::memory_order_relaxed));
 }
 
 Y_UNIT_TEST(ConcurrentAddAndLookup) {
     auto registry = MakeRegistry();
-    constexpr size_t moduleCount = 32;
+    constexpr size_t moduleCount = 64;
     constexpr size_t writerCount = 4;
     constexpr size_t readerCount = 4;
+    constexpr size_t totalThreads = writerCount + readerCount;
 
     std::atomic<size_t> nextIndex{0};
+    std::atomic<size_t> readyCount{0};
+    std::atomic<bool> go{false};
     std::atomic<bool> writersDone{false};
+    std::atomic<ui64> lookupsWhileWriting{0};
+
+    auto waitStart = [&] {
+        readyCount.fetch_add(1, std::memory_order_acq_rel);
+        while (!go.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+    };
 
     TVector<std::thread> writers;
     writers.reserve(writerCount);
     for (size_t w = 0; w < writerCount; ++w) {
         writers.emplace_back([&] {
+            waitStart();
             for (;;) {
                 const size_t i = nextIndex.fetch_add(1, std::memory_order_relaxed);
                 if (i >= moduleCount) {
@@ -396,6 +453,11 @@ Y_UNIT_TEST(ConcurrentAddAndLookup) {
                     name,
                     new TStubUdfModule("Func"));
             }
+            // Do not leave the writing window until a reader has observed an
+            // in-flight add (avoids the flake where all writers finish first).
+            while (lookupsWhileWriting.load(std::memory_order_acquire) == 0) {
+                std::this_thread::yield();
+            }
         });
     }
 
@@ -403,6 +465,7 @@ Y_UNIT_TEST(ConcurrentAddAndLookup) {
     readers.reserve(readerCount);
     for (size_t r = 0; r < readerCount; ++r) {
         readers.emplace_back([&] {
+            waitStart();
             TScopedAlloc alloc(__LOCATION__);
             TTypeEnvironment env(alloc);
             NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
@@ -417,11 +480,19 @@ Y_UNIT_TEST(ConcurrentAddAndLookup) {
                             *registry, env, typeInfoHelper, *runtimeSettings,
                             TStringBuilder() << name << ".Func", &funcInfo);
                         UNIT_ASSERT_C(status.IsOk(), status.GetError());
+                        if (!writersDone.load(std::memory_order_acquire)) {
+                            lookupsWhileWriting.fetch_add(1, std::memory_order_release);
+                        }
                     }
                 }
             }
         });
     }
+
+    while (readyCount.load(std::memory_order_acquire) < totalThreads) {
+        std::this_thread::yield();
+    }
+    go.store(true, std::memory_order_release);
 
     for (auto& t : writers) {
         t.join();
@@ -431,6 +502,7 @@ Y_UNIT_TEST(ConcurrentAddAndLookup) {
         t.join();
     }
 
+    UNIT_ASSERT_GT(lookupsWhileWriting.load(std::memory_order_relaxed), 0u);
     UNIT_ASSERT_VALUES_EQUAL(registry->GetAllModuleNames().size(), moduleCount);
     for (size_t i = 0; i < moduleCount; ++i) {
         const TString name = TStringBuilder() << "Mod" << i;
@@ -439,6 +511,127 @@ Y_UNIT_TEST(ConcurrentAddAndLookup) {
             *registry->FindUdfPath(name),
             TStringBuilder() << "/lib/" << i);
     }
+}
+
+Y_UNIT_TEST(ConcurrentAddRemoveAndLookup) {
+    auto registry = MakeRegistry();
+    constexpr size_t moduleCount = 64;
+    constexpr size_t writerCount = 4;
+    constexpr size_t removerCount = 2;
+    constexpr size_t readerCount = 4;
+    constexpr size_t totalThreads = writerCount + removerCount + readerCount;
+
+    std::atomic<size_t> nextAdd{0};
+    std::atomic<size_t> nextRemove{0};
+    std::atomic<size_t> readyCount{0};
+    std::atomic<bool> go{false};
+    std::atomic<bool> mutationsDone{false};
+    std::atomic<ui64> successfulLookups{0};
+
+    auto waitStart = [&] {
+        readyCount.fetch_add(1, std::memory_order_acq_rel);
+        while (!go.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+    };
+
+    TVector<std::thread> writers;
+    writers.reserve(writerCount);
+    for (size_t w = 0; w < writerCount; ++w) {
+        writers.emplace_back([&] {
+            waitStart();
+            for (;;) {
+                const size_t i = nextAdd.fetch_add(1, std::memory_order_relaxed);
+                if (i >= moduleCount) {
+                    break;
+                }
+                registry->AddModule(
+                    TStringBuilder() << "/lib/" << i,
+                    TStringBuilder() << "Mod" << i,
+                    new TStubUdfModule("Func"));
+            }
+        });
+    }
+
+    TVector<std::thread> removers;
+    removers.reserve(removerCount);
+    for (size_t r = 0; r < removerCount; ++r) {
+        removers.emplace_back([&] {
+            waitStart();
+            for (;;) {
+                // Remove even-indexed modules once (and only once) each.
+                const size_t i = nextRemove.fetch_add(1, std::memory_order_relaxed) * 2;
+                if (i >= moduleCount) {
+                    break;
+                }
+                const TString name = TStringBuilder() << "Mod" << i;
+                while (!mutationsDone.load(std::memory_order_acquire) &&
+                       !registry->IsLoadedUdfModule(name))
+                {
+                    std::this_thread::yield();
+                }
+                Dyn(registry.Get())->RemoveModule(name);
+            }
+        });
+    }
+
+    TVector<std::thread> readers;
+    readers.reserve(readerCount);
+    for (size_t r = 0; r < readerCount; ++r) {
+        readers.emplace_back([&] {
+            waitStart();
+            TScopedAlloc alloc(__LOCATION__);
+            TTypeEnvironment env(alloc);
+            NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+            auto runtimeSettings = NYql::MakeRuntimeSettings();
+
+            while (!mutationsDone.load(std::memory_order_acquire)) {
+                for (size_t i = 0; i < moduleCount; ++i) {
+                    const TString name = TStringBuilder() << "Mod" << i;
+                    TFunctionTypeInfo funcInfo;
+                    auto status = LookupTypeInfo(
+                        *registry, env, typeInfoHelper, *runtimeSettings,
+                        TStringBuilder() << name << ".Func", &funcInfo);
+                    if (status.IsOk()) {
+                        successfulLookups.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    // Else: not registered yet, or already removed — both OK.
+                }
+            }
+        });
+    }
+
+    while (readyCount.load(std::memory_order_acquire) < totalThreads) {
+        std::this_thread::yield();
+    }
+    go.store(true, std::memory_order_release);
+
+    for (auto& t : writers) {
+        t.join();
+    }
+    for (auto& t : removers) {
+        t.join();
+    }
+    mutationsDone.store(true, std::memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    UNIT_ASSERT_GT(successfulLookups.load(std::memory_order_relaxed), 0u);
+
+    // Even modules removed; odd modules remain. No phantom of removed names.
+    for (size_t i = 0; i < moduleCount; ++i) {
+        const TString name = TStringBuilder() << "Mod" << i;
+        if ((i % 2) == 0) {
+            UNIT_ASSERT(!registry->IsLoadedUdfModule(name));
+        } else {
+            UNIT_ASSERT(registry->IsLoadedUdfModule(name));
+            UNIT_ASSERT_VALUES_EQUAL(
+                *registry->FindUdfPath(name),
+                TStringBuilder() << "/lib/" << i);
+        }
+    }
+    UNIT_ASSERT_VALUES_EQUAL(registry->GetAllModuleNames().size(), moduleCount / 2);
 }
 
 } // Y_UNIT_TEST_SUITE(TDynamicFunctionRegistryTest)

--- a/ydb/core/kqp/common/ya.make
+++ b/ydb/core/kqp/common/ya.make
@@ -31,6 +31,7 @@ PEERDIR(
     library/cpp/json/writer
     library/cpp/lwtrace
     library/cpp/protobuf/json
+    library/cpp/threading/hot_swap
     ydb/core/base
     ydb/core/engine
     ydb/core/grpc_services/cancelation


### PR DESCRIPTION
## Summary

Makes `TDynamicFunctionRegistry` safe for concurrent use from actor/compute threads: hot `AddModule` / `RemoveModule` (WASM UDF Store) alongside wait-free lookups during query compile/execution.

Replaces a naive whole-registry lock with an immutable snapshot published via `THotSwap` (COW):

- **Reads** (`Find*` / `Get*` / `IsLoaded*`): wait-free snapshot load; no registry lock across module callbacks
- **Writes** (`AddModule` / `RemoveModule` / `Set*` / commit of `LoadUdfs`): short writer lock, publish a new snapshot
- **Native `LoadUdfs`**: per-`libraryPath` mutex for `dlopen` / `Register` so the same `.so` is not opened concurrently; different paths do not block each other
- After `RemoveModule` publish, new lookups do not see the module (no phantom); in-flight holders of `shared_ptr` can finish without UAF

See also: [RFC 013 — Dynamic Function Registry](https://github.com/akulaad/ydb-rfc/blob/wasm_bridge_rfc/wasm/rfc/013_dynamic_function_registry.md) (YQ-5574).

## Test plan

- [x] Unit tests for `RemoveModule`, `Clone`, lookup/metadata paths
- [x] Concurrent tests: lookup during remove; concurrent add + lookup; concurrent add/remove/lookup
- [ ] `./ya make --build relwithdebinfo -tA ydb/core/kqp/common/ut -F *DynamicFunctionRegistry*`