### PR TITLE
feat: persist scheme change records in SchemeShard

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -308,6 +308,16 @@ enum ESimpleCounters {
     COUNTER_IN_FLIGHT_OPS_TxDropTestShardSet = 238        [(CounterOpts) = {Name: "InFlightOps/DropTestShardSet"}];
 
     COUNTER_RUNNING_STREAMING_QUERY_COUNT = 239           [(CounterOpts) = {Name: "RunningStreamingQueryCount"}];
+
+    // Scheme change outbox. DDL is rejected once depth reaches
+    // MaxSchemeChangeRecords; only an admin force-advance releases it.
+    COUNTER_SCHEME_CHANGE_OUTBOX_DEPTH = 240              [(CounterOpts) = {Name: "SchemeChangeOutboxDepth"}];
+    COUNTER_SCHEME_CHANGE_SUBSCRIBERS = 241               [(CounterOpts) = {Name: "SchemeChangeSubscribers"}];
+    // Has an unrecoverable hole in its stream; must resync from a full snapshot.
+    COUNTER_SCHEME_CHANGE_SUBSCRIBERS_LOST = 242          [(CounterOpts) = {Name: "SchemeChangeSubscribersLost"}];
+    // Idle beyond the stale TTL. Records are still retained, so unlike Lost
+    // this subscriber has lost nothing.
+    COUNTER_SCHEME_CHANGE_SUBSCRIBERS_STALE = 243         [(CounterOpts) = {Name: "SchemeChangeSubscribersStale"}];
 }
 
 enum ECumulativeCounters {
@@ -512,6 +522,17 @@ enum ECumulativeCounters {
 
     // Total time spent in TSchemeShard::Handle(TEvDataShard::TEvPeriodicTableStats), in nanoseconds.
     COUNTER_PERIODIC_TABLE_STATS_HANDLE_TIME_NS = 151 [(CounterOpts) = {Name: "PeriodicTableStatsHandleTimeNs"}];
+
+    // Scheme change outbox.
+    COUNTER_SCHEME_CHANGE_DDL_REJECTED = 152             [(CounterOpts) = {Name: "SchemeChangeDdlRejectedByOutbox"}];
+    // Rows the outbox transactions actually walk. Bounded work keeps this
+    // proportional to rows delivered; a regression that reintroduces an
+    // unbounded scan shows up here as a rate spike with no matching delivery.
+    COUNTER_SCHEME_CHANGE_ROWS_SCANNED = 153             [(CounterOpts) = {Name: "SchemeChangeOutboxRowsScanned"}];
+    COUNTER_SCHEME_CHANGE_DESCRIPTION_BYTES = 154        [(CounterOpts) = {Name: "SchemeChangeDescriptionBytes"}];
+    // An op resolved to no path at propose, so no record was written for it.
+    // Any non-zero value is an extraction gap in the outbox, not a client error.
+    COUNTER_SCHEME_CHANGE_PATH_MISSING = 155             [(CounterOpts) = {Name: "SchemeChangePathMissing"}];
 }
 
 enum EPercentileCounters {
@@ -841,4 +862,13 @@ enum ETxTypes {
     TXTYPE_LIST_SET_COLUMN_CONSTRAINT = 127             [(TxTypeOpts) = {Name: "TxListSetColumnConstraint"}];
     TXTYPE_FORGET_SET_COLUMN_CONSTRAINT = 128          [(TxTypeOpts) = {Name: "TxForgetSetColumnConstraint"}];
     TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT = 129             [(TxTypeOpts) = {Name: "TxCancelSetColumnConstraint"}];
+
+    // Scheme change records subscriber protocol + maintenance.
+    TXTYPE_REGISTER_SCHEME_CHANGE_SUBSCRIBER = 130   [(TxTypeOpts) = {Name: "TxRegisterSchemeChangeSubscriber"}];
+    TXTYPE_UNREGISTER_SCHEME_CHANGE_SUBSCRIBER = 131 [(TxTypeOpts) = {Name: "TxUnregisterSchemeChangeSubscriber"}];
+    TXTYPE_FETCH_SCHEME_CHANGE_RECORDS = 132         [(TxTypeOpts) = {Name: "TxFetchSchemeChangeRecords"}];
+    TXTYPE_FETCH_SCHEME_CHANGE_RECORD_BODIES = 133   [(TxTypeOpts) = {Name: "TxFetchSchemeChangeRecordBodies"}];
+    TXTYPE_ACK_SCHEME_CHANGE_RECORDS = 134           [(TxTypeOpts) = {Name: "TxAckSchemeChangeRecords"}];
+    TXTYPE_SCHEME_CHANGE_RECORDS_CLEANUP = 135       [(TxTypeOpts) = {Name: "TxSchemeChangeRecordsCleanup"}];
+    TXTYPE_FORCE_ADVANCE_SCHEME_CHANGE_SUBSCRIBER = 136 [(TxTypeOpts) = {Name: "TxForceAdvanceSchemeChangeSubscriber"}];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -372,4 +372,5 @@ message TFeatureFlags {
     // Offloads TEvDataShard::TEvPeriodicTableStats parsing to a dedicated aux actor to reduce
     // SchemeShard's single-threaded load.
     optional bool EnablePeriodicTableStatsParseOffload = 317 [default = false];
+    optional bool EnableSchemeChangeRecords = 318 [default = false];
 }

--- a/ydb/core/protos/schemeshard/scheme_change_records.proto
+++ b/ydb/core/protos/schemeshard/scheme_change_records.proto
@@ -1,0 +1,46 @@
+// Scheme change records subscriber protocol. Subscribers register with a
+// stable string ID, fetch records in order, pull bodies for the subset they
+// need, and ack consumed ranges.
+syntax = "proto3";
+
+package NKikimrSchemeShard;
+
+option java_package = "ru.yandex.kikimr.proto";
+
+
+// One target of a scheme change: the object's identity after the change,
+// and where it came from if the op moves or copies. Cardinality of
+// SourcePaths is not assumed 1:1 with the target: a rename has one source
+// for one target, but a future N-sources-into-one-target op would list all
+// of them here rather than picking one arbitrarily -- a consumer must not
+// assume SourcePaths[0] is the only source.
+message TSchemeChangeTarget {
+    // The target's identity after the change. Always set, never empty.
+    string Path = 1;
+    // Old location(s) this target came from: the prior path for a
+    // move/rename, the source table for a copy target. Empty for a plain
+    // create/alter/drop. May hold more than one entry.
+    repeated string SourcePaths = 2;
+}
+
+// Wire/storage encoding for a record's N authoritative targets. Used both as
+// the local-DB column payload (a delimiter could occur inside a path, so a
+// serialized repeated-message is the safe encoding) and internally when
+// carrying targets through in-memory operation state.
+message TSchemeChangeRecordTargets {
+    repeated TSchemeChangeTarget Targets = 1;
+}
+
+// How precisely a record's PlanStep locates it in the coordinator timeline.
+message TSchemeChangePosition {
+    enum EKind {
+        KIND_UNSPECIFIED = 0;
+        // PlanStep is the coordinator step this operation was actually planned
+        // at. Safe to interleave against data records carrying the same clock.
+        KIND_EXACT = 1;
+        // The operation never reached a coordinator, so PlanStep is a LOWER
+        // BOUND: the highest step already applied. Use for window assignment
+        // only; such records touched no shard.
+        KIND_BUCKETED = 2;
+    }
+}

--- a/ydb/core/protos/schemeshard/ya.make
+++ b/ydb/core/protos/schemeshard/ya.make
@@ -9,7 +9,12 @@ IF (OS_WINDOWS)
     NO_OPTIMIZE_PY_PROTOS()
 ENDIF()
 
+PEERDIR(
+    ydb/core/scheme/protos
+)
+
 SRCS(
+    scheme_change_records.proto
     operations.proto
 )
 

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -88,6 +88,7 @@ public:
     FEATURE_FLAG_SETTER(EnableCsDictionaryEncoding)
     FEATURE_FLAG_SETTER(EnableDataShardDetailedMetrics)
     FEATURE_FLAG_SETTER(EnableTopicDeferredPublish)
+    FEATURE_FLAG_SETTER(EnableSchemeChangeRecords)
     #undef FEATURE_FLAG_SETTER
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1375,6 +1375,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_NextPathId, Self->NextLocalPathId));
         RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_NextShardIdx, Self->NextLocalShardIdx));
+        RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_NextSchemeChangeOrder, Self->NextSchemeChangeOrder));
+        RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_LastAssignedPlanStep, Self->LastAssignedPlanStep));
+        RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_SchemeChangeFloorOrder, Self->SchemeChangeFloorOrder));
+
 
         {
             ui64 isReadOnlyModeVal = 0;
@@ -3967,6 +3971,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 txState.MinStep =       txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::MinStep>(InvalidStepId);
                 txState.PlanStep =      txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::PlanStep>(InvalidStepId);
+                if (txState.PlanStep != InvalidStepId) {
+                    Self->AddInFlightPlanStep(ui64(txState.PlanStep));
+                }
+                if (txState.PlanStep != InvalidStepId && ui64(txState.PlanStep) > Self->LastAssignedPlanStep) {
+                    Self->LastAssignedPlanStep = ui64(txState.PlanStep);
+                }
 
                 TString extraData =     txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::ExtraBytes>("");
                 txState.StartTime =     TInstant::MicroSeconds(txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::StartTime>());
@@ -3993,6 +4003,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         Self->PersistRemoveTx(db, operationId, txState);
                         skippedOrphanTxs.insert(operationId);
                         skippedOrphanTxIds.insert(operationId.GetTxId());
+                        // Undo the bump above: RemoveTx never runs for this tx,
+                        // so its step would pin ClosedThroughPlanStep forever.
+                        if (txState.PlanStep != InvalidStepId) {
+                            Self->RemoveInFlightPlanStep(ui64(txState.PlanStep));
+                        }
                         Self->TxInFlight.erase(operationId);
                         if (!txInFlightRowset.Next())
                             return false;
@@ -4338,6 +4353,44 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (!rowset.Next()) {
                     return false;
+                }
+            }
+        }
+
+        {
+            auto rowset = db.Table<Schema::SchemeChangePendingRecords>().Range().Select();
+            if (!rowset.IsReady()) return false;
+            THashMap<TTxId, TMap<ui32, TOperation::TSchemeChangeSlot>> byTx;
+            while (!rowset.EndOfSet()) {
+                TTxId txId = rowset.GetValue<Schema::SchemeChangePendingRecords::TxId>();
+                ui32 idx = rowset.GetValue<Schema::SchemeChangePendingRecords::RequestIdx>();
+                TOperation::TSchemeChangeSlot slot;
+                slot.RequestIdx = idx;
+                slot.Order = rowset.GetValue<Schema::SchemeChangePendingRecords::Order>();
+                slot.Targets = TSchemeShard::DecodeSchemeChangeTargets(
+                    rowset.GetValueOrDefault<Schema::SchemeChangePendingRecords::Path>(""));
+                byTx[txId][idx] = std::move(slot);
+                if (!rowset.Next()) return false;
+            }
+            for (auto& [txId, idxMap] : byTx) {
+                auto opIt = Self->Operations.find(txId);
+                if (opIt == Self->Operations.end()) {
+                    // No operation survived to finalise these rows. Leaving
+                    // CompletedAtUs at 0 would wedge the fetch stream forever.
+                    using T = Schema::SchemeChangeRecords;
+                    for (auto& [idx, slot] : idxMap) {
+                        db.Table<T>().Key(slot.Order).Update(
+                            NIceDb::TUpdate<T::Status>(ui32(NKikimrScheme::StatusPreconditionFailed)),
+                            NIceDb::TUpdate<T::CompletedAtUs>(ctx.Now().MicroSeconds())
+                        );
+                        Self->PersistRemoveSchemeChangePendingOrder(db, txId, idx);
+                    }
+                    continue;
+                }
+                opIt->second->SchemeChangeSlots.clear();
+                opIt->second->SchemeChangeSlots.reserve(idxMap.size());
+                for (auto& [idx, slot] : idxMap) {
+                    opIt->second->SchemeChangeSlots.push_back(std::move(slot));
                 }
             }
         }
@@ -6770,6 +6823,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         });
 
         Self->ScheduleForcedCompactionProgress(ctx);
+
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -308,6 +308,33 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
         }
     }
 
+    // Must stay after every ProcessOperationParts call: writing via NIceDb sets
+    // DirectAccessGranted, which trips Y_VERIFY_S(IsUndoChangesSafe) in a later part.
+
+    // An unresolvable target is skipped and counted, never refused: refusing runs
+    // AbortOperationPropose, whose per-operation stubs are Y_ABORT in 45 places.
+    if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+        NIceDb::TNiceDb db(context.GetDB());
+        operation->SchemeChangeOrderBase = NextSchemeChangeOrder;
+        operation->SchemeChangeOrdersReserved = true;
+        for (ui32 i = 0; i < rewrittenTransactions.size(); ++i) {
+            TString skipReason;
+            if (!CheckSchemeChangeRecordHasPath(rewrittenTransactions[i], skipReason)) {
+                TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_PATH_MISSING].Increment(1);
+                LOG_WARN_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    "scheme change record skipped, target path unresolved"
+                        << ", txId: " << txId
+                        << ", requestIdx: " << i
+                        << ", reason: " << skipReason);
+                continue;
+            }
+            TOperation::TSchemeChangeSlot slot;
+            if (PersistSchemeChangeRecordAtPropose(db, txId, i, rewrittenTransactions[i], slot)) {
+                operation->SchemeChangeSlots.push_back(std::move(slot));
+            }
+        }
+    }
+
     return response;
 }
 
@@ -325,6 +352,11 @@ void TSchemeShard::AbortOperationPropose(const TTxId txId, TOperationContext& co
     }
 
     context.MemChanges.UnDo(context.SS);
+
+    // The local-DB rollback reverts the persisted counter, but not this one.
+    if (operation->SchemeChangeOrdersReserved) {
+        NextSchemeChangeOrder = operation->SchemeChangeOrderBase;
+    }
 
     // And remove aborted operation from existence
     Operations.erase(txId);
@@ -702,6 +734,16 @@ struct TSchemeShard::TTxOperationPlanStep: public NTabletFlatExecutor::TTransact
                         << ", message: " << record.ShortDebugString()
                         << ", at schemeshard: " << Self->TabletID());
 
+        // Flag-guarded: without it, every plan step of every cluster writes a
+        // SysParams row for a ceiling only the outbox ever reads.
+        if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()
+            && ui64(step) > Self->LastAssignedPlanStep)
+        {
+            Self->LastAssignedPlanStep = ui64(step);
+            NIceDb::TNiceDb db(txc.DB);
+            Self->PersistUpdateLastAssignedPlanStep(db);
+        }
+
         for (size_t i = 0; i < txCount; ++i) {
             const auto txId = TTxId(record.GetTransactions(i).GetTxId());
             const auto coordinator = ActorIdFromProto(record.GetTransactions(i).GetAckTo());
@@ -728,6 +770,14 @@ struct TSchemeShard::TTxOperationPlanStep: public NTabletFlatExecutor::TTransact
                                     << " operation part is already done"
                                     << ", operationId: " << opId);
                     continue;
+                }
+
+                if (auto* txState = Self->FindTx(opId)) {
+                    // A redelivered plan step (mediator reconnect) must not bump the refcount twice.
+                    if (txState->PlanStep == InvalidStepId) {
+                        Self->AddInFlightPlanStep(ui64(step));
+                    }
+                    txState->PlanStep = step;
                 }
 
                 TOperationContext context{Self, txc, ctx, OnComplete, MemChanges, DbChanges};

--- a/ydb/core/tx/schemeshard/schemeshard__operation.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.h
@@ -14,6 +14,25 @@ struct TOperation: TSimpleRefCount<TOperation> {
     ui32 PreparedParts = 0;
     TVector<ISubOperation::TPtr> Parts;
 
+    struct TSchemeChangeTarget {
+        TString Path;
+        TVector<TString> SourcePaths;
+    };
+
+    struct TSchemeChangeSlot {
+        ui32 RequestIdx = 0;
+        ui64 Order = 0;
+        // Carried in memory because finalisation cannot re-read it.
+        TVector<TSchemeChangeTarget> Targets;
+        TString UserSid;
+    };
+    TVector<TSchemeChangeSlot> SchemeChangeSlots;
+
+    // Abort rewinds NextSchemeChangeOrder to this. The flag is needed because
+    // base 0 is a valid value.
+    ui64 SchemeChangeOrderBase = 0;
+    bool SchemeChangeOrdersReserved = false;
+
     THashSet<TActorId> Subscribers;
     THashSet<TTxId> DependentOperations;
     THashSet<TTxId> WaitOperations;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -3,8 +3,11 @@
 #include "schemeshard__operation_db_changes.h"
 #include "schemeshard__operation_memory_changes.h"
 #include "schemeshard_impl.h"
+#include "schemeshard_path_describer.h"
 
 #include <ydb/core/tx/tx_processing.h>
+
+#include <util/string/join.h>
 
 namespace NKikimr {
 namespace NSchemeShard {
@@ -984,7 +987,65 @@ void TSideEffects::DoFireFullBackupItemDone(TSchemeShard* ss, const TActorContex
     PendingFullBackupItemDone.clear();
 }
 
+
+void TSideEffects::DoPersistSchemeChangeRecords(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx) {
+    if (DoneTransactions.empty()) {
+        return;
+    }
+
+    // Runs regardless of whether a subscriber exists now: what matters is whether one existed at propose.
+    NIceDb::TNiceDb db(txc.DB);
+
+    for (const auto& txId : DoneTransactions) {
+        auto opIt = ss->Operations.find(txId);
+        if (opIt == ss->Operations.end() || !opIt->second->IsReadyToDone(ctx)) {
+            continue;
+        }
+        const TOperation::TPtr& operation = opIt->second;
+        if (operation->SchemeChangeSlots.empty()) {
+            continue;
+        }
+
+        TStepId planStep = InvalidStepId;
+        // EPathStateDrop on a part's target means AbortUnsafe force-completed it.
+        bool aborted = false;
+        for (ui32 partIdx = 0; partIdx < operation->Parts.size(); ++partIdx) {
+            auto it = ss->TxInFlight.find(TOperationId(txId, partIdx));
+            if (it == ss->TxInFlight.end()) {
+                continue;
+            }
+            if (planStep == InvalidStepId && it->second.PlanStep != InvalidStepId) {
+                planStep = it->second.PlanStep;
+            }
+            if (auto* path = ss->PathsById.FindPtr(it->second.TargetPathId)) {
+                if ((*path)->PathState == NKikimrSchemeOp::EPathState::EPathStateDrop) {
+                    aborted = true;
+                }
+            }
+        }
+
+        for (const auto& slot : operation->SchemeChangeSlots) {
+            ss->FinalizeSchemeChangeRecord(db, ctx, slot, planStep, aborted);
+            ss->PersistRemoveSchemeChangePendingOrder(db, txId, slot.RequestIdx);
+
+
+            TVector<TString> targetPaths;
+            for (const auto& t : slot.Targets) {
+                targetPaths.push_back(t.Path);
+            }
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "DoPersistSchemeChangeRecords: finalised record"
+                    << " order=" << slot.Order
+                    << " txId=" << txId
+                    << " requestIdx=" << slot.RequestIdx
+                    << " paths=" << JoinSeq(",", targetPaths)
+                    << " planStep=" << planStep);
+        }
+    }
+}
+
 void TSideEffects::DoDoneTransactions(TSchemeShard *ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx) {
+    DoPersistSchemeChangeRecords(ss, txc, ctx);  // persist scheme change records before operations are erased
     for (auto& txId: DoneTransactions) {
 
         if (!ss->Operations.contains(txId)) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
@@ -165,6 +165,7 @@ private:
     void DoReleasePathState(TSchemeShard* ss, const TActorContext &ctx);
     void DoDoneParts(TSchemeShard* ss, const TActorContext& ctx);
     void DoDoneTransactions(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext& ctx);
+    void DoPersistSchemeChangeRecords(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx);
     void DoReadyToNotify(TSchemeShard* ss, const TActorContext& ctx);
 
     void DoPersistDependencies(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__scheme_change_records.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__scheme_change_records.cpp
@@ -1,0 +1,522 @@
+#include "schemeshard_impl.h"
+#include "schemeshard_path_describer.h"
+
+#include <ydb/core/protos/schemeshard/scheme_change_records.pb.h>
+
+#include <util/string/join.h>
+
+namespace NKikimr::NSchemeShard {
+
+namespace {
+
+struct TSchemeChangeRawTarget {
+    TString AbsDstPath;
+    TString AbsSrcPath;
+};
+
+TMaybe<TSchemeChangeRawTarget> ExtractSchemeChangeMoveTarget(const NKikimrSchemeOp::TModifyScheme& tx) {
+    if (tx.HasMoveTable()) {
+        return TSchemeChangeRawTarget{tx.GetMoveTable().GetDstPath(), tx.GetMoveTable().GetSrcPath()};
+    }
+    if (tx.HasMoveTableIndex()) {
+        return TSchemeChangeRawTarget{tx.GetMoveTableIndex().GetDstPath(), tx.GetMoveTableIndex().GetSrcPath()};
+    }
+    if (tx.HasMoveSequence()) {
+        return TSchemeChangeRawTarget{tx.GetMoveSequence().GetDstPath(), tx.GetMoveSequence().GetSrcPath()};
+    }
+    if (tx.HasMoveIndex()) {
+        // TMoveIndex Src/DstPath are relative to TablePath, not absolute
+        // (index/operation_move_index.cpp: mainTablePath.Child).
+        const auto& moveIndex = tx.GetMoveIndex();
+        return TSchemeChangeRawTarget{
+            TStringBuilder() << moveIndex.GetTablePath() << '/' << moveIndex.GetDstPath(),
+            TStringBuilder() << moveIndex.GetTablePath() << '/' << moveIndex.GetSrcPath()};
+    }
+    return Nothing();
+}
+
+TVector<TSchemeChangeRawTarget> ExtractSchemeChangeCopyTargets(const NKikimrSchemeOp::TModifyScheme& tx) {
+    TVector<TSchemeChangeRawTarget> result;
+    if (tx.HasCreateConsistentCopyTables()) {
+        for (const auto& copy : tx.GetCreateConsistentCopyTables().GetCopyTableDescriptions()) {
+            result.push_back(TSchemeChangeRawTarget{copy.GetDstPath(), copy.GetSrcPath()});
+        }
+    }
+    return result;
+}
+
+// Found via reflection so a newly added object type needs no switch entry.
+TString ExtractSchemeChangeTargetName(const NKikimrSchemeOp::TModifyScheme& tx) {
+    if (tx.HasCreateIndexedTable()) {
+        return tx.GetCreateIndexedTable().GetTableDescription().GetName();
+    }
+    // Only the standalone alter sets PathName. Create-with-attrs carries the same
+    // message with PathName unset, and its target is named by its own payload.
+    if (tx.HasAlterUserAttributes() && !tx.GetAlterUserAttributes().GetPathName().empty()) {
+        return tx.GetAlterUserAttributes().GetPathName();
+    }
+    // These name their target TableName, not Name. Restore's and Backup's AbortPropose
+    // are unconditional Y_ABORT stubs: an unresolved path crashes the tablet.
+    if (tx.HasTruncateTable()) {
+        return tx.GetTruncateTable().GetTableName();
+    }
+    if (tx.HasCreateContinuousBackup()) {
+        return tx.GetCreateContinuousBackup().GetTableName();
+    }
+    if (tx.HasAlterContinuousBackup()) {
+        return tx.GetAlterContinuousBackup().GetTableName();
+    }
+    if (tx.HasDropContinuousBackup()) {
+        return tx.GetDropContinuousBackup().GetTableName();
+    }
+    if (tx.HasRestore()) {
+        return tx.GetRestore().GetTableName();
+    }
+    if (tx.HasBackup()) {
+        return tx.GetBackup().GetTableName();
+    }
+    if (tx.HasInitiateBuildIndexMainTable()) {
+        return tx.GetInitiateBuildIndexMainTable().GetTableName();
+    }
+    if (tx.HasFinalizeBuildIndexMainTable()) {
+        return tx.GetFinalizeBuildIndexMainTable().GetTableName();
+    }
+    if (tx.HasDropIndex()) {
+        return TStringBuilder() << tx.GetDropIndex().GetTableName() << '/' << tx.GetDropIndex().GetIndexName();
+    }
+    // WorkingDir is already the index path, so the impl table name completes it.
+    if (tx.HasPrepareIndexValidation()) {
+        return tx.GetPrepareIndexValidation().GetTableName();
+    }
+
+    const auto* refl = tx.GetReflection();
+    std::vector<const google::protobuf::FieldDescriptor*> setFields;
+    refl->ListFields(tx, &setFields);
+
+    for (const auto* field : setFields) {
+        if (field->is_repeated()
+            || field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            continue;
+        }
+        const auto& sub = refl->GetMessage(tx, field);
+        const auto* nameField = sub.GetDescriptor()->FindFieldByName("Name");
+        if (!nameField
+            || nameField->is_repeated()
+            || nameField->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_STRING) {
+            continue;
+        }
+        const auto* subRefl = sub.GetReflection();
+        if (!subRefl->HasField(sub, nameField)) {
+            continue;
+        }
+        TString name = subRefl->GetString(sub, nameField);
+        if (!name.empty()) {
+            return name;
+        }
+    }
+    return {};
+}
+
+// Anchored on TPath::Root, not GetDomainPathString: a new subdomain is already its own domain root.
+TString RelativeToDomain(const TPath& resolved, TSchemeShard* ss) {
+    TString abs = resolved.PathString();
+    TString domain = TPath::Root(ss).PathString();
+    Y_DEBUG_ABORT_UNLESS(abs.StartsWith(domain));
+    TString rel = abs.substr(domain.size());
+    if (!rel.empty() && rel[0] == '/') {
+        rel = rel.substr(1);
+    }
+    return rel;
+}
+
+struct TResolvedSchemeChangeTarget {
+    TString Absolute;
+    TString Relative;
+    TVector<TString> RelativeSources;
+};
+
+TString RelativeSourceToDomain(const TString& absSrcPath, TSchemeShard* ss) {
+    if (absSrcPath.empty()) {
+        return {};
+    }
+    TPath src = TPath::Resolve(absSrcPath, ss);
+    if (src.IsResolved()) {
+        return RelativeToDomain(src, ss);
+    }
+    TString domain = TPath::Root(ss).PathString();
+    if (absSrcPath.StartsWith(domain)) {
+        TString rel = absSrcPath.substr(domain.size());
+        if (!rel.empty() && rel[0] == '/') {
+            rel = rel.substr(1);
+        }
+        return rel;
+    }
+    return absSrcPath;
+}
+
+TMaybe<TResolvedSchemeChangeTarget> ResolveRawTarget(const TSchemeChangeRawTarget& raw, TSchemeShard* ss) {
+    TVector<TString> relSources;
+    if (!raw.AbsSrcPath.empty()) {
+        relSources.push_back(RelativeSourceToDomain(raw.AbsSrcPath, ss));
+    }
+    TPath target = TPath::Resolve(raw.AbsDstPath, ss);
+    if (target.IsResolved()) {
+        return TResolvedSchemeChangeTarget{raw.AbsDstPath, RelativeToDomain(target, ss), relSources};
+    }
+    TPath parent = TPath::Resolve(TString(TStringBuf(raw.AbsDstPath).RBefore('/')), ss);
+    if (parent.IsResolved()) {
+        TString relParent = RelativeToDomain(parent, ss);
+        if (!relParent.empty()) {
+            relParent += '/';
+        }
+        TString leaf = TString(TStringBuf(raw.AbsDstPath).RAfter('/'));
+        return TResolvedSchemeChangeTarget{raw.AbsDstPath, relParent + leaf, relSources};
+    }
+    return Nothing();
+}
+
+// Deliberately not dispatched on op type: ConvertToTxType collapses many EOperationType onto TxInvalid.
+// Changefeed ops name their target <TableName>/<StreamName> under WorkingDir -- two
+// levels down, so neither a direct-child lookup nor the reflection walk finds it.
+// TDropCdcStream.StreamName is repeated: one op can drop N changefeeds.
+TVector<TSchemeChangeRawTarget> ExtractSchemeChangeCdcTargets(const NKikimrSchemeOp::TModifyScheme& tx) {
+    TVector<TSchemeChangeRawTarget> result;
+    auto stream = [&tx](const TString& table, const TString& name) {
+        return TString(TStringBuilder() << tx.GetWorkingDir() << '/' << table << '/' << name);
+    };
+    if (tx.HasCreateCdcStream()) {
+        const auto& op = tx.GetCreateCdcStream();
+        result.push_back(TSchemeChangeRawTarget{
+            stream(op.GetTableName(), op.GetStreamDescription().GetName()), {}});
+    } else if (tx.HasAlterCdcStream()) {
+        const auto& op = tx.GetAlterCdcStream();
+        result.push_back(TSchemeChangeRawTarget{
+            stream(op.GetTableName(), op.GetStreamName()), {}});
+    } else if (tx.HasDropCdcStream()) {
+        const auto& op = tx.GetDropCdcStream();
+        for (const auto& name : op.GetStreamName()) {
+            result.push_back(TSchemeChangeRawTarget{stream(op.GetTableName(), name), {}});
+        }
+    } else if (tx.HasRotateCdcStream()) {
+        // The new stream is the identity afterwards; the retired one is its source.
+        const auto& op = tx.GetRotateCdcStream();
+        result.push_back(TSchemeChangeRawTarget{
+            stream(op.GetTableName(), op.GetNewStream().GetStreamDescription().GetName()),
+            stream(op.GetTableName(), op.GetOldStreamName())});
+    }
+    return result;
+}
+
+TMaybe<TVector<TResolvedSchemeChangeTarget>> ResolveSchemeChangeTargets(const NKikimrSchemeOp::TModifyScheme& requestTx, TSchemeShard* ss) {
+    const TVector<TSchemeChangeRawTarget> copyTargets = ExtractSchemeChangeCopyTargets(requestTx);
+    if (!copyTargets.empty()) {
+        TVector<TResolvedSchemeChangeTarget> result;
+        for (const auto& raw : copyTargets) {
+            TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(raw, ss);
+            if (!resolved) {
+                return Nothing();
+            }
+            result.push_back(std::move(*resolved));
+        }
+        return result;
+    }
+
+    const TVector<TSchemeChangeRawTarget> cdcTargets = ExtractSchemeChangeCdcTargets(requestTx);
+    if (!cdcTargets.empty()) {
+        TVector<TResolvedSchemeChangeTarget> result;
+        for (const auto& raw : cdcTargets) {
+            TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(raw, ss);
+            if (!resolved) {
+                return Nothing();
+            }
+            result.push_back(std::move(*resolved));
+        }
+        return result;
+    }
+
+    TMaybe<TSchemeChangeRawTarget> moveTarget = ExtractSchemeChangeMoveTarget(requestTx);
+    if (moveTarget) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(*moveTarget, ss);
+        if (!resolved) {
+            return Nothing();
+        }
+        return TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)};
+    }
+
+    if (requestTx.HasAlterLogin()) {
+        TPath workingDir = TPath::Resolve(requestTx.GetWorkingDir(), ss);
+        if (workingDir.IsResolved()) {
+            return TVector<TResolvedSchemeChangeTarget>{
+                TResolvedSchemeChangeTarget{requestTx.GetWorkingDir(), RelativeToDomain(workingDir, ss), {}}};
+        }
+        return Nothing();
+    }
+
+    if (requestTx.HasInitiateIndexBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetInitiateIndexBuild().GetTable(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    // Column builds carry an absolute table path, like InitiateIndexBuild.
+    if (requestTx.HasInitiateColumnBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetInitiateColumnBuild().GetTable(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    if (requestTx.HasDropColumnBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetDropColumnBuild().GetSettings().GetTable(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    if (requestTx.HasCancelIndexBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetCancelIndexBuild().GetTablePath(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    if (requestTx.HasApplyIndexBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetApplyIndexBuild().GetTablePath(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+
+    const TString targetName = ExtractSchemeChangeTargetName(requestTx);
+    if (targetName.empty()) {
+        // Drop and AlterTable may name their target by path id instead, and then
+        // WorkingDir is not a path at all ("not used").
+        TPathId byId;
+        if (requestTx.HasDrop() && requestTx.GetDrop().GetId() != 0) {
+            byId = ss->MakeLocalId(requestTx.GetDrop().GetId());
+        } else if (requestTx.HasAlterTable()) {
+            const auto& alter = requestTx.GetAlterTable();
+            if (alter.HasPathId()) {
+                byId = TPathId::FromProto(alter.GetPathId());
+            } else if (alter.HasId_Deprecated()) {
+                byId = ss->MakeLocalId(alter.GetId_Deprecated());
+            }
+        }
+        if (byId) {
+            TPath target = TPath::Init(byId, ss);
+            if (target.IsResolved()) {
+                return TVector<TResolvedSchemeChangeTarget>{
+                    TResolvedSchemeChangeTarget{target.PathString(), RelativeToDomain(target, ss), {}}};
+            }
+        }
+        return Nothing();
+    }
+
+    TString abs = requestTx.GetWorkingDir();
+    if (abs.empty() || abs.back() != '/') abs += '/';
+    abs += targetName;
+
+    TPath target = TPath::Resolve(abs, ss);
+    if (target.IsResolved()) {
+        return TVector<TResolvedSchemeChangeTarget>{TResolvedSchemeChangeTarget{abs, RelativeToDomain(target, ss), {}}};
+    }
+
+    TPath workingDir = TPath::Resolve(requestTx.GetWorkingDir(), ss);
+    if (!workingDir.IsResolved()) {
+        return Nothing();
+    }
+    TString relParent = RelativeToDomain(workingDir, ss);
+    if (!relParent.empty()) {
+        relParent += '/';
+    }
+    return TVector<TResolvedSchemeChangeTarget>{TResolvedSchemeChangeTarget{abs, relParent + targetName, {}}};
+}
+
+} // namespace
+
+// Serialized protobuf, never a delimited string: a path may contain any delimiter.
+TString TSchemeShard::EncodeSchemeChangeTargets(const TVector<TOperation::TSchemeChangeTarget>& targets) {
+    NKikimrSchemeShard::TSchemeChangeRecordTargets msg;
+    for (const auto& t : targets) {
+        auto* target = msg.AddTargets();
+        target->SetPath(t.Path);
+        for (const auto& src : t.SourcePaths) {
+            target->AddSourcePaths(src);
+        }
+    }
+    TString result;
+    Y_DEBUG_ABORT_UNLESS(msg.SerializeToString(&result));
+    return result;
+}
+
+TVector<TOperation::TSchemeChangeTarget> TSchemeShard::DecodeSchemeChangeTargets(const TString& encoded) {
+    NKikimrSchemeShard::TSchemeChangeRecordTargets msg;
+    TVector<TOperation::TSchemeChangeTarget> result;
+    if (encoded.empty() || !msg.ParseFromString(encoded)) {
+        return result;
+    }
+    for (const auto& t : msg.GetTargets()) {
+        TOperation::TSchemeChangeTarget target;
+        target.Path = t.GetPath();
+        for (const auto& src : t.GetSourcePaths()) {
+            target.SourcePaths.push_back(src);
+        }
+        result.push_back(std::move(target));
+    }
+    return result;
+}
+
+bool TSchemeShard::CheckSchemeChangeRecordHasPath(const NKikimrSchemeOp::TModifyScheme& requestTx, TString& rejectReason) {
+    if (IsChurnOp(requestTx.GetOperationType()) || IsPathlessOp(requestTx.GetOperationType())) {
+        return true;
+    }
+    if (ResolveSchemeChangeTargets(requestTx, this)) {
+        return true;
+    }
+    rejectReason = TStringBuilder() << "scheme change outbox could not resolve a path for operation type "
+        << NKikimrSchemeOp::EOperationType_Name(requestTx.GetOperationType());
+    return false;
+}
+
+bool TSchemeShard::PersistSchemeChangeRecordAtPropose(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        const NKikimrSchemeOp::TModifyScheme& requestTx, TOperation::TSchemeChangeSlot& slot,
+        const TString& userSid) {
+    if (IsChurnOp(requestTx.GetOperationType())) {
+        return false;
+    }
+
+    TMaybe<TVector<TResolvedSchemeChangeTarget>> targets = ResolveSchemeChangeTargets(requestTx, this);
+
+    // Not redacted yet: the body carries whatever the request carried. Inert only because the flag is off.
+    const NKikimrSchemeOp::TModifyScheme& redacted = requestTx;
+    TVector<TString> redactedFields;
+
+    TString body;
+    {
+        bool ok = redacted.SerializeToString(&body);
+        Y_DEBUG_ABORT_UNLESS(ok);
+    }
+
+    const ui64 order = AllocateSchemeChangeOrderInMemory();
+
+    TestSchemeChangeRedoBytesAccum += body.size() + 128;
+
+    TVector<TOperation::TSchemeChangeTarget> relTargets;
+    TVector<TOperation::TSchemeChangeTarget> absTargets;
+    if (targets) {
+        for (const auto& t : *targets) {
+            relTargets.push_back(TOperation::TSchemeChangeTarget{t.Relative, t.RelativeSources});
+            absTargets.push_back(TOperation::TSchemeChangeTarget{t.Absolute, t.RelativeSources});
+        }
+    }
+
+    using T = Schema::SchemeChangeRecords;
+    db.Table<T>().Key(order).Update(
+        NIceDb::TUpdate<T::TxId>(ui64(txId)),
+        NIceDb::TUpdate<T::OperationType>(static_cast<ui32>(requestTx.GetOperationType())),
+        NIceDb::TUpdate<T::Path>(EncodeSchemeChangeTargets(relTargets)),
+        NIceDb::TUpdate<T::Status>(ui32(NKikimrScheme::StatusAccepted)),
+        NIceDb::TUpdate<T::UserSID>(userSid),
+        NIceDb::TUpdate<T::BodySizeBytes>(body.size()),
+        NIceDb::TUpdate<T::RedactedFields>(JoinSeq("\n", redactedFields)),
+        // Zero keeps the row hidden from fetch until finalisation.
+        NIceDb::TUpdate<T::CompletedAtUs>(ui64(0))
+    );
+    if (!body.empty()) {
+        db.Table<Schema::SchemeChangeRecordDetails>().Key(order).Update(
+            NIceDb::TUpdate<Schema::SchemeChangeRecordDetails::Body>(body)
+        );
+    }
+
+    PersistUpdateNextSchemeChangeOrder(db);
+    PersistSchemeChangePendingOrder(db, txId, requestIdx, order, absTargets);
+
+    slot.RequestIdx = requestIdx;
+    slot.Order = order;
+    slot.Targets = absTargets;
+    slot.UserSid = userSid;
+    return true;
+}
+
+void TSchemeShard::FinalizeSchemeChangeRecord(NIceDb::TNiceDb& db, const TActorContext& ctx,
+        const TOperation::TSchemeChangeSlot& slot, TStepId planStep, bool aborted) {
+    // Ops completing at propose have no coordinator step, so they borrow the ceiling.
+    ui64 step = ui64(planStep);
+    auto positionKind = NKikimrSchemeShard::TSchemeChangePosition::KIND_EXACT;
+    if (step == 0 || planStep == InvalidStepId) {
+        step = LastAssignedPlanStep;
+        positionKind = NKikimrSchemeShard::TSchemeChangePosition::KIND_BUCKETED;
+    }
+    step = Max<ui64>(step, 1);
+
+    TPathId resolvedPathId;
+    auto resolvedObjectType = NKikimrSchemeOp::EPathTypeInvalid;
+    ui64 schemaVersion = 0;
+    TVector<TOperation::TSchemeChangeTarget> canonicalTargets = slot.Targets;
+    bool anyResolved = false;
+    for (size_t i = 0; i < slot.Targets.size(); ++i) {
+        if (slot.Targets[i].Path.empty()) {
+            continue;
+        }
+        TPath resolved = TPath::Resolve(slot.Targets[i].Path, this);
+        if (!resolved.IsResolved()) {
+            continue;
+        }
+        canonicalTargets[i].Path = RelativeToDomain(resolved, this);
+        anyResolved = true;
+        if (i == 0) {
+            resolvedPathId = resolved.Base()->PathId;
+            resolvedObjectType = resolved.Base()->PathType;
+            schemaVersion = resolved.Base()->DirAlterVersion;
+        }
+    }
+
+    // Must be taken now -- after a DROP the object is gone.
+    TString description;
+    // A secret's description carries the value, so it is never captured.
+    if (resolvedPathId && resolvedObjectType != NKikimrSchemeOp::EPathTypeSecret) {
+        // Schema only: partitioning/children would bloat the redo log.
+        NKikimrSchemeOp::TDescribeOptions opts;
+        opts.SetReturnPartitioningInfo(false);
+        opts.SetReturnPartitionConfig(false);
+        opts.SetReturnChildren(false);
+        opts.SetReturnRangeKey(false);
+        auto desc = DescribePath(this, ctx, resolvedPathId, opts);
+        Y_UNUSED(desc->GetRecord().SerializeToString(&description));
+    }
+
+    TestSchemeChangeRedoBytesAccum += description.size();
+    TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_DESCRIPTION_BYTES].Increment(description.size());
+
+    // CompletedAtUs non-zero makes the row visible, so all fields must be set in this Update.
+    using T = Schema::SchemeChangeRecords;
+    db.Table<T>().Key(slot.Order).Update(
+        NIceDb::TUpdate<T::PathOwnerId>(resolvedPathId.OwnerId),
+        NIceDb::TUpdate<T::PathLocalId>(resolvedPathId.LocalPathId),
+        NIceDb::TUpdate<T::ObjectType>(ui32(resolvedObjectType)),
+        NIceDb::TUpdate<T::Status>(ui32(aborted
+            ? NKikimrScheme::StatusPreconditionFailed
+            : NKikimrScheme::StatusSuccess)),
+        NIceDb::TUpdate<T::SchemaVersion>(schemaVersion),
+        NIceDb::TUpdate<T::PlanStep>(step),
+        NIceDb::TUpdate<T::Description>(description),
+        NIceDb::TUpdate<T::PositionKind>(static_cast<ui32>(positionKind)),
+        NIceDb::TUpdate<T::CompletedAtUs>(ctx.Now().MicroSeconds())
+    );
+    if (anyResolved) {
+        db.Table<T>().Key(slot.Order).Update(
+            NIceDb::TUpdate<T::Path>(EncodeSchemeChangeTargets(canonicalTargets))
+        );
+    }
+}
+
+ui64 TSchemeShard::AllocateSchemeChangeOrderInMemory() {
+    return ++NextSchemeChangeOrder;
+}
+
+
+
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -402,6 +402,7 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
 
     StartStopShred();
 
+
     ctx.Send(TxAllocatorClient, MakeHolder<TEvTxAllocatorClient::TEvAllocate>(InitiateCachedTxIdsCount));
 
     // Start local index migration if feature flag is enabled
@@ -4204,6 +4205,49 @@ void TSchemeShard::PersistUpdateNextShardIdx(NIceDb::TNiceDb& db) const {
                 NIceDb::TUpdate<Schema::SysParams::Value>(ToString(NextLocalShardIdx)));
 }
 
+void TSchemeShard::PersistUpdateNextSchemeChangeOrder(NIceDb::TNiceDb& db) const {
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_NextSchemeChangeOrder).Update(
+        NIceDb::TUpdate<Schema::SysParams::Value>(ToString(NextSchemeChangeOrder)));
+    ++NextSchemeChangeOrderPersistCount;
+}
+
+void TSchemeShard::PersistSchemeChangeFloorOrder(NIceDb::TNiceDb& db) const {
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_SchemeChangeFloorOrder).Update(
+        NIceDb::TUpdate<Schema::SysParams::Value>(ToString(SchemeChangeFloorOrder)));
+}
+
+void TSchemeShard::PersistUpdateLastAssignedPlanStep(NIceDb::TNiceDb& db) const {
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_LastAssignedPlanStep).Update(
+        NIceDb::TUpdate<Schema::SysParams::Value>(ToString(LastAssignedPlanStep)));
+}
+
+void TSchemeShard::PersistSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        ui64 order, const TVector<TOperation::TSchemeChangeTarget>& targets) const {
+    db.Table<Schema::SchemeChangePendingRecords>().Key(txId, requestIdx).Update(
+        NIceDb::TUpdate<Schema::SchemeChangePendingRecords::Order>(order),
+        NIceDb::TUpdate<Schema::SchemeChangePendingRecords::Path>(EncodeSchemeChangeTargets(targets)));
+}
+
+void TSchemeShard::PersistRemoveSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx) const {
+    // Point delete, not a range scan: TTxOperationPropose::Execute calls
+    // NoMoreReadsForTx() before this runs, and a later read aborts the tablet.
+    db.Table<Schema::SchemeChangePendingRecords>().Key(txId, requestIdx).Delete();
+}
+
+
+ui64 TSchemeShard::GetVisibleSchemeChangeTail() const {
+    ui64 firstPending = Max<ui64>();
+    for (const auto& [_, operation] : Operations) {
+        for (const auto& slot : operation->SchemeChangeSlots) {
+            firstPending = Min(firstPending, slot.Order);
+        }
+    }
+    return firstPending == Max<ui64>() ? NextSchemeChangeOrder : firstPending - 1;
+}
+
+
+
+
 void TSchemeShard::PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const {
     db.Table<Schema::SysParams>().Key(Schema::SysParam_ParentDomainSchemeShard).Update(
         NIceDb::TUpdate<Schema::SysParams::Value>(ToString(parentDomain.OwnerId)));
@@ -6267,6 +6311,7 @@ void TSchemeShard::RemoveTx(const TActorContext &ctx, NIceDb::TNiceDb &db, TOper
     LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "RemoveTx for txid " << opId);
     auto pathId = txState->TargetPathId;
 
+    RemoveInFlightPlanStep(ui64(txState->PlanStep));
     PersistRemoveTx(db, opId, *txState);
     TabletCounters->Simple()[TxTypeInFlightCounter(txState->TxType)].Sub(1);
 
@@ -8792,6 +8837,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TFeatureFlags& featu
     EnableExternalDataSourcesOnServerless = featureFlags.GetEnableExternalDataSourcesOnServerless();
     EnableShred = featureFlags.GetEnableDataErasure();
     EnableExternalSourceSchemaInference = featureFlags.GetEnableExternalSourceSchemaInference();
+
 }
 
 void TSchemeShard::ConfigureStatsBatching(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -101,6 +101,7 @@ struct TIndexBuildInfo;
 struct TSetColumnConstraintOperationInfo;
 struct TIndexBuildShardStatus;
 
+
 class TSchemeShard
     : public TActor<TSchemeShard>
     , public NTabletFlatExecutor::TTabletExecutedFlat
@@ -283,6 +284,80 @@ public:
     ui64 MaxIncompatibleChange = 0;
     THashMap<TPathId, TPathElement::TPtr> PathsById;
     TLocalPathId NextLocalPathId = 0;
+    ui64 NextSchemeChangeOrder = 0;
+    ui64 SchemeChangeFloorOrder = 0;
+    ui64 MaxSchemeChangeRecords = 100000;
+    // Disabling this serves credentials to every subscriber over an unauthenticated protocol.
+    bool RedactSchemeChangeSensitiveFields = true;
+    TDuration SchemeChangeSubscriberStaleTtl = TDuration::Days(30);
+    ui64 MaxSchemeChangeSubscribers = 100;
+    static constexpr size_t MaxSchemeChangeSubscriberIdLength = 256;
+    ui64 LastAssignedPlanStep = 0;
+    // Do not filter on TTxState::State: a tx in Done that is not yet erased must keep its entry.
+    TMap<ui64, ui32> InFlightByPlanStep;
+
+    void AddInFlightPlanStep(ui64 step) {
+        if (step) {
+            ++InFlightByPlanStep[step];
+        }
+    }
+    void RemoveInFlightPlanStep(ui64 step) {
+        if (!step) {
+            return;
+        }
+        auto it = InFlightByPlanStep.find(step);
+        if (it == InFlightByPlanStep.end()) {
+            return;
+        }
+        if (--it->second == 0) {
+            InFlightByPlanStep.erase(it);
+        }
+    }
+    ui64 GetClosedThroughPlanStep() const {
+        if (InFlightByPlanStep.empty()) {
+            return LastAssignedPlanStep;
+        }
+        const ui64 minInFlight = InFlightByPlanStep.begin()->first;
+        return minInFlight ? minInFlight - 1 : 0;
+    }
+    ui64 SchemeChangeCleanupBatchSize = 1000;
+    TDuration SchemeChangeCleanupInterval = TDuration::MilliSeconds(10);
+
+    ui64 MaxSchemeChangeBodiesPerRequest = 1000;
+
+    mutable ui64 NextSchemeChangeOrderPersistCount = 0;
+    mutable ui64 TestSchemeChangeRedoBytesAccum = 0;
+    ui64 SchemeChangeCleanupTxCount = 0;
+
+    struct TSubscriberInfo {
+        ui64 LastAckedOrder = 0;
+        TInstant LastActivityAt;
+        ui32 State = 1;
+        ui64 StartOrder = 0;
+    };
+    THashMap<TString, TSubscriberInfo> Subscribers;
+
+    ui64 GetVisibleSchemeChangeTail() const;
+
+    void UpdateSchemeChangeGauges() const;
+
+    ui64 GetMinSubscriberOrder(TInstant) const {
+        if (Subscribers.empty()) {
+            return GetVisibleSchemeChangeTail();
+        }
+        ui64 m = Max<ui64>();
+        for (const auto& [_, info] : Subscribers) {
+            m = Min(m, info.LastAckedOrder);
+        }
+        return m;
+    }
+
+    bool IsSubscriberStale(const TSubscriberInfo& info, TInstant now) const {
+        if (!SchemeChangeSubscriberStaleTtl) {
+            return false;
+        }
+        return (now - info.LastActivityAt) >= SchemeChangeSubscriberStaleTtl;
+    }
 
     THashMap<TPathId, TTableInfo::TPtr> Tables;
     THashMap<TPathId, TTableInfo::TPtr> TTLEnabledTables;
@@ -904,6 +979,30 @@ public:
     void PersistShardTx(NIceDb::TNiceDb& db, TShardIdx shardIdx, TTxId txId);
     void PersistUpdateNextPathId(NIceDb::TNiceDb& db) const;
     void PersistUpdateNextShardIdx(NIceDb::TNiceDb& db) const;
+    void PersistUpdateNextSchemeChangeOrder(NIceDb::TNiceDb& db) const;
+    void PersistSchemeChangeFloorOrder(NIceDb::TNiceDb& db) const;
+    void PersistUpdateLastAssignedPlanStep(NIceDb::TNiceDb& db) const;
+
+    void PersistSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        ui64 order, const TVector<TOperation::TSchemeChangeTarget>& targets) const;
+
+    static TString EncodeSchemeChangeTargets(const TVector<TOperation::TSchemeChangeTarget>& targets);
+    static TVector<TOperation::TSchemeChangeTarget> DecodeSchemeChangeTargets(const TString& encoded);
+    void PersistRemoveSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx) const;
+
+    // Must run for the whole batch before any record is persisted: local-DB
+    // writes already made are not undone by AbortOperationPropose.
+    bool CheckSchemeChangeRecordHasPath(const NKikimrSchemeOp::TModifyScheme& requestTx, TString& rejectReason);
+
+    bool PersistSchemeChangeRecordAtPropose(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        const NKikimrSchemeOp::TModifyScheme& requestTx, TOperation::TSchemeChangeSlot& slot,
+        const TString& userSid = {});
+
+    void FinalizeSchemeChangeRecord(NIceDb::TNiceDb& db, const TActorContext& ctx,
+        const TOperation::TSchemeChangeSlot& slot, TStepId planStep, bool aborted = false);
+    ui64 AllocateSchemeChangeOrderInMemory();
+
+    ui32 CountTransactionSupportingDomains() const;
     void PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const;
     void PersistParentDomainEffectiveACL(NIceDb::TNiceDb& db, const TString& owner, const TString& effectiveACL, ui64 effectiveACLVersion) const;
     void PersistShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs);

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2711,6 +2711,53 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<PathId, AlterVersion, TestShards, CmdInitialize>;
     };
 
+    struct SchemeChangeRecords : Table<141> {
+        struct Order :         Column<1, NScheme::NTypeIds::Uint64> {};
+        struct TxId :          Column<2, NScheme::NTypeIds::Uint64> {};
+        struct OperationType : Column<3, NScheme::NTypeIds::Uint32> {};
+        struct PathOwnerId :   Column<4, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct PathLocalId :   Column<5, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        // Serialized protobuf, not a delimited string -- a path may contain any delimiter.
+        struct Path :          Column<6, NScheme::NTypeIds::String> {};
+        struct ObjectType :    Column<7, NScheme::NTypeIds::Uint32> {};
+        struct Status :        Column<8, NScheme::NTypeIds::Uint32> {};
+        struct UserSID :       Column<9, NScheme::NTypeIds::Utf8> {};
+        struct SchemaVersion : Column<10, NScheme::NTypeIds::Uint64> {};
+        struct CompletedAtUs : Column<11, NScheme::NTypeIds::Uint64> {};
+        struct PlanStep :      Column<12, NScheme::NTypeIds::Uint64> {};
+        struct BodySizeBytes :      Column<13, NScheme::NTypeIds::Uint64> {};
+        struct Description :   Column<14, NScheme::NTypeIds::String, false, true> {}; // Sensitive: may describe a secret
+        struct PositionKind :  Column<15, NScheme::NTypeIds::Uint32> {};
+        struct RedactedFields : Column<16, NScheme::NTypeIds::Utf8> {};
+
+        using TKey = TableKey<Order>;
+        using TColumns = TableColumns<Order, TxId, OperationType, PathOwnerId, PathLocalId,
+                                      Path, ObjectType, Status, UserSID, SchemaVersion,
+                                      CompletedAtUs, PlanStep, BodySizeBytes, Description, PositionKind,
+                                      RedactedFields>;
+    };
+
+    struct SchemeChangeRecordDetails : Table<143> {
+        struct Order : Column<1, NScheme::NTypeIds::Uint64> {};
+        // Sensitive: the captured request body can contain a plaintext secret.
+        struct Body :  Column<2, NScheme::NTypeIds::String, false, true> {};
+
+        using TKey = TableKey<Order>;
+        using TColumns = TableColumns<Order, Body>;
+    };
+
+
+    // Path is duplicated here because finalisation runs after NoMoreReadsForTx().
+    struct SchemeChangePendingRecords : Table<144> {
+        struct TxId :       Column<1, NScheme::NTypeIds::Uint64> { using Type = TTxId; };
+        // Index into the request's repeated TModifyScheme list.
+        struct RequestIdx : Column<2, NScheme::NTypeIds::Uint32> {};
+        struct Order :      Column<4, NScheme::NTypeIds::Uint64> {};
+        struct Path :       Column<5, NScheme::NTypeIds::String> {};
+
+        using TKey = TableKey<TxId, RequestIdx>;
+        using TColumns = TableColumns<TxId, RequestIdx, Order, Path>;
+    };
     using TTables = SchemaTables<
         Paths,
         TxInFlight,
@@ -2849,7 +2896,10 @@ struct Schema : NIceDb::Schema {
         FullBackupItems,
         SetColumnConstraint,
         SetColumnConstraintShardStatus,
-        TestShardSet
+        TestShardSet,
+        SchemeChangeRecords,
+        SchemeChangeRecordDetails,
+        SchemeChangePendingRecords
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;
@@ -2866,6 +2916,9 @@ struct Schema : NIceDb::Schema {
     // static constexpr ui64 SysParam_IsOldArgonHashFormatMigrationCompleted = 12; deprecated
     static constexpr ui64 SysParam_TablePartitionsFormatSweepStatus = 13;
     static constexpr ui64 SysParam_TablePartitionsFormatSweepTarget = 14;
+    static constexpr ui64 SysParam_NextSchemeChangeOrder = 15;
+    static constexpr ui64 SysParam_LastAssignedPlanStep = 16;
+    static constexpr ui64 SysParam_SchemeChangeFloorOrder = 17;
 
     // List of incompatible changes:
     // * Change 1: store migrated shards of local tables (e.g. after a rename) as a migrated record

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
@@ -339,6 +339,20 @@ bool IsDrop(ETxType t) {
     }
 }
 
+bool IsChurnOp(NKikimrSchemeOp::EOperationType opType) {
+    switch (opType) {
+        case NKikimrSchemeOp::ESchemeOpSplitMergeTablePartitions:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// None today. Never add an entry to silence a resolution failure.
+bool IsPathlessOp(NKikimrSchemeOp::EOperationType) {
+    return false;
+}
+
 bool CanDeleteParts(ETxType t) {
     switch (t) {
         case TxDropTable:

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.h
@@ -160,4 +160,9 @@ bool IsCreate(ETxType t);
 bool IsDrop(ETxType t);
 bool CanDeleteParts(ETxType t);
 
+// Internal churn ops; they produce no scheme change records.
+bool IsChurnOp(NKikimrSchemeOp::EOperationType opType);
+
+bool IsPathlessOp(NKikimrSchemeOp::EOperationType opType);
+
 }  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/ut_base/ya.make
+++ b/ydb/core/tx/schemeshard/ut_base/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_cdc_stream/ya.make
+++ b/ydb/core/tx/schemeshard/ut_cdc_stream/ya.make
@@ -4,6 +4,10 @@ FORK_SUBTESTS()
 
 SPLIT_FACTOR(2)
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 IF (SANITIZER_TYPE == "thread")
     SIZE(LARGE)
     INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)

--- a/ydb/core/tx/schemeshard/ut_external_table/ya.make
+++ b/ydb/core/tx/schemeshard/ut_external_table/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ya.make
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 IF (SANITIZER_TYPE == "thread")
     SIZE(LARGE)
     INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -230,6 +230,7 @@ namespace NSchemeShardUT_Private {
         UNIT_ASSERT_VALUES_EQUAL(event->Record.GetTxId(), txId);
 
         CheckExpectedResult(expectedResults, event->Record.GetStatus(), event->Record.GetReason());
+        CheckSchemeChangeCorpusInvariant(runtime);
         return event->Record.GetStatus();
     }
 
@@ -1884,6 +1885,15 @@ namespace NSchemeShardUT_Private {
         SetSchemeshardSchemaLimits(runtime, limits, TTestTxConfig::SchemeShard);
     }
 
+    void RebootSchemeShard(TTestActorRuntime& runtime, ui64 schemeShard) {
+        // The tally tracks the default schemeshard only, so leave it alone otherwise.
+        if (schemeShard == TTestTxConfig::SchemeShard) {
+            TSchemeChangePathMissingTally::Instance().OnObservedRestart(runtime);
+        }
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, schemeShard, sender);
+    }
+
 
     TString EscapedDoubleQuote(const TString src) {
         auto result = src;
@@ -1937,8 +1947,7 @@ namespace NSchemeShardUT_Private {
         Cdbg << result << "\n";
         UNIT_ASSERT_VALUES_EQUAL(status, NKikimrProto::EReplyStatus::OK);
 
-        TActorId sender = runtime.AllocateEdgeActor();
-        RebootTablet(runtime, schemeShard, sender);
+        RebootSchemeShard(runtime, schemeShard);
     }
 
     void SetSchemeshardDatabaseQuotas(TTestActorRuntime& runtime, Ydb::Cms::DatabaseQuotas databaseQuotas, ui64 domainId) {
@@ -1966,9 +1975,7 @@ namespace NSchemeShardUT_Private {
         Cdbg << result << "\n";
         UNIT_ASSERT_VALUES_EQUAL(status, NKikimrProto::EReplyStatus::OK);
 
-        TActorId sender = runtime.AllocateEdgeActor();
-        RebootTablet(runtime, schemeShard, sender);
-
+        RebootSchemeShard(runtime, schemeShard);
     }
 
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -587,6 +587,9 @@ namespace NSchemeShardUT_Private {
     bool GetEraseCacheEnabled(TTestActorRuntime& runtime, ui64 tabletId, ui32 table);
     NKikimr::NLocalDb::TCompactionPolicyPtr GetCompactionPolicy(TTestActorRuntime& runtime, ui64 tabletId, ui32 localTableId);
     void SetSchemeshardReadOnlyMode(TTestActorRuntime& runtime, bool isReadOnly);
+    // Use instead of a bare RebootTablet on the schemeshard: it lets the path-missing
+    // tally carry its tablet counter, which restarts at zero, across the reboot.
+    void RebootSchemeShard(TTestActorRuntime& runtime, ui64 schemeShard = TTestTxConfig::SchemeShard);
     void SetSchemeshardSchemaLimits(TTestActorRuntime& runtime, NSchemeShard::TSchemeLimits limits);
     void SetSchemeshardSchemaLimits(TTestActorRuntime& runtime, NSchemeShard::TSchemeLimits limits, ui64 schemeShard);
     void SetSchemeshardDatabaseQuotas(TTestActorRuntime& runtime, Ydb::Cms::DatabaseQuotas databaseQuotas, ui64 domainId);

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
@@ -14,7 +14,7 @@ using namespace NKikimr;
 
 namespace {
 
-NKikimrTabletBase::TEvGetCountersResponse GetCounters(TTestBasicRuntime& runtime) {
+NKikimrTabletBase::TEvGetCountersResponse GetCounters(TTestActorRuntime& runtime) {
     const auto sender = runtime.AllocateEdgeActor();
     runtime.SendToPipe(TTestTxConfig::SchemeShard, sender, new TEvTablet::TEvGetCounters);
     auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvGetCountersResponse>(sender);
@@ -58,7 +58,7 @@ void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 va
     UNIT_ASSERT_VALUES_EQUAL(value, GetSimpleCounter(runtime, name));
 }
 
-ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name) {
+ui64 GetCumulativeCounter(TTestActorRuntime& runtime, const TString& name) {
     const auto counters = GetCounters(runtime);
     for (const auto& counter : counters.GetTabletCounters().GetAppCounters().GetCumulativeCounters()) {
         if (name != counter.GetName()) {

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
@@ -4,6 +4,7 @@
 
 namespace NActors {
 
+class TTestActorRuntime;
 class TTestBasicRuntime;
 
 }
@@ -14,7 +15,7 @@ using namespace NActors;
 
 ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name);
 void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value);
-ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name);
+ui64 GetCumulativeCounter(TTestActorRuntime& runtime, const TString& name);
 ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range);
 void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -1,6 +1,7 @@
 #include "test_env.h"
 
 #include "helpers.h"
+#include "schemeshard_counters.h"
 
 #include <ydb/core/base/backtrace.h>
 #include <ydb/core/base/tablet_resolver.h>
@@ -16,6 +17,7 @@
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
 #include <ydb/core/tx/columnshard/test_helper/columnshard_ut_common.h>
 #include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
 #include <ydb/core/tx/schemeshard/schemeshard_private.h>
 #include <ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h>
 #include <ydb/core/tx/sequenceproxy/sequenceproxy.h>
@@ -26,6 +28,8 @@
 #include <ydb/services/metadata/ds_table/service.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/system/env.h>
 
 
 bool NSchemeShardUT_Private::TTestEnv::ENABLE_SCHEMESHARD_LOG = true;
@@ -38,6 +42,58 @@ static const bool ENABLE_TOPIC_LOG = false;
 
 using namespace NKikimr;
 using namespace NSchemeShard;
+
+bool NSchemeShardUT_Private::SchemeChangeCorpusEnabled() {
+    static const bool enabled = !GetEnv("YDB_SCHEME_CHANGE_CORPUS").empty();
+    return enabled;
+}
+
+std::optional<bool> NSchemeShardUT_Private::SchemeChangeCorpusFlagDefault() {
+    return SchemeChangeCorpusEnabled() ? std::optional<bool>(true) : std::nullopt;
+}
+
+NSchemeShardUT_Private::TSchemeChangePathMissingTally& NSchemeShardUT_Private::TSchemeChangePathMissingTally::Instance() {
+    static TSchemeChangePathMissingTally instance;
+    return instance;
+}
+
+void NSchemeShardUT_Private::TSchemeChangePathMissingTally::Reset() {
+    Accumulated = 0;
+    LastSeen = 0;
+}
+
+ui64 NSchemeShardUT_Private::TSchemeChangePathMissingTally::Sample(TTestActorRuntime& runtime) {
+    const ui64 current = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+    // The counter only grows within one tablet life, so a drop means the tablet
+    // restarted behind the tally's back and everything before that is already lost.
+    UNIT_ASSERT_C(current >= LastSeen,
+        "scheme change path-missing tally missed a tablet restart (" << LastSeen << " -> " << current
+            << "); the outbox invariant is unreliable until that restart path calls OnObservedRestart");
+    LastSeen = current;
+    return current;
+}
+
+void NSchemeShardUT_Private::TSchemeChangePathMissingTally::OnObservedRestart(TTestActorRuntime& runtime) {
+    Sample(runtime);
+    Accumulated += LastSeen;
+    LastSeen = 0;
+}
+
+ui64 NSchemeShardUT_Private::TSchemeChangePathMissingTally::Total(TTestActorRuntime& runtime) {
+    return Accumulated + Sample(runtime);
+}
+
+void NSchemeShardUT_Private::CheckSchemeChangeCorpusInvariant(TTestActorRuntime& runtime) {
+    if (!SchemeChangeCorpusEnabled()) {
+        return;
+    }
+    // An op that cannot name its target is a hole in the outbox, so fail here
+    // instead of silently dropping the record.
+    const ui64 missing = TSchemeChangePathMissingTally::Instance().Total(runtime);
+    UNIT_ASSERT_VALUES_EQUAL_C(missing, 0u,
+        "scheme change outbox failed to resolve a target path; grep the log for"
+        " 'scheme change record skipped' to see which operation type");
+}
 
 // BlockStoreVolume mock for testing schemeshard
 class TFakeBlockStoreVolume : public TActor<TFakeBlockStoreVolume>, public NTabletFlatExecutor::TTabletExecutedFlat {
@@ -623,6 +679,9 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     , ChannelsCount(opts.NChannels_)
 {
     EnableYDBBacktraceFormat();
+    // Per-env, so a gap is reported against the test that hit it rather than
+    // against every test that runs after it in the same binary.
+    TSchemeChangePathMissingTally::Instance().Reset();
     ui64 hive = TTestTxConfig::Hive;
     ui64 schemeRoot = TTestTxConfig::SchemeShard;
     ui64 coordinator = TTestTxConfig::Coordinator;
@@ -677,6 +736,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnableAlterDatabase(opts.EnableAlterDatabase_);
     app.SetEnableAccessToIndexImplTables(opts.EnableAccessToIndexImplTables_);
     app.SetEnableIndexMaterialization(opts.EnableIndexMaterialization_);
+    app.SetEnableSchemeChangeRecords(opts.EnableSchemeChangeRecords_);
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 
@@ -948,6 +1008,7 @@ void NSchemeShardUT_Private::TestWaitNotification(NActors::TTestActorRuntime &ru
         UNIT_ASSERT(txIds.find(eventTxId) != txIds.end());
         txIds.erase(eventTxId);
     }
+    CheckSchemeChangeCorpusInvariant(runtime);
 }
 
 void NSchemeShardUT_Private::TTestEnv::TestWaitNotification(NActors::TTestActorRuntime &runtime, TSet<ui64> txIds, ui64 schemeshardId) {
@@ -1213,6 +1274,9 @@ NSchemeShardUT_Private::TTestWithReboots::TTestWithReboots(bool killOnCommit, NS
     NoRebootEventTypes.insert(TEvSchemeShard::EvMeasureSelfResponseTime);
     NoRebootEventTypes.insert(TEvSchemeShard::EvWakeupToMeasureSelfResponseTime);
     NoRebootEventTypes.insert(TEvTablet::EvLocalMKQL);
+    // The corpus invariant reads a tablet counter after every op; that read must not
+    // become a reboot point of its own.
+    NoRebootEventTypes.insert(TEvTablet::EvGetCounters);
     NoRebootEventTypes.insert(TEvFakeHive::EvSubscribeToTabletDeletion);
     NoRebootEventTypes.insert(TEvSchemeShard::EvCancelTx);
     NoRebootEventTypes.insert(TEvExport::EvCreateExportRequest);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -26,6 +26,32 @@ namespace NSchemeShardUT_Private {
     NActors::TActorId CreateNotificationSubscriber(NActors::TTestActorRuntime &runtime, ui64 schemeshardId);
     NActors::TActorId CreateFakeMetering(NActors::TTestActorRuntime &runtime);
 
+    // A suite opts into the scheme change outbox corpus check with
+    // ENV(YDB_SCHEME_CHANGE_CORPUS=1) in its ya.make; elsewhere these are inert.
+    bool SchemeChangeCorpusEnabled();
+    std::optional<bool> SchemeChangeCorpusFlagDefault();
+
+    // Reads SchemeShard/SchemeChangePathMissing, which is a tablet counter and so
+    // restarts at zero, and carries the pre-restart value across observed reboots.
+    class TSchemeChangePathMissingTally {
+    public:
+        static TSchemeChangePathMissingTally& Instance();
+
+        void Reset();
+        // Must be called while the tablet is still alive, right before it restarts.
+        void OnObservedRestart(NActors::TTestActorRuntime& runtime);
+        ui64 Total(NActors::TTestActorRuntime& runtime);
+
+    private:
+        ui64 Sample(NActors::TTestActorRuntime& runtime);
+
+        ui64 Accumulated = 0;
+        ui64 LastSeen = 0;
+    };
+
+    // Fails if any op proposed so far could not resolve an outbox target.
+    void CheckSchemeChangeCorpusInvariant(NActors::TTestActorRuntime& runtime);
+
     struct TTestEnvOptions {
         using TSelf = TTestEnvOptions;
 
@@ -94,6 +120,7 @@ namespace NSchemeShardUT_Private {
         OPTION(bool, EnableDataShardSplitKeySelection, false);
         OPTION(bool, EnableDataShardSplitHistogramOmission, false);
         OPTION(bool, DisableFileStoreSSDSystemSpaceAccounting, false);
+        OPTION(std::optional<bool>, EnableSchemeChangeRecords, SchemeChangeCorpusFlagDefault());
 
         #undef OPTION
     };

--- a/ydb/core/tx/schemeshard/ut_index_build/ya.make
+++ b/ydb/core/tx/schemeshard/ut_index_build/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_move/ya.make
+++ b/ydb/core/tx/schemeshard/ut_move/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 IF (WITH_VALGRIND)
     SPLIT_FACTOR(40)
 ENDIF()

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records.cpp
@@ -1,0 +1,3991 @@
+#include "ut_scheme_change_records_helpers.h"
+
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <util/string/printf.h>
+#include <util/string/join.h>
+
+#include <functional>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+using namespace NSchemeChangeRecordTestHelpers;
+using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecordsFromTable;
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
+    Y_UNIT_TEST(DisabledByDefaultEmitsNoRecords) {
+        // ReadSchemeChangeRecords itself registers a temp subscriber, which is
+        // refused while disabled; use the order counter as a disabled-safe oracle.
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        // Default options: the flag is off unless a test opts in.
+        TTestEnv env(runtime, TTestEnvOptions(), ssFactory);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->NextSchemeChangeOrder, 0u,
+            "no outbox rows should be reserved while the feature is disabled");
+    }
+
+    Y_UNIT_TEST(CreateTableWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.TxId, (ui64)txId);
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets[0].Path, "Table1");
+                UNIT_ASSERT(e.Order > 0);
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found in notification log");
+    }
+
+    Y_UNIT_TEST(AlterTableWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        ui32 alterCount = 0;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
+                && e.Body.GetAlterTable().GetName() == "Table1") {
+                ++alterCount;
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(alterCount >= 1, "ALTER TABLE entry not found in notification log");
+    }
+
+    // UserSID must record who issued the DDL, not who owns the target: a
+    // ModifyACL changes the owner without that owner issuing anything.
+    Y_UNIT_TEST(UserSIDRecordsIssuerNotOwner) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Positive companion: the owner is genuinely changed to someone who
+        // never issues the later ALTER, so a later match can't be coincidence.
+        TestModifyACL(runtime, ++txId, "/MyRoot", "Table1", "", "bob@builtin");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* alterEntry = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
+                && e.Body.GetAlterTable().GetName() == "Table1") {
+                alterEntry = &e;
+            }
+        }
+        UNIT_ASSERT_C(alterEntry, "ALTER TABLE entry not found in notification log");
+        // The test issues the ALTER with no user token, so the true issuer
+        // SID is empty -- never "bob@builtin", the object's owner.
+        UNIT_ASSERT_VALUES_EQUAL_C(alterEntry->UserSID, "",
+            "UserSID must reflect the DDL issuer (empty, no token supplied here), "
+            "not the target's owner (\"bob@builtin\"); got \"" << alterEntry->UserSID << "\"");
+    }
+
+    // TCreateCdcStream's target is nested under TableName/StreamDescription.Name:
+    // the record must carry the changefeed itself, not the table or the working dir.
+    Y_UNIT_TEST(CdcStreamRecordDoesNotImpersonateParentDirectory) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateCdcStream) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateCdcStream must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_VALUES_UNEQUAL_C(found->Targets[0].Path, "Table1",
+            "the target must be the changefeed, not its parent table");
+        UNIT_ASSERT_VALUES_UNEQUAL_C(found->Targets[0].Path, "",
+            "the target must be the changefeed, not the working directory");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "Table1/Stream1",
+            "expected the changefeed's own path, got \"" << found->Targets[0].Path << "\"");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // TDropCdcStream.StreamName is repeated, so one op can retire N changefeeds:
+    // each must get its own target, not be collapsed into a single entry.
+    Y_UNIT_TEST(DropCdcStreamRecordsEveryStream) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream2"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // showPrivate: a changefeed is not a common-sense path, so the default
+        // describe refuses it before any identity can be read.
+        const auto stream1Version = ExtractPathVersion(
+            DescribePath(runtime, "/MyRoot/Table1/Stream1", false, false, true));
+        const ui64 droppedOwnerId = stream1Version.PathId.OwnerId;
+        const ui64 droppedLocalId = stream1Version.PathId.LocalPathId;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestDropCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            StreamName: "Stream2"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "a multi-stream drop must resolve every target, not bump the path-missing counter");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropCdcStream) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropCdcStream must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 2u,
+            "dropping two changefeeds must record two targets, got " << AllTargetPaths(*found));
+
+        THashSet<TString> paths;
+        for (const auto& target : found->Targets) {
+            UNIT_ASSERT_C(target.SourcePaths.empty(),
+                "a drop has no source, SourcePaths must be empty for " << target.Path);
+            paths.insert(target.Path);
+        }
+        UNIT_ASSERT_C(paths.contains("Table1/Stream1"), "missing Table1/Stream1 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_C(paths.contains("Table1/Stream2"), "missing Table1/Stream2 in " << AllTargetPaths(*found));
+        // The streams are gone by finalize time, so the first target's identity is
+        // checked against the one captured before the drop, not a live re-resolve.
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId,
+            "recorded PathOwnerId must match the first dropped changefeed's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId,
+            "recorded PathLocalId must match the first dropped changefeed's identity");
+    }
+
+    Y_UNIT_TEST(DropTableWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTable
+                && e.Body.GetDrop().GetName() == "Table1") {
+                found = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DROP TABLE entry not found in notification log");
+    }
+
+    Y_UNIT_TEST(OrdersAreMonotonicAcrossOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT(entries.size() >= 2);
+
+        for (size_t i = 1; i < entries.size(); ++i) {
+            UNIT_ASSERT_C(entries[i].Order > entries[i-1].Order,
+                "Orders must be strictly monotonic");
+        }
+    }
+
+    Y_UNIT_TEST(PlanStepIsRecordedForCoordinatedOps) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT(!entries.empty());
+
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = true;
+                UNIT_ASSERT_C(e.PlanStep > 0,
+                    "CreateTable should have a valid PlanStep, got: " << e.PlanStep);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found in notification log");
+    }
+
+    Y_UNIT_TEST(PlanStepIsRecordedForAlterTable) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool sawAlter = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
+                && e.Body.GetAlterTable().GetName() == "Table1") {
+                sawAlter = true;
+                UNIT_ASSERT_C(e.PlanStep > 0,
+                    "AlterTable Table1 should have a valid PlanStep, got: " << e.PlanStep);
+            }
+        }
+        UNIT_ASSERT(sawAlter);
+    }
+
+    Y_UNIT_TEST(PlanStepMonotonicAcrossOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT(entries.size() >= 2);
+
+        ui64 prevPlanStep = 0;
+        for (const auto& e : entries) {
+            // Bootstrap system views (.sys/*) are recorded too now that the
+            // gate is the flag alone; they are not this test's DDL.
+            if (AnyPathContains(e, ".sys/")) {
+                continue;
+            }
+            UNIT_ASSERT_C(e.PlanStep >= prevPlanStep,
+                "PlanStep should be monotonically non-decreasing: prev=" << prevPlanStep
+                    << " current=" << e.PlanStep << " path=" << AllTargetPaths(e));
+            prevPlanStep = e.PlanStep;
+        }
+
+        for (size_t i = 1; i < entries.size(); ++i) {
+            const auto& prev = entries[i-1];
+            const auto& curr = entries[i];
+            // Order is the stream's only total order, and it is what cursors,
+            // acks and retention are defined on.
+            UNIT_ASSERT_C(curr.Order > prev.Order,
+                "Order must strictly increase: prev=" << prev.Order << " curr=" << curr.Order);
+            UNIT_ASSERT_C(curr.PlanStep != 0,
+                "a finalised record must carry a PlanStep, order=" << curr.Order);
+            // (PlanStep, TxId) is deliberately not asserted co-monotonic with Order: Order
+            // is allocated at propose, PlanStep by the coordinator at plan time.
+        }
+    }
+
+    Y_UNIT_TEST(MkDirWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMkDir
+                && e.Body.GetMkDir().GetName() == "DirA") {
+                found = true;
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "MkDir should produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateTableWithIndexProducesSingleParentRecord) {
+        // A multi-part DDL emits exactly one record, carrying the TModifyScheme
+        // as it arrived in the request; the target cluster re-runs decomposition
+        // on replay.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Main"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "IdxByValue"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        ui32 parentCount = 0;
+        bool haveMain = false;
+        bool haveIndex = false;
+        for (const auto& e : entries) {
+            if (e.TxId != (ui64)txId) continue;
+            UNIT_ASSERT_VALUES_EQUAL(
+                (ui32)e.Body.GetOperationType(),
+                (ui32)NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
+            ++parentCount;
+            const auto& ct = e.Body.GetCreateIndexedTable();
+            if (ct.GetTableDescription().GetName() == "Main") haveMain = true;
+            for (const auto& idx : ct.GetIndexDescription()) {
+                if (idx.GetName() == "IdxByValue") haveIndex = true;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(parentCount, 1u,
+            "Expected exactly 1 parent-level record, got " << parentCount);
+        UNIT_ASSERT_C(haveMain, "Parent record must carry the main table description");
+        UNIT_ASSERT_C(haveIndex, "Parent record must carry the index description");
+    }
+
+    Y_UNIT_TEST(AutoMkDirBodyPreservedOnParent) {
+        // Only the user's original CreateTable body is persisted; the target
+        // cluster regenerates the auto-mkdir chain on replay.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "A/B/C/Leaf"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool foundLeaf = false;
+        for (const auto& e : entries) {
+            if (e.TxId != (ui64)txId) continue;
+            UNIT_ASSERT_VALUES_EQUAL(
+                (ui32)e.Body.GetOperationType(),
+                (ui32)NKikimrSchemeOp::ESchemeOpCreateTable);
+            if (e.Body.GetCreateTable().GetName() == "A/B/C/Leaf") {
+                foundLeaf = true;
+            }
+        }
+        UNIT_ASSERT_C(foundLeaf, "The persisted CreateTable body must preserve the path as requested");
+    }
+
+    Y_UNIT_TEST(ParentBodyCarriesFullSubDescriptions) {
+        // Every sub-description the decomposer needs must live inside the one
+        // parent body, or replay cannot reproduce the DDL on the target.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Main"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "IdxByValue"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const NKikimrSchemeOp::TIndexedTableCreationConfig* ct = nullptr;
+        for (const auto& e : entries) {
+            if (e.TxId == (ui64)txId && e.Body.HasCreateIndexedTable()) {
+                ct = &e.Body.GetCreateIndexedTable();
+                break;
+            }
+        }
+        UNIT_ASSERT(ct);
+        UNIT_ASSERT_VALUES_EQUAL(ct->GetTableDescription().GetName(), "Main");
+        UNIT_ASSERT_VALUES_EQUAL(ct->IndexDescriptionSize(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ct->GetIndexDescription(0).GetName(), "IdxByValue");
+    }
+
+    Y_UNIT_TEST(PersistsNextSchemeChangeOrderOncePerBatch) {
+        // A multi-part DDL emits one record, so NextSchemeChangeOrder is
+        // persisted once per batch by construction.
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        schemeshard->NextSchemeChangeOrderPersistCount = 0;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Main"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "IdxByValue"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        size_t thisTxRecords = 0;
+        for (const auto& e : entries) {
+            if (e.TxId == (ui64)txId) ++thisTxRecords;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(thisTxRecords, 1u);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->NextSchemeChangeOrderPersistCount, 1u,
+            "Expected one NextSchemeChangeOrder persist for a batch, got "
+            << schemeshard->NextSchemeChangeOrderPersistCount);
+    }
+
+    // Positive companion to DisabledByDefaultEmitsNoRecords: the identical DDL
+    // with the flag on does produce a row, so the disabled case cannot pass vacuously.
+    Y_UNIT_TEST(EnabledByOptInEmitsRecord) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "expected at least one outbox row with the feature enabled");
+    }
+
+    // Finalize resolves the target but writes back only PathOwnerId/PathLocalId;
+    // Path keeps the propose-time synthesis, which must already be canonical.
+    Y_UNIT_TEST(RecordCarriesCanonicalResolvedPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        // Trailing slash: propose-time string concatenation would leave a
+        // double slash, while TPath::Resolve canonicalizes it away.
+        TestCreateTable(runtime, ++txId, "/MyRoot/", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_C(!found->Targets[0].Path.Contains("//"),
+            "Path must be the canonical resolved path, not a raw concatenation; got \"" << found->Targets[0].Path << "\"");
+    }
+
+    // A stored path must be relative to the database root and must be the full
+    // path to the object -- a path truncated to empty must not pass.
+    Y_UNIT_TEST(RecordPathIsRelativeToDatabaseRoot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot/DirA", R"(
+            Name: "Nested"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Nested") {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_C(!found->Targets[0].Path.StartsWith("/MyRoot"),
+            "Path must not carry the source database prefix; got \"" << found->Targets[0].Path << "\"");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "DirA/Nested",
+            "Path must be the full remainder relative to the database root, "
+            "not truncated to empty or to just the leaf name");
+    }
+
+    // No fallback, ever: across a varied corpus of path-bearing ops, nothing may be
+    // refused for a missing path and every record must name the object it touched.
+    Y_UNIT_TEST(PathBearingOpNeverStoresAnApproximatePath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        ui64 checkedThrough = 0;
+        ui32 checkedRecords = 0;
+        // Checked after every op, before a later drop or rename can invalidate an
+        // already-correct path. targetsStillExist is false once the op removed them.
+        auto verifyNewRecords = [&](bool targetsStillExist) {
+            const auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+            ui64 maxOrder = checkedThrough;
+            for (const auto& e : entries) {
+                maxOrder = Max(maxOrder, e.Order);
+                if (e.Order <= checkedThrough) {
+                    continue;
+                }
+                // Bootstrap system views (.sys/*) are recorded too; not this test's DDL.
+                if (AnyPathContains(e, ".sys/")) {
+                    continue;
+                }
+                const TString opName = NKikimrSchemeOp::EOperationType_Name(e.Body.GetOperationType());
+                // An empty path is the database root itself, per RelativeToDomain's
+                // contract; the resolve below rejects it for anything else.
+                UNIT_ASSERT_C(!e.Targets.empty(), opName << " recorded no target at all");
+                ++checkedRecords;
+                if (!targetsStillExist) {
+                    continue;
+                }
+                for (size_t i = 0; i < e.Targets.size(); ++i) {
+                    AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e, i);
+                }
+            }
+            checkedThrough = maxOrder;
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing"), 0u,
+                "no op in this corpus may fail to resolve a path");
+        };
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "IndexedTable1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "ByValue"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream2"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestAlterCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            Disable {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "SubDomain1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        // Two streams in one op: the repeated StreamName must yield two targets.
+        TestDropCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            StreamName: "Stream2"
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(false);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "MoveSrc"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/MoveSrc", "/MyRoot/MoveDst");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        UNIT_ASSERT_C(checkedRecords >= 10,
+            "the corpus must actually have produced records to check, got " << checkedRecords);
+    }
+
+    // The pathless allowlist is empty today, so an ordinary op must still produce
+    // its record -- the invariant above must not be satisfiable by refusing everything.
+    Y_UNIT_TEST(OrdinaryOpsStillProduceRecordsWhenAllowlistIsEmpty) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "PlainTable"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "PlainTable") {
+                found = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "an ordinary path-bearing op must still produce a record");
+    }
+
+    // One record per TModifyScheme in the request (Body is the atomic replay unit),
+    // so a copy of N tables must list all N as targets, each with its own
+    // destination and source.
+    Y_UNIT_TEST(ConsistentCopyTablesRecordsAllTargetsWithSources) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestConsistentCopyTables(runtime, ++txId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src1"
+                DstPath: "/MyRoot/Dst1"
+            }
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src2"
+                DstPath: "/MyRoot/Dst2"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "a resolvable multi-target copy must not bump the path-missing counter");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateConsistentCopyTables entry not found -- the propose must not be refused");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 2u,
+            "record must list all N copy targets, got " << found->Targets.size());
+
+        THashMap<TString, TString> dstToSrc;
+        for (const auto& target : found->Targets) {
+            UNIT_ASSERT_VALUES_EQUAL_C(target.SourcePaths.size(), 1u,
+                "each copy target must have exactly one source, got "
+                    << target.SourcePaths.size() << " for " << target.Path);
+            dstToSrc[target.Path] = target.SourcePaths[0];
+        }
+        UNIT_ASSERT_C(dstToSrc.contains("Dst1"), "missing Dst1 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_C(dstToSrc.contains("Dst2"), "missing Dst2 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst1"], "Src1",
+            "Dst1's target must record Src1 as its source");
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst2"], "Src2",
+            "Dst2's target must record Src2 as its source");
+        // Every one of the N targets must resolve; only target[0] carries a captured
+        // PathId, so [1] gets a plain resolve check.
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, 0);
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, 1);
+    }
+
+    // A plain single-target op must still yield exactly one target, with SourcePaths
+    // empty -- it is a repeated field, so "empty" is the assertion, not "unset".
+    Y_UNIT_TEST(SingleTargetOpRecordsExactlyOneTarget) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u,
+            "a single-target op must yield exactly one target entry, got " << found->Targets.size());
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets[0].Path, "Table1");
+        UNIT_ASSERT_C(found->Targets[0].SourcePaths.empty(),
+            "a plain create has no source, SourcePaths must be empty");
+    }
+
+    // A rename records the object's new location as Path (where a consumer looks it
+    // up afterwards) and its old location as the sole SourcePaths entry.
+    Y_UNIT_TEST(MoveRecordsDestinationAndSource) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "MoveSrc"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/MoveSrc", "/MyRoot/MoveDst");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMoveTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "MOVE TABLE entry not found -- the propose must not be refused");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "MoveDst",
+            "Path must be the object's new (destination) location, database-relative");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].SourcePaths.size(), 1u,
+            "a rename has exactly one source, got " << found->Targets[0].SourcePaths.size());
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].SourcePaths[0], "MoveSrc",
+            "SourcePaths must record the object's old (source) location, database-relative");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // The domain root's path relative to its own domain is the empty string, per
+    // RelativeToDomain's contract -- that empty path is correct, not approximate.
+    Y_UNIT_TEST(AlterDatabaseRootItselfStoresEmptyPath) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        runtime.GetAppData().FeatureFlags.SetEnableAlterDatabase(true);
+        ui64 txId = 100;
+
+        TestAlterSubDomain(runtime, ++txId, "/", R"(
+            Name: "MyRoot"
+            SchemeLimits {
+                MaxPaths: 1000
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ALTER SUBDOMAIN(root) entry not found -- altering the root must not be refused");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "",
+            "the database root's own path, relative to itself, must be the empty string");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // Exactly one record for the whole requested TModifyScheme, and its path is the
+    // table -- not an index impl table synthesized during the same tx.
+    Y_UNIT_TEST(CreateIndexedTableWritesExactlyOneRecordForTheTable) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "IndexedTable1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "byValue"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        ui32 indexedTableRecords = 0;
+        TVector<TString> storedPaths;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateIndexedTable) {
+                ++indexedTableRecords;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                storedPaths.push_back(e.Targets[0].Path);
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(indexedTableRecords, 1u,
+            "CreateIndexedTable must write exactly one record for the whole requested tx");
+        UNIT_ASSERT_VALUES_EQUAL_C(storedPaths[0], "IndexedTable1",
+            "the stored path must be the table itself, not an index impl table");
+    }
+}
+
+namespace {
+
+// Drivers for the shapes whose recorded target is not a plain WorkingDir/Name.
+// Each runs under a nested working dir, where a prefix mistake cannot hide.
+struct TPathShapeCase {
+    TString Name;
+    NKikimrSchemeOp::EOperationType OpType;
+    TVector<TString> ExpectedPaths;
+    std::function<void(TTestActorRuntime&, TTestEnv&, ui64&)> Drive;
+};
+
+const TVector<TPathShapeCase>& GetPathShapeCases() {
+    static const TVector<TPathShapeCase> cases = {
+        // The record must carry the whole multi-segment path the user asked for,
+        // not just the leaf the auto-mkdir chain ends on.
+        {"CreateTable auto-mkdir", NKikimrSchemeOp::ESchemeOpCreateTable, {"Dir1/A/B/Leaf"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "A/B/Leaf"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // The target is nested one level inside TableDescription, and the op also
+        // synthesizes index impl tables that must not become the target.
+        {"CreateIndexedTable", NKikimrSchemeOp::ESchemeOpCreateIndexedTable, {"Dir1/Table1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateIndexedTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableDescription {
+                     Name: "Table1"
+                     Columns { Name: "key" Type: "Uint64" }
+                     Columns { Name: "value" Type: "Utf8" }
+                     KeyColumnNames: ["key"]
+                 }
+                 IndexDescription {
+                     Name: "Index1"
+                     KeyColumnNames: ["value"]
+                     Type: EIndexTypeGlobal
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // WorkingDir/TableName/StreamDescription.Name: two levels below the working
+        // dir, so neither a direct-child lookup nor the reflection walk finds it.
+        {"CreateCdcStream", NKikimrSchemeOp::ESchemeOpCreateCdcStream, {"Dir1/Table1/Stream1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Table1"
+                 Columns { Name: "key"   Type: "Uint64" }
+                 Columns { Name: "value" Type: "Utf8" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestCreateCdcStream(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableName: "Table1"
+                 StreamDescription {
+                     Name: "Stream1"
+                     Mode: ECdcStreamModeKeysOnly
+                     Format: ECdcStreamFormatProto
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // WorkingDir/TableName/StreamName, and no field literally named Name.
+        {"AlterCdcStream", NKikimrSchemeOp::ESchemeOpAlterCdcStream, {"Dir1/Table1/Stream1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Table1"
+                 Columns { Name: "key"   Type: "Uint64" }
+                 Columns { Name: "value" Type: "Utf8" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestCreateCdcStream(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableName: "Table1"
+                 StreamDescription {
+                     Name: "Stream1"
+                     Mode: ECdcStreamModeKeysOnly
+                     Format: ECdcStreamFormatProto
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestAlterCdcStream(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableName: "Table1"
+                 StreamName: "Stream1"
+                 Disable {}
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // A rename records the destination, so the path a consumer looks up after
+        // the op is the new one, not the vanished source.
+        {"MoveTable", NKikimrSchemeOp::ESchemeOpMoveTable, {"Dir1/MoveDst"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "MoveSrc"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestMoveTable(runtime, ++txId, "/MyRoot/Dir1/MoveSrc", "/MyRoot/Dir1/MoveDst");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // TMoveIndex.SrcPath/DstPath are index names relative to TablePath, not
+        // absolute paths -- treating them as absolute resolved to nothing.
+        {"MoveIndex", NKikimrSchemeOp::ESchemeOpMoveIndex, {"Dir1/Table1/Index2"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateIndexedTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableDescription {
+                     Name: "Table1"
+                     Columns { Name: "key" Type: "Uint64" }
+                     Columns { Name: "value" Type: "Utf8" }
+                     KeyColumnNames: ["key"]
+                 }
+                 IndexDescription {
+                     Name: "Index1"
+                     KeyColumnNames: ["value"]
+                     Type: EIndexTypeGlobal
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestMoveIndex(runtime, ++txId, "/MyRoot/Dir1/Table1", "Index1", "Index2", false);
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // N destinations in one op: each must get its own target, in request order.
+        {"CreateConsistentCopyTables", NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables,
+         {"Dir1/Dst1", "Dir1/Dst2"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Src1"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Src2"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestConsistentCopyTables(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 CopyTableDescriptions {
+                     SrcPath: "/MyRoot/Dir1/Src1"
+                     DstPath: "/MyRoot/Dir1/Dst1"
+                 }
+                 CopyTableDescriptions {
+                     SrcPath: "/MyRoot/Dir1/Src2"
+                     DstPath: "/MyRoot/Dir1/Dst2"
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // TTruncateTable names its target TableName, not Name.
+        {"TruncateTable", NKikimrSchemeOp::ESchemeOpTruncateTable, {"Dir1/Table1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Table1"
+                 Columns { Name: "key"   Type: "Uint64" }
+                 Columns { Name: "value" Type: "Utf8" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestTruncateTable(runtime, ++txId, "/MyRoot/Dir1", "Table1");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // TAlterUserAttributes names its target PathName, not Name.
+        {"AlterUserAttributes", NKikimrSchemeOp::ESchemeOpAlterUserAttributes, {"Dir1/Sub"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestMkDir(runtime, ++txId, "/MyRoot/Dir1", "Sub");
+             env.TestWaitNotification(runtime, txId);
+             TestUserAttrs(runtime, ++txId, "/MyRoot/Dir1", "Sub",
+                 AlterUserAttrs({{"attr1", "value1"}}));
+             env.TestWaitNotification(runtime, txId);
+         }},
+    };
+    return cases;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsPathCorrectnessTests) {
+    // A resolvable-but-wrong path is the failure mode here: the recorded path must
+    // resolve to the very object the operation touched, not to a plausible sibling.
+    Y_UNIT_TEST(RecordedPathResolvesToTouchedObject) {
+        for (const auto& testCase : GetPathShapeCases()) {
+            TTestBasicRuntime runtime;
+            TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+            ui64 txId = 100;
+
+            TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+            env.TestWaitNotification(runtime, txId);
+
+            testCase.Drive(runtime, env, txId);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing"), 0u,
+                testCase.Name << ": the driver must not fail to resolve a path");
+
+            auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+            const TSchemeChangeRecordEntry* found = nullptr;
+            for (const auto& e : entries) {
+                if (e.Body.GetOperationType() == testCase.OpType) {
+                    found = &e;
+                }
+            }
+            UNIT_ASSERT_C(found, testCase.Name << ": no record for "
+                << NKikimrSchemeOp::EOperationType_Name(testCase.OpType));
+            UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), testCase.ExpectedPaths.size(),
+                testCase.Name << ": target count mismatch, got " << AllTargetPaths(*found));
+            for (size_t i = 0; i < testCase.ExpectedPaths.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[i].Path, testCase.ExpectedPaths[i],
+                    testCase.Name << ": target " << i << " path mismatch, got "
+                    << AllTargetPaths(*found));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, i);
+            }
+        }
+    }
+}
+
+// Drives suspected-outage op types against the target extractors.
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
+    Y_UNIT_TEST(AlterUserAttributesRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "SubDir");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestUserAttrs(runtime, ++txId, "/MyRoot", "SubDir",
+            AlterUserAttrs({{"attr1", "value1"}}));
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "AlterUserAttributes must resolve a path; TAlterUserAttributes.PathName is not "
+            "found by the generic reflection walk (it looks for a field literally named Name)");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterUserAttributes) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "SubDir"),
+                    "expected the target to be SubDir, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterUserAttributes must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterTableByPathIdRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tablePathId = DescribePath(runtime, "/MyRoot/Table1").GetPathId();
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // An id-addressed alter names no path at all: WorkingDir is a placeholder
+        // and TTableDescription.Name is unset.
+        TStringBuilder schema;
+        schema << "Id_Deprecated: " << tablePathId << Endl
+               << R"(Columns { Name: "added" Type: "Uint32" })";
+        TestAlterTable(runtime, ++txId, "not used", schema);
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "an alter addressed by path id must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "an id-addressed alter must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateWithUserAttributesRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // A create carries TAlterUserAttributes as a side payload with PathName
+        // unset; the target is still named by the create's own payload.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusAccepted}, AlterUserAttrs({{"attr1", "value1"}}));
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "CreateTable with user attributes must resolve a path, not lose its target to the "
+            "empty AlterUserAttributes.PathName");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateTable with user attributes must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterCdcStreamRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // TAlterCdcStream{TableName,StreamName} has no field literally named Name, so the
+        // generic reflection walk cannot find it; the CDC extractor names it explicitly.
+        TestAlterCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            Disable {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "AlterCdcStream must resolve a path, not bump SchemeChangePathMissing: "
+            "counter went " << rejectedBefore << " -> " << rejectedAfter);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterCdcStream) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "Stream1"),
+                    "expected the target to be the changefeed, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterCdcStream must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(MoveIndexRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "Index1"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TMoveIndex.SrcPath/DstPath are index names relative to TablePath, not
+        // absolute paths, so TPath::Resolve used to fail and refuse the propose.
+        TestMoveIndex(runtime, ++txId, "/MyRoot/Table1", "Index1", "Index2", false);
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "MoveIndex must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMoveIndex) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Index2"),
+                    "expected the target to be the new index name, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "MoveIndex must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(UpgradeSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Already safe: TUpgradeSubDomain.Name is a direct scalar Name field,
+        // found by the generic reflection walk. Kept as a regression guard.
+        TestUpgradeSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "UpgradeSubDomain must resolve a path");
+    }
+
+    Y_UNIT_TEST(TruncateTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TTruncateTable.TableName has no field literally named Name,
+        // so the generic reflection walk used to miss it and refuse the propose.
+        TestTruncateTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "TruncateTable must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpTruncateTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "TruncateTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateContinuousBackupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TCreateContinuousBackup.TableName has no field literally named Name,
+        // so the generic reflection walk used to miss it and refuse the propose.
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "CreateContinuousBackup must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateContinuousBackup) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateContinuousBackup must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(RestoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        // Restore targets an existing table (it restores INTO it), so the target must
+        // already exist for the propose to get past path resolution.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TRestoreTask names its target TableName. Full completion needs a real
+        // backup fixture, so this checks propose-time resolution only.
+        TestRestore(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            TableDescription {
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            }
+            FSSettings {
+                BasePath: "/tmp"
+                Path: "restore"
+            }
+        )");
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "Restore must resolve a path");
+
+        // The op never completes here, so the row is still the propose-time one:
+        // its path is assertable, its PathId is not yet written back.
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpRestore) {
+                found = &e;
+            }
+        }
+        UNIT_ASSERT_C(found, "Restore must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u,
+            "Restore targets one table, got " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "Table1",
+            "the target must be the restored-into table, not its working directory");
+    }
+
+    Y_UNIT_TEST(AlterLoginRecordsAPath) {
+        // TAlterLogin's target is nested inside a oneof (e.g. CreateUser.User), never
+        // a top-level scalar Name/PathName/TableName field.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        const auto hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "alice", hashes.HashedPassword);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "AlterLogin must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterLogin) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterLogin must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u, "AlterLogin");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "",
+            "AlterLogin has no path-bearing target -- it must be attributed to the "
+            "database root itself, relative to which the root's own path is empty");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // Exercises the Drop.Id branch of ResolveSchemeChangeTargets (Drop.Id set,
+    // Drop.Name/WorkingDir unset), as produced by replication's dst_remover.
+    Y_UNIT_TEST(DropByIdRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirToDropById");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/DirToDropById"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestForceDropUnsafe(runtime, ++txId, droppedLocalId);
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "Drop.Id (Drop.Name/WorkingDir unset) must resolve a path by PathId");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpForceDropUnsafe) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ForceDropUnsafe (Drop.Id) must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u, "ForceDropUnsafe");
+        UNIT_ASSERT_C(AnyPathContains(*found, "DirToDropById"),
+            "expected the target to be the dropped directory, got: " << AllTargetPaths(*found));
+        // The object is gone by finalize time, so assert against the identity captured
+        // before the drop rather than a live re-resolve.
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId,
+            "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId,
+            "recorded PathLocalId must match the dropped object's identity, not some other path");
+    }
+
+    Y_UNIT_TEST(CreatePQGroupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            TotalGroupCount: 1
+            PartitionPerTablet: 1
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreatePersQueueGroup) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "PQGroup1"),
+                    "expected the target to be PQGroup1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreatePQGroup must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSubDomain) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "USD1"),
+                    "expected the target to be USD1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSubDomain must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateRtmrVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateRtmrVolume(runtime, ++txId, "/MyRoot", R"(
+            Name: "rtmr1"
+            PartitionsCount: 0
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateRtmrVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "rtmr1"),
+                    "expected the target to be rtmr1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateRtmrVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateBlockStoreVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolume1");
+        auto& vc = *vdescr.MutableVolumeConfig();
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+        TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateBlockStoreVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BSVolume1"),
+                    "expected the target to be BSVolume1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateBlockStoreVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateKesusRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateKesus) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Kesus1"),
+                    "expected the target to be Kesus1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateKesus must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSolomonVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            PartitionCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSolomonVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Solomon1"),
+                    "expected the target to be Solomon1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSolomon must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateFileStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        descr.SetName("FileStore1");
+        auto& config = *descr.MutableConfig();
+        config.SetBlockSize(4096);
+        config.SetBlocksCount(4096);
+        config.SetFileSystemId("FileStore1");
+        config.SetCloudId("cloud");
+        config.SetFolderId("folder");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateFileStore) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "FileStore1"),
+                    "expected the target to be FileStore1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateFileStore must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateColumnStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            ColumnShardCount: 1
+            SchemaPresets {
+                Name: "default"
+                Schema {
+                    Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                    Columns { Name: "data" Type: "Utf8" }
+                    KeyColumnNames: "timestamp"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateColumnStore) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "OlapStore1"),
+                    "expected the target to be OlapStore1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateOlapStore must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateColumnTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateColumnTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ColumnTable1"),
+                    "expected the target to be ColumnTable1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateColumnTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateExtSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExtSubDomain1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateExtSubDomain) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ExtSubDomain1"),
+                    "expected the target to be ExtSubDomain1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateExtSubDomain must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateExternalTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource1"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalTable1"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/ExternalDataSource1"
+            Location: "/"
+            Columns { Name: "key" Type: "Uint64" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateExternalTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ExternalTable1"),
+                    "expected the target to be ExternalTable1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateExternalTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateExternalDataSourceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource2"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateExternalDataSource) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ExternalDataSource2"),
+                    "expected the target to be ExternalDataSource2, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateExternalDataSource must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateView(runtime, ++txId, "/MyRoot", R"(
+            Name: "View1"
+            QueryText: "Some query"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateView) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "View1"),
+                    "expected the target to be View1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateView must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateResourcePoolRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateResourcePool) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ResourcePool1"),
+                    "expected the target to be ResourcePool1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateResourcePool must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateBackupCollectionRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).EnableBackupService(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(
+            Name: "BackupCollection1"
+            ExplicitEntryList {
+                Entries {
+                    Type: ETypeTable
+                    Path: "/MyRoot/Table1"
+                }
+            }
+            Cluster: {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateBackupCollection) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BackupCollection1"),
+                    "expected the target to be BackupCollection1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateBackupCollection must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSysViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys", R"(
+            Name: "sys_view_1"
+            Type: EPartitionStats
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSysView
+                        && AnyPathContains(e, "sys_view_1")) {
+                found = true;
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSysView must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSecretRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot", R"(
+            Name: "Secret1"
+            Value: "value1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSecret) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Secret1"),
+                    "expected the target to be Secret1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSecret must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateStreamingQueryRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateStreamingQuery(runtime, ++txId, "/MyRoot", R"(
+            Name: "StreamingQuery1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateStreamingQuery) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "StreamingQuery1"),
+                    "expected the target to be StreamingQuery1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateStreamingQuery must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateTestShardSetRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTestShardSet(runtime, ++txId, "/MyRoot", CreateTestShardSetConfig("TestShardSet1"));
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTestShardSet) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "TestShardSet1"),
+                    "expected the target to be TestShardSet1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateTestShardSet must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSequenceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSequence(runtime, ++txId, "/MyRoot", R"(
+            Name: "Sequence1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSequence) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Sequence1"),
+                    "expected the target to be Sequence1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSequence must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateLockRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestLock(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateLock) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateLock must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterPersQueueGroupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            TotalGroupCount: 1
+            PartitionPerTablet: 1
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterPQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 20}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterPersQueueGroup) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "PQGroup1"),
+                    "expected the target to be PQGroup1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterPQGroup must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterBlockStoreVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolume1");
+        auto& vc = *vdescr.MutableVolumeConfig();
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription alterDescr;
+        alterDescr.SetName("BSVolume1");
+        auto& alterVc = *alterDescr.MutableVolumeConfig();
+        alterVc.SetVersion(1);
+        alterVc.AddPartitions()->SetBlockCount(16);
+        alterVc.AddPartitions()->SetBlockCount(16);
+        TestAlterBlockStoreVolume(runtime, ++txId, "/MyRoot", alterDescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterBlockStoreVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BSVolume1"),
+                    "expected the target to be BSVolume1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterBlockStoreVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterKesusRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterKesus(runtime, ++txId, "/MyRoot", R"(
+            Name: "Kesus1"
+            Config { self_check_period_millis: 3000 }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterKesus) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Kesus1"),
+                    "expected the target to be Kesus1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterKesus must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterExtSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "ExtSubDomain1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestAlterExtSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExtSubDomain1"
+            ExternalSchemeShard: true
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            StoragePools {
+                Name: "name_USER_0_kind_hdd-1"
+                Kind: "pool-kind-1"
+            }
+            StoragePools {
+                Name: "name_USER_0_kind_hdd-2"
+                Kind: "pool-kind-2"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "AlterExtSubDomain must resolve a path");
+    }
+
+    Y_UNIT_TEST(AlterSolomonVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            PartitionCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Alter with no actual partition/channel change: only that the outbox resolves
+        // the target matters here, not the status the op itself returns.
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        TestAlterSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            ChannelProfileId: 3
+        )", {NKikimrScheme::StatusInvalidParameter});
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "AlterSolomon must resolve a path");
+    }
+
+    Y_UNIT_TEST(AlterColumnStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            ColumnShardCount: 1
+            SchemaPresets {
+                Name: "default"
+                Schema {
+                    Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                    Columns { Name: "data" Type: "Utf8" }
+                    KeyColumnNames: "timestamp"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            AlterSchemaPresets {
+                Name: "default"
+                AlterSchema {
+                    AddColumns { Name: "comment" Type: "Utf8" }
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterColumnStore) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "OlapStore1"),
+                    "expected the target to be OlapStore1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterOlapStore must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterColumnTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            UpsertMultiColumnStatistics { Name: "s1" ColumnNames: "data" Types: COUNT_MIN_SKETCH }
+        )", {NKikimrScheme::StatusSuccess});
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterColumnTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ColumnTable1"),
+                    "expected the target to be ColumnTable1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterColumnTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterSequenceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSequence(runtime, ++txId, "/MyRoot", R"(Name: "Sequence1")");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterSequence(runtime, ++txId, "/MyRoot", R"(
+            Name: "Sequence1"
+            Increment: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterSequence) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Sequence1"),
+                    "expected the target to be Sequence1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterSequence must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterResourcePoolRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+            Properties {
+                Properties {
+                    key: "concurrent_query_limit",
+                    value: "20"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterResourcePool) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ResourcePool1"),
+                    "expected the target to be ResourcePool1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterResourcePool must produce a scheme change record");
+    }
+
+    // The drop-family tests below capture the touched object's identity before the
+    // drop and assert against it, since the path no longer resolves afterwards.
+    Y_UNIT_TEST(DropTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTable must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Table1"),
+            "expected the target to be Table1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropPersQueueGroupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            TotalGroupCount: 1
+            PartitionPerTablet: 1
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/PQGroup1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropPQGroup(runtime, ++txId, "/MyRoot", "PQGroup1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropPersQueueGroup) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropPQGroup must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "PQGroup1"),
+            "expected the target to be PQGroup1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/USD1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSubDomain must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "USD1"),
+            "expected the target to be USD1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropKesusRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Kesus1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropKesus(runtime, ++txId, "/MyRoot", "Kesus1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropKesus) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropKesus must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Kesus1"),
+            "expected the target to be Kesus1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSolomonVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            PartitionCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Solomon1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSolomon(runtime, ++txId, "/MyRoot", "Solomon1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSolomonVolume) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSolomon must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Solomon1"),
+            "expected the target to be Solomon1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(ForceDropSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/USD1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestForceDropSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpForceDropSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ForceDropSubDomain must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "USD1"),
+            "expected the target to be USD1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(ForceDropExtSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "ExtSubDomain1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExtSubDomain1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestForceDropExtSubDomain(runtime, ++txId, "/MyRoot", "ExtSubDomain1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpForceDropExtSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ForceDropExtSubDomain must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ExtSubDomain1"),
+            "expected the target to be ExtSubDomain1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropFileStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        descr.SetName("FileStore1");
+        auto& config = *descr.MutableConfig();
+        config.SetBlockSize(4096);
+        config.SetBlocksCount(4096);
+        config.SetFileSystemId("FileStore1");
+        config.SetCloudId("cloud");
+        config.SetFolderId("folder");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/FileStore1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "FileStore1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropFileStore) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropFileStore must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "FileStore1"),
+            "expected the target to be FileStore1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropColumnStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            ColumnShardCount: 1
+            SchemaPresets {
+                Name: "default"
+                Schema {
+                    Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                    Columns { Name: "data" Type: "Utf8" }
+                    KeyColumnNames: "timestamp"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/OlapStore1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropOlapStore(runtime, ++txId, "/MyRoot", "OlapStore1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropColumnStore) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropOlapStore must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "OlapStore1"),
+            "expected the target to be OlapStore1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropColumnTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ColumnTable1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropColumnTable(runtime, ++txId, "/MyRoot", "ColumnTable1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropColumnTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropColumnTable must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ColumnTable1"),
+            "expected the target to be ColumnTable1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropExternalTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource1"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalTable1"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/ExternalDataSource1"
+            Location: "/"
+            Columns { Name: "key" Type: "Uint64" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExternalTable1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropExternalTable(runtime, ++txId, "/MyRoot", "ExternalTable1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropExternalTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropExternalTable must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ExternalTable1"),
+            "expected the target to be ExternalTable1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropExternalDataSourceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource1"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExternalDataSource1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropExternalDataSource(runtime, ++txId, "/MyRoot", "ExternalDataSource1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropExternalDataSource) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropExternalDataSource must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ExternalDataSource1"),
+            "expected the target to be ExternalDataSource1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateView(runtime, ++txId, "/MyRoot", R"(
+            Name: "View1"
+            QueryText: "Some query"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/View1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropView(runtime, ++txId, "/MyRoot", "View1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropView) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropView must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "View1"),
+            "expected the target to be View1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropContinuousBackupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1"));
+        const ui64 tableOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 tableLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropContinuousBackup) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropContinuousBackup must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Table1"),
+            "expected the target to be Table1, got: " << AllTargetPaths(*found));
+        // The target table is not itself dropped, but the pre-op-captured identity is
+        // used for symmetry with the other Drop* tests in this suite.
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, tableOwnerId, "recorded PathOwnerId must match Table1's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, tableLocalId, "recorded PathLocalId must match Table1's identity");
+    }
+
+    Y_UNIT_TEST(DropResourcePoolRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropResourcePool) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropResourcePool must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ResourcePool1"),
+            "expected the target to be ResourcePool1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropBackupCollectionRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).EnableBackupService(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(
+            Name: "BackupCollection1"
+            ExplicitEntryList {
+                Entries {
+                    Type: ETypeTable
+                    Path: "/MyRoot/Table1"
+                }
+            }
+            Cluster: {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.backups/collections/BackupCollection1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(Name: "BackupCollection1")");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropBackupCollection) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropBackupCollection must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "BackupCollection1"),
+            "expected the target to be BackupCollection1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSysViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys", R"(
+            Name: "sys_view_1"
+            Type: EPartitionStats
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.sys/sys_view_1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSysView(runtime, ++txId, "/MyRoot/.sys", "sys_view_1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSysView) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSysView must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "sys_view_1"),
+            "expected the target to be sys_view_1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSecretRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot", R"(
+            Name: "Secret1"
+            Value: "value1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Secret1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSecret(runtime, ++txId, "/MyRoot", "Secret1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSecret) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSecret must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Secret1"),
+            "expected the target to be Secret1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropStreamingQueryRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateStreamingQuery(runtime, ++txId, "/MyRoot", R"(
+            Name: "StreamingQuery1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/StreamingQuery1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropStreamingQuery(runtime, ++txId, "/MyRoot", "StreamingQuery1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropStreamingQuery) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropStreamingQuery must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "StreamingQuery1"),
+            "expected the target to be StreamingQuery1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropTestShardSetRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTestShardSet(runtime, ++txId, "/MyRoot", CreateTestShardSetConfig("TestShardSet1"));
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/TestShardSet1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTestShardSet(runtime, ++txId, "/MyRoot", "TestShardSet1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTestShardSet) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTestShardSet must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "TestShardSet1"),
+            "expected the target to be TestShardSet1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropTableIndexRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "Index1"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1/Index1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTableIndex(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            IndexName: "Index1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // TestDropTableIndex issues ESchemeOpDropIndex as the top-level OperationType;
+        // ESchemeOpDropTableIndex is a distinct, apparently-unissued enum value.
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropIndex) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTableIndex must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Index1"),
+            "expected the target to be Index1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped index's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped index's identity");
+    }
+
+    Y_UNIT_TEST(DropLockRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestLock(runtime, ++txId, "/MyRoot", "Table1");
+        const ui64 lockId = txId;
+        env.TestWaitNotification(runtime, txId);
+
+        TestUnlock(runtime, ++txId, lockId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropLock) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "DropLock (unlock) must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(RmDirRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirToRemove");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/DirToRemove"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestRmDir(runtime, ++txId, "/MyRoot", "DirToRemove");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpRmDir) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "RmDir must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "DirToRemove"),
+            "expected the target to be DirToRemove, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the removed dir's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the removed dir's identity");
+    }
+
+    Y_UNIT_TEST(ModifyACLRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestModifyACL(runtime, ++txId, "/MyRoot", "Table1", "", "bob@builtin");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpModifyACL) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "ModifyACL must produce a scheme change record");
+    }
+
+    // CreateIndexBuild is a top-level op whose target is InitiateIndexBuild.Table,
+    // an absolute path; an unresolved refusal used to crash the tablet on abort.
+    Y_UNIT_TEST(CreateIndexBuildRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint32" }
+            Columns { Name: "index" Type: "Uint32" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table1",
+            TBuildIndexConfig{"Index1", NKikimrSchemeOp::EIndexTypeGlobal, {"index"}, {}, {}});
+        const ui64 buildIndexId = txId;
+        env.TestWaitNotification(runtime, buildIndexId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateIndexBuild) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateIndexBuild must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CancelIndexBuildRecordsAPath) {
+        // Same fix as CreateIndexBuildRecordsAPath: CancelIndexBuild.TablePath
+        // is an absolute path, resolved directly now instead of refused.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint32" }
+            Columns { Name: "index" Type: "Uint32" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table1",
+            TBuildIndexConfig{"Index1", NKikimrSchemeOp::EIndexTypeGlobal, {"index"}, {}, {}});
+        const ui64 buildIndexId = txId;
+
+        TestCancelBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+        env.TestWaitNotification(runtime, buildIndexId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCancelIndexBuild) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CancelIndexBuild must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateReplicationRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateReplication) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Replication1"),
+                    "expected the target to be Replication1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateReplication must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterReplicationRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            State { Paused {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterReplication) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Replication1"),
+                    "expected the target to be Replication1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterReplication must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(DropReplicationRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Replication1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropReplication(runtime, ++txId, "/MyRoot", "Replication1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropReplication) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropReplication must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Replication1"),
+            "expected the target to be Replication1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropReplicationCascadeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Replication1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropReplicationCascade(runtime, ++txId, "/MyRoot", "Replication1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropReplicationCascade) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropReplicationCascade must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Replication1"),
+            "expected the target to be Replication1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(CreateTransferRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTransfer) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Transfer1"),
+                    "expected the target to be Transfer1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateTransfer must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterTransferRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            State { Paused {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTransfer) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Transfer1"),
+                    "expected the target to be Transfer1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterTransfer must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(DropTransferRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Transfer1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTransfer(runtime, ++txId, "/MyRoot", "Transfer1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTransfer) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTransfer must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Transfer1"),
+            "expected the target to be Transfer1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropTransferCascadeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Transfer1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTransferCascade(runtime, ++txId, "/MyRoot", "Transfer1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTransferCascade) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTransferCascade must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Transfer1"),
+            "expected the target to be Transfer1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(BackupRecordsAPath) {
+        // Driving Backup to completion needs a real S3 endpoint, so this checks only
+        // propose-time path resolution, not the post-finalize resolve.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            S3Settings {
+                Endpoint: "localhost:1"
+                Scheme: HTTP
+            }
+        )");
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "Backup must resolve a path");
+
+        // The op never completes here, so the row is still the propose-time one:
+        // its path is assertable, its PathId is not yet written back.
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpBackup) {
+                found = &e;
+            }
+        }
+        UNIT_ASSERT_C(found, "Backup must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u,
+            "Backup targets one table, got " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "Table1",
+            "the target must be the backed-up table, not its working directory");
+    }
+    Y_UNIT_TEST(AssignBlockStoreVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolume1");
+        auto& vc = *vdescr.MutableVolumeConfig();
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        TestAssignBlockStoreVolume(runtime, ++txId, "/MyRoot", "BSVolume1", "Owner123");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAssignBlockStoreVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BSVolume1"),
+                    "expected the target to be BSVolume1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AssignBlockStoreVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(UpgradeSubDomainDecisionRecordsAPath) {
+        // Upgrading the domain blocks a live read here, so this asserts propose-time
+        // resolution via the rejection counter instead.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
+        env.TestWaitNotification(runtime, txId);
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestUpgradeSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        TestUpgradeSubDomainDecision(runtime, ++txId, "/MyRoot", "USD1", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
+        env.TestWaitNotification(runtime, txId);
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "UpgradeSubDomainDecision must resolve a path");
+    }
+}
+
+namespace {
+
+// An alter addressed by path id ignores WorkingDir, so the op succeeds while the
+// outbox is left with a name under a directory that does not exist.
+ui64 ProposeAlterWithUnresolvableTarget(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+    TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+        Name: "Table1"
+        Columns { Name: "key"   Type: "Uint64" }
+        Columns { Name: "value" Type: "Utf8" }
+        KeyColumnNames: ["key"]
+    )");
+    env.TestWaitNotification(runtime, txId);
+
+    const ui64 tablePathId = DescribePath(runtime, "/MyRoot/Table1").GetPathId();
+
+    TStringBuilder schema;
+    schema << "Id_Deprecated: " << tablePathId << Endl
+           << R"(Name: "Table1")" << Endl
+           << R"(Columns { Name: "added" Type: "Uint32" })";
+    TestAlterTable(runtime, ++txId, "/MyRoot/NoSuchDir", schema);
+    env.TestWaitNotification(runtime, txId);
+
+    return tablePathId;
+}
+
+}  // anonymous namespace
+
+// Proves the tally can be non-zero at all, and that it survives a restart.
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsPathMissingTallyTests) {
+    Y_UNIT_TEST(TallyObservesAnUnresolvableTarget) {
+        // These two tests deliberately break the invariant the corpus mode asserts.
+        if (SchemeChangeCorpusEnabled()) {
+            return;
+        }
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        auto& tally = TSchemeChangePathMissingTally::Instance();
+        UNIT_ASSERT_VALUES_EQUAL_C(tally.Total(runtime), 0u, "nothing has failed to resolve yet");
+
+        ProposeAlterWithUnresolvableTarget(runtime, env, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(tally.Total(runtime), 1u,
+            "an alter whose target names a non-existent directory must be counted as unresolved");
+    }
+
+    Y_UNIT_TEST(TallySurvivesASchemeShardReboot) {
+        if (SchemeChangeCorpusEnabled()) {
+            return;
+        }
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        auto& tally = TSchemeChangePathMissingTally::Instance();
+        ProposeAlterWithUnresolvableTarget(runtime, env, txId);
+        UNIT_ASSERT_VALUES_EQUAL(tally.Total(runtime), 1u);
+
+        RebootSchemeShard(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing"), 0u,
+            "the raw tablet counter must have restarted at zero, otherwise this proves nothing");
+        UNIT_ASSERT_VALUES_EQUAL_C(tally.Total(runtime), 1u,
+            "the tally must carry the pre-reboot increment across the restart");
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/schemeshard/scheme_change_records.pb.h>
+#include <ydb/core/protos/console_config.pb.h>
+#include <ydb/core/cms/console/console.h>
+
+#include <util/string/join.h>
+#include <util/string/split.h>
+
+namespace NSchemeChangeRecordTestHelpers {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+// Mirrors NKikimrSchemeShard::TSchemeChangeTarget: SourcePaths is empty for a
+// plain create/alter/drop, non-empty for a move/rename or copy target.
+struct TTestSchemeChangeTarget {
+    TString Path;
+    TVector<TString> SourcePaths;
+};
+
+struct TSchemeChangeRecordEntry {
+    ui64 Order = 0;
+    ui64 TxId = 0;
+    ui64 PlanStep = 0;
+    ui32 OperationType = 0;
+    ui64 PathOwnerId = 0;
+    ui64 PathLocalId = 0;
+    TVector<TTestSchemeChangeTarget> Targets;
+    ui32 ObjectType = 0;
+    ui32 Status = 0;
+    TString UserSID;
+    ui64 SchemaVersion = 0;
+    ui64 CompletedAtUs = 0;
+    ui32 PositionKind = 0;
+    NKikimrSchemeOp::TModifyScheme Body;
+    // Resolved description captured when the record was written; empty if none.
+    TString Description;
+    // Field paths cleared by redaction; empty when nothing was cleared.
+    TVector<TString> RedactedFields;
+};
+
+// True if any of the entry's N target paths contains the given substring.
+// For single-target test fixtures, where exactly one target is expected.
+inline bool AnyPathContains(const TSchemeChangeRecordEntry& entry, const TString& substr) {
+    for (const auto& target : entry.Targets) {
+        if (target.Path.Contains(substr)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// True if the entry has exactly one target whose Path equals the given value.
+inline bool SinglePathEquals(const TSchemeChangeRecordEntry& entry, const TString& value) {
+    return entry.Targets.size() == 1 && entry.Targets[0].Path == value;
+}
+
+// Comma-joined target paths, for diagnostic messages.
+inline TString AllTargetPaths(const TSchemeChangeRecordEntry& entry) {
+    TVector<TString> paths;
+    for (const auto& target : entry.Targets) {
+        paths.push_back(target.Path);
+    }
+    return JoinSeq(",", paths);
+}
+
+// Asserts the recorded path resolves, in the live scheme, to the very object
+// the operation touched; `entry` must already carry a resolved PathId.
+inline void AssertRecordedPathResolvesToTouchedObject(
+    TTestActorRuntime& runtime, const TString& root, const TSchemeChangeRecordEntry& entry, size_t targetIdx = 0)
+{
+    UNIT_ASSERT_C(targetIdx < entry.Targets.size(),
+        "targetIdx " << targetIdx << " out of range, entry has " << entry.Targets.size() << " targets");
+    const TString& relPath = entry.Targets[targetIdx].Path;
+    const TString absPath = relPath.empty() ? root : (root + "/" + relPath);
+
+    // showPrivate: a changefeed lives under a table, which is not a common-sense
+    // path, so the default describe refuses it before any identity check runs.
+    auto describe = DescribePath(runtime, absPath, false, false, true);
+    UNIT_ASSERT_C(describe.GetStatus() == NKikimrScheme::StatusSuccess,
+        "recorded path \"" << relPath << "\" (absolute: \"" << absPath << "\") does not resolve "
+        "in the live scheme -- a bare/approximate path must fail this check, not pass it");
+
+    const ui64 resolvedOwnerId = describe.GetPathDescription().GetSelf().GetSchemeshardId();
+    const ui64 resolvedLocalId = describe.GetPathDescription().GetSelf().GetPathId();
+    UNIT_ASSERT_C(targetIdx != 0 || (entry.PathOwnerId != 0 || entry.PathLocalId != 0),
+        "entry has no resolved PathId to compare against -- was it read before FinalizeSchemeChangeRecord ran?");
+    if (targetIdx == 0) {
+        UNIT_ASSERT_VALUES_EQUAL_C(resolvedOwnerId, entry.PathOwnerId,
+            "recorded path \"" << relPath << "\" resolves to a different object's owner than "
+            "the one the operation touched (PathOwnerId mismatch)");
+        UNIT_ASSERT_VALUES_EQUAL_C(resolvedLocalId, entry.PathLocalId,
+            "recorded path \"" << relPath << "\" resolves to a different object than "
+            "the one the operation touched (PathLocalId mismatch): expected "
+            << entry.PathLocalId << ", resolved to " << resolvedLocalId);
+    }
+}
+
+struct TSchemeChangeRecordsReadResult {
+    TVector<TSchemeChangeRecordEntry> Entries;
+    ui64 ClosedThroughPlanStep = 0;
+};
+
+// Reads tables 141 + 143 directly, returning every row including unfinalised
+// ones. Select lists stay alphabetical: SelectRange orders columns by name.
+inline TVector<TSchemeChangeRecordEntry> ReadSchemeChangeRecordsFromTable(
+    TTestActorRuntime& runtime)
+{
+    const TString recordsQuery = R"___(
+        (
+            (let range '('('Order (Null) (Void))))
+            (let select '('BodySizeBytes 'CompletedAtUs 'Description 'ObjectType 'OperationType 'Order 'Path 'PathLocalId 'PathOwnerId 'PlanStep 'PositionKind 'RedactedFields 'SchemaVersion 'Status 'TxId 'UserSID))
+            (let result (SelectRange 'SchemeChangeRecords range select '()))
+            (return (AsList (SetResult 'R result)))
+        )
+    )___";
+    auto recordsResult = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, recordsQuery);
+
+    auto strOf = [](const NKikimrMiniKQL::TValue& v) -> TString {
+        return v.HasBytes() ? TString(v.GetBytes()) : TString(v.GetText());
+    };
+
+    TVector<TSchemeChangeRecordEntry> entries;
+    const auto& list = recordsResult.GetValue().GetStruct(0).GetOptional().GetStruct(0);
+    for (size_t i = 0; i < list.ListSize(); ++i) {
+        const auto& row = list.GetList(i);
+        TSchemeChangeRecordEntry entry;
+        entry.CompletedAtUs  = row.GetStruct(1).GetOptional().GetUint64();
+        entry.Description    = strOf(row.GetStruct(2).GetOptional());
+        entry.ObjectType     = row.GetStruct(3).GetOptional().GetUint32();
+        // "OperationType" sorts before "Order" ('p' < 'r'), so these two are
+        // not in the order they read.
+        entry.OperationType  = row.GetStruct(4).GetOptional().GetUint32();
+        entry.Order          = row.GetStruct(5).GetOptional().GetUint64();
+
+        NKikimrSchemeShard::TSchemeChangeRecordTargets targets;
+        const TString rawTargets = strOf(row.GetStruct(6).GetOptional());
+        if (!rawTargets.empty()) {
+            UNIT_ASSERT_C(targets.ParseFromString(rawTargets),
+                "SchemeChangeRecords::Path did not parse as TSchemeChangeRecordTargets");
+        }
+        for (const auto& t : targets.GetTargets()) {
+            TTestSchemeChangeTarget target;
+            target.Path = t.GetPath();
+            for (const auto& src : t.GetSourcePaths()) {
+                target.SourcePaths.push_back(src);
+            }
+            entry.Targets.push_back(std::move(target));
+        }
+
+        entry.PathLocalId    = row.GetStruct(7).GetOptional().GetUint64();
+        entry.PathOwnerId    = row.GetStruct(8).GetOptional().GetUint64();
+        entry.PlanStep       = row.GetStruct(9).GetOptional().GetUint64();
+        entry.PositionKind   = row.GetStruct(10).GetOptional().GetUint32();
+        const TString redacted = strOf(row.GetStruct(11).GetOptional());
+        if (!redacted.empty()) {
+            for (const auto& f : StringSplitter(redacted).Split('\n').SkipEmpty()) {
+                entry.RedactedFields.push_back(TString(f.Token()));
+            }
+        }
+        entry.SchemaVersion  = row.GetStruct(12).GetOptional().GetUint64();
+        entry.Status         = row.GetStruct(13).GetOptional().GetUint32();
+        entry.TxId           = row.GetStruct(14).GetOptional().GetUint64();
+        entry.UserSID        = strOf(row.GetStruct(15).GetOptional());
+        entries.push_back(std::move(entry));
+    }
+
+    // Bodies live in table 143, keyed by the same Order.
+    const TString bodiesQuery = R"___(
+        (
+            (let range '('('Order (Null) (Void))))
+            (let select '('Body 'Order))
+            (let result (SelectRange 'SchemeChangeRecordDetails range select '()))
+            (return (AsList (SetResult 'R result)))
+        )
+    )___";
+    auto bodiesResult = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, bodiesQuery);
+    THashMap<ui64, TString> bodyByOrder;
+    const auto& bodyList = bodiesResult.GetValue().GetStruct(0).GetOptional().GetStruct(0);
+    for (size_t i = 0; i < bodyList.ListSize(); ++i) {
+        const auto& row = bodyList.GetList(i);
+        bodyByOrder.emplace(row.GetStruct(1).GetOptional().GetUint64(),
+                            strOf(row.GetStruct(0).GetOptional()));
+    }
+    for (auto& entry : entries) {
+        auto it = bodyByOrder.find(entry.Order);
+        if (it != bodyByOrder.end() && !it->second.empty()) {
+            Y_ABORT_UNLESS(entry.Body.ParseFromString(it->second));
+        }
+    }
+
+    return entries;
+}
+
+} // namespace NSchemeChangeRecordTestHelpers

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ya.make
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ya.make
@@ -2,9 +2,9 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
-# Runs every op in this suite through the scheme change outbox and fails the
-# test if any of them cannot resolve a target path.
-ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+IF (WITH_VALGRIND)
+    SPLIT_FACTOR(20)
+ENDIF()
 
 SIZE(MEDIUM)
 
@@ -12,16 +12,17 @@ PEERDIR(
     library/cpp/getopt
     library/cpp/regex/pcre
     library/cpp/svnversion
-    ydb/core/metering
-    ydb/core/testlib/default
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/pg
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers
+    yql/essentials/public/udf/service/exception_policy
 )
 
 YQL_LAST_ABI_VERSION()
 
 SRCS(
-    ut_column_build.cpp
+    ut_scheme_change_records.cpp
 )
 
 END()

--- a/ydb/core/tx/schemeshard/ut_sequence/ya.make
+++ b/ydb/core/tx/schemeshard/ut_sequence/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SPLIT_FACTOR(2)
 
 IF (SANITIZER_TYPE == "thread")

--- a/ydb/core/tx/schemeshard/ut_view/ya.make
+++ b/ydb/core/tx/schemeshard/ut_view/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -44,6 +44,7 @@ RECURSE_FOR_TESTS(
     ut_metrics
     ut_move
     ut_move_reboots
+    ut_scheme_change_records
     ut_olap
     ut_olap_reboots
     ut_partition_stats
@@ -118,6 +119,7 @@ SRCS(
     schemeshard__monitoring.cpp
     schemeshard__monitoring.h
     schemeshard__notify.cpp
+    schemeshard__scheme_change_records.cpp
     schemeshard__op_traits.h
     schemeshard__operation.cpp
     schemeshard__operation.h

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -10638,5 +10638,234 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 141,
+        "TableName": "SchemeChangeRecords",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "Order",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "TxId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "OperationType",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "PathOwnerId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "PathLocalId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 6,
+                "ColumnName": "Path",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 7,
+                "ColumnName": "ObjectType",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 8,
+                "ColumnName": "Status",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 9,
+                "ColumnName": "UserSID",
+                "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 10,
+                "ColumnName": "SchemaVersion",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 11,
+                "ColumnName": "CompletedAtUs",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "PlanStep",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 13,
+                "ColumnName": "BodySizeBytes",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 14,
+                "ColumnName": "Description",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 15,
+                "ColumnName": "PositionKind",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 16,
+                "ColumnName": "RedactedFields",
+                "ColumnType": "Utf8"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 143,
+        "TableName": "SchemeChangeRecordDetails",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "Order",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "Body",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 144,
+        "TableName": "SchemeChangePendingRecords",
+        "TableKey": [
+            1,
+            2
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "TxId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "RequestIdx",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "Order",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "Path",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    4,
+                    5
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
### Changelog entry

SchemeShard persists a durable log of DDL, behind the `EnableSchemeChangeRecords` feature flag (off by default).

### Description for reviewers

First slice of RFC-0129. Tables 141/143/144, the record contract, target extraction for all user-level operations, and reserve-at-propose / finalise-at-completion. No subscriber protocol, retention, counters or redaction — those follow.

Gated on the flag alone: an operation whose target cannot be resolved is skipped and counted (`SchemeChangePathMissing`), never refused. The refusal path arrives with subscribers in the next slice.

106 tests, all table-observed.

Known open question: `Order` and `[PlanStep, TxId]` are not co-monotonic — `Order` is allocated at propose, `PlanStep` by the coordinator at plan time. `Order` is the only total order; the proto contract should say so before consumers rely on the timestamp.