### PR TITLE
ydb-bench: add local YDB workload benchmark

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -2,17 +2,19 @@
 
 `ydb_bench` packages actor benchmark executables into one Python tool and runs
 reproducible benchmark profiles described by a YAML file. Build it with the
-profile build type so the same binary can also be used with `perf`:
+profile build type when embedded `ydb` and `ydbd` symbols are needed. Other
+build types store stripped server and CLI binaries to keep the bundle compact:
 
 ```bash
 ./ya make --build=profile ydb/tools/ydb_bench
 ```
 
-The tool provides three benchmarks:
+The tool provides four benchmarks:
 
 - `ping-bench`: pairwise actor ping throughput;
 - `star-ping-bench`: star-topology actor ping throughput.
 - `memory-bandwidth-bench`: mixed sequential-copy and random copy/write memory workload.
+- `local-ydb`: a local static/dynamic YDB cluster driven by `ydb workload kv`.
 
 Inspect them and print the standard JSON Schema for the YAML configuration:
 
@@ -69,7 +71,110 @@ memory-bandwidth-bench:
     duration: 3
     repetitions: 3
     affinity: [none, pack-numa, spread-numa-pack-chiplet]
+
+local-ydb:
+  storage-capacity:
+    workload:
+      type: kv
+      operation: upsert
+      options:
+        init-upserts: 1000
+    geometry:
+      preset: storage
+      static-nodes: 2
+      dynamic-nodes: 1
+      max-dynamic-nodes: 8
+      disk-size-gb: 64
+      storage-groups: 1
+    client:
+      threads: 64
+    load:
+      parameter: rate
+      allow-errors: false
+      search:
+        start: 1000
+        maximum: 1000000
+        resolution-percent: 2
+      objective:
+        type: maximize-throughput
+        target-role: static
+    measurement:
+      warmup: 10
+      duration: 30
+      repetitions: 3
+    affinity:
+      ydb-cli:
+        mode: pack-numa-pack-chiplet-spread-core
+        cpus: one-chiplet
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none
 ```
+
+The local YDB benchmark bundles `ydbd` and the YDB CLI, creates an isolated
+Config V2 cluster backed by in-memory SectorMap PDisks, and stops it after the
+profile. `single` always uses one dynamic node. `storage` may grow the
+dynamic-node count up to `max-dynamic-nodes` when dynamic CPU is saturated but
+static/storage CPU is not; `custom` keeps the explicitly requested geometry.
+Each static node gets its own `NONE`-profile SectorMap with the virtual size
+specified by `disk-size-gb`, so benchmark results are not limited by a host
+block device.
+
+`load.parameter` selects the one monotonic YDB CLI setting controlled by the
+benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. A
+`values` list measures exact points. For adaptive runs, `search` defines the
+range and resolution. `maximize-throughput` uses a discrete ternary search and
+prefers the lowest load with the best observed throughput; a plateau is
+confirmed only when the selected role's CPU is saturated. `latency-slo` uses
+the configured `multiplier` to find the first failing point, then a binary
+search to find the highest load whose millisecond percentile, error count, and
+achieved-rate ratio satisfy the SLO. For example:
+
+```yaml
+    load:
+      parameter: rate
+      search:
+        start: 1000
+        maximum: 1000000
+        multiplier: 2
+        resolution-percent: 2
+      objective:
+        type: latency-slo
+        percentile: p99
+        max-ms: 10
+        max-errors: 0
+        min-achieved-rate-ratio: 0.98
+```
+
+Set `load.allow-errors: true` when request-level errors reported by
+`ydb workload` are an expected part of the experiment. Such points remain
+eligible for selection and the error counts stay in CSV, manifests, tables,
+and charts. The flag does not hide or tolerate a failed CLI process, timeout,
+malformed output, cluster failure, or workload setup/cleanup failure. For a
+latency SLO, it disables the `max-errors` rejection while keeping the latency
+and achieved-rate checks active.
+
+The previous flat `mode`, `start`, and `slo` fields remain accepted for config
+compatibility, but newly generated YAML uses `search` and `objective`.
+
+During a local YDB run, the CLI reports cluster startup, workload initialization,
+warmup, measurement, cleanup, evaluation, and dynamic-node scaling milestones.
+The web profile page shows the same live phase with elapsed time and a countdown
+for warmup and measurement. Completed attempts appear immediately on synchronized
+search-order charts for candidate load, current best load, throughput, latency,
+CPU by role, errors, and retries. Geometry stages and the chronological attempt
+table remain available after completion. Profile `run.json` stores attempt and
+stage timestamps, durations, structured decisions, scaling actions, and the
+final outcome so consumers do not have to parse diagnostic text.
+
+Linux CPU metrics are sampled independently for static nodes, dynamic nodes,
+the YDB CLI, and the whole host. Role affinity uses the existing placement
+modes. `mode: none` deliberately leaves YDB server placement to Linux; the CLI
+is pinned to one chiplet by default and its mask stays fixed throughout the
+search. The web UI Builder edits workload, geometry, load controller,
+measurement, and per-role affinity settings; the YAML tab exposes the same
+portable configuration directly.
 
 The memory benchmark runs every matrix combination in a separate process. Each
 worker owns and first-touches its private buffer after process affinity has been

--- a/ydb/tools/ydb_bench/benchmarks/__init__.py
+++ b/ydb/tools/ydb_bench/benchmarks/__init__.py
@@ -1,7 +1,15 @@
 """Benchmark adapters and the registry used by ydb_bench."""
 
 from ydb.tools.ydb_bench.benchmarks.actors import PING_BENCHMARK, STAR_PING_BENCHMARK
+from ydb.tools.ydb_bench.benchmarks.local_ydb import LOCAL_YDB_BENCHMARK
 from ydb.tools.ydb_bench.benchmarks.memory import MEMORY_BENCHMARK
 from ydb.tools.ydb_bench.benchmarks.registry import BENCHMARKS, BenchmarkRegistry
 
-__all__ = ("BENCHMARKS", "BenchmarkRegistry", "PING_BENCHMARK", "STAR_PING_BENCHMARK", "MEMORY_BENCHMARK")
+__all__ = (
+    "BENCHMARKS",
+    "BenchmarkRegistry",
+    "PING_BENCHMARK",
+    "STAR_PING_BENCHMARK",
+    "MEMORY_BENCHMARK",
+    "LOCAL_YDB_BENCHMARK",
+)

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -1,0 +1,150 @@
+"""Local YDB capacity benchmark metadata and YDB CLI result parsing."""
+
+import csv
+import io
+import statistics
+
+from ydb.tools.ydb_bench.benchmarks.registry import (
+    BENCHMARKS,
+    BenchmarkDefinition,
+    DimensionDefinition,
+    MetricDefinition,
+)
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+DIMENSIONS = (
+    DimensionDefinition("load"),
+    DimensionDefinition("dynamic_nodes"),
+)
+METRICS = tuple(
+    MetricDefinition(name, unit)
+    for name, unit in (
+        ("transactions", "transactions"),
+        ("throughput", "transactions/s"),
+        ("retries", "retries"),
+        ("errors", "errors"),
+        ("p50_ms", "ms"),
+        ("p95_ms", "ms"),
+        ("p99_ms", "ms"),
+        ("pmax_ms", "ms"),
+        ("static_cpu_mean", "%"),
+        ("static_cpu_max", "%"),
+        ("dynamic_cpu_mean", "%"),
+        ("dynamic_cpu_max", "%"),
+        ("cli_cpu_mean", "%"),
+        ("cli_cpu_max", "%"),
+        ("host_cpu_mean", "%"),
+        ("host_cpu_max", "%"),
+    )
+)
+
+
+def parse_cli_metrics(stdout):
+    """Parse the stable Total table printed by generic ``ydb workload``."""
+    lines = [line.strip() for line in stdout.splitlines()]
+    for index, line in enumerate(lines):
+        columns = line.split()
+        if not columns or columns[0] != "Total":
+            continue
+        for values_line in lines[index + 1 :]:
+            values = values_line.split()
+            if not values:
+                continue
+            # Current CLI prints the total duration in the first column below
+            # the "Total" heading.  Older builds omitted that value.
+            if len(values) == 9:
+                values = values[1:]
+            if len(values) != 8:
+                break
+            try:
+                return {
+                    "transactions": int(values[0]),
+                    "throughput": float(values[1]),
+                    "retries": int(values[2]),
+                    "errors": int(values[3]),
+                    "p50_ms": float(values[4]),
+                    "p95_ms": float(values[5]),
+                    "p99_ms": float(values[6]),
+                    "pmax_ms": float(values[7]),
+                }
+            except ValueError:
+                break
+    raise BenchmarkError("YDB CLI workload output does not contain a valid Total row")
+
+
+def parse_metrics(stdout, _benchmark):
+    return [parse_cli_metrics(stdout)]
+
+
+def render_metrics(rows, benchmark):
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=benchmark.csv_columns, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def validate_metrics(rows, configuration, _case):
+    if len(rows) != 1:
+        raise BenchmarkError("local YDB workload must produce exactly one aggregate row")
+    allow_errors = configuration.parameters["local_ydb"]["load"].get("allow_errors", False)
+    if rows[0]["errors"] and not allow_errors:
+        raise BenchmarkError("YDB CLI workload reported {} errors".format(rows[0]["errors"]))
+
+
+def summarize_metrics(repetition_rows, benchmark):
+    grouped = {}
+    for row in repetition_rows:
+        key = tuple(row[item.name] for item in benchmark.dimensions)
+        grouped.setdefault(key, []).append(row)
+    result = []
+    for key in sorted(grouped):
+        rows = grouped[key]
+        record = {item.name: value for item, value in zip(benchmark.dimensions, key)}
+        record["samples"] = len(rows)
+        for metric in benchmark.metrics:
+            values = [row[metric.name] for row in rows]
+            record["median_" + metric.name] = statistics.median(values)
+            record["min_" + metric.name] = min(values)
+            record["max_" + metric.name] = max(values)
+        result.append(record)
+    return result
+
+
+def render_summary(rows, benchmark):
+    columns = [item.name for item in benchmark.dimensions] + ["samples"]
+    for metric in benchmark.metrics:
+        columns += ["median_" + metric.name, "min_" + metric.name, "max_" + metric.name]
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def process_cases(configuration):
+    return ({"threads": configuration.threads[0], "parameters": {}},)
+
+
+LOCAL_YDB_BENCHMARK = BENCHMARKS.register(
+    BenchmarkDefinition(
+        name="local-ydb",
+        description="local YDB cluster capacity under YDB CLI workload",
+        resource_name="ydb_cli",
+        resource_names=("ydbd", "ydb_cli", "process_guard"),
+        parameters=(),
+        dimensions=DIMENSIONS,
+        metrics=METRICS,
+        parse_metrics=parse_metrics,
+        render_metrics=render_metrics,
+        validate_metrics=validate_metrics,
+        summarize_metrics=summarize_metrics,
+        render_summary=render_summary,
+        command=None,
+        environment=None,
+        process_cases=process_cases,
+        profile_kind="local-ydb",
+        executor="local-ydb",
+        builder_supported=True,
+    )
+)

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+import math
 import statistics
 
 from ydb.tools.ydb_bench.benchmarks.registry import (
@@ -57,7 +58,7 @@ def parse_cli_metrics(stdout):
             if len(values) != 8:
                 break
             try:
-                return {
+                result = {
                     "transactions": int(values[0]),
                     "throughput": float(values[1]),
                     "retries": int(values[2]),
@@ -67,6 +68,11 @@ def parse_cli_metrics(stdout):
                     "p99_ms": float(values[6]),
                     "pmax_ms": float(values[7]),
                 }
+                if not all(
+                    math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
+                ):
+                    raise ValueError("non-finite workload metric")
+                return result
             except ValueError:
                 break
     raise BenchmarkError("YDB CLI workload output does not contain a valid Total row")
@@ -100,7 +106,8 @@ def summarize_metrics(repetition_rows, benchmark):
     result = []
     for key in sorted(grouped):
         rows = grouped[key]
-        record = {item.name: value for item, value in zip(benchmark.dimensions, key)}
+        record = {"affinity_mode": "roles"}
+        record.update({item.name: value for item, value in zip(benchmark.dimensions, key)})
         record["samples"] = len(rows)
         for metric in benchmark.metrics:
             values = [row[metric.name] for row in rows]
@@ -112,7 +119,7 @@ def summarize_metrics(repetition_rows, benchmark):
 
 
 def render_summary(rows, benchmark):
-    columns = [item.name for item in benchmark.dimensions] + ["samples"]
+    columns = ["affinity_mode"] + [item.name for item in benchmark.dimensions] + ["samples"]
     for metric in benchmark.metrics:
         columns += ["median_" + metric.name, "min_" + metric.name, "max_" + metric.name]
     output = io.StringIO()

--- a/ydb/tools/ydb_bench/benchmarks/registry.py
+++ b/ydb/tools/ydb_bench/benchmarks/registry.py
@@ -59,6 +59,14 @@ class BenchmarkDefinition:
     render_worker_metrics: object = None
     test_filter: str = ""
     process_measurement_count: object = _single_process_measurement
+    resource_names: tuple = ()
+    profile_kind: str = "process"
+    executor: str = "process"
+    builder_supported: bool = True
+
+    @property
+    def resources(self):
+        return self.resource_names or (self.resource_name,)
 
     @property
     def csv_columns(self):
@@ -72,10 +80,12 @@ class BenchmarkDefinition:
     def parameter_name(self):
         """Compatibility for older discovery/UI clients."""
         varying = [item for item in self.parameters if item.name != "actor-pairs"]
-        return varying[0].name if varying else self.parameters[0].name
+        return varying[0].name if varying else self.parameters[0].name if self.parameters else None
 
     @property
     def parameter_description(self):
+        if self.parameter_name is None:
+            return ""
         return next(item.description for item in self.parameters if item.name == self.parameter_name)
 
     @property

--- a/ydb/tools/ydb_bench/benchmarks/ya.make
+++ b/ydb/tools/ydb_bench/benchmarks/ya.make
@@ -3,6 +3,7 @@ PY3_LIBRARY()
 PY_SRCS(
     __init__.py
     actors.py
+    local_ydb.py
     memory.py
     registry.py
 )

--- a/ydb/tools/ydb_bench/examples/local-ydb-smoke.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-smoke.yaml
@@ -1,0 +1,25 @@
+local-ydb:
+  smoke:
+    workload:
+      type: stock
+      operation: put-rand-order
+      options:
+        min-partitions: 1
+        products: 10
+        quantity: 1000
+        orders: 10
+        auto-partition: 0
+    geometry:
+      preset: single
+      static-nodes: 1
+      disk-size-gb: 64
+      storage-groups: 1
+    client:
+      threads: 2
+    load:
+      parameter: rate
+      values: [10]
+    measurement:
+      warmup: 0
+      duration: 2
+      repetitions: 1

--- a/ydb/tools/ydb_bench/examples/local-ydb-storage.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-storage.yaml
@@ -1,0 +1,37 @@
+local-ydb:
+  storage-capacity:
+    workload:
+      type: kv
+      operation: upsert
+      options:
+        init-upserts: 1000
+    geometry:
+      preset: storage
+      static-nodes: 2
+      dynamic-nodes: 1
+      max-dynamic-nodes: 8
+      disk-size-gb: 64
+      storage-groups: 1
+    client:
+      threads: 64
+    load:
+      parameter: rate
+      search:
+        start: 1000
+        maximum: 1000000
+        resolution-percent: 2
+      objective:
+        type: maximize-throughput
+        target-role: static
+    measurement:
+      warmup: 10
+      duration: 30
+      repetitions: 3
+    affinity:
+      ydb-cli:
+        mode: pack-numa-pack-chiplet-spread-core
+        cpus: one-chiplet
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none

--- a/ydb/tools/ydb_bench/lib/actors_core.py
+++ b/ydb/tools/ydb_bench/lib/actors_core.py
@@ -18,7 +18,6 @@ from ydb.tools.ydb_bench.lib.topology import discover_topology, plan_affinity, p
 from ydb.tools.ydb_bench.benchmarks import PING_BENCHMARK, STAR_PING_BENCHMARK
 from ydb.tools.ydb_bench.benchmarks.registry import BenchmarkDefinition
 
-
 __all__ = (
     "PING_BENCHMARK",
     "STAR_PING_BENCHMARK",
@@ -50,11 +49,15 @@ class RunConfiguration:
         values = dict(self.parameters or {})
         if "actor-pairs" in (item.name for item in self.benchmark.parameters):
             values["actor-pairs"] = self.actor_pairs or values.get("actor-pairs") or (512,)
-            values[self.benchmark.parameter_name] = self.parameter_values or values.get(self.benchmark.parameter_name) or self.benchmark.parameter(self.benchmark.parameter_name).default
+            values[self.benchmark.parameter_name] = (
+                self.parameter_values
+                or values.get(self.benchmark.parameter_name)
+                or self.benchmark.parameter(self.benchmark.parameter_name).default
+            )
         object.__setattr__(self, "parameters", values)
         if not self.actor_pairs and "actor-pairs" in self.parameters:
             object.__setattr__(self, "actor_pairs", tuple(self.parameters["actor-pairs"]))
-        if not self.parameter_values and self.benchmark.parameter_name in self.parameters:
+        if self.benchmark.parameters and not self.parameter_values and self.benchmark.parameter_name in self.parameters:
             object.__setattr__(self, "parameter_values", tuple(self.parameters[self.benchmark.parameter_name]))
 
 
@@ -523,7 +526,14 @@ def run_benchmark(
                 else:
                     repetition_rows.append((placement.mode, background_mode, metrics))
                     for metric_row in metrics:
-                        measurement_rows.append({"affinity_mode": placement.mode, "background_load": background_mode, "repeat": index, **metric_row})
+                        measurement_rows.append(
+                            {
+                                "affinity_mode": placement.mode,
+                                "background_load": background_mode,
+                                "repeat": index,
+                                **metric_row,
+                            }
+                        )
 
             if failure is not None:
                 run_record["error"] = failure
@@ -575,7 +585,17 @@ def run_benchmark(
                             str(relative_directory / record["stderr"]),
                         )
                     )
-                event_sink({"type": "step-artifacts", "affinity": placement.mode, "background_load": background_mode, "threads": threads, "case": case_index, "repeat": index, "artifacts": artifacts})
+                event_sink(
+                    {
+                        "type": "step-artifacts",
+                        "affinity": placement.mode,
+                        "background_load": background_mode,
+                        "threads": threads,
+                        "case": case_index,
+                        "repeat": index,
+                        "artifacts": artifacts,
+                    }
+                )
                 event_sink(
                     {
                         "type": "step-finished",

--- a/ydb/tools/ydb_bench/lib/cli.py
+++ b/ydb/tools/ydb_bench/lib/cli.py
@@ -15,6 +15,7 @@ from ydb.tools.ydb_bench.lib.common import (
     extract_executable,
 )
 from ydb.tools.ydb_bench.lib.config import build_run_plan, config_schema, load_config
+from ydb.tools.ydb_bench.lib.local_ydb import run_local_ydb
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, ResultStore
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, topology_record
 from ydb.tools.ydb_bench.lib.web import production_executor, serve
@@ -30,6 +31,19 @@ def _positive_integer(value):
 def _default_output_directory():
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     return Path("ydb-bench-results") / "{}-ydb-bench".format(timestamp)
+
+
+def _local_ydb_progress_line(progress):
+    parts = ["local-ydb", str(progress.get("phase", "working")).replace("-", " ")]
+    if progress.get("attempt") is not None:
+        parts.append("attempt #{}".format(progress["attempt"]))
+    if progress.get("dynamic_nodes") is not None:
+        parts.append("dynamic nodes={}".format(progress["dynamic_nodes"]))
+    if progress.get("load") is not None:
+        parts.append("{}={}".format(progress.get("parameter", "load"), progress["load"]))
+    if progress.get("repetition") is not None:
+        parts.append("repetition {}/{}".format(progress["repetition"], progress.get("repetitions", "?")))
+    return ": ".join((parts[0], ", ".join(parts[1:])))
 
 
 def _create_parser():
@@ -79,6 +93,8 @@ def _benchmark_record(benchmark):
         "name": benchmark.name,
         "description": benchmark.description,
         "resource": benchmark.resource_name,
+        "resources": list(benchmark.resources),
+        "builder_supported": benchmark.builder_supported,
         "parameters": [
             {
                 "name": item.name,
@@ -96,7 +112,19 @@ def _benchmark_record(benchmark):
         "affinity_modes": list(AFFINITY_MODES),
         "csv_columns": list(benchmark.csv_columns),
         "examples": [
-            {benchmark.name: {"example": {"threads": [1], "duration": 1, "repetitions": 1, "affinity": ["none"]}}}
+            {
+                benchmark.name: {
+                    "example": (
+                        {
+                            "workload": {"type": "kv", "operation": "upsert"},
+                            "geometry": {"preset": "single"},
+                            "load": {"parameter": "rate", "values": [1000]},
+                        }
+                        if benchmark.profile_kind == "local-ydb"
+                        else {"threads": [1], "duration": 1, "repetitions": 1, "affinity": ["none"]}
+                    )
+                }
+            }
         ],
     }
 
@@ -107,7 +135,7 @@ def _describe(benchmark_name, as_json=False):
         print(json.dumps(_benchmark_record(benchmark), indent=2, sort_keys=True))
         return
     print("{}: {}".format(benchmark.name, benchmark.description))
-    print("resource: {}".format(benchmark.resource_name))
+    print("resources: {}".format(", ".join(benchmark.resources)))
     print("parameters: {}".format(", ".join(item.name for item in benchmark.parameters)))
     print("metrics: {}".format(", ".join(item.name for item in benchmark.metrics)))
     print("affinity: {}".format(", ".join(AFFINITY_MODES)))
@@ -237,15 +265,18 @@ def _run(arguments, resource_loader, tool_revision):
             store.write()
 
             for configuration in loaded_config.runs:
-                resource_name = configuration.benchmark.resource_name
-                if resource_name not in binaries:
-                    binaries[resource_name] = extract_executable(
-                        resource_loader(resource_name), temporary_directory, resource_name
-                    )
-                binary = binaries[resource_name]
-                binary_record = {"name": binary.path.name, "sha256": binary.sha256, "size": binary.size}
-                manifest["binaries"][resource_name] = binary_record
-                manifest.setdefault("binary", binary_record)
+                profile_binaries = {}
+                for resource_name in configuration.benchmark.resources:
+                    if resource_name not in binaries:
+                        binaries[resource_name] = extract_executable(
+                            resource_loader(resource_name), temporary_directory, resource_name
+                        )
+                    profile_binaries[resource_name] = binaries[resource_name]
+                    binary = binaries[resource_name]
+                    binary_record = {"name": binary.path.name, "sha256": binary.sha256, "size": binary.size}
+                    manifest["binaries"][resource_name] = binary_record
+                    manifest.setdefault("binary", binary_record)
+                binary = profile_binaries[configuration.benchmark.resource_name]
                 profiler_binary_path = None
                 if arguments.perf:
                     profiler_binary_path = output_directory / "profiler" / binary.path.name
@@ -282,6 +313,10 @@ def _run(arguments, resource_loader, tool_revision):
                             ) from error
                         if event["type"] == "step-started":
                             store.transition_step(step_id, "running", **event.get("fields", {}))
+                        elif event["type"] == "step-progress":
+                            fields = event.get("fields", {})
+                            store.update_step(step_id, **fields)
+                            print(_local_ydb_progress_line(fields.get("progress", {})), file=sys.stderr, flush=True)
                         elif event["type"] == "step-artifacts":
                             store.add_artifacts(
                                 step_id,
@@ -292,16 +327,26 @@ def _run(arguments, resource_loader, tool_revision):
                         else:
                             raise BenchmarkError("unknown benchmark step event: {}".format(event["type"]))
 
-                    profile_manifest = run_benchmark(
-                        binary,
-                        configuration,
-                        profile_directory,
-                        tool_revision=tool_revision,
-                        work_dir_hint=temporary_directory,
-                        profiler_binary_path=profiler_binary_path,
-                        background_binary=background_binary,
-                        event_sink=on_event,
-                    )
+                    if configuration.benchmark.executor == "local-ydb":
+                        profile_manifest = run_local_ydb(
+                            profile_binaries,
+                            configuration,
+                            profile_directory,
+                            tool_revision=tool_revision,
+                            work_dir_hint=temporary_directory,
+                            event_sink=on_event,
+                        )
+                    else:
+                        profile_manifest = run_benchmark(
+                            binary,
+                            configuration,
+                            profile_directory,
+                            tool_revision=tool_revision,
+                            work_dir_hint=temporary_directory,
+                            profiler_binary_path=profiler_binary_path,
+                            background_binary=background_binary,
+                            event_sink=on_event,
+                        )
                 except BenchmarkInterrupted as error:
                     run_record["status"] = "interrupted"
                     run_record["error"] = str(error)
@@ -349,9 +394,7 @@ def _run(arguments, resource_loader, tool_revision):
         return 1
 
     failed = [record for record in manifest["runs"] if record["status"] == "failed"]
-    unsupported = bool(manifest["runs"]) and all(
-        record["status"] == "unsupported" for record in manifest["runs"]
-    )
+    unsupported = bool(manifest["runs"]) and all(record["status"] == "unsupported" for record in manifest["runs"])
     if failed:
         _cancel_unfinished_steps(store, "run completed with failed benchmark profiles")
     manifest["status"] = "failed" if failed else "unsupported" if unsupported else "completed"

--- a/ydb/tools/ydb_bench/lib/common.py
+++ b/ydb/tools/ydb_bench/lib/common.py
@@ -48,7 +48,11 @@ def atomic_write_text(path, text):
 
 
 def atomic_write_json(path, value):
-    atomic_write_text(path, json.dumps(value, indent=2, sort_keys=True) + "\n")
+    try:
+        text = json.dumps(value, allow_nan=False, indent=2, sort_keys=True) + "\n"
+    except (TypeError, ValueError) as error:
+        raise BenchmarkError("cannot serialize JSON with only finite values") from error
+    atomic_write_text(path, text)
 
 
 def atomic_copy_file(source, destination, mode=None):

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -83,6 +83,187 @@ def _parameter_schema(parameter):
 
 
 def _profile_schema(benchmark):
+    if benchmark.profile_kind == "local-ydb":
+        role_affinity = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "mode": {"enum": list(AFFINITY_MODES)},
+                "cpus": {
+                    "oneOf": [
+                        {"type": "integer", "minimum": 1},
+                        {"enum": ["one-chiplet", "remaining"]},
+                    ]
+                },
+            },
+        }
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["workload", "load"],
+            "properties": {
+                "workload": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["type", "operation"],
+                    "properties": {
+                        "type": {"enum": ["kv", "stock"]},
+                        "operation": {
+                            "enum": [
+                                "upsert",
+                                "select",
+                                "read-rows",
+                                "mixed",
+                                "user-hist",
+                                "rand-user-hist",
+                                "add-rand-order",
+                                "put-rand-order",
+                                "put-same-order",
+                            ]
+                        },
+                        "options": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "min-partitions": {"type": "integer", "minimum": 1},
+                                "max-partitions": {"type": "integer", "minimum": 1},
+                                "partition-size-mb": {"type": "integer", "minimum": 1},
+                                "init-upserts": {"type": "integer", "minimum": 0},
+                                "max-first-key": {"type": "integer", "minimum": 1},
+                                "value-size": {"type": "integer", "minimum": 1},
+                                "columns": {"type": "integer", "minimum": 2},
+                                "rows-per-query": {"type": "integer", "minimum": 1},
+                                "products": {"type": "integer", "minimum": 1, "maximum": 500000},
+                                "quantity": {"type": "integer", "minimum": 1},
+                                "orders": {"type": "integer", "minimum": 0},
+                                "auto-partition": {"enum": [0, 1]},
+                                "limit": {"type": "integer", "minimum": 1},
+                            },
+                        },
+                    },
+                },
+                "geometry": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "preset": {"enum": ["single", "storage", "custom"]},
+                        "static-nodes": {"type": "integer", "minimum": 1},
+                        "dynamic-nodes": {"type": "integer", "minimum": 1},
+                        "max-dynamic-nodes": {"type": "integer", "minimum": 1},
+                        "disk-size-gb": {"type": "integer", "minimum": 1},
+                        "storage-groups": {"type": "integer", "minimum": 1},
+                    },
+                },
+                "client": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"threads": {"type": "integer", "minimum": 1}},
+                },
+                "load": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["parameter"],
+                    "properties": {
+                        # ``mode`` and the flat controller fields are retained for
+                        # compatibility with configs written before search and
+                        # objective became separate concepts.
+                        "mode": {"enum": ["points", "maximize-throughput", "latency-slo"]},
+                        "parameter": {"enum": ["rate", "threads"]},
+                        "allow-errors": {"type": "boolean"},
+                        "values": {
+                            "type": "array",
+                            "items": {"type": "integer", "minimum": 1},
+                            "minItems": 1,
+                            "uniqueItems": True,
+                        },
+                        "start": {"type": "integer", "minimum": 1},
+                        "maximum": {"type": "integer", "minimum": 1},
+                        "multiplier": {"type": "number", "exclusiveMinimum": 1},
+                        "target-role": {"enum": ["static", "dynamic", "total"]},
+                        "plateau-gain-percent": {"type": "number", "minimum": 0},
+                        "plateau-points": {"type": "integer", "minimum": 1},
+                        "cpu-saturation-percent": {"type": "number", "exclusiveMinimum": 0, "maximum": 100},
+                        "search-resolution-percent": {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 100,
+                        },
+                        "slo": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "percentile": {"enum": ["p50", "p95", "p99", "pmax"]},
+                                "max-ms": {"type": "number", "minimum": 0},
+                                "max-errors": {"type": "integer", "minimum": 0},
+                                "min-achieved-rate-ratio": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1,
+                                },
+                            },
+                        },
+                        "search": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "required": ["start", "maximum"],
+                            "properties": {
+                                "start": {"type": "integer", "minimum": 1},
+                                "maximum": {"type": "integer", "minimum": 1},
+                                "multiplier": {"type": "number", "exclusiveMinimum": 1},
+                                "resolution-percent": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 100,
+                                },
+                            },
+                        },
+                        "objective": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "required": ["type"],
+                            "properties": {
+                                "type": {"enum": ["maximize-throughput", "latency-slo"]},
+                                "target-role": {"enum": ["static", "dynamic", "total"]},
+                                "plateau-gain-percent": {"type": "number", "minimum": 0},
+                                "plateau-points": {"type": "integer", "minimum": 1},
+                                "cpu-saturation-percent": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 100,
+                                },
+                                "percentile": {"enum": ["p50", "p95", "p99", "pmax"]},
+                                "max-ms": {"type": "number", "minimum": 0},
+                                "max-errors": {"type": "integer", "minimum": 0},
+                                "min-achieved-rate-ratio": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1,
+                                },
+                            },
+                        },
+                    },
+                },
+                "measurement": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "warmup": {"type": "integer", "minimum": 0},
+                        "duration": {"type": "integer", "minimum": 1},
+                        "repetitions": {"type": "integer", "minimum": 1},
+                    },
+                },
+                "affinity": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "ydb-cli": role_affinity,
+                        "static-nodes": role_affinity,
+                        "dynamic-nodes": role_affinity,
+                    },
+                },
+                "timeout": {"type": "number", "exclusiveMinimum": 0},
+            },
+        }
     return {
         "type": "object",
         "additionalProperties": False,
@@ -291,7 +472,394 @@ def _timeout(value, location):
     return value
 
 
+def _mapping(value, location, allowed=()):
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        _config_error(location, "must be a mapping")
+    unknown = sorted((item for item in value if item not in allowed), key=str)
+    if unknown:
+        _config_error(location, "contains unknown fields: {}".format(", ".join(map(str, unknown))))
+    return value
+
+
+def _choice(value, choices, location):
+    if value not in choices:
+        _config_error(location, "must be one of {}".format(", ".join(choices)))
+    return value
+
+
+def _boolean(value, location):
+    if not isinstance(value, bool):
+        _config_error(location, "must be a boolean")
+    return value
+
+
+def _nonnegative_integer(value, location):
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        _config_error(location, "must be a non-negative integer")
+    return value
+
+
+def _finite_number(value, location, minimum=None, maximum=None, exclusive_minimum=False):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+        _config_error(location, "must be a finite number")
+    result = float(value)
+    if minimum is not None and (result <= minimum if exclusive_minimum else result < minimum):
+        _config_error(location, "must be {} {}".format("greater than" if exclusive_minimum else "at least", minimum))
+    if maximum is not None and result > maximum:
+        _config_error(location, "must be at most {}".format(maximum))
+    return result
+
+
+def _local_role_affinity(value, location, default_mode, default_cpus=None):
+    value = _mapping(value, location, ("mode", "cpus"))
+    mode = _choice(value.get("mode", default_mode), AFFINITY_MODES, location + ".mode")
+    cpus = value.get("cpus", None if mode == "none" else default_cpus)
+    if isinstance(cpus, str):
+        _choice(cpus, ("one-chiplet", "remaining"), location + ".cpus")
+    elif cpus is not None:
+        cpus = _positive_integer(cpus, location + ".cpus")
+    if mode == "none" and cpus is not None:
+        _config_error(location + ".cpus", "must be omitted when affinity mode is none")
+    if mode != "none" and cpus is None:
+        _config_error(location + ".cpus", "is required when affinity mode is not none")
+    return {"mode": mode, "cpus": cpus}
+
+
+def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_frequency):
+    location = "{}.{}".format(benchmark.name, profile_name)
+    value = _mapping(value, location, ("workload", "geometry", "client", "load", "measurement", "affinity", "timeout"))
+    if perf_enabled:
+        _config_error(location, "does not support --perf; CPU utilization is collected per process role")
+
+    workload = _mapping(value.get("workload"), location + ".workload", ("type", "operation", "options"))
+    for required in ("type", "operation"):
+        if required not in workload:
+            _config_error(location + ".workload", "missing required field: {}".format(required))
+    workload_type = _choice(workload["type"], ("kv", "stock"), location + ".workload.type")
+    operations = {
+        "kv": ("upsert", "select", "read-rows", "mixed"),
+        "stock": ("user-hist", "rand-user-hist", "add-rand-order", "put-rand-order", "put-same-order"),
+    }
+    operation = _choice(workload["operation"], operations[workload_type], location + ".workload.operation")
+    if workload_type == "kv":
+        option_defaults = {
+            "min-partitions": 40,
+            "max-partitions": 1000,
+            "partition-size-mb": 2000,
+            "init-upserts": 0 if operation == "upsert" else 1000,
+            "max-first-key": 65536,
+            "value-size": 64,
+            "columns": 2,
+            "rows-per-query": 1,
+        }
+    else:
+        option_defaults = {
+            "min-partitions": 40,
+            "products": 100,
+            "quantity": 1000,
+            "orders": 100,
+            "auto-partition": 1,
+            "limit": 10,
+        }
+    raw_options = _mapping(workload.get("options"), location + ".workload.options", tuple(option_defaults))
+    options = {}
+    for name, default in option_defaults.items():
+        raw = raw_options.get(name, default)
+        options[name] = (
+            _nonnegative_integer(raw, location + ".workload.options." + name)
+            if name in ("init-upserts", "orders", "auto-partition")
+            else _positive_integer(raw, location + ".workload.options." + name)
+        )
+    if workload_type == "kv" and options["max-partitions"] < options["min-partitions"]:
+        _config_error(location + ".workload.options.max-partitions", "must not be below min-partitions")
+    if workload_type == "kv" and options["columns"] < 2:
+        _config_error(location + ".workload.options.columns", "must be at least 2")
+    if workload_type == "stock" and options["products"] > 500000:
+        _config_error(location + ".workload.options.products", "must not exceed 500000")
+    if workload_type == "stock" and options["auto-partition"] not in (0, 1):
+        _config_error(location + ".workload.options.auto-partition", "must be 0 or 1")
+
+    geometry = _mapping(
+        value.get("geometry"),
+        location + ".geometry",
+        ("preset", "static-nodes", "dynamic-nodes", "max-dynamic-nodes", "disk-size-gb", "storage-groups"),
+    )
+    preset = _choice(geometry.get("preset", "single"), ("single", "storage", "custom"), location + ".geometry.preset")
+    if preset == "single":
+        if geometry.get("dynamic-nodes", 1) != 1 or geometry.get("max-dynamic-nodes", 1) != 1:
+            _config_error(location + ".geometry", "single preset always uses one dynamic node")
+        dynamic_nodes = 1
+        max_dynamic_nodes = 1
+    elif preset == "storage":
+        dynamic_nodes = _positive_integer(geometry.get("dynamic-nodes", 1), location + ".geometry.dynamic-nodes")
+        max_dynamic_nodes = _positive_integer(
+            geometry.get("max-dynamic-nodes", 8), location + ".geometry.max-dynamic-nodes"
+        )
+    else:
+        if "dynamic-nodes" not in geometry:
+            _config_error(location + ".geometry", "custom preset requires dynamic-nodes")
+        dynamic_nodes = _positive_integer(geometry["dynamic-nodes"], location + ".geometry.dynamic-nodes")
+        max_dynamic_nodes = _positive_integer(
+            geometry.get("max-dynamic-nodes", dynamic_nodes), location + ".geometry.max-dynamic-nodes"
+        )
+    if max_dynamic_nodes < dynamic_nodes:
+        _config_error(location + ".geometry.max-dynamic-nodes", "must not be below dynamic-nodes")
+    storage_groups = _positive_integer(geometry.get("storage-groups", 1), location + ".geometry.storage-groups")
+    static_nodes = _positive_integer(
+        geometry.get("static-nodes", 1),
+        location + ".geometry.static-nodes",
+    )
+    geometry_config = {
+        "preset": preset,
+        "static_nodes": static_nodes,
+        "dynamic_nodes": dynamic_nodes,
+        "max_dynamic_nodes": max_dynamic_nodes,
+        "disk_size_gb": _positive_integer(geometry.get("disk-size-gb", 64), location + ".geometry.disk-size-gb"),
+        "storage_groups": storage_groups,
+    }
+
+    client = _mapping(value.get("client"), location + ".client", ("threads",))
+    client_threads = _positive_integer(client.get("threads", 64), location + ".client.threads")
+
+    load = _mapping(
+        value.get("load"),
+        location + ".load",
+        (
+            "mode",
+            "parameter",
+            "allow-errors",
+            "values",
+            "start",
+            "maximum",
+            "multiplier",
+            "target-role",
+            "plateau-gain-percent",
+            "plateau-points",
+            "cpu-saturation-percent",
+            "search-resolution-percent",
+            "slo",
+            "search",
+            "objective",
+        ),
+    )
+    if "parameter" not in load:
+        _config_error(location + ".load", "missing required field: parameter")
+    parameter = _choice(load["parameter"], ("rate", "threads"), location + ".load.parameter")
+    legacy_fields = {
+        "mode",
+        "start",
+        "maximum",
+        "multiplier",
+        "target-role",
+        "plateau-gain-percent",
+        "plateau-points",
+        "cpu-saturation-percent",
+        "search-resolution-percent",
+        "slo",
+    }
+    if ("search" in load or "objective" in load) and any(field in load for field in legacy_fields):
+        _config_error(location + ".load", "must not mix search/objective with legacy controller fields")
+
+    load_config = {
+        "parameter": parameter,
+        "allow_errors": _boolean(load.get("allow-errors", False), location + ".load.allow-errors"),
+    }
+    if "search" not in load and "objective" not in load:
+        load_mode = _choice(
+            load.get("mode", "points"),
+            ("points", "maximize-throughput", "latency-slo"),
+            location + ".load.mode",
+        )
+        if load_mode == "points":
+            if "values" not in load:
+                _config_error(location + ".load", "manual load requires values")
+            load_config["values"] = list(_positive_integer_list(load["values"], location + ".load.values"))
+        else:
+            for required in ("start", "maximum"):
+                if required not in load:
+                    _config_error(location + ".load", "{} mode requires {}".format(load_mode, required))
+            load_config["search"] = {
+                "start": load["start"],
+                "maximum": load["maximum"],
+                "multiplier": load.get("multiplier", 2),
+                "resolution-percent": load.get("search-resolution-percent", 2),
+            }
+            load_config["objective"] = {
+                "type": load_mode,
+                "target-role": load.get("target-role", "static" if preset == "storage" else "dynamic"),
+                "plateau-gain-percent": load.get("plateau-gain-percent", 2),
+                "plateau-points": load.get("plateau-points", 2),
+                "cpu-saturation-percent": load.get("cpu-saturation-percent", 95),
+                **(load.get("slo") or {}),
+            }
+    else:
+        if "search" not in load or "objective" not in load:
+            _config_error(location + ".load", "automatic load requires both search and objective")
+        if "values" in load:
+            _config_error(location + ".load", "must not combine values with search/objective")
+        load_config["search"] = load["search"]
+        load_config["objective"] = load["objective"]
+
+    if "search" in load_config:
+        search = _mapping(
+            load_config["search"],
+            location + ".load.search",
+            ("start", "maximum", "multiplier", "resolution-percent"),
+        )
+        for required in ("start", "maximum"):
+            if required not in search:
+                _config_error(location + ".load.search", "missing required field: {}".format(required))
+        start = _positive_integer(search["start"], location + ".load.search.start")
+        maximum = _positive_integer(search["maximum"], location + ".load.search.maximum")
+        if maximum < start:
+            _config_error(location + ".load.search.maximum", "must not be below start")
+        load_config["search"] = {
+            "start": start,
+            "maximum": maximum,
+            "multiplier": _finite_number(
+                search.get("multiplier", 2),
+                location + ".load.search.multiplier",
+                1,
+                exclusive_minimum=True,
+            ),
+            "resolution_percent": _finite_number(
+                search.get("resolution-percent", 2),
+                location + ".load.search.resolution-percent",
+                0,
+                100,
+                True,
+            ),
+        }
+        objective = _mapping(
+            load_config["objective"],
+            location + ".load.objective",
+            (
+                "type",
+                "target-role",
+                "plateau-gain-percent",
+                "plateau-points",
+                "cpu-saturation-percent",
+                "percentile",
+                "max-ms",
+                "max-errors",
+                "min-achieved-rate-ratio",
+            ),
+        )
+        if "type" not in objective:
+            _config_error(location + ".load.objective", "missing required field: type")
+        objective_type = _choice(
+            objective["type"],
+            ("maximize-throughput", "latency-slo"),
+            location + ".load.objective.type",
+        )
+        parsed_objective = {"type": objective_type}
+        if objective_type == "maximize-throughput":
+            parsed_objective.update(
+                {
+                    "target_role": _choice(
+                        objective.get("target-role", "static" if preset == "storage" else "dynamic"),
+                        ("static", "dynamic", "total"),
+                        location + ".load.objective.target-role",
+                    ),
+                    "plateau_gain_percent": _finite_number(
+                        objective.get("plateau-gain-percent", 2),
+                        location + ".load.objective.plateau-gain-percent",
+                        0,
+                    ),
+                    "plateau_points": _positive_integer(
+                        objective.get("plateau-points", 2), location + ".load.objective.plateau-points"
+                    ),
+                    "cpu_saturation_percent": _finite_number(
+                        objective.get("cpu-saturation-percent", 95),
+                        location + ".load.objective.cpu-saturation-percent",
+                        0,
+                        100,
+                        True,
+                    ),
+                }
+            )
+        else:
+            if "max-ms" not in objective:
+                _config_error(location + ".load.objective", "latency-slo requires max-ms")
+            parsed_objective.update(
+                {
+                    "percentile": _choice(
+                        objective.get("percentile", "p99"),
+                        ("p50", "p95", "p99", "pmax"),
+                        location + ".load.objective.percentile",
+                    ),
+                    "max_ms": _finite_number(objective["max-ms"], location + ".load.objective.max-ms", 0),
+                    "max_errors": _nonnegative_integer(
+                        objective.get("max-errors", 0), location + ".load.objective.max-errors"
+                    ),
+                    "min_achieved_rate_ratio": _finite_number(
+                        objective.get("min-achieved-rate-ratio", 0.98),
+                        location + ".load.objective.min-achieved-rate-ratio",
+                        0,
+                        1,
+                        True,
+                    ),
+                }
+            )
+        load_config["objective"] = parsed_objective
+
+    measurement = _mapping(value.get("measurement"), location + ".measurement", ("warmup", "duration", "repetitions"))
+    measurement_config = {
+        "warmup": _nonnegative_integer(measurement.get("warmup", 10), location + ".measurement.warmup"),
+        "duration": _positive_integer(measurement.get("duration", 30), location + ".measurement.duration"),
+        "repetitions": _positive_integer(measurement.get("repetitions", 3), location + ".measurement.repetitions"),
+    }
+
+    affinity = _mapping(value.get("affinity"), location + ".affinity", ("ydb-cli", "static-nodes", "dynamic-nodes"))
+    affinity_config = {
+        "ydb_cli": _local_role_affinity(
+            affinity.get("ydb-cli"),
+            location + ".affinity.ydb-cli",
+            "pack-numa-pack-chiplet-spread-core",
+            "one-chiplet",
+        ),
+        "static_nodes": _local_role_affinity(affinity.get("static-nodes"), location + ".affinity.static-nodes", "none"),
+        "dynamic_nodes": _local_role_affinity(
+            affinity.get("dynamic-nodes"), location + ".affinity.dynamic-nodes", "none"
+        ),
+    }
+
+    attempts = len(load_config.get("values", ())) or 64
+    computed_timeout = 300 + attempts * measurement_config["repetitions"] * (
+        measurement_config["warmup"] + measurement_config["duration"] + 10
+    )
+    timeout_explicit = "timeout" in value
+    timeout = _timeout(value.get("timeout", computed_timeout), location + ".timeout")
+    return RunConfiguration(
+        benchmark=benchmark,
+        profile=profile_name,
+        threads=(client_threads,),
+        parameters={
+            "local_ydb": {
+                "workload": {"type": workload_type, "operation": operation, "options": options},
+                "geometry": geometry_config,
+                "client": {"threads": client_threads},
+                "load": load_config,
+                "measurement": measurement_config,
+                "affinity": affinity_config,
+            }
+        },
+        duration_seconds=measurement_config["duration"],
+        repetitions=1,
+        timeout_seconds=timeout,
+        timeout_explicit=timeout_explicit,
+        affinity_modes=("roles",),
+        background_load_modes=("none",),
+        perf_enabled=False,
+        perf_frequency=perf_frequency,
+    )
+
+
 def _parse_profile(benchmark, profile_name, value, perf_enabled, perf_frequency):
+    if benchmark.profile_kind == "local-ydb":
+        return _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_frequency)
     location = "{}.{}".format(benchmark.name, profile_name)
     if not isinstance(value, dict):
         _config_error(location, "must be a mapping")
@@ -334,9 +902,7 @@ def _parse_profile(benchmark, profile_name, value, perf_enabled, perf_frequency)
     duration = _positive_integer(value["duration"], location + ".duration")
     repetitions = _positive_integer(value["repetitions"], location + ".repetitions")
     affinity = _affinity_modes(value["affinity"], location + ".affinity")
-    background_load = _background_load_modes(
-        value.get("background-load", ["none"]), location + ".background-load"
-    )
+    background_load = _background_load_modes(value.get("background-load", ["none"]), location + ".background-load")
     timeout_explicit = "timeout" in value
     timeout = _timeout(
         value["timeout"] if timeout_explicit else benchmark.process_measurement_count(parameters) * duration * 3 + 30,

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -666,6 +666,11 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         "parameter": parameter,
         "allow_errors": _boolean(load.get("allow-errors", False), location + ".load.allow-errors"),
     }
+    legacy_slo = _mapping(
+        load.get("slo"),
+        location + ".load.slo",
+        ("percentile", "max-ms", "max-errors", "min-achieved-rate-ratio"),
+    )
     if "search" not in load and "objective" not in load:
         load_mode = _choice(
             load.get("mode", "points"),
@@ -692,7 +697,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
                 "plateau-gain-percent": load.get("plateau-gain-percent", 2),
                 "plateau-points": load.get("plateau-points", 2),
                 "cpu-saturation-percent": load.get("cpu-saturation-percent", 95),
-                **(load.get("slo") or {}),
+                **legacy_slo,
             }
     else:
         if "search" not in load or "objective" not in load:
@@ -754,7 +759,16 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
             ("maximize-throughput", "latency-slo"),
             location + ".load.objective.type",
         )
-        parsed_objective = {"type": objective_type}
+        parsed_objective = {
+            "type": objective_type,
+            "cpu_saturation_percent": _finite_number(
+                objective.get("cpu-saturation-percent", 95),
+                location + ".load.objective.cpu-saturation-percent",
+                0,
+                100,
+                True,
+            ),
+        }
         if objective_type == "maximize-throughput":
             parsed_objective.update(
                 {
@@ -770,13 +784,6 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
                     ),
                     "plateau_points": _positive_integer(
                         objective.get("plateau-points", 2), location + ".load.objective.plateau-points"
-                    ),
-                    "cpu_saturation_percent": _finite_number(
-                        objective.get("cpu-saturation-percent", 95),
-                        location + ".load.objective.cpu-saturation-percent",
-                        0,
-                        100,
-                        True,
                     ),
                 }
             )

--- a/ydb/tools/ydb_bench/lib/linux_telemetry.py
+++ b/ydb/tools/ydb_bench/lib/linux_telemetry.py
@@ -1,0 +1,122 @@
+"""Linux CPU sampling for benchmark process roles."""
+
+import os
+import threading
+import time
+from pathlib import Path
+
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+class LinuxCpuMonitor:
+    def __init__(self, role_pids, role_cpu_counts, interval=0.5, proc_root=Path("/proc")):
+        self.role_pids = role_pids
+        self.role_cpu_counts = role_cpu_counts
+        self.interval = interval
+        self.proc_root = Path(proc_root)
+        self.clock_ticks = os.sysconf("SC_CLK_TCK")
+        self._stop = threading.Event()
+        self._thread = None
+        self._records = []
+        self._previous_process = {}
+        self._previous_host = None
+        self._previous_time = None
+
+    @property
+    def records(self):
+        return tuple(self._records)
+
+    def start(self):
+        if not self.proc_root.joinpath("stat").is_file():
+            raise BenchmarkError("Linux /proc CPU statistics are unavailable")
+        self._sample()
+        self._thread = threading.Thread(target=self._run, name="ydb-bench-linux-cpu", daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(2.0, self.interval * 3))
+        self._sample()
+        return self.summary()
+
+    def _run(self):
+        while not self._stop.wait(self.interval):
+            self._sample()
+
+    def _read_process_ticks(self, pid):
+        try:
+            value = self.proc_root.joinpath(str(pid), "stat").read_text(encoding="utf-8")
+            fields = value[value.rfind(")") + 2 :].split()
+            return int(fields[11]) + int(fields[12])
+        except (OSError, ValueError, IndexError):
+            return None
+
+    def _read_host_ticks(self):
+        try:
+            fields = self.proc_root.joinpath("stat").read_text(encoding="utf-8").splitlines()[0].split()
+            values = [int(item) for item in fields[1:]]
+        except (OSError, ValueError, IndexError):
+            return None
+        idle = values[3] + (values[4] if len(values) > 4 else 0)
+        return sum(values), idle
+
+    def _sample(self):
+        now = time.monotonic()
+        host = self._read_host_ticks()
+        process_ticks = {
+            role: sum(ticks for pid in tuple(provider()) if (ticks := self._read_process_ticks(pid)) is not None)
+            for role, provider in self.role_pids.items()
+        }
+        if self._previous_time is None:
+            self._previous_time = now
+            self._previous_host = host
+            self._previous_process = process_ticks
+            return
+
+        elapsed = now - self._previous_time
+        if elapsed <= 0:
+            return
+        record = {"elapsed_seconds": elapsed}
+        for role, ticks in process_ticks.items():
+            previous = self._previous_process.get(role)
+            if previous is None or ticks < previous:
+                continue
+            raw_percent = 100.0 * (ticks - previous) / self.clock_ticks / elapsed
+            capacity = max(1, self.role_cpu_counts.get(role, 1))
+            record[role + "_cpu_raw"] = raw_percent
+            record[role + "_cpu"] = min(100.0, raw_percent / capacity)
+        if host is not None and self._previous_host is not None:
+            total_delta = host[0] - self._previous_host[0]
+            idle_delta = host[1] - self._previous_host[1]
+            if total_delta > 0:
+                record["host_cpu"] = 100.0 * (total_delta - idle_delta) / total_delta
+        if len(record) > 1:
+            record["timestamp_monotonic"] = now
+            self._records.append(record)
+        self._previous_time = now
+        self._previous_host = host
+        self._previous_process = process_ticks
+
+    def summary(self):
+        def aggregate(name):
+            samples = [
+                (record[name], record["elapsed_seconds"])
+                for record in self._records
+                if name in record and record["elapsed_seconds"] > 0
+            ]
+            if not samples:
+                return 0.0, 0.0
+            elapsed = sum(duration for _, duration in samples)
+            mean = sum(value * duration for value, duration in samples) / elapsed
+            stable = [value for value, duration in samples if duration >= self.interval * 0.5]
+            return mean, max(stable) if stable else mean
+
+        result = {}
+        for role in self.role_pids:
+            mean, maximum = aggregate(role + "_cpu")
+            result[role + "_cpu_mean"] = mean
+            result[role + "_cpu_max"] = maximum
+        result["host_cpu_mean"], result["host_cpu_max"] = aggregate("host_cpu")
+        return result

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -1,0 +1,292 @@
+"""Adaptive offered-load selection for local YDB benchmarks."""
+
+from dataclasses import dataclass
+
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+@dataclass(frozen=True)
+class LoadSearchResult:
+    attempts: tuple
+    selected_load: object
+    stop_reason: str
+    outcome: str
+    passing_load: object = None
+    failing_load: object = None
+
+
+def _next_geometric(current, maximum, multiplier):
+    candidate = max(current + 1, int(round(current * multiplier)))
+    return min(maximum, candidate)
+
+
+def _target_cpu(metrics, target_role):
+    if target_role == "static":
+        return metrics["static_cpu_mean"]
+    if target_role == "dynamic":
+        return metrics["dynamic_cpu_mean"]
+    return metrics["host_cpu_mean"]
+
+
+def _with_decision(metrics, load, passed, reason):
+    return {**metrics, "load": load, "passed": bool(passed), "decision": reason}
+
+
+def _best_throughput(attempts):
+    candidates = [item for item in attempts if item["passed"]]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: (item["throughput"], -item["load"]))["load"]
+
+
+def _throughput_gain(lower, upper):
+    if lower > 0:
+        return 100.0 * (upper - lower) / lower
+    if upper > lower:
+        return float("inf")
+    return 0.0
+
+
+def _append_attempt(attempts, record, on_attempt):
+    attempts.append(record)
+    if on_attempt is not None:
+        on_attempt(record)
+    return record
+
+
+def _run_points(config, measure, on_attempt):
+    attempts = []
+    allow_errors = config.get("allow_errors", False)
+    for value in config["values"]:
+        metrics = measure(value)
+        errors = metrics["errors"]
+        passed = allow_errors or not errors
+        if errors:
+            reason = "{} workload errors {}".format(errors, "allowed" if allow_errors else "reported")
+        else:
+            reason = "configured point"
+        _append_attempt(
+            attempts,
+            _with_decision(metrics, value, passed, reason),
+            on_attempt,
+        )
+    selected = _best_throughput(attempts)
+    return LoadSearchResult(
+        tuple(attempts),
+        selected,
+        "configured points completed",
+        "best-observed" if selected is not None else "no-feasible-point",
+        passing_load=selected,
+    )
+
+
+def _run_throughput(config, measure, on_attempt):
+    search = config["search"]
+    objective = config["objective"]
+    attempts = []
+    measured = {}
+    allow_errors = config.get("allow_errors", False)
+    failing_load = None
+    plateau = 0
+    plateau_confirmed = False
+
+    def sample(load, reason, baseline=None):
+        nonlocal failing_load
+        if load in measured:
+            return measured[load]
+        metrics = measure(load)
+        saturated = _target_cpu(metrics, objective["target_role"]) >= objective["cpu_saturation_percent"]
+        passed = allow_errors or not metrics["errors"]
+        gain = None if baseline is None else _throughput_gain(baseline["throughput"], metrics["throughput"])
+        if not passed:
+            decision = "workload reported errors"
+            failing_load = load if failing_load is None else min(failing_load, load)
+        else:
+            decision = reason
+            if gain is not None:
+                decision += "; throughput gain {:.3f}%".format(gain)
+            if metrics["errors"]:
+                decision += "; {} workload errors allowed".format(metrics["errors"])
+        record = _with_decision(
+            {**metrics, "throughput_gain_percent": gain, "target_cpu_saturated": saturated},
+            load,
+            passed,
+            decision,
+        )
+        measured[load] = record
+        return _append_attempt(attempts, record, on_attempt)
+
+    start = search["start"]
+    maximum = search["maximum"]
+    first = sample(start, "minimum ternary-search load")
+    if not first["passed"]:
+        return LoadSearchResult(
+            tuple(attempts),
+            None,
+            "workload errors at minimum load {}".format(start),
+            "no-feasible-point",
+            failing_load=start,
+        )
+
+    resolution = max(1, int(round((maximum - start) * search["resolution_percent"] / 100.0)))
+    low = start
+    high = maximum
+    while high - low > resolution:
+        third = max(1, (high - low) // 3)
+        lower_load = low + third
+        upper_load = high - third
+        if lower_load >= upper_load:
+            break
+        lower = sample(lower_load, "lower ternary probe")
+        if not lower["passed"]:
+            plateau = 0
+            high = lower_load - 1
+            continue
+        upper = sample(upper_load, "upper ternary probe", baseline=lower)
+        if not upper["passed"]:
+            plateau = 0
+            high = upper_load - 1
+            continue
+        gain = _throughput_gain(lower["throughput"], upper["throughput"])
+        saturated_plateau = gain < objective["plateau_gain_percent"] and upper["target_cpu_saturated"]
+        if saturated_plateau:
+            plateau += 1
+            plateau_confirmed = plateau_confirmed or plateau >= objective["plateau_points"]
+            high = upper_load - 1
+        elif upper["throughput"] <= lower["throughput"]:
+            plateau = 0
+            high = upper_load - 1
+        else:
+            plateau = 0
+            low = lower_load + 1
+
+    for load in sorted({low, (low + high) // 2, high}):
+        sample(load, "final ternary candidate")
+    selected = _best_throughput(attempts)
+    if selected is None:
+        outcome = "no-feasible-point"
+        stop_reason = "ternary search found no feasible load"
+    elif plateau_confirmed:
+        outcome = "plateau-found"
+        stop_reason = "throughput plateau confirmed by ternary search at saturated {} CPU".format(
+            objective["target_role"]
+        )
+    elif failing_load is not None:
+        outcome = "bounded-by-errors"
+        stop_reason = "workload errors bounded the ternary search below {}".format(failing_load)
+    elif selected == maximum and measured.get(maximum, {}).get("passed"):
+        outcome = "lower-bound"
+        stop_reason = "maximum configured load {} remains the best observed point".format(maximum)
+    else:
+        outcome = "best-observed"
+        stop_reason = "ternary interval [{}, {}] reached resolution {}".format(low, high, resolution)
+    return LoadSearchResult(
+        tuple(attempts),
+        selected,
+        stop_reason,
+        outcome,
+        passing_load=selected,
+        failing_load=failing_load,
+    )
+
+
+def _latency_passes(config, load, metrics):
+    objective = config["objective"]
+    latency = metrics[objective["percentile"] + "_ms"]
+    if latency > objective["max_ms"]:
+        return False, "{} latency {:.3f} ms exceeds {:.3f} ms".format(
+            objective["percentile"], latency, objective["max_ms"]
+        )
+    if not config.get("allow_errors", False) and metrics["errors"] > objective["max_errors"]:
+        return False, "errors {} exceed {}".format(metrics["errors"], objective["max_errors"])
+    if config["parameter"] == "rate":
+        ratio = metrics["throughput"] / load
+        if ratio < objective["min_achieved_rate_ratio"]:
+            return False, "achieved rate ratio {:.4f} is below {:.4f}".format(
+                ratio, objective["min_achieved_rate_ratio"]
+            )
+    reason = "latency SLO satisfied"
+    if metrics["errors"]:
+        reason += "; {} workload errors allowed".format(metrics["errors"])
+    return True, reason
+
+
+def _run_latency(config, measure, on_attempt):
+    search = config["search"]
+    attempts = []
+    measured = {}
+
+    def sample(load):
+        if load in measured:
+            return measured[load]
+        metrics = measure(load)
+        passed, reason = _latency_passes(config, load, metrics)
+        record = _with_decision(metrics, load, passed, reason)
+        _append_attempt(attempts, record, on_attempt)
+        measured[load] = record
+        return record
+
+    current = search["start"]
+    last_pass = None
+    first_fail = None
+    while True:
+        record = sample(current)
+        if record["passed"]:
+            last_pass = current
+            if current >= search["maximum"]:
+                return LoadSearchResult(
+                    tuple(attempts),
+                    current,
+                    "maximum load satisfies latency SLO",
+                    "lower-bound",
+                    passing_load=current,
+                )
+            current = _next_geometric(current, search["maximum"], search["multiplier"])
+        else:
+            first_fail = current
+            break
+
+    if last_pass is None:
+        return LoadSearchResult(
+            tuple(attempts),
+            None,
+            "minimum load {} does not satisfy latency SLO".format(first_fail),
+            "no-feasible-point",
+            failing_load=first_fail,
+        )
+
+    low = last_pass
+    high = first_fail
+    resolution = max(1, int(round(max(high, 1) * search["resolution_percent"] / 100.0)))
+    while high - low > resolution:
+        candidate = max(1, (low + high) // 2)
+        if candidate in measured:
+            break
+        record = sample(candidate)
+        if record["passed"]:
+            low = candidate
+        else:
+            high = candidate
+
+    selected = low or None
+    reason = "latency SLO bracketed between {} and {}".format(low, high)
+    return LoadSearchResult(
+        tuple(attempts),
+        selected,
+        reason,
+        "boundary-found" if selected is not None else "no-feasible-point",
+        passing_load=selected,
+        failing_load=high,
+    )
+
+
+def search_load(config, measure, on_attempt=None):
+    """Run the configured controller using ``measure(load) -> metrics``."""
+    if "values" in config:
+        return _run_points(config, measure, on_attempt)
+    objective_type = config["objective"]["type"]
+    if objective_type == "maximize-throughput":
+        return _run_throughput(config, measure, on_attempt)
+    if objective_type == "latency-slo":
+        return _run_latency(config, measure, on_attempt)
+    raise BenchmarkError("unsupported load objective: {}".format(objective_type))

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -43,7 +43,7 @@ def _throughput_gain(lower, upper):
     if lower > 0:
         return 100.0 * (upper - lower) / lower
     if upper > lower:
-        return float("inf")
+        return None
     return 0.0
 
 
@@ -103,7 +103,9 @@ def _run_throughput(config, measure, on_attempt):
             failing_load = load if failing_load is None else min(failing_load, load)
         else:
             decision = reason
-            if gain is not None:
+            if baseline is not None and gain is None:
+                decision += "; throughput increased from zero baseline"
+            elif gain is not None:
                 decision += "; throughput gain {:.3f}%".format(gain)
             if metrics["errors"]:
                 decision += "; {} workload errors allowed".format(metrics["errors"])
@@ -148,7 +150,9 @@ def _run_throughput(config, measure, on_attempt):
             high = upper_load - 1
             continue
         gain = _throughput_gain(lower["throughput"], upper["throughput"])
-        saturated_plateau = gain < objective["plateau_gain_percent"] and upper["target_cpu_saturated"]
+        saturated_plateau = (
+            gain is not None and gain < objective["plateau_gain_percent"] and upper["target_cpu_saturated"]
+        )
         if saturated_plateau:
             plateau += 1
             plateau_confirmed = plateau_confirmed or plateau >= objective["plateau_points"]

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -1,6 +1,7 @@
 """Local YDB cluster lifecycle and adaptive capacity benchmark executor."""
 
 import csv
+import errno
 import io
 import itertools
 import os
@@ -15,8 +16,8 @@ import grpc
 import yaml
 
 from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2
-from ydb.public.api.grpc import ydb_config_v1_pb2_grpc
-from ydb.public.api.protos import ydb_config_pb2
+from ydb.public.api.grpc import ydb_cms_v1_pb2_grpc, ydb_config_v1_pb2_grpc
+from ydb.public.api.protos import ydb_cms_pb2, ydb_config_pb2, ydb_operation_pb2, ydb_status_codes_pb2
 from ydb.tools.ydb_bench.lib.common import (
     BenchmarkError,
     BenchmarkInterrupted,
@@ -127,21 +128,87 @@ def _split_mask(mask, count):
     return tuple(tuple(group) for group in groups)
 
 
-def _database_status_ready(output):
-    return "State: RUNNING" in output
+def _validate_role_affinity(geometry, affinities):
+    _split_mask(affinities["static_nodes"], geometry["static_nodes"])
+    _split_mask(affinities["dynamic_nodes"], geometry["max_dynamic_nodes"])
+
+
+def _set_process_affinity(pid, mask, proc_root=Path("/proc")):
+    """Apply a process mask to every current thread, not only its leader."""
+    task_directory = proc_root / str(pid) / "task"
+    updated = set()
+    for _ in range(16):
+        try:
+            thread_ids = {int(path.name) for path in task_directory.iterdir() if path.name.isdigit()}
+        except OSError as error:
+            raise BenchmarkError("cannot list threads of dynamic node {}: {}".format(pid, error)) from error
+        if not thread_ids:
+            raise BenchmarkError("cannot update dynamic node CPU affinity: process {} has no threads".format(pid))
+        pending = thread_ids - updated
+        if not pending:
+            return
+        for thread_id in pending:
+            try:
+                os.sched_setaffinity(thread_id, mask)
+            except OSError as error:
+                if error.errno != errno.ESRCH:
+                    raise BenchmarkError("cannot update dynamic node CPU affinity: {}".format(error)) from error
+            updated.add(thread_id)
+    raise BenchmarkError("cannot update dynamic node CPU affinity: thread list did not stabilize")
+
+
+def _registered_database_units(output):
+    units = set()
+    in_registered_units = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped == "Registered units:":
+            in_registered_units = True
+            continue
+        if not in_registered_units:
+            continue
+        if line.startswith("    ") and " - " in stripped:
+            units.add(stripped.split(" - ", 1)[0])
+            continue
+        if stripped:
+            break
+    return units
+
+
+def _database_status_ready(output, expected_units=()):
+    return "State: RUNNING" in output and set(expected_units).issubset(_registered_database_units(output))
+
+
+def _operation_ready(response):
+    return response.operation.ready
+
+
+def _require_successful_operation(description, operation):
+    if not operation.ready:
+        raise BenchmarkError("{} returned an unfinished operation".format(description))
+    if operation.status == ydb_status_codes_pb2.StatusIds.SUCCESS:
+        return
+    try:
+        status = ydb_status_codes_pb2.StatusIds.StatusCode.Name(operation.status)
+    except ValueError:
+        status = str(operation.status)
+    issues = "; ".join(issue.message or str(issue).strip() for issue in operation.issues)
+    raise BenchmarkError("{} failed with {}{}".format(description, status, ": " + issues if issues else ""))
 
 
 def _bootstrap_cluster_request():
     request = ydb_config_pb2.BootstrapClusterRequest()
+    request.operation_params.operation_mode = ydb_operation_pb2.OperationParams.SYNC
     request.self_assembly_uuid = "multinode_cluster"
     return request
 
 
 def _create_tenant_request(database, storage_kind, storage_groups):
-    request = msgbus_pb2.TConsoleRequest()
-    create = request.CreateTenantRequest.Request
-    create.path = database
-    pool = create.resources.storage_units.add()
+    request = ydb_cms_pb2.CreateDatabaseRequest()
+    request.operation_params.operation_mode = ydb_operation_pb2.OperationParams.SYNC
+    request.path = database
+    request.idempotency_key = "ydb-bench-local-ydb"
+    pool = request.resources.storage_units.add()
     pool.unit_kind = storage_kind
     pool.count = storage_groups
     return request
@@ -364,7 +431,9 @@ class LocalYdbCluster:
                 "cluster bootstrap",
                 lambda timeout: stub.BootstrapCluster(_bootstrap_cluster_request(), timeout=timeout),
                 min(self.timeout, 300),
+                ready=_operation_ready,
             )
+            _require_successful_operation("cluster bootstrap", response.operation)
         finally:
             channel.close()
         atomic_write_json(self.directory / "cluster-bootstrap-attempts.json", attempts)
@@ -373,40 +442,54 @@ class LocalYdbCluster:
     def _create_tenant(self):
         channel = grpc.insecure_channel("{}:{}".format(self.hostname, self.static_nodes[0]["grpc_port"]))
         try:
-            stub = grpc_pb2_grpc.TGRpcServerStub(channel)
+            stub = ydb_cms_v1_pb2_grpc.CmsServiceStub(channel)
             response, attempts = self._grpc_eventually(
                 "tenant creation",
-                lambda timeout: stub.ConsoleRequest(
+                lambda timeout: stub.CreateDatabase(
                     _create_tenant_request(self.database, "ssd", self.geometry["storage_groups"]),
                     timeout=timeout,
                 ),
                 min(self.timeout, 300),
+                ready=_operation_ready,
             )
+            _require_successful_operation("tenant creation", response.operation)
         finally:
             channel.close()
         atomic_write_json(self.directory / "database-create-attempts.json", attempts)
         atomic_write_text(self.directory / "database-create.response.txt", str(response))
 
     def _wait_tenant_ready(self, timeout):
-        channel = grpc.insecure_channel("{}:{}".format(self.hostname, self.dynamic_nodes[0]["grpc_port"]))
-        try:
-            stub = grpc_pb2_grpc.TGRpcServerStub(channel)
+        deadline = time.monotonic() + timeout
+        all_attempts = []
+        responses = []
+        for index, node in enumerate(self.dynamic_nodes, 1):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise BenchmarkError("tenant readiness did not complete in {} seconds".format(timeout))
+            channel = grpc.insecure_channel("{}:{}".format(self.hostname, node["grpc_port"]))
+            try:
+                stub = grpc_pb2_grpc.TGRpcServerStub(channel)
 
-            def describe(deadline):
-                request = msgbus_pb2.TSchemeDescribe()
-                request.Path = self.database
-                return stub.SchemeDescribe(request, timeout=deadline)
+                def describe(rpc_timeout):
+                    request = msgbus_pb2.TSchemeDescribe()
+                    request.Path = self.database
+                    return stub.SchemeDescribe(request, timeout=rpc_timeout)
 
-            response, attempts = self._grpc_eventually(
-                "tenant SchemeShard",
-                describe,
-                timeout,
-                ready=lambda value: value.Status == 1,
+                description = "tenant SchemeShard on dynamic node {}".format(index)
+                response, attempts = self._grpc_eventually(
+                    description,
+                    describe,
+                    remaining,
+                    ready=lambda value: value.Status == 1,
+                )
+            finally:
+                channel.close()
+            all_attempts.extend(
+                {"dynamic_node": index, "grpc_port": node["grpc_port"], **attempt} for attempt in attempts
             )
-        finally:
-            channel.close()
-        atomic_write_json(self.directory / "tenant-ready-attempts.json", attempts)
-        atomic_write_text(self.directory / "tenant-ready.response.txt", str(response))
+            responses.append("dynamic node {}:\n{}".format(index, response))
+        atomic_write_json(self.directory / "tenant-ready-attempts.json", all_attempts)
+        atomic_write_text(self.directory / "tenant-ready.response.txt", "\n\n".join(responses))
 
     def init_workload(self, command, timeout=120):
         self._check_cancelled()
@@ -507,7 +590,7 @@ class LocalYdbCluster:
             time.sleep(0.2)
         raise BenchmarkError("{} did not become ready in {} seconds".format(description, timeout))
 
-    def _wait_database_ready(self, timeout=120):
+    def _wait_database_ready(self, expected_units, timeout=120):
         command = [
             self.ydbd,
             "-s",
@@ -522,7 +605,11 @@ class LocalYdbCluster:
         while time.monotonic() < deadline:
             self._check_cancelled()
             last_result = run_command(command, {}, 10, work_dir_hint=self.directory, cancel_event=self.cancel_event)
-            if not last_result.exit_code and not last_result.timed_out and _database_status_ready(last_result.stdout):
+            if (
+                not last_result.exit_code
+                and not last_result.timed_out
+                and _database_status_ready(last_result.stdout, expected_units)
+            ):
                 atomic_write_text(self.directory / "database-status.txt", last_result.stdout)
                 return
             if any(process.poll() is not None for process in self.static_processes + self.dynamic_processes):
@@ -542,10 +629,7 @@ class LocalYdbCluster:
         masks = _split_mask(self.affinities["dynamic_nodes"], final_count)
         if self.affinities["dynamic_nodes"] is not None:
             for process, mask in zip(self.dynamic_processes, masks):
-                try:
-                    os.sched_setaffinity(process.pid, mask)
-                except OSError as error:
-                    raise BenchmarkError("cannot update dynamic node CPU affinity: {}".format(error)) from error
+                _set_process_affinity(process.pid, mask)
         for index in range(start_index, final_count):
             node = self._node_ports()
             self.dynamic_nodes.append(node)
@@ -580,8 +664,10 @@ class LocalYdbCluster:
                 )
             )
         self._progress("waiting-for-database", dynamic_nodes=final_count)
-        self._wait_for_port(self.dynamic_nodes[-1]["grpc_port"], "dynamic node")
-        self._wait_database_ready()
+        for index, node in enumerate(self.dynamic_nodes[start_index:], start_index + 1):
+            self._wait_for_port(node["grpc_port"], "dynamic node {}".format(index))
+        expected_units = {"{}:{}".format(self.hostname, node["ic_port"]) for node in self.dynamic_nodes}
+        self._wait_database_ready(expected_units)
         self._wait_tenant_ready(min(self.timeout, 600))
         self._progress("cluster-ready", dynamic_nodes=final_count)
 
@@ -792,6 +878,7 @@ def run_local_ydb(
     profile = configuration.parameters["local_ydb"]
     topology = discover_topology()
     affinities = plan_role_affinity(profile["affinity"], topology)
+    _validate_role_affinity(profile["geometry"], affinities)
     step = {
         "affinity": "roles",
         "background_load": "none",
@@ -814,6 +901,7 @@ def run_local_ydb(
         "platform": collect_system_info(),
         "cpu_topology": topology_record(topology),
         "parameters": profile,
+        "timeout_seconds": configuration.timeout_seconds,
         "role_affinity": {role: None if mask is None else list(mask) for role, mask in affinities.items()},
         "attempts": [],
         "searches": [],

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -1,0 +1,1239 @@
+"""Local YDB cluster lifecycle and adaptive capacity benchmark executor."""
+
+import csv
+import io
+import itertools
+import os
+import socket
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import grpc
+import yaml
+
+from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2
+from ydb.public.api.grpc import ydb_config_v1_pb2_grpc
+from ydb.public.api.protos import ydb_config_pb2
+from ydb.tools.ydb_bench.lib.common import (
+    BenchmarkError,
+    BenchmarkInterrupted,
+    atomic_write_json,
+    atomic_write_text,
+)
+from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
+from ydb.tools.ydb_bench.lib.load_control import search_load
+from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
+from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
+from ydb.tools.ydb_bench.lib.system_info import collect_system_info
+from ydb.tools.ydb_bench.lib.topology import CpuTopology, discover_topology, plan_affinity, topology_record
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _port_available(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as stream:
+        try:
+            stream.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+def _next_available_port(candidates, name):
+    for port in candidates:
+        if _port_available(port):
+            return port
+    raise BenchmarkError("no available ports in the MNC {} port range".format(name))
+
+
+def _mnc_port_candidates():
+    return {
+        "grpc_port": iter(itertools.chain((2135,), range(20000, 21000))),
+        "ic_port": iter(itertools.chain((19001, 19000), range(19002, 20000))),
+        "mon_port": iter(itertools.chain((8765,), range(31000, 32000))),
+    }
+
+
+def _restricted_topology(topology, allowed):
+    allowed = frozenset(allowed)
+
+    def groups(items):
+        return tuple(tuple(cpu for cpu in cpus if cpu in allowed) for cpus in items if allowed.intersection(cpus))
+
+    return CpuTopology(
+        allowed_cpus=tuple(cpu for cpu in topology.allowed_cpus if cpu in allowed),
+        numa_nodes=tuple(
+            (node, tuple(cpu for cpu in cpus if cpu in allowed))
+            for node, cpus in topology.numa_nodes
+            if allowed.intersection(cpus)
+        ),
+        chiplets=tuple(
+            (node, tuple(cpu for cpu in cpus if cpu in allowed))
+            for node, cpus in topology.chiplets
+            if allowed.intersection(cpus)
+        ),
+        physical_cores=groups(topology.physical_cores),
+        smt_siblings=groups(topology.smt_siblings),
+        hierarchy_reasons=topology.hierarchy_reasons,
+        chiplet_topology_reason=topology.chiplet_topology_reason,
+    )
+
+
+def _role_cpu_count(role, topology):
+    value = role["cpus"]
+    if value == "one-chiplet":
+        if not topology.chiplets:
+            raise BenchmarkError("one-chiplet affinity requires discovered chiplet topology")
+        return len(topology.chiplets[0][1])
+    if value == "remaining":
+        return len(topology.allowed_cpus)
+    return value
+
+
+def plan_role_affinity(config, topology):
+    """Allocate explicit role masks without overlap; ``none`` remains OS-managed."""
+    available = set(topology.allowed_cpus)
+    result = {}
+    # Reserve the workload generator first: it is the only role which is pinned
+    # by default and must keep a stable mask while the controller changes load.
+    for name in ("ydb_cli", "static_nodes", "dynamic_nodes"):
+        role = config[name]
+        if role["mode"] == "none":
+            result[name] = None
+            continue
+        restricted = _restricted_topology(topology, available)
+        required = _role_cpu_count(role, restricted)
+        placement = plan_affinity(role["mode"], restricted, required)
+        if not placement.supported:
+            raise BenchmarkError("{} affinity is unavailable: {}".format(name, placement.reason))
+        result[name] = placement.cpus
+        available.difference_update(placement.cpus)
+    return result
+
+
+def _split_mask(mask, count):
+    if mask is None:
+        return (None,) * count
+    if len(mask) < count:
+        raise BenchmarkError("{} explicitly assigned CPUs cannot host {} nodes".format(len(mask), count))
+    groups = [[] for _ in range(count)]
+    for index, cpu in enumerate(mask):
+        groups[index % count].append(cpu)
+    return tuple(tuple(group) for group in groups)
+
+
+def _database_status_ready(output):
+    return "State: RUNNING" in output
+
+
+def _bootstrap_cluster_request():
+    request = ydb_config_pb2.BootstrapClusterRequest()
+    request.self_assembly_uuid = "multinode_cluster"
+    return request
+
+
+def _create_tenant_request(database, storage_kind, storage_groups):
+    request = msgbus_pb2.TConsoleRequest()
+    create = request.CreateTenantRequest.Request
+    create.path = database
+    pool = create.resources.storage_units.add()
+    pool.unit_kind = storage_kind
+    pool.count = storage_groups
+    return request
+
+
+def _sector_map_path(index, disk_size_gb):
+    return "SectorMap:map_{}:{}:NONE".format(index, disk_size_gb)
+
+
+def _cluster_config(static_nodes, disk_size_gb, hostname=None):
+    # Nameservice and NodeBroker identify a node by its real host name.  Using
+    # localhost here prevents a dynamic node from registering as a compute
+    # unit of the tenant even when all processes run on the same machine.
+    hostname = hostname or socket.getfqdn()
+    hosts = []
+    host_configs = []
+    for sector_map_index, node in enumerate(static_nodes):
+        node_id = sector_map_index + 1
+        hosts.append(
+            {
+                "host": hostname,
+                "port": node["ic_port"],
+                "node_id": node_id,
+                "host_config_id": node_id,
+                "location": {"body": node_id, "data_center": "local", "rack": str(node_id)},
+            }
+        )
+        host_configs.append(
+            {
+                "host_config_id": node_id,
+                "ssd": [_sector_map_path(sector_map_index, disk_size_gb)],
+            }
+        )
+    return {
+        "metadata": {"kind": "MainConfig", "cluster": "", "version": 0},
+        "allowed_labels": {
+            "node_id": {"type": "string"},
+            "host": {"type": "string"},
+            "tenant": {"type": "string"},
+        },
+        "config": {
+            "erasure": "none",
+            "default_disk_type": "SSD",
+            "fail_domain_type": "rack",
+            "yaml_config_enabled": True,
+            "self_management_config": {"enabled": True},
+            "host_configs": host_configs,
+            "hosts": hosts,
+            "domains_config": {"domain": [{"domain_id": 1, "name": "Root"}]},
+        },
+    }
+
+
+class LocalYdbCluster:
+    def __init__(
+        self,
+        ydbd,
+        ydb_cli,
+        process_guard,
+        directory,
+        geometry,
+        affinities,
+        timeout,
+        cancel_event=None,
+        progress=None,
+    ):
+        self.ydbd = Path(ydbd)
+        self.ydb_cli = Path(ydb_cli)
+        self.process_guard = Path(process_guard)
+        self.directory = Path(directory)
+        self.geometry = geometry
+        self.affinities = affinities
+        self.timeout = timeout
+        self.cancel_event = cancel_event
+        self.progress = progress
+        self.static_processes = []
+        self.dynamic_processes = []
+        self.port_candidates = _mnc_port_candidates()
+        self.static_nodes = []
+        self.dynamic_nodes = []
+        self.hostname = socket.getfqdn()
+        self.static_masks = _split_mask(affinities["static_nodes"], geometry["static_nodes"])
+        self.config_path = self.directory / "cluster.yaml"
+        self.database = "/Root/bench"
+
+    def _progress(self, phase, **fields):
+        if self.progress is not None:
+            self.progress(phase, **fields)
+
+    @property
+    def endpoint(self):
+        return "grpc://127.0.0.1:{}".format(self.static_nodes[0]["grpc_port"])
+
+    @property
+    def client_endpoint(self):
+        return "grpc://{}:{}".format(self.hostname, self.static_nodes[0]["grpc_port"])
+
+    @property
+    def static_pids(self):
+        return tuple(process.pid for process in self.static_processes if process.poll() is None)
+
+    @property
+    def dynamic_pids(self):
+        return tuple(process.pid for process in self.dynamic_processes if process.poll() is None)
+
+    def ensure_running(self, context):
+        exited = []
+        for role, processes in (("static", self.static_processes), ("dynamic", self.dynamic_processes)):
+            for index, process in enumerate(processes, 1):
+                exit_code = process.poll()
+                if exit_code is not None:
+                    exited.append("{} node {} exited with code {}".format(role, index, exit_code))
+        if exited:
+            raise BenchmarkError("{}: {}".format(context, "; ".join(exited)))
+
+    def _check_cancelled(self):
+        if self.cancel_event is not None and self.cancel_event.is_set():
+            raise BenchmarkInterrupted("local YDB benchmark was cancelled")
+
+    def _run(self, command, timeout=None, cpu_affinity=None):
+        self._check_cancelled()
+        self.ensure_running("cannot run YDB CLI command")
+        result = run_command(
+            command,
+            {},
+            timeout or self.timeout,
+            work_dir_hint=self.directory,
+            cpu_affinity=cpu_affinity,
+            cancel_event=self.cancel_event,
+        )
+        self.ensure_running("YDB process exited while running a CLI command")
+        if result.interrupted:
+            raise BenchmarkInterrupted("command was interrupted: {}".format(" ".join(map(str, command))))
+        if result.timed_out:
+            raise BenchmarkError("command timed out: {}".format(" ".join(map(str, command))))
+        if result.exit_code:
+            details = "\n".join(
+                "{}:\n{}".format(name, value.strip())
+                for name, value in (("stdout", result.stdout), ("stderr", result.stderr))
+                if value.strip()
+            )
+            raise BenchmarkError(
+                "command exited with code {}: {}{}".format(
+                    result.exit_code,
+                    " ".join(map(str, command)),
+                    "\n" + details if details else "",
+                )
+            )
+        return result
+
+    def _run_eventually(self, command, timeout=120, cpu_affinity=None):
+        deadline = time.monotonic() + timeout
+        attempts = []
+        while True:
+            self._check_cancelled()
+            remaining = deadline - time.monotonic()
+            result = run_command(
+                command,
+                {},
+                min(30, max(1, remaining)),
+                work_dir_hint=self.directory,
+                cpu_affinity=cpu_affinity,
+                cancel_event=self.cancel_event,
+            )
+            attempts.append(result)
+            if not result.exit_code and not result.timed_out and not result.interrupted:
+                return result, attempts
+            if result.interrupted:
+                raise BenchmarkInterrupted("command was interrupted: {}".format(" ".join(map(str, command))))
+            if time.monotonic() >= deadline:
+                details = result.stderr.strip() or result.stdout.strip() or "no diagnostics"
+                raise BenchmarkError(
+                    "command did not succeed in {} seconds: {}\n{}".format(
+                        timeout,
+                        " ".join(map(str, command)),
+                        details,
+                    )
+                )
+            time.sleep(1)
+
+    def _grpc_eventually(self, description, operation, timeout, ready=None):
+        deadline = time.monotonic() + timeout
+        attempts = []
+        ready = ready or (lambda response: True)
+        while True:
+            self._check_cancelled()
+            started_at = time.monotonic()
+            try:
+                response = operation(min(30, max(1, deadline - started_at)))
+                attempts.append(
+                    {
+                        "duration_seconds": time.monotonic() - started_at,
+                        "error": None,
+                        "response": str(response),
+                    }
+                )
+                if ready(response):
+                    return response, attempts
+            except grpc.RpcError as error:
+                attempts.append(
+                    {
+                        "duration_seconds": time.monotonic() - started_at,
+                        "error": error.details() or str(error),
+                        "status": error.code().name,
+                    }
+                )
+                if time.monotonic() >= deadline:
+                    raise BenchmarkError(
+                        "{} did not succeed in {} seconds: {}".format(description, timeout, error.details() or error)
+                    ) from error
+            if time.monotonic() >= deadline:
+                raise BenchmarkError("{} did not become ready in {} seconds".format(description, timeout))
+            time.sleep(1)
+
+    def _bootstrap_cluster(self):
+        channel = grpc.insecure_channel("{}:{}".format(self.hostname, self.static_nodes[0]["grpc_port"]))
+        try:
+            stub = ydb_config_v1_pb2_grpc.ConfigServiceStub(channel)
+            response, attempts = self._grpc_eventually(
+                "cluster bootstrap",
+                lambda timeout: stub.BootstrapCluster(_bootstrap_cluster_request(), timeout=timeout),
+                min(self.timeout, 300),
+            )
+        finally:
+            channel.close()
+        atomic_write_json(self.directory / "cluster-bootstrap-attempts.json", attempts)
+        atomic_write_text(self.directory / "cluster-bootstrap.response.txt", str(response))
+
+    def _create_tenant(self):
+        channel = grpc.insecure_channel("{}:{}".format(self.hostname, self.static_nodes[0]["grpc_port"]))
+        try:
+            stub = grpc_pb2_grpc.TGRpcServerStub(channel)
+            response, attempts = self._grpc_eventually(
+                "tenant creation",
+                lambda timeout: stub.ConsoleRequest(
+                    _create_tenant_request(self.database, "ssd", self.geometry["storage_groups"]),
+                    timeout=timeout,
+                ),
+                min(self.timeout, 300),
+            )
+        finally:
+            channel.close()
+        atomic_write_json(self.directory / "database-create-attempts.json", attempts)
+        atomic_write_text(self.directory / "database-create.response.txt", str(response))
+
+    def _wait_tenant_ready(self, timeout):
+        channel = grpc.insecure_channel("{}:{}".format(self.hostname, self.dynamic_nodes[0]["grpc_port"]))
+        try:
+            stub = grpc_pb2_grpc.TGRpcServerStub(channel)
+
+            def describe(deadline):
+                request = msgbus_pb2.TSchemeDescribe()
+                request.Path = self.database
+                return stub.SchemeDescribe(request, timeout=deadline)
+
+            response, attempts = self._grpc_eventually(
+                "tenant SchemeShard",
+                describe,
+                timeout,
+                ready=lambda value: value.Status == 1,
+            )
+        finally:
+            channel.close()
+        atomic_write_json(self.directory / "tenant-ready-attempts.json", attempts)
+        atomic_write_text(self.directory / "tenant-ready.response.txt", str(response))
+
+    def init_workload(self, command, timeout=120):
+        self._check_cancelled()
+        self.ensure_running("cannot initialize workload")
+        result = run_command(
+            command,
+            {},
+            timeout,
+            work_dir_hint=self.directory,
+            cpu_affinity=self.affinities["ydb_cli"],
+            cancel_event=self.cancel_event,
+        )
+        attempts = [result]
+        self.ensure_running("YDB process exited while initializing the workload")
+        if result.interrupted:
+            raise BenchmarkInterrupted("YDB CLI workload initialization was interrupted")
+        if result.timed_out or result.exit_code:
+            details = result.stderr.strip() or result.stdout.strip() or "no diagnostics"
+            status = "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
+            raise BenchmarkError("workload initialization {}: {}".format(status, details))
+        return result, attempts
+
+    def _node_ports(self):
+        return {name: _next_available_port(candidates, name) for name, candidates in self.port_candidates.items()}
+
+    def start(self):
+        self._progress("preparing-cluster")
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.static_nodes = [self._node_ports() for _ in range(self.geometry["static_nodes"])]
+        for index, node in enumerate(self.static_nodes, 1):
+            node_directory = self.directory / "static-{:02d}".format(index)
+            node_directory.mkdir()
+        cluster_config = _cluster_config(self.static_nodes, self.geometry["disk_size_gb"], self.hostname)
+        atomic_write_text(self.config_path, yaml.safe_dump(cluster_config, sort_keys=False))
+        self._progress("starting-static-nodes", static_nodes=len(self.static_nodes))
+        for index, (node, mask) in enumerate(zip(self.static_nodes, self.static_masks), 1):
+            node_directory = self.directory / "static-{:02d}".format(index)
+            command = [
+                self.ydbd,
+                "server",
+                "--yaml-config",
+                self.config_path,
+                "--node",
+                "static",
+                "--grpc-port",
+                node["grpc_port"],
+                "--ic-port",
+                node["ic_port"],
+                "--mon-port",
+                node["mon_port"],
+            ]
+            self.static_processes.append(
+                start_managed_process(
+                    command,
+                    node_directory / "stdout.txt",
+                    node_directory / "stderr.txt",
+                    cwd=node_directory,
+                    cpu_affinity=mask,
+                    parent_death_wrapper=self.process_guard,
+                )
+            )
+        self._progress("waiting-for-static-nodes", static_nodes=len(self.static_nodes))
+        for index, node in enumerate(self.static_nodes, 1):
+            self._wait_for_port(node["grpc_port"], "static node {}".format(index))
+        self._progress("bootstrapping-cluster")
+        self._bootstrap_cluster()
+        self._progress("creating-database")
+        self._create_tenant()
+        self.add_dynamic_nodes(self.geometry["dynamic_nodes"])
+
+    def _write_attempts(self, name, result, attempts):
+        atomic_write_json(
+            self.directory / "{}-attempts.json".format(name),
+            [
+                {
+                    "exit_code": attempt.exit_code,
+                    "timed_out": attempt.timed_out,
+                    "duration_seconds": attempt.duration_seconds,
+                    "stdout": attempt.stdout,
+                    "stderr": attempt.stderr,
+                }
+                for attempt in attempts
+            ],
+        )
+        atomic_write_text(self.directory / "{}.stdout.txt".format(name), result.stdout)
+        atomic_write_text(self.directory / "{}.stderr.txt".format(name), result.stderr)
+
+    def _wait_for_port(self, port, description, timeout=60):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._check_cancelled()
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as stream:
+                stream.settimeout(0.2)
+                if stream.connect_ex(("127.0.0.1", port)) == 0:
+                    return
+            if any(process.poll() is not None for process in self.static_processes + self.dynamic_processes):
+                raise BenchmarkError("a YDB process exited while waiting for {}".format(description))
+            time.sleep(0.2)
+        raise BenchmarkError("{} did not become ready in {} seconds".format(description, timeout))
+
+    def _wait_database_ready(self, timeout=120):
+        command = [
+            self.ydbd,
+            "-s",
+            self.endpoint,
+            "admin",
+            "database",
+            self.database,
+            "status",
+        ]
+        deadline = time.monotonic() + timeout
+        last_result = None
+        while time.monotonic() < deadline:
+            self._check_cancelled()
+            last_result = run_command(command, {}, 10, work_dir_hint=self.directory, cancel_event=self.cancel_event)
+            if not last_result.exit_code and not last_result.timed_out and _database_status_ready(last_result.stdout):
+                atomic_write_text(self.directory / "database-status.txt", last_result.stdout)
+                return
+            if any(process.poll() is not None for process in self.static_processes + self.dynamic_processes):
+                raise BenchmarkError("a YDB process exited while waiting for database readiness")
+            time.sleep(1)
+        details = last_result.stderr.strip() or last_result.stdout.strip() or "no diagnostics"
+        raise BenchmarkError("database did not reach RUNNING state: {}".format(details))
+
+    def add_dynamic_nodes(self, count):
+        start_index = len(self.dynamic_nodes)
+        final_count = start_index + count
+        self._progress(
+            "starting-dynamic-nodes",
+            dynamic_nodes=start_index,
+            target_dynamic_nodes=final_count,
+        )
+        masks = _split_mask(self.affinities["dynamic_nodes"], final_count)
+        if self.affinities["dynamic_nodes"] is not None:
+            for process, mask in zip(self.dynamic_processes, masks):
+                try:
+                    os.sched_setaffinity(process.pid, mask)
+                except OSError as error:
+                    raise BenchmarkError("cannot update dynamic node CPU affinity: {}".format(error)) from error
+        for index in range(start_index, final_count):
+            node = self._node_ports()
+            self.dynamic_nodes.append(node)
+            node_directory = self.directory / "dynamic-{:02d}".format(index + 1)
+            node_directory.mkdir()
+            command = [
+                self.ydbd,
+                "server",
+                "--yaml-config",
+                self.config_path,
+                "--tenant",
+                self.database,
+                "--node-broker-port",
+                self.static_nodes[0]["grpc_port"],
+                "--grpc-port",
+                node["grpc_port"],
+                "--ic-port",
+                node["ic_port"],
+                "--mon-port",
+                node["mon_port"],
+                "--syslog-service-tag",
+                "ydb_node_dynamic_{}".format(index + 1),
+            ]
+            self.dynamic_processes.append(
+                start_managed_process(
+                    command,
+                    node_directory / "stdout.txt",
+                    node_directory / "stderr.txt",
+                    cwd=node_directory,
+                    cpu_affinity=masks[index],
+                    parent_death_wrapper=self.process_guard,
+                )
+            )
+        self._progress("waiting-for-database", dynamic_nodes=final_count)
+        self._wait_for_port(self.dynamic_nodes[-1]["grpc_port"], "dynamic node")
+        self._wait_database_ready()
+        self._wait_tenant_ready(min(self.timeout, 600))
+        self._progress("cluster-ready", dynamic_nodes=final_count)
+
+    def stop(self):
+        records = []
+        for process in reversed(self.static_processes + self.dynamic_processes):
+            try:
+                records.append(process.stop())
+            except OSError:
+                pass
+        return records
+
+
+def _workload_base(cluster, workload_type, path=None):
+    command = [
+        cluster.ydb_cli,
+        "--endpoint",
+        cluster.client_endpoint,
+        "--database",
+        cluster.database,
+        "workload",
+        workload_type,
+    ]
+    if path is not None:
+        command += ["--path", path]
+    return command
+
+
+def _kv_init_command(cluster, path, options):
+    return _workload_base(cluster, "kv", path) + [
+        "init",
+        "--init-upserts",
+        options["init-upserts"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--max-partitions",
+        options["max-partitions"],
+        "--partition-size",
+        options["partition-size-mb"],
+        "--max-first-key",
+        options["max-first-key"],
+        "--len",
+        options["value-size"],
+        "--cols",
+        options["columns"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--rows",
+        options["rows-per-query"],
+    ]
+
+
+def _kv_run_command(cluster, path, workload, load_config, load, seconds, client_threads):
+    options = workload["options"]
+    threads = load if load_config["parameter"] == "threads" else client_threads
+    command = _workload_base(cluster, "kv", path) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+        "--max-first-key",
+        options["max-first-key"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--cols",
+        options["columns"],
+    ]
+    if workload["operation"] != "mixed":
+        command += ["--rows", options["rows-per-query"]]
+    if workload["operation"] in ("upsert", "mixed"):
+        command += ["--len", options["value-size"]]
+    if load_config["parameter"] == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _stock_init_command(cluster, path, options):
+    del path
+    return _workload_base(cluster, "stock") + [
+        "init",
+        "--products",
+        options["products"],
+        "--quantity",
+        options["quantity"],
+        "--orders",
+        options["orders"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--auto-partition",
+        options["auto-partition"],
+    ]
+
+
+def _stock_run_command(cluster, path, workload, load_config, load, seconds, client_threads):
+    del path
+    options = workload["options"]
+    threads = load if load_config["parameter"] == "threads" else client_threads
+    command = _workload_base(cluster, "stock") + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+    ]
+    if workload["operation"] in ("user-hist", "rand-user-hist"):
+        command += ["--limit", options["limit"]]
+    else:
+        command += ["--products", options["products"]]
+    if load_config["parameter"] == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _init_command(cluster, path, workload):
+    if workload["type"] == "stock":
+        return _stock_init_command(cluster, path, workload["options"])
+    return _kv_init_command(cluster, path, workload["options"])
+
+
+def _run_workload_command(cluster, path, workload, load_config, load, seconds, client_threads):
+    if workload["type"] == "stock":
+        return _stock_run_command(cluster, path, workload, load_config, load, seconds, client_threads)
+    return _kv_run_command(cluster, path, workload, load_config, load, seconds, client_threads)
+
+
+def _workload_table_path(workload_type, path):
+    # Unlike KV, stock has no --path option and creates its tables directly in
+    # the selected database.  "stock" is the first table created by its init.
+    return "stock" if workload_type == "stock" else path
+
+
+def _clean_workload_command(cluster, workload_type, path):
+    if workload_type == "stock":
+        return _workload_base(cluster, workload_type) + ["clean"]
+    return _workload_base(cluster, workload_type, path) + ["clean"]
+
+
+def _command_record(phase, repetition, command, cpu_affinity, result=None):
+    record = {
+        "phase": phase,
+        "repetition": repetition,
+        "argv": [str(part) for part in command],
+        "cpu_affinity": None if cpu_affinity is None else sorted(int(cpu) for cpu in cpu_affinity),
+    }
+    if result is not None:
+        record.update(
+            {
+                "started_at": result.started_at,
+                "finished_at": result.finished_at,
+                "duration_seconds": result.duration_seconds,
+                "exit_code": result.exit_code,
+                "timed_out": result.timed_out,
+                "interrupted": result.interrupted,
+            }
+        )
+    return record
+
+
+def _aggregate_measurements(rows):
+    keys = rows[0]
+    result = {key: statistics.median(row[key] for row in rows) for key in keys}
+    # One clean repetition must not hide request failures in another one. Error
+    # counts describe the whole attempted point; performance metrics remain
+    # medians so that an outlier repetition does not select the load.
+    result["errors"] = sum(row["errors"] for row in rows)
+    return result
+
+
+def _role_capacity(mask, topology):
+    return len(mask) if mask is not None else len(topology.allowed_cpus)
+
+
+def _write_csv(path, rows, columns):
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="ignore", lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    atomic_write_text(path, output.getvalue())
+
+
+def run_local_ydb(
+    binaries,
+    configuration,
+    output_directory,
+    tool_revision,
+    work_dir_hint=None,
+    event_sink=None,
+    cancel_event=None,
+):
+    """Run a local cluster profile using bundled ``ydbd`` and ``ydb`` executables."""
+
+    if not sys.platform.startswith("linux"):
+        raise BenchmarkError("local YDB benchmarks require Linux")
+
+    del work_dir_hint
+    output_directory = Path(output_directory)
+    output_directory.mkdir(parents=True, exist_ok=True)
+    benchmark = configuration.benchmark
+    profile = configuration.parameters["local_ydb"]
+    topology = discover_topology()
+    affinities = plan_role_affinity(profile["affinity"], topology)
+    step = {
+        "affinity": "roles",
+        "background_load": "none",
+        "threads": configuration.threads[0],
+        "case": 1,
+        "repeat": 1,
+    }
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "benchmark": benchmark.name,
+        "profile": configuration.profile,
+        "status": "running",
+        "state": "running",
+        "started_at": _utc_now(),
+        "tool_revision": tool_revision,
+        "binaries": {
+            name: {"name": binary.path.name, "sha256": binary.sha256, "size": binary.size}
+            for name, binary in binaries.items()
+        },
+        "platform": collect_system_info(),
+        "cpu_topology": topology_record(topology),
+        "parameters": profile,
+        "role_affinity": {role: None if mask is None else list(mask) for role, mask in affinities.items()},
+        "attempts": [],
+        "searches": [],
+        "progress": None,
+    }
+    manifest_path = output_directory / "run.json"
+    write_manifest(manifest_path, manifest)
+    if event_sink is not None:
+        event_sink(
+            {
+                "type": "step-started",
+                **step,
+                "fields": {"started_at": manifest["started_at"], "role_affinity": manifest["role_affinity"]},
+            }
+        )
+
+    def publish_progress(phase, **fields):
+        progress = {
+            "phase": phase,
+            "phase_started_at": _utc_now(),
+            **fields,
+        }
+        manifest["progress"] = progress
+        write_manifest(manifest_path, manifest)
+        if event_sink is not None:
+            event_sink({"type": "step-progress", **step, "fields": {"progress": progress}})
+
+    cluster = LocalYdbCluster(
+        binaries["ydbd"].path,
+        binaries["ydb_cli"].path,
+        binaries["process_guard"].path,
+        output_directory / "cluster",
+        profile["geometry"],
+        affinities,
+        configuration.timeout_seconds,
+        cancel_event,
+        publish_progress,
+    )
+    repetition_rows = []
+    cluster_stopped = False
+    try:
+        cluster.start()
+        while True:
+            dynamic_nodes = len(cluster.dynamic_nodes)
+            search_stage = len(manifest["searches"]) + 1
+            search_started_at = _utc_now()
+            search_started_monotonic = time.monotonic()
+            geometry_directory = output_directory / "dynamic-nodes-{:02d}".format(dynamic_nodes)
+            geometry_directory.mkdir()
+
+            def measure(load):
+                attempt = len(manifest["attempts"]) + 1
+                attempt_started_at = _utc_now()
+                attempt_started_monotonic = time.monotonic()
+                samples = []
+                commands = []
+                for repetition in range(1, profile["measurement"]["repetitions"] + 1):
+                    if cancel_event is not None and cancel_event.is_set():
+                        raise BenchmarkInterrupted("local YDB benchmark was cancelled")
+                    directory = geometry_directory / "load-{:08d}".format(load) / "repeat-{:03d}".format(repetition)
+                    directory.mkdir(parents=True)
+                    table_path = "ydb_bench_{}_{}_{}".format(dynamic_nodes, load, repetition)
+                    progress_fields = {
+                        "search_stage": search_stage,
+                        "attempt": attempt,
+                        "dynamic_nodes": dynamic_nodes,
+                        "parameter": profile["load"]["parameter"],
+                        "load": load,
+                        "repetition": repetition,
+                        "repetitions": profile["measurement"]["repetitions"],
+                    }
+                    init_command = _init_command(cluster, table_path, profile["workload"])
+                    publish_progress(
+                        "initializing-workload",
+                        **progress_fields,
+                        current_command=_command_record(
+                            "initializing-workload",
+                            repetition,
+                            init_command,
+                            affinities["ydb_cli"],
+                        ),
+                    )
+                    init, init_attempts = cluster.init_workload(init_command)
+                    commands.extend(
+                        _command_record(
+                            "initializing-workload",
+                            repetition,
+                            init_attempt.command,
+                            affinities["ydb_cli"],
+                            init_attempt,
+                        )
+                        for init_attempt in init_attempts
+                    )
+                    atomic_write_text(directory / "init.stdout.txt", init.stdout)
+                    atomic_write_text(directory / "init.stderr.txt", init.stderr)
+                    atomic_write_json(
+                        directory / "init-attempts.json",
+                        [
+                            {
+                                "command": [str(part) for part in attempt.command],
+                                "exit_code": attempt.exit_code,
+                                "timed_out": attempt.timed_out,
+                                "duration_seconds": attempt.duration_seconds,
+                                "stdout": attempt.stdout,
+                                "stderr": attempt.stderr,
+                            }
+                            for attempt in init_attempts
+                        ],
+                    )
+                    run_error = None
+                    try:
+                        warmup = profile["measurement"]["warmup"]
+                        if warmup:
+                            warmup_command = _run_workload_command(
+                                cluster,
+                                table_path,
+                                profile["workload"],
+                                profile["load"],
+                                load,
+                                warmup,
+                                profile["client"]["threads"],
+                            )
+                            publish_progress(
+                                "warming-up",
+                                **progress_fields,
+                                phase_duration_seconds=warmup,
+                                current_command=_command_record(
+                                    "warming-up",
+                                    repetition,
+                                    warmup_command,
+                                    affinities["ydb_cli"],
+                                ),
+                            )
+                            result = cluster._run(
+                                warmup_command,
+                                timeout=warmup + 30,
+                                cpu_affinity=affinities["ydb_cli"],
+                            )
+                            commands.append(
+                                _command_record(
+                                    "warming-up",
+                                    repetition,
+                                    result.command,
+                                    affinities["ydb_cli"],
+                                    result,
+                                )
+                            )
+                            atomic_write_text(directory / "warmup.stdout.txt", result.stdout)
+                            atomic_write_text(directory / "warmup.stderr.txt", result.stderr)
+
+                        cli_pids = []
+                        monitor = LinuxCpuMonitor(
+                            {
+                                "static": lambda: cluster.static_pids,
+                                "dynamic": lambda: cluster.dynamic_pids,
+                                "cli": lambda: tuple(cli_pids),
+                            },
+                            {
+                                "static": _role_capacity(affinities["static_nodes"], topology),
+                                "dynamic": _role_capacity(affinities["dynamic_nodes"], topology),
+                                "cli": _role_capacity(affinities["ydb_cli"], topology),
+                            },
+                        ).start()
+                        command = _run_workload_command(
+                            cluster,
+                            table_path,
+                            profile["workload"],
+                            profile["load"],
+                            load,
+                            profile["measurement"]["duration"],
+                            profile["client"]["threads"],
+                        )
+                        cluster.ensure_running("cannot start workload measurement")
+                        try:
+                            publish_progress(
+                                "measuring",
+                                **progress_fields,
+                                phase_duration_seconds=profile["measurement"]["duration"],
+                                current_command=_command_record(
+                                    "measuring",
+                                    repetition,
+                                    command,
+                                    affinities["ydb_cli"],
+                                ),
+                            )
+                            result = run_command(
+                                command,
+                                {},
+                                profile["measurement"]["duration"] + 30,
+                                cpu_affinity=affinities["ydb_cli"],
+                                cancel_event=cancel_event,
+                                on_process_started=lambda process: cli_pids.append(process.pid),
+                            )
+                        finally:
+                            cpu = monitor.stop()
+                        cluster.ensure_running("YDB process exited during workload measurement")
+                        commands.append(
+                            _command_record(
+                                "measuring",
+                                repetition,
+                                result.command,
+                                affinities["ydb_cli"],
+                                result,
+                            )
+                        )
+                        atomic_write_text(directory / "stdout.txt", result.stdout)
+                        atomic_write_text(directory / "stderr.txt", result.stderr)
+                        atomic_write_json(directory / "cpu-samples.json", list(monitor.records))
+                        if result.interrupted:
+                            raise BenchmarkInterrupted("YDB CLI workload was interrupted")
+                        if result.timed_out or result.exit_code:
+                            raise BenchmarkError(
+                                "YDB CLI workload {}".format(
+                                    "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
+                                )
+                            )
+                        metrics = {**benchmark.parse_metrics(result.stdout, benchmark)[0], **cpu}
+                        metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
+                        samples.append(metrics)
+                        repetition_rows.append(metrics)
+                    except BaseException as error:
+                        run_error = error
+                        raise
+                    finally:
+                        try:
+                            clean_command = _clean_workload_command(
+                                cluster,
+                                profile["workload"]["type"],
+                                table_path,
+                            )
+                            publish_progress(
+                                "cleaning-workload",
+                                **progress_fields,
+                                current_command=_command_record(
+                                    "cleaning-workload",
+                                    repetition,
+                                    clean_command,
+                                    affinities["ydb_cli"],
+                                ),
+                            )
+                            clean = cluster._run(clean_command, cpu_affinity=affinities["ydb_cli"])
+                            commands.append(
+                                _command_record(
+                                    "cleaning-workload",
+                                    repetition,
+                                    clean.command,
+                                    affinities["ydb_cli"],
+                                    clean,
+                                )
+                            )
+                            atomic_write_text(directory / "clean.stdout.txt", clean.stdout)
+                            atomic_write_text(directory / "clean.stderr.txt", clean.stderr)
+                        except BenchmarkError as error:
+                            atomic_write_text(directory / "clean.error.txt", str(error) + "\n")
+                            if run_error is None:
+                                raise
+                aggregated = _aggregate_measurements(samples)
+                aggregated.update(
+                    {
+                        "load": load,
+                        "dynamic_nodes": dynamic_nodes,
+                        "attempt": attempt,
+                        "search_stage": search_stage,
+                        "started_at": attempt_started_at,
+                        "finished_at": _utc_now(),
+                        "duration_seconds": time.monotonic() - attempt_started_monotonic,
+                        "commands": commands,
+                    }
+                )
+                return aggregated
+
+            def on_attempt(record):
+                stored = dict(record)
+                manifest["attempts"].append(stored)
+                publish_progress(
+                    "evaluating-attempt",
+                    search_stage=search_stage,
+                    attempt=stored["attempt"],
+                    dynamic_nodes=dynamic_nodes,
+                    parameter=profile["load"]["parameter"],
+                    load=stored["load"],
+                    passed=stored["passed"],
+                    decision=stored["decision"],
+                    latest_attempt=stored,
+                )
+
+            result = search_load(profile["load"], measure, on_attempt=on_attempt)
+
+            selected = next(
+                (item for item in result.attempts if item["load"] == result.selected_load),
+                None,
+            )
+            geometry = profile["geometry"]
+            can_scale = geometry["preset"] == "storage" and dynamic_nodes < geometry["max_dynamic_nodes"]
+            saturation_percent = profile["load"].get("objective", {}).get("cpu_saturation_percent", 95)
+            compute_limited = (
+                selected is not None
+                and selected["dynamic_cpu_mean"] >= saturation_percent
+                and selected["static_cpu_mean"] < saturation_percent
+            )
+            search_record = {
+                "stage": search_stage,
+                "dynamic_nodes": dynamic_nodes,
+                "allow_errors": profile["load"].get("allow_errors", False),
+                "started_at": search_started_at,
+                "finished_at": _utc_now(),
+                "duration_seconds": time.monotonic() - search_started_monotonic,
+                "selected_load": result.selected_load,
+                "selected_metrics": selected,
+                "passing_load": result.passing_load,
+                "failing_load": result.failing_load,
+                "outcome": result.outcome,
+                "stop_reason": result.stop_reason,
+            }
+            if can_scale and compute_limited:
+                new_count = min(geometry["max_dynamic_nodes"], max(dynamic_nodes + 1, dynamic_nodes * 2))
+                search_record.update({"next_action": "scale-dynamic-nodes", "next_dynamic_nodes": new_count})
+            else:
+                new_count = None
+                search_record["next_action"] = "finish"
+            manifest["searches"].append(search_record)
+            write_manifest(manifest_path, manifest)
+
+            if new_count is None:
+                manifest["result"] = {
+                    "outcome": result.outcome,
+                    "objective": profile["load"].get("objective", {}).get("type", "points"),
+                    "parameter": profile["load"]["parameter"],
+                    "allow_errors": profile["load"].get("allow_errors", False),
+                    "search_stage": search_stage,
+                    "dynamic_nodes": dynamic_nodes,
+                    "selected_load": result.selected_load,
+                    "selected_metrics": selected,
+                    "passing_load": result.passing_load,
+                    "failing_load": result.failing_load,
+                    "stop_reason": result.stop_reason,
+                }
+                break
+            publish_progress(
+                "scaling-dynamic-nodes",
+                search_stage=search_stage,
+                dynamic_nodes=dynamic_nodes,
+                target_dynamic_nodes=new_count,
+                reason="dynamic nodes saturated before static nodes",
+            )
+            cluster.add_dynamic_nodes(new_count - dynamic_nodes)
+
+        publish_progress("stopping-cluster", result=manifest["result"])
+        cluster.stop()
+        cluster_stopped = True
+        publish_progress("finishing", result=manifest["result"])
+        summary_rows = benchmark.summarize_metrics(repetition_rows, benchmark)
+        _write_csv(
+            output_directory / "repetitions.csv",
+            repetition_rows,
+            [item.name for item in benchmark.dimensions] + ["repetition"] + [item.name for item in benchmark.metrics],
+        )
+        atomic_write_text(output_directory / "summary.csv", benchmark.render_summary(summary_rows, benchmark))
+        manifest.update(
+            {
+                "status": "completed",
+                "state": "passed",
+                "finished_at": _utc_now(),
+                "summary": "summary.csv",
+                "repetitions": "repetitions.csv",
+                "summary_rows": len(summary_rows),
+            }
+        )
+        publish_progress("completed", result=manifest["result"])
+        if event_sink is not None:
+            event_sink(
+                {
+                    "type": "step-artifacts",
+                    **step,
+                    "artifacts": [
+                        "run.json",
+                        "summary.csv",
+                        "repetitions.csv",
+                        "cluster/cluster.yaml",
+                    ],
+                }
+            )
+            event_sink(
+                {
+                    "type": "step-finished",
+                    **step,
+                    "state": "passed",
+                    "fields": {"finished_at": manifest["finished_at"], "selected": manifest["searches"]},
+                }
+            )
+        write_manifest(manifest_path, manifest)
+        return manifest
+    except BenchmarkInterrupted as error:
+        manifest.update({"status": "interrupted", "state": "cancelled", "finished_at": _utc_now(), "error": str(error)})
+        publish_progress("cancelled", error=str(error))
+        write_manifest(manifest_path, manifest)
+        if event_sink is not None:
+            event_sink(
+                {
+                    "type": "step-finished",
+                    **step,
+                    "state": "cancelled",
+                    "fields": {"finished_at": manifest["finished_at"], "reason": str(error)},
+                }
+            )
+        raise
+    except BenchmarkError as error:
+        manifest.update({"status": "failed", "state": "failed", "finished_at": _utc_now(), "error": str(error)})
+        publish_progress("failed", error=str(error))
+        write_manifest(manifest_path, manifest)
+        if event_sink is not None:
+            event_sink(
+                {
+                    "type": "step-finished",
+                    **step,
+                    "state": "failed",
+                    "fields": {"finished_at": manifest["finished_at"], "error": str(error)},
+                }
+            )
+        raise
+    finally:
+        if not cluster_stopped:
+            cluster.stop()

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -845,6 +845,41 @@ def _aggregate_measurements(rows):
     return result
 
 
+def _search_scaling_evidence(result, saturation_percent):
+    """Return the attempt which explains why adding dynamic nodes may help."""
+
+    def attempt_at(load):
+        if load is None:
+            return None
+        return next((item for item in result.attempts if item["load"] == load), None)
+
+    # A failing boundary is the closest observation of the bottleneck.  This
+    # also covers a search whose minimum load failed and therefore has no
+    # selected passing point.
+    def dynamic_limited(item):
+        return (
+            item.get("dynamic_cpu_mean", 0) >= saturation_percent
+            and item.get("static_cpu_mean", 0) < saturation_percent
+        )
+
+    failing = attempt_at(result.failing_load)
+    if failing is not None:
+        reason = "minimum-failing-load" if result.passing_load is None else "failing-boundary"
+        return failing, reason
+
+    # The selected point can precede the probe which exposed a dynamic-only
+    # bottleneck.  Storage profiles target static CPU by default, so this check
+    # must use the role metrics directly rather than target_cpu_saturated.
+    saturated = [item for item in result.attempts if dynamic_limited(item)]
+    if saturated:
+        return max(saturated, key=lambda item: item["load"]), "dynamic-saturation"
+
+    selected = attempt_at(result.selected_load)
+    if selected is not None:
+        return selected, "selected-load"
+    return None, None
+
+
 def _role_capacity(mask, topology):
     return len(mask) if mask is not None else len(topology.allowed_cpus)
 
@@ -1064,18 +1099,19 @@ def run_local_ydb(
                                 "dynamic": _role_capacity(affinities["dynamic_nodes"], topology),
                                 "cli": _role_capacity(affinities["ydb_cli"], topology),
                             },
-                        ).start()
-                        command = _run_workload_command(
-                            cluster,
-                            table_path,
-                            profile["workload"],
-                            profile["load"],
-                            load,
-                            profile["measurement"]["duration"],
-                            profile["client"]["threads"],
                         )
-                        cluster.ensure_running("cannot start workload measurement")
+                        monitor.start()
                         try:
+                            command = _run_workload_command(
+                                cluster,
+                                table_path,
+                                profile["workload"],
+                                profile["load"],
+                                load,
+                                profile["measurement"]["duration"],
+                                profile["client"]["threads"],
+                            )
+                            cluster.ensure_running("cannot start workload measurement")
                             publish_progress(
                                 "measuring",
                                 **progress_fields,
@@ -1197,10 +1233,11 @@ def run_local_ydb(
             geometry = profile["geometry"]
             can_scale = geometry["preset"] == "storage" and dynamic_nodes < geometry["max_dynamic_nodes"]
             saturation_percent = profile["load"].get("objective", {}).get("cpu_saturation_percent", 95)
+            scaling_evidence, scaling_evidence_reason = _search_scaling_evidence(result, saturation_percent)
             compute_limited = (
-                selected is not None
-                and selected["dynamic_cpu_mean"] >= saturation_percent
-                and selected["static_cpu_mean"] < saturation_percent
+                scaling_evidence is not None
+                and scaling_evidence["dynamic_cpu_mean"] >= saturation_percent
+                and scaling_evidence["static_cpu_mean"] < saturation_percent
             )
             search_record = {
                 "stage": search_stage,
@@ -1211,6 +1248,8 @@ def run_local_ydb(
                 "duration_seconds": time.monotonic() - search_started_monotonic,
                 "selected_load": result.selected_load,
                 "selected_metrics": selected,
+                "scaling_evidence_metrics": scaling_evidence,
+                "scaling_evidence_reason": scaling_evidence_reason,
                 "passing_load": result.passing_load,
                 "failing_load": result.failing_load,
                 "outcome": result.outcome,
@@ -1294,9 +1333,21 @@ def run_local_ydb(
             )
         write_manifest(manifest_path, manifest)
         return manifest
-    except BenchmarkInterrupted as error:
-        manifest.update({"status": "interrupted", "state": "cancelled", "finished_at": _utc_now(), "error": str(error)})
-        publish_progress("cancelled", error=str(error))
+    except (BenchmarkInterrupted, KeyboardInterrupt) as error:
+        interruption = (
+            error
+            if isinstance(error, BenchmarkInterrupted)
+            else BenchmarkInterrupted("local YDB benchmark was interrupted")
+        )
+        manifest.update(
+            {
+                "status": "interrupted",
+                "state": "cancelled",
+                "finished_at": _utc_now(),
+                "error": str(interruption),
+            }
+        )
+        publish_progress("cancelled", error=str(interruption))
         write_manifest(manifest_path, manifest)
         if event_sink is not None:
             event_sink(
@@ -1304,10 +1355,12 @@ def run_local_ydb(
                     "type": "step-finished",
                     **step,
                     "state": "cancelled",
-                    "fields": {"finished_at": manifest["finished_at"], "reason": str(error)},
+                    "fields": {"finished_at": manifest["finished_at"], "reason": str(interruption)},
                 }
             )
-        raise
+        if interruption is error:
+            raise
+        raise interruption from error
     except BenchmarkError as error:
         manifest.update({"status": "failed", "state": "failed", "finished_at": _utc_now(), "error": str(error)})
         publish_progress("failed", error=str(error))

--- a/ydb/tools/ydb_bench/lib/results.py
+++ b/ydb/tools/ydb_bench/lib/results.py
@@ -4,11 +4,11 @@ Schema versions before 4 are deliberately rejected by ``load_manifest``.  They
 did not carry immutable plan steps, so interpreting them as resumable results
 would be unsafe.
 """
+
 from copy import deepcopy
 from pathlib import Path
 
 from ydb.tools.ydb_bench.lib.common import BenchmarkError, atomic_write_json
-
 
 SCHEMA_VERSION = 4
 PENDING = "pending"
@@ -33,6 +33,7 @@ def transition(record, state, **fields):
 
 def load_manifest(path):
     import json
+
     try:
         with Path(path).open(encoding="utf-8") as stream:
             value = json.load(stream)
@@ -47,6 +48,7 @@ def load_manifest(path):
 
 class ResultStore:
     """Own a manifest and ensure each published version is atomically replaced."""
+
     def __init__(self, path, manifest):
         self.path = Path(path)
         self.manifest = deepcopy(manifest)
@@ -63,6 +65,18 @@ class ResultStore:
             self.manifest["steps"][index] = transition(record, state, **fields)
             self.write()
             return self.manifest["steps"][index]
+        raise BenchmarkError("unknown run step {}".format(step_id))
+
+    def update_step(self, step_id, **fields):
+        """Atomically add progress fields without changing a running step's state."""
+        for record in self.manifest["steps"]:
+            if record["id"] != step_id:
+                continue
+            if record["state"] != RUNNING:
+                raise BenchmarkError("cannot update step {} in state {}".format(step_id, record["state"]))
+            record.update(fields)
+            self.write()
+            return record
         raise BenchmarkError("unknown run step {}".format(step_id))
 
     def add_artifacts(self, step_id, artifacts):

--- a/ydb/tools/ydb_bench/lib/results.py
+++ b/ydb/tools/ydb_bench/lib/results.py
@@ -20,6 +20,12 @@ _TRANSITIONS = {
 }
 
 
+def _non_finite_json_as_null(_value):
+    """Migrate manifests written before strict finite-number serialization."""
+
+    return None
+
+
 def transition(record, state, **fields):
     """Return a new record after one valid lifecycle transition."""
     old = record["state"]
@@ -36,7 +42,7 @@ def load_manifest(path):
 
     try:
         with Path(path).open(encoding="utf-8") as stream:
-            value = json.load(stream)
+            value = json.load(stream, parse_constant=_non_finite_json_as_null)
     except (OSError, ValueError) as error:
         raise BenchmarkError("cannot read result manifest {}: {}".format(path, error)) from error
     if not isinstance(value, dict):

--- a/ydb/tools/ydb_bench/lib/runner.py
+++ b/ydb/tools/ydb_bench/lib/runner.py
@@ -44,6 +44,39 @@ class BackgroundProcess:
         )
 
 
+class ManagedProcess:
+    def __init__(self, command, process, stdout_file, stderr_file, started_at, started_monotonic):
+        self.command = tuple(command)
+        self.process = process
+        self.stdout_file = stdout_file
+        self.stderr_file = stderr_file
+        self.started_at = started_at
+        self.started_monotonic = started_monotonic
+
+    @property
+    def pid(self):
+        return self.process.pid
+
+    def poll(self):
+        return self.process.poll()
+
+    def stop(self, grace_seconds=10.0):
+        try:
+            _stop_process_group(self.process, signal.SIGINT, grace_seconds)
+        finally:
+            self.stdout_file.close()
+            self.stderr_file.close()
+        return CommandResult(
+            command=self.command,
+            stdout="",
+            stderr="",
+            exit_code=self.process.returncode,
+            started_at=self.started_at,
+            finished_at=_utc_now(),
+            duration_seconds=time.monotonic() - self.started_monotonic,
+        )
+
+
 def _utc_now():
     return datetime.now(timezone.utc).isoformat()
 
@@ -121,6 +154,41 @@ def start_background_process(command, ready_timeout=10.0):
     return BackgroundProcess(command, process, started_at, started_monotonic)
 
 
+def start_managed_process(
+    command,
+    stdout_path,
+    stderr_path,
+    cwd=None,
+    cpu_affinity=None,
+    parent_death_wrapper=None,
+):
+    command = tuple(str(part) for part in command)
+    guarded_command = (
+        command if parent_death_wrapper is None else (str(parent_death_wrapper), str(os.getpid())) + command
+    )
+    launch_command = _command_with_affinity(guarded_command, cpu_affinity)
+    stdout_file = open(stdout_path, "w", encoding="utf-8")
+    stderr_file = open(stderr_path, "w", encoding="utf-8")
+    started_at = _utc_now()
+    started_monotonic = time.monotonic()
+    try:
+        process = subprocess.Popen(
+            launch_command,
+            cwd=None if cwd is None else str(cwd),
+            stdout=stdout_file,
+            stderr=stderr_file,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            start_new_session=True,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        stdout_file.close()
+        stderr_file.close()
+        raise BenchmarkError("cannot start managed process {}: {}".format(command[0], error)) from error
+    return ManagedProcess(command, process, stdout_file, stderr_file, started_at, started_monotonic)
+
+
 def run_command(
     command,
     env_overrides,
@@ -130,6 +198,7 @@ def run_command(
     grace_seconds=2.0,
     cpu_affinity=None,
     cancel_event=None,
+    on_process_started=None,
 ):
     command = tuple(str(part) for part in command)
     environment = os.environ.copy()
@@ -164,6 +233,9 @@ def run_command(
         raise BenchmarkError("cannot start {}: {}".format(command[0], error)) from error
     except subprocess.SubprocessError as error:
         raise BenchmarkError("cannot start {} with CPU affinity: {}".format(command[0], error)) from error
+
+    if on_process_started is not None:
+        on_process_started(process)
 
     timed_out = False
     interrupted = False

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -133,24 +133,33 @@ _CSS = (
     'order:1px solid #d0d5dd;border-bottom-color:#fff;margin-bottom:-1px}.profile-overview td:first-child{font-weight:650}.run'
     '-section-title{display:flex;align-items:baseline;justify-content:space-between;gap:1rem;flex-wrap:wrap}.downloads{display'
     ':inline-block}.downloads summary{cursor:pointer}.downloads .actions{margin-top:.5rem}\n'
-    '.local-live{display:grid;grid-template-columns:minmax(16rem,1.4fr) repeat(3,minmax(9rem,1fr));gap:.8rem;align-items:stre'
-    'tch}.local-live>div,.local-kpis>div{padding:.8rem;border:1px solid #d0d5dd;border-radius:7px;background:var(--panel)}.lo'
-    'cal-live strong,.local-kpis strong{display:block;font-size:1.18rem;margin-top:.2rem}.local-phase{font-size:1.25rem;font-'
-    'weight:700}.local-phase-progress{width:100%;margin-top:.65rem}.local-kpis{display:grid;grid-template-columns:repeat(auto-'
-    'fit,minmax(10rem,1fr));gap:.7rem;margin:.8rem 0}.local-kpis .primary-result{border-color:#84adff;background:#eff6ff}.lo'
-    'cal-stages{display:flex;gap:.55rem;overflow-x:auto;padding:.25rem 0 .7rem}.local-stage{min-width:13rem;padding:.65rem;bo'
-    'rder:1px solid #d0d5dd;border-radius:7px;background:#fff}.local-stage.current{border-color:#84adff;background:#eff6ff'
-    '}.local-stage .stage-arrow{color:var(--muted);margin-top:.35rem}.local-charts{display:grid;grid-template-columns:repeat('
-    '2,minmax(0,1fr));gap:.9rem}.local-charts .chart-panel{margin:0;padding:.8rem;border:1px solid #d0d5dd;border-radius:7p'
-    'x}.local-charts .chart-panel h3{margin-top:0}.local-attempts{display:block;max-width:100%;overflow-x:auto}.local-attempt'
-    's td,.local-attempts th{white-space:nowrap}.local-current-command{margin:.8rem 0;padding:.8rem;border:1px solid #d0d5dd'
-    ';border-radius:7px;background:#101828;color:#fff}.local-current-command .muted{color:#d0d5dd}.local-command-code{margin:'
-    '.45rem 0 0;white-space:pre-wrap;overflow-wrap:anywhere;font:12px ui-monospace,SFMono-Regular,Menlo,monospace}.local-co'
-    'mmand-cell{min-width:20rem;white-space:normal!important}.local-command-history summary{cursor:pointer}.local-command-e'
-    'ntry{margin:.55rem 0;padding:.55rem;border:1px solid #e4e7ec;border-radius:5px;background:var(--panel)}.attempt-pass{co'
-    'lor:var(--good);font-weight:650}.attempt-fail{color:var(--bad);font-weight:650}@media(max-width:900px){.local-live{grid-'
-    'template-columns:1fr 1fr}.local-charts{grid-template-colu'
-    'mns:1fr}}\n'
+    """
+.local-live{display:grid;grid-template-columns:minmax(16rem,1.4fr) repeat(3,minmax(9rem,1fr));gap:.8rem;align-items:stretch}
+.local-live>div,.local-kpis>div{padding:.8rem;border:1px solid #d0d5dd;border-radius:7px;background:var(--panel)}
+.local-live strong,.local-kpis strong{display:block;font-size:1.18rem;margin-top:.2rem}
+.local-phase{font-size:1.25rem;font-weight:700}.local-phase-progress{width:100%;margin-top:.65rem}
+.local-kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(10rem,1fr));gap:.7rem;margin:.8rem 0}
+.local-kpis .primary-result{border-color:#84adff;background:#eff6ff}
+.local-stages{display:flex;gap:.55rem;overflow-x:auto;padding:.25rem 0 .7rem}
+.local-stage{min-width:13rem;padding:.65rem;border:1px solid #d0d5dd;border-radius:7px;background:#fff}
+.local-stage.current{border-color:#84adff;background:#eff6ff}.local-stage .stage-arrow{color:var(--muted);margin-top:.35rem}
+.local-charts{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.9rem}
+.local-charts .chart-panel{margin:0;padding:.8rem;border:1px solid #d0d5dd;border-radius:7px}
+.local-charts .chart-panel h3{margin-top:0}
+.local-attempts-scroll{max-width:100%;overflow-x:auto}
+.local-attempts{width:max-content;min-width:100%}.local-attempts td,.local-attempts th{white-space:nowrap}
+.local-current-command{margin:.8rem 0;padding:.8rem;border:1px solid #d0d5dd;border-radius:7px;background:#101828;color:#fff}
+.local-current-command .muted{color:#d0d5dd}
+.local-command-code{margin:.45rem 0 0;white-space:pre-wrap;overflow-wrap:anywhere;font:12px ui-monospace,SFMono-Regular,Menlo,monospace}
+.local-command-cell{width:22rem;min-width:22rem;max-width:22rem;white-space:normal!important}
+.local-command-history{width:22rem}.local-command-history[open]{max-height:24rem;overflow:auto}
+.local-command-history summary,.local-profile-config summary{cursor:pointer}
+.local-command-entry{margin:.55rem 0;padding:.55rem;border:1px solid #e4e7ec;border-radius:5px;background:var(--panel)}
+.local-profile-config{margin:.8rem 0;padding:.7rem .8rem;border:1px solid #d0d5dd;border-radius:7px;background:#fff}
+.local-profile-config pre{max-height:24rem;overflow:auto;white-space:pre;margin:.7rem 0 0}
+.attempt-pass{color:var(--good);font-weight:650}.attempt-fail{color:var(--bad);font-weight:650}
+@media(max-width:900px){.local-live{grid-template-columns:1fr 1fr}.local-charts{grid-template-columns:1fr}}
+"""
     '.status.queued{color:var(--warn)}\n'
 )
 _JS = (
@@ -227,7 +236,9 @@ _JS = (
     "ig.geometry.preset);for(const [key,yamlKey] of Object.entries(localYdbGeometryKeys))lines.push('      '+yamlKey+': '+c"
     "onfig.geometry[key]);lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
     "+config.load.parameter,'      allow-errors: '+Boolean(config.load.allow_errors));if(config.load.values)lines.push('      values: '+yamlArray(config.load.values));else{lines."
-    "push('      search:','        start: '+config.load.search.start,'        maximum: '+config.load.search.maximum);if(config.load.objective.type==='latency-slo')lines.push('        multiplier: '+config.load.search.multiplier);for(const [key,yamlKey] of Object.entries(localYdbSearchKeys))lines."
+    "push('      search:','        start: '+config.load.search.start,'        maximum: '+config.load.search.maximum);if("
+    "config.load.objective.type==='latency-slo')lines.push('        multiplier: '+config.load.search.multiplier);for("
+    "const [key,yamlKey] of Object.entries(localYdbSearchKeys))lines."
     "push('        '+yamlKey+': '+config.load.search[key]);lines.push('      objective:','        type: '+config.load.object"
     "ive.type);if(config.load.objective.type==='maximize-throughput')for(const [key,yamlKey] of Object.entries(localYdbOb"
     "jectiveKeys))lines.push('        '+yamlKey+': '+config.load.objective[key]);else{lines.push('        percentile: '+config.load.o"
@@ -306,7 +317,9 @@ function localField(id,label,value,help='',attributes=''){
   return '<div class=field><label for="'+id+'">'+esc(label)+'</label><input id="'+id+'" value="'+esc(value)+'" '+attributes+'><small class=muted>'+esc(help)+'</small></div>'
 }
 function localSelect(id,label,value,choices,help=''){
-  return '<div class=field><label for="'+id+'">'+esc(label)+'</label><select id="'+id+'">'+choices.map(choice=>'<option value="'+esc(choice)+'" '+(choice===value?'selected':'')+'>'+esc(choice)+'</option>').join('')+'</select><small class=muted>'+esc(help)+'</small></div>'
+  return '<div class=field><label for="'+id+'">'+esc(label)+'</label><select id="'+id+'">'+
+    choices.map(choice=>'<option value="'+esc(choice)+'" '+(choice===value?'selected':'')+'>'+esc(choice)+'</option>').join('')+
+    '</select><small class=muted>'+esc(help)+'</small></div>'
 }
 function localCheck(id,label,checked,help=''){
   return '<div class=field><label><input id="'+id+'" type=checkbox '+(checked?'checked':'')+'> '+esc(label)+'</label><small class=muted>'+esc(help)+'</small></div>'
@@ -315,39 +328,221 @@ function localYdbProfileEditor(profile){
   const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
   const loadMode=load.values?'points':load.objective.type;
   const options=Object.entries(workload.options).map(([key,value])=>localField('local-option-'+key,key,value)).join('');
-  const geometryFields=Object.entries(localYdbGeometryKeys).map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
-  const loadCommon=localSelect('local-load-mode','Objective',loadMode,['points','maximize-throughput','latency-slo'])+localSelect('local-load-parameter','Parameter',load.parameter,['rate','threads'])+localCheck('local-load-allow-errors','Allow failed workload requests',Boolean(load.allow_errors),'Failed requests remain visible in results but do not limit load search.');
-  const searchFields=loadMode==='points'?'':localField('local-load-start','Start',load.search.start,'','type=number min=1')+localField('local-load-maximum','Maximum',load.search.maximum,'','type=number min=1')+(loadMode==='latency-slo'?localField('local-load-multiplier','Growth multiplier',load.search.multiplier,'Used to find the first failing latency point.','type=number min=1 step=any'):'')+localField('local-load-search-resolution-percent',loadMode==='maximize-throughput'?'Ternary resolution (%)':'Boundary resolution (%)',load.search.resolution_percent,'','type=number min=0 max=100 step=any');
-  const loadFields=loadMode==='points'?localField('local-load-values','Values',(load.values||[]).join(', '),'Comma-separated values and ranges'):searchFields+(loadMode==='maximize-throughput'?localSelect('local-load-target-role','Target role',load.objective.target_role,['static','dynamic','total'])+localField('local-load-plateau-gain-percent','Plateau gain (%)',load.objective.plateau_gain_percent,'','type=number min=0 step=any')+localField('local-load-plateau-points','Plateau comparisons',load.objective.plateau_points,'','type=number min=1')+localField('local-load-cpu-saturation-percent','CPU saturation (%)',load.objective.cpu_saturation_percent,'','type=number min=0 max=100 step=any'):'');
-  const slo=loadMode==='latency-slo'?'<h3>Latency SLO</h3><div class=form-grid>'+localSelect('local-slo-percentile','Percentile',load.objective.percentile,['p50','p95','p99','pmax'])+localField('local-slo-max-ms','Maximum latency (ms)',load.objective.max_ms,'','type=number min=0 step=any')+localField('local-slo-max-errors','Maximum errors',load.objective.max_errors,load.allow_errors?'Ignored while failed requests are allowed.':'','type=number min=0 '+(load.allow_errors?'disabled':''))+localField('local-slo-min-achieved-rate-ratio','Minimum achieved rate ratio',load.objective.min_achieved_rate_ratio,'','type=number min=0 max=1 step=any')+'</div>':'';
-  const affinity=Object.entries(localYdbAffinityKeys).map(([key,label])=>{const role=config.affinity[key],disabled=role.mode==='none'?'disabled':'';return '<div class=card><strong>'+esc(label)+'</strong><div class=form-grid>'+localSelect('local-affinity-'+key+'-mode','Mode',role.mode,editor.model.affinity_modes)+localField('local-affinity-'+key+'-cpus','CPUs',role.cpus??'','integer, one-chiplet, or remaining',disabled)+'</div></div>'}).join('');
-  return '<div id=local-editor><h2 class=page-title>'+esc(profile.benchmark)+' / '+esc(profile.name)+'</h2><div class=form-grid>'+localSelect('benchmark','Benchmark',profile.benchmark,editor.model.benchmarks.map(item=>item.name))+localField('profile-name','Profile name',profile.name,'letters, digits, . _ and -')+'</div><h3>Workload</h3><div class=form-grid>'+localSelect('local-workload-type','Type',workload.type,['kv','stock'])+localSelect('local-workload-operation','Operation',workload.operation,localYdbOperations[workload.type])+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+'</div><h3>Client and load</h3><div class=form-grid>'+localField('local-client-threads','YDB CLI threads',config.client.threads,'','type=number min=1')+loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+localField('local-measurement-duration','Duration (seconds)',measurement.duration,'','type=number min=1')+localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+localField('local-timeout','Timeout (seconds)',profile.timeout??'','empty selects the computed timeout','type=number min=1')+'</div><h3>Role affinity</h3>'+affinity+'<div class=toolbar><button class=danger id=delete-profile>Delete profile</button></div></div>'
+  const geometryFields=Object.entries(localYdbGeometryKeys)
+    .map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
+  const loadCommon=
+    localSelect('local-load-mode','Objective',loadMode,['points','maximize-throughput','latency-slo'])+
+    localSelect('local-load-parameter','Parameter',load.parameter,['rate','threads'])+
+    localCheck(
+      'local-load-allow-errors','Allow failed workload requests',Boolean(load.allow_errors),
+      'Failed requests remain visible in results but do not limit load search.'
+    );
+  const searchFields=loadMode==='points'?'':
+    localField('local-load-start','Start',load.search.start,'','type=number min=1')+
+    localField('local-load-maximum','Maximum',load.search.maximum,'','type=number min=1')+
+    (loadMode==='latency-slo'?
+      localField(
+        'local-load-multiplier','Growth multiplier',load.search.multiplier,
+        'Used to find the first failing latency point.','type=number min=1 step=any'
+      ):'')+
+    localField(
+      'local-load-search-resolution-percent',
+      loadMode==='maximize-throughput'?'Ternary resolution (%)':'Boundary resolution (%)',
+      load.search.resolution_percent,'','type=number min=0 max=100 step=any'
+    );
+  const loadFields=loadMode==='points'?
+    localField('local-load-values','Values',(load.values||[]).join(', '),'Comma-separated values and ranges'):
+    searchFields+(loadMode==='maximize-throughput'?
+      localSelect('local-load-target-role','Target role',load.objective.target_role,['static','dynamic','total'])+
+      localField(
+        'local-load-plateau-gain-percent','Plateau gain (%)',load.objective.plateau_gain_percent,
+        '','type=number min=0 step=any'
+      )+
+      localField('local-load-plateau-points','Plateau comparisons',load.objective.plateau_points,'','type=number min=1')+
+      localField(
+        'local-load-cpu-saturation-percent','CPU saturation (%)',load.objective.cpu_saturation_percent,
+        '','type=number min=0 max=100 step=any'
+      ):'');
+  const slo=loadMode==='latency-slo'?'<h3>Latency SLO</h3><div class=form-grid>'+
+    localSelect('local-slo-percentile','Percentile',load.objective.percentile,['p50','p95','p99','pmax'])+
+    localField('local-slo-max-ms','Maximum latency (ms)',load.objective.max_ms,'','type=number min=0 step=any')+
+    localField(
+      'local-slo-max-errors','Maximum errors',load.objective.max_errors,
+      load.allow_errors?'Ignored while failed requests are allowed.':'',
+      'type=number min=0 '+(load.allow_errors?'disabled':'')
+    )+
+    localField(
+      'local-slo-min-achieved-rate-ratio','Minimum achieved rate ratio',load.objective.min_achieved_rate_ratio,
+      '','type=number min=0 max=1 step=any'
+    )+'</div>':'';
+  const affinity=Object.entries(localYdbAffinityKeys).map(([key,label])=>{
+    const role=config.affinity[key],disabled=role.mode==='none'?'disabled':'';
+    return '<div class=card><strong>'+esc(label)+'</strong><div class=form-grid>'+
+      localSelect('local-affinity-'+key+'-mode','Mode',role.mode,editor.model.affinity_modes)+
+      localField(
+        'local-affinity-'+key+'-cpus','CPUs',role.cpus??'','integer, one-chiplet, or remaining',disabled
+      )+'</div></div>'
+  }).join('');
+  return '<div id=local-editor><h2 class=page-title>'+esc(profile.benchmark)+' / '+esc(profile.name)+'</h2>'+
+    '<div class=form-grid>'+localSelect(
+      'benchmark','Benchmark',profile.benchmark,editor.model.benchmarks.map(item=>item.name)
+    )+localField('profile-name','Profile name',profile.name,'letters, digits, . _ and -')+'</div>'+
+    '<h3>Workload</h3><div class=form-grid>'+localSelect(
+      'local-workload-type','Type',workload.type,['kv','stock']
+    )+localSelect(
+      'local-workload-operation','Operation',workload.operation,localYdbOperations[workload.type]
+    )+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+
+    localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+
+    '</div><h3>Client and load</h3><div class=form-grid>'+
+    localField('local-client-threads','YDB CLI threads',config.client.threads,'','type=number min=1')+
+    loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
+    localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+
+    localField('local-measurement-duration','Duration (seconds)',measurement.duration,'','type=number min=1')+
+    localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+
+    localField(
+      'local-timeout','Timeout (seconds)',profile.timeout??'','empty selects the computed timeout','type=number min=1'
+    )+'</div><h3>Role affinity</h3>'+affinity+
+    '<div class=toolbar><button class=danger id=delete-profile>Delete profile</button></div></div>'
 }
-function localNumber(id,minimum=1){const value=Number(document.querySelector('#'+id).value);if(!Number.isFinite(value)||value<minimum)throw Error(id+' must be a number not below '+minimum+'.');return value}
+function localNumber(id,minimum=1){
+  const value=Number(document.querySelector('#'+id).value);
+  if(!Number.isFinite(value)||value<minimum)throw Error(id+' must be a number not below '+minimum+'.');
+  return value
+}
 function localInteger(id,minimum=1){const value=localNumber(id,minimum);if(!Number.isSafeInteger(value))throw Error(id+' must be an integer.');return value}
-function localCpu(id,mode){if(mode==='none')return null;const raw=document.querySelector('#'+id).value.trim();if(raw==='one-chiplet'||raw==='remaining')return raw;const value=Number(raw);if(!Number.isSafeInteger(value)||value<1)throw Error(id+' must be a positive integer, one-chiplet, or remaining.');return value}
+function localCpu(id,mode){
+  if(mode==='none')return null;
+  const raw=document.querySelector('#'+id).value.trim();
+  if(raw==='one-chiplet'||raw==='remaining')return raw;
+  const value=Number(raw);
+  if(!Number.isSafeInteger(value)||value<1){
+    throw Error(id+' must be a positive integer, one-chiplet, or remaining.')
+  }
+  return value
+}
 function bindLocalYdbEditor(profile){
   const message=()=>document.querySelector('#editor-message');
   const update=event=>{try{
     const benchmarkName=document.querySelector('#benchmark').value,name=document.querySelector('#profile-name').value.trim();
     if(!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/.test(name))throw Error('Profile name is unsafe.');
-    if(editor.model.profiles.some(item=>item.key!==profile.key&&item.benchmark===benchmarkName&&item.name===name))throw Error('A profile with this benchmark and name already exists.');
-    if(benchmarkName!==profile.benchmark){const benchmark=editor.model.benchmarks.find(item=>item.name===benchmarkName);profile.benchmark=benchmarkName;profile.name=name;profile.key=benchmarkName+'/'+name;delete profile.local_ydb;profile.parameters=Object.fromEntries(benchmark.parameters.map(item=>[item.name,item.default]));profile.threads=[1];profile.duration=3;profile.repetitions=1;profile.affinity=['none'];profile.background_load=['none'];editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    if(editor.model.profiles.some(item=>
+      item.key!==profile.key&&item.benchmark===benchmarkName&&item.name===name
+    ))throw Error('A profile with this benchmark and name already exists.');
+    if(benchmarkName!==profile.benchmark){
+      const benchmark=editor.model.benchmarks.find(item=>item.name===benchmarkName);
+      profile.benchmark=benchmarkName;profile.name=name;profile.key=benchmarkName+'/'+name;
+      delete profile.local_ydb;
+      profile.parameters=Object.fromEntries(benchmark.parameters.map(item=>[item.name,item.default]));
+      profile.threads=[1];profile.duration=3;profile.repetitions=1;profile.affinity=['none'];
+      profile.background_load=['none'];editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);
+      saveDraft();renderNew();return
+    }
     profile.name=name;profile.key=benchmarkName+'/'+name;const config=profile.local_ydb;
-    if(event.target.id==='local-workload-type'){config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
-    if(event.target.id==='local-geometry-preset'){const preset=event.target.value;config.geometry.preset=preset;if(preset==='single'){config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1}else if(preset==='storage')config.geometry.max_dynamic_nodes=Math.max(8,config.geometry.dynamic_nodes,config.geometry.max_dynamic_nodes);editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
-    if(event.target.id==='local-load-mode'){const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);if(mode==='points')config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[1000]};else{const search=config.load.search||{start:1000,maximum:100000,multiplier:2,resolution_percent:2},old=config.load.objective||{},objective={type:mode,target_role:old.target_role||'dynamic',plateau_gain_percent:old.plateau_gain_percent??2,plateau_points:old.plateau_points||2,cpu_saturation_percent:old.cpu_saturation_percent||95};if(mode==='latency-slo')Object.assign(objective,{percentile:old.percentile||'p99',max_ms:old.max_ms??10,max_errors:old.max_errors??0,min_achieved_rate_ratio:old.min_achieved_rate_ratio??.98});config.load={parameter:config.load.parameter,allow_errors,search,objective}}editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
-    if(event.target.id.startsWith('local-affinity-')&&event.target.id.endsWith('-mode')){const key=event.target.id.slice('local-affinity-'.length,-'-mode'.length),mode=event.target.value,old=config.affinity[key].cpus;config.affinity[key]={mode,cpus:mode==='none'?null:(old??(key==='ydb_cli'?'one-chiplet':1))};editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    if(event.target.id==='local-workload-type'){
+      config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
+      editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
+    }
+    if(event.target.id==='local-geometry-preset'){
+      const preset=event.target.value;config.geometry.preset=preset;
+      if(preset==='single'){
+        config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1
+      }else if(preset==='storage'){
+        config.geometry.max_dynamic_nodes=Math.max(
+          8,config.geometry.dynamic_nodes,config.geometry.max_dynamic_nodes
+        )
+      }
+      editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
+    }
+    if(event.target.id==='local-load-mode'){
+      const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);
+      if(mode==='points'){
+        config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[1000]}
+      }else{
+        const search=config.load.search||{start:1000,maximum:100000,multiplier:2,resolution_percent:2};
+        const old=config.load.objective||{};
+        const objective={
+          type:mode,target_role:old.target_role||'dynamic',plateau_gain_percent:old.plateau_gain_percent??2,
+          plateau_points:old.plateau_points||2,cpu_saturation_percent:old.cpu_saturation_percent||95
+        };
+        if(mode==='latency-slo')Object.assign(objective,{
+          percentile:old.percentile||'p99',max_ms:old.max_ms??10,max_errors:old.max_errors??0,
+          min_achieved_rate_ratio:old.min_achieved_rate_ratio??.98
+        });
+        config.load={parameter:config.load.parameter,allow_errors,search,objective}
+      }
+      editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
+    }
+    if(event.target.id.startsWith('local-affinity-')&&event.target.id.endsWith('-mode')){
+      const key=event.target.id.slice('local-affinity-'.length,-'-mode'.length);
+      const mode=event.target.value,old=config.affinity[key].cpus;
+      config.affinity[key]={mode,cpus:mode==='none'?null:(old??(key==='ydb_cli'?'one-chiplet':1))};
+      editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
+    }
     config.workload.operation=document.querySelector('#local-workload-operation').value;
-    for(const input of document.querySelectorAll('[id^=local-option-]')){const key=input.id.slice('local-option-'.length),minimum=['init-upserts','orders','auto-partition'].includes(key)?0:1;config.workload.options[key]=localInteger(input.id,minimum)}
-    config.geometry.preset=document.querySelector('#local-geometry-preset').value;for(const key of Object.keys(localYdbGeometryKeys))config.geometry[key]=localInteger('local-geometry-'+key);if(config.geometry.preset==='single'){config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1}
-    config.client.threads=localInteger('local-client-threads');const loadMode=document.querySelector('#local-load-mode').value,parameter=document.querySelector('#local-load-parameter').value;
-    const allow_errors=document.querySelector('#local-load-allow-errors').checked;if(loadMode==='points')config.load={parameter,allow_errors,values:arrayField(document.querySelector('#local-load-values').value)};else{const objective={type:loadMode},multiplier=loadMode==='latency-slo'?localNumber('local-load-multiplier',1):(config.load.search?.multiplier??2);config.load={parameter,allow_errors,search:{start:localInteger('local-load-start'),maximum:localInteger('local-load-maximum'),multiplier,resolution_percent:localNumber('local-load-search-resolution-percent',0)},objective};if(loadMode==='maximize-throughput')Object.assign(objective,{target_role:document.querySelector('#local-load-target-role').value,plateau_gain_percent:localNumber('local-load-plateau-gain-percent',0),plateau_points:localInteger('local-load-plateau-points'),cpu_saturation_percent:localNumber('local-load-cpu-saturation-percent',0)});else Object.assign(objective,{percentile:document.querySelector('#local-slo-percentile').value,max_ms:localNumber('local-slo-max-ms',0),max_errors:localInteger('local-slo-max-errors',0),min_achieved_rate_ratio:localNumber('local-slo-min-achieved-rate-ratio',0)})}
-    config.measurement={warmup:localInteger('local-measurement-warmup',0),duration:localInteger('local-measurement-duration'),repetitions:localInteger('local-measurement-repetitions')};
-    for(const key of Object.keys(localYdbAffinityKeys)){const mode=document.querySelector('#local-affinity-'+key+'-mode').value;config.affinity[key]={mode,cpus:localCpu('local-affinity-'+key+'-cpus',mode)}}
-    const timeout=document.querySelector('#local-timeout').value.trim();profile.timeout=timeout===''?null:localInteger('local-timeout');profile.threads=[config.client.threads];profile.duration=config.measurement.duration;profile.repetitions=1;profile.affinity=['roles'];profile.background_load=['none'];editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id))renderNew()
+    for(const input of document.querySelectorAll('[id^=local-option-]')){
+      const key=input.id.slice('local-option-'.length);
+      const minimum=['init-upserts','orders','auto-partition'].includes(key)?0:1;
+      config.workload.options[key]=localInteger(input.id,minimum)
+    }
+    config.geometry.preset=document.querySelector('#local-geometry-preset').value;
+    for(const key of Object.keys(localYdbGeometryKeys)){
+      config.geometry[key]=localInteger('local-geometry-'+key)
+    }
+    if(config.geometry.preset==='single'){
+      config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1
+    }
+    config.client.threads=localInteger('local-client-threads');
+    const loadMode=document.querySelector('#local-load-mode').value;
+    const parameter=document.querySelector('#local-load-parameter').value;
+    const allow_errors=document.querySelector('#local-load-allow-errors').checked;
+    if(loadMode==='points'){
+      config.load={parameter,allow_errors,values:arrayField(document.querySelector('#local-load-values').value)}
+    }else{
+      const objective={type:loadMode};
+      const multiplier=loadMode==='latency-slo'?
+        localNumber('local-load-multiplier',1):(config.load.search?.multiplier??2);
+      config.load={
+        parameter,allow_errors,
+        search:{
+          start:localInteger('local-load-start'),maximum:localInteger('local-load-maximum'),multiplier,
+          resolution_percent:localNumber('local-load-search-resolution-percent',0)
+        },
+        objective
+      };
+      if(loadMode==='maximize-throughput')Object.assign(objective,{
+        target_role:document.querySelector('#local-load-target-role').value,
+        plateau_gain_percent:localNumber('local-load-plateau-gain-percent',0),
+        plateau_points:localInteger('local-load-plateau-points'),
+        cpu_saturation_percent:localNumber('local-load-cpu-saturation-percent',0)
+      });
+      else Object.assign(objective,{
+        percentile:document.querySelector('#local-slo-percentile').value,
+        max_ms:localNumber('local-slo-max-ms',0),max_errors:localInteger('local-slo-max-errors',0),
+        min_achieved_rate_ratio:localNumber('local-slo-min-achieved-rate-ratio',0)
+      })
+    }
+    config.measurement={
+      warmup:localInteger('local-measurement-warmup',0),
+      duration:localInteger('local-measurement-duration'),
+      repetitions:localInteger('local-measurement-repetitions')
+    };
+    for(const key of Object.keys(localYdbAffinityKeys)){
+      const mode=document.querySelector('#local-affinity-'+key+'-mode').value;
+      config.affinity[key]={mode,cpus:localCpu('local-affinity-'+key+'-cpus',mode)}
+    }
+    const timeout=document.querySelector('#local-timeout').value.trim();
+    profile.timeout=timeout===''?null:localInteger('local-timeout');
+    profile.threads=[config.client.threads];profile.duration=config.measurement.duration;
+    profile.repetitions=1;profile.affinity=['roles'];profile.background_load=['none'];
+    editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();
+    if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id))renderNew()
   }catch(error){message().innerHTML=displayError(error)}};
-  for(const input of document.querySelectorAll('#local-editor input,#local-editor select'))input.onchange=update;document.querySelector('#delete-profile').onclick=()=>{editor.model.profiles=editor.model.profiles.filter(item=>item.key!==profile.key);editor.selected=editor.model.profiles[0]?.key||null;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()}
+  for(const input of document.querySelectorAll('#local-editor input,#local-editor select'))input.onchange=update;
+  document.querySelector('#delete-profile').onclick=()=>{
+    editor.model.profiles=editor.model.profiles.filter(item=>item.key!==profile.key);
+    editor.selected=editor.model.profiles[0]?.key||null;editor.yaml=serializeConfig(editor.model);
+    saveDraft();renderNew()
+  }
 }
 """
     'function profileEditor(profile){\n'
@@ -401,27 +596,68 @@ function bindLocalYdbEditor(profile){
     """
 function bindProfileEditor(profile){
   const update=event=>{try{
-    const name=document.querySelector('#profile-name').value.trim(),benchmarkName=document.querySelector('#benchmark').value,benchmark=editor.model.benchmarks.find(item=>item.name===benchmarkName),benchmarkChanged=event?.target?.id==='benchmark';
+    const name=document.querySelector('#profile-name').value.trim();
+    const benchmarkName=document.querySelector('#benchmark').value;
+    const benchmark=editor.model.benchmarks.find(item=>item.name===benchmarkName);
+    const benchmarkChanged=event?.target?.id==='benchmark';
     if(!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/.test(name))throw Error('Profile name is unsafe.');
-    if(editor.model.profiles.some(item=>item.key!==profile.key&&item.benchmark===benchmarkName&&item.name===name))throw Error('A profile with this benchmark and name already exists.');
+    if(editor.model.profiles.some(item=>
+      item.key!==profile.key&&item.benchmark===benchmarkName&&item.name===name
+    ))throw Error('A profile with this benchmark and name already exists.');
     updateProfile(profile.key,item=>{
       item.benchmark=benchmarkName;item.name=name;item.key=benchmarkName+'/'+name;
-      if(benchmarkChanged&&benchmark.profile_kind==='local-ydb'){item.local_ydb=defaultLocalYdb();item.parameters={};item.threads=[64];item.duration=30;item.repetitions=1;item.affinity=['roles'];item.background_load=['none'];return}
+      if(benchmarkChanged&&benchmark.profile_kind==='local-ydb'){
+        item.local_ydb=defaultLocalYdb();item.parameters={};item.threads=[64];item.duration=30;
+        item.repetitions=1;item.affinity=['roles'];item.background_load=['none'];return
+      }
       delete item.local_ydb;item.threads=arrayField(document.querySelector('#threads').value);item.parameters={};
-      benchmark.parameters.forEach((parameter,index)=>{if(benchmarkChanged){item.parameters[parameter.name]=[...parameter.default];return}if(parameter.choices.length){const selected=[...document.querySelectorAll('.parameter-choice[data-parameter-index="'+index+'"]:checked')].map(input=>input.value);if(!selected.length)throw Error('Select at least one value for '+parameter.name+'.');item.parameters[parameter.name]=selected;return}const raw=document.querySelector('#parameter-'+index)?.value||parameter.default.join(', ');item.parameters[parameter.name]=parameter.type==='integer'?arrayField(raw,parameter.minimum??1):raw.split(',').map(value=>value.trim()).filter(Boolean)});
-      item.duration=Number(document.querySelector('#duration').value);item.repetitions=Number(document.querySelector('#repetitions').value);item.affinity=[...document.querySelectorAll('.affinity:checked')].map(input=>input.value);item.background_load=[...document.querySelectorAll('.background-load:checked')].map(input=>input.value);if(!item.background_load.length)throw Error('Select at least one background load mode.')
+      benchmark.parameters.forEach((parameter,index)=>{
+        if(benchmarkChanged){item.parameters[parameter.name]=[...parameter.default];return}
+        if(parameter.choices.length){
+          const selector='.parameter-choice[data-parameter-index="'+index+'"]:checked';
+          const selected=[...document.querySelectorAll(selector)].map(input=>input.value);
+          if(!selected.length)throw Error('Select at least one value for '+parameter.name+'.');
+          item.parameters[parameter.name]=selected;return
+        }
+        const raw=document.querySelector('#parameter-'+index)?.value||parameter.default.join(', ');
+        item.parameters[parameter.name]=parameter.type==='integer'?
+          arrayField(raw,parameter.minimum??1):raw.split(',').map(value=>value.trim()).filter(Boolean)
+      });
+      item.duration=Number(document.querySelector('#duration').value);
+      item.repetitions=Number(document.querySelector('#repetitions').value);
+      item.affinity=[...document.querySelectorAll('.affinity:checked')].map(input=>input.value);
+      item.background_load=[...document.querySelectorAll('.background-load:checked')].map(input=>input.value);
+      if(!item.background_load.length)throw Error('Select at least one background load mode.')
     });
-    editor.selected=benchmarkName+'/'+name;if(benchmarkChanged||(!event?.target?.classList.contains('affinity')&&!event?.target?.classList.contains('background-load')&&!event?.target?.classList.contains('parameter-choice')))renderNew()
+    editor.selected=benchmarkName+'/'+name;
+    if(benchmarkChanged||(
+      !event?.target?.classList.contains('affinity')&&
+      !event?.target?.classList.contains('background-load')&&
+      !event?.target?.classList.contains('parameter-choice')
+    ))renderNew()
   }catch(error){document.querySelector('#editor-message').innerHTML=displayError(error)}};
-  for(const input of document.querySelectorAll('#benchmark,#profile-name,#threads,[id^=parameter-],.parameter-choice,#duration,#repetitions,.affinity,.background-load'))input.onchange=update;
-  document.querySelector('#delete-profile').onclick=()=>{editor.model.profiles=editor.model.profiles.filter(item=>item.key!==profile.key);editor.selected=editor.model.profiles[0]?.key||null;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()}
+  const selector=
+    '#benchmark,#profile-name,#threads,[id^=parameter-],.parameter-choice,'+
+    '#duration,#repetitions,.affinity,.background-load';
+  for(const input of document.querySelectorAll(selector))input.onchange=update;
+  document.querySelector('#delete-profile').onclick=()=>{
+    editor.model.profiles=editor.model.profiles.filter(item=>item.key!==profile.key);
+    editor.selected=editor.model.profiles[0]?.key||null;editor.yaml=serializeConfig(editor.model);
+    saveDraft();renderNew()
+  }
 }
 """
     """
 function addProfile(){
-  const selectedBenchmark=document.querySelector('#add-benchmark')?.value,benchmark=editor.model.benchmarks.find(item=>item.name===selectedBenchmark)||editor.model.benchmarks[0];let suffix=1,name='profile';
+  const selectedBenchmark=document.querySelector('#add-benchmark')?.value;
+  const benchmark=editor.model.benchmarks.find(item=>item.name===selectedBenchmark)||editor.model.benchmarks[0];
+  let suffix=1,name='profile';
   while((editor.model.profiles||[]).some(item=>item.benchmark===benchmark.name&&item.name===name))name='profile-'+suffix++;
-  const profile={key:benchmark.name+'/'+name,benchmark:benchmark.name,name,threads:[1],parameters:Object.fromEntries(benchmark.parameters.map(item=>[item.name,item.default])),duration:3,repetitions:1,timeout:null,affinity:['none'],background_load:['none']};
+  const profile={
+    key:benchmark.name+'/'+name,benchmark:benchmark.name,name,threads:[1],
+    parameters:Object.fromEntries(benchmark.parameters.map(item=>[item.name,item.default])),
+    duration:3,repetitions:1,timeout:null,affinity:['none'],background_load:['none']
+  };
   if(benchmark.profile_kind==='local-ydb'){profile.local_ydb=defaultLocalYdb();profile.threads=[64];profile.duration=30;profile.repetitions=1;profile.affinity=['roles']}
   editor.model.profiles.push(profile);editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()
 }
@@ -527,7 +763,9 @@ function addProfile(){
     '}\n'
     """
 function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,synchronize=false){
-  const width=900,left=78,right=24,plotWidth=width-left-right,numericX=xValues.map(Number),xMin=Math.min(...numericX),xMax=Math.max(...numericX),xPos=value=>left+(xMax===xMin?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth);
+  const width=900,left=78,right=24,plotWidth=width-left-right,numericX=xValues.map(Number);
+  const xMin=Math.min(...numericX),xMax=Math.max(...numericX);
+  const xPos=value=>left+(xMax===xMin?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth);
   const seriesFor=metric=>Array.isArray(seriesRows)?seriesRows:(seriesRows[metric]||[]);
   const panels=[...container.querySelectorAll('.chart-panel')].map(panel=>({
     panel,
@@ -537,22 +775,41 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     tooltip:panel.querySelector('.chart-tooltip'),
     cursor:panel.querySelector('.chart-cursor'),
   })).filter(item=>item.svg&&item.surface&&item.tooltip&&item.cursor&&metrics.includes(item.metric));
-  const hideAll=()=>{for(const item of panels){item.tooltip.hidden=true;item.cursor.setAttribute('visibility','hidden');item.cursor.removeAttribute('data-selected-x')}};
+  const hideAll=()=>{for(const item of panels){
+    item.tooltip.hidden=true;item.cursor.setAttribute('visibility','hidden');
+    item.cursor.removeAttribute('data-selected-x')
+  }};
   const syncBoundary=synchronize?panels[0]?.panel.closest('.local-charts'):null;
   if(syncBoundary)syncBoundary.onmouseleave=hideAll;
   for(const active of panels){
     if(!syncBoundary)active.svg.onmouseleave=hideAll;
     active.svg.onmousemove=event=>{
       const bounds=active.svg.getBoundingClientRect(),viewX=(event.clientX-bounds.left)*width/bounds.width;
-      const selected=xValues.reduce((best,value)=>Math.abs(xPos(value)-viewX)<Math.abs(xPos(best)-viewX)?value:best,xValues[0]),cursorX=xPos(selected),targets=synchronize?panels:[active];
+      const selected=xValues.reduce(
+        (best,value)=>Math.abs(xPos(value)-viewX)<Math.abs(xPos(best)-viewX)?value:best,xValues[0]
+      );
+      const cursorX=xPos(selected),targets=synchronize?panels:[active];
       for(const item of panels)item.tooltip.hidden=true;
-      for(const item of targets){item.cursor.setAttribute('x1',cursorX);item.cursor.setAttribute('x2',cursorX);item.cursor.setAttribute('visibility','visible');item.cursor.setAttribute('data-selected-x',selected)}
-      const values=seriesFor(active.metric).map((item,index)=>({label:item.label,colorClass:(item.colorIndex??index)%chartColors.length,value:chartNumber(item.rows.get(String(selected))?.[item.metric||active.metric])})).filter(item=>Number.isFinite(item.value)).sort((leftItem,rightItem)=>rightItem.value-leftItem.value||leftItem.label.localeCompare(rightItem.label));
+      for(const item of targets){
+        item.cursor.setAttribute('x1',cursorX);item.cursor.setAttribute('x2',cursorX);
+        item.cursor.setAttribute('visibility','visible');item.cursor.setAttribute('data-selected-x',selected)
+      }
+      const values=seriesFor(active.metric).map((item,index)=>({
+        label:item.label,colorClass:(item.colorIndex??index)%chartColors.length,
+        value:chartNumber(item.rows.get(String(selected))?.[item.metric||active.metric])
+      })).filter(item=>Number.isFinite(item.value)).sort((leftItem,rightItem)=>
+        rightItem.value-leftItem.value||leftItem.label.localeCompare(rightItem.label)
+      );
       if(!values.length)return;
-      active.tooltip.innerHTML='<strong>'+esc(xName)+' = '+esc(metricLabel(selected))+'</strong>'+values.map(item=>'<div class=tooltip-row><i class="tooltip-dot chart-bg-'+item.colorClass+'"></i><span class="chart-color-'+item.colorClass+'">'+esc(item.label)+'</span><span class=tooltip-value>'+esc(metricLabel(item.value))+'</span></div>').join('');
+      active.tooltip.innerHTML='<strong>'+esc(xName)+' = '+esc(metricLabel(selected))+'</strong>'+
+        values.map(item=>'<div class=tooltip-row><i class="tooltip-dot chart-bg-'+item.colorClass+
+          '"></i><span class="chart-color-'+item.colorClass+'">'+esc(item.label)+
+          '</span><span class=tooltip-value>'+esc(metricLabel(item.value))+'</span></div>').join('');
       active.tooltip.hidden=false;
-      const surfaceBounds=active.surface.getBoundingClientRect(),tooltipWidth=active.tooltip.offsetWidth,rawLeft=event.clientX-surfaceBounds.left+12;
-      active.tooltip.style.left=Math.max(4,Math.min(rawLeft,surfaceBounds.width-tooltipWidth-4))+'px';active.tooltip.style.top=Math.max(4,event.clientY-surfaceBounds.top-active.tooltip.offsetHeight-10)+'px'
+      const surfaceBounds=active.surface.getBoundingClientRect(),tooltipWidth=active.tooltip.offsetWidth;
+      const rawLeft=event.clientX-surfaceBounds.left+12;
+      active.tooltip.style.left=Math.max(4,Math.min(rawLeft,surfaceBounds.width-tooltipWidth-4))+'px';
+      active.tooltip.style.top=Math.max(4,event.clientY-surfaceBounds.top-active.tooltip.offsetHeight-10)+'px'
     }
   }
 }
@@ -749,14 +1006,57 @@ const localPhaseLabels={
 };
 function localPhaseLabel(phase){return localPhaseLabels[phase]||String(phase||'Preparing').replaceAll('-',' ')}
 function localShellArg(value){value=String(value);return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value)?value:"'"+value.replaceAll("'","'\\\"'\\\"'")+"'"}
-function localCommandText(record){const argv=Array.isArray(record?.argv)?record.argv:[],command=argv.map(localShellArg).join(' '),cpus=Array.isArray(record?.cpu_affinity)?record.cpu_affinity:[];return cpus.length?'taskset --cpu-list '+localShellArg(cpus.join(','))+' '+command:command}
-function localCommandDetails(item,open){const commands=Array.isArray(item.commands)?item.commands:[];if(!commands.length)return '—';return '<details class=local-command-history data-command-attempt="'+esc(item.attempt)+'"'+(open?' open':'')+'><summary>'+commands.length+' commands</summary>'+commands.map(command=>'<div class=local-command-entry><strong>Repetition '+esc(command.repetition)+' · '+esc(localPhaseLabel(command.phase))+'</strong><pre class=local-command-code><code>'+esc(localCommandText(command))+'</code></pre></div>').join('')+'</details>'}
-function localElapsed(started,finished=null){const value=Date.parse(started),end=finished?Date.parse(finished):Date.now();return Number.isFinite(value)&&Number.isFinite(end)?Math.max(0,(end-value)/1000):0}
-function localKpi(label,value,help='',primary=false){return '<div class="'+(primary?'primary-result':'')+'"><span class=muted>'+esc(label)+'</span><strong>'+esc(value??'—')+'</strong>'+(help?'<small class=muted>'+esc(help)+'</small>':'')+'</div>'}
-function localOutcomeLabel(outcome){return ({'boundary-found':'SLO boundary found','plateau-found':'Throughput plateau found','lower-bound':'Capacity lower bound','best-observed':'Best observed point','no-feasible-point':'No feasible point','bounded-by-errors':'Bounded by workload errors','search-limit-reached':'Search limit reached'})[outcome]||outcome||'Search in progress'}
-function localSearchAxisLabel(parameter,workload){if(parameter==='threads')return 'YDB CLI threads';if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';return parameter||'Search value'}
+function localCommandText(record){
+  const argv=Array.isArray(record?.argv)?record.argv:[];
+  const command=argv.map(localShellArg).join(' ');
+  const cpus=Array.isArray(record?.cpu_affinity)?record.cpu_affinity:[];
+  return cpus.length?'taskset --cpu-list '+localShellArg(cpus.join(','))+' '+command:command
+}
+function localCommandDetails(item,open){
+  const commands=Array.isArray(item.commands)?item.commands:[];
+  if(!commands.length)return '—';
+  return '<details class=local-command-history data-command-attempt="'+esc(item.attempt)+'"'+
+    (open?' open':'')+'><summary>'+commands.length+' commands</summary>'+commands.map(command=>
+      '<div class=local-command-entry><strong>Repetition '+esc(command.repetition)+' · '+
+      esc(localPhaseLabel(command.phase))+'</strong><pre class=local-command-code><code>'+esc(localCommandText(command))+
+      '</code></pre></div>'
+    ).join('')+'</details>'
+}
+function localProfileDetails(data,open){
+  const configuration={
+    parameters:data.parameters||{},timeout_seconds:data.timeout_seconds??null,role_affinity:data.role_affinity||{}
+  };
+  return '<details class=local-profile-config data-local-profile-config'+(open?' open':'')+
+    '><summary><strong>Launch parameters</strong> <span class=muted>Normalized profile and effective CPU affinity; '+
+    'exact commands are listed per attempt.</span></summary><pre><code>'+esc(JSON.stringify(configuration,null,2))+
+    '</code></pre></details>'
+}
+function localElapsed(started,finished=null){
+  const value=Date.parse(started),end=finished?Date.parse(finished):Date.now();
+  return Number.isFinite(value)&&Number.isFinite(end)?Math.max(0,(end-value)/1000):0
+}
+function localKpi(label,value,help='',primary=false){
+  return '<div class="'+(primary?'primary-result':'')+'"><span class=muted>'+esc(label)+'</span><strong>'+esc(value??'—')+
+    '</strong>'+(help?'<small class=muted>'+esc(help)+'</small>':'')+'</div>'
+}
+function localOutcomeLabel(outcome){
+  return ({
+    'boundary-found':'SLO boundary found','plateau-found':'Throughput plateau found',
+    'lower-bound':'Capacity lower bound','best-observed':'Best observed point',
+    'no-feasible-point':'No feasible point','bounded-by-errors':'Bounded by workload errors',
+    'search-limit-reached':'Search limit reached'
+  })[outcome]||outcome||'Search in progress'
+}
+function localSearchAxisLabel(parameter,workload){
+  if(parameter==='threads')return 'YDB CLI threads';
+  if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';
+  return parameter||'Search value'
+}
 function localAttemptRows(attempts,xField='attempt'){return new Map(attempts.map(item=>[String(item[xField]),item]))}
-function localChart(title,metric,xName,xValues,series){return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+svgChart(metric,xName,xValues,series,chartColors)+'</section>'}
+function localChart(title,metric,xName,xValues,series){
+  return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+
+    svgChart(metric,xName,xValues,series,chartColors)+'</section>'
+}
 function localBestRows(attempts,objective,xField='attempt'){
   let bestLoad=null,bestThroughput=-Infinity,currentStage=null;const rows=new Map;
   for(const item of attempts){
@@ -770,41 +1070,197 @@ function localBestRows(attempts,objective,xField='attempt'){
   return rows
 }
 function renderLocalYdbProfile(container,data){
-  if(data.state==='preparing'){container.innerHTML='<div class=notice>Preparing local YDB profile and extracting binaries…</div>';return}
-  const openCommandAttempts=new Set([...container.querySelectorAll('[data-command-attempt][open]')].map(details=>details.dataset.commandAttempt));
-  const progress=data.progress||{},attempts=data.attempts||[],searches=data.searches||[],result=data.result||null,parameters=data.parameters||{},loadConfig=parameters.load||{},objective=loadConfig.objective?.type||'points';
-  const phaseElapsed=localElapsed(progress.phase_started_at),phaseDuration=Number(progress.phase_duration_seconds),profileElapsed=localElapsed(data.started_at,data.finished_at),remaining=Number.isFinite(phaseDuration)?Math.max(0,phaseDuration-phaseElapsed):null;
-  const phaseHelp=[progress.attempt?'attempt #'+progress.attempt:null,progress.repetition?'repetition '+progress.repetition+'/'+progress.repetitions:null,Number.isFinite(remaining)?elapsedLabel(remaining)+' remaining':null].filter(Boolean).join(' · ');
-  const phaseProgress=Number.isFinite(phaseDuration)?'<progress class=local-phase-progress max="'+phaseDuration+'" value="'+Math.min(phaseDuration,phaseElapsed)+'"></progress>':'';
-  let html=loadConfig.allow_errors?'<div class=notice>Failed workload requests are allowed for this profile and remain visible in metrics.</div>':'';html+='<div class=local-live><div><span class=muted>Current phase</span><div class=local-phase>'+esc(localPhaseLabel(progress.phase||data.state))+'</div><div class=muted>'+esc(phaseHelp||'Waiting for the next milestone')+'</div>'+phaseProgress+'</div>';
-  html+=localKpi('Profile elapsed',elapsedLabel(profileElapsed))+localKpi('Geometry',(parameters.geometry?.static_nodes??'—')+' static · '+(progress.dynamic_nodes??result?.dynamic_nodes??parameters.geometry?.dynamic_nodes??'—')+' dynamic')+localKpi('Candidate',progress.load===undefined?'—':(progress.parameter||loadConfig.parameter||'load')+' '+metricLabel(progress.load))+'</div>';
-  if(progress.current_command?.argv?.length)html+='<section class=local-current-command><span class=muted>Running command</span><pre class=local-command-code><code>'+esc(localCommandText(progress.current_command))+'</code></pre></section>';
-  if(result){const selected=result.selected_metrics||{},latencyMetric=(loadConfig.objective?.percentile||'p99')+'_ms',selectedLabel=result.selected_load===null||result.selected_load===undefined?'—':metricLabel(result.selected_load);html+='<div class=local-kpis>'+localKpi(localOutcomeLabel(result.outcome),selectedLabel,result.parameter||loadConfig.parameter,true)+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),'transactions/s')+localKpi(loadConfig.objective?.percentile||'p99',metricLabel(selected[latencyMetric]??'—'),'ms')+localKpi('Dynamic nodes',result.dynamic_nodes,result.stop_reason||'')+'</div>'}
-  else html+='<div class=local-kpis>'+localKpi('Completed attempts',attempts.length,'search stage '+(progress.search_stage||1),true)+localKpi('Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—','transactions/s')+localKpi('Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms')+'</div>';
-  const currentStage=Number(progress.search_stage||0),lastStored=searches.length?Math.max(...searches.map(item=>Number(item.stage)||0)):0,xAxis=container.dataset.localYdbXAxis==='parameter'?'parameter':'attempt',searchParameter=loadConfig.parameter||result?.parameter||'load',searchAxisLabel=localSearchAxisLabel(searchParameter,parameters.workload?.type);let chartBinding=null;
-  html+='<h3>Geometry stages</h3><div class=local-stages>'+searches.map(item=>'<div class=local-stage><strong>Stage '+esc(item.stage)+' · '+esc(item.dynamic_nodes)+' dynamic</strong><div>'+esc(localOutcomeLabel(item.outcome))+'</div><div class=muted>selected '+esc(metricLabel(item.selected_load))+' · '+esc(elapsedLabel(item.duration_seconds))+'</div><div class=stage-arrow>'+esc(item.next_action==='scale-dynamic-nodes'?'Scale → '+item.next_dynamic_nodes+' dynamic nodes':item.stop_reason||'Finish')+'</div></div>').join('')+(currentStage>lastStored&&data.state==='running'?'<div class="local-stage current"><strong>Stage '+esc(currentStage)+' · '+esc(progress.dynamic_nodes??'—')+' dynamic</strong><div>In progress</div><div class=muted>'+esc(attempts.filter(item=>Number(item.search_stage)===currentStage).length)+' completed attempts</div></div>':'')+'</div>';
+  if(data.state==='preparing'){
+    container.innerHTML='<div class=notice>Preparing local YDB profile and extracting binaries…</div>';return
+  }
+  const openCommandAttempts=new Set(
+    [...container.querySelectorAll('[data-command-attempt][open]')].map(details=>details.dataset.commandAttempt)
+  );
+  const profileConfigOpen=container.querySelector('[data-local-profile-config][open]')!==null;
+  const progress=data.progress||{},attempts=data.attempts||[],searches=data.searches||[];
+  const result=data.result||null,parameters=data.parameters||{},loadConfig=parameters.load||{};
+  const objective=loadConfig.objective?.type||'points';
+  const phaseElapsed=localElapsed(progress.phase_started_at);
+  const phaseDuration=Number(progress.phase_duration_seconds);
+  const profileElapsed=localElapsed(data.started_at,data.finished_at);
+  const remaining=Number.isFinite(phaseDuration)?Math.max(0,phaseDuration-phaseElapsed):null;
+  const phaseHelp=[
+    progress.attempt?'attempt #'+progress.attempt:null,
+    progress.repetition?'repetition '+progress.repetition+'/'+progress.repetitions:null,
+    Number.isFinite(remaining)?elapsedLabel(remaining)+' remaining':null
+  ].filter(Boolean).join(' · ');
+  const phaseProgress=Number.isFinite(phaseDuration)?
+    '<progress class=local-phase-progress max="'+phaseDuration+'" value="'+
+      Math.min(phaseDuration,phaseElapsed)+'"></progress>':'';
+  let html=loadConfig.allow_errors?
+    '<div class=notice>Failed workload requests are allowed for this profile and remain visible in metrics.</div>':'';
+  html+='<div class=local-live><div><span class=muted>Current phase</span><div class=local-phase>'+
+    esc(localPhaseLabel(progress.phase||data.state))+'</div><div class=muted>'+
+    esc(phaseHelp||'Waiting for the next milestone')+'</div>'+phaseProgress+'</div>';
+  const dynamicNodes=
+    progress.dynamic_nodes??result?.dynamic_nodes??parameters.geometry?.dynamic_nodes??'—';
+  const candidate=progress.load===undefined?
+    '—':(progress.parameter||loadConfig.parameter||'load')+' '+metricLabel(progress.load);
+  html+=localKpi('Profile elapsed',elapsedLabel(profileElapsed))+
+    localKpi('Geometry',(parameters.geometry?.static_nodes??'—')+' static · '+dynamicNodes+' dynamic')+
+    localKpi('Candidate',candidate)+'</div>';
+  html+=localProfileDetails(data,profileConfigOpen);
+  if(progress.current_command?.argv?.length){
+    html+='<section class=local-current-command><span class=muted>Running command</span>'+
+      '<pre class=local-command-code><code>'+esc(localCommandText(progress.current_command))+
+      '</code></pre></section>'
+  }
+  if(result){
+    const selected=result.selected_metrics||{};
+    const latencyMetric=(loadConfig.objective?.percentile||'p99')+'_ms';
+    const selectedLabel=result.selected_load===null||result.selected_load===undefined?
+      '—':metricLabel(result.selected_load);
+    html+='<div class=local-kpis>'+localKpi(
+      localOutcomeLabel(result.outcome),selectedLabel,result.parameter||loadConfig.parameter,true
+    )+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),'transactions/s')+
+      localKpi(
+        loadConfig.objective?.percentile||'p99',metricLabel(selected[latencyMetric]??'—'),'ms'
+      )+localKpi('Dynamic nodes',result.dynamic_nodes,result.stop_reason||'')+'</div>'
+  }else{
+    html+='<div class=local-kpis>'+localKpi(
+      'Completed attempts',attempts.length,'search stage '+(progress.search_stage||1),true
+    )+localKpi(
+      'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—','transactions/s'
+    )+localKpi(
+      'Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms'
+    )+'</div>'
+  }
+  const currentStage=Number(progress.search_stage||0);
+  const lastStored=searches.length?Math.max(...searches.map(item=>Number(item.stage)||0)):0;
+  const xAxis=container.dataset.localYdbXAxis==='parameter'?'parameter':'attempt';
+  const searchParameter=loadConfig.parameter||result?.parameter||'load';
+  const searchAxisLabel=localSearchAxisLabel(searchParameter,parameters.workload?.type);
+  let chartBinding=null;
+  const stageCards=searches.map(item=>
+    '<div class=local-stage><strong>Stage '+esc(item.stage)+' · '+esc(item.dynamic_nodes)+
+    ' dynamic</strong><div>'+esc(localOutcomeLabel(item.outcome))+'</div><div class=muted>selected '+
+    esc(metricLabel(item.selected_load))+' · '+esc(elapsedLabel(item.duration_seconds))+
+    '</div><div class=stage-arrow>'+esc(
+      item.next_action==='scale-dynamic-nodes'?
+        'Scale → '+item.next_dynamic_nodes+' dynamic nodes':item.stop_reason||'Finish'
+    )+'</div></div>'
+  ).join('');
+  const currentStageCard=currentStage>lastStored&&data.state==='running'?
+    '<div class="local-stage current"><strong>Stage '+esc(currentStage)+' · '+
+    esc(progress.dynamic_nodes??'—')+' dynamic</strong><div>In progress</div><div class=muted>'+
+    esc(attempts.filter(item=>Number(item.search_stage)===currentStage).length)+
+    ' completed attempts</div></div>':'';
+  html+='<h3>Geometry stages</h3><div class=local-stages>'+stageCards+currentStageCard+'</div>';
   if(attempts.length){
-    const xField=xAxis==='parameter'?'load':'attempt',xName=xAxis==='parameter'?searchAxisLabel:'Attempt',xValues=xAxis==='parameter'?[...new Set(attempts.map(item=>Number(item.load)))].sort((left,right)=>left-right):attempts.map(item=>item.attempt),stages=[];
-    for(const item of attempts){let stage=stages.find(value=>value.search_stage===item.search_stage);if(!stage){stage={search_stage:item.search_stage,dynamic_nodes:item.dynamic_nodes,attempts:[]};stages.push(stage)}stage.attempts.push(item)}
-    const groups=(xAxis==='parameter'?stages:[{attempts}]).map(item=>({rows:localAttemptRows(item.attempts,xField),bestRows:localBestRows(item.attempts,objective,xField),suffix:xAxis==='parameter'&&stages.length>1?' · stage '+item.search_stage+' · '+item.dynamic_nodes+' dynamic':''}));
-    const candidateSeries=groups.flatMap(group=>[{rows:group.bestRows,metric:'load',label:'Candidate'+group.suffix,colorIndex:7},{rows:group.bestRows,metric:'current_best',label:'Current best'+group.suffix,colorIndex:0},{rows:group.bestRows,metric:'passed_load',label:'Passed'+group.suffix,colorIndex:10},{rows:group.bestRows,metric:'failed_load',label:'Failed'+group.suffix,colorIndex:8}]);
-    const throughputSeries=groups.flatMap(group=>{const result=[{rows:group.rows,metric:'throughput',label:'Achieved throughput'+group.suffix,colorIndex:0}];if(loadConfig.parameter==='rate')result.push({rows:group.rows,metric:'load',label:'Offered rate'+group.suffix,colorIndex:7});return result});
-    const latencySeries=groups.flatMap(group=>['p50_ms','p95_ms','p99_ms','pmax_ms'].map((metric,index)=>({rows:group.rows,metric,label:metric.replace('_ms','')+group.suffix,colorIndex:index})));if(loadConfig.objective?.type==='latency-slo'){const sloRows=new Map(xValues.map(value=>[String(value),{slo_ms:loadConfig.objective.max_ms}]));latencySeries.push({rows:sloRows,metric:'slo_ms',label:'SLO',colorIndex:8})}
-    const cpuSeries=groups.flatMap(group=>[['static_cpu_mean','Static'],['dynamic_cpu_mean','Dynamic'],['cli_cpu_mean','YDB CLI'],['host_cpu_mean','Host']].map(([metric,label],index)=>({rows:group.rows,metric,label:label+group.suffix,colorIndex:index})));
-    const errorSeries=groups.flatMap(group=>[{rows:group.rows,metric:'errors',label:'Errors'+group.suffix,colorIndex:8},{rows:group.rows,metric:'retries',label:'Retries'+group.suffix,colorIndex:1}]);
-    chartBinding={xName,xValues,series:{load:candidateSeries,throughput:throughputSeries,latency_ms:latencySeries,cpu_percent:cpuSeries,errors:errorSeries}};
-    const axisHelp=xAxis==='parameter'?'Points are ordered by the searched parameter; geometry stages remain separate.':'Execution order shows how the controller moved through candidate values.';
-    html+='<div class=run-section-title><h3>Search process</h3><div class=actions><span class=muted>X axis</span><button type=button data-local-chart-x=attempt class="'+(xAxis==='attempt'?'primary':'')+'" aria-pressed="'+(xAxis==='attempt')+'">Attempts (search order)</button><button type=button data-local-chart-x=parameter class="'+(xAxis==='parameter'?'primary':'')+'" aria-pressed="'+(xAxis==='parameter')+'">'+esc(searchAxisLabel)+'</button></div></div><p class=muted>'+esc(axisHelp)+'</p><div class=local-charts>'+localChart('Candidate and current best','load',xName,xValues,candidateSeries)+localChart('Offered and achieved throughput','throughput',xName,xValues,throughputSeries)+localChart('Latency','latency_ms',xName,xValues,latencySeries)+localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+localChart('Errors and retries','errors',xName,xValues,errorSeries)+'</div>';
-    html+='<h3>Attempts</h3><table class=local-attempts><thead><tr><th>#</th><th>Stage</th><th>Dynamic</th><th>Candidate</th><th>Throughput</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th><th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+'</td><td>'+esc(metricLabel(item.p99_ms))+' ms</td><td>'+esc(item.errors)+'</td><td>'+esc(metricLabel(item.static_cpu_mean))+'%</td><td>'+esc(metricLabel(item.dynamic_cpu_mean))+'%</td><td>'+esc(metricLabel(item.cli_cpu_mean))+'%</td><td class="'+(item.passed?'attempt-pass':'attempt-fail')+'">'+(item.passed?'PASS':'FAIL')+'</td><td>'+esc(item.decision)+'</td><td>'+esc(elapsedLabel(item.duration_seconds))+'</td><td class=local-command-cell>'+localCommandDetails(item,openCommandAttempts.has(String(item.attempt)))+'</td></tr>').join('')+'</tbody></table>';
+    const xField=xAxis==='parameter'?'load':'attempt';
+    const xName=xAxis==='parameter'?searchAxisLabel:'Attempt';
+    const xValues=xAxis==='parameter'?
+      [...new Set(attempts.map(item=>Number(item.load)))].sort((left,right)=>left-right):
+      attempts.map(item=>item.attempt);
+    const stages=[];
+    for(const item of attempts){
+      let stage=stages.find(value=>value.search_stage===item.search_stage);
+      if(!stage){
+        stage={search_stage:item.search_stage,dynamic_nodes:item.dynamic_nodes,attempts:[]};stages.push(stage)
+      }
+      stage.attempts.push(item)
+    }
+    const groups=(xAxis==='parameter'?stages:[{attempts}]).map(item=>({
+      rows:localAttemptRows(item.attempts,xField),bestRows:localBestRows(item.attempts,objective,xField),
+      suffix:xAxis==='parameter'&&stages.length>1?
+        ' · stage '+item.search_stage+' · '+item.dynamic_nodes+' dynamic':''
+    }));
+    const candidateSeries=groups.flatMap(group=>[
+      {rows:group.bestRows,metric:'load',label:'Candidate'+group.suffix,colorIndex:7},
+      {rows:group.bestRows,metric:'current_best',label:'Current best'+group.suffix,colorIndex:0},
+      {rows:group.bestRows,metric:'passed_load',label:'Passed'+group.suffix,colorIndex:10},
+      {rows:group.bestRows,metric:'failed_load',label:'Failed'+group.suffix,colorIndex:8}
+    ]);
+    const throughputSeries=groups.flatMap(group=>{
+      const values=[{
+        rows:group.rows,metric:'throughput',label:'Achieved throughput'+group.suffix,colorIndex:0
+      }];
+      if(loadConfig.parameter==='rate')values.push({
+        rows:group.rows,metric:'load',label:'Offered rate'+group.suffix,colorIndex:7
+      });
+      return values
+    });
+    const latencySeries=groups.flatMap(group=>
+      ['p50_ms','p95_ms','p99_ms','pmax_ms'].map((metric,index)=>({
+        rows:group.rows,metric,label:metric.replace('_ms','')+group.suffix,colorIndex:index
+      }))
+    );
+    if(loadConfig.objective?.type==='latency-slo'){
+      const sloRows=new Map(xValues.map(value=>[String(value),{slo_ms:loadConfig.objective.max_ms}]));
+      latencySeries.push({rows:sloRows,metric:'slo_ms',label:'SLO',colorIndex:8})
+    }
+    const cpuMetrics=[
+      ['static_cpu_mean','Static'],['dynamic_cpu_mean','Dynamic'],
+      ['cli_cpu_mean','YDB CLI'],['host_cpu_mean','Host']
+    ];
+    const cpuSeries=groups.flatMap(group=>cpuMetrics.map(([metric,label],index)=>({
+      rows:group.rows,metric,label:label+group.suffix,colorIndex:index
+    })));
+    const errorSeries=groups.flatMap(group=>[
+      {rows:group.rows,metric:'errors',label:'Errors'+group.suffix,colorIndex:8},
+      {rows:group.rows,metric:'retries',label:'Retries'+group.suffix,colorIndex:1}
+    ]);
+    chartBinding={
+      xName,xValues,
+      series:{
+        load:candidateSeries,throughput:throughputSeries,latency_ms:latencySeries,
+        cpu_percent:cpuSeries,errors:errorSeries
+      }
+    };
+    const axisHelp=xAxis==='parameter'?
+      'Points are ordered by the searched parameter; geometry stages remain separate.':
+      'Execution order shows how the controller moved through candidate values.';
+    html+='<div class=run-section-title><h3>Search process</h3><div class=actions><span class=muted>X axis</span>'+
+      '<button type=button data-local-chart-x=attempt class="'+(xAxis==='attempt'?'primary':'')+
+      '" aria-pressed="'+(xAxis==='attempt')+'">Attempts (search order)</button>'+
+      '<button type=button data-local-chart-x=parameter class="'+(xAxis==='parameter'?'primary':'')+
+      '" aria-pressed="'+(xAxis==='parameter')+'">'+esc(searchAxisLabel)+'</button></div></div>'+
+      '<p class=muted>'+esc(axisHelp)+'</p><div class=local-charts>'+
+      localChart('Candidate and current best','load',xName,xValues,candidateSeries)+
+      localChart('Offered and achieved throughput','throughput',xName,xValues,throughputSeries)+
+      localChart('Latency','latency_ms',xName,xValues,latencySeries)+
+      localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+
+      localChart('Errors and retries','errors',xName,xValues,errorSeries)+'</div>';
+    html+='<h3>Attempts</h3><div class=local-attempts-scroll tabindex=0 role=region aria-label="Search attempts">'+
+      '<table class=local-attempts><thead><tr><th>#</th><th>Stage</th><th>Dynamic</th><th>Candidate</th>'+
+      '<th>Throughput</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th>'+
+      '<th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+
+      attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+
+        esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+
+        '</td><td>'+esc(metricLabel(item.p99_ms))+' ms</td><td>'+esc(item.errors)+'</td><td>'+
+        esc(metricLabel(item.static_cpu_mean))+'%</td><td>'+esc(metricLabel(item.dynamic_cpu_mean))+
+        '%</td><td>'+esc(metricLabel(item.cli_cpu_mean))+'%</td><td class="'+
+        (item.passed?'attempt-pass':'attempt-fail')+'">'+(item.passed?'PASS':'FAIL')+'</td><td>'+esc(item.decision)+
+        '</td><td>'+esc(elapsedLabel(item.duration_seconds))+'</td><td class=local-command-cell>'+
+        localCommandDetails(item,openCommandAttempts.has(String(item.attempt)))+'</td></tr>'
+      ).join('')+'</tbody></table></div>';
   }else html+='<div class=empty>No completed search attempts yet. The timeline will appear after the first measurement.</div>';
   container.innerHTML=html;
-  for(const axisButton of container.querySelectorAll('[data-local-chart-x]'))axisButton.onclick=()=>{container.dataset.localYdbXAxis=axisButton.dataset.localChartX;renderLocalYdbProfile(container,data)};
-  if(chartBinding)bindChartTooltips(container,chartBinding.xName,chartBinding.xValues,chartBinding.series,Object.keys(chartBinding.series),chartColors,true)
+  for(const axisButton of container.querySelectorAll('[data-local-chart-x]'))axisButton.onclick=()=>{
+    container.dataset.localYdbXAxis=axisButton.dataset.localChartX;renderLocalYdbProfile(container,data)
+  };
+  if(chartBinding)bindChartTooltips(
+    container,chartBinding.xName,chartBinding.xValues,chartBinding.series,
+    Object.keys(chartBinding.series),chartColors,true
+  )
 }
 async function mountLocalYdbProfile(container,runId,profile,runState){
   let loading=false,terminal=false;
   const scheduleRunRefresh=()=>{if(['running','queued'].includes(runState)&&!refreshTimer)refreshTimer=setTimeout(()=>renderRun(runId,'local-ydb/'+profile),700)};
-  const refresh=async()=>{if(loading)return;loading=true;try{const data=await api('/api/runs/'+enc(runId)+'/local-ydb-profile?profile='+enc(profile));renderLocalYdbProfile(container,data);terminal=!['running','preparing'].includes(data.state);if(terminal&&refreshTimer){clearInterval(refreshTimer);refreshTimer=null}if(terminal)scheduleRunRefresh()}catch(error){container.innerHTML=displayError(error)}finally{loading=false}};
+  const refresh=async()=>{
+    if(loading)return;loading=true;
+    try{
+      const data=await api('/api/runs/'+enc(runId)+'/local-ydb-profile?profile='+enc(profile));
+      renderLocalYdbProfile(container,data);terminal=!['running','preparing'].includes(data.state);
+      if(terminal&&refreshTimer){clearInterval(refreshTimer);refreshTimer=null}
+      if(terminal)scheduleRunRefresh()
+    }catch(error){container.innerHTML=displayError(error)}finally{loading=false}
+  };
   await refresh();if(!terminal&&['running','queued','recovery_required'].includes(runState)&&!refreshTimer)refreshTimer=setInterval(refresh,1000)
 }
     """
@@ -858,7 +1314,11 @@ async function mountLocalYdbProfile(container,runId,profile,runState){
     "ter(step=>!['pending','running'].includes(step.state)).length,affinities=new Set(steps.map(step=>step.affinity)).size;re"
     "turn '<tr><td><a href=\"#run/'+enc(id)+'/profile/'+enc(key)+'\">'+esc(key)+'</a></td><td>'+done+' / '+steps.length+'</td"
     "><td>'+status(aggregateState(steps))+'</td><td>'+affinities+'</td></tr>'}).join('')+'</table></section>';\n"
-    "    if(activeProfile)content+=activeBenchmark==='local-ydb'?'<section class=card><div class=run-section-title><h2>YDB load search</h2><strong>'+esc(activeProfile)+'</strong></div><div id=local-ydb-result>Loading live search data…</div></section>':'<section class=card><div class=run-section-title><h2>Results</h2><strong>'+esc(activeProfile)+'</strong></div><p class=muted>Affinity variants are lines. Choose a common X axis, one or more Y metrics, and fixed values for the remaining dimensions.</p><div id=run-chart>Loading summary data…</div></section>';\n"
+    "    if(activeProfile)content+=activeBenchmark==='local-ydb'?'<section class=card><div class=run-section-title><h2>YDB "
+    "load search</h2><strong>'+esc(activeProfile)+'</strong></div><div id=local-ydb-result>Loading live search data…</div>"
+    "</section>':'<section class=card><div class=run-section-title><h2>Results</h2><strong>'+esc(activeProfile)+'</strong>"
+    "</div><p class=muted>Affinity variants are lines. Choose a common X axis, one or more Y metrics, and fixed values for "
+    "the remaining dimensions.</p><div id=run-chart>Loading summary data…</div></section>';\n"
     "    if(activeProfile){const steps=groups[activeProfile],open=run.state==='running'?' open':'';content+='<section class=\""
     "card run-tree\"><details'+open+'><summary><strong>Execution details</strong> — affinity, cases and artifacts</summary><"
     "table><tr><th>Affinity</th><th>Runs</th><th>State</th></tr>'+affinityRows(id,steps)+'</table></details></section>'}\n"
@@ -875,7 +1335,10 @@ async function mountLocalYdbProfile(container,runId,profile,runState){
     "    const cancel=document.querySelector('#cancel-run');\n"
     "    if(cancel)cancel.onclick=async()=>{try{await api('/api/runs/'+enc(id)+'/cancel',{method:'POST'});renderRun(id,acti"
     'veProfile)}catch(error){alert(error.message)}};\n'
-    "    if(activeProfile){const pieces=activeProfile.split('/'),benchmark=pieces.shift(),profile=pieces.join('/');if(benchmark==='local-ydb')await mountLocalYdbProfile(document.querySelector('#local-ydb-result'),id,profile,run.state);else try{mountChartBuilder(document.querySelector('#run-chart'),await loadChartData([id]),{benchmark,profile,singleProfile:true})}catch(error){document.querySelector('#run-chart').innerHTML=displayError(error)}}\n"
+    "    if(activeProfile){const pieces=activeProfile.split('/'),benchmark=pieces.shift(),profile=pieces.join('/');if("
+    "benchmark==='local-ydb')await mountLocalYdbProfile(document.querySelector('#local-ydb-result'),id,profile,run.state);"
+    "else try{mountChartBuilder(document.querySelector('#run-chart'),await loadChartData([id]),{benchmark,profile,"
+    "singleProfile:true})}catch(error){document.querySelector('#run-chart').innerHTML=displayError(error)}}\n"
     "  }catch(error){app.innerHTML=shell('runs',breadcrumbs([{route:'runs',label:'Runs'},{route:'run/'+enc(id),label:id}])+di"
     'splayError(error))}\n'
     '}\n'
@@ -1889,6 +2352,7 @@ class RunService:
             "started_at",
             "finished_at",
             "parameters",
+            "timeout_seconds",
             "role_affinity",
             "progress",
             "attempts",

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -29,6 +29,7 @@ from ydb.tools.ydb_bench.lib.results import ResultStore, load_manifest
 from ydb.tools.ydb_bench.lib.actors_core import run_benchmark
 from ydb.tools.ydb_bench.lib.common import extract_executable
 from ydb.tools.ydb_bench.lib.import_results import MAX_TOTAL_SIZE, export_archive, import_archive
+from ydb.tools.ydb_bench.lib.local_ydb import run_local_ydb
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, plan_affinity, topology_record
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
@@ -132,6 +133,24 @@ _CSS = (
     'order:1px solid #d0d5dd;border-bottom-color:#fff;margin-bottom:-1px}.profile-overview td:first-child{font-weight:650}.run'
     '-section-title{display:flex;align-items:baseline;justify-content:space-between;gap:1rem;flex-wrap:wrap}.downloads{display'
     ':inline-block}.downloads summary{cursor:pointer}.downloads .actions{margin-top:.5rem}\n'
+    '.local-live{display:grid;grid-template-columns:minmax(16rem,1.4fr) repeat(3,minmax(9rem,1fr));gap:.8rem;align-items:stre'
+    'tch}.local-live>div,.local-kpis>div{padding:.8rem;border:1px solid #d0d5dd;border-radius:7px;background:var(--panel)}.lo'
+    'cal-live strong,.local-kpis strong{display:block;font-size:1.18rem;margin-top:.2rem}.local-phase{font-size:1.25rem;font-'
+    'weight:700}.local-phase-progress{width:100%;margin-top:.65rem}.local-kpis{display:grid;grid-template-columns:repeat(auto-'
+    'fit,minmax(10rem,1fr));gap:.7rem;margin:.8rem 0}.local-kpis .primary-result{border-color:#84adff;background:#eff6ff}.lo'
+    'cal-stages{display:flex;gap:.55rem;overflow-x:auto;padding:.25rem 0 .7rem}.local-stage{min-width:13rem;padding:.65rem;bo'
+    'rder:1px solid #d0d5dd;border-radius:7px;background:#fff}.local-stage.current{border-color:#84adff;background:#eff6ff'
+    '}.local-stage .stage-arrow{color:var(--muted);margin-top:.35rem}.local-charts{display:grid;grid-template-columns:repeat('
+    '2,minmax(0,1fr));gap:.9rem}.local-charts .chart-panel{margin:0;padding:.8rem;border:1px solid #d0d5dd;border-radius:7p'
+    'x}.local-charts .chart-panel h3{margin-top:0}.local-attempts{display:block;max-width:100%;overflow-x:auto}.local-attempt'
+    's td,.local-attempts th{white-space:nowrap}.local-current-command{margin:.8rem 0;padding:.8rem;border:1px solid #d0d5dd'
+    ';border-radius:7px;background:#101828;color:#fff}.local-current-command .muted{color:#d0d5dd}.local-command-code{margin:'
+    '.45rem 0 0;white-space:pre-wrap;overflow-wrap:anywhere;font:12px ui-monospace,SFMono-Regular,Menlo,monospace}.local-co'
+    'mmand-cell{min-width:20rem;white-space:normal!important}.local-command-history summary{cursor:pointer}.local-command-e'
+    'ntry{margin:.55rem 0;padding:.55rem;border:1px solid #e4e7ec;border-radius:5px;background:var(--panel)}.attempt-pass{co'
+    'lor:var(--good);font-weight:650}.attempt-fail{color:var(--bad);font-weight:650}@media(max-width:900px){.local-live{grid-'
+    'template-columns:1fr 1fr}.local-charts{grid-template-colu'
+    'mns:1fr}}\n'
     '.status.queued{color:var(--warn)}\n'
 )
 _JS = (
@@ -184,9 +203,45 @@ _JS = (
     'et index=0;index<numbers.length;){let end=index;while(end+1<numbers.length&&numbers[end+1]===numbers[end]+1)end++;parts.'
     "push(index===end?String(numbers[index]):numbers[index]+'-'+numbers[end]);index=end+1}return parts.join(', ')}\n"
     "function yamlArray(values){return '['+values.map(value=>String(value)).join(', ')+']'}\n"
+    "const localYdbOperations={kv:['upsert','select','read-rows','mixed'],stock:['user-hist','rand-user-hist','add-rand-"
+    "order','put-rand-order','put-same-order']};\n"
+    "const localYdbGeometryKeys={static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes',max_dynamic_nodes:'max-dynamic-"
+    "nodes',disk_size_gb:'disk-size-gb',storage_groups:'storage-groups'};\n"
+    "const localYdbSearchKeys={resolution_percent:'resolution-percent'};\n"
+    "const localYdbObjectiveKeys={target_role:'target-role',plateau_gain_percent:'plateau-gain-percent',plateau_points:'p"
+    "lateau-points',cpu_saturation_percent:'cpu-saturation-percent'};\n"
+    "const localYdbSloKeys={max_ms:'max-ms',max_errors:'max-errors',min_achieved_rate_ratio:'min-achieved-rate-ratio'};\n"
+    "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
+    "function defaultLocalYdbWorkload(type){return type==='stock'?{type:'stock',operation:'put-rand-order',options:{'min-p"
+    "artitions':40,products:100,quantity:1000,orders:100,'auto-partition':1,limit:10}}:{type:'kv',operation:'upsert',options"
+    ":{'min-partitions':40,'max-partitions':1000,'partition-size-mb':2000,'init-upserts':0,'max-first-key':65536,'value-siz"
+    "e':64,columns:2,'rows-per-query':1}}}\n"
+    "function defaultLocalYdb(){return {workload:defaultLocalYdbWorkload('kv'),"
+    "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
+    ":{threads:64},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
+    "etitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
+    ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
+    "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
+    "load:','      type: '+workload.type,'      operation: '+workload.operation,'      options:');for(const [key,value] of "
+    "Object.entries(workload.options))lines.push('        '+key+': '+value);lines.push('    geometry:','      preset: '+conf"
+    "ig.geometry.preset);for(const [key,yamlKey] of Object.entries(localYdbGeometryKeys))lines.push('      '+yamlKey+': '+c"
+    "onfig.geometry[key]);lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
+    "+config.load.parameter,'      allow-errors: '+Boolean(config.load.allow_errors));if(config.load.values)lines.push('      values: '+yamlArray(config.load.values));else{lines."
+    "push('      search:','        start: '+config.load.search.start,'        maximum: '+config.load.search.maximum);if(config.load.objective.type==='latency-slo')lines.push('        multiplier: '+config.load.search.multiplier);for(const [key,yamlKey] of Object.entries(localYdbSearchKeys))lines."
+    "push('        '+yamlKey+': '+config.load.search[key]);lines.push('      objective:','        type: '+config.load.object"
+    "ive.type);if(config.load.objective.type==='maximize-throughput')for(const [key,yamlKey] of Object.entries(localYdbOb"
+    "jectiveKeys))lines.push('        '+yamlKey+': '+config.load.objective[key]);else{lines.push('        percentile: '+config.load.o"
+    "bjective.percentile);for(const [key,yamlKey] of Object.entries(localYdbSloKeys))lines.push('        '+yamlKey+': '+con"
+    "fig.load.objective[key])}}lines.push('    measurement:','      warmup: '+config.measurement.warmup,' "
+    "     duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,'    affinity:');f"
+    "or(const [key,yamlKey] of Object.entries(localYdbAffinityKeys)){const role=config.affinity[key];lines.push('      '+yam"
+    "lKey+':','        mode: '+role.mode);if(role.cpus!==null&&role.cpus!==undefined)lines.push('        cpus: '+role.cpus)}"
+    "if(profile.timeout!==null&&profile.timeout!==undefined&&profile.timeout!=='')lines.push('    timeout: '+profile.timeo"
+    "ut)}\n"
     'function serializeConfig(model){let lines=[];for(const benchmark of model.benchmarks||[]){const entries=(model.profiles|'
     "|[]).filter(profile=>profile.benchmark===benchmark.name);if(!entries.length)continue;lines.push(benchmark.name+':');for("
-    "const profile of entries){lines.push('  '+profile.name+':');lines.push('    threads: '+yamlArray(profile.threads));for(c"
+    "const profile of entries){lines.push('  '+profile.name+':');if(benchmark.profile_kind==='local-ydb'){serializeLocalYdb"
+    "(lines,profile);continue}lines.push('    threads: '+yamlArray(profile.threads));for(c"
     "onst parameter of benchmark.parameters)lines.push('    '+parameter.name+': '+yamlArray(profile.parameters[parameter.name"
     "]||parameter.default));lines.push('    duration: '+profile.duration);lines.push('    repetitions: '+profile.repetitions)"
     ";lines.push('    affinity: '+yamlArray(profile.affinity));lines.push('    background-load: '+yamlArray(profile.background_"
@@ -246,8 +301,61 @@ _JS = (
     "    catch(error){showMessage(error.message,'error')}\n"
     '  }\n'
     '}\n'
+    """
+function localField(id,label,value,help='',attributes=''){
+  return '<div class=field><label for="'+id+'">'+esc(label)+'</label><input id="'+id+'" value="'+esc(value)+'" '+attributes+'><small class=muted>'+esc(help)+'</small></div>'
+}
+function localSelect(id,label,value,choices,help=''){
+  return '<div class=field><label for="'+id+'">'+esc(label)+'</label><select id="'+id+'">'+choices.map(choice=>'<option value="'+esc(choice)+'" '+(choice===value?'selected':'')+'>'+esc(choice)+'</option>').join('')+'</select><small class=muted>'+esc(help)+'</small></div>'
+}
+function localCheck(id,label,checked,help=''){
+  return '<div class=field><label><input id="'+id+'" type=checkbox '+(checked?'checked':'')+'> '+esc(label)+'</label><small class=muted>'+esc(help)+'</small></div>'
+}
+function localYdbProfileEditor(profile){
+  const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
+  const loadMode=load.values?'points':load.objective.type;
+  const options=Object.entries(workload.options).map(([key,value])=>localField('local-option-'+key,key,value)).join('');
+  const geometryFields=Object.entries(localYdbGeometryKeys).map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
+  const loadCommon=localSelect('local-load-mode','Objective',loadMode,['points','maximize-throughput','latency-slo'])+localSelect('local-load-parameter','Parameter',load.parameter,['rate','threads'])+localCheck('local-load-allow-errors','Allow failed workload requests',Boolean(load.allow_errors),'Failed requests remain visible in results but do not limit load search.');
+  const searchFields=loadMode==='points'?'':localField('local-load-start','Start',load.search.start,'','type=number min=1')+localField('local-load-maximum','Maximum',load.search.maximum,'','type=number min=1')+(loadMode==='latency-slo'?localField('local-load-multiplier','Growth multiplier',load.search.multiplier,'Used to find the first failing latency point.','type=number min=1 step=any'):'')+localField('local-load-search-resolution-percent',loadMode==='maximize-throughput'?'Ternary resolution (%)':'Boundary resolution (%)',load.search.resolution_percent,'','type=number min=0 max=100 step=any');
+  const loadFields=loadMode==='points'?localField('local-load-values','Values',(load.values||[]).join(', '),'Comma-separated values and ranges'):searchFields+(loadMode==='maximize-throughput'?localSelect('local-load-target-role','Target role',load.objective.target_role,['static','dynamic','total'])+localField('local-load-plateau-gain-percent','Plateau gain (%)',load.objective.plateau_gain_percent,'','type=number min=0 step=any')+localField('local-load-plateau-points','Plateau comparisons',load.objective.plateau_points,'','type=number min=1')+localField('local-load-cpu-saturation-percent','CPU saturation (%)',load.objective.cpu_saturation_percent,'','type=number min=0 max=100 step=any'):'');
+  const slo=loadMode==='latency-slo'?'<h3>Latency SLO</h3><div class=form-grid>'+localSelect('local-slo-percentile','Percentile',load.objective.percentile,['p50','p95','p99','pmax'])+localField('local-slo-max-ms','Maximum latency (ms)',load.objective.max_ms,'','type=number min=0 step=any')+localField('local-slo-max-errors','Maximum errors',load.objective.max_errors,load.allow_errors?'Ignored while failed requests are allowed.':'','type=number min=0 '+(load.allow_errors?'disabled':''))+localField('local-slo-min-achieved-rate-ratio','Minimum achieved rate ratio',load.objective.min_achieved_rate_ratio,'','type=number min=0 max=1 step=any')+'</div>':'';
+  const affinity=Object.entries(localYdbAffinityKeys).map(([key,label])=>{const role=config.affinity[key],disabled=role.mode==='none'?'disabled':'';return '<div class=card><strong>'+esc(label)+'</strong><div class=form-grid>'+localSelect('local-affinity-'+key+'-mode','Mode',role.mode,editor.model.affinity_modes)+localField('local-affinity-'+key+'-cpus','CPUs',role.cpus??'','integer, one-chiplet, or remaining',disabled)+'</div></div>'}).join('');
+  return '<div id=local-editor><h2 class=page-title>'+esc(profile.benchmark)+' / '+esc(profile.name)+'</h2><div class=form-grid>'+localSelect('benchmark','Benchmark',profile.benchmark,editor.model.benchmarks.map(item=>item.name))+localField('profile-name','Profile name',profile.name,'letters, digits, . _ and -')+'</div><h3>Workload</h3><div class=form-grid>'+localSelect('local-workload-type','Type',workload.type,['kv','stock'])+localSelect('local-workload-operation','Operation',workload.operation,localYdbOperations[workload.type])+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+'</div><h3>Client and load</h3><div class=form-grid>'+localField('local-client-threads','YDB CLI threads',config.client.threads,'','type=number min=1')+loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+localField('local-measurement-duration','Duration (seconds)',measurement.duration,'','type=number min=1')+localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+localField('local-timeout','Timeout (seconds)',profile.timeout??'','empty selects the computed timeout','type=number min=1')+'</div><h3>Role affinity</h3>'+affinity+'<div class=toolbar><button class=danger id=delete-profile>Delete profile</button></div></div>'
+}
+function localNumber(id,minimum=1){const value=Number(document.querySelector('#'+id).value);if(!Number.isFinite(value)||value<minimum)throw Error(id+' must be a number not below '+minimum+'.');return value}
+function localInteger(id,minimum=1){const value=localNumber(id,minimum);if(!Number.isSafeInteger(value))throw Error(id+' must be an integer.');return value}
+function localCpu(id,mode){if(mode==='none')return null;const raw=document.querySelector('#'+id).value.trim();if(raw==='one-chiplet'||raw==='remaining')return raw;const value=Number(raw);if(!Number.isSafeInteger(value)||value<1)throw Error(id+' must be a positive integer, one-chiplet, or remaining.');return value}
+function bindLocalYdbEditor(profile){
+  const message=()=>document.querySelector('#editor-message');
+  const update=event=>{try{
+    const benchmarkName=document.querySelector('#benchmark').value,name=document.querySelector('#profile-name').value.trim();
+    if(!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/.test(name))throw Error('Profile name is unsafe.');
+    if(editor.model.profiles.some(item=>item.key!==profile.key&&item.benchmark===benchmarkName&&item.name===name))throw Error('A profile with this benchmark and name already exists.');
+    if(benchmarkName!==profile.benchmark){const benchmark=editor.model.benchmarks.find(item=>item.name===benchmarkName);profile.benchmark=benchmarkName;profile.name=name;profile.key=benchmarkName+'/'+name;delete profile.local_ydb;profile.parameters=Object.fromEntries(benchmark.parameters.map(item=>[item.name,item.default]));profile.threads=[1];profile.duration=3;profile.repetitions=1;profile.affinity=['none'];profile.background_load=['none'];editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    profile.name=name;profile.key=benchmarkName+'/'+name;const config=profile.local_ydb;
+    if(event.target.id==='local-workload-type'){config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    if(event.target.id==='local-geometry-preset'){const preset=event.target.value;config.geometry.preset=preset;if(preset==='single'){config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1}else if(preset==='storage')config.geometry.max_dynamic_nodes=Math.max(8,config.geometry.dynamic_nodes,config.geometry.max_dynamic_nodes);editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    if(event.target.id==='local-load-mode'){const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);if(mode==='points')config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[1000]};else{const search=config.load.search||{start:1000,maximum:100000,multiplier:2,resolution_percent:2},old=config.load.objective||{},objective={type:mode,target_role:old.target_role||'dynamic',plateau_gain_percent:old.plateau_gain_percent??2,plateau_points:old.plateau_points||2,cpu_saturation_percent:old.cpu_saturation_percent||95};if(mode==='latency-slo')Object.assign(objective,{percentile:old.percentile||'p99',max_ms:old.max_ms??10,max_errors:old.max_errors??0,min_achieved_rate_ratio:old.min_achieved_rate_ratio??.98});config.load={parameter:config.load.parameter,allow_errors,search,objective}}editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    if(event.target.id.startsWith('local-affinity-')&&event.target.id.endsWith('-mode')){const key=event.target.id.slice('local-affinity-'.length,-'-mode'.length),mode=event.target.value,old=config.affinity[key].cpus;config.affinity[key]={mode,cpus:mode==='none'?null:(old??(key==='ydb_cli'?'one-chiplet':1))};editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return}
+    config.workload.operation=document.querySelector('#local-workload-operation').value;
+    for(const input of document.querySelectorAll('[id^=local-option-]')){const key=input.id.slice('local-option-'.length),minimum=['init-upserts','orders','auto-partition'].includes(key)?0:1;config.workload.options[key]=localInteger(input.id,minimum)}
+    config.geometry.preset=document.querySelector('#local-geometry-preset').value;for(const key of Object.keys(localYdbGeometryKeys))config.geometry[key]=localInteger('local-geometry-'+key);if(config.geometry.preset==='single'){config.geometry.dynamic_nodes=1;config.geometry.max_dynamic_nodes=1}
+    config.client.threads=localInteger('local-client-threads');const loadMode=document.querySelector('#local-load-mode').value,parameter=document.querySelector('#local-load-parameter').value;
+    const allow_errors=document.querySelector('#local-load-allow-errors').checked;if(loadMode==='points')config.load={parameter,allow_errors,values:arrayField(document.querySelector('#local-load-values').value)};else{const objective={type:loadMode},multiplier=loadMode==='latency-slo'?localNumber('local-load-multiplier',1):(config.load.search?.multiplier??2);config.load={parameter,allow_errors,search:{start:localInteger('local-load-start'),maximum:localInteger('local-load-maximum'),multiplier,resolution_percent:localNumber('local-load-search-resolution-percent',0)},objective};if(loadMode==='maximize-throughput')Object.assign(objective,{target_role:document.querySelector('#local-load-target-role').value,plateau_gain_percent:localNumber('local-load-plateau-gain-percent',0),plateau_points:localInteger('local-load-plateau-points'),cpu_saturation_percent:localNumber('local-load-cpu-saturation-percent',0)});else Object.assign(objective,{percentile:document.querySelector('#local-slo-percentile').value,max_ms:localNumber('local-slo-max-ms',0),max_errors:localInteger('local-slo-max-errors',0),min_achieved_rate_ratio:localNumber('local-slo-min-achieved-rate-ratio',0)})}
+    config.measurement={warmup:localInteger('local-measurement-warmup',0),duration:localInteger('local-measurement-duration'),repetitions:localInteger('local-measurement-repetitions')};
+    for(const key of Object.keys(localYdbAffinityKeys)){const mode=document.querySelector('#local-affinity-'+key+'-mode').value;config.affinity[key]={mode,cpus:localCpu('local-affinity-'+key+'-cpus',mode)}}
+    const timeout=document.querySelector('#local-timeout').value.trim();profile.timeout=timeout===''?null:localInteger('local-timeout');profile.threads=[config.client.threads];profile.duration=config.measurement.duration;profile.repetitions=1;profile.affinity=['roles'];profile.background_load=['none'];editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id))renderNew()
+  }catch(error){message().innerHTML=displayError(error)}};
+  for(const input of document.querySelectorAll('#local-editor input,#local-editor select'))input.onchange=update;document.querySelector('#delete-profile').onclick=()=>{editor.model.profiles=editor.model.profiles.filter(item=>item.key!==profile.key);editor.selected=editor.model.profiles[0]?.key||null;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()}
+}
+"""
     'function profileEditor(profile){\n'
     '  const benchmark=(editor.model.benchmarks||[]).find(item=>item.name===profile.benchmark);\n'
+    "  if(benchmark.profile_kind==='local-ydb')return localYdbProfileEditor(profile);\n"
+    "  if(!benchmark.builder_supported)return '<h2 class=page-title>'+esc(profile.benchmark)+' / '+esc(profile.name)+"
+    "'</h2><div class=notice>Edit this benchmark in the YAML tab; its nested cluster, workload, load controller, and role "
+    "affinity settings are preserved there.</div>';\n"
     '  const field=(id,label,value,help=\'\')=>\'<div class=field><label for="\'+id+\'">\'+esc(label)+\'</label><input id="\'+id+\'" v'
     'alue="\'+esc(value)+\'"><small class=muted>\'+esc(help)+\'</small></div>\';\n'
     "  const parameterFields=benchmark.parameters.map((parameter,index)=>parameter.choices.length?'<div class=field><label>'+"
@@ -290,34 +398,34 @@ _JS = (
     '  }\n'
     '  return values\n'
     '}\n'
-    "function bindProfileEditor(profile){const update=event=>{try{const name=document.querySelector('#profile-name').value.tr"
-    "im(),benchmarkName=document.querySelector('#benchmark').value,benchmark=editor.model.benchmarks.find(item=>item.name===b"
-    "enchmarkName),benchmarkChanged=event?.target?.id==='benchmark';if(!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/.test(name))throw "
-    "Error('Profile name is unsafe.');if(editor.model.profiles.some(item=>item.key!==profile.key&&item.benchmark===benchmarkN"
-    "ame&&item.name===name))throw Error('A profile with this benchmark and name already exists.');updateProfile(profile.key,i"
-    "tem=>{item.benchmark=benchmarkName;item.name=name;item.key=benchmarkName+'/'+name;item.threads=arrayField(document.query"
-    "Selector('#threads').value);item.parameters={};benchmark.parameters.forEach((parameter,index)=>{if(benchmarkChanged){ite"
-    'm.parameters[parameter.name]=[...parameter.default];return}if(parameter.choices.length){const selected=[...document.quer'
-    'ySelectorAll(\'.parameter-choice[data-parameter-index="\'+index+\'"]:checked\')].map(input=>input.value);if(!selected.length'
-    ")throw Error('Select at least one value for '+parameter.name+'.');item.parameters[parameter.name]=selected;return}const "
-    "raw=document.querySelector('#parameter-'+index)?.value||parameter.default.join(', ');item.parameters[parameter.name]=par"
-    "ameter.type==='integer'?arrayField(raw,parameter.minimum??1):raw.split(',').map(value=>value.trim()).filter(Boolean)});i"
-    "tem.duration=Number(document.querySelector('#duration').value);item.repetitions=Number(document.querySelector('#repetiti"
-    "ons').value);item.affinity=[...document.querySelectorAll('.affinity:checked')].map(input=>input.value);item.background_l"
-    "oad=[...document.querySelectorAll('.background-load:checked')].map(input=>input.value);if(!item.background_load.length)"
-    "throw Error('Select at least one background load mode.')} );editor.selected"
-    "=benchmarkName+'/'+name;if(!event?.target?.classList.contains('affinity')&&!event?.target?.classList.contains('background-load')&&!event?.target?.classList.contains('parameter"
-    "-choice'))renderNew()}catch(error){document.querySelector('#editor-message').innerHTML=displayError(error)}};for(const i"
-    "nput of document.querySelectorAll('#benchmark,#profile-name,#threads,[id^=parameter-],.parameter-choice,#duration,#repet"
-    "itions,.affinity,.background-load'))input.onchange=update;document.querySelector('#delete-profile').onclick=()=>{editor.model.profiles=ed"
-    'itor.model.profiles.filter(item=>item.key!==profile.key);editor.selected=editor.model.profiles[0]?.key||null;editor.yaml'
-    '=serializeConfig(editor.model);saveDraft();renderNew()}}\n'
-    "function addProfile(){const selectedBenchmark=document.querySelector('#add-benchmark')?.value;const benchmark=editor.mod"
-    "el.benchmarks.find(item=>item.name===selectedBenchmark)||editor.model.benchmarks[0];let suffix=1,name='profile';while((e"
-    "ditor.model.profiles||[]).some(item=>item.benchmark===benchmark.name&&item.name===name))name='profile-'+suffix++;editor."
-    "model.profiles.push({key:benchmark.name+'/'+name,benchmark:benchmark.name,name,threads:[1],parameters:Object.fromEntries"
-    "(benchmark.parameters.map(item=>[item.name,item.default])),duration:3,repetitions:1,timeout:null,affinity:['none'],background_load:['none']});edi"
-    "tor.selected=benchmark.name+'/'+name;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()}\n"
+    """
+function bindProfileEditor(profile){
+  const update=event=>{try{
+    const name=document.querySelector('#profile-name').value.trim(),benchmarkName=document.querySelector('#benchmark').value,benchmark=editor.model.benchmarks.find(item=>item.name===benchmarkName),benchmarkChanged=event?.target?.id==='benchmark';
+    if(!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/.test(name))throw Error('Profile name is unsafe.');
+    if(editor.model.profiles.some(item=>item.key!==profile.key&&item.benchmark===benchmarkName&&item.name===name))throw Error('A profile with this benchmark and name already exists.');
+    updateProfile(profile.key,item=>{
+      item.benchmark=benchmarkName;item.name=name;item.key=benchmarkName+'/'+name;
+      if(benchmarkChanged&&benchmark.profile_kind==='local-ydb'){item.local_ydb=defaultLocalYdb();item.parameters={};item.threads=[64];item.duration=30;item.repetitions=1;item.affinity=['roles'];item.background_load=['none'];return}
+      delete item.local_ydb;item.threads=arrayField(document.querySelector('#threads').value);item.parameters={};
+      benchmark.parameters.forEach((parameter,index)=>{if(benchmarkChanged){item.parameters[parameter.name]=[...parameter.default];return}if(parameter.choices.length){const selected=[...document.querySelectorAll('.parameter-choice[data-parameter-index="'+index+'"]:checked')].map(input=>input.value);if(!selected.length)throw Error('Select at least one value for '+parameter.name+'.');item.parameters[parameter.name]=selected;return}const raw=document.querySelector('#parameter-'+index)?.value||parameter.default.join(', ');item.parameters[parameter.name]=parameter.type==='integer'?arrayField(raw,parameter.minimum??1):raw.split(',').map(value=>value.trim()).filter(Boolean)});
+      item.duration=Number(document.querySelector('#duration').value);item.repetitions=Number(document.querySelector('#repetitions').value);item.affinity=[...document.querySelectorAll('.affinity:checked')].map(input=>input.value);item.background_load=[...document.querySelectorAll('.background-load:checked')].map(input=>input.value);if(!item.background_load.length)throw Error('Select at least one background load mode.')
+    });
+    editor.selected=benchmarkName+'/'+name;if(benchmarkChanged||(!event?.target?.classList.contains('affinity')&&!event?.target?.classList.contains('background-load')&&!event?.target?.classList.contains('parameter-choice')))renderNew()
+  }catch(error){document.querySelector('#editor-message').innerHTML=displayError(error)}};
+  for(const input of document.querySelectorAll('#benchmark,#profile-name,#threads,[id^=parameter-],.parameter-choice,#duration,#repetitions,.affinity,.background-load'))input.onchange=update;
+  document.querySelector('#delete-profile').onclick=()=>{editor.model.profiles=editor.model.profiles.filter(item=>item.key!==profile.key);editor.selected=editor.model.profiles[0]?.key||null;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()}
+}
+"""
+    """
+function addProfile(){
+  const selectedBenchmark=document.querySelector('#add-benchmark')?.value,benchmark=editor.model.benchmarks.find(item=>item.name===selectedBenchmark)||editor.model.benchmarks[0];let suffix=1,name='profile';
+  while((editor.model.profiles||[]).some(item=>item.benchmark===benchmark.name&&item.name===name))name='profile-'+suffix++;
+  const profile={key:benchmark.name+'/'+name,benchmark:benchmark.name,name,threads:[1],parameters:Object.fromEntries(benchmark.parameters.map(item=>[item.name,item.default])),duration:3,repetitions:1,timeout:null,affinity:['none'],background_load:['none']};
+  if(benchmark.profile_kind==='local-ydb'){profile.local_ydb=defaultLocalYdb();profile.threads=[64];profile.duration=30;profile.repetitions=1;profile.affinity=['roles']}
+  editor.model.profiles.push(profile);editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();renderNew()
+}
+"""
     "async function renderNew(tab){clearRefresh();if(tab)sessionStorage.setItem('ydb-bench-editor-tab',tab);tab=sessionStorag"
     "e.getItem('ydb-bench-editor-tab')||'builder';await syncEditor();const summary=planSummary();let content='<h1 class=page-"
     'title>New run</h1><div class=tabs><a class="\'+(tab===\'builder\'?\'active\':\'\')+\'" href="#new">Builder</a><a class="\'+(tab=='
@@ -337,7 +445,9 @@ _JS = (
     "on><section class=card>'+ (selected?profileEditor(selected):'<div class=empty>Add a benchmark profile to begin.</div>')+"
     "'</section></div>';app.innerHTML=shell('new',content);bindEditorControls();document.querySelector('#add-profile').onclic"
     "k=addProfile;for(const button of document.querySelectorAll('[data-profile]'))button.onclick=()=>{editor.selected=button."
-    'dataset.profile;renderNew()};if(selected)bindProfileEditor(selected)}\n'
+    "dataset.profile;renderNew()};if(selected){const benchmark=editor.model.benchmarks.find(item=>item.name===selected.bench"
+    "mark);if(benchmark?.profile_kind==='local-ydb')bindLocalYdbEditor(selected);else if(benchmark?.builder_supported)bindPro"
+    "fileEditor(selected)}}\n"
     'function clearRefresh(){if(refreshTimer){clearInterval(refreshTimer);refreshTimer=null}}\n'
     "function runFilters(){return '<div class=filters><div class=field><label>Status</label><select id=f-status><option value"
     '="">Any</option><option>queued</option><option>running</option><option>completed</option><option>failed</option><option>'
@@ -376,6 +486,7 @@ _JS = (
     'function metricLabel(value){const number=Number(value);if(!Number.isFinite(number))return String(value);return Math.abs('
     "number)>=1e9?(number/1e9).toFixed(2)+'B':Math.abs(number)>=1e6?(number/1e6).toFixed(2)+'M':Math.abs(number)>=1e3?(number"
     "/1e3).toFixed(2)+'k':Number.isInteger(number)?String(number):number.toFixed(2)}\n"
+    'function chartNumber(value){return value===null||value===undefined?NaN:Number(value)}\n'
     "function chartSeriesLabel(series,compact=false){return compact?series.affinity:series.run+' / '+series.profile+' / '+ser"
     'ies.affinity}\n'
     "function seriesCpuNote(series){if(series.cpu_masks&&Object.keys(series.cpu_masks).length)return 'CPUs by threads: '+Obje"
@@ -384,7 +495,7 @@ _JS = (
     "restricted':'CPUs: '+cpuRanges(series.cpus)):'CPUs: not recorded'}\n"
     'function svgChart(metric,xName,xValues,seriesRows,colors){\n'
     '  const width=900,height=330,left=78,right=24,top=24,bottom=52,plotWidth=width-left-right,plotHeight=height-top-bottom,v'
-    'alueFor=(item,row)=>Number(row?.[item.metric||metric]);\n'
+    'alueFor=(item,row)=>chartNumber(row?.[item.metric||metric]);\n'
     '  const values=[];for(const item of seriesRows)for(const x of xValues){const value=valueFor(item,item.rows.get(String(x)'
     '));if(Number.isFinite(value))values.push(value)}\n'
     "  if(!values.length)return '<div class=empty>No numeric values for '+esc(metric)+'.</div>';\n"
@@ -411,38 +522,41 @@ _JS = (
     '\',\'+yPos(point.y)).join(\' \')+\'"/>\';for(const point of segments.flat())svg+=\'<circle class=chart-point fill="\'+color+\'"'
     ' cx="\'+xPos(point.x)+\'" cy="\'+yPos(point.y)+\'" r="4"><title>\'+esc(item.label+\'; \'+xName+\'=\'+point.x+\'; \'+(item.me'
     'tric||metric)+\'=\'+point.y)+\'</title></circle>\'});\n'
-    '  svg+=\'<line class=chart-cursor x1="0" y1="\'+top+\'" x2="0" y2="\'+(top+plotHeight)+\'" visibility=hidden/>\';\n'
+    '  svg+=\'<line class=chart-cursor x1="0" y1="\'+top+\'" x2="0" y2="\'+(top+plotHeight)+\'" visibility="hidden"/>\';\n'
     "  return '<div class=chart-surface>'+svg+'</svg><div class=chart-tooltip hidden></div></div>'\n"
     '}\n'
-    'function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors){\n'
-    '  const width=900,left=78,right=24,plotWidth=width-left-right,numericX=xValues.map(Number),xMin=Math.min(...numericX),xM'
-    'ax=Math.max(...numericX),xPos=value=>left+(xMax===xMin?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth);\n'
-    "  for(const panel of container.querySelectorAll('.chart-panel')){\n"
-    "    const metric=panel.dataset.metric,svg=panel.querySelector('svg'),surface=panel.querySelector('.chart-surface'),toolt"
-    "ip=panel.querySelector('.chart-tooltip'),cursor=panel.querySelector('.chart-cursor');\n"
-    '    if(!svg||!surface||!tooltip||!cursor||!metrics.includes(metric))continue;\n'
-    "    const hide=()=>{tooltip.hidden=true;cursor.setAttribute('visibility','hidden')};\n"
-    '    svg.onmouseleave=hide;\n'
-    '    svg.onmousemove=event=>{\n'
-    '      const bounds=svg.getBoundingClientRect(),viewX=(event.clientX-bounds.left)*width/bounds.width;\n'
-    '      const selected=xValues.reduce((best,value)=>Math.abs(xPos(value)-viewX)<Math.abs(xPos(best)-viewX)?value:best,xVal'
-    'ues[0]),cursorX=xPos(selected);\n'
-    '      const values=seriesRows.map((item,index)=>({label:item.label,colorClass:(item.colorIndex??index)%chartColors.lengt'
-    'h,value:Number(item.rows.get(String(selected))?.[item.metric||metric])})).filter(item=>Number.isFinite(item.value)).sort'
-    '((leftItem,rightItem)=>rightItem.value-leftItem.value||leftItem.label.localeCompare(rightItem.label));\n'
-    '      if(!values.length)return hide();\n'
-    "      cursor.setAttribute('x1',cursorX);cursor.setAttribute('x2',cursorX);cursor.setAttribute('visibility','visible');\n"
-    "      tooltip.innerHTML='<strong>'+esc(xName)+' = '+esc(metricLabel(selected))+'</strong>'+values.map(item=>'<div class="
-    'tooltip-row><i class="tooltip-dot chart-bg-\'+item.colorClass+\'"></i><span class="chart-color-\'+item.colorClass+\'">\'+esc('
-    "item.label)+'</span><span class=tooltip-value>'+esc(metricLabel(item.value))+'</span></div>').join('');\n"
-    '      tooltip.hidden=false;\n'
-    '      const surfaceBounds=surface.getBoundingClientRect(),tooltipWidth=tooltip.offsetWidth,rawLeft=event.clientX-surface'
-    'Bounds.left+12;\n'
-    "      tooltip.style.left=Math.max(4,Math.min(rawLeft,surfaceBounds.width-tooltipWidth-4))+'px';tooltip.style.top=Math.ma"
-    "x(4,event.clientY-surfaceBounds.top-tooltip.offsetHeight-10)+'px'\n"
-    '    }\n'
-    '  }\n'
-    '}\n'
+    """
+function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,synchronize=false){
+  const width=900,left=78,right=24,plotWidth=width-left-right,numericX=xValues.map(Number),xMin=Math.min(...numericX),xMax=Math.max(...numericX),xPos=value=>left+(xMax===xMin?plotWidth/2:(Number(value)-xMin)/(xMax-xMin)*plotWidth);
+  const seriesFor=metric=>Array.isArray(seriesRows)?seriesRows:(seriesRows[metric]||[]);
+  const panels=[...container.querySelectorAll('.chart-panel')].map(panel=>({
+    panel,
+    metric:panel.dataset.metric,
+    svg:panel.querySelector('svg'),
+    surface:panel.querySelector('.chart-surface'),
+    tooltip:panel.querySelector('.chart-tooltip'),
+    cursor:panel.querySelector('.chart-cursor'),
+  })).filter(item=>item.svg&&item.surface&&item.tooltip&&item.cursor&&metrics.includes(item.metric));
+  const hideAll=()=>{for(const item of panels){item.tooltip.hidden=true;item.cursor.setAttribute('visibility','hidden');item.cursor.removeAttribute('data-selected-x')}};
+  const syncBoundary=synchronize?panels[0]?.panel.closest('.local-charts'):null;
+  if(syncBoundary)syncBoundary.onmouseleave=hideAll;
+  for(const active of panels){
+    if(!syncBoundary)active.svg.onmouseleave=hideAll;
+    active.svg.onmousemove=event=>{
+      const bounds=active.svg.getBoundingClientRect(),viewX=(event.clientX-bounds.left)*width/bounds.width;
+      const selected=xValues.reduce((best,value)=>Math.abs(xPos(value)-viewX)<Math.abs(xPos(best)-viewX)?value:best,xValues[0]),cursorX=xPos(selected),targets=synchronize?panels:[active];
+      for(const item of panels)item.tooltip.hidden=true;
+      for(const item of targets){item.cursor.setAttribute('x1',cursorX);item.cursor.setAttribute('x2',cursorX);item.cursor.setAttribute('visibility','visible');item.cursor.setAttribute('data-selected-x',selected)}
+      const values=seriesFor(active.metric).map((item,index)=>({label:item.label,colorClass:(item.colorIndex??index)%chartColors.length,value:chartNumber(item.rows.get(String(selected))?.[item.metric||active.metric])})).filter(item=>Number.isFinite(item.value)).sort((leftItem,rightItem)=>rightItem.value-leftItem.value||leftItem.label.localeCompare(rightItem.label));
+      if(!values.length)return;
+      active.tooltip.innerHTML='<strong>'+esc(xName)+' = '+esc(metricLabel(selected))+'</strong>'+values.map(item=>'<div class=tooltip-row><i class="tooltip-dot chart-bg-'+item.colorClass+'"></i><span class="chart-color-'+item.colorClass+'">'+esc(item.label)+'</span><span class=tooltip-value>'+esc(metricLabel(item.value))+'</span></div>').join('');
+      active.tooltip.hidden=false;
+      const surfaceBounds=active.surface.getBoundingClientRect(),tooltipWidth=active.tooltip.offsetWidth,rawLeft=event.clientX-surfaceBounds.left+12;
+      active.tooltip.style.left=Math.max(4,Math.min(rawLeft,surfaceBounds.width-tooltipWidth-4))+'px';active.tooltip.style.top=Math.max(4,event.clientY-surfaceBounds.top-active.tooltip.offsetHeight-10)+'px'
+    }
+  }
+}
+"""
     "async function loadChartData(runIds){const query=new URLSearchParams;for(const run of runIds)query.append('run',run);ret"
     "urn api('/api/chart-data?'+query)}\n"
     "function globLabelMatch(value,pattern){value=String(value);pattern=String(pattern||'*');return pattern.split('|').map(it"
@@ -624,6 +738,76 @@ _JS = (
     'rt.open=false}}\n'
     '  renderBoard()\n'
     '}\n'
+    """
+const localPhaseLabels={
+  'preparing-cluster':'Preparing cluster','starting-static-nodes':'Starting static nodes','waiting-for-static-nodes':'Waiting for static nodes',
+  'bootstrapping-cluster':'Bootstrapping cluster','creating-database':'Creating database','starting-dynamic-nodes':'Starting dynamic nodes',
+  'waiting-for-database':'Waiting for database','cluster-ready':'Cluster ready','initializing-workload':'Initializing workload',
+  'warming-up':'Warming up','measuring':'Measuring','cleaning-workload':'Cleaning workload','evaluating-attempt':'Evaluating attempt',
+  'scaling-dynamic-nodes':'Scaling dynamic nodes','stopping-cluster':'Stopping cluster','finishing':'Writing results',
+  completed:'Completed',failed:'Failed',cancelled:'Cancelled'
+};
+function localPhaseLabel(phase){return localPhaseLabels[phase]||String(phase||'Preparing').replaceAll('-',' ')}
+function localShellArg(value){value=String(value);return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value)?value:"'"+value.replaceAll("'","'\\\"'\\\"'")+"'"}
+function localCommandText(record){const argv=Array.isArray(record?.argv)?record.argv:[],command=argv.map(localShellArg).join(' '),cpus=Array.isArray(record?.cpu_affinity)?record.cpu_affinity:[];return cpus.length?'taskset --cpu-list '+localShellArg(cpus.join(','))+' '+command:command}
+function localCommandDetails(item,open){const commands=Array.isArray(item.commands)?item.commands:[];if(!commands.length)return '—';return '<details class=local-command-history data-command-attempt="'+esc(item.attempt)+'"'+(open?' open':'')+'><summary>'+commands.length+' commands</summary>'+commands.map(command=>'<div class=local-command-entry><strong>Repetition '+esc(command.repetition)+' · '+esc(localPhaseLabel(command.phase))+'</strong><pre class=local-command-code><code>'+esc(localCommandText(command))+'</code></pre></div>').join('')+'</details>'}
+function localElapsed(started,finished=null){const value=Date.parse(started),end=finished?Date.parse(finished):Date.now();return Number.isFinite(value)&&Number.isFinite(end)?Math.max(0,(end-value)/1000):0}
+function localKpi(label,value,help='',primary=false){return '<div class="'+(primary?'primary-result':'')+'"><span class=muted>'+esc(label)+'</span><strong>'+esc(value??'—')+'</strong>'+(help?'<small class=muted>'+esc(help)+'</small>':'')+'</div>'}
+function localOutcomeLabel(outcome){return ({'boundary-found':'SLO boundary found','plateau-found':'Throughput plateau found','lower-bound':'Capacity lower bound','best-observed':'Best observed point','no-feasible-point':'No feasible point','bounded-by-errors':'Bounded by workload errors','search-limit-reached':'Search limit reached'})[outcome]||outcome||'Search in progress'}
+function localSearchAxisLabel(parameter,workload){if(parameter==='threads')return 'YDB CLI threads';if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';return parameter||'Search value'}
+function localAttemptRows(attempts,xField='attempt'){return new Map(attempts.map(item=>[String(item[xField]),item]))}
+function localChart(title,metric,xName,xValues,series){return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+svgChart(metric,xName,xValues,series,chartColors)+'</section>'}
+function localBestRows(attempts,objective,xField='attempt'){
+  let bestLoad=null,bestThroughput=-Infinity,currentStage=null;const rows=new Map;
+  for(const item of attempts){
+    if(currentStage!==item.search_stage){currentStage=item.search_stage;bestLoad=null;bestThroughput=-Infinity}
+    if(item.passed){
+      if(objective==='latency-slo'){if(bestLoad===null||item.load>bestLoad)bestLoad=item.load}
+      else if(Number(item.throughput)>bestThroughput){bestThroughput=Number(item.throughput);bestLoad=item.load}
+    }
+    rows.set(String(item[xField]),{...item,current_best:bestLoad,passed_load:item.passed?item.load:null,failed_load:item.passed?null:item.load})
+  }
+  return rows
+}
+function renderLocalYdbProfile(container,data){
+  if(data.state==='preparing'){container.innerHTML='<div class=notice>Preparing local YDB profile and extracting binaries…</div>';return}
+  const openCommandAttempts=new Set([...container.querySelectorAll('[data-command-attempt][open]')].map(details=>details.dataset.commandAttempt));
+  const progress=data.progress||{},attempts=data.attempts||[],searches=data.searches||[],result=data.result||null,parameters=data.parameters||{},loadConfig=parameters.load||{},objective=loadConfig.objective?.type||'points';
+  const phaseElapsed=localElapsed(progress.phase_started_at),phaseDuration=Number(progress.phase_duration_seconds),profileElapsed=localElapsed(data.started_at,data.finished_at),remaining=Number.isFinite(phaseDuration)?Math.max(0,phaseDuration-phaseElapsed):null;
+  const phaseHelp=[progress.attempt?'attempt #'+progress.attempt:null,progress.repetition?'repetition '+progress.repetition+'/'+progress.repetitions:null,Number.isFinite(remaining)?elapsedLabel(remaining)+' remaining':null].filter(Boolean).join(' · ');
+  const phaseProgress=Number.isFinite(phaseDuration)?'<progress class=local-phase-progress max="'+phaseDuration+'" value="'+Math.min(phaseDuration,phaseElapsed)+'"></progress>':'';
+  let html=loadConfig.allow_errors?'<div class=notice>Failed workload requests are allowed for this profile and remain visible in metrics.</div>':'';html+='<div class=local-live><div><span class=muted>Current phase</span><div class=local-phase>'+esc(localPhaseLabel(progress.phase||data.state))+'</div><div class=muted>'+esc(phaseHelp||'Waiting for the next milestone')+'</div>'+phaseProgress+'</div>';
+  html+=localKpi('Profile elapsed',elapsedLabel(profileElapsed))+localKpi('Geometry',(parameters.geometry?.static_nodes??'—')+' static · '+(progress.dynamic_nodes??result?.dynamic_nodes??parameters.geometry?.dynamic_nodes??'—')+' dynamic')+localKpi('Candidate',progress.load===undefined?'—':(progress.parameter||loadConfig.parameter||'load')+' '+metricLabel(progress.load))+'</div>';
+  if(progress.current_command?.argv?.length)html+='<section class=local-current-command><span class=muted>Running command</span><pre class=local-command-code><code>'+esc(localCommandText(progress.current_command))+'</code></pre></section>';
+  if(result){const selected=result.selected_metrics||{},latencyMetric=(loadConfig.objective?.percentile||'p99')+'_ms',selectedLabel=result.selected_load===null||result.selected_load===undefined?'—':metricLabel(result.selected_load);html+='<div class=local-kpis>'+localKpi(localOutcomeLabel(result.outcome),selectedLabel,result.parameter||loadConfig.parameter,true)+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),'transactions/s')+localKpi(loadConfig.objective?.percentile||'p99',metricLabel(selected[latencyMetric]??'—'),'ms')+localKpi('Dynamic nodes',result.dynamic_nodes,result.stop_reason||'')+'</div>'}
+  else html+='<div class=local-kpis>'+localKpi('Completed attempts',attempts.length,'search stage '+(progress.search_stage||1),true)+localKpi('Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—','transactions/s')+localKpi('Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms')+'</div>';
+  const currentStage=Number(progress.search_stage||0),lastStored=searches.length?Math.max(...searches.map(item=>Number(item.stage)||0)):0,xAxis=container.dataset.localYdbXAxis==='parameter'?'parameter':'attempt',searchParameter=loadConfig.parameter||result?.parameter||'load',searchAxisLabel=localSearchAxisLabel(searchParameter,parameters.workload?.type);let chartBinding=null;
+  html+='<h3>Geometry stages</h3><div class=local-stages>'+searches.map(item=>'<div class=local-stage><strong>Stage '+esc(item.stage)+' · '+esc(item.dynamic_nodes)+' dynamic</strong><div>'+esc(localOutcomeLabel(item.outcome))+'</div><div class=muted>selected '+esc(metricLabel(item.selected_load))+' · '+esc(elapsedLabel(item.duration_seconds))+'</div><div class=stage-arrow>'+esc(item.next_action==='scale-dynamic-nodes'?'Scale → '+item.next_dynamic_nodes+' dynamic nodes':item.stop_reason||'Finish')+'</div></div>').join('')+(currentStage>lastStored&&data.state==='running'?'<div class="local-stage current"><strong>Stage '+esc(currentStage)+' · '+esc(progress.dynamic_nodes??'—')+' dynamic</strong><div>In progress</div><div class=muted>'+esc(attempts.filter(item=>Number(item.search_stage)===currentStage).length)+' completed attempts</div></div>':'')+'</div>';
+  if(attempts.length){
+    const xField=xAxis==='parameter'?'load':'attempt',xName=xAxis==='parameter'?searchAxisLabel:'Attempt',xValues=xAxis==='parameter'?[...new Set(attempts.map(item=>Number(item.load)))].sort((left,right)=>left-right):attempts.map(item=>item.attempt),stages=[];
+    for(const item of attempts){let stage=stages.find(value=>value.search_stage===item.search_stage);if(!stage){stage={search_stage:item.search_stage,dynamic_nodes:item.dynamic_nodes,attempts:[]};stages.push(stage)}stage.attempts.push(item)}
+    const groups=(xAxis==='parameter'?stages:[{attempts}]).map(item=>({rows:localAttemptRows(item.attempts,xField),bestRows:localBestRows(item.attempts,objective,xField),suffix:xAxis==='parameter'&&stages.length>1?' · stage '+item.search_stage+' · '+item.dynamic_nodes+' dynamic':''}));
+    const candidateSeries=groups.flatMap(group=>[{rows:group.bestRows,metric:'load',label:'Candidate'+group.suffix,colorIndex:7},{rows:group.bestRows,metric:'current_best',label:'Current best'+group.suffix,colorIndex:0},{rows:group.bestRows,metric:'passed_load',label:'Passed'+group.suffix,colorIndex:10},{rows:group.bestRows,metric:'failed_load',label:'Failed'+group.suffix,colorIndex:8}]);
+    const throughputSeries=groups.flatMap(group=>{const result=[{rows:group.rows,metric:'throughput',label:'Achieved throughput'+group.suffix,colorIndex:0}];if(loadConfig.parameter==='rate')result.push({rows:group.rows,metric:'load',label:'Offered rate'+group.suffix,colorIndex:7});return result});
+    const latencySeries=groups.flatMap(group=>['p50_ms','p95_ms','p99_ms','pmax_ms'].map((metric,index)=>({rows:group.rows,metric,label:metric.replace('_ms','')+group.suffix,colorIndex:index})));if(loadConfig.objective?.type==='latency-slo'){const sloRows=new Map(xValues.map(value=>[String(value),{slo_ms:loadConfig.objective.max_ms}]));latencySeries.push({rows:sloRows,metric:'slo_ms',label:'SLO',colorIndex:8})}
+    const cpuSeries=groups.flatMap(group=>[['static_cpu_mean','Static'],['dynamic_cpu_mean','Dynamic'],['cli_cpu_mean','YDB CLI'],['host_cpu_mean','Host']].map(([metric,label],index)=>({rows:group.rows,metric,label:label+group.suffix,colorIndex:index})));
+    const errorSeries=groups.flatMap(group=>[{rows:group.rows,metric:'errors',label:'Errors'+group.suffix,colorIndex:8},{rows:group.rows,metric:'retries',label:'Retries'+group.suffix,colorIndex:1}]);
+    chartBinding={xName,xValues,series:{load:candidateSeries,throughput:throughputSeries,latency_ms:latencySeries,cpu_percent:cpuSeries,errors:errorSeries}};
+    const axisHelp=xAxis==='parameter'?'Points are ordered by the searched parameter; geometry stages remain separate.':'Execution order shows how the controller moved through candidate values.';
+    html+='<div class=run-section-title><h3>Search process</h3><div class=actions><span class=muted>X axis</span><button type=button data-local-chart-x=attempt class="'+(xAxis==='attempt'?'primary':'')+'" aria-pressed="'+(xAxis==='attempt')+'">Attempts (search order)</button><button type=button data-local-chart-x=parameter class="'+(xAxis==='parameter'?'primary':'')+'" aria-pressed="'+(xAxis==='parameter')+'">'+esc(searchAxisLabel)+'</button></div></div><p class=muted>'+esc(axisHelp)+'</p><div class=local-charts>'+localChart('Candidate and current best','load',xName,xValues,candidateSeries)+localChart('Offered and achieved throughput','throughput',xName,xValues,throughputSeries)+localChart('Latency','latency_ms',xName,xValues,latencySeries)+localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+localChart('Errors and retries','errors',xName,xValues,errorSeries)+'</div>';
+    html+='<h3>Attempts</h3><table class=local-attempts><thead><tr><th>#</th><th>Stage</th><th>Dynamic</th><th>Candidate</th><th>Throughput</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th><th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+'</td><td>'+esc(metricLabel(item.p99_ms))+' ms</td><td>'+esc(item.errors)+'</td><td>'+esc(metricLabel(item.static_cpu_mean))+'%</td><td>'+esc(metricLabel(item.dynamic_cpu_mean))+'%</td><td>'+esc(metricLabel(item.cli_cpu_mean))+'%</td><td class="'+(item.passed?'attempt-pass':'attempt-fail')+'">'+(item.passed?'PASS':'FAIL')+'</td><td>'+esc(item.decision)+'</td><td>'+esc(elapsedLabel(item.duration_seconds))+'</td><td class=local-command-cell>'+localCommandDetails(item,openCommandAttempts.has(String(item.attempt)))+'</td></tr>').join('')+'</tbody></table>';
+  }else html+='<div class=empty>No completed search attempts yet. The timeline will appear after the first measurement.</div>';
+  container.innerHTML=html;
+  for(const axisButton of container.querySelectorAll('[data-local-chart-x]'))axisButton.onclick=()=>{container.dataset.localYdbXAxis=axisButton.dataset.localChartX;renderLocalYdbProfile(container,data)};
+  if(chartBinding)bindChartTooltips(container,chartBinding.xName,chartBinding.xValues,chartBinding.series,Object.keys(chartBinding.series),chartColors,true)
+}
+async function mountLocalYdbProfile(container,runId,profile,runState){
+  let loading=false,terminal=false;
+  const scheduleRunRefresh=()=>{if(['running','queued'].includes(runState)&&!refreshTimer)refreshTimer=setTimeout(()=>renderRun(runId,'local-ydb/'+profile),700)};
+  const refresh=async()=>{if(loading)return;loading=true;try{const data=await api('/api/runs/'+enc(runId)+'/local-ydb-profile?profile='+enc(profile));renderLocalYdbProfile(container,data);terminal=!['running','preparing'].includes(data.state);if(terminal&&refreshTimer){clearInterval(refreshTimer);refreshTimer=null}if(terminal)scheduleRunRefresh()}catch(error){container.innerHTML=displayError(error)}finally{loading=false}};
+  await refresh();if(!terminal&&['running','queued','recovery_required'].includes(runState)&&!refreshTimer)refreshTimer=setInterval(refresh,1000)
+}
+    """
     "function profileGroups(steps){const groups={};for(const step of steps){const key=step.benchmark+'/'+step.profile;(groups"
     '[key]??=[]).push(step)}return groups}\n'
     'function affinityGroups(steps){const groups={};for(const step of steps)(groups[step.affinity]??=[]).push(step);return gr'
@@ -652,7 +836,7 @@ _JS = (
     "or the dispatcher.')+'</div>':'';\n"
     "    sessionStorage.setItem('ydb-bench-active-run',activeRun);\n"
     '    const groups=profileGroups(run.steps||[]),profileKeys=Object.keys(groups),activeProfile=groups[selectedProfile]?sele'
-    "ctedProfile:profileKeys.length===1?profileKeys[0]:'';\n"
+    "ctedProfile:profileKeys.length===1?profileKeys[0]:'',activeBenchmark=activeProfile?activeProfile.split('/')[0]:'';\n"
     "    const crumbs=[{route:'runs',label:'Runs'},{route:'run/'+enc(id),label:id}];if(activeProfile&&profileKeys.length>1)cr"
     "umbs.push({route:'run/'+enc(id)+'/profile/'+enc(activeProfile),label:activeProfile});\n"
     "    let content=breadcrumbs(crumbs)+queueNotice+'<h1 class=page-title>'+esc(id)+'</h1><div class=toolbar><button id=ref"
@@ -674,9 +858,7 @@ _JS = (
     "ter(step=>!['pending','running'].includes(step.state)).length,affinities=new Set(steps.map(step=>step.affinity)).size;re"
     "turn '<tr><td><a href=\"#run/'+enc(id)+'/profile/'+enc(key)+'\">'+esc(key)+'</a></td><td>'+done+' / '+steps.length+'</td"
     "><td>'+status(aggregateState(steps))+'</td><td>'+affinities+'</td></tr>'}).join('')+'</table></section>';\n"
-    "    if(activeProfile)content+='<section class=card><div class=run-section-title><h2>Results</h2><strong>'+esc(activeProf"
-    "ile)+'</strong></div><p class=muted>Affinity variants are lines. Choose a common X axis, one or more Y metrics, and fix"
-    "ed values for the remaining dimensions.</p><div id=run-chart>Loading summary data…</div></section>';\n"
+    "    if(activeProfile)content+=activeBenchmark==='local-ydb'?'<section class=card><div class=run-section-title><h2>YDB load search</h2><strong>'+esc(activeProfile)+'</strong></div><div id=local-ydb-result>Loading live search data…</div></section>':'<section class=card><div class=run-section-title><h2>Results</h2><strong>'+esc(activeProfile)+'</strong></div><p class=muted>Affinity variants are lines. Choose a common X axis, one or more Y metrics, and fixed values for the remaining dimensions.</p><div id=run-chart>Loading summary data…</div></section>';\n"
     "    if(activeProfile){const steps=groups[activeProfile],open=run.state==='running'?' open':'';content+='<section class=\""
     "card run-tree\"><details'+open+'><summary><strong>Execution details</strong> — affinity, cases and artifacts</summary><"
     "table><tr><th>Affinity</th><th>Runs</th><th>State</th></tr>'+affinityRows(id,steps)+'</table></details></section>'}\n"
@@ -693,9 +875,7 @@ _JS = (
     "    const cancel=document.querySelector('#cancel-run');\n"
     "    if(cancel)cancel.onclick=async()=>{try{await api('/api/runs/'+enc(id)+'/cancel',{method:'POST'});renderRun(id,acti"
     'veProfile)}catch(error){alert(error.message)}};\n'
-    "    if(activeProfile){const pieces=activeProfile.split('/'),benchmark=pieces.shift(),profile=pieces.join('/');try{mount"
-    "ChartBuilder(document.querySelector('#run-chart'),await loadChartData([id]),{benchmark,profile,singleProfile:true})}cat"
-    "ch(error){document.querySelector('#run-chart').innerHTML=displayError(error)}}\n"
+    "    if(activeProfile){const pieces=activeProfile.split('/'),benchmark=pieces.shift(),profile=pieces.join('/');if(benchmark==='local-ydb')await mountLocalYdbProfile(document.querySelector('#local-ydb-result'),id,profile,run.state);else try{mountChartBuilder(document.querySelector('#run-chart'),await loadChartData([id]),{benchmark,profile,singleProfile:true})}catch(error){document.querySelector('#run-chart').innerHTML=displayError(error)}}\n"
     "  }catch(error){app.innerHTML=shell('runs',breadcrumbs([{route:'runs',label:'Runs'},{route:'run/'+enc(id),label:id}])+di"
     'splayError(error))}\n'
     '}\n'
@@ -912,6 +1092,8 @@ def benchmark_catalog():
         {
             "name": item.name,
             "description": item.description,
+            "builder_supported": item.builder_supported,
+            "profile_kind": item.profile_kind,
             "parameter_name": item.parameter_name,
             "parameter_description": item.parameter_description,
             "parameters": [
@@ -939,20 +1121,23 @@ def editor_model(loaded, output):
     profiles = []
     for configuration in loaded.runs:
         benchmark = configuration.benchmark
-        profiles.append(
-            {
-                "key": "{}/{}".format(benchmark.name, configuration.profile),
-                "benchmark": benchmark.name,
-                "name": configuration.profile,
-                "threads": list(configuration.threads),
-                "parameters": {name: list(values) for name, values in configuration.parameters.items()},
-                "duration": configuration.duration_seconds,
-                "repetitions": configuration.repetitions,
-                "timeout": configuration.timeout_seconds if configuration.timeout_explicit else None,
-                "affinity": list(configuration.affinity_modes),
-                "background_load": list(configuration.background_load_modes),
-            }
-        )
+        profile = {
+            "key": "{}/{}".format(benchmark.name, configuration.profile),
+            "benchmark": benchmark.name,
+            "name": configuration.profile,
+            "threads": list(configuration.threads),
+            "parameters": {},
+            "duration": configuration.duration_seconds,
+            "repetitions": configuration.repetitions,
+            "timeout": configuration.timeout_seconds if configuration.timeout_explicit else None,
+            "affinity": list(configuration.affinity_modes),
+            "background_load": list(configuration.background_load_modes),
+        }
+        if benchmark.profile_kind == "local-ydb":
+            profile["local_ydb"] = configuration.parameters["local_ydb"]
+        else:
+            profile["parameters"] = {name: list(values) for name, values in configuration.parameters.items()}
+        profiles.append(profile)
     return {
         "output": str(Path(output).resolve()),
         "benchmarks": benchmark_catalog(),
@@ -1421,6 +1606,8 @@ class RunService:
         step_id = event.get("step_id")
         if event.get("type") == "step-started" and step_id:
             run["store"].transition_step(step_id, "running", **event.get("fields", {}))
+        if event.get("type") == "step-progress" and step_id:
+            run["store"].update_step(step_id, **event.get("fields", {}))
         if event.get("type") == "step-artifacts" and step_id:
             run["store"].add_artifacts(step_id, event.get("artifacts", []))
             for artifact in event.get("artifacts", []):
@@ -1655,6 +1842,62 @@ class RunService:
     def chart_data(self, run_ids):
         return chart_data(self.output, run_ids)
 
+    def local_ydb_profile(self, run_id, profile):
+        root = _run_directory(self.output, run_id)
+        manifest = load_manifest(root / "run.json")
+        record = next(
+            (
+                item
+                for item in manifest.get("runs", [])
+                if item.get("benchmark") == "local-ydb" and item.get("profile") == profile
+            ),
+            None,
+        )
+        if record is None:
+            if any(
+                item.get("benchmark") == "local-ydb" and item.get("profile") == profile
+                for item in manifest.get("steps", [])
+            ):
+                return {
+                    "benchmark": "local-ydb",
+                    "profile": profile,
+                    "status": "preparing",
+                    "state": "preparing",
+                }
+            raise BenchmarkError("local-ydb profile not found: {}".format(profile))
+        relative = record.get("manifest") or str(Path(record.get("directory", "")) / "run.json")
+        unresolved = root / relative
+        candidate = unresolved.resolve()
+        if candidate == root or root not in candidate.parents or unresolved.is_symlink():
+            raise BenchmarkError("local-ydb profile manifest escapes the run directory")
+        if not candidate.is_file():
+            return {
+                "benchmark": "local-ydb",
+                "profile": profile,
+                "status": record.get("status", "preparing"),
+                "state": "preparing",
+            }
+        if candidate.stat().st_size > 16 * 1024 * 1024:
+            raise BenchmarkError("local-ydb profile manifest is too large")
+        value = load_manifest(candidate)
+        fields = (
+            "schema_version",
+            "benchmark",
+            "profile",
+            "status",
+            "state",
+            "started_at",
+            "finished_at",
+            "parameters",
+            "role_affinity",
+            "progress",
+            "attempts",
+            "searches",
+            "result",
+            "error",
+        )
+        return {name: value[name] for name in fields if name in value}
+
     def comparisons(self, selected=None):
         model = self.model()
         if selected is None:
@@ -1713,10 +1956,14 @@ def production_executor(resource_loader, tool_revision):
             if any("none" != mode for config in run["loaded"].runs for mode in config.background_load_modes):
                 background_binary = extract_executable(resource_loader("background_load"), work, "background_load")
             for configuration in run["loaded"].runs:
-                resource_name = configuration.benchmark.resource_name
-                if resource_name not in binaries:
-                    binaries[resource_name] = extract_executable(resource_loader(resource_name), work, resource_name)
-                binary = binaries[resource_name]
+                profile_binaries = {}
+                for resource_name in configuration.benchmark.resources:
+                    if resource_name not in binaries:
+                        binaries[resource_name] = extract_executable(
+                            resource_loader(resource_name), work, resource_name
+                        )
+                    profile_binaries[resource_name] = binaries[resource_name]
+                binary = profile_binaries[configuration.benchmark.resource_name]
                 if cancelled.is_set():
                     return
                 relative = Path(configuration.benchmark.name) / configuration.profile
@@ -1755,16 +2002,27 @@ def production_executor(resource_loader, tool_revision):
                         emit(item)
 
                 try:
-                    profile = run_benchmark(
-                        binary,
-                        configuration,
-                        directory,
-                        tool_revision,
-                        work_dir_hint=work,
-                        event_sink=event,
-                        cancel_event=cancelled,
-                        background_binary=background_binary,
-                    )
+                    if configuration.benchmark.executor == "local-ydb":
+                        profile = run_local_ydb(
+                            profile_binaries,
+                            configuration,
+                            directory,
+                            tool_revision,
+                            work_dir_hint=work,
+                            event_sink=event,
+                            cancel_event=cancelled,
+                        )
+                    else:
+                        profile = run_benchmark(
+                            binary,
+                            configuration,
+                            directory,
+                            tool_revision,
+                            work_dir_hint=work,
+                            event_sink=event,
+                            cancel_event=cancelled,
+                            background_binary=background_binary,
+                        )
                 except BenchmarkInterrupted:
                     with run["lock"]:
                         if run["finalized"]:
@@ -1937,6 +2195,16 @@ def _handler(service):
                 return self._json(200, service.comparisons())
             if path == "/api/chart-data":
                 return self._json(200, service.chart_data(parse_qs(parsed.query).get("run", [])))
+            if path.startswith("/api/runs/") and path.endswith("/local-ydb-profile"):
+                run_id = unquote(path[len("/api/runs/") : -len("/local-ydb-profile")])
+                profile = parse_qs(parsed.query).get("profile", [""])[-1]
+                if not profile:
+                    return self._json(400, {"error": "local-ydb profile is required"})
+                try:
+                    value = service.local_ydb_profile(run_id, profile)
+                except BenchmarkError as error:
+                    return self._json(400, {"error": str(error)})
+                return self._json(202 if value.get("state") == "preparing" else 200, value)
             if path.startswith("/api/runs/") and path.endswith("/config.json"):
                 return self._json(200, service.run_config(unquote(path[len("/api/runs/") : -len("/config.json")])))
             if path.startswith("/api/runs/") and path.endswith("/config"):

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -25,7 +25,7 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 from ydb.tools.ydb_bench.benchmarks import BENCHMARKS
 from ydb.tools.ydb_bench.lib.common import BenchmarkError, BenchmarkInterrupted, atomic_write_json, atomic_write_text
 from ydb.tools.ydb_bench.lib.config import BACKGROUND_LOAD_MODES, build_run_plan, load_config
-from ydb.tools.ydb_bench.lib.results import ResultStore, load_manifest
+from ydb.tools.ydb_bench.lib.results import ResultStore, _non_finite_json_as_null, load_manifest
 from ydb.tools.ydb_bench.lib.actors_core import run_benchmark
 from ydb.tools.ydb_bench.lib.common import extract_executable
 from ydb.tools.ydb_bench.lib.import_results import MAX_TOTAL_SIZE, export_archive, import_archive
@@ -2063,6 +2063,10 @@ class RunService:
         event = dict(event)
         event["sequence"] = run["store"].manifest.get("events", 0) + 1
         event["at"] = _utc_now()
+        try:
+            serialized_event = json.dumps(event, sort_keys=True, allow_nan=False)
+        except ValueError as error:
+            raise BenchmarkError("event contains a non-finite JSON number") from error
         if event.get("type") in ("stdout", "stderr"):
             key = event["type"]
             run["tail"][key] = (run["tail"][key] + str(event.get("data", "")))[-self.tail_limit :]
@@ -2087,7 +2091,7 @@ class RunService:
         run["events"].append(event)
         run["store"].manifest["events"] = event["sequence"]
         with (run["root"] / "events.jsonl").open("a", encoding="utf-8") as stream:
-            stream.write(json.dumps(event, sort_keys=True) + "\n")
+            stream.write(serialized_event + "\n")
         run["store"].write()
 
     def _unsupported_executor(self, run, emit, cancelled):
@@ -2308,6 +2312,11 @@ class RunService:
     def local_ydb_profile(self, run_id, profile):
         root = _run_directory(self.output, run_id)
         manifest = load_manifest(root / "run.json")
+        steps = [
+            item
+            for item in manifest.get("steps", [])
+            if item.get("benchmark") == "local-ydb" and item.get("profile") == profile
+        ]
         record = next(
             (
                 item
@@ -2316,17 +2325,54 @@ class RunService:
             ),
             None,
         )
+
+        def unavailable_profile(record_status=None, error=None):
+            state_by_status = {
+                "completed": "passed",
+                "interrupted": "cancelled",
+                "pending": "preparing",
+                "queued": "preparing",
+                "running": "preparing",
+            }
+            if record_status:
+                state = state_by_status.get(record_status, record_status)
+                status = record_status
+            elif any(item.get("state") == "running" for item in steps):
+                state = status = "preparing"
+            elif any(item.get("state") == "failed" for item in steps):
+                state = status = "failed"
+            elif any(item.get("state") == "pending" for item in steps):
+                state = status = "preparing"
+            elif any(item.get("state") == "cancelled" for item in steps):
+                state = status = "cancelled"
+            elif steps and all(item.get("state") == "unsupported" for item in steps):
+                state = status = "unsupported"
+            else:
+                state, status = "passed", "completed"
+
+            top_state = manifest.get("state")
+            if state == "preparing" and top_state not in ("pending", "queued", "running"):
+                state = top_state or "failed"
+                status = manifest.get("status") or state
+
+            value = {
+                "benchmark": "local-ydb",
+                "profile": profile,
+                "status": status,
+                "state": state,
+            }
+            step_error = next(
+                (item.get("error") or item.get("reason") for item in steps if item.get("error") or item.get("reason")),
+                None,
+            )
+            error = error or step_error or (manifest.get("error") if state not in ("preparing", "passed") else None)
+            if error:
+                value["error"] = error
+            return value
+
         if record is None:
-            if any(
-                item.get("benchmark") == "local-ydb" and item.get("profile") == profile
-                for item in manifest.get("steps", [])
-            ):
-                return {
-                    "benchmark": "local-ydb",
-                    "profile": profile,
-                    "status": "preparing",
-                    "state": "preparing",
-                }
+            if steps:
+                return unavailable_profile()
             raise BenchmarkError("local-ydb profile not found: {}".format(profile))
         relative = record.get("manifest") or str(Path(record.get("directory", "")) / "run.json")
         unresolved = root / relative
@@ -2334,15 +2380,16 @@ class RunService:
         if candidate == root or root not in candidate.parents or unresolved.is_symlink():
             raise BenchmarkError("local-ydb profile manifest escapes the run directory")
         if not candidate.is_file():
-            return {
-                "benchmark": "local-ydb",
-                "profile": profile,
-                "status": record.get("status", "preparing"),
-                "state": "preparing",
-            }
+            return unavailable_profile(record.get("status"), record.get("error"))
         if candidate.stat().st_size > 16 * 1024 * 1024:
             raise BenchmarkError("local-ydb profile manifest is too large")
         value = load_manifest(candidate)
+        top_state = manifest.get("state")
+        if value.get("state") in ("preparing", "running") and top_state not in ("pending", "queued", "running"):
+            value["state"] = top_state or "failed"
+            value["status"] = manifest.get("status") or value["state"]
+            if manifest.get("error"):
+                value["error"] = manifest["error"]
         fields = (
             "schema_version",
             "benchmark",
@@ -2392,17 +2439,43 @@ class RunService:
         return item
 
     def events(self, run_id, after=0):
+        path = _run_directory(self.output, run_id) / "events.jsonl"
         with self._lock:
             run = self._runs.get(run_id)
         if run:
             with run["lock"]:
-                return [dict(e) for e in run["events"] if e["sequence"] > after]
-        path = _run_directory(self.output, run_id) / "events.jsonl"
+                live_events = [dict(event) for event in run["events"]]
+                last_sequence = run["store"].manifest.get("events", 0)
+                if after >= last_sequence:
+                    return []
+                if live_events and after >= live_events[0]["sequence"] - 1:
+                    return [event for event in live_events if event["sequence"] > after]
+                if path.is_symlink():
+                    raise BenchmarkError("run event log must be a regular file")
+                try:
+                    snapshot_size = path.stat().st_size
+                except FileNotFoundError:
+                    return [event for event in live_events if event["sequence"] > after]
+            # Capture the byte boundary while emissions are locked, then read
+            # outside the lock.  Later appends belong to the next poll and
+            # cannot expose a partially written JSON line in this replay.
+            with path.open("rb") as stream:
+                payload = stream.read(snapshot_size)
+            return [
+                event
+                for line in payload.decode("utf-8").splitlines()
+                if (event := json.loads(line, parse_constant=_non_finite_json_as_null))["sequence"] > after
+            ]
+        if path.is_symlink():
+            raise BenchmarkError("run event log must be a regular file")
         if not path.is_file():
             return []
+        snapshot_size = path.stat().st_size
+        with path.open("rb") as stream:
+            payload = stream.read(snapshot_size)
         events = []
-        for line in path.read_text(encoding="utf-8").splitlines():
-            event = json.loads(line)
+        for line in payload.decode("utf-8").splitlines():
+            event = json.loads(line, parse_constant=_non_finite_json_as_null)
             if event["sequence"] > after:
                 events.append(event)
         return events
@@ -2556,7 +2629,12 @@ def _handler(service):
             self.wfile.write(body)
 
         def _json(self, status, value):
-            self._send(status, "application/json", json.dumps(value).encode())
+            try:
+                body = json.dumps(value, allow_nan=False).encode()
+            except ValueError:
+                status = 500
+                body = b'{"error": "response contains a non-finite JSON number"}'
+            self._send(status, "application/json", body)
 
         def _attachment(self, content_type, filename, body):
             self._send(200, content_type, body, {"Content-Disposition": _content_disposition(filename)})
@@ -2682,10 +2760,14 @@ def _handler(service):
             if path.startswith("/api/runs/") and path.endswith("/manifest"):
                 run_id = unquote(path[len("/api/runs/") : -len("/manifest")])
                 manifest = load_manifest(_run_directory(service.output, run_id) / "run.json")
+                try:
+                    body = (json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+                except ValueError:
+                    return self._json(500, {"error": "run manifest contains a non-finite JSON number"})
                 return self._attachment(
                     "application/json",
                     "{}-run.json".format(run_id.replace("/", "-")),
-                    (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(),
+                    body,
                 )
             if path.startswith("/api/runs/") and path.endswith("/archive"):
                 run_id = unquote(path[len("/api/runs/") : -len("/archive")])
@@ -2705,10 +2787,16 @@ def _handler(service):
                 except ValueError:
                     return self._json(400, {"error": "events after must be an integer"})
                 events = service.events(run_id, after)
-                payload = (
-                    b"".join(("id: %s\ndata: %s\n\n" % (e["sequence"], json.dumps(e))).encode() for e in events)
-                    or b": connected\n\n"
-                )
+                try:
+                    payload = (
+                        b"".join(
+                            ("id: %s\ndata: %s\n\n" % (event["sequence"], json.dumps(event, allow_nan=False))).encode()
+                            for event in events
+                        )
+                        or b": connected\n\n"
+                    )
+                except ValueError:
+                    return self._json(500, {"error": "event log contains a non-finite JSON number"})
                 return self._send(200, "text/event-stream", payload)
             if path.startswith("/api/runs/"):
                 item = service.detail(unquote(path[len("/api/runs/") :]))

--- a/ydb/tools/ydb_bench/lib/ya.make
+++ b/ydb/tools/ydb_bench/lib/ya.make
@@ -7,6 +7,9 @@ PY_SRCS(
     common.py
     config.py
     import_results.py
+    load_control.py
+    local_ydb.py
+    linux_telemetry.py
     runner.py
     results.py
     system_info.py
@@ -15,7 +18,11 @@ PY_SRCS(
 )
 
 PEERDIR(
+    contrib/python/grpcio
     contrib/python/PyYAML
+    ydb/core/protos
+    ydb/public/api/grpc
+    ydb/public/api/protos
     ydb/tools/ydb_bench/benchmarks
 )
 

--- a/ydb/tools/ydb_bench/process_guard/main.cpp
+++ b/ydb/tools/ydb_bench/process_guard/main.cpp
@@ -1,0 +1,57 @@
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
+#if defined(_WIN32)
+    #include <process.h>
+#else
+    #include <unistd.h>
+#endif
+
+#if defined(__linux__)
+    #include <sys/prctl.h>
+#endif
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: process_guard PARENT_PID COMMAND [ARG...]\n");
+        return 2;
+    }
+
+    char* end = nullptr;
+    errno = 0;
+    const long parsedParent = std::strtol(argv[1], &end, 10);
+    if (errno != 0 || end == argv[1] || *end != '\0' || parsedParent <= 0) {
+        std::fprintf(stderr, "invalid parent pid: %s\n", argv[1]);
+        return 2;
+    }
+
+#if defined(__linux__)
+    if (parsedParent > std::numeric_limits<pid_t>::max()) {
+        std::fprintf(stderr, "invalid parent pid: %s\n", argv[1]);
+        return 2;
+    }
+    const pid_t parent = static_cast<pid_t>(parsedParent);
+    if (getppid() != parent) {
+        return 125;
+    }
+    if (prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) {
+        std::fprintf(stderr, "cannot set parent-death signal: %s\n", std::strerror(errno));
+        return 126;
+    }
+    if (getppid() != parent) {
+        return 125;
+    }
+#endif
+
+#if defined(_WIN32)
+    _execvp(argv[2], reinterpret_cast<const char* const*>(argv + 2));
+#else
+    execvp(argv[2], argv + 2);
+#endif
+    std::fprintf(stderr, "cannot execute %s: %s\n", argv[2], std::strerror(errno));
+    return 127;
+}

--- a/ydb/tools/ydb_bench/process_guard/ya.make
+++ b/ydb/tools/ydb_bench/process_guard/ya.make
@@ -1,0 +1,7 @@
+PROGRAM(ydb_bench_process_guard)
+
+SRCS(
+    main.cpp
+)
+
+END()

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -495,6 +495,7 @@ class YdbBenchTest(unittest.TestCase):
             )
 
         commands = manifest["attempts"][0]["commands"]
+        self.assertEqual(manifest["timeout_seconds"], configuration.timeout_seconds)
         self.assertEqual(
             [command["phase"] for command in commands],
             ["initializing-workload", "warming-up", "measuring", "cleaning-workload"],
@@ -742,6 +743,28 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(masks, ((0, 3), (1, 4), (2, 5)))
         self.assertEqual(set.intersection(*(set(mask) for mask in masks)), set())
 
+    def test_local_ydb_role_affinity_is_validated_for_largest_geometry(self):
+        geometry = {"static_nodes": 2, "max_dynamic_nodes": 4}
+        affinities = {"static_nodes": (0, 1), "dynamic_nodes": (2, 3, 4)}
+        with self.assertRaisesRegex(BenchmarkError, "3 explicitly assigned CPUs cannot host 4 nodes"):
+            local_ydb._validate_role_affinity(geometry, affinities)
+
+        local_ydb._validate_role_affinity(
+            geometry,
+            {"static_nodes": (0, 1), "dynamic_nodes": None},
+        )
+
+    def test_local_ydb_updates_affinity_for_every_process_thread(self):
+        task_directory = self.root / "proc" / "101" / "task"
+        for thread_id in (101, 102, 103):
+            (task_directory / str(thread_id)).mkdir(parents=True)
+        with mock.patch.object(local_ydb.os, "sched_setaffinity", create=True) as set_affinity:
+            local_ydb._set_process_affinity(101, (4, 6), self.root / "proc")
+        self.assertEqual(
+            {call.args for call in set_affinity.call_args_list},
+            {(101, (4, 6)), (102, (4, 6)), (103, (4, 6))},
+        )
+
     def test_local_ydb_uses_mnc_port_ranges(self):
         candidates = local_ydb._mnc_port_candidates()
         with mock.patch.object(local_ydb, "_port_available", return_value=True):
@@ -759,10 +782,19 @@ class YdbBenchTest(unittest.TestCase):
         status = """Database /Root/bench status:
   State: RUNNING
   Registered units:
-    host:1234 -
+    host:1234 - dynamic
+    host:5678 - dynamic
+  Data size hard quota: 0
 """
-        self.assertTrue(local_ydb._database_status_ready(status))
-        self.assertFalse(local_ydb._database_status_ready(status.replace("RUNNING", "PENDING_RESOURCES")))
+        self.assertEqual(local_ydb._registered_database_units(status), {"host:1234", "host:5678"})
+        self.assertTrue(local_ydb._database_status_ready(status, {"host:1234", "host:5678"}))
+        self.assertFalse(local_ydb._database_status_ready(status, {"host:1234", "host:9999"}))
+        self.assertFalse(
+            local_ydb._database_status_ready(
+                status.replace("RUNNING", "PENDING_RESOURCES"),
+                {"host:1234"},
+            )
+        )
 
     def test_local_ydb_static_nodes_use_self_management(self):
         config = local_ydb._cluster_config(
@@ -812,6 +844,82 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(config["config"]["host_configs"][0]["ssd"], ["SectorMap:map_0:64:NONE"])
         self.assertEqual(start_process.call_args.kwargs["parent_death_wrapper"], self.root / "process_guard")
 
+    def test_local_ydb_scaling_waits_for_every_new_registered_node(self):
+        cluster_directory = self.root / "scaling-cluster"
+        cluster_directory.mkdir()
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            cluster_directory,
+            {
+                "static_nodes": 1,
+                "dynamic_nodes": 1,
+                "max_dynamic_nodes": 2,
+                "storage_groups": 1,
+                "disk_size_gb": 64,
+            },
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            30,
+        )
+        cluster.hostname = "benchmark-host"
+        cluster.static_nodes = [{"grpc_port": 2135}]
+        nodes = (
+            {"grpc_port": 2136, "ic_port": 19002, "mon_port": 8766},
+            {"grpc_port": 2137, "ic_port": 19003, "mon_port": 8767},
+        )
+        with mock.patch.object(cluster, "_node_ports", side_effect=nodes), mock.patch.object(
+            cluster, "_wait_for_port"
+        ) as wait_for_port, mock.patch.object(cluster, "_wait_database_ready") as wait_database, mock.patch.object(
+            cluster, "_wait_tenant_ready"
+        ), mock.patch.object(
+            local_ydb, "start_managed_process", side_effect=(mock.Mock(pid=101), mock.Mock(pid=102))
+        ):
+            cluster.add_dynamic_nodes(2)
+
+        self.assertEqual(
+            wait_for_port.call_args_list,
+            [mock.call(2136, "dynamic node 1"), mock.call(2137, "dynamic node 2")],
+        )
+        wait_database.assert_called_once_with({"benchmark-host:19002", "benchmark-host:19003"})
+
+    def test_local_ydb_tenant_readiness_checks_every_dynamic_node(self):
+        cluster_directory = self.root / "tenant-ready-cluster"
+        cluster_directory.mkdir()
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            cluster_directory,
+            {"static_nodes": 1, "dynamic_nodes": 1, "max_dynamic_nodes": 2, "disk_size_gb": 64},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            30,
+        )
+        cluster.hostname = "benchmark-host"
+        cluster.dynamic_nodes = [{"grpc_port": 2136}, {"grpc_port": 2137}]
+        channels = (mock.Mock(), mock.Mock())
+        responses = (mock.Mock(Status=1), mock.Mock(Status=1))
+        with mock.patch.object(
+            local_ydb.grpc, "insecure_channel", side_effect=channels
+        ) as open_channel, mock.patch.object(local_ydb.grpc_pb2_grpc, "TGRpcServerStub"), mock.patch.object(
+            cluster,
+            "_grpc_eventually",
+            side_effect=((responses[0], [{"response": "first"}]), (responses[1], [{"response": "second"}])),
+        ) as eventually:
+            cluster._wait_tenant_ready(30)
+
+        self.assertEqual(
+            open_channel.call_args_list,
+            [mock.call("benchmark-host:2136"), mock.call("benchmark-host:2137")],
+        )
+        self.assertEqual(
+            [call.args[0] for call in eventually.call_args_list],
+            ["tenant SchemeShard on dynamic node 1", "tenant SchemeShard on dynamic node 2"],
+        )
+        attempts = json.loads((cluster_directory / "tenant-ready-attempts.json").read_text(encoding="utf-8"))
+        self.assertEqual([attempt["dynamic_node"] for attempt in attempts], [1, 2])
+        self.assertTrue(all(channel.close.called for channel in channels))
+
     def test_local_ydb_init_rejects_partial_schema_after_cli_failure(self):
         cluster = local_ydb.LocalYdbCluster(
             self.root / "ydbd",
@@ -857,13 +965,25 @@ class YdbBenchTest(unittest.TestCase):
     def test_local_ydb_uses_mnc_bootstrap_and_tenant_requests(self):
         bootstrap = local_ydb._bootstrap_cluster_request()
         self.assertEqual(bootstrap.self_assembly_uuid, "multinode_cluster")
+        self.assertEqual(bootstrap.operation_params.operation_mode, local_ydb.ydb_operation_pb2.OperationParams.SYNC)
 
         request = local_ydb._create_tenant_request("/Root/bench", "ssd", 3)
-        create = request.CreateTenantRequest.Request
-        self.assertEqual(create.path, "/Root/bench")
-        self.assertEqual(len(create.resources.storage_units), 1)
-        self.assertEqual(create.resources.storage_units[0].unit_kind, "ssd")
-        self.assertEqual(create.resources.storage_units[0].count, 3)
+        self.assertEqual(request.path, "/Root/bench")
+        self.assertEqual(request.idempotency_key, "ydb-bench-local-ydb")
+        self.assertEqual(request.operation_params.operation_mode, local_ydb.ydb_operation_pb2.OperationParams.SYNC)
+        self.assertEqual(len(request.resources.storage_units), 1)
+        self.assertEqual(request.resources.storage_units[0].unit_kind, "ssd")
+        self.assertEqual(request.resources.storage_units[0].count, 3)
+
+        response = local_ydb.ydb_config_pb2.BootstrapClusterResponse()
+        response.operation.ready = True
+        response.operation.status = local_ydb.ydb_status_codes_pb2.StatusIds.SUCCESS
+        self.assertTrue(local_ydb._operation_ready(response))
+        local_ydb._require_successful_operation("bootstrap", response.operation)
+        response.operation.status = local_ydb.ydb_status_codes_pb2.StatusIds.GENERIC_ERROR
+        response.operation.issues.add(message="configuration rejected")
+        with self.assertRaisesRegex(BenchmarkError, "GENERIC_ERROR: configuration rejected"):
+            local_ydb._require_successful_operation("bootstrap", response.operation)
 
         with mock.patch.object(local_ydb.socket, "getfqdn", return_value="benchmark-host.example.net"):
             default_config = local_ydb._cluster_config(
@@ -2644,6 +2764,8 @@ class WebTest(unittest.TestCase):
                 "state": "running",
                 "started_at": "2025-01-01T00:00:00+00:00",
                 "parameters": {"load": {"parameter": "rate", "values": [10]}},
+                "timeout_seconds": 300,
+                "role_affinity": {"ydb_cli": [0, 128], "static_nodes": None, "dynamic_nodes": [1, 2]},
                 "progress": {
                     "phase": "measuring",
                     "attempt": 1,
@@ -2676,6 +2798,8 @@ class WebTest(unittest.TestCase):
             self.assertEqual(projected["progress"]["current_command"]["argv"][3], "run")
             self.assertEqual(projected["attempts"][0]["load"], 10)
             self.assertEqual(projected["attempts"][0]["commands"][0]["argv"][-1], "add-rand-order")
+            self.assertEqual(projected["timeout_seconds"], 300)
+            self.assertEqual(projected["role_affinity"]["dynamic_nodes"], [1, 2])
         finally:
             service.shutdown()
 
@@ -2913,6 +3037,11 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"function localCommandDetails", script)
                 self.assertIn(b"progress.current_command", script)
                 self.assertIn(b"<th>Commands</th>", script)
+                self.assertIn(b"class=local-attempts-scroll", script)
+                self.assertIn(b"data-local-profile-config", script)
+                self.assertIn(b"profileConfigOpen", script)
+                self.assertIn(b"role_affinity", script)
+                self.assertIn(b"Launch parameters", script)
                 self.assertIn(b"local-ydb-profile?profile=", script)
                 self.assertIn(b"function defaultActorCharts", script)
                 self.assertIn(b"function defaultMemoryCharts", script)
@@ -2955,6 +3084,11 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b'chart-color-', script)
                 self.assertNotIn(b'<span style="color:', script)
                 self.assertIn(b'CPUs: not recorded', script)
+            with urllib.request.urlopen(base + "/app.css") as response:
+                stylesheet = response.read()
+                self.assertIn(b".local-attempts-scroll{max-width:100%;overflow-x:auto}", stylesheet)
+                self.assertIn(b".local-attempts{width:max-content;min-width:100%}", stylesheet)
+                self.assertNotIn(b".local-attempts{display:block", stylesheet)
             with urllib.request.urlopen(base + "/api/runs") as response:
                 self.assertEqual(json.loads(response.read())[0]["id"], "complete")
             request = urllib.request.Request(base + "/api/import", data=self._portable_archive(), method="POST")

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -22,7 +22,19 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from unittest import mock
 
-from ydb.tools.ydb_bench.lib import actors_core, cli, import_results, runner, topology, web
+import yaml
+
+from ydb.tools.ydb_bench.lib import (
+    actors_core,
+    cli,
+    import_results,
+    linux_telemetry,
+    load_control,
+    local_ydb,
+    runner,
+    topology,
+    web,
+)
 from ydb.tools.ydb_bench.lib.actors_core import (
     PING_BENCHMARK,
     STAR_PING_BENCHMARK,
@@ -30,7 +42,8 @@ from ydb.tools.ydb_bench.lib.actors_core import (
     parse_metrics,
     run_actors_core,
 )
-from ydb.tools.ydb_bench.benchmarks import MEMORY_BENCHMARK
+from ydb.tools.ydb_bench.benchmarks import LOCAL_YDB_BENCHMARK, MEMORY_BENCHMARK
+from ydb.tools.ydb_bench.benchmarks.local_ydb import parse_cli_metrics
 from ydb.tools.ydb_bench.benchmarks.memory import parse_worker_metrics, validate_metrics as validate_memory_metrics
 from ydb.tools.ydb_bench.benchmarks.registry import (
     BenchmarkDefinition,
@@ -151,7 +164,713 @@ class YdbBenchTest(unittest.TestCase):
         with redirect_stdout(schema_output):
             self.assertEqual(main(["config-schema"]), 0)
         self.assertEqual(json.loads(schema_output.getvalue()), CONFIG_SCHEMA)
-        self.assertEqual(set(CONFIG_SCHEMA["properties"]), {"ping-bench", "star-ping-bench", "memory-bandwidth-bench"})
+        self.assertEqual(
+            set(CONFIG_SCHEMA["properties"]),
+            {"ping-bench", "star-ping-bench", "memory-bandwidth-bench", "local-ydb"},
+        )
+        local_load_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["load"]
+        self.assertEqual(local_load_schema["properties"]["allow-errors"], {"type": "boolean"})
+
+    def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
+        metrics = parse_cli_metrics("""
+            Window Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+
+            Total    Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+                     9000 3000.5 4 2 1.2 2.5 4.0 9.5
+            """)
+        self.assertEqual(metrics["transactions"], 9000)
+        self.assertEqual(metrics["throughput"], 3000.5)
+        self.assertEqual(metrics["p99_ms"], 4.0)
+
+    def test_local_ydb_cli_total_row_accepts_duration_column(self):
+        metrics = parse_cli_metrics("""
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            2 20 10 0 0 137 317 419 419
+            """)
+        self.assertEqual(metrics["transactions"], 20)
+        self.assertEqual(metrics["throughput"], 10)
+        self.assertEqual(metrics["p99_ms"], 419)
+
+    def test_local_ydb_profile_parses_geometry_load_and_role_affinity(self):
+        loaded = load_config(self._config("""
+                local-ydb:
+                  storage-capacity:
+                    workload:
+                      type: kv
+                      operation: upsert
+                    geometry:
+                      preset: storage
+                      static-nodes: 2
+                      dynamic-nodes: 2
+                      max-dynamic-nodes: 6
+                    client:
+                      threads: 96
+                    load:
+                      parameter: rate
+                      allow-errors: true
+                      search:
+                        start: 1000
+                        maximum: 100000
+                        multiplier: 2
+                        resolution-percent: 5
+                      objective:
+                        type: latency-slo
+                        percentile: p99
+                        max-ms: 10
+                    affinity:
+                      ydb-cli:
+                        mode: pack-numa-pack-chiplet-spread-core
+                        cpus: one-chiplet
+                      static-nodes:
+                        mode: none
+                      dynamic-nodes:
+                        mode: none
+                """))
+        configuration = loaded.runs[0]
+        self.assertIs(configuration.benchmark, LOCAL_YDB_BENCHMARK)
+        self.assertEqual(configuration.affinity_modes, ("roles",))
+        profile = configuration.parameters["local_ydb"]
+        self.assertEqual(profile["geometry"]["static_nodes"], 2)
+        self.assertEqual(profile["geometry"]["max_dynamic_nodes"], 6)
+        self.assertEqual(profile["load"]["search"]["resolution_percent"], 5)
+        self.assertEqual(profile["load"]["objective"]["max_ms"], 10)
+        self.assertTrue(profile["load"]["allow_errors"])
+        self.assertEqual(profile["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
+
+    def test_local_ydb_allow_errors_defaults_to_false_and_requires_boolean(self):
+        loaded = load_config(self._config("""
+                local-ydb:
+                  strict:
+                    workload: {type: kv, operation: upsert}
+                    load: {parameter: rate, values: [10]}
+            """))
+        self.assertFalse(loaded.runs[0].parameters["local_ydb"]["load"]["allow_errors"])
+
+        invalid = self._config("""
+            local-ydb:
+              invalid:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, allow-errors: 1, values: [10]}
+        """)
+        with self.assertRaisesRegex(BenchmarkError, "allow-errors"):
+            load_config(invalid)
+
+    def test_local_ydb_kv_requires_at_least_two_columns(self):
+        invalid = self._config("""
+            local-ydb:
+              invalid:
+                workload:
+                  type: kv
+                  operation: upsert
+                  options: {columns: 1}
+                load: {parameter: rate, values: [10]}
+        """)
+        with self.assertRaisesRegex(BenchmarkError, "columns.*at least 2"):
+            load_config(invalid)
+
+    def test_local_ydb_legacy_load_controller_is_normalized(self):
+        loaded = load_config(self._config("""
+                local-ydb:
+                  legacy:
+                    workload: {type: kv, operation: upsert}
+                    load:
+                      mode: latency-slo
+                      parameter: rate
+                      start: 100
+                      maximum: 1000
+                      search-resolution-percent: 5
+                      slo: {percentile: p95, max-ms: 20}
+            """))
+        load = loaded.runs[0].parameters["local_ydb"]["load"]
+        self.assertNotIn("mode", load)
+        self.assertEqual(load["search"]["resolution_percent"], 5)
+        self.assertEqual(load["objective"]["type"], "latency-slo")
+        self.assertEqual(load["objective"]["percentile"], "p95")
+
+    def test_local_ydb_profile_is_editable_by_web_builder(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              ui:
+                workload:
+                  type: stock
+                  operation: put-rand-order
+                geometry:
+                  preset: storage
+                  static-nodes: 2
+                  dynamic-nodes: 2
+                  max-dynamic-nodes: 4
+                load:
+                  parameter: rate
+                  allow-errors: true
+                  values: [10, 20]
+                affinity:
+                  ydb-cli:
+                    mode: pack-numa-pack-chiplet-spread-core
+                    cpus: one-chiplet
+        """))
+        model = web.editor_model(loaded, self.root / "results")
+        benchmark = next(item for item in model["benchmarks"] if item["name"] == "local-ydb")
+        profile = model["profiles"][0]
+        self.assertTrue(benchmark["builder_supported"])
+        self.assertEqual(benchmark["profile_kind"], "local-ydb")
+        self.assertEqual(profile["local_ydb"]["workload"]["type"], "stock")
+        self.assertEqual(profile["local_ydb"]["geometry"]["max_dynamic_nodes"], 4)
+        self.assertEqual(profile["local_ydb"]["load"]["values"], [10, 20])
+        self.assertTrue(profile["local_ydb"]["load"]["allow_errors"])
+        self.assertEqual(profile["local_ydb"]["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
+        self.assertEqual(profile["parameters"], {})
+
+    def test_local_ydb_profile_rejects_custom_geometry_without_dynamic_nodes(self):
+        config = self._config("""
+            local-ydb:
+              invalid:
+                workload: {type: kv, operation: select}
+                geometry: {preset: custom}
+                load: {mode: points, parameter: threads, values: [1]}
+            """)
+        with self.assertRaisesRegex(BenchmarkError, "custom preset requires dynamic-nodes"):
+            load_config(config)
+
+    def test_local_ydb_stock_profile(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              stock-smoke:
+                workload:
+                  type: stock
+                  operation: put-rand-order
+                  options: {products: 10, orders: 0, min-partitions: 1, auto-partition: 0}
+                load: {parameter: rate, values: [10]}
+            """))
+        workload = loaded.runs[0].parameters["local_ydb"]["workload"]
+        self.assertEqual(workload["type"], "stock")
+        self.assertEqual(workload["operation"], "put-rand-order")
+        self.assertEqual(workload["options"]["products"], 10)
+
+    def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
+        cluster = mock.Mock(
+            ydb_cli=Path("ydb"),
+            client_endpoint="grpc://host.example:2135",
+            database="/Root/bench",
+        )
+        command = local_ydb._stock_init_command(
+            cluster,
+            "ignored-table-prefix",
+            {
+                "products": 10,
+                "quantity": 100,
+                "orders": 0,
+                "min-partitions": 1,
+                "auto-partition": 0,
+            },
+        )
+        self.assertNotIn("--path", command)
+        self.assertNotIn("ignored-table-prefix", command)
+        self.assertEqual(local_ydb._workload_table_path("stock", "ignored-table-prefix"), "stock")
+        self.assertNotIn("--path", local_ydb._clean_workload_command(cluster, "stock", "ignored-table-prefix"))
+
+        run_options = {"products": 10, "limit": 5}
+        add_command = local_ydb._stock_run_command(
+            cluster,
+            "ignored-table-prefix",
+            {"operation": "add-rand-order", "options": run_options},
+            {"parameter": "threads"},
+            8,
+            30,
+            64,
+        )
+        put_command = local_ydb._stock_run_command(
+            cluster,
+            "ignored-table-prefix",
+            {"operation": "put-rand-order", "options": run_options},
+            {"parameter": "threads"},
+            8,
+            30,
+            64,
+        )
+        self.assertEqual(add_command[add_command.index("run") + 1], "add-rand-order")
+        self.assertEqual(put_command[put_command.index("run") + 1], "put-rand-order")
+        self.assertEqual(add_command[add_command.index("--threads") + 1], 8)
+
+    def test_local_ydb_command_record_preserves_argv_and_affinity(self):
+        result = runner.CommandResult(
+            command=("/tmp/ydb cli", "workload", "stock", "run", "add-rand-order", "<unsafe>"),
+            stdout="",
+            stderr="",
+            exit_code=0,
+            started_at="2026-08-25T10:00:00+00:00",
+            finished_at="2026-08-25T10:00:01+00:00",
+            duration_seconds=1.0,
+        )
+        record = local_ydb._command_record("measuring", 2, result.command, (128, 0), result)
+        self.assertEqual(record["argv"], list(result.command))
+        self.assertEqual(record["cpu_affinity"], [0, 128])
+        self.assertEqual(record["phase"], "measuring")
+        self.assertEqual(record["repetition"], 2)
+        self.assertEqual(record["exit_code"], 0)
+        self.assertFalse(record["timed_out"])
+
+    def test_local_ydb_search_records_commands_for_each_workload_phase(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              audit:
+                workload: {type: stock, operation: add-rand-order}
+                load: {parameter: threads, values: [8]}
+                measurement: {warmup: 1, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+
+        def command_result(command, stdout=""):
+            return runner.CommandResult(
+                command=tuple(str(part) for part in command),
+                stdout=stdout,
+                stderr="",
+                exit_code=0,
+                started_at="2026-08-25T10:00:00+00:00",
+                finished_at="2026-08-25T10:00:01+00:00",
+                duration_seconds=1.0,
+            )
+
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb cli"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            dynamic_nodes=[{}],
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command: (
+            command_result(command),
+            [command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.start.return_value = monitor
+        monitor.stop.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        measurement_stdout = """
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            1 10 10 0 0 1 2 3 4
+        """
+        events = []
+        output = self.root / "command-audit"
+        binaries = {
+            name: mock.Mock(path=self.root / name, sha256=name + "-digest", size=1)
+            for name in ("ydbd", "ydb_cli", "process_guard")
+        }
+        with mock.patch.object(local_ydb, "LocalYdbCluster", return_value=cluster), mock.patch.object(
+            local_ydb, "LinuxCpuMonitor", return_value=monitor
+        ), mock.patch.object(
+            local_ydb,
+            "discover_topology",
+            return_value=CpuTopology(
+                allowed_cpus=(0,),
+                numa_nodes=((0, (0,)),),
+                chiplets=(),
+                physical_cores=((0,),),
+            ),
+        ), mock.patch.object(
+            local_ydb, "collect_system_info", return_value={}
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: command_result(command, measurement_stdout),
+        ):
+            manifest = local_ydb.run_local_ydb(
+                binaries,
+                configuration,
+                output,
+                tool_revision="test",
+                event_sink=events.append,
+            )
+
+        commands = manifest["attempts"][0]["commands"]
+        self.assertEqual(
+            [command["phase"] for command in commands],
+            ["initializing-workload", "warming-up", "measuring", "cleaning-workload"],
+        )
+        self.assertTrue(all(any(part in ("init", "run", "clean") for part in command["argv"]) for command in commands))
+        measuring = next(command for command in commands if command["phase"] == "measuring")
+        self.assertEqual(measuring["argv"][measuring["argv"].index("run") + 1], "add-rand-order")
+        progress = [event["fields"]["progress"] for event in events if event["type"] == "step-progress"]
+        running = [item for item in progress if item.get("current_command")]
+        self.assertEqual([item["phase"] for item in running[:4]], [command["phase"] for command in commands])
+
+    def test_local_ydb_kv_commands_keep_table_path(self):
+        cluster = mock.Mock(
+            ydb_cli=Path("ydb"),
+            client_endpoint="grpc://host.example:2135",
+            database="/Root/bench",
+        )
+        command = local_ydb._workload_base(cluster, "kv", "table-prefix")
+        self.assertEqual(command[-2:], ["--path", "table-prefix"])
+        self.assertEqual(local_ydb._workload_table_path("kv", "table-prefix"), "table-prefix")
+
+    def test_load_controllers_find_capacity_and_latency_boundary(self):
+        throughput_attempts = []
+        throughput = load_control.search_load(
+            {
+                "parameter": "rate",
+                "search": {"start": 10, "maximum": 80, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "maximize-throughput",
+                    "target_role": "dynamic",
+                    "cpu_saturation_percent": 90,
+                    "plateau_gain_percent": 5,
+                    "plateau_points": 1,
+                },
+            },
+            lambda load: {
+                "throughput": min(load, 40),
+                "errors": 0,
+                "dynamic_cpu_mean": min(100, load * 2.5),
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+            on_attempt=lambda attempt: throughput_attempts.append(attempt["load"]),
+        )
+        self.assertEqual(throughput.selected_load, 40)
+        self.assertEqual(throughput.outcome, "plateau-found")
+        self.assertEqual(throughput_attempts[0], 10)
+        self.assertEqual(len(throughput_attempts), len(set(throughput_attempts)))
+        self.assertTrue(any(load not in (10, 20, 40, 80) for load in throughput_attempts))
+        self.assertIn("plateau", throughput.stop_reason)
+
+        latency_attempts = []
+        latency = load_control.search_load(
+            {
+                "parameter": "rate",
+                "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "max_ms": 10,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            lambda load: {
+                "throughput": load,
+                "errors": 0,
+                "p99_ms": 5 if load <= 60 else 15,
+            },
+            on_attempt=lambda attempt: latency_attempts.append(attempt["load"]),
+        )
+        self.assertGreaterEqual(latency.selected_load, 58)
+        self.assertLessEqual(latency.selected_load, 60)
+        self.assertEqual(latency.outcome, "boundary-found")
+        self.assertEqual(latency.passing_load, latency.selected_load)
+        self.assertGreater(latency.failing_load, latency.passing_load)
+        self.assertEqual(len(latency_attempts), len(set(latency_attempts)))
+        self.assertEqual(latency_attempts[:5], [10, 20, 40, 80, 60])
+
+        below_start_attempts = []
+        no_feasible_latency = load_control.search_load(
+            {
+                "parameter": "rate",
+                "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "max_ms": 10,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            lambda load: {"throughput": load, "errors": 0, "p99_ms": 15},
+            on_attempt=lambda attempt: below_start_attempts.append(attempt["load"]),
+        )
+        self.assertIsNone(no_feasible_latency.selected_load)
+        self.assertEqual(no_feasible_latency.outcome, "no-feasible-point")
+        self.assertEqual(no_feasible_latency.failing_load, 10)
+        self.assertEqual(below_start_attempts, [10])
+
+    def test_throughput_controller_uses_ternary_search_and_error_bounds(self):
+        config = {
+            "parameter": "rate",
+            "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 2},
+            "objective": {
+                "type": "maximize-throughput",
+                "target_role": "dynamic",
+                "cpu_saturation_percent": 90,
+                "plateau_gain_percent": 1,
+                "plateau_points": 2,
+            },
+        }
+        attempted = []
+        result = load_control.search_load(
+            config,
+            lambda load: {
+                "throughput": 100 - abs(load - 55),
+                "errors": int(load >= 70),
+                "dynamic_cpu_mean": 50,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+            on_attempt=lambda item: attempted.append(item["load"]),
+        )
+        self.assertLessEqual(abs(result.selected_load - 55), 2)
+        self.assertEqual(result.outcome, "bounded-by-errors")
+        self.assertEqual(result.failing_load, 70)
+        self.assertEqual(len(attempted), len(set(attempted)))
+
+        lower_bound = load_control.search_load(
+            {**config, "search": {**config["search"], "maximum": 30}},
+            lambda load: {
+                "throughput": load,
+                "errors": 0,
+                "dynamic_cpu_mean": 50,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+        )
+        self.assertEqual(lower_bound.selected_load, 30)
+        self.assertEqual(lower_bound.outcome, "lower-bound")
+
+        no_feasible = load_control.search_load(
+            config,
+            lambda load: {
+                "throughput": load,
+                "errors": 1,
+                "dynamic_cpu_mean": 1,
+                "static_cpu_mean": 1,
+                "host_cpu_mean": 1,
+            },
+        )
+        self.assertIsNone(no_feasible.selected_load)
+        self.assertEqual(no_feasible.outcome, "no-feasible-point")
+        self.assertEqual(no_feasible.failing_load, 10)
+
+    def test_load_controllers_can_accept_reported_request_errors(self):
+        strict = load_control.search_load(
+            {"parameter": "rate", "values": [10]},
+            lambda load: {"throughput": load, "errors": 1},
+        )
+        self.assertIsNone(strict.selected_load)
+        self.assertEqual(strict.outcome, "no-feasible-point")
+
+        points = load_control.search_load(
+            {"parameter": "rate", "allow_errors": True, "values": [10, 20]},
+            lambda load: {"throughput": load, "errors": load // 10},
+        )
+        self.assertEqual(points.selected_load, 20)
+        self.assertTrue(all(item["passed"] for item in points.attempts))
+        self.assertIn("errors allowed", points.attempts[-1]["decision"])
+
+        throughput = load_control.search_load(
+            {
+                "parameter": "rate",
+                "allow_errors": True,
+                "search": {"start": 10, "maximum": 20, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "maximize-throughput",
+                    "target_role": "dynamic",
+                    "cpu_saturation_percent": 90,
+                    "plateau_gain_percent": 1,
+                    "plateau_points": 2,
+                },
+            },
+            lambda load: {
+                "throughput": load,
+                "errors": 1,
+                "dynamic_cpu_mean": 50,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+        )
+        self.assertEqual(throughput.attempts[0]["load"], 10)
+        self.assertEqual(len(throughput.attempts), len({item["load"] for item in throughput.attempts}))
+        self.assertTrue(all(item["passed"] for item in throughput.attempts))
+        self.assertEqual(throughput.selected_load, 20)
+
+        latency = load_control.search_load(
+            {
+                "parameter": "rate",
+                "allow_errors": True,
+                "search": {"start": 10, "maximum": 20, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "max_ms": 10,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            lambda load: {"throughput": load, "errors": 100, "p99_ms": 5 if load == 10 else 15},
+        )
+        self.assertEqual(latency.selected_load, 10)
+        self.assertGreater(latency.failing_load, latency.selected_load)
+        self.assertTrue(latency.attempts[0]["passed"])
+        self.assertIn("latency", latency.attempts[-1]["decision"])
+
+    def test_linux_cpu_summary_weights_intervals_and_ignores_short_spikes_for_max(self):
+        monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1}, interval=0.5)
+        monitor._records = [
+            {"elapsed_seconds": 0.5, "dynamic_cpu": 10.0, "host_cpu": 20.0},
+            {"elapsed_seconds": 1.5, "dynamic_cpu": 30.0, "host_cpu": 40.0},
+            {"elapsed_seconds": 0.01, "dynamic_cpu": 100.0, "host_cpu": 100.0},
+        ]
+        summary = monitor.summary()
+        self.assertAlmostEqual(summary["dynamic_cpu_mean"], (5 + 45 + 1) / 2.01)
+        self.assertEqual(summary["dynamic_cpu_max"], 30.0)
+        self.assertAlmostEqual(summary["host_cpu_mean"], (10 + 60 + 1) / 2.01)
+        self.assertEqual(summary["host_cpu_max"], 40.0)
+
+    def test_local_ydb_attempt_aggregates_errors_across_repetitions(self):
+        metrics = local_ydb._aggregate_measurements(
+            [
+                {"throughput": 10, "errors": 0},
+                {"throughput": 20, "errors": 0},
+                {"throughput": 30, "errors": 100},
+            ]
+        )
+        self.assertEqual(metrics["throughput"], 20)
+        self.assertEqual(metrics["errors"], 100)
+
+    def test_role_masks_are_split_without_overlap(self):
+        masks = local_ydb._split_mask((0, 1, 2, 3, 4, 5), 3)
+        self.assertEqual(masks, ((0, 3), (1, 4), (2, 5)))
+        self.assertEqual(set.intersection(*(set(mask) for mask in masks)), set())
+
+    def test_local_ydb_uses_mnc_port_ranges(self):
+        candidates = local_ydb._mnc_port_candidates()
+        with mock.patch.object(local_ydb, "_port_available", return_value=True):
+            first = {name: local_ydb._next_available_port(ports, name) for name, ports in candidates.items()}
+            second = {name: local_ydb._next_available_port(ports, name) for name, ports in candidates.items()}
+        self.assertEqual(first, {"grpc_port": 2135, "ic_port": 19001, "mon_port": 8765})
+        self.assertEqual(second, {"grpc_port": 20000, "ic_port": 19000, "mon_port": 31000})
+
+    def test_local_ydb_skips_occupied_mnc_ports(self):
+        with mock.patch.object(local_ydb, "_port_available", side_effect=(False, True)):
+            port = local_ydb._next_available_port(iter((2135, 20000)), "grpc")
+        self.assertEqual(port, 20000)
+
+    def test_local_ydb_database_status_requires_running_state(self):
+        status = """Database /Root/bench status:
+  State: RUNNING
+  Registered units:
+    host:1234 -
+"""
+        self.assertTrue(local_ydb._database_status_ready(status))
+        self.assertFalse(local_ydb._database_status_ready(status.replace("RUNNING", "PENDING_RESOURCES")))
+
+    def test_local_ydb_static_nodes_use_self_management(self):
+        config = local_ydb._cluster_config(
+            (
+                {"ic_port": 19001},
+                {"ic_port": 19002},
+            ),
+            64,
+            hostname="benchmark-host",
+        )
+        hosts = config["config"]["hosts"]
+        host_configs = config["config"]["host_configs"]
+        self.assertEqual([host["host"] for host in hosts], ["benchmark-host", "benchmark-host"])
+        self.assertEqual(
+            [host_config["ssd"] for host_config in host_configs],
+            [["SectorMap:map_0:64:NONE"], ["SectorMap:map_1:64:NONE"]],
+        )
+        self.assertTrue(config["config"]["self_management_config"]["enabled"])
+        self.assertNotIn("grpc_config", config["config"])
+
+    def test_local_ydb_cluster_start_does_not_create_pdisk_files(self):
+        cluster_directory = self.root / "sector-map-cluster"
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            cluster_directory,
+            {"static_nodes": 1, "dynamic_nodes": 1, "disk_size_gb": 64},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            30,
+        )
+        ports = {"grpc_port": 2135, "ic_port": 19001, "mon_port": 8765}
+        with mock.patch.object(cluster, "_node_ports", return_value=ports), mock.patch.object(
+            cluster, "_wait_for_port"
+        ), mock.patch.object(cluster, "_bootstrap_cluster"), mock.patch.object(
+            cluster, "_create_tenant"
+        ), mock.patch.object(
+            cluster, "add_dynamic_nodes"
+        ), mock.patch.object(
+            local_ydb, "start_managed_process", return_value=mock.Mock(pid=1)
+        ) as start_process:
+            cluster.start()
+
+        self.assertTrue((cluster_directory / "static-01").is_dir())
+        self.assertFalse((cluster_directory / "static-01" / "pdisk.dat").exists())
+        config = yaml.safe_load((cluster_directory / "cluster.yaml").read_text(encoding="utf-8"))
+        self.assertEqual(config["config"]["host_configs"][0]["ssd"], ["SectorMap:map_0:64:NONE"])
+        self.assertEqual(start_process.call_args.kwargs["parent_death_wrapper"], self.root / "process_guard")
+
+    def test_local_ydb_init_rejects_partial_schema_after_cli_failure(self):
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            self.root / "partial-init-cluster",
+            {"static_nodes": 1, "dynamic_nodes": 1, "disk_size_gb": 64},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            30,
+        )
+        cluster.static_processes = [mock.Mock(poll=mock.Mock(return_value=None))]
+        cluster.dynamic_processes = [mock.Mock(poll=mock.Mock(return_value=None))]
+        failed = runner.CommandResult(
+            command=("ydb", "workload", "stock", "init"),
+            stdout="tables were created before the failure",
+            stderr="initial data load failed",
+            exit_code=1,
+            started_at="2026-08-25T10:00:00+00:00",
+            finished_at="2026-08-25T10:00:01+00:00",
+            duration_seconds=1.0,
+        )
+        describe_would_succeed = replace(failed, command=("ydb", "scheme", "describe"), exit_code=0)
+        with mock.patch.object(local_ydb, "run_command", side_effect=(failed, describe_would_succeed)) as execute:
+            with self.assertRaisesRegex(BenchmarkError, "initial data load failed"):
+                cluster.init_workload(failed.command)
+        self.assertEqual(execute.call_count, 1)
+
+    def test_local_ydb_detects_exited_cluster_nodes(self):
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            self.root / "dead-node-cluster",
+            {"static_nodes": 1, "dynamic_nodes": 1, "disk_size_gb": 64},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            30,
+        )
+        cluster.static_processes = [mock.Mock(poll=mock.Mock(return_value=None))]
+        cluster.dynamic_processes = [mock.Mock(poll=mock.Mock(return_value=17))]
+        with self.assertRaisesRegex(BenchmarkError, "dynamic node 1 exited with code 17"):
+            cluster.ensure_running("measurement failed")
+
+    def test_local_ydb_uses_mnc_bootstrap_and_tenant_requests(self):
+        bootstrap = local_ydb._bootstrap_cluster_request()
+        self.assertEqual(bootstrap.self_assembly_uuid, "multinode_cluster")
+
+        request = local_ydb._create_tenant_request("/Root/bench", "ssd", 3)
+        create = request.CreateTenantRequest.Request
+        self.assertEqual(create.path, "/Root/bench")
+        self.assertEqual(len(create.resources.storage_units), 1)
+        self.assertEqual(create.resources.storage_units[0].unit_kind, "ssd")
+        self.assertEqual(create.resources.storage_units[0].count, 3)
+
+        with mock.patch.object(local_ydb.socket, "getfqdn", return_value="benchmark-host.example.net"):
+            default_config = local_ydb._cluster_config(
+                ({"ic_port": 19001},),
+                64,
+            )
+        self.assertEqual(default_config["config"]["hosts"][0]["host"], "benchmark-host.example.net")
 
     def test_cli_json_discovery_and_validation_do_not_create_output(self):
         config = self._config("""
@@ -681,6 +1400,19 @@ class YdbBenchTest(unittest.TestCase):
         with self.assertRaisesRegex(BenchmarkError, "state passed"):
             store.add_artifacts("step-1", ["stdout.txt"])
 
+    def test_result_store_updates_progress_only_for_running_steps(self):
+        path = self.root / "progress-run.json"
+        store = ResultStore(path, {"steps": [{"id": "step-1", "state": "pending", "artifacts": []}]})
+        store.write()
+        with self.assertRaisesRegex(BenchmarkError, "state pending"):
+            store.update_step("step-1", progress={"phase": "preparing"})
+        store.transition_step("step-1", "running")
+        store.update_step("step-1", progress={"phase": "measuring", "attempt": 3})
+        self.assertEqual(load_manifest(path)["steps"][0]["progress"]["attempt"], 3)
+        store.transition_step("step-1", "passed")
+        with self.assertRaisesRegex(BenchmarkError, "state passed"):
+            store.update_step("step-1", progress={"phase": "completed"})
+
     def test_config_rejects_empty_arrays_unknown_fields_and_unsafe_profile_names(self):
         """Reject empty threads, then an unknown field, then an unsafe profile path."""
         cases = (
@@ -1195,6 +1927,36 @@ class YdbBenchTest(unittest.TestCase):
         self.assertNotIn("preexec_fn", popen.call_args.kwargs)
         self.assertTrue(popen.call_args.kwargs["start_new_session"])
         self.assertEqual(result.command, command)
+
+    def test_managed_process_guard_receives_expected_parent_pid(self):
+        process = mock.Mock()
+        command = ("benchmark", "--flag")
+
+        with mock.patch.object(runner.os, "getpid", return_value=4321), mock.patch.object(
+            runner.subprocess, "Popen", return_value=process
+        ) as popen:
+            managed = runner.start_managed_process(
+                command,
+                self.root / "stdout.txt",
+                self.root / "stderr.txt",
+                parent_death_wrapper=self.root / "process_guard",
+            )
+
+        try:
+            self.assertEqual(
+                popen.call_args.args[0],
+                (str(self.root / "process_guard"), "4321", "benchmark", "--flag"),
+            )
+            self.assertEqual(managed.command, command)
+        finally:
+            managed.stdout_file.close()
+            managed.stderr_file.close()
+
+    def test_local_ydb_requires_linux(self):
+        with mock.patch.object(local_ydb.sys, "platform", "darwin"), self.assertRaisesRegex(
+            BenchmarkError, "require Linux"
+        ):
+            local_ydb.run_local_ydb({}, None, self.root, {})
 
     @unittest.skipUnless(
         hasattr(os, "sched_getaffinity") and shutil.which("taskset"),
@@ -1838,6 +2600,85 @@ class WebTest(unittest.TestCase):
         self.assertEqual([event["type"] for event in events], ["second"])
         self.assertEqual(decode.call_count, 2)
 
+    def test_local_ydb_profile_projection_supports_preparing_and_live_results(self):
+        run_root = self.root / "local-ydb-run"
+        self._manifest(run_root, "running")
+        main_path = run_root / "run.json"
+        main = json.loads(main_path.read_text(encoding="utf-8"))
+        main["runs"] = []
+        main["steps"] = [
+            {
+                "id": "step-1",
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "affinity": "roles",
+                "threads": 64,
+                "case": 1,
+                "parameters": {},
+                "repeat": 1,
+                "state": "pending",
+                "artifacts": [],
+            }
+        ]
+        main_path.write_text(json.dumps(main), encoding="utf-8")
+        service = RunService(self.root)
+        try:
+            self.assertEqual(service.local_ydb_profile("local-ydb-run", "capacity")["state"], "preparing")
+            relative = Path("local-ydb") / "capacity"
+            profile_root = run_root / relative
+            profile_root.mkdir(parents=True)
+            main["runs"] = [
+                {
+                    "benchmark": "local-ydb",
+                    "profile": "capacity",
+                    "status": "running",
+                    "directory": str(relative),
+                }
+            ]
+            main_path.write_text(json.dumps(main), encoding="utf-8")
+            profile_manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "status": "running",
+                "state": "running",
+                "started_at": "2025-01-01T00:00:00+00:00",
+                "parameters": {"load": {"parameter": "rate", "values": [10]}},
+                "progress": {
+                    "phase": "measuring",
+                    "attempt": 1,
+                    "load": 10,
+                    "current_command": {
+                        "argv": ["/tmp/ydb cli", "workload", "stock", "run", "add-rand-order"],
+                        "cpu_affinity": [0, 128],
+                    },
+                },
+                "attempts": [
+                    {
+                        "attempt": 1,
+                        "load": 10,
+                        "passed": True,
+                        "commands": [
+                            {
+                                "phase": "measuring",
+                                "repetition": 1,
+                                "argv": ["/tmp/ydb cli", "workload", "stock", "run", "add-rand-order"],
+                                "cpu_affinity": [0, 128],
+                            }
+                        ],
+                    }
+                ],
+                "searches": [],
+            }
+            (profile_root / "run.json").write_text(json.dumps(profile_manifest), encoding="utf-8")
+            projected = service.local_ydb_profile("local-ydb-run", "capacity")
+            self.assertEqual(projected["progress"]["phase"], "measuring")
+            self.assertEqual(projected["progress"]["current_command"]["argv"][3], "run")
+            self.assertEqual(projected["attempts"][0]["load"], 10)
+            self.assertEqual(projected["attempts"][0]["commands"][0]["argv"][-1], "add-rand-order")
+        finally:
+            service.shutdown()
+
     def test_download_content_disposition_encodes_hostile_run_and_artifact_names(self):
         run_id = 'run"\r\n\\é'
         artifact_name = 'report"\r\n\\é.txt'
@@ -2050,6 +2891,29 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"segments.push(segment)", script)
                 self.assertIn(b"for(const points of segments)", script)
                 self.assertIn(b"function mountChartBuilder", script)
+                self.assertIn(b"function mountLocalYdbProfile", script)
+                self.assertIn(b"local-load-allow-errors", script)
+                self.assertIn(b"allow-errors: ", script)
+                self.assertIn(b"Failed workload requests are allowed", script)
+                self.assertIn(b"function localElapsed(started,finished=null)", script)
+                self.assertIn(b"Search process", script)
+                self.assertIn(b"function localSearchAxisLabel", script)
+                self.assertIn(b"data-local-chart-x", script)
+                self.assertIn(b"Attempts (search order)", script)
+                self.assertIn(b"container.dataset.localYdbXAxis", script)
+                self.assertIn(b"sort((left,right)=>left-right)", script)
+                self.assertIn(b"stages.length>1", script)
+                self.assertIn(b"chartBinding.xName", script)
+                self.assertIn(b"Ternary resolution (%)", script)
+                self.assertIn(b"Growth multiplier", script)
+                self.assertIn(b"Geometry stages", script)
+                self.assertIn(b"Current phase", script)
+                self.assertIn(b"Running command", script)
+                self.assertIn(b"function localShellArg", script)
+                self.assertIn(b"function localCommandDetails", script)
+                self.assertIn(b"progress.current_command", script)
+                self.assertIn(b"<th>Commands</th>", script)
+                self.assertIn(b"local-ydb-profile?profile=", script)
                 self.assertIn(b"function defaultActorCharts", script)
                 self.assertIn(b"function defaultMemoryCharts", script)
                 self.assertIn(b"function defaultChartScope", script)
@@ -2080,6 +2944,13 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"class=modal-backdrop", script)
                 self.assertIn(b"role=dialog", script)
                 self.assertIn(b"function bindChartTooltips", script)
+                self.assertIn(b"function chartNumber", script)
+                self.assertIn(b"synchronize=false", script)
+                self.assertIn(b"targets=synchronize?panels:[active]", script)
+                self.assertIn(b"data-selected-x", script)
+                self.assertIn(b"chartBinding.series", script)
+                self.assertIn(b'visibility="hidden"', script)
+                self.assertNotIn(b"visibility=hidden/>", script)
                 self.assertIn(b"rightItem.value-leftItem.value", script)
                 self.assertIn(b'chart-color-', script)
                 self.assertNotIn(b'<span style="color:', script)
@@ -2170,6 +3041,13 @@ class WebTest(unittest.TestCase):
         def fake_executor(run, emit, cancelled):
             step = run["store"].manifest["steps"][0]
             emit({"type": "step-started", "step_id": step["id"]})
+            emit(
+                {
+                    "type": "step-progress",
+                    "step_id": step["id"],
+                    "fields": {"progress": {"phase": "measuring", "attempt": 2}},
+                }
+            )
             emit({"type": "stdout", "data": "fake output\\n"})
             started.set()
             while not release.wait(0.01):
@@ -2196,6 +3074,7 @@ class WebTest(unittest.TestCase):
             self.assertTrue(started.wait(2))
             detail = request("/api/runs/" + created["id"])
             self.assertEqual(detail["steps"][0]["state"], "running")
+            self.assertEqual(detail["steps"][0]["progress"], {"phase": "measuring", "attempt": 2})
             self.assertIn("fake output", detail["tail"]["stdout"])
             self.assertIn(
                 "step-started", urllib.request.urlopen(base + "/api/runs/" + created["id"] + "/events").read().decode()

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -27,6 +27,7 @@ import yaml
 from ydb.tools.ydb_bench.lib import (
     actors_core,
     cli,
+    common,
     import_results,
     linux_telemetry,
     load_control,
@@ -191,6 +192,13 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(metrics["throughput"], 10)
         self.assertEqual(metrics["p99_ms"], 419)
 
+    def test_local_ydb_cli_total_row_rejects_non_finite_metrics(self):
+        with self.assertRaisesRegex(BenchmarkError, "valid Total row"):
+            parse_cli_metrics("""
+                Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+                20 nan 0 0 1 2 3 4
+            """)
+
     def test_local_ydb_profile_parses_geometry_load_and_role_affinity(self):
         loaded = load_config(self._config("""
                 local-ydb:
@@ -217,6 +225,7 @@ class YdbBenchTest(unittest.TestCase):
                         type: latency-slo
                         percentile: p99
                         max-ms: 10
+                        cpu-saturation-percent: 80
                     affinity:
                       ydb-cli:
                         mode: pack-numa-pack-chiplet-spread-core
@@ -234,6 +243,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(profile["geometry"]["max_dynamic_nodes"], 6)
         self.assertEqual(profile["load"]["search"]["resolution_percent"], 5)
         self.assertEqual(profile["load"]["objective"]["max_ms"], 10)
+        self.assertEqual(profile["load"]["objective"]["cpu_saturation_percent"], 80)
         self.assertTrue(profile["load"]["allow_errors"])
         self.assertEqual(profile["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
 
@@ -279,6 +289,7 @@ class YdbBenchTest(unittest.TestCase):
                       start: 100
                       maximum: 1000
                       search-resolution-percent: 5
+                      cpu-saturation-percent: 85
                       slo: {percentile: p95, max-ms: 20}
             """))
         load = loaded.runs[0].parameters["local_ydb"]["load"]
@@ -286,6 +297,31 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(load["search"]["resolution_percent"], 5)
         self.assertEqual(load["objective"]["type"], "latency-slo")
         self.assertEqual(load["objective"]["percentile"], "p95")
+        self.assertEqual(load["objective"]["cpu_saturation_percent"], 85)
+
+    def test_local_ydb_legacy_slo_requires_known_mapping_fields(self):
+        invalid_slos = (
+            "1",
+            "{type: maximize-throughput, max-ms: 20}",
+        )
+        for index, slo in enumerate(invalid_slos):
+            with self.subTest(slo=slo), self.assertRaisesRegex(BenchmarkError, r"load\.slo"):
+                load_config(
+                    self._config(
+                        """
+                        local-ydb:
+                          invalid:
+                            workload: {type: kv, operation: upsert}
+                            load:
+                              mode: latency-slo
+                              parameter: rate
+                              start: 10
+                              maximum: 100
+                              slo: __SLO__
+                        """.replace("__SLO__", slo),
+                        name="invalid-slo-{}.yaml".format(index),
+                    )
+                )
 
     def test_local_ydb_profile_is_editable_by_web_builder(self):
         loaded = load_config(self._config("""
@@ -652,6 +688,38 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(no_feasible.outcome, "no-feasible-point")
         self.assertEqual(no_feasible.failing_load, 10)
 
+    def test_throughput_controller_keeps_zero_baseline_gain_json_safe(self):
+        result = load_control.search_load(
+            {
+                "parameter": "rate",
+                "search": {"start": 1, "maximum": 10, "multiplier": 2, "resolution_percent": 2},
+                "objective": {
+                    "type": "maximize-throughput",
+                    "target_role": "dynamic",
+                    "cpu_saturation_percent": 90,
+                    "plateau_gain_percent": 1,
+                    "plateau_points": 2,
+                },
+            },
+            lambda load: {
+                "throughput": 0 if load <= 4 else load,
+                "errors": 0,
+                "dynamic_cpu_mean": 20,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 30,
+            },
+        )
+        zero_baseline_probe = next(item for item in result.attempts if item["load"] == 7)
+        self.assertIsNone(zero_baseline_probe["throughput_gain_percent"])
+        self.assertIn("zero baseline", zero_baseline_probe["decision"])
+        json.dumps([dict(item) for item in result.attempts], allow_nan=False)
+
+    def test_atomic_json_rejects_non_finite_numbers(self):
+        path = self.root / "non-finite.json"
+        with self.assertRaisesRegex(BenchmarkError, "finite values"):
+            common.atomic_write_json(path, {"value": float("inf")})
+        self.assertFalse(path.exists())
+
     def test_load_controllers_can_accept_reported_request_errors(self):
         strict = load_control.search_load(
             {"parameter": "rate", "values": [10]},
@@ -737,6 +805,160 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(metrics["throughput"], 20)
         self.assertEqual(metrics["errors"], 100)
+
+    def test_local_ydb_scaling_uses_failing_boundary_and_minimum_attempt(self):
+        attempts = (
+            {"load": 50, "dynamic_cpu_mean": 90, "static_cpu_mean": 20},
+            {"load": 100, "dynamic_cpu_mean": 100, "static_cpu_mean": 20},
+        )
+        boundary = load_control.LoadSearchResult(
+            attempts,
+            50,
+            "latency SLO boundary",
+            "boundary-found",
+            passing_load=50,
+            failing_load=100,
+        )
+        evidence, reason = local_ydb._search_scaling_evidence(boundary, 95)
+        self.assertEqual(evidence["load"], 100)
+        self.assertEqual(reason, "failing-boundary")
+
+        minimum = load_control.LoadSearchResult(
+            (attempts[-1],),
+            None,
+            "minimum load failed",
+            "no-feasible-point",
+            failing_load=100,
+        )
+        evidence, reason = local_ydb._search_scaling_evidence(minimum, 95)
+        self.assertEqual(evidence["load"], 100)
+        self.assertEqual(reason, "minimum-failing-load")
+
+        dynamic_probe = load_control.LoadSearchResult(
+            (
+                {"load": 40, "throughput": 40, "dynamic_cpu_mean": 80, "static_cpu_mean": 20},
+                {"load": 70, "throughput": 35, "dynamic_cpu_mean": 100, "static_cpu_mean": 20},
+            ),
+            40,
+            "best observed point",
+            "best-observed",
+            passing_load=40,
+        )
+        evidence, reason = local_ydb._search_scaling_evidence(dynamic_probe, 95)
+        self.assertEqual(evidence["load"], 70)
+        self.assertEqual(reason, "dynamic-saturation")
+
+        static_boundary = load_control.LoadSearchResult(
+            (
+                {"load": 50, "dynamic_cpu_mean": 100, "static_cpu_mean": 20},
+                {"load": 100, "dynamic_cpu_mean": 100, "static_cpu_mean": 100},
+            ),
+            50,
+            "static CPU boundary",
+            "boundary-found",
+            passing_load=50,
+            failing_load=100,
+        )
+        evidence, reason = local_ydb._search_scaling_evidence(static_boundary, 95)
+        self.assertEqual(evidence["load"], 100)
+        self.assertEqual(reason, "failing-boundary")
+
+    def test_local_ydb_stops_cpu_monitor_when_node_dies_before_measurement(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              monitor-cleanup:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        command_result = runner.CommandResult(
+            command=("ydb", "workload", "kv", "init"),
+            stdout="",
+            stderr="",
+            exit_code=0,
+            started_at="2026-08-26T10:00:00+00:00",
+            finished_at="2026-08-26T10:00:01+00:00",
+            duration_seconds=1.0,
+        )
+        cluster = mock.Mock(
+            ydb_cli=Path("ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            dynamic_nodes=[{}],
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.return_value = (command_result, [command_result])
+        cluster._run.return_value = command_result
+        cluster.ensure_running.side_effect = BenchmarkError("dynamic node exited")
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        binaries = {
+            name: mock.Mock(path=self.root / name, sha256=name + "-digest", size=1)
+            for name in ("ydbd", "ydb_cli", "process_guard")
+        }
+        cpu_topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        with mock.patch.object(local_ydb, "LocalYdbCluster", return_value=cluster), mock.patch.object(
+            local_ydb, "LinuxCpuMonitor", return_value=monitor
+        ), mock.patch.object(local_ydb, "discover_topology", return_value=cpu_topology), mock.patch.object(
+            local_ydb, "collect_system_info", return_value={}
+        ):
+            with self.assertRaisesRegex(BenchmarkError, "dynamic node exited"):
+                local_ydb.run_local_ydb(
+                    binaries,
+                    configuration,
+                    self.root / "monitor-cleanup",
+                    tool_revision="test",
+                )
+
+        monitor.start.assert_called_once_with()
+        monitor.stop.assert_called_once_with()
+        cluster.stop.assert_called_once_with()
+
+    def test_local_ydb_ctrl_c_marks_profile_cancelled(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              interrupted-startup:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        cluster = mock.Mock()
+        cluster.start.side_effect = KeyboardInterrupt()
+        binaries = {
+            name: mock.Mock(path=self.root / name, sha256=name + "-digest", size=1)
+            for name in ("ydbd", "ydb_cli", "process_guard")
+        }
+        cpu_topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        output = self.root / "interrupted-startup"
+        with mock.patch.object(local_ydb, "LocalYdbCluster", return_value=cluster), mock.patch.object(
+            local_ydb, "discover_topology", return_value=cpu_topology
+        ), mock.patch.object(local_ydb, "collect_system_info", return_value={}):
+            with self.assertRaisesRegex(BenchmarkInterrupted, "was interrupted"):
+                local_ydb.run_local_ydb(binaries, configuration, output, tool_revision="test")
+
+        manifest = json.loads((output / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["status"], "interrupted")
+        self.assertEqual(manifest["state"], "cancelled")
+        self.assertEqual(manifest["progress"]["phase"], "cancelled")
+        cluster.stop.assert_called_once_with()
 
     def test_role_masks_are_split_without_overlap(self):
         masks = local_ydb._split_mask((0, 1, 2, 3, 4, 5), 3)
@@ -2710,7 +2932,7 @@ class WebTest(unittest.TestCase):
     def test_run_service_events_decodes_each_persisted_line_once(self):
         self._manifest(self.root / "complete")
         (self.root / "complete" / "events.jsonl").write_text(
-            '{"sequence":1,"type":"first"}\n{"sequence":2,"type":"second"}\n',
+            '{"sequence":1,"type":"first"}\n' '{"sequence":2,"type":"second","throughput_gain_percent":Infinity}\n',
             encoding="utf-8",
         )
         service = RunService(self.root)
@@ -2718,13 +2940,56 @@ class WebTest(unittest.TestCase):
         with mock.patch.object(web.json, "loads", wraps=loads) as decode:
             events = service.events("complete", after=1)
         self.assertEqual([event["type"] for event in events], ["second"])
+        self.assertIsNone(events[0]["throughput_gain_percent"])
         self.assertEqual(decode.call_count, 2)
+
+    def test_run_service_migrates_non_finite_manifest_values_on_recovery(self):
+        run_root = self.root / "non-finite-recovery"
+        self._manifest(run_root, "running")
+        path = run_root / "run.json"
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        manifest["attempts"] = [{"throughput_gain_percent": float("inf")}]
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        service = RunService(self.root)
+        try:
+            stored_text = path.read_text(encoding="utf-8")
+            stored = json.loads(stored_text)
+            self.assertNotIn("Infinity", stored_text)
+            self.assertIsNone(stored["attempts"][0]["throughput_gain_percent"])
+            self.assertEqual(stored["state"], "recovery_required")
+        finally:
+            service.shutdown()
+
+    def test_run_service_replays_events_evicted_from_live_deque(self):
+        def fake_executor(run, emit, _cancelled):
+            step_id = run["store"].manifest["steps"][0]["id"]
+            emit({"type": "step-started", "step_id": step_id})
+            for index in range(5):
+                emit({"type": "step-progress", "step_id": step_id, "fields": {"progress": {"index": index}}})
+            emit({"type": "step-finished", "step_id": step_id, "state": "passed"})
+
+        service = RunService(self.root, executor=fake_executor, event_limit=2)
+        try:
+            run_id = service.start(
+                "ping-bench:\n  replay: {threads: [1], duration: 1, repetitions: 1, affinity: [none]}\n"
+            )["id"]
+            run = service._runs[run_id]
+            self.assertTrue(run["finished"].wait(2))
+            replayed = service.events(run_id, after=0)
+            persisted = [json.loads(line) for line in (run["root"] / "events.jsonl").read_text().splitlines()]
+            self.assertGreater(len(replayed), service.event_limit)
+            self.assertEqual(replayed, persisted)
+            self.assertEqual(service.events(run_id, after=replayed[-3]["sequence"]), replayed[-2:])
+        finally:
+            service.shutdown()
 
     def test_local_ydb_profile_projection_supports_preparing_and_live_results(self):
         run_root = self.root / "local-ydb-run"
         self._manifest(run_root, "running")
         main_path = run_root / "run.json"
         main = json.loads(main_path.read_text(encoding="utf-8"))
+        main.update({"status": "queued", "state": "queued"})
         main["runs"] = []
         main["steps"] = [
             {
@@ -2800,6 +3065,60 @@ class WebTest(unittest.TestCase):
             self.assertEqual(projected["attempts"][0]["commands"][0]["argv"][-1], "add-rand-order")
             self.assertEqual(projected["timeout_seconds"], 300)
             self.assertEqual(projected["role_affinity"]["dynamic_nodes"], [1, 2])
+
+            main.update({"status": "recovery_required", "state": "recovery_required"})
+            main_path.write_text(json.dumps(main), encoding="utf-8")
+            recovered = service.local_ydb_profile("local-ydb-run", "capacity")
+            self.assertEqual(recovered["status"], "recovery_required")
+            self.assertEqual(recovered["state"], "recovery_required")
+        finally:
+            service.shutdown()
+
+    def test_local_ydb_profile_projection_preserves_terminal_state_without_nested_manifest(self):
+        run_root = self.root / "terminal-local-ydb-run"
+        self._manifest(run_root)
+        main_path = run_root / "run.json"
+        main = json.loads(main_path.read_text(encoding="utf-8"))
+        main.update({"status": "cancelled", "state": "cancelled"})
+        main["runs"] = []
+        main["steps"] = [
+            {
+                "id": "step-1",
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "affinity": "roles",
+                "threads": 64,
+                "case": 1,
+                "parameters": {},
+                "repeat": 1,
+                "state": "cancelled",
+                "reason": "cancelled before startup",
+                "artifacts": [],
+            }
+        ]
+        main_path.write_text(json.dumps(main), encoding="utf-8")
+        service = RunService(self.root)
+        try:
+            cancelled = service.local_ydb_profile("terminal-local-ydb-run", "capacity")
+            self.assertEqual(cancelled["status"], "cancelled")
+            self.assertEqual(cancelled["state"], "cancelled")
+
+            main.update({"status": "failed", "state": "failed", "error": "startup failed"})
+            main["runs"] = [
+                {
+                    "benchmark": "local-ydb",
+                    "profile": "capacity",
+                    "status": "failed",
+                    "directory": "local-ydb/capacity",
+                    "error": "startup failed",
+                }
+            ]
+            main["steps"][0].update({"state": "failed", "error": "startup failed"})
+            main_path.write_text(json.dumps(main), encoding="utf-8")
+            failed = service.local_ydb_profile("terminal-local-ydb-run", "capacity")
+            self.assertEqual(failed["status"], "failed")
+            self.assertEqual(failed["state"], "failed")
+            self.assertEqual(failed["error"], "startup failed")
         finally:
             service.shutdown()
 
@@ -2927,6 +3246,24 @@ class WebTest(unittest.TestCase):
         self.assertIsNone(value["series"][0]["cpus"])
         self.assertEqual(value["series"][1]["cpus"], [0, 1, 2, 4])
         self.assertIn("dimension_metadata", value)
+
+    def test_local_ydb_summary_is_available_to_comparison_charts(self):
+        self._manifest(self.root / "complete")
+        summary = self.root / "complete" / "local-ydb" / "capacity" / "summary.csv"
+        summary.parent.mkdir(parents=True)
+        row = {"load": 10, "dynamic_nodes": 2}
+        row.update({metric.name: index + 1 for index, metric in enumerate(LOCAL_YDB_BENCHMARK.metrics)})
+        summarized = LOCAL_YDB_BENCHMARK.summarize_metrics([row], LOCAL_YDB_BENCHMARK)
+        summary.write_text(
+            LOCAL_YDB_BENCHMARK.render_summary(summarized, LOCAL_YDB_BENCHMARK),
+            encoding="utf-8",
+        )
+
+        value = chart_data(self.root, ["complete"])
+        self.assertEqual(len(value["series"]), 1)
+        self.assertEqual(value["series"][0]["benchmark"], "local-ydb")
+        self.assertEqual(value["series"][0]["affinity"], "roles")
+        self.assertEqual(value["series"][0]["rows"][0]["load"], 10)
 
     def test_memory_fairness_is_derived_per_repeat_before_aggregation(self):
         dimensions = ["threads", "random_percent", "scope", "worker_aggregation"]

--- a/ydb/tools/ydb_bench/ya.make
+++ b/ydb/tools/ydb_bench/ya.make
@@ -16,6 +16,40 @@ BUNDLE(
     ydb/tools/ydb_bench/background NAME background_load
 )
 
+BUNDLE(
+    ydb/tools/ydb_bench/process_guard NAME process_guard_binary
+)
+
+IF(BUILD_TYPE == PROFILE)
+    BUNDLE(
+        ydb/apps/ydbd NAME ydbd
+    )
+
+    BUNDLE(
+        ydb/apps/ydb NAME ydb_cli
+    )
+ELSE()
+    BUNDLE(
+        ydb/apps/ydbd NAME ydbd.unstripped
+    )
+
+    RUN_PROGRAM(
+        contrib/libs/llvm18/tools/llvm-objcopy --strip-all ydbd.unstripped ydbd
+        IN ydbd.unstripped
+        OUT ydbd
+    )
+
+    BUNDLE(
+        ydb/apps/ydb NAME ydb_cli.unstripped
+    )
+
+    RUN_PROGRAM(
+        contrib/libs/llvm18/tools/llvm-objcopy --strip-all ydb_cli.unstripped ydb_cli
+        IN ydb_cli.unstripped
+        OUT ydb_cli
+    )
+ENDIF()
+
 RESOURCE(
     actors_core_ut_fat actors_core_ut_fat
 )
@@ -28,6 +62,18 @@ RESOURCE(
     background_load background_load
 )
 
+RESOURCE(
+    process_guard_binary process_guard
+)
+
+RESOURCE(
+    ydbd ydbd
+)
+
+RESOURCE(
+    ydb_cli ydb_cli
+)
+
 RESOURCE(- ydb_bench/build_type=${BUILD_TYPE})
 
 PEERDIR(
@@ -37,6 +83,10 @@ PEERDIR(
 )
 
 END()
+
+RECURSE(
+    process_guard
+)
 
 RECURSE_FOR_TESTS(
     tests


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added a local YDB capacity benchmark with YDB CLI workloads, adaptive load search, role-aware CPU metrics, and live web results.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The benchmark runs bundled YDB server and CLI binaries against an isolated SectorMap-backed cluster, searches throughput or latency targets, and records per-role telemetry and live search progress.