### PR TITLE
feat: export scheme change outbox counters

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -308,6 +308,16 @@ enum ESimpleCounters {
     COUNTER_IN_FLIGHT_OPS_TxDropTestShardSet = 238        [(CounterOpts) = {Name: "InFlightOps/DropTestShardSet"}];
 
     COUNTER_RUNNING_STREAMING_QUERY_COUNT = 239           [(CounterOpts) = {Name: "RunningStreamingQueryCount"}];
+
+    // Scheme change outbox. DDL is rejected once depth reaches
+    // MaxSchemeChangeRecords; only an admin force-advance releases it.
+    COUNTER_SCHEME_CHANGE_OUTBOX_DEPTH = 240              [(CounterOpts) = {Name: "SchemeChangeOutboxDepth"}];
+    COUNTER_SCHEME_CHANGE_SUBSCRIBERS = 241               [(CounterOpts) = {Name: "SchemeChangeSubscribers"}];
+    // Has an unrecoverable hole in its stream; must resync from a full snapshot.
+    COUNTER_SCHEME_CHANGE_SUBSCRIBERS_LOST = 242          [(CounterOpts) = {Name: "SchemeChangeSubscribersLost"}];
+    // Idle beyond the stale TTL. Records are still retained, so unlike Lost
+    // this subscriber has lost nothing.
+    COUNTER_SCHEME_CHANGE_SUBSCRIBERS_STALE = 243         [(CounterOpts) = {Name: "SchemeChangeSubscribersStale"}];
 }
 
 enum ECumulativeCounters {
@@ -512,6 +522,17 @@ enum ECumulativeCounters {
 
     // Total time spent in TSchemeShard::Handle(TEvDataShard::TEvPeriodicTableStats), in nanoseconds.
     COUNTER_PERIODIC_TABLE_STATS_HANDLE_TIME_NS = 151 [(CounterOpts) = {Name: "PeriodicTableStatsHandleTimeNs"}];
+
+    // Scheme change outbox.
+    COUNTER_SCHEME_CHANGE_DDL_REJECTED = 152             [(CounterOpts) = {Name: "SchemeChangeDdlRejectedByOutbox"}];
+    // Rows the outbox transactions actually walk. Bounded work keeps this
+    // proportional to rows delivered; a regression that reintroduces an
+    // unbounded scan shows up here as a rate spike with no matching delivery.
+    COUNTER_SCHEME_CHANGE_ROWS_SCANNED = 153             [(CounterOpts) = {Name: "SchemeChangeOutboxRowsScanned"}];
+    COUNTER_SCHEME_CHANGE_DESCRIPTION_BYTES = 154        [(CounterOpts) = {Name: "SchemeChangeDescriptionBytes"}];
+    // An op resolved to no path at propose, so no record was written for it.
+    // Any non-zero value is an extraction gap in the outbox, not a client error.
+    COUNTER_SCHEME_CHANGE_PATH_MISSING = 155             [(CounterOpts) = {Name: "SchemeChangePathMissing"}];
 }
 
 enum EPercentileCounters {
@@ -841,4 +862,13 @@ enum ETxTypes {
     TXTYPE_LIST_SET_COLUMN_CONSTRAINT = 127             [(TxTypeOpts) = {Name: "TxListSetColumnConstraint"}];
     TXTYPE_FORGET_SET_COLUMN_CONSTRAINT = 128          [(TxTypeOpts) = {Name: "TxForgetSetColumnConstraint"}];
     TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT = 129             [(TxTypeOpts) = {Name: "TxCancelSetColumnConstraint"}];
+
+    // Scheme change records subscriber protocol + maintenance.
+    TXTYPE_REGISTER_SCHEME_CHANGE_SUBSCRIBER = 130   [(TxTypeOpts) = {Name: "TxRegisterSchemeChangeSubscriber"}];
+    TXTYPE_UNREGISTER_SCHEME_CHANGE_SUBSCRIBER = 131 [(TxTypeOpts) = {Name: "TxUnregisterSchemeChangeSubscriber"}];
+    TXTYPE_FETCH_SCHEME_CHANGE_RECORDS = 132         [(TxTypeOpts) = {Name: "TxFetchSchemeChangeRecords"}];
+    TXTYPE_FETCH_SCHEME_CHANGE_RECORD_BODIES = 133   [(TxTypeOpts) = {Name: "TxFetchSchemeChangeRecordBodies"}];
+    TXTYPE_ACK_SCHEME_CHANGE_RECORDS = 134           [(TxTypeOpts) = {Name: "TxAckSchemeChangeRecords"}];
+    TXTYPE_SCHEME_CHANGE_RECORDS_CLEANUP = 135       [(TxTypeOpts) = {Name: "TxSchemeChangeRecordsCleanup"}];
+    TXTYPE_FORCE_ADVANCE_SCHEME_CHANGE_SUBSCRIBER = 136 [(TxTypeOpts) = {Name: "TxForceAdvanceSchemeChangeSubscriber"}];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -372,4 +372,5 @@ message TFeatureFlags {
     // Offloads TEvDataShard::TEvPeriodicTableStats parsing to a dedicated aux actor to reduce
     // SchemeShard's single-threaded load.
     optional bool EnablePeriodicTableStatsParseOffload = 317 [default = false];
+    optional bool EnableSchemeChangeRecords = 318 [default = false];
 }

--- a/ydb/core/protos/schemeshard/scheme_change_records.proto
+++ b/ydb/core/protos/schemeshard/scheme_change_records.proto
@@ -1,0 +1,46 @@
+// Scheme change records subscriber protocol. Subscribers register with a
+// stable string ID, fetch records in order, pull bodies for the subset they
+// need, and ack consumed ranges.
+syntax = "proto3";
+
+package NKikimrSchemeShard;
+
+option java_package = "ru.yandex.kikimr.proto";
+
+
+// One target of a scheme change: the object's identity after the change,
+// and where it came from if the op moves or copies. Cardinality of
+// SourcePaths is not assumed 1:1 with the target: a rename has one source
+// for one target, but a future N-sources-into-one-target op would list all
+// of them here rather than picking one arbitrarily -- a consumer must not
+// assume SourcePaths[0] is the only source.
+message TSchemeChangeTarget {
+    // The target's identity after the change. Always set, never empty.
+    string Path = 1;
+    // Old location(s) this target came from: the prior path for a
+    // move/rename, the source table for a copy target. Empty for a plain
+    // create/alter/drop. May hold more than one entry.
+    repeated string SourcePaths = 2;
+}
+
+// Wire/storage encoding for a record's N authoritative targets. Used both as
+// the local-DB column payload (a delimiter could occur inside a path, so a
+// serialized repeated-message is the safe encoding) and internally when
+// carrying targets through in-memory operation state.
+message TSchemeChangeRecordTargets {
+    repeated TSchemeChangeTarget Targets = 1;
+}
+
+// How precisely a record's PlanStep locates it in the coordinator timeline.
+message TSchemeChangePosition {
+    enum EKind {
+        KIND_UNSPECIFIED = 0;
+        // PlanStep is the coordinator step this operation was actually planned
+        // at. Safe to interleave against data records carrying the same clock.
+        KIND_EXACT = 1;
+        // The operation never reached a coordinator, so PlanStep is a LOWER
+        // BOUND: the highest step already applied. Use for window assignment
+        // only; such records touched no shard.
+        KIND_BUCKETED = 2;
+    }
+}

--- a/ydb/core/protos/schemeshard/scheme_change_records.proto
+++ b/ydb/core/protos/schemeshard/scheme_change_records.proto
@@ -7,6 +7,7 @@ package NKikimrSchemeShard;
 
 option java_package = "ru.yandex.kikimr.proto";
 
+import "ydb/core/scheme/protos/pathid.proto";
 
 // One target of a scheme change: the object's identity after the change,
 // and where it came from if the op moves or copies. Cardinality of
@@ -31,6 +32,31 @@ message TSchemeChangeRecordTargets {
     repeated TSchemeChangeTarget Targets = 1;
 }
 
+// Status enum for scheme change records subscriber protocol results.
+message TSchemeChangeRecordsStatus {
+    enum EStatus {
+        STATUS_UNSPECIFIED = 0;
+        STATUS_SUCCESS = 1;
+        STATUS_NOT_REGISTERED = 2;
+        STATUS_INVALID_REQUEST = 3;
+        STATUS_INTERNAL_ERROR = 4;
+    }
+}
+
+// Lifecycle state of a subscriber's cursor.
+message TSchemeChangeSubscriberState {
+    enum EState {
+        STATE_UNSPECIFIED = 0;
+        // Streaming normally.
+        STATE_READY = 1;
+        // Reserved for snapshot backfill; no mechanism exists yet.
+        STATE_SCAN = 2;
+        // Cursor advanced past records never received; SkippedEntries
+        // says how many.
+        STATE_LOST = 3;
+    }
+}
+
 // How precisely a record's PlanStep locates it in the coordinator timeline.
 message TSchemeChangePosition {
     enum EKind {
@@ -43,4 +69,155 @@ message TSchemeChangePosition {
         // only; such records touched no shard.
         KIND_BUCKETED = 2;
     }
+}
+
+// Register a subscriber to the scheme change records log. Idempotent.
+message TEvRegisterSubscriber {
+    string SubscriberId = 1;
+    // Absent => start at the tail.
+    // Present => clamped up to the retention floor if below it
+    // (State=STATE_LOST + SkippedEntries); rejected if beyond the tail.
+    optional uint64 StartOrder = 2;
+}
+
+// CurrentOrder is the subscriber's cursor after registration.
+message TEvRegisterSubscriberResult {
+    optional TSchemeChangeRecordsStatus.EStatus Status = 1;
+    string Reason = 2;
+    uint64 CurrentOrder = 3;
+    optional TSchemeChangeSubscriberState.EState State = 4;
+    // Non-zero only when an explicit StartOrder was clamped up: records
+    // already swept and never deliverable to this subscriber.
+    uint64 SkippedEntries = 5;
+}
+
+// One TModifyScheme from the request. `Body` (via TEvFetchSchemeChangeRecordBodies)
+// is the source of truth; the metadata fields below are advisory and may be
+// unset when the operation targets no single identifiable path.
+//
+// Consumer contract:
+// - Body is authoritative except for fields listed in RedactedFields, which
+//   were stripped before persisting and are never recoverable from the record.
+// - Cross-cluster identity is Targets[].Path (database-relative), not PathId:
+//   PathId is source-local and meaningless on another cluster.
+// - Targets has exactly one entry for single-target operations, N for a
+//   multi-target operation (e.g. a consistent copy of N tables), and is
+//   NEVER empty: an operation that resolves no target refuses the propose.
+//   Targets[0].Path is the primary identity for a consumer keying by one path.
+// - Each Target's SourcePaths is populated only for a move/rename (the old
+//   location) or a copy target (the table copied from); empty for a plain
+//   create/alter/drop. May hold more than one entry -- a consumer must not
+//   assume SourcePaths[0] is the only source.
+// - Partitioning and partition config are not carried here; a consumer gets
+//   them from a snapshot taken at restore time, not from this record.
+// - The record is not directly executable: a consumer must translate any
+//   request that names its target by source-local id or absolute path
+//   (TDrop.Id, TMove.SrcPath/DstPath) into its own namespace first.
+message TSchemeChangeRecord {
+    uint64 Order = 1;
+    uint64 TxId = 2;
+    uint64 PlanStep = 3;
+    uint32 OperationType = 4;
+    NKikimrProto.TPathID PathId = 5;
+    repeated TSchemeChangeTarget Targets = 6;
+    uint32 ObjectType = 7;
+    optional uint32 Status = 8;
+    string UserSID = 9;
+    uint64 SchemaVersion = 10;
+    uint64 CompletedAtUs = 11;
+    uint64 BodySizeBytes = 13;
+    // Window membership ranks by (PlanStep, PositionKind), EXACT < BUCKETED.
+    // No tiebreak: records equal on both are concurrent, so consumers must not
+    // infer an order from delivery. TxId is identity, never an order.
+    optional TSchemeChangePosition.EKind PositionKind = 14;
+    // Paths of fields cleared from Body by redaction. Empty when redaction is
+    // disabled or nothing in this record was sensitive; never inferred from
+    // absence alone.
+    repeated string RedactedFields = 15;
+}
+
+// Request metadata for records after the given order, up to MaxCount entries.
+message TEvFetchSchemeChangeRecords {
+    string SubscriberId = 1;
+    uint64 AfterOrder = 2;
+    uint32 MaxCount = 3;
+}
+
+// Response containing metadata entries. Bodies must be fetched separately
+// via TEvFetchSchemeChangeRecordBodies. Tail order is Entries.back().Order.
+message TEvFetchSchemeChangeRecordsResult {
+    optional TSchemeChangeRecordsStatus.EStatus Status = 1;
+    string Reason = 2;
+    repeated TSchemeChangeRecord Entries = 3;
+    bool HasMore = 5;
+    // Entries fast-forwarded because AfterOrder was behind the persisted
+    // LastAckedOrder. Informational: those records are already acked.
+    uint64 SkippedEntries = 6;
+    // STATE_LOST means unconsumed records were swept; SkippedEntries counts them.
+    optional TSchemeChangeSubscriberState.EState State = 8;
+    // Highest PlanStep through which the stream is COMPLETE. A consumer may
+    // close window (S_prev, S] once this is >= S. Needed because Order is
+    // completion order while PlanStep is plan order, and the two diverge.
+    uint64 ClosedThroughPlanStep = 7;
+}
+
+// Acknowledge consumption up to UpToOrder. Advances the subscriber cursor
+// and may trigger inline cleanup of acked records.
+message TEvAckSchemeChangeRecords {
+    string SubscriberId = 1;
+    uint64 UpToOrder = 2;
+}
+
+// Response to ack; LastAckedOrder reflects the actual cursor position
+// after clamping.
+message TEvAckSchemeChangeRecordsResult {
+    optional TSchemeChangeRecordsStatus.EStatus Status = 1;
+    string Reason = 2;
+    uint64 LastAckedOrder = 3;
+}
+
+// Advance a subscriber's cursor to the tail regardless of consumption. Used
+// to unblock overflow caused by a dead subscriber.
+message TEvForceAdvanceSubscriber {
+    string SubscriberId = 1;
+}
+
+// Response to force-advance.
+message TEvForceAdvanceSubscriberResult {
+    optional TSchemeChangeRecordsStatus.EStatus Status = 1;
+    string Reason = 2;
+    uint64 LastAckedOrder = 3;
+}
+
+// Remove a subscriber.
+message TEvUnregisterSubscriber {
+    string SubscriberId = 1;
+}
+
+// Response to unregister.
+message TEvUnregisterSubscriberResult {
+    optional TSchemeChangeRecordsStatus.EStatus Status = 1;
+    string Reason = 2;
+}
+
+// Pull bodies for specific record orders. Requires a registered subscriber.
+message TEvFetchSchemeChangeRecordBodies {
+    string SubscriberId = 1;
+    repeated uint64 Orders = 2;
+}
+
+// Response containing serialized TModifyScheme bodies for the requested
+// orders. Records that have been cleaned up since the corresponding Fetch
+// are silently skipped.
+message TEvFetchSchemeChangeRecordBodiesResult {
+    message TEntry {
+        uint64 Order = 1;
+        bytes Body = 2;
+        // Serialized TEvDescribeSchemeResult as of when the record was
+        // written. Travels with Body because it is large.
+        bytes Description = 3;
+    }
+    optional TSchemeChangeRecordsStatus.EStatus Status = 1;
+    string Reason = 2;
+    repeated TEntry Entries = 3;
 }

--- a/ydb/core/protos/schemeshard/ya.make
+++ b/ydb/core/protos/schemeshard/ya.make
@@ -9,7 +9,12 @@ IF (OS_WINDOWS)
     NO_OPTIMIZE_PY_PROTOS()
 ENDIF()
 
+PEERDIR(
+    ydb/core/scheme/protos
+)
+
 SRCS(
+    scheme_change_records.proto
     operations.proto
 )
 

--- a/ydb/core/protos/schemeshard_config.proto
+++ b/ydb/core/protos/schemeshard_config.proto
@@ -47,4 +47,19 @@ message TSchemeShardConfig {
 
     // maximum recent index build operations to maintain (older ones are removed)
     optional uint32 MaxStoredIndexBuilds = 11 [default = 1000];
+
+    // Scheme change records overflow threshold.
+    // New schema operations are rejected when this limit is reached.
+    optional uint64 MaxSchemeChangeRecords = 12 [default = 100000];
+
+    // A scheme change subscriber that has not fetched or acked for this long
+    // is reported as stale via a counter. It still holds down the retention
+    // floor; only an admin force-advance releases it. Default 30 days.
+    optional uint64 SchemeChangeSubscriberStaleTtlSeconds = 13 [default = 2592000];
+
+    // Strip (Ydb.sensitive) fields (passwords, access keys, secret values)
+    // from scheme change record bodies before persisting. Disabling this
+    // persists and serves credentials to every subscriber over a protocol
+    // that has no authentication; only safe once subscriber-side auth exists.
+    optional bool RedactSensitiveSchemeChangeFields = 14 [default = true];
 }

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -88,6 +88,7 @@ public:
     FEATURE_FLAG_SETTER(EnableCsDictionaryEncoding)
     FEATURE_FLAG_SETTER(EnableDataShardDetailedMetrics)
     FEATURE_FLAG_SETTER(EnableTopicDeferredPublish)
+    FEATURE_FLAG_SETTER(EnableSchemeChangeRecords)
     #undef FEATURE_FLAG_SETTER
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard.h
+++ b/ydb/core/tx/schemeshard/schemeshard.h
@@ -6,6 +6,7 @@
 #include <ydb/core/base/storage_pools.h>
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
+#include <ydb/core/protos/schemeshard/scheme_change_records.pb.h>
 #include <ydb/core/protos/tx_scheme.pb.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
@@ -113,6 +114,19 @@ namespace TEvSchemeShard {
         EvShredInfoRequest,
         EvShredInfoResponse,
         EvShredManualStartupRequest,
+
+        EvRegisterSubscriber,
+        EvRegisterSubscriberResult,
+        EvFetchSchemeChangeRecords,
+        EvFetchSchemeChangeRecordsResult,
+        EvAckSchemeChangeRecords,
+        EvAckSchemeChangeRecordsResult,
+        EvForceAdvanceSubscriber,
+        EvForceAdvanceSubscriberResult,
+        EvUnregisterSubscriber,
+        EvUnregisterSubscriberResult,
+        EvFetchSchemeChangeRecordBodies,
+        EvFetchSchemeChangeRecordBodiesResult,
 
         EvEnd
     };
@@ -730,6 +744,31 @@ namespace TEvSchemeShard {
     };
 
     struct TEvShredManualStartupRequest : TEventPB<TEvShredManualStartupRequest, NKikimrScheme::TEvShredManualStartupRequest, EvShredManualStartupRequest> {};
+
+    struct TEvRegisterSubscriber : public TEventPB<TEvRegisterSubscriber,
+        NKikimrSchemeShard::TEvRegisterSubscriber, EvRegisterSubscriber> {};
+    struct TEvRegisterSubscriberResult : public TEventPB<TEvRegisterSubscriberResult,
+        NKikimrSchemeShard::TEvRegisterSubscriberResult, EvRegisterSubscriberResult> {};
+    struct TEvFetchSchemeChangeRecords : public TEventPB<TEvFetchSchemeChangeRecords,
+        NKikimrSchemeShard::TEvFetchSchemeChangeRecords, EvFetchSchemeChangeRecords> {};
+    struct TEvFetchSchemeChangeRecordsResult : public TEventPB<TEvFetchSchemeChangeRecordsResult,
+        NKikimrSchemeShard::TEvFetchSchemeChangeRecordsResult, EvFetchSchemeChangeRecordsResult> {};
+    struct TEvAckSchemeChangeRecords : public TEventPB<TEvAckSchemeChangeRecords,
+        NKikimrSchemeShard::TEvAckSchemeChangeRecords, EvAckSchemeChangeRecords> {};
+    struct TEvAckSchemeChangeRecordsResult : public TEventPB<TEvAckSchemeChangeRecordsResult,
+        NKikimrSchemeShard::TEvAckSchemeChangeRecordsResult, EvAckSchemeChangeRecordsResult> {};
+    struct TEvForceAdvanceSubscriber : public TEventPB<TEvForceAdvanceSubscriber,
+        NKikimrSchemeShard::TEvForceAdvanceSubscriber, EvForceAdvanceSubscriber> {};
+    struct TEvForceAdvanceSubscriberResult : public TEventPB<TEvForceAdvanceSubscriberResult,
+        NKikimrSchemeShard::TEvForceAdvanceSubscriberResult, EvForceAdvanceSubscriberResult> {};
+    struct TEvUnregisterSubscriber : public TEventPB<TEvUnregisterSubscriber,
+        NKikimrSchemeShard::TEvUnregisterSubscriber, EvUnregisterSubscriber> {};
+    struct TEvUnregisterSubscriberResult : public TEventPB<TEvUnregisterSubscriberResult,
+        NKikimrSchemeShard::TEvUnregisterSubscriberResult, EvUnregisterSubscriberResult> {};
+    struct TEvFetchSchemeChangeRecordBodies : public TEventPB<TEvFetchSchemeChangeRecordBodies,
+        NKikimrSchemeShard::TEvFetchSchemeChangeRecordBodies, EvFetchSchemeChangeRecordBodies> {};
+    struct TEvFetchSchemeChangeRecordBodiesResult : public TEventPB<TEvFetchSchemeChangeRecordBodiesResult,
+        NKikimrSchemeShard::TEvFetchSchemeChangeRecordBodiesResult, EvFetchSchemeChangeRecordBodiesResult> {};
 };
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1379,6 +1379,28 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_LastAssignedPlanStep, Self->LastAssignedPlanStep));
         RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_SchemeChangeFloorOrder, Self->SchemeChangeFloorOrder));
 
+        {
+            auto subRowset = db.Table<Schema::SchemeChangeSubscribers>().Range().Select();
+            if (!subRowset.IsReady()) return false;
+            Self->Subscribers.clear();
+            while (!subRowset.EndOfSet()) {
+                TString id = subRowset.GetValue<Schema::SchemeChangeSubscribers::SubscriberId>();
+                TSchemeShard::TSubscriberInfo info;
+                info.LastAckedOrder = subRowset.GetValue<Schema::SchemeChangeSubscribers::LastAckedOrder>();
+                info.LastActivityAt = TInstant::MicroSeconds(
+                    subRowset.GetValue<Schema::SchemeChangeSubscribers::LastActivityAtUs>());
+                // Rows written before these columns existed read as absent;
+                // keep TSubscriberInfo's defaults (State = READY) in that case.
+                if (subRowset.HaveValue<Schema::SchemeChangeSubscribers::State>()) {
+                    info.State = subRowset.GetValue<Schema::SchemeChangeSubscribers::State>();
+                }
+                if (subRowset.HaveValue<Schema::SchemeChangeSubscribers::StartOrder>()) {
+                    info.StartOrder = subRowset.GetValue<Schema::SchemeChangeSubscribers::StartOrder>();
+                }
+                Self->Subscribers.emplace(std::move(id), info);
+                if (!subRowset.Next()) return false;
+            }
+        }
 
         {
             ui64 isReadOnlyModeVal = 0;
@@ -6824,6 +6846,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         Self->ScheduleForcedCompactionProgress(ctx);
 
+        // The only other enqueue sites are Complete() hooks gated on the flag, so a
+        // tablet rebooting with the flag off would otherwise never drain.
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords() &&
+            Self->NextSchemeChangeOrder > Self->SchemeChangeFloorOrder) {
+            Self->EnqueueSchemeChangeRecordsCleanup(ctx);
+        }
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1375,6 +1375,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_NextPathId, Self->NextLocalPathId));
         RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_NextShardIdx, Self->NextLocalShardIdx));
+        RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_NextSchemeChangeOrder, Self->NextSchemeChangeOrder));
+        RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_LastAssignedPlanStep, Self->LastAssignedPlanStep));
+        RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_SchemeChangeFloorOrder, Self->SchemeChangeFloorOrder));
+
 
         {
             ui64 isReadOnlyModeVal = 0;
@@ -3967,6 +3971,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 txState.MinStep =       txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::MinStep>(InvalidStepId);
                 txState.PlanStep =      txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::PlanStep>(InvalidStepId);
+                if (txState.PlanStep != InvalidStepId) {
+                    Self->AddInFlightPlanStep(ui64(txState.PlanStep));
+                }
+                if (txState.PlanStep != InvalidStepId && ui64(txState.PlanStep) > Self->LastAssignedPlanStep) {
+                    Self->LastAssignedPlanStep = ui64(txState.PlanStep);
+                }
 
                 TString extraData =     txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::ExtraBytes>("");
                 txState.StartTime =     TInstant::MicroSeconds(txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::StartTime>());
@@ -3993,6 +4003,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         Self->PersistRemoveTx(db, operationId, txState);
                         skippedOrphanTxs.insert(operationId);
                         skippedOrphanTxIds.insert(operationId.GetTxId());
+                        // Undo the bump above: RemoveTx never runs for this tx,
+                        // so its step would pin ClosedThroughPlanStep forever.
+                        if (txState.PlanStep != InvalidStepId) {
+                            Self->RemoveInFlightPlanStep(ui64(txState.PlanStep));
+                        }
                         Self->TxInFlight.erase(operationId);
                         if (!txInFlightRowset.Next())
                             return false;
@@ -4338,6 +4353,44 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (!rowset.Next()) {
                     return false;
+                }
+            }
+        }
+
+        {
+            auto rowset = db.Table<Schema::SchemeChangePendingRecords>().Range().Select();
+            if (!rowset.IsReady()) return false;
+            THashMap<TTxId, TMap<ui32, TOperation::TSchemeChangeSlot>> byTx;
+            while (!rowset.EndOfSet()) {
+                TTxId txId = rowset.GetValue<Schema::SchemeChangePendingRecords::TxId>();
+                ui32 idx = rowset.GetValue<Schema::SchemeChangePendingRecords::RequestIdx>();
+                TOperation::TSchemeChangeSlot slot;
+                slot.RequestIdx = idx;
+                slot.Order = rowset.GetValue<Schema::SchemeChangePendingRecords::Order>();
+                slot.Targets = TSchemeShard::DecodeSchemeChangeTargets(
+                    rowset.GetValueOrDefault<Schema::SchemeChangePendingRecords::Path>(""));
+                byTx[txId][idx] = std::move(slot);
+                if (!rowset.Next()) return false;
+            }
+            for (auto& [txId, idxMap] : byTx) {
+                auto opIt = Self->Operations.find(txId);
+                if (opIt == Self->Operations.end()) {
+                    // No operation survived to finalise these rows. Leaving
+                    // CompletedAtUs at 0 would wedge the fetch stream forever.
+                    using T = Schema::SchemeChangeRecords;
+                    for (auto& [idx, slot] : idxMap) {
+                        db.Table<T>().Key(slot.Order).Update(
+                            NIceDb::TUpdate<T::Status>(ui32(NKikimrScheme::StatusPreconditionFailed)),
+                            NIceDb::TUpdate<T::CompletedAtUs>(ctx.Now().MicroSeconds())
+                        );
+                        Self->PersistRemoveSchemeChangePendingOrder(db, txId, idx);
+                    }
+                    continue;
+                }
+                opIt->second->SchemeChangeSlots.clear();
+                opIt->second->SchemeChangeSlots.reserve(idxMap.size());
+                for (auto& [idx, slot] : idxMap) {
+                    opIt->second->SchemeChangeSlots.push_back(std::move(slot));
                 }
             }
         }
@@ -6770,6 +6823,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         });
 
         Self->ScheduleForcedCompactionProgress(ctx);
+
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -123,6 +123,7 @@ struct TCgi {
     // static const TParam FixAccessDatabaseInheritanceDryRun;
     static const TParam Page;
     static const TParam BuildIndexId;
+    static const TParam SubscriberId;
     static const TParam UpdateCoordinatorsConfig;
     static const TParam UpdateCoordinatorsConfigDryRun;
     static const TParam Action;
@@ -153,6 +154,7 @@ struct TCgi {
         static constexpr TStringBuf TablePartitionsFormatSwitch = "TablePartitionsFormatSwitch";
         static constexpr TStringBuf TablePartitionsFormatSweep = "TablePartitionsFormatSweep";
         static constexpr TStringBuf MoveToStoragePool = "MoveToStoragePool";
+        static constexpr TStringBuf ForceAdvanceSchemeChangeSubscriber = "ForceAdvanceSchemeChangeSubscriber";
     };
 };
 
@@ -173,6 +175,7 @@ const TCgi::TParam TCgi::IsReadOnlyMode = TStringBuf("IsReadOnlyMode");
 // const TCgi::TParam TCgi::FixAccessDatabaseInheritanceDryRun = TStringBuf("FixAccessDatabaseInheritanceDryRun");
 const TCgi::TParam TCgi::Page = TStringBuf("Page");
 const TCgi::TParam TCgi::BuildIndexId = TStringBuf("BuildIndexId");
+const TCgi::TParam TCgi::SubscriberId = TStringBuf("SubscriberId");
 const TCgi::TParam TCgi::UpdateCoordinatorsConfig = TStringBuf("UpdateCoordinatorsConfig");
 const TCgi::TParam TCgi::UpdateCoordinatorsConfigDryRun = TStringBuf("UpdateCoordinatorsConfigDryRun");
 const TCgi::TParam TCgi::TablePartitionsFormat = TStringBuf("format");
@@ -2257,6 +2260,26 @@ private:
             }
 
             ctx.Register(new TMonitoringForceDropUnsafe(std::move(Ev), Self->TabletID(), path.PathString()));
+
+        } else if (action == TCgi::TActions::ForceAdvanceSchemeChangeSubscriber) {
+            const TString subscriberId = params.Get(TCgi::SubscriberId);
+            if (subscriberId.empty()) {
+                SendBadRequest("SubscriberId must be specified", ctx);
+                return;
+            }
+            if (!Self->Subscribers.contains(subscriberId)) {
+                SendBadRequest(TStringBuilder()
+                    << "No scheme change subscriber '" << subscriberId << "'", ctx);
+                return;
+            }
+            // Escape hatch for a dead subscriber wedging DDL.
+            Self->Execute(Self->CreateTxForceAdvanceSubscriberFromMonitoring(
+                subscriberId, TActorId()), ctx);
+            ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
+                TStringBuilder() << "HTTP/1.1 200 Ok\r\nConnection: Close\r\n\r\n"
+                    << "Force-advancing scheme change subscriber '" << subscriberId
+                    << "'; it will be marked Lost.\r\n"));
+            return;
 
         } else if (action == TCgi::TActions::MoveToStoragePool) {
             const TTabletId tabletId = TTabletId(TryParseTabletId(params.Get(TCgi::ShardID)));

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -110,11 +110,23 @@ bool TSchemeShard::ProcessOperationParts(
         context.IsAllowedPrivateTables = true;
     }
 
+    // Overflow is a whole-schemeshard condition, not per-part; compute it
+    // once for the batch instead of rescanning Subscribers each iteration.
+    TString overflowErr;
+    const bool schemeChangeRecordsOverflow = !context.SS->CheckSchemeChangeRecordsOverflow(overflowErr, context.Ctx.Now());
+
     for (auto& part : parts) {
         TString errStr;
         if (!context.SS->CheckInFlightLimit(part->GetTransaction().GetOperationType(), errStr)) {
             response.Reset(new TProposeResponse(NKikimrScheme::StatusResourceExhausted, ui64(txId), ui64(selfId)));
             response->SetError(NKikimrScheme::StatusResourceExhausted, errStr);
+        } else if (schemeChangeRecordsOverflow
+                && !part->GetTransaction().GetInternal()
+                && !IsChurnOp(part->GetTransaction().GetOperationType())) {
+            // Internal ops are never rejected: refusing split/merge or temp-dir GC
+            // is an outage, not backpressure.
+            response.Reset(new TProposeResponse(NKikimrScheme::StatusResourceExhausted, ui64(txId), ui64(selfId)));
+            response->SetError(NKikimrScheme::StatusResourceExhausted, overflowErr);
         } else {
             response = part->Propose(owner, context);
         }
@@ -313,21 +325,26 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
 
     // An unresolvable target is skipped and counted, never refused: refusing runs
     // AbortOperationPropose, whose per-operation stubs are Y_ABORT in 45 places.
-    if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+    //
+    // Subscribers.empty() alone is not enough: subscriber rows reload at TTxInit,
+    // so with the flag off and rows on disk reservation would stay live.
+    if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords() && !Subscribers.empty()) {
+        // Must reject before the first local-DB write below: AbortOperationPropose
+        // undoes in-memory operation state only, never local-DB writes.
+        for (const auto& transaction : rewrittenTransactions) {
+            TString rejectReason;
+            if (!CheckSchemeChangeRecordHasPath(transaction, rejectReason)) {
+                AbortOperationPropose(txId, context);
+                response.Reset(new TProposeResponse(NKikimrScheme::StatusInvalidParameter, ui64(txId), ui64(selfId)));
+                response->SetError(NKikimrScheme::StatusInvalidParameter, rejectReason);
+                return response;
+            }
+        }
+
         NIceDb::TNiceDb db(context.GetDB());
         operation->SchemeChangeOrderBase = NextSchemeChangeOrder;
         operation->SchemeChangeOrdersReserved = true;
         for (ui32 i = 0; i < rewrittenTransactions.size(); ++i) {
-            TString skipReason;
-            if (!CheckSchemeChangeRecordHasPath(rewrittenTransactions[i], skipReason)) {
-                TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_PATH_MISSING].Increment(1);
-                LOG_WARN_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                    "scheme change record skipped, target path unresolved"
-                        << ", txId: " << txId
-                        << ", requestIdx: " << i
-                        << ", reason: " << skipReason);
-                continue;
-            }
             TOperation::TSchemeChangeSlot slot;
             if (PersistSchemeChangeRecordAtPropose(db, txId, i, rewrittenTransactions[i], slot)) {
                 operation->SchemeChangeSlots.push_back(std::move(slot));

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -308,6 +308,33 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
         }
     }
 
+    // Must stay after every ProcessOperationParts call: writing via NIceDb sets
+    // DirectAccessGranted, which trips Y_VERIFY_S(IsUndoChangesSafe) in a later part.
+
+    // An unresolvable target is skipped and counted, never refused: refusing runs
+    // AbortOperationPropose, whose per-operation stubs are Y_ABORT in 45 places.
+    if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+        NIceDb::TNiceDb db(context.GetDB());
+        operation->SchemeChangeOrderBase = NextSchemeChangeOrder;
+        operation->SchemeChangeOrdersReserved = true;
+        for (ui32 i = 0; i < rewrittenTransactions.size(); ++i) {
+            TString skipReason;
+            if (!CheckSchemeChangeRecordHasPath(rewrittenTransactions[i], skipReason)) {
+                TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_PATH_MISSING].Increment(1);
+                LOG_WARN_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    "scheme change record skipped, target path unresolved"
+                        << ", txId: " << txId
+                        << ", requestIdx: " << i
+                        << ", reason: " << skipReason);
+                continue;
+            }
+            TOperation::TSchemeChangeSlot slot;
+            if (PersistSchemeChangeRecordAtPropose(db, txId, i, rewrittenTransactions[i], slot)) {
+                operation->SchemeChangeSlots.push_back(std::move(slot));
+            }
+        }
+    }
+
     return response;
 }
 
@@ -325,6 +352,11 @@ void TSchemeShard::AbortOperationPropose(const TTxId txId, TOperationContext& co
     }
 
     context.MemChanges.UnDo(context.SS);
+
+    // The local-DB rollback reverts the persisted counter, but not this one.
+    if (operation->SchemeChangeOrdersReserved) {
+        NextSchemeChangeOrder = operation->SchemeChangeOrderBase;
+    }
 
     // And remove aborted operation from existence
     Operations.erase(txId);
@@ -702,6 +734,16 @@ struct TSchemeShard::TTxOperationPlanStep: public NTabletFlatExecutor::TTransact
                         << ", message: " << record.ShortDebugString()
                         << ", at schemeshard: " << Self->TabletID());
 
+        // Flag-guarded: without it, every plan step of every cluster writes a
+        // SysParams row for a ceiling only the outbox ever reads.
+        if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()
+            && ui64(step) > Self->LastAssignedPlanStep)
+        {
+            Self->LastAssignedPlanStep = ui64(step);
+            NIceDb::TNiceDb db(txc.DB);
+            Self->PersistUpdateLastAssignedPlanStep(db);
+        }
+
         for (size_t i = 0; i < txCount; ++i) {
             const auto txId = TTxId(record.GetTransactions(i).GetTxId());
             const auto coordinator = ActorIdFromProto(record.GetTransactions(i).GetAckTo());
@@ -728,6 +770,14 @@ struct TSchemeShard::TTxOperationPlanStep: public NTabletFlatExecutor::TTransact
                                     << " operation part is already done"
                                     << ", operationId: " << opId);
                     continue;
+                }
+
+                if (auto* txState = Self->FindTx(opId)) {
+                    // A redelivered plan step (mediator reconnect) must not bump the refcount twice.
+                    if (txState->PlanStep == InvalidStepId) {
+                        Self->AddInFlightPlanStep(ui64(step));
+                    }
+                    txState->PlanStep = step;
                 }
 
                 TOperationContext context{Self, txc, ctx, OnComplete, MemChanges, DbChanges};

--- a/ydb/core/tx/schemeshard/schemeshard__operation.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.h
@@ -14,6 +14,25 @@ struct TOperation: TSimpleRefCount<TOperation> {
     ui32 PreparedParts = 0;
     TVector<ISubOperation::TPtr> Parts;
 
+    struct TSchemeChangeTarget {
+        TString Path;
+        TVector<TString> SourcePaths;
+    };
+
+    struct TSchemeChangeSlot {
+        ui32 RequestIdx = 0;
+        ui64 Order = 0;
+        // Carried in memory because finalisation cannot re-read it.
+        TVector<TSchemeChangeTarget> Targets;
+        TString UserSid;
+    };
+    TVector<TSchemeChangeSlot> SchemeChangeSlots;
+
+    // Abort rewinds NextSchemeChangeOrder to this. The flag is needed because
+    // base 0 is a valid value.
+    ui64 SchemeChangeOrderBase = 0;
+    bool SchemeChangeOrdersReserved = false;
+
     THashSet<TActorId> Subscribers;
     THashSet<TTxId> DependentOperations;
     THashSet<TTxId> WaitOperations;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -1028,6 +1028,8 @@ void TSideEffects::DoPersistSchemeChangeRecords(TSchemeShard* ss, NTabletFlatExe
             ss->FinalizeSchemeChangeRecord(db, ctx, slot, planStep, aborted);
             ss->PersistRemoveSchemeChangePendingOrder(db, txId, slot.RequestIdx);
 
+            ss->UpdateSchemeChangeGauges();
+
 
             TVector<TString> targetPaths;
             for (const auto& t : slot.Targets) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -3,8 +3,11 @@
 #include "schemeshard__operation_db_changes.h"
 #include "schemeshard__operation_memory_changes.h"
 #include "schemeshard_impl.h"
+#include "schemeshard_path_describer.h"
 
 #include <ydb/core/tx/tx_processing.h>
+
+#include <util/string/join.h>
 
 namespace NKikimr {
 namespace NSchemeShard {
@@ -984,7 +987,65 @@ void TSideEffects::DoFireFullBackupItemDone(TSchemeShard* ss, const TActorContex
     PendingFullBackupItemDone.clear();
 }
 
+
+void TSideEffects::DoPersistSchemeChangeRecords(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx) {
+    if (DoneTransactions.empty()) {
+        return;
+    }
+
+    // Runs regardless of whether a subscriber exists now: what matters is whether one existed at propose.
+    NIceDb::TNiceDb db(txc.DB);
+
+    for (const auto& txId : DoneTransactions) {
+        auto opIt = ss->Operations.find(txId);
+        if (opIt == ss->Operations.end() || !opIt->second->IsReadyToDone(ctx)) {
+            continue;
+        }
+        const TOperation::TPtr& operation = opIt->second;
+        if (operation->SchemeChangeSlots.empty()) {
+            continue;
+        }
+
+        TStepId planStep = InvalidStepId;
+        // EPathStateDrop on a part's target means AbortUnsafe force-completed it.
+        bool aborted = false;
+        for (ui32 partIdx = 0; partIdx < operation->Parts.size(); ++partIdx) {
+            auto it = ss->TxInFlight.find(TOperationId(txId, partIdx));
+            if (it == ss->TxInFlight.end()) {
+                continue;
+            }
+            if (planStep == InvalidStepId && it->second.PlanStep != InvalidStepId) {
+                planStep = it->second.PlanStep;
+            }
+            if (auto* path = ss->PathsById.FindPtr(it->second.TargetPathId)) {
+                if ((*path)->PathState == NKikimrSchemeOp::EPathState::EPathStateDrop) {
+                    aborted = true;
+                }
+            }
+        }
+
+        for (const auto& slot : operation->SchemeChangeSlots) {
+            ss->FinalizeSchemeChangeRecord(db, ctx, slot, planStep, aborted);
+            ss->PersistRemoveSchemeChangePendingOrder(db, txId, slot.RequestIdx);
+
+
+            TVector<TString> targetPaths;
+            for (const auto& t : slot.Targets) {
+                targetPaths.push_back(t.Path);
+            }
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "DoPersistSchemeChangeRecords: finalised record"
+                    << " order=" << slot.Order
+                    << " txId=" << txId
+                    << " requestIdx=" << slot.RequestIdx
+                    << " paths=" << JoinSeq(",", targetPaths)
+                    << " planStep=" << planStep);
+        }
+    }
+}
+
 void TSideEffects::DoDoneTransactions(TSchemeShard *ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx) {
+    DoPersistSchemeChangeRecords(ss, txc, ctx);  // persist scheme change records before operations are erased
     for (auto& txId: DoneTransactions) {
 
         if (!ss->Operations.contains(txId)) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
@@ -165,6 +165,7 @@ private:
     void DoReleasePathState(TSchemeShard* ss, const TActorContext &ctx);
     void DoDoneParts(TSchemeShard* ss, const TActorContext& ctx);
     void DoDoneTransactions(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext& ctx);
+    void DoPersistSchemeChangeRecords(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx);
     void DoReadyToNotify(TSchemeShard* ss, const TActorContext& ctx);
 
     void DoPersistDependencies(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__scheme_change_records.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__scheme_change_records.cpp
@@ -1,0 +1,522 @@
+#include "schemeshard_impl.h"
+#include "schemeshard_path_describer.h"
+
+#include <ydb/core/protos/schemeshard/scheme_change_records.pb.h>
+
+#include <util/string/join.h>
+
+namespace NKikimr::NSchemeShard {
+
+namespace {
+
+struct TSchemeChangeRawTarget {
+    TString AbsDstPath;
+    TString AbsSrcPath;
+};
+
+TMaybe<TSchemeChangeRawTarget> ExtractSchemeChangeMoveTarget(const NKikimrSchemeOp::TModifyScheme& tx) {
+    if (tx.HasMoveTable()) {
+        return TSchemeChangeRawTarget{tx.GetMoveTable().GetDstPath(), tx.GetMoveTable().GetSrcPath()};
+    }
+    if (tx.HasMoveTableIndex()) {
+        return TSchemeChangeRawTarget{tx.GetMoveTableIndex().GetDstPath(), tx.GetMoveTableIndex().GetSrcPath()};
+    }
+    if (tx.HasMoveSequence()) {
+        return TSchemeChangeRawTarget{tx.GetMoveSequence().GetDstPath(), tx.GetMoveSequence().GetSrcPath()};
+    }
+    if (tx.HasMoveIndex()) {
+        // TMoveIndex Src/DstPath are relative to TablePath, not absolute
+        // (index/operation_move_index.cpp: mainTablePath.Child).
+        const auto& moveIndex = tx.GetMoveIndex();
+        return TSchemeChangeRawTarget{
+            TStringBuilder() << moveIndex.GetTablePath() << '/' << moveIndex.GetDstPath(),
+            TStringBuilder() << moveIndex.GetTablePath() << '/' << moveIndex.GetSrcPath()};
+    }
+    return Nothing();
+}
+
+TVector<TSchemeChangeRawTarget> ExtractSchemeChangeCopyTargets(const NKikimrSchemeOp::TModifyScheme& tx) {
+    TVector<TSchemeChangeRawTarget> result;
+    if (tx.HasCreateConsistentCopyTables()) {
+        for (const auto& copy : tx.GetCreateConsistentCopyTables().GetCopyTableDescriptions()) {
+            result.push_back(TSchemeChangeRawTarget{copy.GetDstPath(), copy.GetSrcPath()});
+        }
+    }
+    return result;
+}
+
+// Found via reflection so a newly added object type needs no switch entry.
+TString ExtractSchemeChangeTargetName(const NKikimrSchemeOp::TModifyScheme& tx) {
+    if (tx.HasCreateIndexedTable()) {
+        return tx.GetCreateIndexedTable().GetTableDescription().GetName();
+    }
+    // Only the standalone alter sets PathName. Create-with-attrs carries the same
+    // message with PathName unset, and its target is named by its own payload.
+    if (tx.HasAlterUserAttributes() && !tx.GetAlterUserAttributes().GetPathName().empty()) {
+        return tx.GetAlterUserAttributes().GetPathName();
+    }
+    // These name their target TableName, not Name. Restore's and Backup's AbortPropose
+    // are unconditional Y_ABORT stubs: an unresolved path crashes the tablet.
+    if (tx.HasTruncateTable()) {
+        return tx.GetTruncateTable().GetTableName();
+    }
+    if (tx.HasCreateContinuousBackup()) {
+        return tx.GetCreateContinuousBackup().GetTableName();
+    }
+    if (tx.HasAlterContinuousBackup()) {
+        return tx.GetAlterContinuousBackup().GetTableName();
+    }
+    if (tx.HasDropContinuousBackup()) {
+        return tx.GetDropContinuousBackup().GetTableName();
+    }
+    if (tx.HasRestore()) {
+        return tx.GetRestore().GetTableName();
+    }
+    if (tx.HasBackup()) {
+        return tx.GetBackup().GetTableName();
+    }
+    if (tx.HasInitiateBuildIndexMainTable()) {
+        return tx.GetInitiateBuildIndexMainTable().GetTableName();
+    }
+    if (tx.HasFinalizeBuildIndexMainTable()) {
+        return tx.GetFinalizeBuildIndexMainTable().GetTableName();
+    }
+    if (tx.HasDropIndex()) {
+        return TStringBuilder() << tx.GetDropIndex().GetTableName() << '/' << tx.GetDropIndex().GetIndexName();
+    }
+    // WorkingDir is already the index path, so the impl table name completes it.
+    if (tx.HasPrepareIndexValidation()) {
+        return tx.GetPrepareIndexValidation().GetTableName();
+    }
+
+    const auto* refl = tx.GetReflection();
+    std::vector<const google::protobuf::FieldDescriptor*> setFields;
+    refl->ListFields(tx, &setFields);
+
+    for (const auto* field : setFields) {
+        if (field->is_repeated()
+            || field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            continue;
+        }
+        const auto& sub = refl->GetMessage(tx, field);
+        const auto* nameField = sub.GetDescriptor()->FindFieldByName("Name");
+        if (!nameField
+            || nameField->is_repeated()
+            || nameField->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_STRING) {
+            continue;
+        }
+        const auto* subRefl = sub.GetReflection();
+        if (!subRefl->HasField(sub, nameField)) {
+            continue;
+        }
+        TString name = subRefl->GetString(sub, nameField);
+        if (!name.empty()) {
+            return name;
+        }
+    }
+    return {};
+}
+
+// Anchored on TPath::Root, not GetDomainPathString: a new subdomain is already its own domain root.
+TString RelativeToDomain(const TPath& resolved, TSchemeShard* ss) {
+    TString abs = resolved.PathString();
+    TString domain = TPath::Root(ss).PathString();
+    Y_DEBUG_ABORT_UNLESS(abs.StartsWith(domain));
+    TString rel = abs.substr(domain.size());
+    if (!rel.empty() && rel[0] == '/') {
+        rel = rel.substr(1);
+    }
+    return rel;
+}
+
+struct TResolvedSchemeChangeTarget {
+    TString Absolute;
+    TString Relative;
+    TVector<TString> RelativeSources;
+};
+
+TString RelativeSourceToDomain(const TString& absSrcPath, TSchemeShard* ss) {
+    if (absSrcPath.empty()) {
+        return {};
+    }
+    TPath src = TPath::Resolve(absSrcPath, ss);
+    if (src.IsResolved()) {
+        return RelativeToDomain(src, ss);
+    }
+    TString domain = TPath::Root(ss).PathString();
+    if (absSrcPath.StartsWith(domain)) {
+        TString rel = absSrcPath.substr(domain.size());
+        if (!rel.empty() && rel[0] == '/') {
+            rel = rel.substr(1);
+        }
+        return rel;
+    }
+    return absSrcPath;
+}
+
+TMaybe<TResolvedSchemeChangeTarget> ResolveRawTarget(const TSchemeChangeRawTarget& raw, TSchemeShard* ss) {
+    TVector<TString> relSources;
+    if (!raw.AbsSrcPath.empty()) {
+        relSources.push_back(RelativeSourceToDomain(raw.AbsSrcPath, ss));
+    }
+    TPath target = TPath::Resolve(raw.AbsDstPath, ss);
+    if (target.IsResolved()) {
+        return TResolvedSchemeChangeTarget{raw.AbsDstPath, RelativeToDomain(target, ss), relSources};
+    }
+    TPath parent = TPath::Resolve(TString(TStringBuf(raw.AbsDstPath).RBefore('/')), ss);
+    if (parent.IsResolved()) {
+        TString relParent = RelativeToDomain(parent, ss);
+        if (!relParent.empty()) {
+            relParent += '/';
+        }
+        TString leaf = TString(TStringBuf(raw.AbsDstPath).RAfter('/'));
+        return TResolvedSchemeChangeTarget{raw.AbsDstPath, relParent + leaf, relSources};
+    }
+    return Nothing();
+}
+
+// Deliberately not dispatched on op type: ConvertToTxType collapses many EOperationType onto TxInvalid.
+// Changefeed ops name their target <TableName>/<StreamName> under WorkingDir -- two
+// levels down, so neither a direct-child lookup nor the reflection walk finds it.
+// TDropCdcStream.StreamName is repeated: one op can drop N changefeeds.
+TVector<TSchemeChangeRawTarget> ExtractSchemeChangeCdcTargets(const NKikimrSchemeOp::TModifyScheme& tx) {
+    TVector<TSchemeChangeRawTarget> result;
+    auto stream = [&tx](const TString& table, const TString& name) {
+        return TString(TStringBuilder() << tx.GetWorkingDir() << '/' << table << '/' << name);
+    };
+    if (tx.HasCreateCdcStream()) {
+        const auto& op = tx.GetCreateCdcStream();
+        result.push_back(TSchemeChangeRawTarget{
+            stream(op.GetTableName(), op.GetStreamDescription().GetName()), {}});
+    } else if (tx.HasAlterCdcStream()) {
+        const auto& op = tx.GetAlterCdcStream();
+        result.push_back(TSchemeChangeRawTarget{
+            stream(op.GetTableName(), op.GetStreamName()), {}});
+    } else if (tx.HasDropCdcStream()) {
+        const auto& op = tx.GetDropCdcStream();
+        for (const auto& name : op.GetStreamName()) {
+            result.push_back(TSchemeChangeRawTarget{stream(op.GetTableName(), name), {}});
+        }
+    } else if (tx.HasRotateCdcStream()) {
+        // The new stream is the identity afterwards; the retired one is its source.
+        const auto& op = tx.GetRotateCdcStream();
+        result.push_back(TSchemeChangeRawTarget{
+            stream(op.GetTableName(), op.GetNewStream().GetStreamDescription().GetName()),
+            stream(op.GetTableName(), op.GetOldStreamName())});
+    }
+    return result;
+}
+
+TMaybe<TVector<TResolvedSchemeChangeTarget>> ResolveSchemeChangeTargets(const NKikimrSchemeOp::TModifyScheme& requestTx, TSchemeShard* ss) {
+    const TVector<TSchemeChangeRawTarget> copyTargets = ExtractSchemeChangeCopyTargets(requestTx);
+    if (!copyTargets.empty()) {
+        TVector<TResolvedSchemeChangeTarget> result;
+        for (const auto& raw : copyTargets) {
+            TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(raw, ss);
+            if (!resolved) {
+                return Nothing();
+            }
+            result.push_back(std::move(*resolved));
+        }
+        return result;
+    }
+
+    const TVector<TSchemeChangeRawTarget> cdcTargets = ExtractSchemeChangeCdcTargets(requestTx);
+    if (!cdcTargets.empty()) {
+        TVector<TResolvedSchemeChangeTarget> result;
+        for (const auto& raw : cdcTargets) {
+            TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(raw, ss);
+            if (!resolved) {
+                return Nothing();
+            }
+            result.push_back(std::move(*resolved));
+        }
+        return result;
+    }
+
+    TMaybe<TSchemeChangeRawTarget> moveTarget = ExtractSchemeChangeMoveTarget(requestTx);
+    if (moveTarget) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(*moveTarget, ss);
+        if (!resolved) {
+            return Nothing();
+        }
+        return TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)};
+    }
+
+    if (requestTx.HasAlterLogin()) {
+        TPath workingDir = TPath::Resolve(requestTx.GetWorkingDir(), ss);
+        if (workingDir.IsResolved()) {
+            return TVector<TResolvedSchemeChangeTarget>{
+                TResolvedSchemeChangeTarget{requestTx.GetWorkingDir(), RelativeToDomain(workingDir, ss), {}}};
+        }
+        return Nothing();
+    }
+
+    if (requestTx.HasInitiateIndexBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetInitiateIndexBuild().GetTable(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    // Column builds carry an absolute table path, like InitiateIndexBuild.
+    if (requestTx.HasInitiateColumnBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetInitiateColumnBuild().GetTable(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    if (requestTx.HasDropColumnBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetDropColumnBuild().GetSettings().GetTable(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    if (requestTx.HasCancelIndexBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetCancelIndexBuild().GetTablePath(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+    if (requestTx.HasApplyIndexBuild()) {
+        TMaybe<TResolvedSchemeChangeTarget> resolved = ResolveRawTarget(
+            TSchemeChangeRawTarget{requestTx.GetApplyIndexBuild().GetTablePath(), {}}, ss);
+        return resolved
+            ? TMaybe<TVector<TResolvedSchemeChangeTarget>>{TVector<TResolvedSchemeChangeTarget>{std::move(*resolved)}}
+            : Nothing();
+    }
+
+    const TString targetName = ExtractSchemeChangeTargetName(requestTx);
+    if (targetName.empty()) {
+        // Drop and AlterTable may name their target by path id instead, and then
+        // WorkingDir is not a path at all ("not used").
+        TPathId byId;
+        if (requestTx.HasDrop() && requestTx.GetDrop().GetId() != 0) {
+            byId = ss->MakeLocalId(requestTx.GetDrop().GetId());
+        } else if (requestTx.HasAlterTable()) {
+            const auto& alter = requestTx.GetAlterTable();
+            if (alter.HasPathId()) {
+                byId = TPathId::FromProto(alter.GetPathId());
+            } else if (alter.HasId_Deprecated()) {
+                byId = ss->MakeLocalId(alter.GetId_Deprecated());
+            }
+        }
+        if (byId) {
+            TPath target = TPath::Init(byId, ss);
+            if (target.IsResolved()) {
+                return TVector<TResolvedSchemeChangeTarget>{
+                    TResolvedSchemeChangeTarget{target.PathString(), RelativeToDomain(target, ss), {}}};
+            }
+        }
+        return Nothing();
+    }
+
+    TString abs = requestTx.GetWorkingDir();
+    if (abs.empty() || abs.back() != '/') abs += '/';
+    abs += targetName;
+
+    TPath target = TPath::Resolve(abs, ss);
+    if (target.IsResolved()) {
+        return TVector<TResolvedSchemeChangeTarget>{TResolvedSchemeChangeTarget{abs, RelativeToDomain(target, ss), {}}};
+    }
+
+    TPath workingDir = TPath::Resolve(requestTx.GetWorkingDir(), ss);
+    if (!workingDir.IsResolved()) {
+        return Nothing();
+    }
+    TString relParent = RelativeToDomain(workingDir, ss);
+    if (!relParent.empty()) {
+        relParent += '/';
+    }
+    return TVector<TResolvedSchemeChangeTarget>{TResolvedSchemeChangeTarget{abs, relParent + targetName, {}}};
+}
+
+} // namespace
+
+// Serialized protobuf, never a delimited string: a path may contain any delimiter.
+TString TSchemeShard::EncodeSchemeChangeTargets(const TVector<TOperation::TSchemeChangeTarget>& targets) {
+    NKikimrSchemeShard::TSchemeChangeRecordTargets msg;
+    for (const auto& t : targets) {
+        auto* target = msg.AddTargets();
+        target->SetPath(t.Path);
+        for (const auto& src : t.SourcePaths) {
+            target->AddSourcePaths(src);
+        }
+    }
+    TString result;
+    Y_DEBUG_ABORT_UNLESS(msg.SerializeToString(&result));
+    return result;
+}
+
+TVector<TOperation::TSchemeChangeTarget> TSchemeShard::DecodeSchemeChangeTargets(const TString& encoded) {
+    NKikimrSchemeShard::TSchemeChangeRecordTargets msg;
+    TVector<TOperation::TSchemeChangeTarget> result;
+    if (encoded.empty() || !msg.ParseFromString(encoded)) {
+        return result;
+    }
+    for (const auto& t : msg.GetTargets()) {
+        TOperation::TSchemeChangeTarget target;
+        target.Path = t.GetPath();
+        for (const auto& src : t.GetSourcePaths()) {
+            target.SourcePaths.push_back(src);
+        }
+        result.push_back(std::move(target));
+    }
+    return result;
+}
+
+bool TSchemeShard::CheckSchemeChangeRecordHasPath(const NKikimrSchemeOp::TModifyScheme& requestTx, TString& rejectReason) {
+    if (IsChurnOp(requestTx.GetOperationType()) || IsPathlessOp(requestTx.GetOperationType())) {
+        return true;
+    }
+    if (ResolveSchemeChangeTargets(requestTx, this)) {
+        return true;
+    }
+    rejectReason = TStringBuilder() << "scheme change outbox could not resolve a path for operation type "
+        << NKikimrSchemeOp::EOperationType_Name(requestTx.GetOperationType());
+    return false;
+}
+
+bool TSchemeShard::PersistSchemeChangeRecordAtPropose(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        const NKikimrSchemeOp::TModifyScheme& requestTx, TOperation::TSchemeChangeSlot& slot,
+        const TString& userSid) {
+    if (IsChurnOp(requestTx.GetOperationType())) {
+        return false;
+    }
+
+    TMaybe<TVector<TResolvedSchemeChangeTarget>> targets = ResolveSchemeChangeTargets(requestTx, this);
+
+    // Not redacted yet: the body carries whatever the request carried. Inert only because the flag is off.
+    const NKikimrSchemeOp::TModifyScheme& redacted = requestTx;
+    TVector<TString> redactedFields;
+
+    TString body;
+    {
+        bool ok = redacted.SerializeToString(&body);
+        Y_DEBUG_ABORT_UNLESS(ok);
+    }
+
+    const ui64 order = AllocateSchemeChangeOrderInMemory();
+
+    TestSchemeChangeRedoBytesAccum += body.size() + 128;
+
+    TVector<TOperation::TSchemeChangeTarget> relTargets;
+    TVector<TOperation::TSchemeChangeTarget> absTargets;
+    if (targets) {
+        for (const auto& t : *targets) {
+            relTargets.push_back(TOperation::TSchemeChangeTarget{t.Relative, t.RelativeSources});
+            absTargets.push_back(TOperation::TSchemeChangeTarget{t.Absolute, t.RelativeSources});
+        }
+    }
+
+    using T = Schema::SchemeChangeRecords;
+    db.Table<T>().Key(order).Update(
+        NIceDb::TUpdate<T::TxId>(ui64(txId)),
+        NIceDb::TUpdate<T::OperationType>(static_cast<ui32>(requestTx.GetOperationType())),
+        NIceDb::TUpdate<T::Path>(EncodeSchemeChangeTargets(relTargets)),
+        NIceDb::TUpdate<T::Status>(ui32(NKikimrScheme::StatusAccepted)),
+        NIceDb::TUpdate<T::UserSID>(userSid),
+        NIceDb::TUpdate<T::BodySizeBytes>(body.size()),
+        NIceDb::TUpdate<T::RedactedFields>(JoinSeq("\n", redactedFields)),
+        // Zero keeps the row hidden from fetch until finalisation.
+        NIceDb::TUpdate<T::CompletedAtUs>(ui64(0))
+    );
+    if (!body.empty()) {
+        db.Table<Schema::SchemeChangeRecordDetails>().Key(order).Update(
+            NIceDb::TUpdate<Schema::SchemeChangeRecordDetails::Body>(body)
+        );
+    }
+
+    PersistUpdateNextSchemeChangeOrder(db);
+    PersistSchemeChangePendingOrder(db, txId, requestIdx, order, absTargets);
+
+    slot.RequestIdx = requestIdx;
+    slot.Order = order;
+    slot.Targets = absTargets;
+    slot.UserSid = userSid;
+    return true;
+}
+
+void TSchemeShard::FinalizeSchemeChangeRecord(NIceDb::TNiceDb& db, const TActorContext& ctx,
+        const TOperation::TSchemeChangeSlot& slot, TStepId planStep, bool aborted) {
+    // Ops completing at propose have no coordinator step, so they borrow the ceiling.
+    ui64 step = ui64(planStep);
+    auto positionKind = NKikimrSchemeShard::TSchemeChangePosition::KIND_EXACT;
+    if (step == 0 || planStep == InvalidStepId) {
+        step = LastAssignedPlanStep;
+        positionKind = NKikimrSchemeShard::TSchemeChangePosition::KIND_BUCKETED;
+    }
+    step = Max<ui64>(step, 1);
+
+    TPathId resolvedPathId;
+    auto resolvedObjectType = NKikimrSchemeOp::EPathTypeInvalid;
+    ui64 schemaVersion = 0;
+    TVector<TOperation::TSchemeChangeTarget> canonicalTargets = slot.Targets;
+    bool anyResolved = false;
+    for (size_t i = 0; i < slot.Targets.size(); ++i) {
+        if (slot.Targets[i].Path.empty()) {
+            continue;
+        }
+        TPath resolved = TPath::Resolve(slot.Targets[i].Path, this);
+        if (!resolved.IsResolved()) {
+            continue;
+        }
+        canonicalTargets[i].Path = RelativeToDomain(resolved, this);
+        anyResolved = true;
+        if (i == 0) {
+            resolvedPathId = resolved.Base()->PathId;
+            resolvedObjectType = resolved.Base()->PathType;
+            schemaVersion = resolved.Base()->DirAlterVersion;
+        }
+    }
+
+    // Must be taken now -- after a DROP the object is gone.
+    TString description;
+    // A secret's description carries the value, so it is never captured.
+    if (resolvedPathId && resolvedObjectType != NKikimrSchemeOp::EPathTypeSecret) {
+        // Schema only: partitioning/children would bloat the redo log.
+        NKikimrSchemeOp::TDescribeOptions opts;
+        opts.SetReturnPartitioningInfo(false);
+        opts.SetReturnPartitionConfig(false);
+        opts.SetReturnChildren(false);
+        opts.SetReturnRangeKey(false);
+        auto desc = DescribePath(this, ctx, resolvedPathId, opts);
+        Y_UNUSED(desc->GetRecord().SerializeToString(&description));
+    }
+
+    TestSchemeChangeRedoBytesAccum += description.size();
+    TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_DESCRIPTION_BYTES].Increment(description.size());
+
+    // CompletedAtUs non-zero makes the row visible, so all fields must be set in this Update.
+    using T = Schema::SchemeChangeRecords;
+    db.Table<T>().Key(slot.Order).Update(
+        NIceDb::TUpdate<T::PathOwnerId>(resolvedPathId.OwnerId),
+        NIceDb::TUpdate<T::PathLocalId>(resolvedPathId.LocalPathId),
+        NIceDb::TUpdate<T::ObjectType>(ui32(resolvedObjectType)),
+        NIceDb::TUpdate<T::Status>(ui32(aborted
+            ? NKikimrScheme::StatusPreconditionFailed
+            : NKikimrScheme::StatusSuccess)),
+        NIceDb::TUpdate<T::SchemaVersion>(schemaVersion),
+        NIceDb::TUpdate<T::PlanStep>(step),
+        NIceDb::TUpdate<T::Description>(description),
+        NIceDb::TUpdate<T::PositionKind>(static_cast<ui32>(positionKind)),
+        NIceDb::TUpdate<T::CompletedAtUs>(ctx.Now().MicroSeconds())
+    );
+    if (anyResolved) {
+        db.Table<T>().Key(slot.Order).Update(
+            NIceDb::TUpdate<T::Path>(EncodeSchemeChangeTargets(canonicalTargets))
+        );
+    }
+}
+
+ui64 TSchemeShard::AllocateSchemeChangeOrderInMemory() {
+    return ++NextSchemeChangeOrder;
+}
+
+
+
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__scheme_change_records.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__scheme_change_records.cpp
@@ -516,7 +516,59 @@ ui64 TSchemeShard::AllocateSchemeChangeOrderInMemory() {
     return ++NextSchemeChangeOrder;
 }
 
+void TSchemeShard::EnqueueSchemeChangeRecordsCleanup(const TActorContext& ctx) {
+    ctx.Schedule(SchemeChangeCleanupInterval, new TEvPrivate::TEvSchemeChangeRecordsCleanup());
+}
 
+void TSchemeShard::Handle(TEvPrivate::TEvSchemeChangeRecordsCleanup::TPtr&, const TActorContext& ctx) {
+    Execute(CreateTxSchemeChangeRecordsCleanup(), ctx);
+}
 
+bool TSchemeShard::DeleteAckedSchemeChangeRecords(NIceDb::TNiceDb& db, ui64 newMinOrder,
+        ui64 limit, bool& hasMore) {
+    hasMore = false;
+    // SchemeChangeFloorOrder is the only sound lower bound: it is what was actually
+    // deleted, not a watermark a prior pass may have stopped short of.
+    if (newMinOrder <= SchemeChangeFloorOrder) {
+        return true;
+    }
+    const ui64 from = SchemeChangeFloorOrder + 1;
+    // Bound both ends: an unbounded GreaterOrEqual().Select() would precharge
+    // the whole tail of the table.
+    auto logRowset = db.Table<Schema::SchemeChangeRecords>()
+        .GreaterOrEqual(from)
+        .LessOrEqual(newMinOrder)
+        .Select();
+    if (!logRowset.IsReady()) {
+        return false;
+    }
+    ui64 deleted = 0;
+    ui64 lastDeleted = 0;
+    while (!logRowset.EndOfSet()) {
+        TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_ROWS_SCANNED].Increment(1);
+        ui64 order = logRowset.GetValue<Schema::SchemeChangeRecords::Order>();
+        if (order > newMinOrder) {
+            break;
+        }
+        if (deleted >= limit) {
+            hasMore = true;
+            break;
+        }
+        db.Table<Schema::SchemeChangeRecords>().Key(order).Delete();
+        db.Table<Schema::SchemeChangeRecordDetails>().Key(order).Delete();
+        lastDeleted = order;
+        ++deleted;
+        if (!logRowset.Next()) {
+            return false;
+        }
+    }
+    // Advance to the last row actually removed, not newMinOrder: the batch
+    // limit may have stopped short.
+    if (lastDeleted > SchemeChangeFloorOrder) {
+        SchemeChangeFloorOrder = lastDeleted;
+        PersistSchemeChangeFloorOrder(db);
+    }
+    return true;
+}
 
 } // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__scheme_change_records_cleanup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__scheme_change_records_cleanup.cpp
@@ -1,0 +1,150 @@
+#include "schemeshard_impl.h"
+
+#include <ydb/core/base/appdata.h>
+
+namespace NKikimr::NSchemeShard {
+
+struct TTxSchemeChangeRecordsCleanup : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    bool HasMoreToCleanup = false;
+
+    TTxSchemeChangeRecordsCleanup(TSchemeShard* self)
+        : TTransactionBase(self)
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_SCHEME_CHANGE_RECORDS_CLEANUP; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        HasMoreToCleanup = false;
+        NIceDb::TNiceDb db(txc.DB);
+        const ui64 minOrder = Self->GetMinSubscriberOrder(ctx.Now());
+        if (minOrder == 0) {
+            return true;
+        }
+        return Self->DeleteAckedSchemeChangeRecords(db, minOrder,
+            Self->SchemeChangeCleanupBatchSize, HasMoreToCleanup);
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        ++Self->SchemeChangeCleanupTxCount;
+        if (HasMoreToCleanup) {
+            Self->EnqueueSchemeChangeRecordsCleanup(ctx);
+        }
+    }
+};
+
+struct TTxForceAdvanceSubscriber : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TString SubscriberId;
+    TActorId ReplyTo;
+    THolder<TEvSchemeShard::TEvForceAdvanceSubscriberResult> Result;
+    bool HasMoreToCleanup = false;
+
+    TTxForceAdvanceSubscriber(TSchemeShard* self, TEvSchemeShard::TEvForceAdvanceSubscriber::TPtr& ev)
+        : TTransactionBase(self)
+        , SubscriberId(ev->Get()->Record.GetSubscriberId())
+        , ReplyTo(ev->Sender)
+        , Result(MakeHolder<TEvSchemeShard::TEvForceAdvanceSubscriberResult>())
+    {}
+
+    TTxForceAdvanceSubscriber(TSchemeShard* self, const TString& subscriberId, TActorId replyTo)
+        : TTransactionBase(self)
+        , SubscriberId(subscriberId)
+        , ReplyTo(replyTo)
+        , Result(MakeHolder<TEvSchemeShard::TEvForceAdvanceSubscriberResult>())
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_FORCE_ADVANCE_SCHEME_CHANGE_SUBSCRIBER; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        HasMoreToCleanup = false;
+        const TString& subscriberId = SubscriberId;
+
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason("Scheme change records are disabled");
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        auto rowset = db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+
+        if (!rowset.IsValid()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED);
+            Result->Record.SetReason("Subscriber not registered: " + subscriberId);
+            return true;
+        }
+
+        const ui64 oldOrder = rowset.GetValue<Schema::SchemeChangeSubscribers::LastAckedOrder>();
+        // Use the visible tail, not the reserved one: the cursor must not sit
+        // above a record an in-flight operation has yet to finalise.
+        const ui64 newOrder = Max(oldOrder, Self->GetVisibleSchemeChangeTail());
+        const TInstant now = ctx.Now();
+
+        // Only mark Lost if records are actually skipped; force-advancing an
+        // already-drained subscriber loses nothing.
+        const bool losesRecords = newOrder > oldOrder;
+        const auto newState = losesRecords
+            ? NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST
+            : NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY;
+
+        db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Update(
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastAckedOrder>(newOrder),
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::State>(newState),
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastActivityAtUs>(now.MicroSeconds())
+        );
+
+        if (auto it = Self->Subscribers.find(subscriberId); it != Self->Subscribers.end()) {
+            it->second.LastAckedOrder = newOrder;
+            it->second.State = newState;
+            it->second.LastActivityAt = now;
+        }
+
+        if (!Self->DeleteAckedSchemeChangeRecords(db, Self->GetMinSubscriberOrder(ctx.Now()),
+                Self->SchemeChangeCleanupBatchSize, HasMoreToCleanup)) {
+            return false;
+        }
+
+        Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        Result->Record.SetLastAckedOrder(newOrder);
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        // Empty when driven from the monitoring page, which replies directly.
+        if (ReplyTo) {
+            ctx.Send(ReplyTo, Result.Release());
+        }
+        if (HasMoreToCleanup) {
+            Self->EnqueueSchemeChangeRecordsCleanup(ctx);
+        }
+    }
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxSchemeChangeRecordsCleanup() {
+    return new TTxSchemeChangeRecordsCleanup(this);
+}
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxForceAdvanceSubscriberFromMonitoring(
+    const TString& subscriberId, TActorId replyTo)
+{
+    return new TTxForceAdvanceSubscriber(this, subscriberId, replyTo);
+}
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxForceAdvanceSubscriber(TEvSchemeShard::TEvForceAdvanceSubscriber::TPtr& ev) {
+    return new TTxForceAdvanceSubscriber(this, ev);
+}
+
+void TSchemeShard::Handle(TEvSchemeShard::TEvForceAdvanceSubscriber::TPtr& ev, const TActorContext& ctx) {
+    if (RejectSchemeChangeRequestIfDisabled<TEvSchemeShard::TEvForceAdvanceSubscriberResult>(ctx, ev->Sender)) {
+        return;
+    }
+    Execute(CreateTxForceAdvanceSubscriber(ev), ctx);
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__scheme_change_records_fetch.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__scheme_change_records_fetch.cpp
@@ -1,0 +1,645 @@
+#include "schemeshard_impl.h"
+
+#include <ydb/core/base/appdata.h>
+
+#include <util/string/split.h>
+
+namespace NKikimr::NSchemeShard {
+
+namespace {
+
+// An empty SubscriberId is dangerous: two consumers that both leave it unset
+// silently share one cursor, so one's ack deletes records the other never saw.
+template <class TResultRecord>
+bool CheckSubscriberId(const TString& subscriberId, TResultRecord& result) {
+    if (subscriberId.empty()) {
+        result.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+        result.SetReason("SubscriberId must not be empty");
+        return false;
+    }
+    if (subscriberId.size() > TSchemeShard::MaxSchemeChangeSubscriberIdLength) {
+        result.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+        result.SetReason(TStringBuilder() << "SubscriberId exceeds "
+            << TSchemeShard::MaxSchemeChangeSubscriberIdLength << " bytes");
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+struct TTxRegisterSubscriber : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TEvSchemeShard::TEvRegisterSubscriber::TPtr Request;
+    THolder<TEvSchemeShard::TEvRegisterSubscriberResult> Result;
+
+    TTxRegisterSubscriber(TSchemeShard* self, TEvSchemeShard::TEvRegisterSubscriber::TPtr& ev)
+        : TTransactionBase(self)
+        , Request(ev)
+        , Result(MakeHolder<TEvSchemeShard::TEvRegisterSubscriberResult>())
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_REGISTER_SCHEME_CHANGE_SUBSCRIBER; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        const auto& record = Request->Get()->Record;
+        const TString& subscriberId = record.GetSubscriberId();
+
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason("Scheme change records are disabled");
+            return true;
+        }
+
+        if (!CheckSubscriberId(subscriberId, Result->Record)) {
+            return true;
+        }
+
+        // A plain (non-Ext) SubDomain can serve several coordinator timelines,
+        // which would let a Bucketed record borrow a step from a foreign domain.
+        if (Self->CountTransactionSupportingDomains() > 1) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason(
+                "Scheme change subscribers require a SchemeShard serving a single"
+                " transaction-supporting domain; use an external subdomain");
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        auto rowset = db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+
+        if (rowset.IsValid()) {
+            const ui64 currentOrder = rowset.GetValue<Schema::SchemeChangeSubscribers::LastAckedOrder>();
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+            Result->Record.SetCurrentOrder(currentOrder);
+            auto it = Self->Subscribers.find(subscriberId);
+            Result->Record.SetState(static_cast<NKikimrSchemeShard::TSchemeChangeSubscriberState::EState>(
+                it != Self->Subscribers.end()
+                    ? it->second.State
+                    : NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY));
+            return true;
+        }
+
+        // Cap only new ids, so re-registration after a restart stays idempotent.
+        if (Self->Subscribers.size() >= Self->MaxSchemeChangeSubscribers) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason(TStringBuilder()
+                << "Too many scheme change subscribers (limit: "
+                << Self->MaxSchemeChangeSubscribers << ")");
+            return true;
+        }
+
+        // Use the visible tail, not the raw allocation counter: a subscriber
+        // must start below rows already reserved by an in-flight DDL.
+        const ui64 tail = Self->GetVisibleSchemeChangeTail();
+
+        const ui64 floor = Self->GetMinSubscriberOrder(ctx.Now());
+
+        ui64 startOrder = tail;
+        ui64 skipped = 0;
+        auto state = NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY;
+
+        if (record.HasStartOrder()) {
+            const ui64 requested = record.GetStartOrder();
+            if (requested > tail) {
+                Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+                Result->Record.SetReason(TStringBuilder()
+                    << "StartOrder " << requested << " is beyond the log tail " << tail);
+                return true;
+            }
+            if (requested < floor) {
+                // Clamp up rather than reject: a new subscriber must never
+                // widen the unacked window and stall DDL.
+                startOrder = floor;
+                skipped = floor - requested;
+                state = NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST;
+            } else {
+                startOrder = requested;
+            }
+        }
+
+        const TInstant now = ctx.Now();
+        db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Update(
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastAckedOrder>(startOrder),
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastActivityAtUs>(now.MicroSeconds()),
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::State>(state),
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::StartOrder>(startOrder)
+        );
+
+        TSchemeShard::TSubscriberInfo info;
+        info.LastAckedOrder = startOrder;
+        info.LastActivityAt = now;
+        info.State = state;
+        info.StartOrder = startOrder;
+        Self->Subscribers.emplace(subscriberId, info);
+
+        Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        Result->Record.SetCurrentOrder(startOrder);
+        Result->Record.SetState(state);
+        Result->Record.SetSkippedEntries(skipped);
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        ctx.Send(Request->Sender, Result.Release());
+    }
+};
+
+struct TTxFetchSchemeChangeRecords : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TEvSchemeShard::TEvFetchSchemeChangeRecords::TPtr Request;
+    THolder<TEvSchemeShard::TEvFetchSchemeChangeRecordsResult> Result;
+
+    TTxFetchSchemeChangeRecords(TSchemeShard* self, TEvSchemeShard::TEvFetchSchemeChangeRecords::TPtr& ev)
+        : TTransactionBase(self)
+        , Request(ev)
+        , Result(MakeHolder<TEvSchemeShard::TEvFetchSchemeChangeRecordsResult>())
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_FETCH_SCHEME_CHANGE_RECORDS; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        const auto& record = Request->Get()->Record;
+        const TString& subscriberId = record.GetSubscriberId();
+        const ui64 afterOrder = record.GetAfterOrder();
+        ui32 maxCount = record.GetMaxCount();
+
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason("Scheme change records are disabled");
+            return true;
+        }
+
+        if (maxCount == 0 || maxCount > 1000) {
+            maxCount = 1000;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        auto subRowset = db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Select();
+        if (!subRowset.IsReady()) {
+            return false;
+        }
+
+        if (!subRowset.IsValid()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED);
+            Result->Record.SetReason("Subscriber not registered: " + subscriberId);
+            return true;
+        }
+
+        const ui64 storedOrder = subRowset.GetValue<Schema::SchemeChangeSubscribers::LastAckedOrder>();
+
+        ui64 effectiveAfterOrder = afterOrder;
+        ui64 skippedEntries = 0;
+        bool subscriberLost = false;
+        if (storedOrder > afterOrder) {
+            skippedEntries = storedOrder - afterOrder;
+            effectiveAfterOrder = storedOrder;
+        }
+
+        Y_ENSURE(effectiveAfterOrder < Max<ui64>(), "effectiveAfterOrder overflow");
+        // Bound both ends: an unbounded GreaterOrEqual().Select() would precharge the
+        // whole tail. No order exceeds NextSchemeChangeOrder, so no real row is excluded.
+        auto rowset = db.Table<Schema::SchemeChangeRecords>()
+            .GreaterOrEqual(effectiveAfterOrder + 1)
+            .LessOrEqual(Self->NextSchemeChangeOrder)
+            .Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+
+        ui32 count = 0;
+        bool hasMore = false;
+        bool firstRow = true;
+        bool blockedByPending = false;
+
+        while (!rowset.EndOfSet()) {
+            if (count >= maxCount) {
+                hasMore = true;
+                break;
+            }
+
+            Self->TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_ROWS_SCANNED].Increment(1);
+            ui64 order = rowset.GetValue<Schema::SchemeChangeRecords::Order>();
+
+            // Stop, don't skip, at the first in-flight row: the cursor is one watermark,
+            // so handing out a later record would let an ack skip past this one.
+            if (rowset.GetValueOrDefault<Schema::SchemeChangeRecords::CompletedAtUs>(0) == 0) {
+                blockedByPending = true;
+                break;
+            }
+
+            auto* entry = Result->Record.AddEntries();
+
+            // A first row above effectiveAfterOrder+1 means records in between
+            // were swept while this subscriber still needed them; report it.
+            if (firstRow) {
+                firstRow = false;
+                if (order > effectiveAfterOrder + 1) {
+                    skippedEntries += order - 1 - effectiveAfterOrder;
+                    subscriberLost = true;
+                }
+            }
+            entry->SetOrder(order);
+            entry->SetTxId(rowset.GetValue<Schema::SchemeChangeRecords::TxId>());
+            entry->SetOperationType(rowset.GetValue<Schema::SchemeChangeRecords::OperationType>());
+            auto* pathId = entry->MutablePathId();
+            pathId->SetOwnerId(rowset.GetValue<Schema::SchemeChangeRecords::PathOwnerId>());
+            pathId->SetLocalId(rowset.GetValue<Schema::SchemeChangeRecords::PathLocalId>());
+            for (const auto& t : TSchemeShard::DecodeSchemeChangeTargets(rowset.GetValue<Schema::SchemeChangeRecords::Path>())) {
+                auto* target = entry->AddTargets();
+                target->SetPath(t.Path);
+                for (const auto& src : t.SourcePaths) {
+                    target->AddSourcePaths(src);
+                }
+            }
+            entry->SetObjectType(rowset.GetValue<Schema::SchemeChangeRecords::ObjectType>());
+            entry->SetStatus(rowset.GetValue<Schema::SchemeChangeRecords::Status>());
+            entry->SetUserSID(rowset.GetValue<Schema::SchemeChangeRecords::UserSID>());
+            entry->SetSchemaVersion(rowset.GetValue<Schema::SchemeChangeRecords::SchemaVersion>());
+            entry->SetCompletedAtUs(rowset.GetValue<Schema::SchemeChangeRecords::CompletedAtUs>());
+            entry->SetPlanStep(rowset.GetValueOrDefault<Schema::SchemeChangeRecords::PlanStep>(0));
+            entry->SetBodySizeBytes(rowset.GetValueOrDefault<Schema::SchemeChangeRecords::BodySizeBytes>(0));
+            entry->SetPositionKind(static_cast<NKikimrSchemeShard::TSchemeChangePosition::EKind>(
+                rowset.GetValueOrDefault<Schema::SchemeChangeRecords::PositionKind>(
+                    NKikimrSchemeShard::TSchemeChangePosition::KIND_EXACT)));
+            {
+                const TString redacted = rowset.GetValueOrDefault<Schema::SchemeChangeRecords::RedactedFields>(TString());
+                if (!redacted.empty()) {
+                    for (const auto& field : StringSplitter(redacted).Split('\n')) {
+                        entry->AddRedactedFields(TString(field.Token()));
+                    }
+                }
+            }
+
+            ++count;
+
+            if (!rowset.Next()) {
+                return false;
+            }
+        }
+
+        // Total-loss case: the loop above never ran, excluding blockedByPending
+        // since an in-flight record is a not-yet, not a loss.
+        if (count == 0 && !blockedByPending && effectiveAfterOrder < Self->GetVisibleSchemeChangeTail()) {
+            skippedEntries += Self->GetVisibleSchemeChangeTail() - effectiveAfterOrder;
+            subscriberLost = true;
+            // Advance to the tail, or the same loss re-reports on every fetch.
+            effectiveAfterOrder = Self->GetVisibleSchemeChangeTail();
+        }
+
+        const TInstant now = ctx.Now();
+        if (subscriberLost) {
+            db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Update(
+                NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastAckedOrder>(effectiveAfterOrder),
+                NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastActivityAtUs>(now.MicroSeconds()),
+                NIceDb::TUpdate<Schema::SchemeChangeSubscribers::State>(
+                    NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST)
+            );
+        } else {
+            db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Update(
+                NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastActivityAtUs>(now.MicroSeconds())
+            );
+        }
+        if (auto it = Self->Subscribers.find(subscriberId); it != Self->Subscribers.end()) {
+            it->second.LastActivityAt = now;
+            if (subscriberLost) {
+                it->second.State = NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST;
+                it->second.LastAckedOrder = effectiveAfterOrder;
+            }
+        }
+
+        Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        Result->Record.SetHasMore(hasMore);
+        Result->Record.SetSkippedEntries(skippedEntries);
+        if (auto it = Self->Subscribers.find(subscriberId); it != Self->Subscribers.end()) {
+            Result->Record.SetState(
+                static_cast<NKikimrSchemeShard::TSchemeChangeSubscriberState::EState>(it->second.State));
+        }
+
+        // Order is completion order while plan step is plan order, and they can
+        // diverge, so a consumer needs this to know window (S_prev, S] is complete.
+        Result->Record.SetClosedThroughPlanStep(Self->GetClosedThroughPlanStep());
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        ctx.Send(Request->Sender, Result.Release());
+    }
+};
+
+struct TTxAckSchemeChangeRecords : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TEvSchemeShard::TEvAckSchemeChangeRecords::TPtr Request;
+    THolder<TEvSchemeShard::TEvAckSchemeChangeRecordsResult> Result;
+    bool HasMoreToCleanup = false;
+
+    TTxAckSchemeChangeRecords(TSchemeShard* self, TEvSchemeShard::TEvAckSchemeChangeRecords::TPtr& ev)
+        : TTransactionBase(self)
+        , Request(ev)
+        , Result(MakeHolder<TEvSchemeShard::TEvAckSchemeChangeRecordsResult>())
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_ACK_SCHEME_CHANGE_RECORDS; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        HasMoreToCleanup = false;
+        const auto& record = Request->Get()->Record;
+        const TString& subscriberId = record.GetSubscriberId();
+        const ui64 upToOrder = record.GetUpToOrder();
+
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason("Scheme change records are disabled");
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        auto rowset = db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+
+        if (!rowset.IsValid()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED);
+            Result->Record.SetReason("Subscriber not registered: " + subscriberId);
+            return true;
+        }
+
+        const ui64 currentOrder = rowset.GetValue<Schema::SchemeChangeSubscribers::LastAckedOrder>();
+
+        ui64 newOrder = Max(currentOrder, upToOrder);
+
+        // Clamp to the visible tail, not the reserved one: a cursor above an
+        // in-flight row would drop that record once it finalises.
+        if (newOrder > Self->GetVisibleSchemeChangeTail()) {
+            newOrder = Self->GetVisibleSchemeChangeTail();
+        }
+
+        const TInstant now = ctx.Now();
+        db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Update(
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastAckedOrder>(newOrder),
+            NIceDb::TUpdate<Schema::SchemeChangeSubscribers::LastActivityAtUs>(now.MicroSeconds())
+        );
+
+        if (auto it = Self->Subscribers.find(subscriberId); it != Self->Subscribers.end()) {
+            it->second.LastAckedOrder = newOrder;
+            it->second.LastActivityAt = now;
+        }
+
+        if (!Self->DeleteAckedSchemeChangeRecords(db, Self->GetMinSubscriberOrder(ctx.Now()),
+                Self->SchemeChangeCleanupBatchSize, HasMoreToCleanup)) {
+            return false;
+        }
+
+        Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        Result->Record.SetLastAckedOrder(newOrder);
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        ctx.Send(Request->Sender, Result.Release());
+        if (HasMoreToCleanup) {
+            Self->EnqueueSchemeChangeRecordsCleanup(ctx);
+        }
+    }
+};
+
+struct TTxUnregisterSubscriber : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TEvSchemeShard::TEvUnregisterSubscriber::TPtr Request;
+    THolder<TEvSchemeShard::TEvUnregisterSubscriberResult> Result;
+    bool HasMoreToCleanup = false;
+
+    TTxUnregisterSubscriber(TSchemeShard* self, TEvSchemeShard::TEvUnregisterSubscriber::TPtr& ev)
+        : TTransactionBase(self)
+        , Request(ev)
+        , Result(MakeHolder<TEvSchemeShard::TEvUnregisterSubscriberResult>())
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_UNREGISTER_SCHEME_CHANGE_SUBSCRIBER; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        HasMoreToCleanup = false;
+        const auto& record = Request->Get()->Record;
+        const TString& subscriberId = record.GetSubscriberId();
+
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason("Scheme change records are disabled");
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        auto rowset = db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+
+        if (!rowset.IsValid()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED);
+            Result->Record.SetReason("Subscriber not registered: " + subscriberId);
+            return true;
+        }
+
+        db.Table<Schema::SchemeChangeSubscribers>().Key(subscriberId).Delete();
+        Self->Subscribers.erase(subscriberId);
+
+        if (!Self->DeleteAckedSchemeChangeRecords(db, Self->GetMinSubscriberOrder(ctx.Now()),
+                Self->SchemeChangeCleanupBatchSize, HasMoreToCleanup)) {
+            return false;
+        }
+
+        Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        ctx.Send(Request->Sender, Result.Release());
+        if (HasMoreToCleanup) {
+            Self->EnqueueSchemeChangeRecordsCleanup(ctx);
+        }
+    }
+};
+
+struct TTxFetchSchemeChangeRecordBodies : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TEvSchemeShard::TEvFetchSchemeChangeRecordBodies::TPtr Request;
+    THolder<TEvSchemeShard::TEvFetchSchemeChangeRecordBodiesResult> Result;
+
+    TTxFetchSchemeChangeRecordBodies(TSchemeShard* self, TEvSchemeShard::TEvFetchSchemeChangeRecordBodies::TPtr& ev)
+        : TTransactionBase(self)
+        , Request(ev)
+        , Result(MakeHolder<TEvSchemeShard::TEvFetchSchemeChangeRecordBodiesResult>())
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_FETCH_SCHEME_CHANGE_RECORD_BODIES; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        const auto& record = Request->Get()->Record;
+        const TString& subscriberId = record.GetSubscriberId();
+
+        if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason("Scheme change records are disabled");
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        if (!Self->Subscribers.contains(subscriberId)) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED);
+            Result->Record.SetReason("Subscriber not registered: " + subscriberId);
+            return true;
+        }
+
+        const auto& requestedOrders = record.GetOrders();
+        if (requestedOrders.empty()) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+            return true;
+        }
+
+        // Reject rather than truncate: a truncated reply is indistinguishable
+        // from "those records no longer exist".
+        if ((ui64)requestedOrders.size() > Self->MaxSchemeChangeBodiesPerRequest) {
+            Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+            Result->Record.SetReason(TStringBuilder()
+                << "Too many orders requested: " << requestedOrders.size()
+                << ", max " << Self->MaxSchemeChangeBodiesPerRequest);
+            return true;
+        }
+
+        THashSet<ui64> requestedSet(requestedOrders.begin(), requestedOrders.end());
+
+        // Point lookups, not a [min,max] span scan: cost is |requestedSet|.
+        THashMap<ui64, TString> descriptionByOrder;
+        THashSet<ui64> metaExisting;
+        bool allReady = true;
+        for (ui64 order : requestedSet) {
+            Self->TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_ROWS_SCANNED].Increment(1);
+            auto row = db.Table<Schema::SchemeChangeRecords>().Key(order).Select();
+            if (!row.IsReady()) {
+                allReady = false;
+                continue;
+            }
+            if (!row.IsValid()) {
+                continue;
+            }
+            metaExisting.insert(order);
+            auto desc = row.GetValueOrDefault<Schema::SchemeChangeRecords::Description>(TString());
+            if (!desc.empty()) {
+                descriptionByOrder.emplace(order, std::move(desc));
+            }
+        }
+
+        THashMap<ui64, TString> bodyByOrder;
+        for (ui64 order : metaExisting) {
+            Self->TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_ROWS_SCANNED].Increment(1);
+            auto row = db.Table<Schema::SchemeChangeRecordDetails>().Key(order).Select();
+            if (!row.IsReady()) {
+                allReady = false;
+                continue;
+            }
+            if (!row.IsValid()) {
+                continue;
+            }
+            bodyByOrder.emplace(order, row.GetValue<Schema::SchemeChangeRecordDetails::Body>());
+        }
+
+        // Nothing written to Result yet, so restart here is clean.
+        if (!allReady) {
+            return false;
+        }
+
+        // Iterate requestedOrders (not metaExisting) to preserve request order and duplicates.
+        for (ui64 order : requestedOrders) {
+            if (!metaExisting.contains(order)) {
+                continue;
+            }
+            auto* entry = Result->Record.AddEntries();
+            entry->SetOrder(order);
+            auto it = bodyByOrder.find(order);
+            if (it != bodyByOrder.end()) {
+                entry->SetBody(it->second);
+            }
+            auto descIt = descriptionByOrder.find(order);
+            if (descIt != descriptionByOrder.end()) {
+                entry->SetDescription(descIt->second);
+            }
+        }
+
+        Result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Self->UpdateSchemeChangeGauges();
+        ctx.Send(Request->Sender, Result.Release());
+    }
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxUnregisterSubscriber(TEvSchemeShard::TEvUnregisterSubscriber::TPtr& ev) {
+    return new TTxUnregisterSubscriber(this, ev);
+}
+
+void TSchemeShard::Handle(TEvSchemeShard::TEvUnregisterSubscriber::TPtr& ev, const TActorContext& ctx) {
+    if (RejectSchemeChangeRequestIfDisabled<TEvSchemeShard::TEvUnregisterSubscriberResult>(ctx, ev->Sender)) {
+        return;
+    }
+    Execute(CreateTxUnregisterSubscriber(ev), ctx);
+}
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxRegisterSubscriber(TEvSchemeShard::TEvRegisterSubscriber::TPtr& ev) {
+    return new TTxRegisterSubscriber(this, ev);
+}
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxFetchSchemeChangeRecords(TEvSchemeShard::TEvFetchSchemeChangeRecords::TPtr& ev) {
+    return new TTxFetchSchemeChangeRecords(this, ev);
+}
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxAckSchemeChangeRecords(TEvSchemeShard::TEvAckSchemeChangeRecords::TPtr& ev) {
+    return new TTxAckSchemeChangeRecords(this, ev);
+}
+
+void TSchemeShard::Handle(TEvSchemeShard::TEvRegisterSubscriber::TPtr& ev, const TActorContext& ctx) {
+    if (RejectSchemeChangeRequestIfDisabled<TEvSchemeShard::TEvRegisterSubscriberResult>(ctx, ev->Sender)) {
+        return;
+    }
+    Execute(CreateTxRegisterSubscriber(ev), ctx);
+}
+
+void TSchemeShard::Handle(TEvSchemeShard::TEvFetchSchemeChangeRecords::TPtr& ev, const TActorContext& ctx) {
+    if (RejectSchemeChangeRequestIfDisabled<TEvSchemeShard::TEvFetchSchemeChangeRecordsResult>(ctx, ev->Sender)) {
+        return;
+    }
+    Execute(CreateTxFetchSchemeChangeRecords(ev), ctx);
+}
+
+void TSchemeShard::Handle(TEvSchemeShard::TEvAckSchemeChangeRecords::TPtr& ev, const TActorContext& ctx) {
+    if (RejectSchemeChangeRequestIfDisabled<TEvSchemeShard::TEvAckSchemeChangeRecordsResult>(ctx, ev->Sender)) {
+        return;
+    }
+    Execute(CreateTxAckSchemeChangeRecords(ev), ctx);
+}
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxFetchSchemeChangeRecordBodies(TEvSchemeShard::TEvFetchSchemeChangeRecordBodies::TPtr& ev) {
+    return new TTxFetchSchemeChangeRecordBodies(this, ev);
+}
+
+void TSchemeShard::Handle(TEvSchemeShard::TEvFetchSchemeChangeRecordBodies::TPtr& ev, const TActorContext& ctx) {
+    if (RejectSchemeChangeRequestIfDisabled<TEvSchemeShard::TEvFetchSchemeChangeRecordBodiesResult>(ctx, ev->Sender)) {
+        return;
+    }
+    Execute(CreateTxFetchSchemeChangeRecordBodies(ev), ctx);
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -402,6 +402,13 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
 
     StartStopShred();
 
+    // The flag alone is not a sufficient guard: a cluster that had the feature on
+    // still needs this pass to drain acked rows after it is turned off.
+    if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()
+        || NextSchemeChangeOrder != SchemeChangeFloorOrder)
+    {
+        Execute(CreateTxSchemeChangeRecordsCleanup(), ctx);
+    }
 
     ctx.Send(TxAllocatorClient, MakeHolder<TEvTxAllocatorClient::TEvAllocate>(InitiateCachedTxIdsCount));
 
@@ -4234,6 +4241,29 @@ void TSchemeShard::PersistRemoveSchemeChangePendingOrder(NIceDb::TNiceDb& db, TT
     db.Table<Schema::SchemeChangePendingRecords>().Key(txId, requestIdx).Delete();
 }
 
+void TSchemeShard::UpdateSchemeChangeGauges() const {
+    const TInstant now = AppData()->TimeProvider->Now();
+    ui64 lost = 0;
+    ui64 stale = 0;
+    for (const auto& [_, info] : Subscribers) {
+        if (info.State == NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST) {
+            ++lost;
+        }
+        if (IsSubscriberStale(info, now)) {
+            ++stale;
+        }
+    }
+
+    // Depth is meaningless without a consumer.
+    const ui64 depth = Subscribers.empty()
+        ? 0
+        : NextSchemeChangeOrder - GetMinSubscriberOrder(now);
+
+    TabletCounters->Simple()[COUNTER_SCHEME_CHANGE_OUTBOX_DEPTH].Set(depth);
+    TabletCounters->Simple()[COUNTER_SCHEME_CHANGE_SUBSCRIBERS].Set(Subscribers.size());
+    TabletCounters->Simple()[COUNTER_SCHEME_CHANGE_SUBSCRIBERS_LOST].Set(lost);
+    TabletCounters->Simple()[COUNTER_SCHEME_CHANGE_SUBSCRIBERS_STALE].Set(stale);
+}
 
 ui64 TSchemeShard::GetVisibleSchemeChangeTail() const {
     ui64 firstPending = Max<ui64>();
@@ -4246,7 +4276,42 @@ ui64 TSchemeShard::GetVisibleSchemeChangeTail() const {
 }
 
 
+ui32 TSchemeShard::CountTransactionSupportingDomains() const {
+    ui32 count = 0;
+    for (const auto& [_, domain] : SubDomains) {
+        if (domain && domain->IsSupportTransactions()) {
+            ++count;
+        }
+    }
+    return count;
+}
 
+bool TSchemeShard::CheckSchemeChangeRecordsOverflow(TString& errStr, TInstant now) const {
+    // Kill switch: disabled means DDL is never refused by the outbox,
+    // checked before anything else so a wedged cluster is always rescuable.
+    if (!AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+        return true;
+    }
+
+    // Refresh the gauges here too: a wedged cluster runs no outbox
+    // transactions, which would otherwise leave the gauges frozen.
+    UpdateSchemeChangeGauges();
+
+    if (Subscribers.empty()) {
+        return true;
+    }
+    const ui64 unacked = NextSchemeChangeOrder - GetMinSubscriberOrder(now);
+    if (unacked >= MaxSchemeChangeRecords) {
+        // DDL is now refused cluster-wide until an admin force-advance clears it.
+        TabletCounters->Cumulative()[COUNTER_SCHEME_CHANGE_DDL_REJECTED].Increment(1);
+        errStr = TStringBuilder()
+            << "scheme change records is full: " << unacked
+            << " unacked entries (limit: " << MaxSchemeChangeRecords << ")."
+            << " Subscribers may not be draining.";
+        return false;
+    }
+    return true;
+}
 
 void TSchemeShard::PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const {
     db.Table<Schema::SysParams>().Key(Schema::SysParam_ParentDomainSchemeShard).Update(
@@ -6013,6 +6078,8 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(NReplication::TEvController::TEvAlterReplicationResult, Handle);
         HFuncTraced(NReplication::TEvController::TEvDropReplicationResult, Handle);
 
+        HFuncTraced(TEvPrivate::TEvSchemeChangeRecordsCleanup, Handle);
+
         // conditional erase
         HFuncTraced(TEvPrivate::TEvRunConditionalErase, Handle);
         HFuncTraced(TEvPrivate::TEvFlushConditionalEraseBatch, Handle);
@@ -6202,6 +6269,12 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvSchemeShard::TEvShredManualStartupRequest, Handle);
         HFuncTraced(TEvBlobStorage::TEvControllerShredResponse, Handle);
         HFuncTraced(TEvSchemeShard::TEvWakeupToRunShredBSC, Handle);
+        HFuncTraced(TEvSchemeShard::TEvRegisterSubscriber, Handle);
+        HFuncTraced(TEvSchemeShard::TEvFetchSchemeChangeRecords, Handle);
+        HFuncTraced(TEvSchemeShard::TEvAckSchemeChangeRecords, Handle);
+        HFuncTraced(TEvSchemeShard::TEvUnregisterSubscriber, Handle);
+        HFuncTraced(TEvSchemeShard::TEvForceAdvanceSubscriber, Handle);
+        HFuncTraced(TEvSchemeShard::TEvFetchSchemeChangeRecordBodies, Handle);
 
         HFuncTraced(NKikimr::NTestShard::TEvControlResponse, Handle);
 
@@ -8780,6 +8853,17 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TAppConfig& appConfi
         MaxBuildIndexShardsInFlight = schemeShardConfig.GetMaxBuildIndexShardsInFlight();
         MaxStoredIndexBuilds = schemeShardConfig.GetMaxStoredIndexBuilds();
         ConfigureCondErase(schemeShardConfig, ctx);
+        // A zero cap rejects every DDL unconditionally, force-advance
+        // included, since unacked >= 0 always holds. Keep the previous value.
+        if (const ui64 maxRecords = schemeShardConfig.GetMaxSchemeChangeRecords()) {
+            MaxSchemeChangeRecords = maxRecords;
+        } else {
+            LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "Ignoring MaxSchemeChangeRecords=0, keeping " << MaxSchemeChangeRecords);
+        }
+        RedactSchemeChangeSensitiveFields = schemeShardConfig.GetRedactSensitiveSchemeChangeFields();
+        SchemeChangeSubscriberStaleTtl =
+            TDuration::Seconds(schemeShardConfig.GetSchemeChangeSubscriberStaleTtlSeconds());
     }
 
     if (appConfig.HasTableProfilesConfig()) {
@@ -8838,6 +8922,11 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TFeatureFlags& featu
     EnableShred = featureFlags.GetEnableDataErasure();
     EnableExternalSourceSchemaInference = featureFlags.GetEnableExternalSourceSchemaInference();
 
+    // Cleanup self-chains only from Complete() hooks that are gated on the flag,
+    // so kick a drain here or rows sit on disk until the flag comes back on.
+    if (!featureFlags.GetEnableSchemeChangeRecords() && NextSchemeChangeOrder > SchemeChangeFloorOrder) {
+        EnqueueSchemeChangeRecordsCleanup(ctx);
+    }
 }
 
 void TSchemeShard::ConfigureStatsBatching(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -402,6 +402,7 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
 
     StartStopShred();
 
+
     ctx.Send(TxAllocatorClient, MakeHolder<TEvTxAllocatorClient::TEvAllocate>(InitiateCachedTxIdsCount));
 
     // Start local index migration if feature flag is enabled
@@ -4204,6 +4205,49 @@ void TSchemeShard::PersistUpdateNextShardIdx(NIceDb::TNiceDb& db) const {
                 NIceDb::TUpdate<Schema::SysParams::Value>(ToString(NextLocalShardIdx)));
 }
 
+void TSchemeShard::PersistUpdateNextSchemeChangeOrder(NIceDb::TNiceDb& db) const {
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_NextSchemeChangeOrder).Update(
+        NIceDb::TUpdate<Schema::SysParams::Value>(ToString(NextSchemeChangeOrder)));
+    ++NextSchemeChangeOrderPersistCount;
+}
+
+void TSchemeShard::PersistSchemeChangeFloorOrder(NIceDb::TNiceDb& db) const {
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_SchemeChangeFloorOrder).Update(
+        NIceDb::TUpdate<Schema::SysParams::Value>(ToString(SchemeChangeFloorOrder)));
+}
+
+void TSchemeShard::PersistUpdateLastAssignedPlanStep(NIceDb::TNiceDb& db) const {
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_LastAssignedPlanStep).Update(
+        NIceDb::TUpdate<Schema::SysParams::Value>(ToString(LastAssignedPlanStep)));
+}
+
+void TSchemeShard::PersistSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        ui64 order, const TVector<TOperation::TSchemeChangeTarget>& targets) const {
+    db.Table<Schema::SchemeChangePendingRecords>().Key(txId, requestIdx).Update(
+        NIceDb::TUpdate<Schema::SchemeChangePendingRecords::Order>(order),
+        NIceDb::TUpdate<Schema::SchemeChangePendingRecords::Path>(EncodeSchemeChangeTargets(targets)));
+}
+
+void TSchemeShard::PersistRemoveSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx) const {
+    // Point delete, not a range scan: TTxOperationPropose::Execute calls
+    // NoMoreReadsForTx() before this runs, and a later read aborts the tablet.
+    db.Table<Schema::SchemeChangePendingRecords>().Key(txId, requestIdx).Delete();
+}
+
+
+ui64 TSchemeShard::GetVisibleSchemeChangeTail() const {
+    ui64 firstPending = Max<ui64>();
+    for (const auto& [_, operation] : Operations) {
+        for (const auto& slot : operation->SchemeChangeSlots) {
+            firstPending = Min(firstPending, slot.Order);
+        }
+    }
+    return firstPending == Max<ui64>() ? NextSchemeChangeOrder : firstPending - 1;
+}
+
+
+
+
 void TSchemeShard::PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const {
     db.Table<Schema::SysParams>().Key(Schema::SysParam_ParentDomainSchemeShard).Update(
         NIceDb::TUpdate<Schema::SysParams::Value>(ToString(parentDomain.OwnerId)));
@@ -6267,6 +6311,7 @@ void TSchemeShard::RemoveTx(const TActorContext &ctx, NIceDb::TNiceDb &db, TOper
     LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "RemoveTx for txid " << opId);
     auto pathId = txState->TargetPathId;
 
+    RemoveInFlightPlanStep(ui64(txState->PlanStep));
     PersistRemoveTx(db, opId, *txState);
     TabletCounters->Simple()[TxTypeInFlightCounter(txState->TxType)].Sub(1);
 
@@ -8792,6 +8837,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TFeatureFlags& featu
     EnableExternalDataSourcesOnServerless = featureFlags.GetEnableExternalDataSourcesOnServerless();
     EnableShred = featureFlags.GetEnableDataErasure();
     EnableExternalSourceSchemaInference = featureFlags.GetEnableExternalSourceSchemaInference();
+
 }
 
 void TSchemeShard::ConfigureStatsBatching(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -101,6 +101,7 @@ struct TIndexBuildInfo;
 struct TSetColumnConstraintOperationInfo;
 struct TIndexBuildShardStatus;
 
+
 class TSchemeShard
     : public TActor<TSchemeShard>
     , public NTabletFlatExecutor::TTabletExecutedFlat
@@ -283,6 +284,80 @@ public:
     ui64 MaxIncompatibleChange = 0;
     THashMap<TPathId, TPathElement::TPtr> PathsById;
     TLocalPathId NextLocalPathId = 0;
+    ui64 NextSchemeChangeOrder = 0;
+    ui64 SchemeChangeFloorOrder = 0;
+    ui64 MaxSchemeChangeRecords = 100000;
+    // Disabling this serves credentials to every subscriber over an unauthenticated protocol.
+    bool RedactSchemeChangeSensitiveFields = true;
+    TDuration SchemeChangeSubscriberStaleTtl = TDuration::Days(30);
+    ui64 MaxSchemeChangeSubscribers = 100;
+    static constexpr size_t MaxSchemeChangeSubscriberIdLength = 256;
+    ui64 LastAssignedPlanStep = 0;
+    // Do not filter on TTxState::State: a tx in Done that is not yet erased must keep its entry.
+    TMap<ui64, ui32> InFlightByPlanStep;
+
+    void AddInFlightPlanStep(ui64 step) {
+        if (step) {
+            ++InFlightByPlanStep[step];
+        }
+    }
+    void RemoveInFlightPlanStep(ui64 step) {
+        if (!step) {
+            return;
+        }
+        auto it = InFlightByPlanStep.find(step);
+        if (it == InFlightByPlanStep.end()) {
+            return;
+        }
+        if (--it->second == 0) {
+            InFlightByPlanStep.erase(it);
+        }
+    }
+    ui64 GetClosedThroughPlanStep() const {
+        if (InFlightByPlanStep.empty()) {
+            return LastAssignedPlanStep;
+        }
+        const ui64 minInFlight = InFlightByPlanStep.begin()->first;
+        return minInFlight ? minInFlight - 1 : 0;
+    }
+    ui64 SchemeChangeCleanupBatchSize = 1000;
+    TDuration SchemeChangeCleanupInterval = TDuration::MilliSeconds(10);
+
+    ui64 MaxSchemeChangeBodiesPerRequest = 1000;
+
+    mutable ui64 NextSchemeChangeOrderPersistCount = 0;
+    mutable ui64 TestSchemeChangeRedoBytesAccum = 0;
+    ui64 SchemeChangeCleanupTxCount = 0;
+
+    struct TSubscriberInfo {
+        ui64 LastAckedOrder = 0;
+        TInstant LastActivityAt;
+        ui32 State = 1;
+        ui64 StartOrder = 0;
+    };
+    THashMap<TString, TSubscriberInfo> Subscribers;
+
+    ui64 GetVisibleSchemeChangeTail() const;
+
+    void UpdateSchemeChangeGauges() const;
+
+    ui64 GetMinSubscriberOrder(TInstant) const {
+        if (Subscribers.empty()) {
+            return GetVisibleSchemeChangeTail();
+        }
+        ui64 m = Max<ui64>();
+        for (const auto& [_, info] : Subscribers) {
+            m = Min(m, info.LastAckedOrder);
+        }
+        return m;
+    }
+
+    bool IsSubscriberStale(const TSubscriberInfo& info, TInstant now) const {
+        if (!SchemeChangeSubscriberStaleTtl) {
+            return false;
+        }
+        return (now - info.LastActivityAt) >= SchemeChangeSubscriberStaleTtl;
+    }
 
     THashMap<TPathId, TTableInfo::TPtr> Tables;
     THashMap<TPathId, TTableInfo::TPtr> TTLEnabledTables;
@@ -904,6 +979,30 @@ public:
     void PersistShardTx(NIceDb::TNiceDb& db, TShardIdx shardIdx, TTxId txId);
     void PersistUpdateNextPathId(NIceDb::TNiceDb& db) const;
     void PersistUpdateNextShardIdx(NIceDb::TNiceDb& db) const;
+    void PersistUpdateNextSchemeChangeOrder(NIceDb::TNiceDb& db) const;
+    void PersistSchemeChangeFloorOrder(NIceDb::TNiceDb& db) const;
+    void PersistUpdateLastAssignedPlanStep(NIceDb::TNiceDb& db) const;
+
+    void PersistSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        ui64 order, const TVector<TOperation::TSchemeChangeTarget>& targets) const;
+
+    static TString EncodeSchemeChangeTargets(const TVector<TOperation::TSchemeChangeTarget>& targets);
+    static TVector<TOperation::TSchemeChangeTarget> DecodeSchemeChangeTargets(const TString& encoded);
+    void PersistRemoveSchemeChangePendingOrder(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx) const;
+
+    // Must run for the whole batch before any record is persisted: local-DB
+    // writes already made are not undone by AbortOperationPropose.
+    bool CheckSchemeChangeRecordHasPath(const NKikimrSchemeOp::TModifyScheme& requestTx, TString& rejectReason);
+
+    bool PersistSchemeChangeRecordAtPropose(NIceDb::TNiceDb& db, TTxId txId, ui32 requestIdx,
+        const NKikimrSchemeOp::TModifyScheme& requestTx, TOperation::TSchemeChangeSlot& slot,
+        const TString& userSid = {});
+
+    void FinalizeSchemeChangeRecord(NIceDb::TNiceDb& db, const TActorContext& ctx,
+        const TOperation::TSchemeChangeSlot& slot, TStepId planStep, bool aborted = false);
+    ui64 AllocateSchemeChangeOrderInMemory();
+
+    ui32 CountTransactionSupportingDomains() const;
     void PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const;
     void PersistParentDomainEffectiveACL(NIceDb::TNiceDb& db, const TString& owner, const TString& effectiveACL, ui64 effectiveACLVersion) const;
     void PersistShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -101,6 +101,19 @@ struct TIndexBuildInfo;
 struct TSetColumnConstraintOperationInfo;
 struct TIndexBuildShardStatus;
 
+// Refuse before the executor: without this, anything able to reach the tablet pipe
+// could drive a disabled feature into unbounded empty tablet transactions.
+template <typename TResultEvent>
+inline bool RejectSchemeChangeRequestIfDisabled(const TActorContext& ctx, const TActorId& sender) {
+    if (AppData()->FeatureFlags.GetEnableSchemeChangeRecords()) {
+        return false;
+    }
+    auto result = MakeHolder<TResultEvent>();
+    result->Record.SetStatus(NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST);
+    result->Record.SetReason("Scheme change records are disabled");
+    ctx.Send(sender, result.Release());
+    return true;
+}
 
 class TSchemeShard
     : public TActor<TSchemeShard>
@@ -1002,6 +1015,29 @@ public:
         const TOperation::TSchemeChangeSlot& slot, TStepId planStep, bool aborted = false);
     ui64 AllocateSchemeChangeOrderInMemory();
 
+    NTabletFlatExecutor::ITransaction* CreateTxRegisterSubscriber(TEvSchemeShard::TEvRegisterSubscriber::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxFetchSchemeChangeRecords(TEvSchemeShard::TEvFetchSchemeChangeRecords::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxAckSchemeChangeRecords(TEvSchemeShard::TEvAckSchemeChangeRecords::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxFetchSchemeChangeRecordBodies(TEvSchemeShard::TEvFetchSchemeChangeRecordBodies::TPtr& ev);
+    void Handle(TEvSchemeShard::TEvRegisterSubscriber::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvSchemeShard::TEvFetchSchemeChangeRecords::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvSchemeShard::TEvAckSchemeChangeRecords::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvSchemeShard::TEvFetchSchemeChangeRecordBodies::TPtr& ev, const TActorContext& ctx);
+    NTabletFlatExecutor::ITransaction* CreateTxUnregisterSubscriber(TEvSchemeShard::TEvUnregisterSubscriber::TPtr& ev);
+    void Handle(TEvSchemeShard::TEvUnregisterSubscriber::TPtr& ev, const TActorContext& ctx);
+    NTabletFlatExecutor::ITransaction* CreateTxSchemeChangeRecordsCleanup();
+    NTabletFlatExecutor::ITransaction* CreateTxForceAdvanceSubscriber(TEvSchemeShard::TEvForceAdvanceSubscriber::TPtr& ev);
+    // Force-advance initiated from the monitoring page, which has already
+    // authorized the caller; this in-process entry point skips the admin check.
+    NTabletFlatExecutor::ITransaction* CreateTxForceAdvanceSubscriberFromMonitoring(
+        const TString& subscriberId, TActorId replyTo);
+    void Handle(TEvSchemeShard::TEvForceAdvanceSubscriber::TPtr& ev, const TActorContext& ctx);
+    bool DeleteAckedSchemeChangeRecords(NIceDb::TNiceDb& db, ui64 newMinOrder,
+        ui64 limit, bool& hasMore);
+    void EnqueueSchemeChangeRecordsCleanup(const TActorContext& ctx);
+    bool CheckSchemeChangeRecordsOverflow(TString& errStr, TInstant now) const;
+    // The outbox is scoped to a single domain, which keeps the borrowed
+    // LastAssignedPlanStep a sound lower bound.
     ui32 CountTransactionSupportingDomains() const;
     void PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const;
     void PersistParentDomainEffectiveACL(NIceDb::TNiceDb& db, const TString& owner, const TString& effectiveACL, ui64 effectiveACLVersion) const;
@@ -1671,6 +1707,7 @@ public:
     bool ProcessPendingConditionalEraseResponseBatch(const TInstant& now, const TActorContext& ctx);
     void ScheduleConditionalEraseRun(const TActorContext& ctx);
     void Handle(TEvPrivate::TEvRunConditionalErase::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvSchemeChangeRecordsCleanup::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvFlushConditionalEraseBatch::TPtr& ev, const TActorContext& ctx);
 
     void Handle(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev, const TActorContext& ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1741,24 +1741,39 @@ void TSchemeShard::DescribeReplication(const TPathId& pathId, const TString& nam
     DescribeReplication(pathId, name, it->second, desc);
 }
 
-static void ClearSensitiveFields(google::protobuf::Message* message) {
+namespace {
+
+void ClearSensitiveFieldsImpl(google::protobuf::Message* message, TVector<TString>* clearedFields) {
     const auto* desc = message->GetDescriptor();
     const auto* self = message->GetReflection();
 
     for (int i = 0; i < desc->field_count(); ++i) {
         const auto* field = desc->field(i);
         if (field->options().GetExtension(Ydb::sensitive)) {
+            if (clearedFields && self->HasField(*message, field)) {
+                clearedFields->push_back(field->name());
+            }
             self->ClearField(message, field);
         } else if (field->message_type()) {
             if (!field->is_repeated() && self->HasField(*message, field)) {
-                ClearSensitiveFields(self->MutableMessage(message, field));
+                ClearSensitiveFieldsImpl(self->MutableMessage(message, field), clearedFields);
             } else if (field->is_repeated()) {
                 for (int j = 0, size = self->FieldSize(*message, field); j < size; ++j) {
-                    ClearSensitiveFields(self->MutableRepeatedMessage(message, field, j));
+                    ClearSensitiveFieldsImpl(self->MutableRepeatedMessage(message, field, j), clearedFields);
                 }
             }
         }
     }
+}
+
+} // anonymous namespace
+
+void ClearSensitiveFields(google::protobuf::Message* message) {
+    ClearSensitiveFieldsImpl(message, nullptr);
+}
+
+void ClearSensitiveFields(google::protobuf::Message* message, TVector<TString>& clearedFields) {
+    ClearSensitiveFieldsImpl(message, &clearedFields);
 }
 
 void TSchemeShard::DescribeReplication(const TPathId& pathId, const TString& name, TReplicationInfo::TPtr info,

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.h
@@ -6,9 +6,15 @@
 
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 
 namespace NKikimr {
 namespace NSchemeShard {
+
+// Descends into nested messages.
+void ClearSensitiveFields(google::protobuf::Message* message);
+
+void ClearSensitiveFields(google::protobuf::Message* message, TVector<TString>& clearedFields);
 
 class TPathDescriber {
     void FillPathDescr(NKikimrSchemeOp::TDirEntry* descr, TPathElement::TPtr pathEl,

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -58,6 +58,7 @@ namespace TEvPrivate {
         EvProgressForcedCompaction,
         EvMoveShardToStoragePool,
         EvPeriodicTableStatsParsed,
+        EvSchemeChangeRecordsCleanup,
         EvEnd
     };
 
@@ -96,6 +97,11 @@ namespace TEvPrivate {
     };
 
     struct TEvRunConditionalErase: public TEventLocal<TEvRunConditionalErase, EvRunConditionalErase> {
+    };
+
+    // Self-send wakeup driving the next batch of a multi-batch sweep. The delay lets
+    // other SS work interleave so a large backlog doesn't monopolize the executor.
+    struct TEvSchemeChangeRecordsCleanup: public TEventLocal<TEvSchemeChangeRecordsCleanup, EvSchemeChangeRecordsCleanup> {
     };
 
     struct TEvFlushConditionalEraseBatch : public TEventLocal<TEvFlushConditionalEraseBatch, EvFlushConditionalEraseBatch> {

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2711,6 +2711,53 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<PathId, AlterVersion, TestShards, CmdInitialize>;
     };
 
+    struct SchemeChangeRecords : Table<141> {
+        struct Order :         Column<1, NScheme::NTypeIds::Uint64> {};
+        struct TxId :          Column<2, NScheme::NTypeIds::Uint64> {};
+        struct OperationType : Column<3, NScheme::NTypeIds::Uint32> {};
+        struct PathOwnerId :   Column<4, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct PathLocalId :   Column<5, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        // Serialized protobuf, not a delimited string -- a path may contain any delimiter.
+        struct Path :          Column<6, NScheme::NTypeIds::String> {};
+        struct ObjectType :    Column<7, NScheme::NTypeIds::Uint32> {};
+        struct Status :        Column<8, NScheme::NTypeIds::Uint32> {};
+        struct UserSID :       Column<9, NScheme::NTypeIds::Utf8> {};
+        struct SchemaVersion : Column<10, NScheme::NTypeIds::Uint64> {};
+        struct CompletedAtUs : Column<11, NScheme::NTypeIds::Uint64> {};
+        struct PlanStep :      Column<12, NScheme::NTypeIds::Uint64> {};
+        struct BodySizeBytes :      Column<13, NScheme::NTypeIds::Uint64> {};
+        struct Description :   Column<14, NScheme::NTypeIds::String, false, true> {}; // Sensitive: may describe a secret
+        struct PositionKind :  Column<15, NScheme::NTypeIds::Uint32> {};
+        struct RedactedFields : Column<16, NScheme::NTypeIds::Utf8> {};
+
+        using TKey = TableKey<Order>;
+        using TColumns = TableColumns<Order, TxId, OperationType, PathOwnerId, PathLocalId,
+                                      Path, ObjectType, Status, UserSID, SchemaVersion,
+                                      CompletedAtUs, PlanStep, BodySizeBytes, Description, PositionKind,
+                                      RedactedFields>;
+    };
+
+    struct SchemeChangeRecordDetails : Table<143> {
+        struct Order : Column<1, NScheme::NTypeIds::Uint64> {};
+        // Sensitive: the captured request body can contain a plaintext secret.
+        struct Body :  Column<2, NScheme::NTypeIds::String, false, true> {};
+
+        using TKey = TableKey<Order>;
+        using TColumns = TableColumns<Order, Body>;
+    };
+
+
+    // Path is duplicated here because finalisation runs after NoMoreReadsForTx().
+    struct SchemeChangePendingRecords : Table<144> {
+        struct TxId :       Column<1, NScheme::NTypeIds::Uint64> { using Type = TTxId; };
+        // Index into the request's repeated TModifyScheme list.
+        struct RequestIdx : Column<2, NScheme::NTypeIds::Uint32> {};
+        struct Order :      Column<4, NScheme::NTypeIds::Uint64> {};
+        struct Path :       Column<5, NScheme::NTypeIds::String> {};
+
+        using TKey = TableKey<TxId, RequestIdx>;
+        using TColumns = TableColumns<TxId, RequestIdx, Order, Path>;
+    };
     using TTables = SchemaTables<
         Paths,
         TxInFlight,
@@ -2849,7 +2896,10 @@ struct Schema : NIceDb::Schema {
         FullBackupItems,
         SetColumnConstraint,
         SetColumnConstraintShardStatus,
-        TestShardSet
+        TestShardSet,
+        SchemeChangeRecords,
+        SchemeChangeRecordDetails,
+        SchemeChangePendingRecords
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;
@@ -2866,6 +2916,9 @@ struct Schema : NIceDb::Schema {
     // static constexpr ui64 SysParam_IsOldArgonHashFormatMigrationCompleted = 12; deprecated
     static constexpr ui64 SysParam_TablePartitionsFormatSweepStatus = 13;
     static constexpr ui64 SysParam_TablePartitionsFormatSweepTarget = 14;
+    static constexpr ui64 SysParam_NextSchemeChangeOrder = 15;
+    static constexpr ui64 SysParam_LastAssignedPlanStep = 16;
+    static constexpr ui64 SysParam_SchemeChangeFloorOrder = 17;
 
     // List of incompatible changes:
     // * Change 1: store migrated shards of local tables (e.g. after a rename) as a migrated record

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2746,6 +2746,18 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<Order, Body>;
     };
 
+    struct SchemeChangeSubscribers : Table<142> {
+        struct SubscriberId :   Column<1, NScheme::NTypeIds::Utf8> {};
+        struct LastAckedOrder : Column<2, NScheme::NTypeIds::Uint64> {};
+        struct LastActivityAtUs : Column<3, NScheme::NTypeIds::Uint64> {};
+        // NKikimrSchemeShard::TSchemeChangeSubscriberState::EState. LOST means a
+        // cursor was advanced past records the subscriber never received.
+        struct State :          Column<4, NScheme::NTypeIds::Uint32> {};
+        struct StartOrder :     Column<5, NScheme::NTypeIds::Uint64> {};
+
+        using TKey = TableKey<SubscriberId>;
+        using TColumns = TableColumns<SubscriberId, LastAckedOrder, LastActivityAtUs, State, StartOrder>;
+    };
 
     // Path is duplicated here because finalisation runs after NoMoreReadsForTx().
     struct SchemeChangePendingRecords : Table<144> {
@@ -2899,6 +2911,7 @@ struct Schema : NIceDb::Schema {
         TestShardSet,
         SchemeChangeRecords,
         SchemeChangeRecordDetails,
+        SchemeChangeSubscribers,
         SchemeChangePendingRecords
     >;
 

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
@@ -339,6 +339,20 @@ bool IsDrop(ETxType t) {
     }
 }
 
+bool IsChurnOp(NKikimrSchemeOp::EOperationType opType) {
+    switch (opType) {
+        case NKikimrSchemeOp::ESchemeOpSplitMergeTablePartitions:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// None today. Never add an entry to silence a resolution failure.
+bool IsPathlessOp(NKikimrSchemeOp::EOperationType) {
+    return false;
+}
+
 bool CanDeleteParts(ETxType t) {
     switch (t) {
         case TxDropTable:

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.h
@@ -160,4 +160,9 @@ bool IsCreate(ETxType t);
 bool IsDrop(ETxType t);
 bool CanDeleteParts(ETxType t);
 
+// Internal churn ops; they produce no scheme change records.
+bool IsChurnOp(NKikimrSchemeOp::EOperationType opType);
+
+bool IsPathlessOp(NKikimrSchemeOp::EOperationType opType);
+
 }  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/ut_base/ya.make
+++ b/ydb/core/tx/schemeshard/ut_base/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_cdc_stream/ya.make
+++ b/ydb/core/tx/schemeshard/ut_cdc_stream/ya.make
@@ -4,6 +4,10 @@ FORK_SUBTESTS()
 
 SPLIT_FACTOR(2)
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 IF (SANITIZER_TYPE == "thread")
     SIZE(LARGE)
     INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)

--- a/ydb/core/tx/schemeshard/ut_external_table/ya.make
+++ b/ydb/core/tx/schemeshard/ut_external_table/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ya.make
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 IF (SANITIZER_TYPE == "thread")
     SIZE(LARGE)
     INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -230,6 +230,7 @@ namespace NSchemeShardUT_Private {
         UNIT_ASSERT_VALUES_EQUAL(event->Record.GetTxId(), txId);
 
         CheckExpectedResult(expectedResults, event->Record.GetStatus(), event->Record.GetReason());
+        CheckSchemeChangeCorpusInvariant(runtime);
         return event->Record.GetStatus();
     }
 
@@ -1884,6 +1885,15 @@ namespace NSchemeShardUT_Private {
         SetSchemeshardSchemaLimits(runtime, limits, TTestTxConfig::SchemeShard);
     }
 
+    void RebootSchemeShard(TTestActorRuntime& runtime, ui64 schemeShard) {
+        // The tally tracks the default schemeshard only, so leave it alone otherwise.
+        if (schemeShard == TTestTxConfig::SchemeShard) {
+            TSchemeChangePathMissingTally::Instance().OnObservedRestart(runtime);
+        }
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, schemeShard, sender);
+    }
+
 
     TString EscapedDoubleQuote(const TString src) {
         auto result = src;
@@ -1937,8 +1947,7 @@ namespace NSchemeShardUT_Private {
         Cdbg << result << "\n";
         UNIT_ASSERT_VALUES_EQUAL(status, NKikimrProto::EReplyStatus::OK);
 
-        TActorId sender = runtime.AllocateEdgeActor();
-        RebootTablet(runtime, schemeShard, sender);
+        RebootSchemeShard(runtime, schemeShard);
     }
 
     void SetSchemeshardDatabaseQuotas(TTestActorRuntime& runtime, Ydb::Cms::DatabaseQuotas databaseQuotas, ui64 domainId) {
@@ -1966,9 +1975,7 @@ namespace NSchemeShardUT_Private {
         Cdbg << result << "\n";
         UNIT_ASSERT_VALUES_EQUAL(status, NKikimrProto::EReplyStatus::OK);
 
-        TActorId sender = runtime.AllocateEdgeActor();
-        RebootTablet(runtime, schemeShard, sender);
-
+        RebootSchemeShard(runtime, schemeShard);
     }
 
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -587,6 +587,9 @@ namespace NSchemeShardUT_Private {
     bool GetEraseCacheEnabled(TTestActorRuntime& runtime, ui64 tabletId, ui32 table);
     NKikimr::NLocalDb::TCompactionPolicyPtr GetCompactionPolicy(TTestActorRuntime& runtime, ui64 tabletId, ui32 localTableId);
     void SetSchemeshardReadOnlyMode(TTestActorRuntime& runtime, bool isReadOnly);
+    // Use instead of a bare RebootTablet on the schemeshard: it lets the path-missing
+    // tally carry its tablet counter, which restarts at zero, across the reboot.
+    void RebootSchemeShard(TTestActorRuntime& runtime, ui64 schemeShard = TTestTxConfig::SchemeShard);
     void SetSchemeshardSchemaLimits(TTestActorRuntime& runtime, NSchemeShard::TSchemeLimits limits);
     void SetSchemeshardSchemaLimits(TTestActorRuntime& runtime, NSchemeShard::TSchemeLimits limits, ui64 schemeShard);
     void SetSchemeshardDatabaseQuotas(TTestActorRuntime& runtime, Ydb::Cms::DatabaseQuotas databaseQuotas, ui64 domainId);

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
@@ -72,6 +72,20 @@ ui64 GetCumulativeCounter(TTestActorRuntime& runtime, const TString& name) {
     return 0; // unreachable
 }
 
+ui64 GetExecutorCumulativeCounter(TTestBasicRuntime& runtime, const TString& name) {
+    const auto counters = GetCounters(runtime);
+    for (const auto& counter : counters.GetTabletCounters().GetExecutorCounters().GetCumulativeCounters()) {
+        if (name != counter.GetName()) {
+            continue;
+        }
+
+        return counter.GetValue();
+    }
+
+    UNIT_ASSERT_C(false, "Executor cumulative counter not found: " << name);
+    return 0; // unreachable
+}
+
 ui64 GetPercentileCounter(const auto& counters, const TString& range) {
     for (ui32 i = 0; i < counters.RangesSize(); ++i) {
         if (range != counters.GetRanges(i)) {

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
@@ -14,7 +14,7 @@ using namespace NKikimr;
 
 namespace {
 
-NKikimrTabletBase::TEvGetCountersResponse GetCounters(TTestBasicRuntime& runtime) {
+NKikimrTabletBase::TEvGetCountersResponse GetCounters(TTestActorRuntime& runtime) {
     const auto sender = runtime.AllocateEdgeActor();
     runtime.SendToPipe(TTestTxConfig::SchemeShard, sender, new TEvTablet::TEvGetCounters);
     auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvGetCountersResponse>(sender);
@@ -58,7 +58,7 @@ void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 va
     UNIT_ASSERT_VALUES_EQUAL(value, GetSimpleCounter(runtime, name));
 }
 
-ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name) {
+ui64 GetCumulativeCounter(TTestActorRuntime& runtime, const TString& name) {
     const auto counters = GetCounters(runtime);
     for (const auto& counter : counters.GetTabletCounters().GetAppCounters().GetCumulativeCounters()) {
         if (name != counter.GetName()) {

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
@@ -4,6 +4,7 @@
 
 namespace NActors {
 
+class TTestActorRuntime;
 class TTestBasicRuntime;
 
 }
@@ -14,7 +15,7 @@ using namespace NActors;
 
 ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name);
 void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value);
-ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name);
+ui64 GetCumulativeCounter(TTestActorRuntime& runtime, const TString& name);
 ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range);
 void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
@@ -16,6 +16,9 @@ using namespace NActors;
 ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name);
 void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value);
 ui64 GetCumulativeCounter(TTestActorRuntime& runtime, const TString& name);
+// Executor-level counter (flat_executor_counters.h), not an app counter. Needed
+// to observe key/page charge cost, which no app-level counter can see.
+ui64 GetExecutorCumulativeCounter(TTestBasicRuntime& runtime, const TString& name);
 ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range);
 void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -1,6 +1,7 @@
 #include "test_env.h"
 
 #include "helpers.h"
+#include "schemeshard_counters.h"
 
 #include <ydb/core/base/backtrace.h>
 #include <ydb/core/base/tablet_resolver.h>
@@ -16,6 +17,7 @@
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
 #include <ydb/core/tx/columnshard/test_helper/columnshard_ut_common.h>
 #include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
 #include <ydb/core/tx/schemeshard/schemeshard_private.h>
 #include <ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h>
 #include <ydb/core/tx/sequenceproxy/sequenceproxy.h>
@@ -26,6 +28,8 @@
 #include <ydb/services/metadata/ds_table/service.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/system/env.h>
 
 
 bool NSchemeShardUT_Private::TTestEnv::ENABLE_SCHEMESHARD_LOG = true;
@@ -38,6 +42,58 @@ static const bool ENABLE_TOPIC_LOG = false;
 
 using namespace NKikimr;
 using namespace NSchemeShard;
+
+bool NSchemeShardUT_Private::SchemeChangeCorpusEnabled() {
+    static const bool enabled = !GetEnv("YDB_SCHEME_CHANGE_CORPUS").empty();
+    return enabled;
+}
+
+std::optional<bool> NSchemeShardUT_Private::SchemeChangeCorpusFlagDefault() {
+    return SchemeChangeCorpusEnabled() ? std::optional<bool>(true) : std::nullopt;
+}
+
+NSchemeShardUT_Private::TSchemeChangePathMissingTally& NSchemeShardUT_Private::TSchemeChangePathMissingTally::Instance() {
+    static TSchemeChangePathMissingTally instance;
+    return instance;
+}
+
+void NSchemeShardUT_Private::TSchemeChangePathMissingTally::Reset() {
+    Accumulated = 0;
+    LastSeen = 0;
+}
+
+ui64 NSchemeShardUT_Private::TSchemeChangePathMissingTally::Sample(TTestActorRuntime& runtime) {
+    const ui64 current = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+    // The counter only grows within one tablet life, so a drop means the tablet
+    // restarted behind the tally's back and everything before that is already lost.
+    UNIT_ASSERT_C(current >= LastSeen,
+        "scheme change path-missing tally missed a tablet restart (" << LastSeen << " -> " << current
+            << "); the outbox invariant is unreliable until that restart path calls OnObservedRestart");
+    LastSeen = current;
+    return current;
+}
+
+void NSchemeShardUT_Private::TSchemeChangePathMissingTally::OnObservedRestart(TTestActorRuntime& runtime) {
+    Sample(runtime);
+    Accumulated += LastSeen;
+    LastSeen = 0;
+}
+
+ui64 NSchemeShardUT_Private::TSchemeChangePathMissingTally::Total(TTestActorRuntime& runtime) {
+    return Accumulated + Sample(runtime);
+}
+
+void NSchemeShardUT_Private::CheckSchemeChangeCorpusInvariant(TTestActorRuntime& runtime) {
+    if (!SchemeChangeCorpusEnabled()) {
+        return;
+    }
+    // An op that cannot name its target is a hole in the outbox, so fail here
+    // instead of silently dropping the record.
+    const ui64 missing = TSchemeChangePathMissingTally::Instance().Total(runtime);
+    UNIT_ASSERT_VALUES_EQUAL_C(missing, 0u,
+        "scheme change outbox failed to resolve a target path; grep the log for"
+        " 'scheme change record skipped' to see which operation type");
+}
 
 // BlockStoreVolume mock for testing schemeshard
 class TFakeBlockStoreVolume : public TActor<TFakeBlockStoreVolume>, public NTabletFlatExecutor::TTabletExecutedFlat {
@@ -623,6 +679,9 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     , ChannelsCount(opts.NChannels_)
 {
     EnableYDBBacktraceFormat();
+    // Per-env, so a gap is reported against the test that hit it rather than
+    // against every test that runs after it in the same binary.
+    TSchemeChangePathMissingTally::Instance().Reset();
     ui64 hive = TTestTxConfig::Hive;
     ui64 schemeRoot = TTestTxConfig::SchemeShard;
     ui64 coordinator = TTestTxConfig::Coordinator;
@@ -677,6 +736,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnableAlterDatabase(opts.EnableAlterDatabase_);
     app.SetEnableAccessToIndexImplTables(opts.EnableAccessToIndexImplTables_);
     app.SetEnableIndexMaterialization(opts.EnableIndexMaterialization_);
+    app.SetEnableSchemeChangeRecords(opts.EnableSchemeChangeRecords_);
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 
@@ -948,6 +1008,7 @@ void NSchemeShardUT_Private::TestWaitNotification(NActors::TTestActorRuntime &ru
         UNIT_ASSERT(txIds.find(eventTxId) != txIds.end());
         txIds.erase(eventTxId);
     }
+    CheckSchemeChangeCorpusInvariant(runtime);
 }
 
 void NSchemeShardUT_Private::TTestEnv::TestWaitNotification(NActors::TTestActorRuntime &runtime, TSet<ui64> txIds, ui64 schemeshardId) {
@@ -1213,6 +1274,9 @@ NSchemeShardUT_Private::TTestWithReboots::TTestWithReboots(bool killOnCommit, NS
     NoRebootEventTypes.insert(TEvSchemeShard::EvMeasureSelfResponseTime);
     NoRebootEventTypes.insert(TEvSchemeShard::EvWakeupToMeasureSelfResponseTime);
     NoRebootEventTypes.insert(TEvTablet::EvLocalMKQL);
+    // The corpus invariant reads a tablet counter after every op; that read must not
+    // become a reboot point of its own.
+    NoRebootEventTypes.insert(TEvTablet::EvGetCounters);
     NoRebootEventTypes.insert(TEvFakeHive::EvSubscribeToTabletDeletion);
     NoRebootEventTypes.insert(TEvSchemeShard::EvCancelTx);
     NoRebootEventTypes.insert(TEvExport::EvCreateExportRequest);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -26,6 +26,32 @@ namespace NSchemeShardUT_Private {
     NActors::TActorId CreateNotificationSubscriber(NActors::TTestActorRuntime &runtime, ui64 schemeshardId);
     NActors::TActorId CreateFakeMetering(NActors::TTestActorRuntime &runtime);
 
+    // A suite opts into the scheme change outbox corpus check with
+    // ENV(YDB_SCHEME_CHANGE_CORPUS=1) in its ya.make; elsewhere these are inert.
+    bool SchemeChangeCorpusEnabled();
+    std::optional<bool> SchemeChangeCorpusFlagDefault();
+
+    // Reads SchemeShard/SchemeChangePathMissing, which is a tablet counter and so
+    // restarts at zero, and carries the pre-restart value across observed reboots.
+    class TSchemeChangePathMissingTally {
+    public:
+        static TSchemeChangePathMissingTally& Instance();
+
+        void Reset();
+        // Must be called while the tablet is still alive, right before it restarts.
+        void OnObservedRestart(NActors::TTestActorRuntime& runtime);
+        ui64 Total(NActors::TTestActorRuntime& runtime);
+
+    private:
+        ui64 Sample(NActors::TTestActorRuntime& runtime);
+
+        ui64 Accumulated = 0;
+        ui64 LastSeen = 0;
+    };
+
+    // Fails if any op proposed so far could not resolve an outbox target.
+    void CheckSchemeChangeCorpusInvariant(NActors::TTestActorRuntime& runtime);
+
     struct TTestEnvOptions {
         using TSelf = TTestEnvOptions;
 
@@ -94,6 +120,7 @@ namespace NSchemeShardUT_Private {
         OPTION(bool, EnableDataShardSplitKeySelection, false);
         OPTION(bool, EnableDataShardSplitHistogramOmission, false);
         OPTION(bool, DisableFileStoreSSDSystemSpaceAccounting, false);
+        OPTION(std::optional<bool>, EnableSchemeChangeRecords, SchemeChangeCorpusFlagDefault());
 
         #undef OPTION
     };

--- a/ydb/core/tx/schemeshard/ut_index_build/ya.make
+++ b/ydb/core/tx/schemeshard/ut_index_build/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_move/ya.make
+++ b/ydb/core/tx/schemeshard/ut_move/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 IF (WITH_VALGRIND)
     SPLIT_FACTOR(40)
 ENDIF()

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records.cpp
@@ -13,20 +13,97 @@ using namespace NKikimr;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
 using namespace NSchemeChangeRecordTestHelpers;
+using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecords;
+using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecordsFull;
 using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecordsFromTable;
 
 Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
-    Y_UNIT_TEST(DisabledByDefaultEmitsNoRecords) {
-        // ReadSchemeChangeRecords itself registers a temp subscriber, which is
-        // refused while disabled; use the order counter as a disabled-safe oracle.
-        TSchemeShard* schemeshard = nullptr;
-        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
-            schemeshard = new TSchemeShard(tablet, info);
-            return schemeshard;
-        };
+    // The table reader must be a faithful substitute for the protocol reader
+    // before the audit tests are moved onto it, or the migration silently
+    // weakens what they check. Drives a multi-target op so Targets/SourcePaths
+    // and the table-143 body join are both exercised.
+    Y_UNIT_TEST(TableReaderMatchesProtocolReader) {
         TTestBasicRuntime runtime;
-        // Default options: the flag is off unless a test opts in.
-        TTestEnv env(runtime, TTestEnvOptions(), ssFactory);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "parity:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestConsistentCopyTables(runtime, ++txId, "/", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src"
+                DstPath: "/MyRoot/Dst"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto viaTable = ReadSchemeChangeRecordsFromTable(runtime);
+        auto viaProtocol = ReadSchemeChangeRecords(runtime);
+
+        UNIT_ASSERT_C(!viaTable.empty(), "table reader returned nothing");
+        UNIT_ASSERT_VALUES_EQUAL_C(viaTable.size(), viaProtocol.size(),
+            "readers disagree on record count");
+
+        for (size_t i = 0; i < viaTable.size(); ++i) {
+            const auto& t = viaTable[i];
+            const auto& p = viaProtocol[i];
+            UNIT_ASSERT_VALUES_EQUAL(t.Order, p.Order);
+            UNIT_ASSERT_VALUES_EQUAL(t.TxId, p.TxId);
+            UNIT_ASSERT_VALUES_EQUAL(t.PathOwnerId, p.PathOwnerId);
+            UNIT_ASSERT_VALUES_EQUAL(t.PathLocalId, p.PathLocalId);
+            UNIT_ASSERT_VALUES_EQUAL(t.ObjectType, p.ObjectType);
+            UNIT_ASSERT_VALUES_EQUAL(t.Status, p.Status);
+            UNIT_ASSERT_VALUES_EQUAL(t.SchemaVersion, p.SchemaVersion);
+            UNIT_ASSERT_VALUES_EQUAL(t.PlanStep, p.PlanStep);
+            UNIT_ASSERT_VALUES_EQUAL(t.PositionKind, p.PositionKind);
+            UNIT_ASSERT_VALUES_EQUAL(t.UserSID, p.UserSID);
+            UNIT_ASSERT_VALUES_EQUAL_C(AllTargetPaths(t), AllTargetPaths(p),
+                "target paths disagree at order " << t.Order);
+            UNIT_ASSERT_VALUES_EQUAL_C(t.Targets.size(), p.Targets.size(),
+                "target count disagrees at order " << t.Order);
+            for (size_t j = 0; j < t.Targets.size(); ++j) {
+                UNIT_ASSERT_VALUES_EQUAL(JoinSeq(",", t.Targets[j].SourcePaths),
+                                         JoinSeq(",", p.Targets[j].SourcePaths));
+            }
+            // The body is what audit tests select on, so parity here is the
+            // load-bearing part of the migration.
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                (ui32)t.Body.GetOperationType(), (ui32)p.Body.GetOperationType(),
+                "body OperationType disagrees at order " << t.Order);
+        }
+
+        // A record carrying SourcePaths must actually be present, or the
+        // SourcePaths comparison above passed vacuously.
+        bool sawSourcePaths = false;
+        for (const auto& e : viaTable) {
+            for (const auto& target : e.Targets) {
+                if (!target.SourcePaths.empty()) {
+                    sawSourcePaths = true;
+                }
+            }
+        }
+        UNIT_ASSERT_C(sawSourcePaths,
+            "expected at least one record carrying SourcePaths (the consistent copy)");
+    }
+
+    Y_UNIT_TEST(SchemeChangeRecordsTableExists) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        auto entries = ReadSchemeChangeRecords(runtime);
+        Y_UNUSED(entries);
+    }
+
+    Y_UNIT_TEST(NoRecordsCreatedWithoutSubscribers) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -36,14 +113,57 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->NextSchemeChangeOrder, 0u,
-            "no outbox rows should be reserved while the feature is disabled");
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(entries.empty(),
+            "No records should be created without subscribers, got " << entries.size());
+    }
+
+    Y_UNIT_TEST(RecordsCreatedAfterSubscriberRegistered) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        // Create T1 without subscriber -- no record expected
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Register subscriber
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        // Create T2 with subscriber -- record expected
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        bool foundT1 = false;
+        bool foundT2 = false;
+        for (const auto& e : entries) {
+            if (e.Body.HasCreateTable()) {
+                const auto& name = e.Body.GetCreateTable().GetName();
+                if (name == "T1") foundT1 = true;
+                if (name == "T2") foundT2 = true;
+            }
+        }
+        UNIT_ASSERT_C(!foundT1, "T1 record should not exist (created before subscriber)");
+        UNIT_ASSERT_C(foundT2, "T2 record should exist (created after subscriber)");
     }
 
     Y_UNIT_TEST(CreateTableWritesLogEntry) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -53,7 +173,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         bool found = false;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
@@ -75,6 +195,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
             Columns { Name: "key"   Type: "Uint64" }
@@ -89,7 +212,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         ui32 alterCount = 0;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
@@ -101,12 +224,17 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         UNIT_ASSERT_C(alterCount >= 1, "ALTER TABLE entry not found in notification log");
     }
 
-    // UserSID must record who issued the DDL, not who owns the target: a
-    // ModifyACL changes the owner without that owner issuing anything.
+    // UserSID must record who issued the DDL, not who owns the target object.
+    // A ModifyACL changes the owner without the owner ever issuing anything;
+    // a later ALTER by a different (here: anonymous-token) issuer must not be
+    // attributed to that owner.
     Y_UNIT_TEST(UserSIDRecordsIssuerNotOwner) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -127,7 +255,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* alterEntry = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
@@ -149,6 +277,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -193,6 +324,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -275,6 +409,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
             Columns { Name: "key"   Type: "Uint64" }
@@ -286,7 +423,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         bool found = false;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTable
@@ -303,6 +440,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "T1"
             Columns { Name: "key" Type: "Uint64" }
@@ -317,7 +457,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         UNIT_ASSERT(entries.size() >= 2);
 
         for (size_t i = 1; i < entries.size(); ++i) {
@@ -326,10 +466,204 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         }
     }
 
+    Y_UNIT_TEST(OverflowRejectsNewOperations) {
+        TSchemeShard* schemeshard;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        auto baseline = ReadSchemeChangeRecords(runtime);
+        schemeshard->MaxSchemeChangeRecords = baseline.size() + 2;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(entries.size() >= baseline.size() + 2, "Expected at least baseline+2 entries");
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T3"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusResourceExhausted});
+    }
+
+    Y_UNIT_TEST(AckFreesOverflowCapacityImmediately) {
+        // Overflow check uses (NextSchemeChangeOrder - MinSubscriberOrder), so
+        // an ack restores capacity immediately without waiting for cleanup.
+        TSchemeShard* schemeshard;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        auto baseline = ReadSchemeChangeRecords(runtime);
+        schemeshard->MaxSchemeChangeRecords = baseline.size() + 2;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // At capacity: next op rejected
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T3a"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusResourceExhausted});
+
+        // Ack everything (without manually firing background cleanup)
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT(!entries.empty());
+        ui64 lastOrder = entries.back().Order;
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "test:sub", lastOrder, ackHandle);
+
+        // Capacity must be free immediately after ack: overflow check is based
+        // on unacked range, not row count.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T3b"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(RaisingLimitViaConfigUnblocksOperations) {
+        TSchemeShard* schemeshard;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        auto baseline = ReadSchemeChangeRecords(runtime);
+        {
+            auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            request->Record.MutableConfig()->MutableSchemeShardConfig()->SetMaxSchemeChangeRecords(baseline.size() + 2);
+            SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
+        }
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T3"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusResourceExhausted});
+
+        {
+            auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            request->Record.MutableConfig()->MutableSchemeShardConfig()->SetMaxSchemeChangeRecords(baseline.size() + 10);
+            SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
+        }
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T3"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(LoweringLimitViaConfigBlocksOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            request->Record.MutableConfig()->MutableSchemeShardConfig()->SetMaxSchemeChangeRecords(1);
+            SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
+        }
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T3"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusResourceExhausted});
+    }
+
     Y_UNIT_TEST(PlanStepIsRecordedForCoordinatedOps) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -338,7 +672,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         UNIT_ASSERT(!entries.empty());
 
         bool found = false;
@@ -359,6 +693,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
             Columns { Name: "key"   Type: "Uint64" }
@@ -373,7 +710,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         bool sawAlter = false;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
@@ -391,6 +728,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "T1"
             Columns { Name: "key" Type: "Uint64" }
@@ -405,16 +745,11 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         UNIT_ASSERT(entries.size() >= 2);
 
         ui64 prevPlanStep = 0;
         for (const auto& e : entries) {
-            // Bootstrap system views (.sys/*) are recorded too now that the
-            // gate is the flag alone; they are not this test's DDL.
-            if (AnyPathContains(e, ".sys/")) {
-                continue;
-            }
             UNIT_ASSERT_C(e.PlanStep >= prevPlanStep,
                 "PlanStep should be monotonically non-decreasing: prev=" << prevPlanStep
                     << " current=" << e.PlanStep << " path=" << AllTargetPaths(e));
@@ -424,14 +759,13 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         for (size_t i = 1; i < entries.size(); ++i) {
             const auto& prev = entries[i-1];
             const auto& curr = entries[i];
-            // Order is the stream's only total order, and it is what cursors,
-            // acks and retention are defined on.
-            UNIT_ASSERT_C(curr.Order > prev.Order,
-                "Order must strictly increase: prev=" << prev.Order << " curr=" << curr.Order);
-            UNIT_ASSERT_C(curr.PlanStep != 0,
-                "a finalised record must carry a PlanStep, order=" << curr.Order);
-            // (PlanStep, TxId) is deliberately not asserted co-monotonic with Order: Order
-            // is allocated at propose, PlanStep by the coordinator at plan time.
+            if (curr.PlanStep != prev.PlanStep || curr.TxId != prev.TxId) {
+                bool planStepTxIdOrdering = std::tie(curr.PlanStep, curr.TxId) > std::tie(prev.PlanStep, prev.TxId);
+                UNIT_ASSERT_C(planStepTxIdOrdering,
+                    "(PlanStep, TxId) ordering must match Order ordering:"
+                        << " prev=(" << prev.PlanStep << "," << prev.TxId << ") order=" << prev.Order
+                        << " curr=(" << curr.PlanStep << "," << curr.TxId << ") order=" << curr.Order);
+            }
         }
     }
 
@@ -440,10 +774,13 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         bool found = false;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMkDir
@@ -456,6 +793,119 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         UNIT_ASSERT_C(found, "MkDir should produce a scheme change record");
     }
 
+    Y_UNIT_TEST(WatermarkDoesNotRegressAfterAllOpsComplete) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto result = ReadSchemeChangeRecordsFull(runtime);
+        UNIT_ASSERT(!result.Entries.empty());
+        // ClosedThroughPlanStep must be monotonic even when TxInFlight empties.
+        UNIT_ASSERT_C(result.ClosedThroughPlanStep > 0,
+            "ClosedThroughPlanStep must not regress to 0 after an op completes, got: "
+                << result.ClosedThroughPlanStep);
+    }
+
+    Y_UNIT_TEST(WatermarkSurvivesTabletReboot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "reboot:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto before = ReadSchemeChangeRecordsFull(runtime);
+        UNIT_ASSERT_C(before.ClosedThroughPlanStep > 0,
+            "Pre-reboot watermark should be > 0, got: " << before.ClosedThroughPlanStep);
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        auto after = ReadSchemeChangeRecordsFull(runtime);
+        UNIT_ASSERT_C(after.ClosedThroughPlanStep >= before.ClosedThroughPlanStep,
+            "Post-reboot watermark must not regress: before="
+                << before.ClosedThroughPlanStep << " after=" << after.ClosedThroughPlanStep);
+    }
+
+    Y_UNIT_TEST(WatermarkReflectsInFlightPlanStep) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        TVector<THolder<IEventHandle>> heldEvents;
+        ui64 firstTxId = txId + 1;
+        bool captured = false;
+
+        auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvDataShard::EvSchemaChanged) {
+                auto* msg = ev->Get<TEvDataShard::TEvSchemaChanged>();
+                if (msg->Record.GetTxId() == firstTxId) {
+                    captured = true;
+                    heldEvents.push_back(THolder<IEventHandle>(ev.Release()));
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observer);
+
+        AsyncCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+
+        {
+            TDispatchOptions opts;
+            opts.CustomFinalCondition = [&]() { return captured; };
+            runtime.DispatchEvents(opts);
+        }
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Table2 should be present, Table1 still in-flight.
+        auto result = ReadSchemeChangeRecordsFull(runtime);
+
+        UNIT_ASSERT_C(result.ClosedThroughPlanStep > 0,
+            "ClosedThroughPlanStep should be > 0 while Table1 is still in-flight, got: "
+                << result.ClosedThroughPlanStep);
+
+        for (auto& ev : heldEvents) {
+            runtime.Send(ev.Release());
+        }
+        heldEvents.clear();
+        env.TestWaitNotification(runtime, firstTxId);
+
+        auto result2 = ReadSchemeChangeRecordsFull(runtime);
+        UNIT_ASSERT_C(result2.ClosedThroughPlanStep >= result.ClosedThroughPlanStep,
+            "ClosedThroughPlanStep must not regress after all ops complete: had "
+                << result.ClosedThroughPlanStep << ", now " << result2.ClosedThroughPlanStep);
+    }
+
     Y_UNIT_TEST(CreateTableWithIndexProducesSingleParentRecord) {
         // A multi-part DDL emits exactly one record, carrying the TModifyScheme
         // as it arrived in the request; the target cluster re-runs decomposition
@@ -463,6 +913,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
             TableDescription {
@@ -478,7 +931,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         ui32 parentCount = 0;
         bool haveMain = false;
         bool haveIndex = false;
@@ -507,6 +960,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "A/B/C/Leaf"
             Columns { Name: "key" Type: "Uint64" }
@@ -514,7 +970,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         bool foundLeaf = false;
         for (const auto& e : entries) {
             if (e.TxId != (ui64)txId) continue;
@@ -535,6 +991,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "body:sub", regHandle);
+
         TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
             TableDescription {
                 Name: "Main"
@@ -549,7 +1008,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const NKikimrSchemeOp::TIndexedTableCreationConfig* ct = nullptr;
         for (const auto& e : entries) {
             if (e.TxId == (ui64)txId && e.Body.HasCreateIndexedTable()) {
@@ -561,6 +1020,169 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         UNIT_ASSERT_VALUES_EQUAL(ct->GetTableDescription().GetName(), "Main");
         UNIT_ASSERT_VALUES_EQUAL(ct->IndexDescriptionSize(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(ct->GetIndexDescription(0).GetName(), "IdxByValue");
+    }
+
+    Y_UNIT_TEST(FetchBodiesReturnsOnlyRequestedSparseOrders) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "bodies:sub", regHandle);
+
+        for (int i = 1; i <= 10; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "Table%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "bodies:sub", 0, 1000, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(fetch->Record.EntriesSize(), 10u);
+
+        TVector<ui64> allOrders;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            allOrders.push_back(fetch->Record.GetEntries(i).GetOrder());
+        }
+
+        TVector<ui64> requested = {allOrders[1], allOrders[4], allOrders[7]};
+
+        TAutoPtr<IEventHandle> bodiesHandle;
+        auto* bodies = FetchSchemeChangeRecordBodies(runtime, "bodies:sub", requested, bodiesHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)bodies->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(bodies->Record.EntriesSize(), requested.size());
+
+        THashSet<ui64> requestedSet(requested.begin(), requested.end());
+        for (size_t i = 0; i < static_cast<size_t>(bodies->Record.EntriesSize()); ++i) {
+            const auto& e = bodies->Record.GetEntries(i);
+            UNIT_ASSERT_C(requestedSet.contains(e.GetOrder()),
+                "FetchBodies returned unrequested order " << e.GetOrder());
+            UNIT_ASSERT_C(!e.GetBody().empty(),
+                "FetchBodies returned empty body for order " << e.GetOrder());
+            NKikimrSchemeOp::TModifyScheme body;
+            UNIT_ASSERT(body.ParseFromString(e.GetBody()));
+            UNIT_ASSERT_VALUES_EQUAL((ui32)body.GetOperationType(), (ui32)NKikimrSchemeOp::ESchemeOpCreateTable);
+        }
+    }
+
+    Y_UNIT_TEST(AckWithLargeBacklogDrainsAcrossMultipleTxs) {
+        // A single Ack tx deletes at most SchemeChangeCleanupBatchSize rows;
+        // the rest drains via follow-up cleanup txs. Ack reply must return
+        // with the correct LastAckedOrder before the drain completes.
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "backlog:sub", regHandle);
+
+        // Small cap so we can trigger continuation without creating 1000+ records.
+        schemeshard->SchemeChangeCleanupBatchSize = 3;
+
+        constexpr int kRecords = 10;
+        for (int i = 0; i < kRecords; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "B%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "backlog:sub", 0, 1000, fetchHandle);
+        UNIT_ASSERT(fetch->Record.EntriesSize() >= kRecords);
+        ui64 latest = 0;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            latest = Max(latest, fetch->Record.GetEntries(i).GetOrder());
+        }
+
+        // Measure only the chain triggered by the single Ack below.
+        schemeshard->SchemeChangeCleanupTxCount = 0;
+
+        TAutoPtr<IEventHandle> ackHandle;
+        auto* ackRes = AckSchemeChangeRecords(runtime, "backlog:sub", latest, ackHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)ackRes->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ackRes->Record.GetLastAckedOrder(), latest);
+
+        for (int i = 0; i < 50; ++i) {
+            runtime.SimulateSleep(TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT_C(schemeshard->SchemeChangeCleanupTxCount >= 3,
+            "Expected >=3 continuation cleanup txs for " << kRecords
+            << " records at batch size 3, got " << schemeshard->SchemeChangeCleanupTxCount);
+    }
+
+    // Bounding the fetch scan by NextSchemeChangeOrder must not change which
+    // records are returned. This does NOT prove the precharge cost bound --
+    // charge counters stay at 0 in this in-memory test regardless of range
+    // width, so the cost effect is unobservable here. It only proves the
+    // upper bound is not off-by-one at the boundary or under a maxCount cap.
+    Y_UNIT_TEST(FetchUpperBoundDoesNotChangeResults) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "bound:sub", regHandle);
+
+        constexpr int kRecords = 10;
+        for (int i = 0; i < kRecords; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Bound%d", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // Ground truth: a fetch wide enough to cover everything at once. The
+        // boundary/capped cases below are checked against this, not against
+        // an independent oracle -- ReadSchemeChangeRecords is itself built on
+        // this same fetch path, so it cannot serve as an independent check.
+        TAutoPtr<IEventHandle> fullHandle;
+        auto* full = FetchSchemeChangeRecords(runtime, "bound:sub", 0, 1000, fullHandle);
+        UNIT_ASSERT_C(full->Record.EntriesSize() >= kRecords,
+            "precondition: the unbounded fetch must see all " << kRecords << " records");
+        TVector<ui64> allOrders;
+        ui64 maxOrder = 0;
+        for (size_t i = 0; i < static_cast<size_t>(full->Record.EntriesSize()); ++i) {
+            const ui64 order = full->Record.GetEntries(i).GetOrder();
+            allOrders.push_back(order);
+            maxOrder = Max(maxOrder, order);
+        }
+
+        // Boundary case: AfterOrder pinned one below the true max, so the
+        // query's GreaterOrEqual/LessOrEqual window collapses to exactly the
+        // last row. An off-by-one bound would return zero entries here.
+        TAutoPtr<IEventHandle> boundaryHandle;
+        auto* boundary = FetchSchemeChangeRecords(runtime, "bound:sub", maxOrder - 1, 1000, boundaryHandle);
+        UNIT_ASSERT_VALUES_EQUAL_C(boundary->Record.EntriesSize(), 1,
+            "the last record must still be reachable right at the upper bound");
+        UNIT_ASSERT_VALUES_EQUAL(boundary->Record.GetEntries(0).GetOrder(), maxOrder);
+
+        // Count-capped case: maxCount stops the scan before the bound would.
+        // Same leading records as the unbounded fetch, in the same order.
+        TAutoPtr<IEventHandle> cappedHandle;
+        auto* capped = FetchSchemeChangeRecords(runtime, "bound:sub", 0, 3, cappedHandle);
+        UNIT_ASSERT_VALUES_EQUAL(capped->Record.EntriesSize(), 3);
+        UNIT_ASSERT_C(capped->Record.GetHasMore(), "capped fetch must report more entries remain");
+        for (int i = 0; i < 3; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(capped->Record.GetEntries(i).GetOrder(), allOrders[i]);
+        }
     }
 
     Y_UNIT_TEST(PersistsNextSchemeChangeOrderOncePerBatch) {
@@ -576,6 +1198,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         opts.EnableSchemeChangeRecords(true);
         TTestEnv env(runtime, opts, ssFactory);
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "batchpersist:sub", regHandle);
 
         schemeshard->NextSchemeChangeOrderPersistCount = 0;
 
@@ -593,7 +1218,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         size_t thisTxRecords = 0;
         for (const auto& e : entries) {
             if (e.TxId == (ui64)txId) ++thisTxRecords;
@@ -605,11 +1230,94 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
             << schemeshard->NextSchemeChangeOrderPersistCount);
     }
 
-    // Positive companion to DisabledByDefaultEmitsNoRecords: the identical DDL
-    // with the flag on does produce a row, so the disabled case cannot pass vacuously.
-    Y_UNIT_TEST(EnabledByOptInEmitsRecord) {
+    Y_UNIT_TEST(FetchBodiesUnorderedAndDuplicateRequestedOrdersHandled) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "bodies:sub2", regHandle);
+
+        for (int i = 1; i <= 5; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "T%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "bodies:sub2", 0, 1000, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL(fetch->Record.EntriesSize(), 5u);
+
+        TVector<ui64> all;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            all.push_back(fetch->Record.GetEntries(i).GetOrder());
+        }
+
+        TVector<ui64> requested = {all[3], all[0], all[3], all[2]};
+
+        TAutoPtr<IEventHandle> bodiesHandle;
+        auto* bodies = FetchSchemeChangeRecordBodies(runtime, "bodies:sub2", requested, bodiesHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)bodies->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        THashSet<ui64> returned;
+        for (size_t i = 0; i < static_cast<size_t>(bodies->Record.EntriesSize()); ++i) {
+            returned.insert(bodies->Record.GetEntries(i).GetOrder());
+        }
+        // Dedup expected: each requested order returned at most once
+        UNIT_ASSERT_C(returned.contains(all[0]), "order " << all[0] << " missing");
+        UNIT_ASSERT_C(returned.contains(all[2]), "order " << all[2] << " missing");
+        UNIT_ASSERT_C(returned.contains(all[3]), "order " << all[3] << " missing");
+        UNIT_ASSERT_VALUES_EQUAL(returned.size(), 3u);
+    }
+
+    Y_UNIT_TEST(ZeroMaxSchemeChangeRecordsIsIgnored) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "zero:sub", regHandle);
+
+        const ui64 before = schemeshard->MaxSchemeChangeRecords;
+        UNIT_ASSERT_C(before > 0, "precondition: the default cap must be non-zero");
+
+        {
+            auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            request->Record.MutableConfig()->MutableSchemeShardConfig()->SetMaxSchemeChangeRecords(0);
+            SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->MaxSchemeChangeRecords, before,
+            "a zero cap rejects every DDL including after a force-advance, so it "
+            "must be ignored rather than applied");
+
+        // The consequence that matters: DDL is still accepted.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(DisabledByDefaultEmitsNoRecords) {
+        // ReadSchemeChangeRecords itself registers a temp subscriber, which is
+        // refused while disabled; use the order counter as a disabled-safe oracle.
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        // Default options: the flag is off unless a test opts in.
+        TTestEnv env(runtime, TTestEnvOptions(), ssFactory);
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -619,16 +1327,268 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->NextSchemeChangeOrder, 0u,
+            "no outbox rows should be reserved while the feature is disabled");
+    }
+
+    // Positive companion to DisabledByDefaultEmitsNoRecords: the identical DDL
+    // with the flag on does produce a row, so the disabled case can't pass
+    // vacuously because DDL itself failed.
+    Y_UNIT_TEST(EnabledByOptInEmitsRecord) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
         UNIT_ASSERT_C(!entries.empty(), "expected at least one outbox row with the feature enabled");
     }
 
-    // Finalize resolves the target but writes back only PathOwnerId/PathLocalId;
-    // Path keeps the propose-time synthesis, which must already be canonical.
+    Y_UNIT_TEST(DisabledRefusesRegistration) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TAutoPtr<IEventHandle> regHandle;
+        auto* result = RegisterSubscriberExpect(runtime, "test:sub",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, regHandle);
+        UNIT_ASSERT_C(!result->Record.GetReason().empty(),
+            "a disabled-feature refusal must carry a clear reason, not a silent failure");
+    }
+
+    Y_UNIT_TEST(DisabledNeverBlocksDdl) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true), ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        auto baseline = ReadSchemeChangeRecords(runtime);
+        schemeshard->MaxSchemeChangeRecords = baseline.size() + 1;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Seed the outbox to the cap: this DDL must be refused while enabled.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusResourceExhausted});
+
+        // The kill switch: disabling must rescue a cluster wedged by a full outbox.
+        runtime.GetAppData().FeatureFlags.SetEnableSchemeChangeRecords(false);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(FlagFlipTakesEffectWithoutReboot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Disabled: registration is refused.
+        TAutoPtr<IEventHandle> regHandle1;
+        RegisterSubscriberExpect(runtime, "test:sub",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, regHandle1);
+
+        // Flip live, on the same running tablet -- no reboot.
+        runtime.GetAppData().FeatureFlags.SetEnableSchemeChangeRecords(true);
+
+        TAutoPtr<IEventHandle> regHandle2;
+        RegisterSubscriber(runtime, "test:sub", regHandle2);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!entries.empty(),
+            "record emission must follow the flag flip without a tablet restart");
+    }
+
+    Y_UNIT_TEST(ReEnablingResumesWithoutReportingLoss) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Mid-stream: fetch but don't ack past the tail, so the subscriber's
+        // cursor sits in the middle of the retained log.
+        TAutoPtr<IEventHandle> fetchHandle;
+        FetchSchemeChangeRecords(runtime, "test:sub", 0, 1000, fetchHandle);
+
+        // Disable, then re-enable: the cursor and its record window must survive.
+        runtime.GetAppData().FeatureFlags.SetEnableSchemeChangeRecords(false);
+        runtime.GetAppData().FeatureFlags.SetEnableSchemeChangeRecords(true);
+
+        TAutoPtr<IEventHandle> regHandle2;
+        auto* result = RegisterSubscriberExpect(runtime, "test:sub",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS, regHandle2);
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "a subscriber that was mid-stream across a disable/enable cycle "
+            "must not be reported as STATE_LOST");
+    }
+
+    // Cleanup is only ever enqueued from the Complete() hooks of outbox
+    // transactions, and those are gated on the flag. Suppress the scheduled
+    // continuation so the self-chain cannot drain on its own; only the
+    // disable path (ApplyConsoleConfigs) may rescue it.
+    Y_UNIT_TEST(DisablingDrainsAckedRecords) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        // Small cap so the Ack's own tx cannot finish the drain in one shot.
+        schemeshard->SchemeChangeCleanupBatchSize = 1;
+
+        constexpr int kRecords = 3;
+        for (int i = 0; i < kRecords; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Dir%d", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "test:sub", 0, 1000, fetchHandle);
+        ui64 latest = 0;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            latest = Max(latest, fetch->Record.GetEntries(i).GetOrder());
+        }
+
+        auto before = ProbeRecordOrdersPresent(runtime, "test:sub", {latest});
+        UNIT_ASSERT_C(!before.empty(), "precondition: the record must exist before acking");
+
+        // Suppress the scheduled continuation before acking, so the batch-size
+        // limited remainder cannot drain via the ordinary self-chain.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvPrivate::TEvSchemeChangeRecordsCleanup::EventType);
+
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "test:sub", latest, ackHandle);
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+        auto stillPresent = ProbeRecordOrdersPresent(runtime, "test:sub", {latest});
+        UNIT_ASSERT_C(!stillPresent.empty(),
+            "precondition: the continuation must be suppressed, so acked "
+            "records are not yet swept");
+
+        // Stop suppressing, but deliberately drop the already-suppressed
+        // continuation instead of replaying it: the drain below must come
+        // from a freshly enqueued cleanup, not from that stale one.
+        runtime.SetObserverFunc(prevObserver);
+        suppressed.clear();
+
+        // Disabling must kick the drain despite the dropped continuation.
+        {
+            auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            request->Record.MutableConfig()->MutableFeatureFlags()->SetEnableSchemeChangeRecords(false);
+            SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
+        }
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+        runtime.GetAppData().FeatureFlags.SetEnableSchemeChangeRecords(true);
+        auto after = ProbeRecordOrdersPresent(runtime, "test:sub", {latest});
+        UNIT_ASSERT_C(after.empty(),
+            "disabling the flag must self-start a drain of already-acked records");
+    }
+
+    // Scope limit: disabling must not bypass GetMinSubscriberOrder. An
+    // unacked record stays retained so re-enabling resumes losslessly.
+    Y_UNIT_TEST(DisablingRetainsUnackedRecords) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "test:sub", 0, 1000, fetchHandle);
+        ui64 latest = 0;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            latest = Max(latest, fetch->Record.GetEntries(i).GetOrder());
+        }
+
+        auto before = ProbeRecordOrdersPresent(runtime, "test:sub", {latest});
+        UNIT_ASSERT_C(!before.empty(), "precondition: the record must exist before disabling");
+
+        // No ack: the subscriber's cursor still sits below this record.
+        {
+            auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            request->Record.MutableConfig()->MutableFeatureFlags()->SetEnableSchemeChangeRecords(false);
+            SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
+        }
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+        runtime.GetAppData().FeatureFlags.SetEnableSchemeChangeRecords(true);
+        auto after = ProbeRecordOrdersPresent(runtime, "test:sub", {latest});
+        UNIT_ASSERT_C(!after.empty(),
+            "an unacked record must survive disabling: the retention floor "
+            "must not be bypassed");
+    }
+
+    // (a) FinalizeSchemeChangeRecord resolves the target via TPath::Resolve but
+    // only writes PathOwnerId/PathLocalId back -- Path itself keeps the
+    // propose-time synthesis. A WorkingDir with a trailing slash still
+    // canonicalizes on resolve, so the two differ and the record must carry
+    // the canonical one.
     Y_UNIT_TEST(RecordCarriesCanonicalResolvedPath) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         // Trailing slash: propose-time string concatenation would leave a
         // double slash, while TPath::Resolve canonicalizes it away.
@@ -639,7 +1599,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
@@ -654,12 +1614,16 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
             "Path must be the canonical resolved path, not a raw concatenation; got \"" << found->Targets[0].Path << "\"");
     }
 
-    // A stored path must be relative to the database root and must be the full
-    // path to the object -- a path truncated to empty must not pass.
+    // (b) + (c) A stored path must be relative to the database root, and the
+    // relative remainder must be the full path to the object -- a path
+    // truncated to empty must not pass.
     Y_UNIT_TEST(RecordPathIsRelativeToDatabaseRoot) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
         env.TestWaitNotification(runtime, txId);
@@ -671,7 +1635,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
@@ -695,6 +1659,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         ui64 checkedThrough = 0;
         ui32 checkedRecords = 0;
@@ -820,12 +1787,17 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
             "the corpus must actually have produced records to check, got " << checkedRecords);
     }
 
-    // The pathless allowlist is empty today, so an ordinary op must still produce
-    // its record -- the invariant above must not be satisfiable by refusing everything.
+    // Positive companion to PathBearingOpNeverStoresAnApproximatePath: the
+    // pathless allowlist is empty today, so an ordinary op must still produce
+    // its record -- the invariant above must not be satisfiable by refusing
+    // everything.
     Y_UNIT_TEST(OrdinaryOpsStillProduceRecordsWhenAllowlistIsEmpty) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "PlainTable"
@@ -834,7 +1806,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         bool found = false;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
@@ -846,13 +1818,19 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         UNIT_ASSERT_C(found, "an ordinary path-bearing op must still produce a record");
     }
 
-    // One record per TModifyScheme in the request (Body is the atomic replay unit),
-    // so a copy of N tables must list all N as targets, each with its own
-    // destination and source.
+    // CreateConsistentCopyTables carries N targets in one repeated
+    // TCopyTableConfig field, each pairing a destination with its own source.
+    // The record carries N (Path, SourcePaths) targets per record (one record
+    // per TModifyScheme in the request, since Body is the atomic replay unit),
+    // so this propose must succeed and the record must list every copy as a
+    // target with both its destination Path and its source populated.
     Y_UNIT_TEST(ConsistentCopyTablesRecordsAllTargetsWithSources) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Src1"
@@ -885,7 +1863,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
             "a resolvable multi-target copy must not bump the path-missing counter");
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables) {
@@ -910,18 +1888,25 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
             "Dst1's target must record Src1 as its source");
         UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst2"], "Src2",
             "Dst2's target must record Src2 as its source");
-        // Every one of the N targets must resolve; only target[0] carries a captured
-        // PathId, so [1] gets a plain resolve check.
+        // Every one of the N targets must resolve, not just the first (the
+        // extractor only captures PathId for target[0], so [0] gets the full
+        // PathId cross-check and [1] gets a plain resolve check).
         AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, 0);
         AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, 1);
     }
 
-    // A plain single-target op must still yield exactly one target, with SourcePaths
-    // empty -- it is a repeated field, so "empty" is the assertion, not "unset".
+    // Guards against the repeated field silently turning every record into a
+    // list of one-or-more by accident: a plain single-target op must still
+    // yield exactly one target, with an empty SourcePaths (a create has no
+    // source, it is a repeated field so "empty" is the correct assertion,
+    // not "unset").
     Y_UNIT_TEST(SingleTargetOpRecordsExactlyOneTarget) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -930,7 +1915,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
@@ -947,12 +1932,19 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
             "a plain create has no source, SourcePaths must be empty");
     }
 
-    // A rename records the object's new location as Path (where a consumer looks it
-    // up afterwards) and its old location as the sole SourcePaths entry.
+    // TMove carries SrcPath/DstPath, no `Name` field at all, so a plain
+    // reflection-based lookup for "Name" finds nothing and the propose was
+    // being refused outright (see git history / diagnosis notes). A rename
+    // must be accepted and must record the object's new location (DstPath,
+    // since that is where a consumer would look the object up afterwards)
+    // as Path, and its old location as the sole entry in SourcePaths.
     Y_UNIT_TEST(MoveRecordsDestinationAndSource) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "MoveSrc"
@@ -964,7 +1956,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TestMoveTable(runtime, ++txId, "/MyRoot/MoveSrc", "/MyRoot/MoveDst");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMoveTable) {
@@ -983,8 +1975,12 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
     }
 
-    // The domain root's path relative to its own domain is the empty string, per
-    // RelativeToDomain's contract -- that empty path is correct, not approximate.
+    // Altering the database root itself: WorkingDir="/", Name="MyRoot"
+    // targets /MyRoot, which TTestEnv sets up as the domain root -- so
+    // RelativeToDomain collapses the resolved path down to the empty string,
+    // per its documented contract (a domain root's PathString() equals the
+    // domain prefix). This must succeed and must not carry an approximate
+    // or non-empty path.
     Y_UNIT_TEST(AlterDatabaseRootItselfStoresEmptyPath) {
         TTestBasicRuntime runtime;
         TTestEnvOptions opts;
@@ -992,6 +1988,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         TTestEnv env(runtime, opts);
         runtime.GetAppData().FeatureFlags.SetEnableAlterDatabase(true);
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestAlterSubDomain(runtime, ++txId, "/", R"(
             Name: "MyRoot"
@@ -1001,7 +2000,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
             if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterSubDomain) {
@@ -1016,12 +2015,18 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
     }
 
-    // Exactly one record for the whole requested TModifyScheme, and its path is the
-    // table -- not an index impl table synthesized during the same tx.
+    // CreateIndexedTable already has a special case in
+    // ExtractSchemeChangeTargetName (returns TableDescription.Name directly),
+    // bypassing the reflection loop entirely. Confirm it actually produces
+    // exactly one record and that the stored path is the table, not an
+    // index impl table synthesized during the same tx.
     Y_UNIT_TEST(CreateIndexedTableWritesExactlyOneRecordForTheTable) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
             TableDescription {
@@ -1038,7 +2043,7 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        auto entries = ReadSchemeChangeRecords(runtime);
         ui32 indexedTableRecords = 0;
         TVector<TString> storedPaths;
         for (const auto& e : entries) {
@@ -1253,6 +2258,11 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsPathCorrectnessTests) {
             TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
             ui64 txId = 100;
 
+            // Cleanup retires records no subscriber still needs, so one must be
+            // registered for the driver's record to survive to the read below.
+            TAutoPtr<IEventHandle> regHandle;
+            RegisterSubscriber(runtime, "test:sub", regHandle);
+
             TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
             env.TestWaitNotification(runtime, txId);
 
@@ -1289,6 +2299,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestMkDir(runtime, ++txId, "/MyRoot", "SubDir");
         env.TestWaitNotification(runtime, txId);
@@ -1418,6 +2431,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
         // TAlterCdcStream{TableName,StreamName} has no field literally named Name, so the
@@ -1448,10 +2464,16 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         UNIT_ASSERT_C(found, "AlterCdcStream must produce a scheme change record");
     }
 
+    // DropCdcStream resolves every stream in its repeated StreamName field, so its
+    // propose is no longer refused; see DropCdcStreamRecordsEveryStream.
+
     Y_UNIT_TEST(MoveIndexRecordsAPath) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
             TableDescription {
@@ -1470,8 +2492,11 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
 
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
-        // Fixed: TMoveIndex.SrcPath/DstPath are index names relative to TablePath, not
-        // absolute paths, so TPath::Resolve used to fail and refuse the propose.
+        // Fixed: ExtractSchemeChangeMoveTarget used to treat TMoveIndex.SrcPath/
+        // DstPath as absolute paths, but they are relative index names under
+        // TablePath (confirmed via mainTablePath.Child(srcIndex) in
+        // index/operation_move_index.cpp), so TPath::Resolve used to fail and
+        // refuse the propose.
         TestMoveIndex(runtime, ++txId, "/MyRoot/Table1", "Index1", "Index2", false);
         env.TestWaitNotification(runtime, txId);
 
@@ -1496,6 +2521,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
             Name: "USD1"
         )");
@@ -1518,12 +2546,20 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
 
         const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
         UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "UpgradeSubDomain must resolve a path");
+        // Not verified via ReadSchemeChangeRecords here: registering a second
+        // subscriber (its internal read-only helper) is refused once the
+        // domain has been upgraded to serve transactions on its own, since
+        // scheme change subscribers require a single transaction-supporting
+        // domain. The counter check above is the load-bearing assertion.
     }
 
     Y_UNIT_TEST(TruncateTableRecordsAPath) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
@@ -1561,6 +2597,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
             Columns { Name: "key"   Type: "Uint64" }
@@ -1571,8 +2610,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
 
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
-        // Fixed: TCreateContinuousBackup.TableName has no field literally named Name,
-        // so the generic reflection walk used to miss it and refuse the propose.
+        // Fixed: TCreateContinuousBackup.TableName (and the sibling Alter/Drop
+        // messages) have no field literally named Name, so the generic
+        // reflection walk used to miss them and refuse the propose.
         TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table1"
             ContinuousBackupDescription {
@@ -1602,8 +2642,12 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
-        // Restore targets an existing table (it restores INTO it), so the target must
-        // already exist for the propose to get past path resolution.
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        // Restore targets an existing table (it restores INTO it), unlike
+        // Create; the target must already exist for the propose to get past
+        // path resolution at all.
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table1"
             Columns { Name: "key" Type: "Uint64" }
@@ -1613,8 +2657,17 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
 
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
-        // Fixed: TRestoreTask names its target TableName. Full completion needs a real
-        // backup fixture, so this checks propose-time resolution only.
+        // TRestoreTask names its target TableName, like TTruncateTable/
+        // TCreateContinuousBackup before their extractor fixes -- not yet
+        // special-cased here. Driving Restore to full completion needs a
+        // real backup at the FS/S3 path (see ut_restore's TS3Mock rig); with
+        // no such fixture the data phase hangs, so this only checks the
+        // propose-time behavior (the same shape the outbox's own check
+        // observes) rather than the post-finalize resolve. That is still a
+        // real, meaningful assertion: before this fix, the propose itself
+        // was refused -- see the crash this test produced before the fix
+        // (Restore's AbortPropose is also an unconditional Y_ABORT stub, so
+        // the refusal took the tablet down rather than cleanly failing).
         TestRestore(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table1"
             TableDescription {
@@ -1648,11 +2701,16 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
     }
 
     Y_UNIT_TEST(AlterLoginRecordsAPath) {
-        // TAlterLogin's target is nested inside a oneof (e.g. CreateUser.User), never
-        // a top-level scalar Name/PathName/TableName field.
+        // TAlterLogin's target (the user/group being altered) is nested
+        // inside a oneof (e.g. CreateUser.User), never a top-level scalar
+        // Name/PathName/TableName field -- the generic reflection walk and
+        // every existing special case both miss it.
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
@@ -1678,8 +2736,12 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
     }
 
-    // Exercises the Drop.Id branch of ResolveSchemeChangeTargets (Drop.Id set,
-    // Drop.Name/WorkingDir unset), as produced by replication's dst_remover.
+    // The Drop.Id branch in ResolveSchemeChangeTargets (a
+    // TModifyScheme with Drop.Id set and Drop.Name/WorkingDir unset) is read
+    // but was never exercised by a test. Its only production producer is
+    // ydb/core/tx/replication/controller/dst_remover.cpp:46. TestForceDropUnsafe
+    // drives this exact shape: DROP_BY_PATH_ID_HELPERS builds TDrop with only
+    // Id set, no Name, no WorkingDir.
     Y_UNIT_TEST(DropByIdRecordsAPath) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
@@ -1691,6 +2753,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/DirToDropById"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
@@ -1713,8 +2778,10 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u, "ForceDropUnsafe");
         UNIT_ASSERT_C(AnyPathContains(*found, "DirToDropById"),
             "expected the target to be the dropped directory, got: " << AllTargetPaths(*found));
-        // The object is gone by finalize time, so assert against the identity captured
-        // before the drop rather than a live re-resolve.
+        // The object is gone by finalize time, so the record must carry the
+        // resolved-at-propose PathId of the object the drop actually
+        // targeted -- assert against the identity captured before the drop,
+        // not a live re-resolve (which would correctly fail post-drop).
         UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId,
             "recorded PathOwnerId must match the dropped object's owner");
         UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId,
@@ -1725,6 +2792,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
             Name: "PQGroup1"
@@ -1752,6 +2822,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
             Name: "USD1"
         )");
@@ -1774,6 +2847,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateRtmrVolume(runtime, ++txId, "/MyRoot", R"(
             Name: "rtmr1"
@@ -1798,6 +2874,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
         vdescr.SetName("BSVolume1");
@@ -1830,6 +2909,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
         env.TestWaitNotification(runtime, txId);
 
@@ -1850,6 +2932,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
             Name: "Solomon1"
@@ -1874,6 +2959,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         NKikimrSchemeOp::TFileStoreDescription descr;
         descr.SetName("FileStore1");
@@ -1909,6 +2997,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
             Name: "OlapStore1"
             ColumnShardCount: 1
@@ -1941,6 +3032,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
             Name: "ColumnTable1"
             ColumnShardCount: 1
@@ -1970,6 +3064,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(
             Name: "ExtSubDomain1"
         )");
@@ -1992,6 +3089,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
             Name: "ExternalDataSource1"
@@ -2028,6 +3128,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
             Name: "ExternalDataSource2"
             SourceType: "ObjectStorage"
@@ -2054,6 +3157,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateView(runtime, ++txId, "/MyRoot", R"(
             Name: "View1"
             QueryText: "Some query"
@@ -2077,6 +3183,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
@@ -2103,6 +3212,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).EnableBackupService(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
         env.TestWaitNotification(runtime, txId);
@@ -2146,6 +3258,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys", R"(
             Name: "sys_view_1"
             Type: EPartitionStats
@@ -2155,9 +3270,10 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         auto entries = ReadSchemeChangeRecordsFromTable(runtime);
         bool found = false;
         for (const auto& e : entries) {
-            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSysView
-                        && AnyPathContains(e, "sys_view_1")) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSysView) {
                 found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "sys_view_1"),
+                    "expected the target to be sys_view_1, got: " << AllTargetPaths(e));
                 AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
             }
         }
@@ -2168,6 +3284,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateSecret(runtime, ++txId, "/MyRoot", R"(
             Name: "Secret1"
@@ -2193,6 +3312,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateStreamingQuery(runtime, ++txId, "/MyRoot", R"(
             Name: "StreamingQuery1"
         )");
@@ -2216,6 +3338,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCreateTestShardSet(runtime, ++txId, "/MyRoot", CreateTestShardSetConfig("TestShardSet1"));
         env.TestWaitNotification(runtime, txId);
 
@@ -2236,6 +3361,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateSequence(runtime, ++txId, "/MyRoot", R"(
             Name: "Sequence1"
@@ -2267,6 +3395,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestLock(runtime, ++txId, "/MyRoot", "Table1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2295,6 +3426,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
             PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
         )");
         env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestAlterPQGroup(runtime, ++txId, "/MyRoot", R"(
             Name: "PQGroup1"
@@ -2332,6 +3466,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         NKikimrSchemeOp::TBlockStoreVolumeDescription alterDescr;
         alterDescr.SetName("BSVolume1");
         auto& alterVc = *alterDescr.MutableVolumeConfig();
@@ -2362,6 +3499,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestAlterKesus(runtime, ++txId, "/MyRoot", R"(
             Name: "Kesus1"
             Config { self_check_period_millis: 3000 }
@@ -2389,6 +3529,15 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "ExtSubDomain1")");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        // Not verified via ReadSchemeChangeRecords here, same constraint as
+        // UpgradeSubDomainRecordsAPath: ExternalSchemeShard:true turns this
+        // SchemeShard into one no longer serving a single transaction-
+        // supporting domain, so registering a second (internal, read-only)
+        // subscriber is refused. The counter check is the load-bearing
+        // assertion -- it fires before the domain state changes.
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
         TestAlterExtSubDomain(runtime, ++txId, "/MyRoot", R"(
@@ -2424,8 +3573,13 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        // Alter with no actual partition/channel change: only that the outbox resolves
-        // the target matters here, not the status the op itself returns.
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
+        // Alter without any actual partition/channel change: a real alter needs
+        // reflecting the just-created shard layout, which this test does not
+        // need -- only that the outbox resolves the target before whatever
+        // status the op itself returns.
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
         TestAlterSolomon(runtime, ++txId, "/MyRoot", R"(
             Name: "Solomon1"
@@ -2453,6 +3607,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
             }
         )");
         env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestAlterOlapStore(runtime, ++txId, "/MyRoot", R"(
             Name: "OlapStore1"
@@ -2494,6 +3651,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestAlterColumnTable(runtime, ++txId, "/MyRoot", R"(
             Name: "ColumnTable1"
             UpsertMultiColumnStatistics { Name: "s1" ColumnNames: "data" Types: COUNT_MIN_SKETCH }
@@ -2520,6 +3680,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
 
         TestCreateSequence(runtime, ++txId, "/MyRoot", R"(Name: "Sequence1")");
         env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestAlterSequence(runtime, ++txId, "/MyRoot", R"(
             Name: "Sequence1"
@@ -2552,6 +3715,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
             Name: "ResourcePool1"
             Properties {
@@ -2576,8 +3742,12 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         UNIT_ASSERT_C(found, "AlterResourcePool must produce a scheme change record");
     }
 
-    // The drop-family tests below capture the touched object's identity before the
-    // drop and assert against it, since the path no longer resolves afterwards.
+    // For the drop-family tests below the object is gone by finalize time, so
+    // each of these captures the
+    // touched object's identity BEFORE the drop (like DropByIdRecordsAPath)
+    // and asserts the record's PathOwnerId/PathLocalId against that captured
+    // identity, rather than re-resolving a path that no longer exists.
+
     Y_UNIT_TEST(DropTableRecordsAPath) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
@@ -2593,6 +3763,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
         env.TestWaitNotification(runtime, txId);
@@ -2629,6 +3802,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropPQGroup(runtime, ++txId, "/MyRoot", "PQGroup1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2659,6 +3835,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropSubDomain(runtime, ++txId, "/MyRoot", "USD1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2688,6 +3867,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Kesus1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropKesus(runtime, ++txId, "/MyRoot", "Kesus1");
         env.TestWaitNotification(runtime, txId);
@@ -2722,6 +3904,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropSolomon(runtime, ++txId, "/MyRoot", "Solomon1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2752,6 +3937,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestForceDropSubDomain(runtime, ++txId, "/MyRoot", "USD1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2781,6 +3969,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExtSubDomain1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestForceDropExtSubDomain(runtime, ++txId, "/MyRoot", "ExtSubDomain1");
         env.TestWaitNotification(runtime, txId);
@@ -2824,6 +4015,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropFileStore(runtime, ++txId, "/MyRoot", "FileStore1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2865,6 +4059,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropOlapStore(runtime, ++txId, "/MyRoot", "OlapStore1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2902,6 +4099,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ColumnTable1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot", "ColumnTable1");
         env.TestWaitNotification(runtime, txId);
@@ -2946,6 +4146,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropExternalTable(runtime, ++txId, "/MyRoot", "ExternalTable1");
         env.TestWaitNotification(runtime, txId);
 
@@ -2981,6 +4184,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropExternalDataSource(runtime, ++txId, "/MyRoot", "ExternalDataSource1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3013,6 +4219,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/View1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropView(runtime, ++txId, "/MyRoot", "View1");
         env.TestWaitNotification(runtime, txId);
@@ -3056,6 +4265,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 tableOwnerId = pathVersion.PathId.OwnerId;
         const ui64 tableLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropContinuousBackup(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table1"
         )");
@@ -3072,8 +4284,10 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         UNIT_ASSERT_C(found, "DropContinuousBackup must produce a scheme change record");
         UNIT_ASSERT_C(AnyPathContains(*found, "Table1"),
             "expected the target to be Table1, got: " << AllTargetPaths(*found));
-        // The target table is not itself dropped, but the pre-op-captured identity is
-        // used for symmetry with the other Drop* tests in this suite.
+        // DropContinuousBackup's target is the table it was created on -- the
+        // table itself is not dropped, so the ordinary live-resolve
+        // assertion would also work here, but the pre-op-captured identity
+        // is used for symmetry with the other Drop* rows in this suite.
         UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, tableOwnerId, "recorded PathOwnerId must match Table1's owner");
         UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, tableLocalId, "recorded PathLocalId must match Table1's identity");
     }
@@ -3093,6 +4307,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool1");
         env.TestWaitNotification(runtime, txId);
@@ -3143,6 +4360,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(Name: "BackupCollection1")");
         env.TestWaitNotification(runtime, txId);
 
@@ -3175,6 +4395,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.sys/sys_view_1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropSysView(runtime, ++txId, "/MyRoot/.sys", "sys_view_1");
         env.TestWaitNotification(runtime, txId);
@@ -3209,6 +4432,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropSecret(runtime, ++txId, "/MyRoot", "Secret1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3241,6 +4467,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropStreamingQuery(runtime, ++txId, "/MyRoot", "StreamingQuery1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3270,6 +4499,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/TestShardSet1"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestDropTestShardSet(runtime, ++txId, "/MyRoot", "TestShardSet1");
         env.TestWaitNotification(runtime, txId);
@@ -3312,14 +4544,19 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropTableIndex(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table1"
             IndexName: "Index1"
         )");
         env.TestWaitNotification(runtime, txId);
 
-        // TestDropTableIndex issues ESchemeOpDropIndex as the top-level OperationType;
-        // ESchemeOpDropTableIndex is a distinct, apparently-unissued enum value.
+        // TestDropTableIndex issues ESchemeOpDropIndex as the top-level
+        // OperationType (see GENERIC_HELPERS(DropTableIndex, ...ESchemeOpDropIndex,
+        // ...) in ut_helpers/helpers.cpp) -- ESchemeOpDropTableIndex is a
+        // distinct, apparently-unissued enum value.
         auto entries = ReadSchemeChangeRecordsFromTable(runtime);
         const TSchemeChangeRecordEntry* found = nullptr;
         for (const auto& e : entries) {
@@ -3351,6 +4588,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 lockId = txId;
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestUnlock(runtime, ++txId, lockId, "/MyRoot", "Table1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3378,6 +4618,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/DirToRemove"));
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestRmDir(runtime, ++txId, "/MyRoot", "DirToRemove");
         env.TestWaitNotification(runtime, txId);
@@ -3409,6 +4652,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestModifyACL(runtime, ++txId, "/MyRoot", "Table1", "", "bob@builtin");
         env.TestWaitNotification(runtime, txId);
 
@@ -3425,8 +4671,24 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         UNIT_ASSERT_C(found, "ModifyACL must produce a scheme change record");
     }
 
-    // CreateIndexBuild is a top-level op whose target is InitiateIndexBuild.Table,
-    // an absolute path; an unresolved refusal used to crash the tablet on abort.
+    // ESchemeOpCreateIndexBuild IS issued as a top-level
+    // TModifyScheme.OperationType by TIndexBuilder (InitiateIndexBuild.Table,
+    // an absolute path) -- ConstructParts then decomposes it into
+    // TCreateTableIndex/TInitializeBuildIndex/... sub-ops. Before the
+    // extractor fix below, InitiateIndexBuild.Table was not recognized by
+    // any special case or the generic Name-field walk, so the propose was
+    // refused. That refusal is worse than a clean StatusInvalidParameter:
+    // AbortOperationPropose unconditionally calls AbortPropose on every
+    // already-proposed part in the same request, including the index's
+    // impl-table TCreateTable sub-op -- whose AbortPropose is a Y_ABORT
+    // stub ("no AbortPropose for TCreateTable") -- so the refusal crashed
+    // the tablet (SIGABRT) instead of failing cleanly. VERBATIM crash seen
+    // before the fix: "VERIFY failed: no AbortPropose for TCreateTable" at
+    // schemeshard__operation_create_table.cpp:814, reached via
+    // AbortOperationPropose <- CheckSchemeChangeRecordHasPath rejecting
+    // InitiateIndexBuild. Fixed by resolving InitiateIndexBuild.Table (and
+    // CancelIndexBuild.TablePath, same shape) directly in
+    // ResolveSchemeChangeTargets -- see schemeshard__scheme_change_records.cpp.
     Y_UNIT_TEST(CreateIndexBuildRecordsAPath) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
@@ -3439,6 +4701,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
             KeyColumnNames: ["key"]
         )");
         env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table1",
             TBuildIndexConfig{"Index1", NKikimrSchemeOp::EIndexTypeGlobal, {"index"}, {}, {}});
@@ -3477,6 +4742,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
             TBuildIndexConfig{"Index1", NKikimrSchemeOp::EIndexTypeGlobal, {"index"}, {}, {}});
         const ui64 buildIndexId = txId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestCancelBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
         env.TestWaitNotification(runtime, buildIndexId);
 
@@ -3497,6 +4765,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
             Name: "Replication1"
@@ -3542,6 +4813,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestAlterReplication(runtime, ++txId, "/MyRoot", R"(
             Name: "Replication1"
             State { Paused {} }
@@ -3583,6 +4857,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropReplication(runtime, ++txId, "/MyRoot", "Replication1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3623,6 +4900,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropReplicationCascade(runtime, ++txId, "/MyRoot", "Replication1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3645,6 +4925,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
         ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
@@ -3704,6 +4987,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestAlterTransfer(runtime, ++txId, "/MyRoot", R"(
             Name: "Transfer1"
             State { Paused {} }
@@ -3752,6 +5038,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropTransfer(runtime, ++txId, "/MyRoot", "Transfer1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3799,6 +5088,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
         const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestDropTransferCascade(runtime, ++txId, "/MyRoot", "Transfer1");
         env.TestWaitNotification(runtime, txId);
 
@@ -3818,8 +5110,11 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
     }
 
     Y_UNIT_TEST(BackupRecordsAPath) {
-        // Driving Backup to completion needs a real S3 endpoint, so this checks only
-        // propose-time path resolution, not the post-finalize resolve.
+        // Same shape as RestoreRecordsAPath above: driving Backup to full
+        // completion needs a real/mocked S3 endpoint (see ut_backup's
+        // TS3Mock rig); without it the data phase hangs, so this only
+        // checks the propose-time path resolution -- the same check the
+        // outbox itself performs -- not the post-finalize resolve.
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
@@ -3830,6 +5125,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
             KeyColumnNames: ["key"]
         )");
         env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
 
@@ -3876,6 +5174,9 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
         TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
         env.TestWaitNotification(runtime, txId);
 
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
+
         TestAssignBlockStoreVolume(runtime, ++txId, "/MyRoot", "BSVolume1", "Owner123");
         env.TestWaitNotification(runtime, txId);
 
@@ -3893,11 +5194,20 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
     }
 
     Y_UNIT_TEST(UpgradeSubDomainDecisionRecordsAPath) {
-        // Upgrading the domain blocks a live read here, so this asserts propose-time
-        // resolution via the rejection counter instead.
+        // Same registration constraint as UpgradeSubDomainRecordsAPath: once
+        // the domain is upgraded to serve transactions on its own, a second
+        // subscriber registration is refused, so this asserts via the
+        // rejection counter (propose-time resolution), not a live read.
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
         ui64 txId = 100;
+
+        // Must register before AlterSubDomain(Coordinators/Mediators): that
+        // alone already breaks single-domain-serving, and RegisterSubscriber
+        // itself would then be refused (not just a later ReadSchemeChangeRecords
+        // call) -- same ordering constraint as UpgradeSubDomainRecordsAPath.
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub", regHandle);
 
         TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records.cpp
@@ -1,0 +1,3991 @@
+#include "ut_scheme_change_records_helpers.h"
+
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <util/string/printf.h>
+#include <util/string/join.h>
+
+#include <functional>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+using namespace NSchemeChangeRecordTestHelpers;
+using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecordsFromTable;
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSchemaTests) {
+    Y_UNIT_TEST(DisabledByDefaultEmitsNoRecords) {
+        // ReadSchemeChangeRecords itself registers a temp subscriber, which is
+        // refused while disabled; use the order counter as a disabled-safe oracle.
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        // Default options: the flag is off unless a test opts in.
+        TTestEnv env(runtime, TTestEnvOptions(), ssFactory);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->NextSchemeChangeOrder, 0u,
+            "no outbox rows should be reserved while the feature is disabled");
+    }
+
+    Y_UNIT_TEST(CreateTableWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.TxId, (ui64)txId);
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets[0].Path, "Table1");
+                UNIT_ASSERT(e.Order > 0);
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found in notification log");
+    }
+
+    Y_UNIT_TEST(AlterTableWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        ui32 alterCount = 0;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
+                && e.Body.GetAlterTable().GetName() == "Table1") {
+                ++alterCount;
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(alterCount >= 1, "ALTER TABLE entry not found in notification log");
+    }
+
+    // UserSID must record who issued the DDL, not who owns the target: a
+    // ModifyACL changes the owner without that owner issuing anything.
+    Y_UNIT_TEST(UserSIDRecordsIssuerNotOwner) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Positive companion: the owner is genuinely changed to someone who
+        // never issues the later ALTER, so a later match can't be coincidence.
+        TestModifyACL(runtime, ++txId, "/MyRoot", "Table1", "", "bob@builtin");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* alterEntry = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
+                && e.Body.GetAlterTable().GetName() == "Table1") {
+                alterEntry = &e;
+            }
+        }
+        UNIT_ASSERT_C(alterEntry, "ALTER TABLE entry not found in notification log");
+        // The test issues the ALTER with no user token, so the true issuer
+        // SID is empty -- never "bob@builtin", the object's owner.
+        UNIT_ASSERT_VALUES_EQUAL_C(alterEntry->UserSID, "",
+            "UserSID must reflect the DDL issuer (empty, no token supplied here), "
+            "not the target's owner (\"bob@builtin\"); got \"" << alterEntry->UserSID << "\"");
+    }
+
+    // TCreateCdcStream's target is nested under TableName/StreamDescription.Name:
+    // the record must carry the changefeed itself, not the table or the working dir.
+    Y_UNIT_TEST(CdcStreamRecordDoesNotImpersonateParentDirectory) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateCdcStream) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateCdcStream must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_VALUES_UNEQUAL_C(found->Targets[0].Path, "Table1",
+            "the target must be the changefeed, not its parent table");
+        UNIT_ASSERT_VALUES_UNEQUAL_C(found->Targets[0].Path, "",
+            "the target must be the changefeed, not the working directory");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "Table1/Stream1",
+            "expected the changefeed's own path, got \"" << found->Targets[0].Path << "\"");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // TDropCdcStream.StreamName is repeated, so one op can retire N changefeeds:
+    // each must get its own target, not be collapsed into a single entry.
+    Y_UNIT_TEST(DropCdcStreamRecordsEveryStream) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream2"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // showPrivate: a changefeed is not a common-sense path, so the default
+        // describe refuses it before any identity can be read.
+        const auto stream1Version = ExtractPathVersion(
+            DescribePath(runtime, "/MyRoot/Table1/Stream1", false, false, true));
+        const ui64 droppedOwnerId = stream1Version.PathId.OwnerId;
+        const ui64 droppedLocalId = stream1Version.PathId.LocalPathId;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestDropCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            StreamName: "Stream2"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "a multi-stream drop must resolve every target, not bump the path-missing counter");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropCdcStream) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropCdcStream must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 2u,
+            "dropping two changefeeds must record two targets, got " << AllTargetPaths(*found));
+
+        THashSet<TString> paths;
+        for (const auto& target : found->Targets) {
+            UNIT_ASSERT_C(target.SourcePaths.empty(),
+                "a drop has no source, SourcePaths must be empty for " << target.Path);
+            paths.insert(target.Path);
+        }
+        UNIT_ASSERT_C(paths.contains("Table1/Stream1"), "missing Table1/Stream1 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_C(paths.contains("Table1/Stream2"), "missing Table1/Stream2 in " << AllTargetPaths(*found));
+        // The streams are gone by finalize time, so the first target's identity is
+        // checked against the one captured before the drop, not a live re-resolve.
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId,
+            "recorded PathOwnerId must match the first dropped changefeed's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId,
+            "recorded PathLocalId must match the first dropped changefeed's identity");
+    }
+
+    Y_UNIT_TEST(DropTableWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTable
+                && e.Body.GetDrop().GetName() == "Table1") {
+                found = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DROP TABLE entry not found in notification log");
+    }
+
+    Y_UNIT_TEST(OrdersAreMonotonicAcrossOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT(entries.size() >= 2);
+
+        for (size_t i = 1; i < entries.size(); ++i) {
+            UNIT_ASSERT_C(entries[i].Order > entries[i-1].Order,
+                "Orders must be strictly monotonic");
+        }
+    }
+
+    Y_UNIT_TEST(PlanStepIsRecordedForCoordinatedOps) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT(!entries.empty());
+
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = true;
+                UNIT_ASSERT_C(e.PlanStep > 0,
+                    "CreateTable should have a valid PlanStep, got: " << e.PlanStep);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found in notification log");
+    }
+
+    Y_UNIT_TEST(PlanStepIsRecordedForAlterTable) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool sawAlter = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable
+                && e.Body.GetAlterTable().GetName() == "Table1") {
+                sawAlter = true;
+                UNIT_ASSERT_C(e.PlanStep > 0,
+                    "AlterTable Table1 should have a valid PlanStep, got: " << e.PlanStep);
+            }
+        }
+        UNIT_ASSERT(sawAlter);
+    }
+
+    Y_UNIT_TEST(PlanStepMonotonicAcrossOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT(entries.size() >= 2);
+
+        ui64 prevPlanStep = 0;
+        for (const auto& e : entries) {
+            // Bootstrap system views (.sys/*) are recorded too now that the
+            // gate is the flag alone; they are not this test's DDL.
+            if (AnyPathContains(e, ".sys/")) {
+                continue;
+            }
+            UNIT_ASSERT_C(e.PlanStep >= prevPlanStep,
+                "PlanStep should be monotonically non-decreasing: prev=" << prevPlanStep
+                    << " current=" << e.PlanStep << " path=" << AllTargetPaths(e));
+            prevPlanStep = e.PlanStep;
+        }
+
+        for (size_t i = 1; i < entries.size(); ++i) {
+            const auto& prev = entries[i-1];
+            const auto& curr = entries[i];
+            // Order is the stream's only total order, and it is what cursors,
+            // acks and retention are defined on.
+            UNIT_ASSERT_C(curr.Order > prev.Order,
+                "Order must strictly increase: prev=" << prev.Order << " curr=" << curr.Order);
+            UNIT_ASSERT_C(curr.PlanStep != 0,
+                "a finalised record must carry a PlanStep, order=" << curr.Order);
+            // (PlanStep, TxId) is deliberately not asserted co-monotonic with Order: Order
+            // is allocated at propose, PlanStep by the coordinator at plan time.
+        }
+    }
+
+    Y_UNIT_TEST(MkDirWritesLogEntry) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMkDir
+                && e.Body.GetMkDir().GetName() == "DirA") {
+                found = true;
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "MkDir should produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateTableWithIndexProducesSingleParentRecord) {
+        // A multi-part DDL emits exactly one record, carrying the TModifyScheme
+        // as it arrived in the request; the target cluster re-runs decomposition
+        // on replay.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Main"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "IdxByValue"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        ui32 parentCount = 0;
+        bool haveMain = false;
+        bool haveIndex = false;
+        for (const auto& e : entries) {
+            if (e.TxId != (ui64)txId) continue;
+            UNIT_ASSERT_VALUES_EQUAL(
+                (ui32)e.Body.GetOperationType(),
+                (ui32)NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
+            ++parentCount;
+            const auto& ct = e.Body.GetCreateIndexedTable();
+            if (ct.GetTableDescription().GetName() == "Main") haveMain = true;
+            for (const auto& idx : ct.GetIndexDescription()) {
+                if (idx.GetName() == "IdxByValue") haveIndex = true;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(parentCount, 1u,
+            "Expected exactly 1 parent-level record, got " << parentCount);
+        UNIT_ASSERT_C(haveMain, "Parent record must carry the main table description");
+        UNIT_ASSERT_C(haveIndex, "Parent record must carry the index description");
+    }
+
+    Y_UNIT_TEST(AutoMkDirBodyPreservedOnParent) {
+        // Only the user's original CreateTable body is persisted; the target
+        // cluster regenerates the auto-mkdir chain on replay.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "A/B/C/Leaf"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool foundLeaf = false;
+        for (const auto& e : entries) {
+            if (e.TxId != (ui64)txId) continue;
+            UNIT_ASSERT_VALUES_EQUAL(
+                (ui32)e.Body.GetOperationType(),
+                (ui32)NKikimrSchemeOp::ESchemeOpCreateTable);
+            if (e.Body.GetCreateTable().GetName() == "A/B/C/Leaf") {
+                foundLeaf = true;
+            }
+        }
+        UNIT_ASSERT_C(foundLeaf, "The persisted CreateTable body must preserve the path as requested");
+    }
+
+    Y_UNIT_TEST(ParentBodyCarriesFullSubDescriptions) {
+        // Every sub-description the decomposer needs must live inside the one
+        // parent body, or replay cannot reproduce the DDL on the target.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Main"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "IdxByValue"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const NKikimrSchemeOp::TIndexedTableCreationConfig* ct = nullptr;
+        for (const auto& e : entries) {
+            if (e.TxId == (ui64)txId && e.Body.HasCreateIndexedTable()) {
+                ct = &e.Body.GetCreateIndexedTable();
+                break;
+            }
+        }
+        UNIT_ASSERT(ct);
+        UNIT_ASSERT_VALUES_EQUAL(ct->GetTableDescription().GetName(), "Main");
+        UNIT_ASSERT_VALUES_EQUAL(ct->IndexDescriptionSize(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ct->GetIndexDescription(0).GetName(), "IdxByValue");
+    }
+
+    Y_UNIT_TEST(PersistsNextSchemeChangeOrderOncePerBatch) {
+        // A multi-part DDL emits one record, so NextSchemeChangeOrder is
+        // persisted once per batch by construction.
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        schemeshard->NextSchemeChangeOrderPersistCount = 0;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Main"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "IdxByValue"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        size_t thisTxRecords = 0;
+        for (const auto& e : entries) {
+            if (e.TxId == (ui64)txId) ++thisTxRecords;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(thisTxRecords, 1u);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->NextSchemeChangeOrderPersistCount, 1u,
+            "Expected one NextSchemeChangeOrder persist for a batch, got "
+            << schemeshard->NextSchemeChangeOrderPersistCount);
+    }
+
+    // Positive companion to DisabledByDefaultEmitsNoRecords: the identical DDL
+    // with the flag on does produce a row, so the disabled case cannot pass vacuously.
+    Y_UNIT_TEST(EnabledByOptInEmitsRecord) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "expected at least one outbox row with the feature enabled");
+    }
+
+    // Finalize resolves the target but writes back only PathOwnerId/PathLocalId;
+    // Path keeps the propose-time synthesis, which must already be canonical.
+    Y_UNIT_TEST(RecordCarriesCanonicalResolvedPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        // Trailing slash: propose-time string concatenation would leave a
+        // double slash, while TPath::Resolve canonicalizes it away.
+        TestCreateTable(runtime, ++txId, "/MyRoot/", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_C(!found->Targets[0].Path.Contains("//"),
+            "Path must be the canonical resolved path, not a raw concatenation; got \"" << found->Targets[0].Path << "\"");
+    }
+
+    // A stored path must be relative to the database root and must be the full
+    // path to the object -- a path truncated to empty must not pass.
+    Y_UNIT_TEST(RecordPathIsRelativeToDatabaseRoot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot/DirA", R"(
+            Name: "Nested"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Nested") {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_C(!found->Targets[0].Path.StartsWith("/MyRoot"),
+            "Path must not carry the source database prefix; got \"" << found->Targets[0].Path << "\"");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "DirA/Nested",
+            "Path must be the full remainder relative to the database root, "
+            "not truncated to empty or to just the leaf name");
+    }
+
+    // No fallback, ever: across a varied corpus of path-bearing ops, nothing may be
+    // refused for a missing path and every record must name the object it touched.
+    Y_UNIT_TEST(PathBearingOpNeverStoresAnApproximatePath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        ui64 checkedThrough = 0;
+        ui32 checkedRecords = 0;
+        // Checked after every op, before a later drop or rename can invalidate an
+        // already-correct path. targetsStillExist is false once the op removed them.
+        auto verifyNewRecords = [&](bool targetsStillExist) {
+            const auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+            ui64 maxOrder = checkedThrough;
+            for (const auto& e : entries) {
+                maxOrder = Max(maxOrder, e.Order);
+                if (e.Order <= checkedThrough) {
+                    continue;
+                }
+                // Bootstrap system views (.sys/*) are recorded too; not this test's DDL.
+                if (AnyPathContains(e, ".sys/")) {
+                    continue;
+                }
+                const TString opName = NKikimrSchemeOp::EOperationType_Name(e.Body.GetOperationType());
+                // An empty path is the database root itself, per RelativeToDomain's
+                // contract; the resolve below rejects it for anything else.
+                UNIT_ASSERT_C(!e.Targets.empty(), opName << " recorded no target at all");
+                ++checkedRecords;
+                if (!targetsStillExist) {
+                    continue;
+                }
+                for (size_t i = 0; i < e.Targets.size(); ++i) {
+                    AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e, i);
+                }
+            }
+            checkedThrough = maxOrder;
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing"), 0u,
+                "no op in this corpus may fail to resolve a path");
+        };
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "IndexedTable1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "ByValue"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream2"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestAlterCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            Disable {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "SubDomain1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        // Two streams in one op: the repeated StreamName must yield two targets.
+        TestDropCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            StreamName: "Stream2"
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(false);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "MoveSrc"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/MoveSrc", "/MyRoot/MoveDst");
+        env.TestWaitNotification(runtime, txId);
+        verifyNewRecords(true);
+
+        UNIT_ASSERT_C(checkedRecords >= 10,
+            "the corpus must actually have produced records to check, got " << checkedRecords);
+    }
+
+    // The pathless allowlist is empty today, so an ordinary op must still produce
+    // its record -- the invariant above must not be satisfiable by refusing everything.
+    Y_UNIT_TEST(OrdinaryOpsStillProduceRecordsWhenAllowlistIsEmpty) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "PlainTable"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "PlainTable") {
+                found = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "an ordinary path-bearing op must still produce a record");
+    }
+
+    // One record per TModifyScheme in the request (Body is the atomic replay unit),
+    // so a copy of N tables must list all N as targets, each with its own
+    // destination and source.
+    Y_UNIT_TEST(ConsistentCopyTablesRecordsAllTargetsWithSources) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestConsistentCopyTables(runtime, ++txId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src1"
+                DstPath: "/MyRoot/Dst1"
+            }
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src2"
+                DstPath: "/MyRoot/Dst2"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "a resolvable multi-target copy must not bump the path-missing counter");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateConsistentCopyTables entry not found -- the propose must not be refused");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 2u,
+            "record must list all N copy targets, got " << found->Targets.size());
+
+        THashMap<TString, TString> dstToSrc;
+        for (const auto& target : found->Targets) {
+            UNIT_ASSERT_VALUES_EQUAL_C(target.SourcePaths.size(), 1u,
+                "each copy target must have exactly one source, got "
+                    << target.SourcePaths.size() << " for " << target.Path);
+            dstToSrc[target.Path] = target.SourcePaths[0];
+        }
+        UNIT_ASSERT_C(dstToSrc.contains("Dst1"), "missing Dst1 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_C(dstToSrc.contains("Dst2"), "missing Dst2 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst1"], "Src1",
+            "Dst1's target must record Src1 as its source");
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst2"], "Src2",
+            "Dst2's target must record Src2 as its source");
+        // Every one of the N targets must resolve; only target[0] carries a captured
+        // PathId, so [1] gets a plain resolve check.
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, 0);
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, 1);
+    }
+
+    // A plain single-target op must still yield exactly one target, with SourcePaths
+    // empty -- it is a repeated field, so "empty" is the assertion, not "unset".
+    Y_UNIT_TEST(SingleTargetOpRecordsExactlyOneTarget) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable
+                && e.Body.GetCreateTable().GetName() == "Table1") {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "CREATE TABLE entry not found");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u,
+            "a single-target op must yield exactly one target entry, got " << found->Targets.size());
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets[0].Path, "Table1");
+        UNIT_ASSERT_C(found->Targets[0].SourcePaths.empty(),
+            "a plain create has no source, SourcePaths must be empty");
+    }
+
+    // A rename records the object's new location as Path (where a consumer looks it
+    // up afterwards) and its old location as the sole SourcePaths entry.
+    Y_UNIT_TEST(MoveRecordsDestinationAndSource) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "MoveSrc"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/MoveSrc", "/MyRoot/MoveDst");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMoveTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "MOVE TABLE entry not found -- the propose must not be refused");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "MoveDst",
+            "Path must be the object's new (destination) location, database-relative");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].SourcePaths.size(), 1u,
+            "a rename has exactly one source, got " << found->Targets[0].SourcePaths.size());
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].SourcePaths[0], "MoveSrc",
+            "SourcePaths must record the object's old (source) location, database-relative");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // The domain root's path relative to its own domain is the empty string, per
+    // RelativeToDomain's contract -- that empty path is correct, not approximate.
+    Y_UNIT_TEST(AlterDatabaseRootItselfStoresEmptyPath) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        runtime.GetAppData().FeatureFlags.SetEnableAlterDatabase(true);
+        ui64 txId = 100;
+
+        TestAlterSubDomain(runtime, ++txId, "/", R"(
+            Name: "MyRoot"
+            SchemeLimits {
+                MaxPaths: 1000
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ALTER SUBDOMAIN(root) entry not found -- altering the root must not be refused");
+        UNIT_ASSERT_VALUES_EQUAL(found->Targets.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "",
+            "the database root's own path, relative to itself, must be the empty string");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // Exactly one record for the whole requested TModifyScheme, and its path is the
+    // table -- not an index impl table synthesized during the same tx.
+    Y_UNIT_TEST(CreateIndexedTableWritesExactlyOneRecordForTheTable) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "IndexedTable1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "byValue"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        ui32 indexedTableRecords = 0;
+        TVector<TString> storedPaths;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateIndexedTable) {
+                ++indexedTableRecords;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                storedPaths.push_back(e.Targets[0].Path);
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(indexedTableRecords, 1u,
+            "CreateIndexedTable must write exactly one record for the whole requested tx");
+        UNIT_ASSERT_VALUES_EQUAL_C(storedPaths[0], "IndexedTable1",
+            "the stored path must be the table itself, not an index impl table");
+    }
+}
+
+namespace {
+
+// Drivers for the shapes whose recorded target is not a plain WorkingDir/Name.
+// Each runs under a nested working dir, where a prefix mistake cannot hide.
+struct TPathShapeCase {
+    TString Name;
+    NKikimrSchemeOp::EOperationType OpType;
+    TVector<TString> ExpectedPaths;
+    std::function<void(TTestActorRuntime&, TTestEnv&, ui64&)> Drive;
+};
+
+const TVector<TPathShapeCase>& GetPathShapeCases() {
+    static const TVector<TPathShapeCase> cases = {
+        // The record must carry the whole multi-segment path the user asked for,
+        // not just the leaf the auto-mkdir chain ends on.
+        {"CreateTable auto-mkdir", NKikimrSchemeOp::ESchemeOpCreateTable, {"Dir1/A/B/Leaf"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "A/B/Leaf"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // The target is nested one level inside TableDescription, and the op also
+        // synthesizes index impl tables that must not become the target.
+        {"CreateIndexedTable", NKikimrSchemeOp::ESchemeOpCreateIndexedTable, {"Dir1/Table1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateIndexedTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableDescription {
+                     Name: "Table1"
+                     Columns { Name: "key" Type: "Uint64" }
+                     Columns { Name: "value" Type: "Utf8" }
+                     KeyColumnNames: ["key"]
+                 }
+                 IndexDescription {
+                     Name: "Index1"
+                     KeyColumnNames: ["value"]
+                     Type: EIndexTypeGlobal
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // WorkingDir/TableName/StreamDescription.Name: two levels below the working
+        // dir, so neither a direct-child lookup nor the reflection walk finds it.
+        {"CreateCdcStream", NKikimrSchemeOp::ESchemeOpCreateCdcStream, {"Dir1/Table1/Stream1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Table1"
+                 Columns { Name: "key"   Type: "Uint64" }
+                 Columns { Name: "value" Type: "Utf8" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestCreateCdcStream(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableName: "Table1"
+                 StreamDescription {
+                     Name: "Stream1"
+                     Mode: ECdcStreamModeKeysOnly
+                     Format: ECdcStreamFormatProto
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // WorkingDir/TableName/StreamName, and no field literally named Name.
+        {"AlterCdcStream", NKikimrSchemeOp::ESchemeOpAlterCdcStream, {"Dir1/Table1/Stream1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Table1"
+                 Columns { Name: "key"   Type: "Uint64" }
+                 Columns { Name: "value" Type: "Utf8" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestCreateCdcStream(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableName: "Table1"
+                 StreamDescription {
+                     Name: "Stream1"
+                     Mode: ECdcStreamModeKeysOnly
+                     Format: ECdcStreamFormatProto
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestAlterCdcStream(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableName: "Table1"
+                 StreamName: "Stream1"
+                 Disable {}
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // A rename records the destination, so the path a consumer looks up after
+        // the op is the new one, not the vanished source.
+        {"MoveTable", NKikimrSchemeOp::ESchemeOpMoveTable, {"Dir1/MoveDst"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "MoveSrc"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestMoveTable(runtime, ++txId, "/MyRoot/Dir1/MoveSrc", "/MyRoot/Dir1/MoveDst");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // TMoveIndex.SrcPath/DstPath are index names relative to TablePath, not
+        // absolute paths -- treating them as absolute resolved to nothing.
+        {"MoveIndex", NKikimrSchemeOp::ESchemeOpMoveIndex, {"Dir1/Table1/Index2"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateIndexedTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 TableDescription {
+                     Name: "Table1"
+                     Columns { Name: "key" Type: "Uint64" }
+                     Columns { Name: "value" Type: "Utf8" }
+                     KeyColumnNames: ["key"]
+                 }
+                 IndexDescription {
+                     Name: "Index1"
+                     KeyColumnNames: ["value"]
+                     Type: EIndexTypeGlobal
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestMoveIndex(runtime, ++txId, "/MyRoot/Dir1/Table1", "Index1", "Index2", false);
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // N destinations in one op: each must get its own target, in request order.
+        {"CreateConsistentCopyTables", NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables,
+         {"Dir1/Dst1", "Dir1/Dst2"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Src1"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Src2"
+                 Columns { Name: "key" Type: "Uint64" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestConsistentCopyTables(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 CopyTableDescriptions {
+                     SrcPath: "/MyRoot/Dir1/Src1"
+                     DstPath: "/MyRoot/Dir1/Dst1"
+                 }
+                 CopyTableDescriptions {
+                     SrcPath: "/MyRoot/Dir1/Src2"
+                     DstPath: "/MyRoot/Dir1/Dst2"
+                 }
+             )");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // TTruncateTable names its target TableName, not Name.
+        {"TruncateTable", NKikimrSchemeOp::ESchemeOpTruncateTable, {"Dir1/Table1"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestCreateTable(runtime, ++txId, "/MyRoot/Dir1", R"(
+                 Name: "Table1"
+                 Columns { Name: "key"   Type: "Uint64" }
+                 Columns { Name: "value" Type: "Utf8" }
+                 KeyColumnNames: ["key"]
+             )");
+             env.TestWaitNotification(runtime, txId);
+             TestTruncateTable(runtime, ++txId, "/MyRoot/Dir1", "Table1");
+             env.TestWaitNotification(runtime, txId);
+         }},
+
+        // TAlterUserAttributes names its target PathName, not Name.
+        {"AlterUserAttributes", NKikimrSchemeOp::ESchemeOpAlterUserAttributes, {"Dir1/Sub"},
+         [](TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+             TestMkDir(runtime, ++txId, "/MyRoot/Dir1", "Sub");
+             env.TestWaitNotification(runtime, txId);
+             TestUserAttrs(runtime, ++txId, "/MyRoot/Dir1", "Sub",
+                 AlterUserAttrs({{"attr1", "value1"}}));
+             env.TestWaitNotification(runtime, txId);
+         }},
+    };
+    return cases;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsPathCorrectnessTests) {
+    // A resolvable-but-wrong path is the failure mode here: the recorded path must
+    // resolve to the very object the operation touched, not to a plausible sibling.
+    Y_UNIT_TEST(RecordedPathResolvesToTouchedObject) {
+        for (const auto& testCase : GetPathShapeCases()) {
+            TTestBasicRuntime runtime;
+            TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+            ui64 txId = 100;
+
+            TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+            env.TestWaitNotification(runtime, txId);
+
+            testCase.Drive(runtime, env, txId);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing"), 0u,
+                testCase.Name << ": the driver must not fail to resolve a path");
+
+            auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+            const TSchemeChangeRecordEntry* found = nullptr;
+            for (const auto& e : entries) {
+                if (e.Body.GetOperationType() == testCase.OpType) {
+                    found = &e;
+                }
+            }
+            UNIT_ASSERT_C(found, testCase.Name << ": no record for "
+                << NKikimrSchemeOp::EOperationType_Name(testCase.OpType));
+            UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), testCase.ExpectedPaths.size(),
+                testCase.Name << ": target count mismatch, got " << AllTargetPaths(*found));
+            for (size_t i = 0; i < testCase.ExpectedPaths.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[i].Path, testCase.ExpectedPaths[i],
+                    testCase.Name << ": target " << i << " path mismatch, got "
+                    << AllTargetPaths(*found));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found, i);
+            }
+        }
+    }
+}
+
+// Drives suspected-outage op types against the target extractors.
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsOperationAuditTests) {
+    Y_UNIT_TEST(AlterUserAttributesRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "SubDir");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestUserAttrs(runtime, ++txId, "/MyRoot", "SubDir",
+            AlterUserAttrs({{"attr1", "value1"}}));
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "AlterUserAttributes must resolve a path; TAlterUserAttributes.PathName is not "
+            "found by the generic reflection walk (it looks for a field literally named Name)");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterUserAttributes) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "SubDir"),
+                    "expected the target to be SubDir, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterUserAttributes must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterTableByPathIdRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tablePathId = DescribePath(runtime, "/MyRoot/Table1").GetPathId();
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // An id-addressed alter names no path at all: WorkingDir is a placeholder
+        // and TTableDescription.Name is unset.
+        TStringBuilder schema;
+        schema << "Id_Deprecated: " << tablePathId << Endl
+               << R"(Columns { Name: "added" Type: "Uint32" })";
+        TestAlterTable(runtime, ++txId, "not used", schema);
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "an alter addressed by path id must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "an id-addressed alter must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateWithUserAttributesRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // A create carries TAlterUserAttributes as a side payload with PathName
+        // unset; the target is still named by the create's own payload.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusAccepted}, AlterUserAttrs({{"attr1", "value1"}}));
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "CreateTable with user attributes must resolve a path, not lose its target to the "
+            "empty AlterUserAttributes.PathName");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTable) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateTable with user attributes must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterCdcStreamRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamDescription {
+                Name: "Stream1"
+                Mode: ECdcStreamModeKeysOnly
+                Format: ECdcStreamFormatProto
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // TAlterCdcStream{TableName,StreamName} has no field literally named Name, so the
+        // generic reflection walk cannot find it; the CDC extractor names it explicitly.
+        TestAlterCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            StreamName: "Stream1"
+            Disable {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "AlterCdcStream must resolve a path, not bump SchemeChangePathMissing: "
+            "counter went " << rejectedBefore << " -> " << rejectedAfter);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterCdcStream) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(e.Targets.size(), 1u);
+                UNIT_ASSERT_C(AnyPathContains(e, "Stream1"),
+                    "expected the target to be the changefeed, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterCdcStream must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(MoveIndexRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "Index1"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TMoveIndex.SrcPath/DstPath are index names relative to TablePath, not
+        // absolute paths, so TPath::Resolve used to fail and refuse the propose.
+        TestMoveIndex(runtime, ++txId, "/MyRoot/Table1", "Index1", "Index2", false);
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "MoveIndex must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpMoveIndex) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Index2"),
+                    "expected the target to be the new index name, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "MoveIndex must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(UpgradeSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Already safe: TUpgradeSubDomain.Name is a direct scalar Name field,
+        // found by the generic reflection walk. Kept as a regression guard.
+        TestUpgradeSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "UpgradeSubDomain must resolve a path");
+    }
+
+    Y_UNIT_TEST(TruncateTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TTruncateTable.TableName has no field literally named Name,
+        // so the generic reflection walk used to miss it and refuse the propose.
+        TestTruncateTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "TruncateTable must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpTruncateTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "TruncateTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateContinuousBackupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TCreateContinuousBackup.TableName has no field literally named Name,
+        // so the generic reflection walk used to miss it and refuse the propose.
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "CreateContinuousBackup must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateContinuousBackup) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateContinuousBackup must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(RestoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        // Restore targets an existing table (it restores INTO it), so the target must
+        // already exist for the propose to get past path resolution.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        // Fixed: TRestoreTask names its target TableName. Full completion needs a real
+        // backup fixture, so this checks propose-time resolution only.
+        TestRestore(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            TableDescription {
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            }
+            FSSettings {
+                BasePath: "/tmp"
+                Path: "restore"
+            }
+        )");
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "Restore must resolve a path");
+
+        // The op never completes here, so the row is still the propose-time one:
+        // its path is assertable, its PathId is not yet written back.
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpRestore) {
+                found = &e;
+            }
+        }
+        UNIT_ASSERT_C(found, "Restore must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u,
+            "Restore targets one table, got " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "Table1",
+            "the target must be the restored-into table, not its working directory");
+    }
+
+    Y_UNIT_TEST(AlterLoginRecordsAPath) {
+        // TAlterLogin's target is nested inside a oneof (e.g. CreateUser.User), never
+        // a top-level scalar Name/PathName/TableName field.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        const auto hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "alice", hashes.HashedPassword);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "AlterLogin must resolve a path");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterLogin) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterLogin must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u, "AlterLogin");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "",
+            "AlterLogin has no path-bearing target -- it must be attributed to the "
+            "database root itself, relative to which the root's own path is empty");
+        AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", *found);
+    }
+
+    // Exercises the Drop.Id branch of ResolveSchemeChangeTargets (Drop.Id set,
+    // Drop.Name/WorkingDir unset), as produced by replication's dst_remover.
+    Y_UNIT_TEST(DropByIdRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirToDropById");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/DirToDropById"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestForceDropUnsafe(runtime, ++txId, droppedLocalId);
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore,
+            "Drop.Id (Drop.Name/WorkingDir unset) must resolve a path by PathId");
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpForceDropUnsafe) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ForceDropUnsafe (Drop.Id) must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u, "ForceDropUnsafe");
+        UNIT_ASSERT_C(AnyPathContains(*found, "DirToDropById"),
+            "expected the target to be the dropped directory, got: " << AllTargetPaths(*found));
+        // The object is gone by finalize time, so assert against the identity captured
+        // before the drop rather than a live re-resolve.
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId,
+            "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId,
+            "recorded PathLocalId must match the dropped object's identity, not some other path");
+    }
+
+    Y_UNIT_TEST(CreatePQGroupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            TotalGroupCount: 1
+            PartitionPerTablet: 1
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreatePersQueueGroup) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "PQGroup1"),
+                    "expected the target to be PQGroup1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreatePQGroup must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSubDomain) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "USD1"),
+                    "expected the target to be USD1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSubDomain must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateRtmrVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateRtmrVolume(runtime, ++txId, "/MyRoot", R"(
+            Name: "rtmr1"
+            PartitionsCount: 0
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateRtmrVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "rtmr1"),
+                    "expected the target to be rtmr1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateRtmrVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateBlockStoreVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolume1");
+        auto& vc = *vdescr.MutableVolumeConfig();
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+        TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateBlockStoreVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BSVolume1"),
+                    "expected the target to be BSVolume1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateBlockStoreVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateKesusRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateKesus) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Kesus1"),
+                    "expected the target to be Kesus1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateKesus must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSolomonVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            PartitionCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSolomonVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Solomon1"),
+                    "expected the target to be Solomon1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSolomon must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateFileStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        descr.SetName("FileStore1");
+        auto& config = *descr.MutableConfig();
+        config.SetBlockSize(4096);
+        config.SetBlocksCount(4096);
+        config.SetFileSystemId("FileStore1");
+        config.SetCloudId("cloud");
+        config.SetFolderId("folder");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateFileStore) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "FileStore1"),
+                    "expected the target to be FileStore1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateFileStore must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateColumnStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            ColumnShardCount: 1
+            SchemaPresets {
+                Name: "default"
+                Schema {
+                    Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                    Columns { Name: "data" Type: "Utf8" }
+                    KeyColumnNames: "timestamp"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateColumnStore) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "OlapStore1"),
+                    "expected the target to be OlapStore1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateOlapStore must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateColumnTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateColumnTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ColumnTable1"),
+                    "expected the target to be ColumnTable1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateColumnTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateExtSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExtSubDomain1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateExtSubDomain) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ExtSubDomain1"),
+                    "expected the target to be ExtSubDomain1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateExtSubDomain must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateExternalTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource1"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalTable1"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/ExternalDataSource1"
+            Location: "/"
+            Columns { Name: "key" Type: "Uint64" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateExternalTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ExternalTable1"),
+                    "expected the target to be ExternalTable1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateExternalTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateExternalDataSourceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource2"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateExternalDataSource) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ExternalDataSource2"),
+                    "expected the target to be ExternalDataSource2, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateExternalDataSource must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateView(runtime, ++txId, "/MyRoot", R"(
+            Name: "View1"
+            QueryText: "Some query"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateView) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "View1"),
+                    "expected the target to be View1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateView must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateResourcePoolRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateResourcePool) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ResourcePool1"),
+                    "expected the target to be ResourcePool1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateResourcePool must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateBackupCollectionRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).EnableBackupService(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(
+            Name: "BackupCollection1"
+            ExplicitEntryList {
+                Entries {
+                    Type: ETypeTable
+                    Path: "/MyRoot/Table1"
+                }
+            }
+            Cluster: {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateBackupCollection) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BackupCollection1"),
+                    "expected the target to be BackupCollection1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateBackupCollection must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSysViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys", R"(
+            Name: "sys_view_1"
+            Type: EPartitionStats
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSysView
+                        && AnyPathContains(e, "sys_view_1")) {
+                found = true;
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSysView must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSecretRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot", R"(
+            Name: "Secret1"
+            Value: "value1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSecret) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Secret1"),
+                    "expected the target to be Secret1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSecret must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateStreamingQueryRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateStreamingQuery(runtime, ++txId, "/MyRoot", R"(
+            Name: "StreamingQuery1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateStreamingQuery) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "StreamingQuery1"),
+                    "expected the target to be StreamingQuery1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateStreamingQuery must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateTestShardSetRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTestShardSet(runtime, ++txId, "/MyRoot", CreateTestShardSetConfig("TestShardSet1"));
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTestShardSet) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "TestShardSet1"),
+                    "expected the target to be TestShardSet1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateTestShardSet must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateSequenceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSequence(runtime, ++txId, "/MyRoot", R"(
+            Name: "Sequence1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSequence) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Sequence1"),
+                    "expected the target to be Sequence1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateSequence must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateLockRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestLock(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateLock) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateLock must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterPersQueueGroupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            TotalGroupCount: 1
+            PartitionPerTablet: 1
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterPQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 20}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterPersQueueGroup) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "PQGroup1"),
+                    "expected the target to be PQGroup1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterPQGroup must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterBlockStoreVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolume1");
+        auto& vc = *vdescr.MutableVolumeConfig();
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription alterDescr;
+        alterDescr.SetName("BSVolume1");
+        auto& alterVc = *alterDescr.MutableVolumeConfig();
+        alterVc.SetVersion(1);
+        alterVc.AddPartitions()->SetBlockCount(16);
+        alterVc.AddPartitions()->SetBlockCount(16);
+        TestAlterBlockStoreVolume(runtime, ++txId, "/MyRoot", alterDescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterBlockStoreVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BSVolume1"),
+                    "expected the target to be BSVolume1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterBlockStoreVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterKesusRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterKesus(runtime, ++txId, "/MyRoot", R"(
+            Name: "Kesus1"
+            Config { self_check_period_millis: 3000 }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterKesus) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Kesus1"),
+                    "expected the target to be Kesus1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterKesus must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterExtSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "ExtSubDomain1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestAlterExtSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExtSubDomain1"
+            ExternalSchemeShard: true
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            StoragePools {
+                Name: "name_USER_0_kind_hdd-1"
+                Kind: "pool-kind-1"
+            }
+            StoragePools {
+                Name: "name_USER_0_kind_hdd-2"
+                Kind: "pool-kind-2"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "AlterExtSubDomain must resolve a path");
+    }
+
+    Y_UNIT_TEST(AlterSolomonVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            PartitionCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Alter with no actual partition/channel change: only that the outbox resolves
+        // the target matters here, not the status the op itself returns.
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        TestAlterSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            ChannelProfileId: 3
+        )", {NKikimrScheme::StatusInvalidParameter});
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "AlterSolomon must resolve a path");
+    }
+
+    Y_UNIT_TEST(AlterColumnStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            ColumnShardCount: 1
+            SchemaPresets {
+                Name: "default"
+                Schema {
+                    Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                    Columns { Name: "data" Type: "Utf8" }
+                    KeyColumnNames: "timestamp"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            AlterSchemaPresets {
+                Name: "default"
+                AlterSchema {
+                    AddColumns { Name: "comment" Type: "Utf8" }
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterColumnStore) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "OlapStore1"),
+                    "expected the target to be OlapStore1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterOlapStore must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterColumnTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            UpsertMultiColumnStatistics { Name: "s1" ColumnNames: "data" Types: COUNT_MIN_SKETCH }
+        )", {NKikimrScheme::StatusSuccess});
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterColumnTable) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ColumnTable1"),
+                    "expected the target to be ColumnTable1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterColumnTable must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterSequenceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSequence(runtime, ++txId, "/MyRoot", R"(Name: "Sequence1")");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterSequence(runtime, ++txId, "/MyRoot", R"(
+            Name: "Sequence1"
+            Increment: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterSequence) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Sequence1"),
+                    "expected the target to be Sequence1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterSequence must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterResourcePoolRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+            Properties {
+                Properties {
+                    key: "concurrent_query_limit",
+                    value: "20"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterResourcePool) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "ResourcePool1"),
+                    "expected the target to be ResourcePool1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterResourcePool must produce a scheme change record");
+    }
+
+    // The drop-family tests below capture the touched object's identity before the
+    // drop and assert against it, since the path no longer resolves afterwards.
+    Y_UNIT_TEST(DropTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTable must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Table1"),
+            "expected the target to be Table1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropPersQueueGroupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreatePQGroup(runtime, ++txId, "/MyRoot", R"(
+            Name: "PQGroup1"
+            TotalGroupCount: 1
+            PartitionPerTablet: 1
+            PQTabletConfig: {PartitionConfig { LifetimeSeconds : 10}}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/PQGroup1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropPQGroup(runtime, ++txId, "/MyRoot", "PQGroup1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropPersQueueGroup) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropPQGroup must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "PQGroup1"),
+            "expected the target to be PQGroup1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/USD1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSubDomain must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "USD1"),
+            "expected the target to be USD1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropKesusRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateKesus(runtime, ++txId, "/MyRoot", R"(Name: "Kesus1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Kesus1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropKesus(runtime, ++txId, "/MyRoot", "Kesus1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropKesus) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropKesus must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Kesus1"),
+            "expected the target to be Kesus1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSolomonVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSolomon(runtime, ++txId, "/MyRoot", R"(
+            Name: "Solomon1"
+            PartitionCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Solomon1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSolomon(runtime, ++txId, "/MyRoot", "Solomon1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSolomonVolume) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSolomon must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Solomon1"),
+            "expected the target to be Solomon1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(ForceDropSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/USD1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestForceDropSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpForceDropSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ForceDropSubDomain must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "USD1"),
+            "expected the target to be USD1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(ForceDropExtSubDomainRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "ExtSubDomain1")");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExtSubDomain1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestForceDropExtSubDomain(runtime, ++txId, "/MyRoot", "ExtSubDomain1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpForceDropExtSubDomain) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "ForceDropExtSubDomain must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ExtSubDomain1"),
+            "expected the target to be ExtSubDomain1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropFileStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        descr.SetName("FileStore1");
+        auto& config = *descr.MutableConfig();
+        config.SetBlockSize(4096);
+        config.SetBlocksCount(4096);
+        config.SetFileSystemId("FileStore1");
+        config.SetCloudId("cloud");
+        config.SetFolderId("folder");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/FileStore1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "FileStore1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropFileStore) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropFileStore must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "FileStore1"),
+            "expected the target to be FileStore1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropColumnStoreRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateOlapStore(runtime, ++txId, "/MyRoot", R"(
+            Name: "OlapStore1"
+            ColumnShardCount: 1
+            SchemaPresets {
+                Name: "default"
+                Schema {
+                    Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                    Columns { Name: "data" Type: "Utf8" }
+                    KeyColumnNames: "timestamp"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/OlapStore1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropOlapStore(runtime, ++txId, "/MyRoot", "OlapStore1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropColumnStore) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropOlapStore must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "OlapStore1"),
+            "expected the target to be OlapStore1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropColumnTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable1"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ColumnTable1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropColumnTable(runtime, ++txId, "/MyRoot", "ColumnTable1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropColumnTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropColumnTable must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ColumnTable1"),
+            "expected the target to be ColumnTable1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropExternalTableRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource1"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalTable1"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/ExternalDataSource1"
+            Location: "/"
+            Columns { Name: "key" Type: "Uint64" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExternalTable1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropExternalTable(runtime, ++txId, "/MyRoot", "ExternalTable1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropExternalTable) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropExternalTable must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ExternalTable1"),
+            "expected the target to be ExternalTable1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropExternalDataSourceRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).RunFakeConfigDispatcher(true));
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalDataSource1"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/my_bucket"
+            Auth { None {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/ExternalDataSource1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropExternalDataSource(runtime, ++txId, "/MyRoot", "ExternalDataSource1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropExternalDataSource) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropExternalDataSource must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ExternalDataSource1"),
+            "expected the target to be ExternalDataSource1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateView(runtime, ++txId, "/MyRoot", R"(
+            Name: "View1"
+            QueryText: "Some query"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/View1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropView(runtime, ++txId, "/MyRoot", "View1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropView) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropView must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "View1"),
+            "expected the target to be View1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropContinuousBackupRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1"));
+        const ui64 tableOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 tableLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropContinuousBackup) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropContinuousBackup must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Table1"),
+            "expected the target to be Table1, got: " << AllTargetPaths(*found));
+        // The target table is not itself dropped, but the pre-op-captured identity is
+        // used for symmetry with the other Drop* tests in this suite.
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, tableOwnerId, "recorded PathOwnerId must match Table1's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, tableLocalId, "recorded PathLocalId must match Table1's identity");
+    }
+
+    Y_UNIT_TEST(DropResourcePoolRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
+            Name: "ResourcePool1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropResourcePool) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropResourcePool must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "ResourcePool1"),
+            "expected the target to be ResourcePool1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropBackupCollectionRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).EnableBackupService(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(
+            Name: "BackupCollection1"
+            ExplicitEntryList {
+                Entries {
+                    Type: ETypeTable
+                    Path: "/MyRoot/Table1"
+                }
+            }
+            Cluster: {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.backups/collections/BackupCollection1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(Name: "BackupCollection1")");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropBackupCollection) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropBackupCollection must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "BackupCollection1"),
+            "expected the target to be BackupCollection1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSysViewRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys", R"(
+            Name: "sys_view_1"
+            Type: EPartitionStats
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/.sys/sys_view_1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSysView(runtime, ++txId, "/MyRoot/.sys", "sys_view_1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSysView) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSysView must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "sys_view_1"),
+            "expected the target to be sys_view_1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropSecretRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot", R"(
+            Name: "Secret1"
+            Value: "value1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Secret1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropSecret(runtime, ++txId, "/MyRoot", "Secret1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropSecret) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropSecret must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Secret1"),
+            "expected the target to be Secret1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropStreamingQueryRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateStreamingQuery(runtime, ++txId, "/MyRoot", R"(
+            Name: "StreamingQuery1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/StreamingQuery1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropStreamingQuery(runtime, ++txId, "/MyRoot", "StreamingQuery1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropStreamingQuery) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropStreamingQuery must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "StreamingQuery1"),
+            "expected the target to be StreamingQuery1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropTestShardSetRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTestShardSet(runtime, ++txId, "/MyRoot", CreateTestShardSetConfig("TestShardSet1"));
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/TestShardSet1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTestShardSet(runtime, ++txId, "/MyRoot", "TestShardSet1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTestShardSet) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTestShardSet must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "TestShardSet1"),
+            "expected the target to be TestShardSet1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropTableIndexRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+                Name: "Index1"
+                KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Table1/Index1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTableIndex(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            IndexName: "Index1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // TestDropTableIndex issues ESchemeOpDropIndex as the top-level OperationType;
+        // ESchemeOpDropTableIndex is a distinct, apparently-unissued enum value.
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropIndex) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTableIndex must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Index1"),
+            "expected the target to be Index1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped index's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped index's identity");
+    }
+
+    Y_UNIT_TEST(DropLockRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestLock(runtime, ++txId, "/MyRoot", "Table1");
+        const ui64 lockId = txId;
+        env.TestWaitNotification(runtime, txId);
+
+        TestUnlock(runtime, ++txId, lockId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropLock) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "DropLock (unlock) must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(RmDirRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirToRemove");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/DirToRemove"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestRmDir(runtime, ++txId, "/MyRoot", "DirToRemove");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpRmDir) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "RmDir must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "DirToRemove"),
+            "expected the target to be DirToRemove, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the removed dir's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the removed dir's identity");
+    }
+
+    Y_UNIT_TEST(ModifyACLRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestModifyACL(runtime, ++txId, "/MyRoot", "Table1", "", "bob@builtin");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpModifyACL) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "ModifyACL must produce a scheme change record");
+    }
+
+    // CreateIndexBuild is a top-level op whose target is InitiateIndexBuild.Table,
+    // an absolute path; an unresolved refusal used to crash the tablet on abort.
+    Y_UNIT_TEST(CreateIndexBuildRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint32" }
+            Columns { Name: "index" Type: "Uint32" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table1",
+            TBuildIndexConfig{"Index1", NKikimrSchemeOp::EIndexTypeGlobal, {"index"}, {}, {}});
+        const ui64 buildIndexId = txId;
+        env.TestWaitNotification(runtime, buildIndexId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateIndexBuild) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateIndexBuild must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CancelIndexBuildRecordsAPath) {
+        // Same fix as CreateIndexBuildRecordsAPath: CancelIndexBuild.TablePath
+        // is an absolute path, resolved directly now instead of refused.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint32" }
+            Columns { Name: "index" Type: "Uint32" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table1",
+            TBuildIndexConfig{"Index1", NKikimrSchemeOp::EIndexTypeGlobal, {"index"}, {}, {}});
+        const ui64 buildIndexId = txId;
+
+        TestCancelBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+        env.TestWaitNotification(runtime, buildIndexId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCancelIndexBuild) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Table1"),
+                    "expected the target to be Table1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CancelIndexBuild must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(CreateReplicationRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateReplication) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Replication1"),
+                    "expected the target to be Replication1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateReplication must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterReplicationRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            State { Paused {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterReplication) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Replication1"),
+                    "expected the target to be Replication1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterReplication must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(DropReplicationRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Replication1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropReplication(runtime, ++txId, "/MyRoot", "Replication1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropReplication) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropReplication must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Replication1"),
+            "expected the target to be Replication1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropReplicationCascadeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Replication1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropReplicationCascade(runtime, ++txId, "/MyRoot", "Replication1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropReplicationCascade) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropReplicationCascade must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Replication1"),
+            "expected the target to be Replication1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(CreateTransferRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateTransfer) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Transfer1"),
+                    "expected the target to be Transfer1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "CreateTransfer must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(AlterTransferRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            State { Paused {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTransfer) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "Transfer1"),
+                    "expected the target to be Transfer1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AlterTransfer must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(DropTransferRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Transfer1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTransfer(runtime, ++txId, "/MyRoot", "Transfer1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTransfer) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTransfer must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Transfer1"),
+            "expected the target to be Transfer1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(DropTransferCascadeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true).InitYdbDriver(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer1"
+            Config {
+              TransferSpecific {
+                Target {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathVersion = ExtractPathVersion(DescribePath(runtime, "/MyRoot/Transfer1"));
+        const ui64 droppedOwnerId = pathVersion.PathId.OwnerId;
+        const ui64 droppedLocalId = pathVersion.PathId.LocalPathId;
+
+        TestDropTransferCascade(runtime, ++txId, "/MyRoot", "Transfer1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropTransferCascade) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "DropTransferCascade must produce a scheme change record");
+        UNIT_ASSERT_C(AnyPathContains(*found, "Transfer1"),
+            "expected the target to be Transfer1, got: " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathOwnerId, droppedOwnerId, "recorded PathOwnerId must match the dropped object's owner");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->PathLocalId, droppedLocalId, "recorded PathLocalId must match the dropped object's identity");
+    }
+
+    Y_UNIT_TEST(BackupRecordsAPath) {
+        // Driving Backup to completion needs a real S3 endpoint, so this checks only
+        // propose-time path resolution, not the post-finalize resolve.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+
+        TestBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table1"
+            S3Settings {
+                Endpoint: "localhost:1"
+                Scheme: HTTP
+            }
+        )");
+
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "Backup must resolve a path");
+
+        // The op never completes here, so the row is still the propose-time one:
+        // its path is assertable, its PathId is not yet written back.
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpBackup) {
+                found = &e;
+            }
+        }
+        UNIT_ASSERT_C(found, "Backup must produce a scheme change record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 1u,
+            "Backup targets one table, got " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets[0].Path, "Table1",
+            "the target must be the backed-up table, not its working directory");
+    }
+    Y_UNIT_TEST(AssignBlockStoreVolumeRecordsAPath) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolume1");
+        auto& vc = *vdescr.MutableVolumeConfig();
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        TestCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        TestAssignBlockStoreVolume(runtime, ++txId, "/MyRoot", "BSVolume1", "Owner123");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecordsFromTable(runtime);
+        bool found = false;
+        for (const auto& e : entries) {
+            if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpAssignBlockStoreVolume) {
+                found = true;
+                UNIT_ASSERT_C(AnyPathContains(e, "BSVolume1"),
+                    "expected the target to be BSVolume1, got: " << AllTargetPaths(e));
+                AssertRecordedPathResolvesToTouchedObject(runtime, "/MyRoot", e);
+            }
+        }
+        UNIT_ASSERT_C(found, "AssignBlockStoreVolume must produce a scheme change record");
+    }
+
+    Y_UNIT_TEST(UpgradeSubDomainDecisionRecordsAPath) {
+        // Upgrading the domain blocks a live read here, so this asserts propose-time
+        // resolution via the rejection counter instead.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USD1")");
+        env.TestWaitNotification(runtime, txId);
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot", R"(
+            Name: "USD1"
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestUpgradeSubDomain(runtime, ++txId, "/MyRoot", "USD1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 rejectedBefore = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        TestUpgradeSubDomainDecision(runtime, ++txId, "/MyRoot", "USD1", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
+        env.TestWaitNotification(runtime, txId);
+        const ui64 rejectedAfter = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing");
+        UNIT_ASSERT_VALUES_EQUAL_C(rejectedAfter, rejectedBefore, "UpgradeSubDomainDecision must resolve a path");
+    }
+}
+
+namespace {
+
+// An alter addressed by path id ignores WorkingDir, so the op succeeds while the
+// outbox is left with a name under a directory that does not exist.
+ui64 ProposeAlterWithUnresolvableTarget(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+    TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+        Name: "Table1"
+        Columns { Name: "key"   Type: "Uint64" }
+        Columns { Name: "value" Type: "Utf8" }
+        KeyColumnNames: ["key"]
+    )");
+    env.TestWaitNotification(runtime, txId);
+
+    const ui64 tablePathId = DescribePath(runtime, "/MyRoot/Table1").GetPathId();
+
+    TStringBuilder schema;
+    schema << "Id_Deprecated: " << tablePathId << Endl
+           << R"(Name: "Table1")" << Endl
+           << R"(Columns { Name: "added" Type: "Uint32" })";
+    TestAlterTable(runtime, ++txId, "/MyRoot/NoSuchDir", schema);
+    env.TestWaitNotification(runtime, txId);
+
+    return tablePathId;
+}
+
+}  // anonymous namespace
+
+// Proves the tally can be non-zero at all, and that it survives a restart.
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsPathMissingTallyTests) {
+    Y_UNIT_TEST(TallyObservesAnUnresolvableTarget) {
+        // These two tests deliberately break the invariant the corpus mode asserts.
+        if (SchemeChangeCorpusEnabled()) {
+            return;
+        }
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        auto& tally = TSchemeChangePathMissingTally::Instance();
+        UNIT_ASSERT_VALUES_EQUAL_C(tally.Total(runtime), 0u, "nothing has failed to resolve yet");
+
+        ProposeAlterWithUnresolvableTarget(runtime, env, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(tally.Total(runtime), 1u,
+            "an alter whose target names a non-existent directory must be counted as unresolved");
+    }
+
+    Y_UNIT_TEST(TallySurvivesASchemeShardReboot) {
+        if (SchemeChangeCorpusEnabled()) {
+            return;
+        }
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        auto& tally = TSchemeChangePathMissingTally::Instance();
+        ProposeAlterWithUnresolvableTarget(runtime, env, txId);
+        UNIT_ASSERT_VALUES_EQUAL(tally.Total(runtime), 1u);
+
+        RebootSchemeShard(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetCumulativeCounter(runtime, "SchemeShard/SchemeChangePathMissing"), 0u,
+            "the raw tablet counter must have restarted at zero, otherwise this proves nothing");
+        UNIT_ASSERT_VALUES_EQUAL_C(tally.Total(runtime), 1u,
+            "the tally must carry the pre-reboot increment across the restart");
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h
@@ -3,7 +3,6 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/protos/schemeshard/scheme_change_records.pb.h>
 #include <ydb/core/protos/console_config.pb.h>
 #include <ydb/core/cms/console/console.h>
 
@@ -16,8 +15,193 @@ using namespace NKikimr;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
 
-// Mirrors NKikimrSchemeShard::TSchemeChangeTarget: SourcePaths is empty for a
-// plain create/alter/drop, non-empty for a move/rename or copy target.
+// Register with the default start position: the tail. A new subscriber sees
+// what happens next, never history.
+inline TEvSchemeShard::TEvRegisterSubscriberResult* RegisterSubscriber(
+    TTestActorRuntime& runtime, const TString& subscriberId,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvRegisterSubscriber>();
+    req->Record.SetSubscriberId(subscriberId);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvRegisterSubscriberResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(),
+        (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS,
+        "RegisterSubscriber failed: " << result->Record.GetReason());
+    return result;
+}
+
+// Register with the default start position, asserting a specific status.
+inline TEvSchemeShard::TEvRegisterSubscriberResult* RegisterSubscriberExpect(
+    TTestActorRuntime& runtime, const TString& subscriberId,
+    NKikimrSchemeShard::TSchemeChangeRecordsStatus::EStatus expected,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvRegisterSubscriber>();
+    req->Record.SetSubscriberId(subscriberId);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvRegisterSubscriberResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(), (ui32)expected,
+        "RegisterSubscriber status mismatch: " << result->Record.GetReason());
+    return result;
+}
+
+// Register at an explicit start position. `startOrder` is an exclusive cursor
+// (0 means "everything retained"); values below the retention floor are
+// clamped up and reported as STATE_LOST.
+inline TEvSchemeShard::TEvRegisterSubscriberResult* RegisterSubscriberAtExpect(
+    TTestActorRuntime& runtime, const TString& subscriberId, ui64 startOrder,
+    NKikimrSchemeShard::TSchemeChangeRecordsStatus::EStatus expected,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvRegisterSubscriber>();
+    req->Record.SetSubscriberId(subscriberId);
+    req->Record.SetStartOrder(startOrder);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvRegisterSubscriberResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(), (ui32)expected,
+        "RegisterSubscriberAt status mismatch: " << result->Record.GetReason());
+    return result;
+}
+
+inline TEvSchemeShard::TEvRegisterSubscriberResult* RegisterSubscriberAt(
+    TTestActorRuntime& runtime, const TString& subscriberId, ui64 startOrder,
+    TAutoPtr<IEventHandle>& handle)
+{
+    return RegisterSubscriberAtExpect(runtime, subscriberId, startOrder,
+        NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS, handle);
+}
+
+inline TEvSchemeShard::TEvFetchSchemeChangeRecordsResult* FetchSchemeChangeRecordsExpect(
+    TTestActorRuntime& runtime, const TString& subscriberId, ui64 afterOrder, ui32 maxCount,
+    NKikimrSchemeShard::TSchemeChangeRecordsStatus::EStatus expected,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvFetchSchemeChangeRecords>();
+    req->Record.SetSubscriberId(subscriberId);
+    req->Record.SetAfterOrder(afterOrder);
+    req->Record.SetMaxCount(maxCount);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvFetchSchemeChangeRecordsResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(), (ui32)expected,
+        "FetchSchemeChangeRecords status mismatch: " << result->Record.GetReason());
+    return result;
+}
+
+// Asserts STATUS_SUCCESS, so a failed fetch cannot pass an emptiness check
+// meant to verify a sweep happened.
+inline TEvSchemeShard::TEvFetchSchemeChangeRecordsResult* FetchSchemeChangeRecords(
+    TTestActorRuntime& runtime, const TString& subscriberId, ui64 afterOrder, ui32 maxCount,
+    TAutoPtr<IEventHandle>& handle)
+{
+    return FetchSchemeChangeRecordsExpect(runtime, subscriberId, afterOrder, maxCount,
+        NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS, handle);
+}
+
+inline TEvSchemeShard::TEvAckSchemeChangeRecordsResult* AckSchemeChangeRecords(
+    TTestActorRuntime& runtime, const TString& subscriberId, ui64 upToOrder,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvAckSchemeChangeRecords>();
+    req->Record.SetSubscriberId(subscriberId);
+    req->Record.SetUpToOrder(upToOrder);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvAckSchemeChangeRecordsResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(),
+        (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS,
+        "AckSchemeChangeRecords failed: " << result->Record.GetReason());
+    return result;
+}
+
+inline TEvSchemeShard::TEvForceAdvanceSubscriberResult* ForceAdvanceSubscriberExpect(
+    TTestActorRuntime& runtime, const TString& subscriberId,
+    NKikimrSchemeShard::TSchemeChangeRecordsStatus::EStatus expected,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvForceAdvanceSubscriber>();
+    req->Record.SetSubscriberId(subscriberId);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvForceAdvanceSubscriberResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(), (ui32)expected,
+        "ForceAdvanceSubscriber status mismatch: " << result->Record.GetReason());
+    return result;
+}
+
+inline TEvSchemeShard::TEvForceAdvanceSubscriberResult* ForceAdvanceSubscriber(
+    TTestActorRuntime& runtime, const TString& subscriberId,
+    TAutoPtr<IEventHandle>& handle)
+{
+    return ForceAdvanceSubscriberExpect(runtime, subscriberId,
+        NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS, handle);
+}
+
+inline TEvSchemeShard::TEvUnregisterSubscriberResult* UnregisterSubscriberExpect(
+    TTestActorRuntime& runtime, const TString& subscriberId,
+    NKikimrSchemeShard::TSchemeChangeRecordsStatus::EStatus expected,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvUnregisterSubscriber>();
+    req->Record.SetSubscriberId(subscriberId);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvUnregisterSubscriberResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(), (ui32)expected,
+        "UnregisterSubscriber status mismatch: " << result->Record.GetReason());
+    return result;
+}
+
+inline TEvSchemeShard::TEvUnregisterSubscriberResult* UnregisterSubscriber(
+    TTestActorRuntime& runtime, const TString& subscriberId,
+    TAutoPtr<IEventHandle>& handle)
+{
+    return UnregisterSubscriberExpect(runtime, subscriberId,
+        NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS, handle);
+}
+
+inline TEvSchemeShard::TEvFetchSchemeChangeRecordBodiesResult* FetchSchemeChangeRecordBodiesExpect(
+    TTestActorRuntime& runtime, const TString& subscriberId, const TVector<ui64>& orders,
+    NKikimrSchemeShard::TSchemeChangeRecordsStatus::EStatus expected,
+    TAutoPtr<IEventHandle>& handle)
+{
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvFetchSchemeChangeRecordBodies>();
+    req->Record.SetSubscriberId(subscriberId);
+    for (ui64 order : orders) {
+        req->Record.AddOrders(order);
+    }
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvFetchSchemeChangeRecordBodiesResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C((ui32)result->Record.GetStatus(), (ui32)expected,
+        "FetchSchemeChangeRecordBodies status mismatch: " << result->Record.GetReason());
+    return result;
+}
+
+inline TEvSchemeShard::TEvFetchSchemeChangeRecordBodiesResult* FetchSchemeChangeRecordBodies(
+    TTestActorRuntime& runtime, const TString& subscriberId, const TVector<ui64>& orders,
+    TAutoPtr<IEventHandle>& handle)
+{
+    return FetchSchemeChangeRecordBodiesExpect(runtime, subscriberId, orders,
+        NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS, handle);
+}
+
+
+// Mirrors NKikimrSchemeShard::TSchemeChangeTarget: Path is the target's
+// identity after the change, SourcePaths is empty for a plain create/alter/
+// drop and non-empty for a move/rename or copy target.
 struct TTestSchemeChangeTarget {
     TString Path;
     TVector<TString> SourcePaths;
@@ -69,8 +253,13 @@ inline TString AllTargetPaths(const TSchemeChangeRecordEntry& entry) {
     return JoinSeq(",", paths);
 }
 
-// Asserts the recorded path resolves, in the live scheme, to the very object
-// the operation touched; `entry` must already carry a resolved PathId.
+// The assertion that would have caught the TMoveIndex bug: not "the recorded
+// string looks plausible", but "the recorded path resolves, in the live
+// scheme, to the very object the operation touched". `root` is the database
+// root (e.g. "/MyRoot"); `entry` must carry a resolved PathOwnerId/PathLocalId
+// (i.e. this runs after the op has completed, not mid-flight). Fails loudly
+// if the database-relative Path does not resolve, or resolves to a different
+// object than the one the extractor captured.
 inline void AssertRecordedPathResolvesToTouchedObject(
     TTestActorRuntime& runtime, const TString& root, const TSchemeChangeRecordEntry& entry, size_t targetIdx = 0)
 {
@@ -106,8 +295,108 @@ struct TSchemeChangeRecordsReadResult {
     ui64 ClosedThroughPlanStep = 0;
 };
 
-// Reads tables 141 + 143 directly, returning every row including unfinalised
-// ones. Select lists stay alphabetical: SelectRange orders columns by name.
+inline TSchemeChangeRecordsReadResult ReadSchemeChangeRecordsFull(
+    TTestActorRuntime& runtime)
+{
+    const TString tempSubId = "__internal_read_sub__";
+
+    // Register at 0, not at the tail: this helper reads the log's whole
+    // retained contents. If the floor has advanced, 0 clamps up to it and
+    // reports LOST, which correctly reads everything still retained.
+    TAutoPtr<IEventHandle> regHandle;
+    RegisterSubscriberAt(runtime, tempSubId, 0, regHandle);
+
+    // Step 1: Fetch metadata only (body is no longer returned by Fetch).
+    TAutoPtr<IEventHandle> fetchHandle;
+    auto* fetch = FetchSchemeChangeRecords(runtime, tempSubId, 0, 1000, fetchHandle);
+
+    TSchemeChangeRecordsReadResult result;
+    result.ClosedThroughPlanStep = fetch->Record.GetClosedThroughPlanStep();
+
+    TVector<ui64> ordersWithBody;
+    for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+        const auto& proto = fetch->Record.GetEntries(i);
+        TSchemeChangeRecordEntry entry;
+        entry.Order = proto.GetOrder();
+        entry.TxId = proto.GetTxId();
+        entry.PlanStep = proto.GetPlanStep();
+        entry.OperationType = proto.GetOperationType();
+        entry.PathOwnerId = proto.GetPathId().GetOwnerId();
+        entry.PathLocalId = proto.GetPathId().GetLocalId();
+        for (const auto& t : proto.GetTargets()) {
+            TTestSchemeChangeTarget target;
+            target.Path = t.GetPath();
+            for (const auto& src : t.GetSourcePaths()) {
+                target.SourcePaths.push_back(src);
+            }
+            entry.Targets.push_back(std::move(target));
+        }
+        entry.ObjectType = proto.GetObjectType();
+        entry.Status = proto.GetStatus();
+        entry.UserSID = proto.GetUserSID();
+        entry.SchemaVersion = proto.GetSchemaVersion();
+        entry.CompletedAtUs = proto.GetCompletedAtUs();
+        entry.PositionKind = (ui32)proto.GetPositionKind();
+        for (const auto& field : proto.GetRedactedFields()) {
+            entry.RedactedFields.push_back(field);
+        }
+        if (proto.GetBodySizeBytes() > 0) {
+            ordersWithBody.push_back(proto.GetOrder());
+        }
+        result.Entries.push_back(std::move(entry));
+    }
+
+    // Step 2: Fetch bodies for entries with non-zero BodySizeBytes; merge back.
+    if (!ordersWithBody.empty()) {
+        TAutoPtr<IEventHandle> bodiesHandle;
+        auto* bodies = FetchSchemeChangeRecordBodies(runtime, tempSubId, ordersWithBody, bodiesHandle);
+        THashMap<ui64, TString> bodyByOrder;
+        THashMap<ui64, TString> descByOrder;
+        for (size_t i = 0; i < static_cast<size_t>(bodies->Record.EntriesSize()); ++i) {
+            const auto& b = bodies->Record.GetEntries(i);
+            bodyByOrder.emplace(b.GetOrder(), b.GetBody());
+            descByOrder.emplace(b.GetOrder(), b.GetDescription());
+        }
+        for (auto& entry : result.Entries) {
+            auto it = bodyByOrder.find(entry.Order);
+            if (it != bodyByOrder.end() && !it->second.empty()) {
+                Y_ABORT_UNLESS(entry.Body.ParseFromString(it->second));
+            }
+            auto dIt = descByOrder.find(entry.Order);
+            if (dIt != descByOrder.end()) {
+                entry.Description = dIt->second;
+            }
+        }
+    }
+
+    // Unregister temp subscriber
+    TAutoPtr<IEventHandle> unregHandle;
+    UnregisterSubscriber(runtime, tempSubId, unregHandle);
+
+    return result;
+}
+
+inline TVector<TSchemeChangeRecordEntry> ReadSchemeChangeRecords(
+    TTestActorRuntime& runtime)
+{
+    return ReadSchemeChangeRecordsFull(runtime).Entries;
+}
+
+// Reads the durable rows of tables 141 + 143 directly, with no protocol
+// involvement: no subscriber is registered, so unlike ReadSchemeChangeRecordsFull
+// this does not perturb GetMinSubscriberOrder(). Asserts what was persisted
+// rather than what the fetch handler chose to project.
+//
+// NOT equivalent to the protocol reader in one respect: this returns every row,
+// including reserved-but-unfinalised ones (CompletedAtUs == 0), where a fetch
+// stops at that barrier. Fine for a test that drives an op to completion and
+// then locates its record; wrong for anything asserting a record COUNT, an
+// emptiness, or barrier visibility -- use the protocol reader for those.
+//
+// SelectRange returns the selected columns ordered by column NAME, not by the
+// order they appear in the select list, and reading the wrong index yields an
+// empty value rather than an error. Both lists below are kept alphabetical so
+// the two orderings coincide.
 inline TVector<TSchemeChangeRecordEntry> ReadSchemeChangeRecordsFromTable(
     TTestActorRuntime& runtime)
 {
@@ -195,6 +484,47 @@ inline TVector<TSchemeChangeRecordEntry> ReadSchemeChangeRecordsFromTable(
     }
 
     return entries;
+}
+
+// Cursor-independent physical-row oracle: returns the subset of `orders`
+// still present on disk, gated only on subscriber existence. Pass an existing
+// subscriber; a temp one would itself perturb GetMinSubscriberOrder().
+inline TVector<ui64> ProbeRecordOrdersPresent(
+    TTestActorRuntime& runtime, const TString& subscriberId, const TVector<ui64>& orders)
+{
+    TAutoPtr<IEventHandle> handle;
+    auto* bodies = FetchSchemeChangeRecordBodies(runtime, subscriberId, orders, handle);
+    TVector<ui64> present;
+    for (size_t i = 0; i < static_cast<size_t>(bodies->Record.EntriesSize()); ++i) {
+        present.push_back(bodies->Record.GetEntries(i).GetOrder());
+    }
+    Sort(present);
+    return present;
+}
+
+// SchemeShard config knobs applied in one config notification. Unset members
+// keep the caller's previous value instead of reverting to the default.
+struct TSchemeShardConfigOverrides {
+    TMaybe<ui64> MaxSchemeChangeRecords;
+    TMaybe<ui64> SchemeChangeSubscriberStaleTtlSeconds;
+    TMaybe<bool> RedactSensitiveSchemeChangeFields;
+};
+
+inline void ApplySchemeShardConfig(
+    TTestActorRuntime& runtime, const TSchemeShardConfigOverrides& overrides)
+{
+    auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+    auto& cfg = *request->Record.MutableConfig()->MutableSchemeShardConfig();
+    if (overrides.MaxSchemeChangeRecords) {
+        cfg.SetMaxSchemeChangeRecords(*overrides.MaxSchemeChangeRecords);
+    }
+    if (overrides.SchemeChangeSubscriberStaleTtlSeconds) {
+        cfg.SetSchemeChangeSubscriberStaleTtlSeconds(*overrides.SchemeChangeSubscriberStaleTtlSeconds);
+    }
+    if (overrides.RedactSensitiveSchemeChangeFields) {
+        cfg.SetRedactSensitiveSchemeChangeFields(*overrides.RedactSensitiveSchemeChangeFields);
+    }
+    SetConfig(runtime, TTestTxConfig::SchemeShard, std::move(request));
 }
 
 } // namespace NSchemeChangeRecordTestHelpers

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/schemeshard/scheme_change_records.pb.h>
+#include <ydb/core/protos/console_config.pb.h>
+#include <ydb/core/cms/console/console.h>
+
+#include <util/string/join.h>
+#include <util/string/split.h>
+
+namespace NSchemeChangeRecordTestHelpers {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+// Mirrors NKikimrSchemeShard::TSchemeChangeTarget: SourcePaths is empty for a
+// plain create/alter/drop, non-empty for a move/rename or copy target.
+struct TTestSchemeChangeTarget {
+    TString Path;
+    TVector<TString> SourcePaths;
+};
+
+struct TSchemeChangeRecordEntry {
+    ui64 Order = 0;
+    ui64 TxId = 0;
+    ui64 PlanStep = 0;
+    ui32 OperationType = 0;
+    ui64 PathOwnerId = 0;
+    ui64 PathLocalId = 0;
+    TVector<TTestSchemeChangeTarget> Targets;
+    ui32 ObjectType = 0;
+    ui32 Status = 0;
+    TString UserSID;
+    ui64 SchemaVersion = 0;
+    ui64 CompletedAtUs = 0;
+    ui32 PositionKind = 0;
+    NKikimrSchemeOp::TModifyScheme Body;
+    // Resolved description captured when the record was written; empty if none.
+    TString Description;
+    // Field paths cleared by redaction; empty when nothing was cleared.
+    TVector<TString> RedactedFields;
+};
+
+// True if any of the entry's N target paths contains the given substring.
+// For single-target test fixtures, where exactly one target is expected.
+inline bool AnyPathContains(const TSchemeChangeRecordEntry& entry, const TString& substr) {
+    for (const auto& target : entry.Targets) {
+        if (target.Path.Contains(substr)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// True if the entry has exactly one target whose Path equals the given value.
+inline bool SinglePathEquals(const TSchemeChangeRecordEntry& entry, const TString& value) {
+    return entry.Targets.size() == 1 && entry.Targets[0].Path == value;
+}
+
+// Comma-joined target paths, for diagnostic messages.
+inline TString AllTargetPaths(const TSchemeChangeRecordEntry& entry) {
+    TVector<TString> paths;
+    for (const auto& target : entry.Targets) {
+        paths.push_back(target.Path);
+    }
+    return JoinSeq(",", paths);
+}
+
+// Asserts the recorded path resolves, in the live scheme, to the very object
+// the operation touched; `entry` must already carry a resolved PathId.
+inline void AssertRecordedPathResolvesToTouchedObject(
+    TTestActorRuntime& runtime, const TString& root, const TSchemeChangeRecordEntry& entry, size_t targetIdx = 0)
+{
+    UNIT_ASSERT_C(targetIdx < entry.Targets.size(),
+        "targetIdx " << targetIdx << " out of range, entry has " << entry.Targets.size() << " targets");
+    const TString& relPath = entry.Targets[targetIdx].Path;
+    const TString absPath = relPath.empty() ? root : (root + "/" + relPath);
+
+    // showPrivate: a changefeed lives under a table, which is not a common-sense
+    // path, so the default describe refuses it before any identity check runs.
+    auto describe = DescribePath(runtime, absPath, false, false, true);
+    UNIT_ASSERT_C(describe.GetStatus() == NKikimrScheme::StatusSuccess,
+        "recorded path \"" << relPath << "\" (absolute: \"" << absPath << "\") does not resolve "
+        "in the live scheme -- a bare/approximate path must fail this check, not pass it");
+
+    const ui64 resolvedOwnerId = describe.GetPathDescription().GetSelf().GetSchemeshardId();
+    const ui64 resolvedLocalId = describe.GetPathDescription().GetSelf().GetPathId();
+    UNIT_ASSERT_C(targetIdx != 0 || (entry.PathOwnerId != 0 || entry.PathLocalId != 0),
+        "entry has no resolved PathId to compare against -- was it read before FinalizeSchemeChangeRecord ran?");
+    if (targetIdx == 0) {
+        UNIT_ASSERT_VALUES_EQUAL_C(resolvedOwnerId, entry.PathOwnerId,
+            "recorded path \"" << relPath << "\" resolves to a different object's owner than "
+            "the one the operation touched (PathOwnerId mismatch)");
+        UNIT_ASSERT_VALUES_EQUAL_C(resolvedLocalId, entry.PathLocalId,
+            "recorded path \"" << relPath << "\" resolves to a different object than "
+            "the one the operation touched (PathLocalId mismatch): expected "
+            << entry.PathLocalId << ", resolved to " << resolvedLocalId);
+    }
+}
+
+struct TSchemeChangeRecordsReadResult {
+    TVector<TSchemeChangeRecordEntry> Entries;
+    ui64 ClosedThroughPlanStep = 0;
+};
+
+// Reads tables 141 + 143 directly, returning every row including unfinalised
+// ones. Select lists stay alphabetical: SelectRange orders columns by name.
+inline TVector<TSchemeChangeRecordEntry> ReadSchemeChangeRecordsFromTable(
+    TTestActorRuntime& runtime)
+{
+    const TString recordsQuery = R"___(
+        (
+            (let range '('('Order (Null) (Void))))
+            (let select '('BodySizeBytes 'CompletedAtUs 'Description 'ObjectType 'OperationType 'Order 'Path 'PathLocalId 'PathOwnerId 'PlanStep 'PositionKind 'RedactedFields 'SchemaVersion 'Status 'TxId 'UserSID))
+            (let result (SelectRange 'SchemeChangeRecords range select '()))
+            (return (AsList (SetResult 'R result)))
+        )
+    )___";
+    auto recordsResult = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, recordsQuery);
+
+    auto strOf = [](const NKikimrMiniKQL::TValue& v) -> TString {
+        return v.HasBytes() ? TString(v.GetBytes()) : TString(v.GetText());
+    };
+
+    TVector<TSchemeChangeRecordEntry> entries;
+    const auto& list = recordsResult.GetValue().GetStruct(0).GetOptional().GetStruct(0);
+    for (size_t i = 0; i < list.ListSize(); ++i) {
+        const auto& row = list.GetList(i);
+        TSchemeChangeRecordEntry entry;
+        entry.CompletedAtUs  = row.GetStruct(1).GetOptional().GetUint64();
+        entry.Description    = strOf(row.GetStruct(2).GetOptional());
+        entry.ObjectType     = row.GetStruct(3).GetOptional().GetUint32();
+        // "OperationType" sorts before "Order" ('p' < 'r'), so these two are
+        // not in the order they read.
+        entry.OperationType  = row.GetStruct(4).GetOptional().GetUint32();
+        entry.Order          = row.GetStruct(5).GetOptional().GetUint64();
+
+        NKikimrSchemeShard::TSchemeChangeRecordTargets targets;
+        const TString rawTargets = strOf(row.GetStruct(6).GetOptional());
+        if (!rawTargets.empty()) {
+            UNIT_ASSERT_C(targets.ParseFromString(rawTargets),
+                "SchemeChangeRecords::Path did not parse as TSchemeChangeRecordTargets");
+        }
+        for (const auto& t : targets.GetTargets()) {
+            TTestSchemeChangeTarget target;
+            target.Path = t.GetPath();
+            for (const auto& src : t.GetSourcePaths()) {
+                target.SourcePaths.push_back(src);
+            }
+            entry.Targets.push_back(std::move(target));
+        }
+
+        entry.PathLocalId    = row.GetStruct(7).GetOptional().GetUint64();
+        entry.PathOwnerId    = row.GetStruct(8).GetOptional().GetUint64();
+        entry.PlanStep       = row.GetStruct(9).GetOptional().GetUint64();
+        entry.PositionKind   = row.GetStruct(10).GetOptional().GetUint32();
+        const TString redacted = strOf(row.GetStruct(11).GetOptional());
+        if (!redacted.empty()) {
+            for (const auto& f : StringSplitter(redacted).Split('\n').SkipEmpty()) {
+                entry.RedactedFields.push_back(TString(f.Token()));
+            }
+        }
+        entry.SchemaVersion  = row.GetStruct(12).GetOptional().GetUint64();
+        entry.Status         = row.GetStruct(13).GetOptional().GetUint32();
+        entry.TxId           = row.GetStruct(14).GetOptional().GetUint64();
+        entry.UserSID        = strOf(row.GetStruct(15).GetOptional());
+        entries.push_back(std::move(entry));
+    }
+
+    // Bodies live in table 143, keyed by the same Order.
+    const TString bodiesQuery = R"___(
+        (
+            (let range '('('Order (Null) (Void))))
+            (let select '('Body 'Order))
+            (let result (SelectRange 'SchemeChangeRecordDetails range select '()))
+            (return (AsList (SetResult 'R result)))
+        )
+    )___";
+    auto bodiesResult = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, bodiesQuery);
+    THashMap<ui64, TString> bodyByOrder;
+    const auto& bodyList = bodiesResult.GetValue().GetStruct(0).GetOptional().GetStruct(0);
+    for (size_t i = 0; i < bodyList.ListSize(); ++i) {
+        const auto& row = bodyList.GetList(i);
+        bodyByOrder.emplace(row.GetStruct(1).GetOptional().GetUint64(),
+                            strOf(row.GetStruct(0).GetOptional()));
+    }
+    for (auto& entry : entries) {
+        auto it = bodyByOrder.find(entry.Order);
+        if (it != bodyByOrder.end() && !it->second.empty()) {
+            Y_ABORT_UNLESS(entry.Body.ParseFromString(it->second));
+        }
+    }
+
+    return entries;
+}
+
+} // namespace NSchemeChangeRecordTestHelpers

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_protocol.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_protocol.cpp
@@ -1,0 +1,283 @@
+#include "ut_scheme_change_records_helpers.h"
+
+#include <util/string/printf.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+using namespace NSchemeChangeRecordTestHelpers;
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsProtocolTests) {
+    Y_UNIT_TEST(RegisterSubscriberCreatesEmptyCursor) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> handle;
+        auto result = RegisterSubscriber(runtime, "test:sub:1", handle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)result->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetCurrentOrder(), 0u);
+    }
+
+    Y_UNIT_TEST(RegisterSubscriberIdempotent) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> h1;
+        auto r1 = RegisterSubscriber(runtime, "test:sub:1", h1);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)r1->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        TAutoPtr<IEventHandle> h2;
+        auto r2 = RegisterSubscriber(runtime, "test:sub:1", h2);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)r2->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+    }
+
+    Y_UNIT_TEST(FetchReturnsEntriesAfterCursor) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub:1", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "test:sub:1", 0, 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(fetch->Record.EntriesSize() >= 2);
+    }
+
+    Y_UNIT_TEST(FetchRespectsMaxCount) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub:1", regHandle);
+
+        for (int i = 1; i <= 5; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "T%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "test:sub:1", 0, 2, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(fetch->Record.EntriesSize(), 2);
+        UNIT_ASSERT(fetch->Record.GetHasMore());
+    }
+
+    Y_UNIT_TEST(AckAdvancesCursor) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub:1", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetch1Handle;
+        auto fetch1 = FetchSchemeChangeRecords(runtime, "test:sub:1", 0, 100, fetch1Handle);
+        UNIT_ASSERT(fetch1->Record.EntriesSize() >= 2);
+
+        ui64 firstOrder = fetch1->Record.GetEntries(0).GetOrder();
+        TAutoPtr<IEventHandle> ackHandle;
+        auto ack = AckSchemeChangeRecords(runtime, "test:sub:1", firstOrder, ackHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)ack->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ack->Record.GetLastAckedOrder(), firstOrder);
+
+        TAutoPtr<IEventHandle> fetch2Handle;
+        auto fetch2 = FetchSchemeChangeRecords(runtime, "test:sub:1", firstOrder, 100, fetch2Handle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch2->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(fetch2->Record.EntriesSize() < fetch1->Record.EntriesSize());
+    }
+
+    Y_UNIT_TEST(FetchForUnknownSubscriberReturnsError) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        FetchSchemeChangeRecordsExpect(runtime, "nonexistent:sub", 0, 100,
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED, fetchHandle);
+    }
+
+    Y_UNIT_TEST(MultipleSubscribersIndependentCursors) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> reg1Handle, reg2Handle;
+        RegisterSubscriber(runtime, "sub1", reg1Handle);
+        RegisterSubscriber(runtime, "sub2", reg2Handle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetch1Handle, fetch2Handle;
+        auto fetch1 = FetchSchemeChangeRecords(runtime, "sub1", 0, 100, fetch1Handle);
+        auto fetch2 = FetchSchemeChangeRecords(runtime, "sub2", 0, 100, fetch2Handle);
+
+        UNIT_ASSERT_VALUES_EQUAL(fetch1->Record.EntriesSize(), fetch2->Record.EntriesSize());
+
+        ui64 lastOrder = fetch1->Record.EntriesSize() > 0
+            ? fetch1->Record.GetEntries(fetch1->Record.EntriesSize() - 1).GetOrder()
+            : 0;
+        ui64 firstOrder = fetch1->Record.GetEntries(0).GetOrder();
+        TAutoPtr<IEventHandle> ack1Handle, ack2Handle;
+        AckSchemeChangeRecords(runtime, "sub1", lastOrder, ack1Handle);
+        AckSchemeChangeRecords(runtime, "sub2", firstOrder, ack2Handle);
+
+        TAutoPtr<IEventHandle> fetch1bHandle, fetch2bHandle;
+        auto fetch1b = FetchSchemeChangeRecords(runtime, "sub1", lastOrder, 100, fetch1bHandle);
+        auto fetch2b = FetchSchemeChangeRecords(runtime, "sub2", firstOrder, 100, fetch2bHandle);
+        UNIT_ASSERT_VALUES_EQUAL(fetch1b->Record.EntriesSize(), 0);
+        UNIT_ASSERT(fetch2b->Record.EntriesSize() > 0);
+    }
+
+    Y_UNIT_TEST(UnregisterSubscriberRemovesSubscriber) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub:1", regHandle);
+
+        TAutoPtr<IEventHandle> unregHandle;
+        UnregisterSubscriber(runtime, "test:sub:1", unregHandle);
+
+        // Fetch should fail -- subscriber no longer exists
+        TAutoPtr<IEventHandle> fetchHandle;
+        FetchSchemeChangeRecordsExpect(runtime, "test:sub:1", 0, 100,
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED, fetchHandle);
+    }
+
+    Y_UNIT_TEST(UnregisterLastSubscriberStopsRecordCreation) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "test:sub:1", regHandle);
+
+        // Create T1 with subscriber -- record expected
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "test:sub:1", 0, 100, fetchHandle);
+        UNIT_ASSERT(fetch->Record.EntriesSize() >= 1);
+
+        // T1's order, needed for the physical-row probe below.
+        ui64 t1Order = 0;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            const auto& targets = fetch->Record.GetEntries(i).GetTargets();
+            if (targets.size() == 1 && targets[0].GetPath() == "T1") {
+                t1Order = fetch->Record.GetEntries(i).GetOrder();
+            }
+        }
+        UNIT_ASSERT_C(t1Order != 0, "precondition: T1's record must be present before unregister");
+
+        // Positive companion, via the cursor-independent physical-row probe
+        // (point lookup by order, gated only on subscriber existence -- see
+        // RecordIsWrittenAtProposeTime for the same technique): T1's row must
+        // actually exist on disk before the last subscriber unregisters.
+        {
+            TAutoPtr<IEventHandle> bodiesHandle;
+            auto* bodies = FetchSchemeChangeRecordBodies(runtime, "test:sub:1", {t1Order}, bodiesHandle);
+            UNIT_ASSERT_VALUES_EQUAL_C(bodies->Record.EntriesSize(), 1,
+                "precondition: T1's row must physically exist before unregister");
+        }
+
+        // Unregister
+        TAutoPtr<IEventHandle> unregHandle;
+        UnregisterSubscriber(runtime, "test:sub:1", unregHandle);
+
+        // Create T2 without subscriber -- no record expected
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Probe again with a throwaway subscriber. A cursor-based fetch
+        // cannot tell "swept" from "outside a fresh cursor's window" here: a
+        // newly registered subscriber starts at the tail regardless of what
+        // was deleted, so it would prove nothing either way. The physical-row
+        // probe is a direct point lookup by order, independent of any cursor.
+        TAutoPtr<IEventHandle> probeRegHandle;
+        RegisterSubscriberAt(runtime, "probe:sub", 0, probeRegHandle);
+
+        // Unregistering the last subscriber drops all retained records: with
+        // no subscribers, GetMinSubscriberOrder() collapses to
+        // NextSchemeChangeOrder and inline cleanup deletes everything.
+        TAutoPtr<IEventHandle> afterHandle;
+        auto* after = FetchSchemeChangeRecordBodies(runtime, "probe:sub", {t1Order}, afterHandle);
+        UNIT_ASSERT_VALUES_EQUAL_C(after->Record.EntriesSize(), 0,
+            "T1's row must be physically gone once the last subscriber unregisters");
+
+        // T2 never got a chance to be recorded in the first place (no
+        // subscriber existed when it was created), so its order was never
+        // even allocated; confirm the outbox produced nothing for it via a
+        // wide fetch from a subscriber positioned at the very start.
+        TAutoPtr<IEventHandle> afterFetchHandle;
+        auto* afterFetch = FetchSchemeChangeRecords(runtime, "probe:sub", 0, 100, afterFetchHandle);
+        for (size_t i = 0; i < static_cast<size_t>(afterFetch->Record.EntriesSize()); ++i) {
+            const auto& targets = afterFetch->Record.GetEntries(i).GetTargets();
+            UNIT_ASSERT_C(!(targets.size() == 1 && targets[0].GetPath() == "T2"),
+                "T2 record must not exist (created after last subscriber unregistered)");
+        }
+    }
+
+    Y_UNIT_TEST(UnregisterNonexistentSubscriberReturnsError) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> unregHandle;
+        UnregisterSubscriberExpect(runtime, "nonexistent:sub",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED, unregHandle);
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_subscriber.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_subscriber.cpp
@@ -3187,4 +3187,53 @@ Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSubscriberTests) {
             "every acked row through order 7 must eventually be deleted; "
             << after.size() << " still present");
     }
+
+    Y_UNIT_TEST(OutboxCountersAreExported) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribers"), 0u,
+            "no subscriber registered yet");
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "w3:sub", regHandle);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribers"), 1u,
+            "the registered subscriber must be visible to monitoring");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeOutboxDepth"), 0u,
+            "nothing emitted yet, so the backlog must read zero");
+
+        for (int i = 0; i < 3; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "t%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeOutboxDepth"), 3u,
+            "three unacked records must show as a backlog of three");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribersLost"), 0u,
+            "nobody has lost anything");
+        UNIT_ASSERT_C(
+            GetCumulativeCounter(runtime, "SchemeShard/SchemeChangeDescriptionBytes") > 0,
+            "the redo cost of captured descriptions must be attributed somewhere");
+
+        // Draining the backlog must bring the gauge back down.
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "w3:sub", 3, ackHandle);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeOutboxDepth"), 0u,
+            "after acking everything the backlog must return to zero");
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_subscriber.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_subscriber.cpp
@@ -1,0 +1,3190 @@
+#include "ut_scheme_change_records_helpers.h"
+
+#include <ydb/core/tx/schemeshard/ut_helpers/mon_helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
+
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
+
+#include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/tx/datashard/datashard.h>
+
+#include <util/string/printf.h>
+#include <util/string/join.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+using namespace NSchemeChangeRecordTestHelpers;
+using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecords;
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsSubscriberTests) {
+    Y_UNIT_TEST(MockBackupSubscriberEndToEnd) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "backup:collection:1", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table1"
+            Columns { Name: "extra" Type: "Uint32" }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table1");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "backup:collection:1", 0, 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        // Should have at least 4 entries (CREATE, ALTER, CREATE, DROP)
+        UNIT_ASSERT_C(fetch->Record.EntriesSize() >= 4,
+            "Expected >= 4 entries, got " << fetch->Record.EntriesSize());
+
+        // Verify order is monotonic
+        for (int i = 1; i < (int)fetch->Record.EntriesSize(); ++i) {
+            UNIT_ASSERT(fetch->Record.GetEntries(i).GetOrder() >
+                        fetch->Record.GetEntries(i-1).GetOrder());
+        }
+
+        // ACK all
+        ui64 lastOrder = fetch->Record.EntriesSize() > 0
+            ? fetch->Record.GetEntries(fetch->Record.EntriesSize() - 1).GetOrder()
+            : 0;
+        TAutoPtr<IEventHandle> ackHandle;
+        auto ack = AckSchemeChangeRecords(runtime, "backup:collection:1", lastOrder, ackHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)ack->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        // Fetch again - should be empty
+        TAutoPtr<IEventHandle> fetch2Handle;
+        auto fetch2 = FetchSchemeChangeRecords(runtime, "backup:collection:1", lastOrder, 100, fetch2Handle);
+        UNIT_ASSERT_VALUES_EQUAL(fetch2->Record.EntriesSize(), 0);
+        UNIT_ASSERT(!fetch2->Record.GetHasMore());
+    }
+
+    Y_UNIT_TEST(MockBackupSubscriberPaginatedFetch) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "backup:sub", regHandle);
+
+        for (int i = 1; i <= 5; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "T%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        ui64 cursor = 0;
+        ui32 totalFetched = 0;
+        while (true) {
+            TAutoPtr<IEventHandle> fetchHandle;
+            auto fetch = FetchSchemeChangeRecords(runtime, "backup:sub", cursor, 2, fetchHandle);
+            UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+            if (fetch->Record.EntriesSize() == 0) {
+                break;
+            }
+            totalFetched += fetch->Record.EntriesSize();
+            cursor = fetch->Record.EntriesSize() > 0
+                ? fetch->Record.GetEntries(fetch->Record.EntriesSize() - 1).GetOrder()
+                : cursor;
+            TAutoPtr<IEventHandle> ackHandle;
+            AckSchemeChangeRecords(runtime, "backup:sub", cursor, ackHandle);
+            if (!fetch->Record.GetHasMore()) {
+                break;
+            }
+        }
+
+        UNIT_ASSERT(totalFetched >= 5);
+    }
+
+    Y_UNIT_TEST(TwoSubscribersIndependentConsumption) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> reg1Handle, reg2Handle;
+        RegisterSubscriber(runtime, "backup:collection:1", reg1Handle);
+        RegisterSubscriber(runtime, "audit:system", reg2Handle);
+
+        for (int i = 1; i <= 3; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "T%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // backup fetches and acks all
+        TAutoPtr<IEventHandle> backupFetchHandle;
+        auto backupFetch = FetchSchemeChangeRecords(runtime, "backup:collection:1", 0, 100, backupFetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)backupFetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(backupFetch->Record.EntriesSize() >= 3);
+        ui64 backupLastOrder = backupFetch->Record.EntriesSize() > 0
+            ? backupFetch->Record.GetEntries(backupFetch->Record.EntriesSize() - 1).GetOrder()
+            : 0;
+        TAutoPtr<IEventHandle> backupAckHandle;
+        AckSchemeChangeRecords(runtime, "backup:collection:1", backupLastOrder, backupAckHandle);
+
+        // audit fetches but only acks first entry
+        TAutoPtr<IEventHandle> auditFetchHandle;
+        auto auditFetch = FetchSchemeChangeRecords(runtime, "audit:system", 0, 100, auditFetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)auditFetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(auditFetch->Record.EntriesSize() >= 3);
+        ui64 auditFirstOrder = auditFetch->Record.GetEntries(0).GetOrder();
+        TAutoPtr<IEventHandle> auditAckHandle;
+        AckSchemeChangeRecords(runtime, "audit:system", auditFirstOrder, auditAckHandle);
+
+        // backup should have nothing new
+        TAutoPtr<IEventHandle> backupFetch2Handle;
+        auto backupFetch2 = FetchSchemeChangeRecords(runtime, "backup:collection:1", backupLastOrder, 100, backupFetch2Handle);
+        UNIT_ASSERT_VALUES_EQUAL(backupFetch2->Record.EntriesSize(), 0);
+
+        // audit should still have remaining entries
+        TAutoPtr<IEventHandle> auditFetch2Handle;
+        auto auditFetch2 = FetchSchemeChangeRecords(runtime, "audit:system", auditFirstOrder, 100, auditFetch2Handle);
+        UNIT_ASSERT(auditFetch2->Record.EntriesSize() > 0);
+    }
+
+    Y_UNIT_TEST(ForceAdvanceSubscriber) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "stuck:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> advHandle;
+        auto result = ForceAdvanceSubscriber(runtime, "stuck:sub", advHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)result->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(result->Record.GetLastAckedOrder() > 0);
+
+        // Fetch should return empty (cursor is at tail)
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "stuck:sub", result->Record.GetLastAckedOrder(), 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL(fetch->Record.EntriesSize(), 0);
+    }
+
+    Y_UNIT_TEST(ForceAdvanceUnknownSubscriberReturnsError) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> advHandle;
+        ForceAdvanceSubscriberExpect(runtime, "nonexistent:sub",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED, advHandle);
+    }
+
+    Y_UNIT_TEST(FetchReturnsMetadataWithoutBody) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "meta:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "meta:sub", 0, 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(fetch->Record.EntriesSize() >= 1);
+        for (int i = 0; i < (int)fetch->Record.EntriesSize(); ++i) {
+            const auto& entry = fetch->Record.GetEntries(i);
+            UNIT_ASSERT_C(entry.GetBodySizeBytes() > 0,
+                "Metadata should include non-zero BodySizeBytes for entry " << entry.GetOrder());
+        }
+    }
+
+    Y_UNIT_TEST(FetchBodiesReturnsRequestedBodies) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "body:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "body:sub", 0, 100, fetchHandle);
+        UNIT_ASSERT(fetch->Record.EntriesSize() >= 1);
+
+        TVector<ui64> orders;
+        for (int i = 0; i < (int)fetch->Record.EntriesSize(); ++i) {
+            orders.push_back(fetch->Record.GetEntries(i).GetOrder());
+        }
+
+        TAutoPtr<IEventHandle> bodiesHandle;
+        auto bodies = FetchSchemeChangeRecordBodies(runtime, "body:sub", orders, bodiesHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)bodies->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(bodies->Record.EntriesSize(), orders.size());
+        for (int i = 0; i < (int)bodies->Record.EntriesSize(); ++i) {
+            UNIT_ASSERT(!bodies->Record.GetEntries(i).GetBody().empty());
+        }
+    }
+
+    Y_UNIT_TEST(FetchBodiesUnregisteredSubscriberRejected) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TVector<ui64> orders = {1, 2, 3};
+        TAutoPtr<IEventHandle> bodiesHandle;
+        FetchSchemeChangeRecordBodiesExpect(runtime, "ghost:sub", orders,
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED, bodiesHandle);
+    }
+
+    Y_UNIT_TEST(FetchUnknownSubscriberReturnsNotRegistered) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        FetchSchemeChangeRecordsExpect(runtime, "ghost:sub", 0, 100,
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_NOT_REGISTERED, fetchHandle);
+    }
+
+    Y_UNIT_TEST(AckDeletesAckedRecordsInline) {
+        // Ack tx deletes records in the same transaction; no background sweep needed.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "cleanup:sub", regHandle);
+
+        for (int i = 1; i <= 3; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "T%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "cleanup:sub", 0, 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)fetch->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT(fetch->Record.EntriesSize() >= 3);
+        ui64 lastOrder = fetch->Record.EntriesSize() > 0
+            ? fetch->Record.GetEntries(fetch->Record.EntriesSize() - 1).GetOrder()
+            : 0;
+
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "cleanup:sub", lastOrder, ackHandle);
+
+        // Records must be gone as a side effect of the ack tx — no wakeup needed.
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(entries.empty(),
+            "Records should be deleted inline by ack, got " << entries.size());
+    }
+
+    Y_UNIT_TEST(FetchResultHasNoTailOrderField) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "tail:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto fetch = FetchSchemeChangeRecords(runtime, "tail:sub", 0, 100, fetchHandle);
+        UNIT_ASSERT(fetch->Record.EntriesSize() > 0);
+
+        // Tail is computed from entries, not a separate field
+        ui64 tailOrder = fetch->Record.GetEntries(fetch->Record.EntriesSize() - 1).GetOrder();
+        UNIT_ASSERT(tailOrder > 0);
+
+        // Ack using entries-derived tail works end-to-end
+        TAutoPtr<IEventHandle> ackHandle;
+        auto ack = AckSchemeChangeRecords(runtime, "tail:sub", tailOrder, ackHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)ack->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+    }
+
+    // Pull tail order across Fetch's 1000-record server-side cap.
+    static ui64 FetchTailOrder(TTestBasicRuntime& runtime, const TString& subscriberId) {
+        ui64 tailOrder = 0;
+        ui64 cursor = 0;
+        while (true) {
+            TAutoPtr<IEventHandle> h;
+            auto fetch = FetchSchemeChangeRecords(runtime, subscriberId, cursor, 1000, h);
+            if (fetch->Record.EntriesSize() == 0) break;
+            tailOrder = fetch->Record.GetEntries(fetch->Record.EntriesSize() - 1).GetOrder();
+            cursor = tailOrder;
+            if (!fetch->Record.GetHasMore()) break;
+        }
+        return tailOrder;
+    }
+
+    Y_UNIT_TEST(AckDeletesAllAckedRecordsRegardlessOfCount) {
+        // A backlog larger than SchemeChangeCleanupBatchSize drains via a
+        // scheduled continuation chain; poll until empty.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "bulk:sub", regHandle);
+
+        const int kCount = 1200;
+        for (int i = 1; i <= kCount; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("D%d", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        ui64 tailOrder = FetchTailOrder(runtime, "bulk:sub");
+        UNIT_ASSERT_C(tailOrder >= (ui64)kCount,
+            "Expected tail >= " << kCount << ", got " << tailOrder);
+
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "bulk:sub", tailOrder, ackHandle);
+
+        TVector<TSchemeChangeRecordEntry> entries;
+        for (int i = 0; i < 200; ++i) {
+            entries = ReadSchemeChangeRecords(runtime);
+            if (entries.empty()) break;
+            runtime.SimulateSleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(entries.empty(),
+            "All " << kCount << " records must eventually drain; "
+                << entries.size() << " still remaining");
+    }
+
+    Y_UNIT_TEST(ForceAdvanceDeletesStaleRecordsInline) {
+        // ForceAdvance jumps the cursor to tail and must delete newly-stale
+        // records inline, same as Ack/Unregister.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "stuck:sub", regHandle);
+
+        for (int i = 1; i <= 5; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("D%d", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        auto before = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT(!before.empty());
+
+        TAutoPtr<IEventHandle> advHandle;
+        auto result = ForceAdvanceSubscriber(runtime, "stuck:sub", advHandle);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)result->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        // IMMEDIATE read — no wakeup, no time advance.
+        auto after = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(after.empty(),
+            "ForceAdvance must sweep records inline; got " << after.size() << " remaining");
+    }
+
+    Y_UNIT_TEST(UnregisterSweepsStaleRecordsRegardlessOfCount) {
+        // Slow subscriber holds min cursor at 0 while fast acks everything.
+        // Unregistering the slow one must sweep all records immediately.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> reg1Handle, reg2Handle;
+        RegisterSubscriber(runtime, "slow:sub", reg1Handle);
+        RegisterSubscriber(runtime, "fast:sub", reg2Handle);
+
+        const int kCount = 1100;
+        for (int i = 1; i <= kCount; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("D%d", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        ui64 tailOrder = FetchTailOrder(runtime, "fast:sub");
+        UNIT_ASSERT_C(tailOrder >= (ui64)kCount,
+            "Expected tail >= " << kCount << ", got " << tailOrder);
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "fast:sub", tailOrder, ackHandle);
+
+        // slow:sub still at 0 -> records held by slow
+        auto stillThere = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT(!stillThere.empty());
+
+        // Unregister slow: min jumps to fast's tail, draining via continuation chain.
+        TAutoPtr<IEventHandle> unregHandle;
+        UnregisterSubscriber(runtime, "slow:sub", unregHandle);
+
+        TVector<TSchemeChangeRecordEntry> entries;
+        for (int i = 0; i < 200; ++i) {
+            entries = ReadSchemeChangeRecords(runtime);
+            if (entries.empty()) break;
+            runtime.SimulateSleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(entries.empty(),
+            "Unregister of the slow subscriber must eventually sweep all "
+                << kCount << " stale records; " << entries.size() << " still remaining");
+    }
+
+    // NextSchemeChangeOrder is the last assigned order, not the next one, so
+    // "register at tail" means LastAckedOrder == NextSchemeChangeOrder exactly.
+
+    Y_UNIT_TEST(RegisterSubscriberDefaultsToTailNotZero) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        // A first subscriber makes records start accumulating.
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "sub-A", regA);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail > 0, "precondition: some records must exist");
+
+        // A brand-new subscriber must start at the tail, not at 0: starting at
+        // 0 replays unwanted history and pins the retention floor low (see the
+        // next test).
+        TAutoPtr<IEventHandle> regB;
+        auto* resB = RegisterSubscriber(runtime, "sub-B", regB);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)resB->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL_C(resB->Record.GetCurrentOrder(), tail,
+            "a new subscriber must register at the tail (NextSchemeChangeOrder), not at 0");
+    }
+
+    Y_UNIT_TEST(RegisterSubscriberOnMatureClusterDoesNotBlockDdl) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "sub-A", regA);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir3");
+        env.TestWaitNotification(runtime, txId);
+
+        // sub-A drains everything, so the retention floor sits at the tail and
+        // acked records are swept.
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail > 0, "precondition: some records must exist");
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "sub-A", tail, ackHandle);
+
+        // "Mature cluster": rather than driving 100k MkDirs to reach the
+        // default cap, lower the cap to the current tail instead.
+        schemeshard->MaxSchemeChangeRecords = tail;
+
+        // Registering a second subscriber must not pin the floor back to 0.
+        TAutoPtr<IEventHandle> regB;
+        auto* resB = RegisterSubscriber(runtime, "sub-B", regB);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)resB->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+
+        // The anti-wedge invariant: registering a subscriber must leave the
+        // unacked window unchanged.
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            schemeshard->NextSchemeChangeOrder - schemeshard->GetMinSubscriberOrder(runtime.GetCurrentTime()), 0u,
+            "registering a subscriber must not widen the unacked window");
+
+        // And DDL must still be accepted.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir4", {NKikimrScheme::StatusAccepted});
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(ExplicitStartOrderBelowRetentionClampsAndReportsLost) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "sub-A", regA);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        // Drain with sub-A so the retention floor advances off 0.
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "sub-A", tail, ackHandle);
+
+        const ui64 floor = schemeshard->GetMinSubscriberOrder(runtime.GetCurrentTime());
+        UNIT_ASSERT_C(floor > 0, "precondition: the retention floor must have advanced");
+        const ui64 unackedBefore =
+            schemeshard->NextSchemeChangeOrder - schemeshard->GetMinSubscriberOrder(runtime.GetCurrentTime());
+
+        // Ask for history that has already been swept.
+        TAutoPtr<IEventHandle> regB;
+        auto* resB = RegisterSubscriberAt(runtime, "sub-B", 0, regB);
+
+        UNIT_ASSERT_VALUES_EQUAL((ui32)resB->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL_C(resB->Record.GetCurrentOrder(), floor,
+            "a StartOrder below the retention floor must be clamped up to the floor");
+        UNIT_ASSERT_VALUES_EQUAL_C(resB->Record.GetSkippedEntries(), floor,
+            "SkippedEntries must report the size of the hole");
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)resB->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST,
+            "a clamped subscriber must be told its stream has a hole");
+
+        // Clamping must preserve the anti-wedge invariant: registering must
+        // never widen the unacked window.
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            schemeshard->NextSchemeChangeOrder - schemeshard->GetMinSubscriberOrder(runtime.GetCurrentTime()),
+            unackedBefore,
+            "registering below the floor must not widen the unacked window");
+    }
+
+    Y_UNIT_TEST(ExplicitStartOrderOnEmptyLogAccepted) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        // Zero subscribers, zero records: the floor is the tail is 0.
+        TAutoPtr<IEventHandle> reg;
+        auto* res = RegisterSubscriberAt(runtime, "sub-A", 0, reg);
+
+        UNIT_ASSERT_VALUES_EQUAL((ui32)res->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(res->Record.GetCurrentOrder(), 0u);
+        UNIT_ASSERT_VALUES_EQUAL(res->Record.GetSkippedEntries(), 0u);
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)res->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "an empty log has no hole to report");
+    }
+
+    Y_UNIT_TEST(ExplicitStartOrderAtFloorAccepted) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "sub-A", regA);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "sub-A", tail, ackHandle);
+        const ui64 floor = schemeshard->GetMinSubscriberOrder(runtime.GetCurrentTime());
+
+        // Exactly at the floor is accepted verbatim: an off-by-one here would
+        // reject every legitimate unswept read.
+        TAutoPtr<IEventHandle> regB;
+        auto* resB = RegisterSubscriberAt(runtime, "sub-B", floor, regB);
+
+        UNIT_ASSERT_VALUES_EQUAL((ui32)resB->Record.GetStatus(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(resB->Record.GetCurrentOrder(), floor);
+        UNIT_ASSERT_VALUES_EQUAL_C(resB->Record.GetSkippedEntries(), 0u,
+            "registering exactly at the floor skips nothing");
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)resB->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "registering exactly at the floor is not Lost");
+    }
+
+    Y_UNIT_TEST(ExplicitStartOrderBeyondTailRejected) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+
+        TAutoPtr<IEventHandle> reg;
+        // Beyond the tail is not a real position.
+        RegisterSubscriberAtExpect(
+            runtime, "sub-A", schemeshard->NextSchemeChangeOrder + 100,
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, reg);
+    }
+
+    Y_UNIT_TEST(SubscriberCarriesStateAndStartOrder) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "sub-A", regA);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        TAutoPtr<IEventHandle> regB;
+        RegisterSubscriber(runtime, "sub-B", regB);
+
+        {
+            auto it = schemeshard->Subscribers.find("sub-B");
+            UNIT_ASSERT(it != schemeshard->Subscribers.end());
+            UNIT_ASSERT_VALUES_EQUAL(it->second.StartOrder, tail);
+            UNIT_ASSERT_VALUES_EQUAL((ui32)it->second.State,
+                (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY);
+        }
+
+        // Both columns must survive a reboot.
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        {
+            auto it = schemeshard->Subscribers.find("sub-B");
+            UNIT_ASSERT_C(it != schemeshard->Subscribers.end(),
+                "subscriber must survive reboot");
+            UNIT_ASSERT_VALUES_EQUAL_C(it->second.StartOrder, tail,
+                "StartOrder must round-trip through reboot");
+            UNIT_ASSERT_VALUES_EQUAL_C((ui32)it->second.State,
+                (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+                "State must round-trip through reboot");
+        }
+    }
+
+    Y_UNIT_TEST(ReadHelperSeesAllRecordsRegardlessOfTail) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "keeper:sub", regA);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir3");
+        env.TestWaitNotification(runtime, txId);
+
+        // The read helper mints a temp subscriber fresh each call. Without an
+        // explicit StartOrder it would scan from tail+1 and return empty on
+        // every call made after any DDL.
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(entries.size() >= 3,
+            "read helper must see the whole retained log, not start at the tail; got "
+                << entries.size());
+
+        // Must still work on a second call, i.e. not sensitive to its own
+        // previous registration.
+        auto again = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(again.size(), entries.size(),
+            "read helper must be idempotent across calls");
+    }
+
+    Y_UNIT_TEST(ReadHelperReturnsEmptyOnlyWhenLogIsEmpty) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regA;
+        RegisterSubscriber(runtime, "keeper:sub", regA);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail >= 2, "precondition: records must exist");
+
+        // Cursor-independent oracle: the rows are physically there.
+        auto present = ProbeRecordOrdersPresent(runtime, "keeper:sub", {1, tail});
+        UNIT_ASSERT_C(!present.empty(),
+            "physical probe must see rows before the sweep");
+
+        // Force-advance the only subscriber, which sweeps everything.
+        TAutoPtr<IEventHandle> faHandle;
+        ForceAdvanceSubscriber(runtime, "keeper:sub", faHandle);
+
+        // The helper must return empty because the log is empty, not because
+        // its registration was rejected or its cursor clamped past live rows.
+        // The physical probe below independently confirms the rows are gone.
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(entries.size(), 0u,
+            "after a full sweep the helper must read empty");
+
+        auto afterSweep = ProbeRecordOrdersPresent(runtime, "keeper:sub", {1, tail});
+        UNIT_ASSERT_VALUES_EQUAL_C(afterSweep.size(), 0u,
+            "emptiness must be real: no record rows may remain on disk");
+    }
+
+    // The measurement is taken mid-DDL, after a reboot: TTxInit rebuilds
+    // Operations[txId]->SchemeChangeSlots only from persisted rows, so
+    // "nothing was reserved at propose" is directly visible.
+
+    Y_UNIT_TEST(NoSubscribersMeansNoReservedOutboxRows) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        // Deliberately NO subscriber.
+        const ui64 opTxId = ++txId;
+        TestCreateTable(runtime, opTxId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        auto it = schemeshard->Operations.find(TTxId(opTxId));
+        if (it != schemeshard->Operations.end()) {
+            UNIT_ASSERT_C(it->second->SchemeChangeSlots.empty(),
+                "with no subscribers no outbox row may be reserved; found "
+                    << it->second->SchemeChangeSlots.size() << " restored slots");
+        }
+
+        env.TestWaitNotification(runtime, opTxId);
+
+        // Absence above must mean "never written", not "written and swept".
+        UNIT_ASSERT_VALUES_EQUAL_C(ReadSchemeChangeRecords(runtime).size(), 0u,
+            "an unsubscribed cluster must leave the outbox completely empty");
+    }
+
+    Y_UNIT_TEST(SubscriberPresentMeansRowsArePersisted) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "keeper:sub", regHandle);
+
+        const ui64 opTxId = ++txId;
+        TestCreateTable(runtime, opTxId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Mirror of the test above: the gate must not kill durability across
+        // a propose->done reboot.
+        auto it = schemeshard->Operations.find(TTxId(opTxId));
+        if (it != schemeshard->Operations.end()) {
+            UNIT_ASSERT_C(!it->second->SchemeChangeSlots.empty(),
+                "with a subscriber registered the reserved outbox rows must survive "
+                "a propose->done reboot");
+        }
+
+        env.TestWaitNotification(runtime, opTxId);
+
+        // The reservation must actually turn into a delivered record.
+        UNIT_ASSERT_VALUES_EQUAL_C(ReadSchemeChangeRecords(runtime).size(), 1u,
+            "the surviving reservation must be finalised into a fetchable record");
+    }
+
+    // A stale subscriber still holds the retention floor and DDL wedges until
+    // an admin acts. Letting it stop holding the floor would silently drop
+    // the forgotten consumer's records. Staleness detection must still work
+    // even though nothing gets swept automatically.
+
+    Y_UNIT_TEST(StaleSubscriberBlocksDdlUntilAdminOverride) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        const ui64 ttlSeconds = 100;
+        ApplySchemeShardConfig(runtime, {
+            .MaxSchemeChangeRecords = 2,
+            .SchemeChangeSubscriberStaleTtlSeconds = ttlSeconds,
+        });
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "dead:sub", regHandle);
+
+        // Drive DDL past the cap without acking; cap=2 means exactly 2 records
+        // fit, so the next DDL is at the cap.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        // The subscriber goes dark for well past the TTL.
+        runtime.SimulateSleep(TDuration::Seconds(2 * ttlSeconds));
+
+        // Going dark buys it nothing: it still holds the floor, so DDL stays
+        // wedged.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir3", {NKikimrScheme::StatusResourceExhausted});
+
+        // Staleness must still be detected, or an operator cannot tell which
+        // consumer to blame.
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribersStale"), 1u,
+            "the idle subscriber must be visible as stale even though nothing was swept");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribersLost"), 0u,
+            "stale is not lost: it has been told nothing, but it has lost nothing either");
+
+        // The admin override is the only way out.
+        TAutoPtr<IEventHandle> advHandle;
+        ForceAdvanceSubscriber(runtime, "dead:sub", advHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir3", {NKikimrScheme::StatusAccepted});
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(FreshSubscriberStillBlocksDdl) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        const ui64 ttlSeconds = 100;
+        ApplySchemeShardConfig(runtime, {
+            .MaxSchemeChangeRecords = 2,
+            .SchemeChangeSubscriberStaleTtlSeconds = ttlSeconds,
+        });
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "slow:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        // Alive but slow: it keeps fetching inside the TTL without acking.
+        runtime.SimulateSleep(TDuration::Seconds(ttlSeconds / 2));
+        TAutoPtr<IEventHandle> fetchHandle;
+        FetchSchemeChangeRecords(runtime, "slow:sub", 0, 10, fetchHandle);
+        runtime.SimulateSleep(TDuration::Seconds(ttlSeconds / 2));
+
+        // Backpressure must still apply, not just when a subscriber is stale.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir3", {NKikimrScheme::StatusResourceExhausted});
+    }
+
+    // A live subscriber's ack must not sweep a stale one's unread records.
+    Y_UNIT_TEST(StaleSubscriberRecordsSurviveAnotherSubscribersAck) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        // Keep the TTL small: SimulateSleep cost scales with simulated time.
+        const ui64 ttlSeconds = 5;
+        ApplySchemeShardConfig(runtime, {
+            .SchemeChangeSubscriberStaleTtlSeconds = ttlSeconds,
+        });
+
+        // Both register on an empty log so both cursors sit at 0 and the ack
+        // path's delete range (oldMin, newMin] covers what dead:sub never read.
+        // No reboot here: it would restore the 30-day default TTL.
+        TAutoPtr<IEventHandle> regDead, regLive;
+        RegisterSubscriber(runtime, "dead:sub", regDead);
+        RegisterSubscriber(runtime, "live:sub", regLive);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail >= 2, "precondition: records must exist");
+
+        // Both go quiet past the TTL...
+        runtime.SimulateSleep(TDuration::Seconds(2 * ttlSeconds));
+
+        // ...but live:sub comes back and drains the whole log. dead:sub still
+        // holds the retention floor, so live:sub's ack must not sweep records
+        // dead:sub never consumed.
+        TAutoPtr<IEventHandle> liveFetch;
+        FetchSchemeChangeRecords(runtime, "live:sub", 0, 100, liveFetch);
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "live:sub", tail, ackHandle);
+
+        // Physical survival, read by explicit order so no cursor can mask it.
+        auto present = ProbeRecordOrdersPresent(runtime, "live:sub", {1, 2});
+        UNIT_ASSERT_VALUES_EQUAL_C(present.size(), 2u,
+            "a stale subscriber still pins retention; another subscriber's ack "
+            "must not delete records it never read");
+
+        // And when it comes back it gets its records, not a loss report.
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "dead:sub", 0, 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL_C(fetch->Record.GetSkippedEntries(), 0u,
+            "nothing was swept, so nothing may be reported as lost");
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)fetch->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "a subscriber that lost nothing must not be marked Lost");
+        UNIT_ASSERT_VALUES_EQUAL_C(fetch->Record.EntriesSize(), 2u,
+            "it must actually receive the records it was owed");
+    }
+
+    // Internal ops (split/merge, temp-dir GC, export/import) are never
+    // rejected by the cap; rejecting them would be a cluster outage, not
+    // backpressure. Churn ops are excluded separately since a user-initiated
+    // split is not Internal=true but still emits no record. The cap is
+    // enforced at the propose gate by refusing user DDL; only an admin
+    // force-advance may discard records to relieve it.
+
+    Y_UNIT_TEST(UserDdlStillRejectedAtCap) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        ApplySchemeShardConfig(runtime, {.MaxSchemeChangeRecords = 2});
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "stuck:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        // The bypass must not leak to ordinary user DDL: plain, non-internal,
+        // non-churn operations are still subject to backpressure.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir3", {NKikimrScheme::StatusResourceExhausted});
+    }
+
+    Y_UNIT_TEST(UserInitiatedSplitAtCapNotRejected) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "stuck:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "Key"   Type: "Utf8" }
+            Columns { Name: "Value" Type: "Utf8" }
+            KeyColumnNames: ["Key", "Value"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Park the subscriber at the cap without acking; the CreateTable above
+        // already put it at or above the cap, so no extra DDL is needed.
+        ApplySchemeShardConfig(runtime, {.MaxSchemeChangeRecords = 1});
+
+        // A user-initiated split is not Internal=true, so this pins the churn
+        // clause specifically, not just the Internal bypass.
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", R"(
+            SourceTabletId: 72075186233409546
+            SplitBoundary {
+                KeyPrefix {
+                    Tuple { Optional { Text: "A" } }
+                }
+            })", {NKikimrScheme::StatusAccepted});
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(ChurnOpsAtCapDoNotMarkSubscriberLost) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "parked:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "Key"   Type: "Utf8" }
+            Columns { Name: "Value" Type: "Utf8" }
+            KeyColumnNames: ["Key", "Value"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        ApplySchemeShardConfig(runtime, {.MaxSchemeChangeRecords = 1});
+        const auto before = ReadSchemeChangeRecords(runtime);
+
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", R"(
+            SourceTabletId: 72075186233409546
+            SplitBoundary {
+                KeyPrefix {
+                    Tuple { Optional { Text: "A" } }
+                }
+            })", {NKikimrScheme::StatusAccepted});
+        env.TestWaitNotification(runtime, txId);
+
+        // Churn allocates no order, so it must not consume the outbox budget
+        // or ever mark a subscriber Lost.
+        const auto after = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(after.size(), before.size(),
+            "a split must not append scheme change records");
+
+        auto it = schemeshard->Subscribers.find("parked:sub");
+        UNIT_ASSERT(it != schemeshard->Subscribers.end());
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)it->second.State,
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "churn at the cap must not mark the subscriber Lost");
+    }
+
+    Y_UNIT_TEST(EmptySubscriberIdRejected) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        // Two consumers that both leave SubscriberId unset would silently
+        // share one cursor.
+        TAutoPtr<IEventHandle> handle;
+        RegisterSubscriberExpect(runtime, "",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, handle);
+    }
+
+    Y_UNIT_TEST(OverlongSubscriberIdRejected) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        TAutoPtr<IEventHandle> handle;
+        RegisterSubscriberExpect(runtime, TString(300, 'x'),
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, handle);
+    }
+
+    Y_UNIT_TEST(SubscriberCountCapped) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+
+        schemeshard->MaxSchemeChangeSubscribers = 2;
+
+        TAutoPtr<IEventHandle> h1, h2, h3;
+        RegisterSubscriber(runtime, "sub-1", h1);
+        RegisterSubscriber(runtime, "sub-2", h2);
+
+        // Each subscriber pins retention and costs a pass on the DDL admission
+        // path, so the count must be bounded.
+        RegisterSubscriberExpect(runtime, "sub-3",
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, h3);
+
+        // Re-registering an existing id must still succeed: registration is
+        // idempotent.
+        TAutoPtr<IEventHandle> h4;
+        RegisterSubscriber(runtime, "sub-1", h4);
+    }
+
+    Y_UNIT_TEST(ForceAdvanceReachableFromMonitoring) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "stuck:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir2");
+        env.TestWaitNotification(runtime, txId);
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail >= 2, "precondition: the subscriber must be behind");
+        UNIT_ASSERT_VALUES_EQUAL(schemeshard->Subscribers.at("stuck:sub").LastAckedOrder, 0u);
+
+        // Drive it the way an operator would.
+        auto resp = SendSchemeShardMonRequest(runtime, TTestTxConfig::SchemeShard,
+            "/app?Action=ForceAdvanceSchemeChangeSubscriber&SubscriberId=stuck:sub",
+            HTTP_METHOD_POST);
+        UNIT_ASSERT_C(resp.Body.Contains("stuck:sub"),
+            "the action must answer the HTTP request, got: " << resp.Body);
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        const auto& info = schemeshard->Subscribers.at("stuck:sub");
+        UNIT_ASSERT_VALUES_EQUAL_C(info.LastAckedOrder, tail,
+            "the monitoring action must advance the stuck cursor to the tail");
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)info.State,
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_LOST,
+            "and must mark the subscriber Lost -- its unread records are gone");
+    }
+
+    Y_UNIT_TEST(ForceAdvanceFromMonitoringRejectsUnknownSubscriber) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+
+        auto resp = SendSchemeShardMonRequest(runtime, TTestTxConfig::SchemeShard,
+            "/app?Action=ForceAdvanceSchemeChangeSubscriber&SubscriberId=ghost:sub",
+            HTTP_METHOD_POST);
+        UNIT_ASSERT_C(resp.Body.Contains("ghost:sub") || resp.Body.Contains("No scheme change subscriber"),
+            "an unknown subscriber must produce a clear operator-facing error, got: " << resp.Body);
+    }
+
+    Y_UNIT_TEST(RecordCarriesResolvedIdentity) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "id:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "a CREATE must produce a record");
+        const auto& rec = entries.back();
+
+        // A consumer must be able to act on identity without parsing the
+        // request body.
+        UNIT_ASSERT_VALUES_EQUAL_C(rec.OperationType,
+            (ui32)NKikimrSchemeOp::ESchemeOpCreateTable,
+            "OperationType must be the requested EOperationType, not a TxType placeholder");
+        UNIT_ASSERT_C(rec.PathLocalId != 0,
+            "PathId must be resolved, not left empty");
+        UNIT_ASSERT_VALUES_EQUAL_C(rec.ObjectType,
+            (ui32)NKikimrSchemeOp::EPathTypeTable,
+            "ObjectType must be resolved");
+        UNIT_ASSERT_C(AnyPathContains(rec, "T1"),
+            "Path must name the target, got: " << AllTargetPaths(rec));
+    }
+
+    Y_UNIT_TEST(CreateRecordCarriesResolvedDescription) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "desc:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "extra" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "a CREATE must produce a record");
+        const auto& rec = entries.back();
+
+        UNIT_ASSERT_C(!rec.Description.empty(),
+            "the record must carry a resolved description");
+
+        // The description makes the object reconstructible from the record
+        // alone, with no call back into SchemeShard.
+        NKikimrScheme::TEvDescribeSchemeResult desc;
+        UNIT_ASSERT_C(desc.ParseFromString(rec.Description),
+            "the description must be a parseable TEvDescribeSchemeResult");
+        const auto& tableDesc = desc.GetPathDescription().GetTable();
+        UNIT_ASSERT_VALUES_EQUAL_C(tableDesc.GetName(), "T1",
+            "the description must describe the created object");
+        UNIT_ASSERT_C(tableDesc.ColumnsSize() >= 2,
+            "the description must carry the resolved column set, got "
+                << tableDesc.ColumnsSize());
+    }
+
+    Y_UNIT_TEST(SplitMergeProducesNoRecords) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "churn:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "Key"   Type: "Utf8" }
+            Columns { Name: "Value" Type: "Utf8" }
+            KeyColumnNames: ["Key", "Value"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto before = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!before.empty(), "precondition: the CREATE must have been recorded");
+
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", R"(
+            SourceTabletId: 72075186233409546
+            SplitBoundary {
+                KeyPrefix {
+                    Tuple { Optional { Text: "A" } }
+                }
+            })", {NKikimrScheme::StatusAccepted});
+        env.TestWaitNotification(runtime, txId);
+
+        // Partitioning is layout, not data-encoding, so no consumer needs the
+        // history of splits; streaming them would flood the outbox budget.
+        const auto after = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(after.size(), before.size(),
+            "auto-partitioning must never reach the outbox");
+    }
+
+    Y_UNIT_TEST(ChurnListIsTheOnlyFilter) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "filter:sub", regHandle);
+
+        // Everything not on the churn list is logged, including ops a naive
+        // "user-facing only" rule would drop.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "T1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        THashSet<ui32> seen;
+        for (const auto& rec : entries) {
+            seen.insert(rec.OperationType);
+        }
+        UNIT_ASSERT_C(seen.contains((ui32)NKikimrSchemeOp::ESchemeOpMkDir),
+            "MkDir must be logged");
+        UNIT_ASSERT_C(seen.contains((ui32)NKikimrSchemeOp::ESchemeOpCreateTable),
+            "CreateTable must be logged");
+        UNIT_ASSERT_C(seen.contains((ui32)NKikimrSchemeOp::ESchemeOpDropTable),
+            "DropTable must be logged");
+        UNIT_ASSERT_C(!seen.contains((ui32)NKikimrSchemeOp::ESchemeOpSplitMergeTablePartitions),
+            "the churn list must be the only thing excluded");
+    }
+
+    // If targetName is empty, Path falls back to WorkingDir, which resolves to
+    // the parent directory -- confidently wrong identity, worse than none.
+
+    Y_UNIT_TEST(NonTableObjectsCarryTheirOwnIdentity) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().RunFakeConfigDispatcher(true).EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "types:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+                Name: "ExtSrc"
+                SourceType: "ObjectStorage"
+                Location: "https://s3.cloud.net/my_bucket"
+                Auth {
+                    None {
+                    }
+                }
+            )", {NKikimrScheme::StatusAccepted});
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "records must exist");
+
+        const TSchemeChangeRecordEntry* extSrc = nullptr;
+        for (const auto& rec : entries) {
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpCreateExternalDataSource) {
+                extSrc = &rec;
+            }
+        }
+        UNIT_ASSERT_C(extSrc, "the external data source CREATE must be recorded");
+
+        UNIT_ASSERT_C(AnyPathContains(*extSrc, "ExtSrc"),
+            "Path must name the object itself, not just its parent dir; got: " << AllTargetPaths(*extSrc));
+        UNIT_ASSERT_VALUES_EQUAL_C(extSrc->ObjectType,
+            (ui32)NKikimrSchemeOp::EPathTypeExternalDataSource,
+            "ObjectType must be the object's own type, not the parent's EPathTypeDir");
+    }
+
+    Y_UNIT_TEST(EveryRecordHasNonZeroPlanStep) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "ps:sub", regHandle);
+
+        // A coordinated op...
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        // ...and a propose-time one. TModifyACL has no TxState at all, so it
+        // never reaches a coordinator and has no step of its own.
+        TestModifyACL(runtime, ++txId, "/MyRoot", "Dir1", "", "user1@builtin");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "records must exist");
+        for (const auto& rec : entries) {
+            // A persisted 0 would sort a record before everything when a
+            // consumer buckets by (PlanStep, PositionKind).
+            UNIT_ASSERT_C(rec.PlanStep != 0,
+                "no record may carry PlanStep 0; order=" << rec.Order
+                    << " opType=" << rec.OperationType);
+            UNIT_ASSERT_C(rec.PositionKind != 0,
+                "every record must declare its position kind; order=" << rec.Order);
+        }
+    }
+
+    Y_UNIT_TEST(BucketedRecordsCarryLowerBoundPlanStep) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "kind:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+        TestModifyACL(runtime, ++txId, "/MyRoot", "Dir1", "", "user1@builtin");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* coordinated = nullptr;
+        const TSchemeChangeRecordEntry* proposeTime = nullptr;
+        for (const auto& rec : entries) {
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpMkDir) {
+                coordinated = &rec;
+            } else if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpModifyACL) {
+                proposeTime = &rec;
+            }
+        }
+        UNIT_ASSERT_C(coordinated, "the MkDir must be recorded");
+        UNIT_ASSERT_C(proposeTime, "the ACL change must be recorded");
+
+        UNIT_ASSERT_VALUES_EQUAL_C(coordinated->PositionKind,
+            (ui32)NKikimrSchemeShard::TSchemeChangePosition::KIND_EXACT,
+            "a coordinated op has a real PlanStep and must be Exact");
+        UNIT_ASSERT_VALUES_EQUAL_C(proposeTime->PositionKind,
+            (ui32)NKikimrSchemeShard::TSchemeChangePosition::KIND_BUCKETED,
+            "a propose-time op has no step of its own and must be Bucketed");
+
+        // The borrow is a lower bound, so Bucketed sorts after Exact at equal step.
+        UNIT_ASSERT_C(proposeTime->PlanStep >= coordinated->PlanStep,
+            "a borrowed step must be >= the step it borrowed from; got "
+                << proposeTime->PlanStep << " vs " << coordinated->PlanStep);
+    }
+
+    Y_UNIT_TEST(IncrementalBackupProducesIdentifiableSyncPoint) {
+        TTestBasicRuntime runtime;
+        // Backup collections are feature-gated; without this the op is rejected
+        // with StatusPreconditionFailed and the test proves nothing.
+        TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true).EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "sync:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Collections live under a fixed reserved path.
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(
+            Name: "MyCollection"
+            ExplicitEntryList {
+                Entries { Type: ETypeTable Path: "/MyRoot/T1" }
+            }
+            Cluster {}
+            IncrementalBackupConfig {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // The actual sync point is the backup run, not the collection object.
+        TestBackupBackupCollection(runtime, ++txId, "/MyRoot", R"(
+            Name: ".backups/collections/MyCollection"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Backup artifacts are named from the wall clock at second granularity;
+        // without this sleep the incremental backup collides with the full
+        // backup's stream name.
+        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        TestBackupIncrementalBackupCollection(runtime, ++txId, "/MyRoot", R"(
+            Name: ".backups/collections/MyCollection"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(!entries.empty(), "records must exist");
+
+        bool sawIncremental = false;
+        for (const auto& rec : entries) {
+            if (rec.OperationType
+                    == (ui32)NKikimrSchemeOp::ESchemeOpBackupIncrementalBackupCollection) {
+                sawIncremental = true;
+                UNIT_ASSERT_C(rec.PlanStep != 0,
+                    "the sync point must carry a usable PlanStep");
+            }
+        }
+        UNIT_ASSERT_C(sawIncremental,
+            "BACKUP INCREMENTAL -- the actual sync point -- must appear in the stream "
+            "with its own EOperationType");
+
+        // The sync point must be identifiable by the body's EOperationType, not
+        // ETxType: ConvertToTxType maps it onto TxInvalid along with other ops.
+        bool sawCollection = false;
+        for (const auto& rec : entries) {
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpCreateBackupCollection) {
+                sawCollection = true;
+                UNIT_ASSERT_C(rec.PlanStep != 0,
+                    "a sync-point-bearing record must carry a usable PlanStep");
+            }
+        }
+        UNIT_ASSERT_C(sawCollection,
+            "backup collection ops must reach the outbox with their own EOperationType, "
+            "otherwise a consumer cannot locate window boundaries");
+    }
+
+    Y_UNIT_TEST(ClosedThroughPlanStepIsInclusiveAtQuiesce) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "close:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        auto result = ReadSchemeChangeRecordsFull(runtime);
+        UNIT_ASSERT_C(!result.Entries.empty(), "a record must exist");
+        const ui64 lastStep = result.Entries.back().PlanStep;
+
+        // With nothing in flight the bound must reach the newest record's own step.
+        UNIT_ASSERT_C(result.ClosedThroughPlanStep >= lastStep,
+            "a quiesced cluster must be able to close its newest window: closed="
+                << result.ClosedThroughPlanStep << " lastRecordStep=" << lastStep);
+    }
+
+    Y_UNIT_TEST(PerObjectOrderingHoldsWithoutGlobalOrdering) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "order:sub", regHandle);
+
+        // Two independent objects; no cross-object ordering is required, only
+        // per-object order.
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirB");
+        env.TestWaitNotification(runtime, txId);
+        TestRmDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        ui64 createA = 0, dropA = 0;
+        for (const auto& rec : entries) {
+            if (!AnyPathContains(rec, "DirA")) {
+                continue;
+            }
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpMkDir) {
+                createA = rec.Order;
+            } else if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpRmDir) {
+                dropA = rec.Order;
+            }
+        }
+        UNIT_ASSERT_C(createA && dropA, "both DirA records must exist");
+        UNIT_ASSERT_C(createA < dropA,
+            "per-object order must hold: a create must precede its drop");
+    }
+
+    Y_UNIT_TEST(SingleTransactionSupportingDomainPerSchemeShard) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+
+        // A second transaction-supporting domain under one SchemeShard would
+        // break the global-max borrow as a sound lower bound.
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->CountTransactionSupportingDomains(), 1u,
+            "the default test env must serve exactly one transaction-supporting domain");
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "domain:sub", regHandle);
+    }
+
+    Y_UNIT_TEST(DdlBucketsIntoCorrectBackupWindow) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true).EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "window:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+
+        auto makeSyncPoint = [&](const TString& name) {
+            TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", Sprintf(R"(
+                Name: "%s"
+                ExplicitEntryList { Entries { Type: ETypeTable Path: "/MyRoot/T1" } }
+                Cluster {}
+                IncrementalBackupConfig {}
+            )", name.c_str()));
+            env.TestWaitNotification(runtime, txId);
+        };
+
+        //   S1 . CREATE T2 . ALTER T1 . S2 . DROP T2
+        // Everything between S1 and S2 must land in window (S1, S2].
+        makeSyncPoint("C1");
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        makeSyncPoint("C2");
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "T2");
+        env.TestWaitNotification(runtime, txId);
+
+        auto result = ReadSchemeChangeRecordsFull(runtime);
+        const auto& entries = result.Entries;
+        UNIT_ASSERT_C(!entries.empty(), "records must exist");
+
+        // Locate the two sync points by the body's EOperationType: ConvertToTxType
+        // maps backup-collection ops onto TxInvalid, shared with other ops.
+        TVector<ui64> syncSteps;
+        for (const auto& rec : entries) {
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpCreateBackupCollection) {
+                syncSteps.push_back(rec.PlanStep);
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(syncSteps.size(), 2u,
+            "both sync points must be identifiable in the stream");
+        Sort(syncSteps);
+        const ui64 s1 = syncSteps[0], s2 = syncSteps[1];
+
+        // Bucket by rank (PlanStep, PositionKind) against the sync points.
+        auto windowOf = [&](const TSchemeChangeRecordEntry& r) -> int {
+            if (r.PlanStep <= s1) return 0;      // at or before S1
+            if (r.PlanStep <= s2) return 1;      // (S1, S2]
+            return 2;                            // after S2
+        };
+
+        const TSchemeChangeRecordEntry* createT2 = nullptr;
+        const TSchemeChangeRecordEntry* dropT2 = nullptr;
+        for (const auto& rec : entries) {
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpCreateTable
+                && AnyPathContains(rec, "T2")) {
+                createT2 = &rec;
+            } else if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpDropTable
+                && AnyPathContains(rec, "T2")) {
+                dropT2 = &rec;
+            }
+        }
+        UNIT_ASSERT_C(createT2, "CREATE T2 must be recorded");
+        UNIT_ASSERT_C(dropT2, "DROP T2 must be recorded");
+
+        UNIT_ASSERT_VALUES_EQUAL_C(windowOf(*createT2), 1,
+            "CREATE T2 happened between the sync points and must bucket into (S1, S2]");
+        UNIT_ASSERT_VALUES_EQUAL_C(windowOf(*dropT2), 2,
+            "DROP T2 happened after S2 and must NOT be squeezed into the earlier window");
+
+        // Seeing the S2 record is not sufficient: Order is completion order
+        // while plan step diverges, so a DDL planned before S2 can be
+        // persisted after it. The consumer may only close (S1, S2] once the
+        // closure bound has passed S2.
+        UNIT_ASSERT_C(result.ClosedThroughPlanStep >= s2,
+            "with everything quiesced the consumer must be able to close the window: closed="
+                << result.ClosedThroughPlanStep << " s2=" << s2);
+    }
+
+    Y_UNIT_TEST(ClosureBoundIsIndexedNotScanned) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "nfr:sub", regHandle);
+
+        for (int i = 0; i < 8; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Dir%d", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // The bound is served from an incrementally maintained index. Once
+        // everything completes it must be empty, or the bound would silently
+        // stop advancing.
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->InFlightByPlanStep.size(), 0u,
+            "every completed op must release its closure-index entry");
+        UNIT_ASSERT_C(schemeshard->GetClosedThroughPlanStep() > 0,
+            "with nothing in flight the bound must report the ceiling");
+    }
+
+    Y_UNIT_TEST(DdlOverheadWithSubscriberIsBounded) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        // With NO subscriber the outbox must cost exactly nothing.
+        TestMkDir(runtime, ++txId, "/MyRoot", "Unwatched");
+        env.TestWaitNotification(runtime, txId);
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->TestSchemeChangeRedoBytesAccum, 0u,
+            "an unsubscribed cluster must pay no outbox redo cost at all");
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "perf:sub", regHandle);
+
+        const ui64 before = schemeshard->TestSchemeChangeRedoBytesAccum;
+        TestMkDir(runtime, ++txId, "/MyRoot", "Watched");
+        env.TestWaitNotification(runtime, txId);
+        const ui64 perDdl = schemeshard->TestSchemeChangeRedoBytesAccum - before;
+
+        UNIT_ASSERT_C(perDdl > 0, "a watched DDL must actually write a record");
+        // A MkDir's request body and description are both small.
+        UNIT_ASSERT_C(perDdl < 16384,
+            "outbox redo per DDL must stay bounded; got " << perDdl << " bytes");
+    }
+
+    Y_UNIT_TEST(SyncPointPlanStepIsTheWindowEdge) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true).EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "edge:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "T1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", ".backups");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot/.backups", "collections");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections", R"(
+            Name: "MyCollection"
+            ExplicitEntryList { Entries { Type: ETypeTable Path: "/MyRoot/T1" } }
+            Cluster {}
+            IncrementalBackupConfig {}
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestBackupBackupCollection(runtime, ++txId, "/MyRoot", R"(
+            Name: ".backups/collections/MyCollection"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // DDL strictly before the sync point.
+        TestMkDir(runtime, ++txId, "/MyRoot", "BeforeSync");
+        env.TestWaitNotification(runtime, txId);
+
+        runtime.SimulateSleep(TDuration::Seconds(5));
+        TestBackupIncrementalBackupCollection(runtime, ++txId, "/MyRoot", R"(
+            Name: ".backups/collections/MyCollection"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // DDL strictly after it.
+        TestMkDir(runtime, ++txId, "/MyRoot", "AfterSync");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        ui64 syncStep = 0, beforeStep = 0, afterStep = 0;
+        for (const auto& rec : entries) {
+            if (rec.OperationType
+                    == (ui32)NKikimrSchemeOp::ESchemeOpBackupIncrementalBackupCollection) {
+                syncStep = rec.PlanStep;
+            } else if (AnyPathContains(rec, "BeforeSync")) {
+                beforeStep = rec.PlanStep;
+            } else if (AnyPathContains(rec, "AfterSync")) {
+                afterStep = rec.PlanStep;
+            }
+        }
+        UNIT_ASSERT_C(syncStep && beforeStep && afterStep,
+            "sync point and both DDLs must be recorded");
+
+        // The backup op is a coordinated tx, so its PlanStep is the cut: DDL
+        // before it falls inside the window, DDL after falls out.
+        UNIT_ASSERT_C(beforeStep < syncStep,
+            "DDL before the sync point must sit below its PlanStep: "
+                << beforeStep << " vs " << syncStep);
+        UNIT_ASSERT_C(afterStep > syncStep,
+            "DDL after the sync point must sit above its PlanStep: "
+                << afterStep << " vs " << syncStep);
+    }
+
+    Y_UNIT_TEST(ClosureBoundHeldBackByInFlightOp) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "held:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Settled");
+        env.TestWaitNotification(runtime, txId);
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->InFlightByPlanStep.size(), 0u,
+            "precondition: nothing in flight");
+
+        // Pin an operation between plan-step assignment and completion. The
+        // first state after the step is assigned is ProposedWaitParts, where
+        // SchemeShard awaits TEvSchemaChanged; holding that leaves the op with
+        // a PlanStep and no emitted record.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 heldTxId = ++txId;
+        TestCreateTable(runtime, heldTxId, "/MyRoot", R"(
+            Name: "Held"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(!schemeshard->InFlightByPlanStep.empty(),
+            "the held op must be tracked in the closure index");
+        UNIT_ASSERT_C(
+            schemeshard->GetClosedThroughPlanStep() < schemeshard->LastAssignedPlanStep,
+            "the bound must NOT close over a step whose op is still in flight: closed="
+                << schemeshard->GetClosedThroughPlanStep()
+                << " ceiling=" << schemeshard->LastAssignedPlanStep);
+
+        // Release it; the bound must then catch up.
+        runtime.SetObserverFunc(prevObserver);
+        for (auto& ev : suppressed) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        suppressed.clear();
+        env.TestWaitNotification(runtime, heldTxId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->InFlightByPlanStep.size(), 0u,
+            "the index must drain once the op completes");
+        UNIT_ASSERT_C(
+            schemeshard->GetClosedThroughPlanStep() >= schemeshard->LastAssignedPlanStep,
+            "once quiesced the bound must reach the ceiling again");
+    }
+
+    // A SchemeShard restart between propose and done must still emit the
+    // record; the rest of the reboots suite reboots around completion rather
+    // than inside this window, so it would not catch a regression here.
+
+    Y_UNIT_TEST(RecordSurvivesProposeToDoneReboot) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "durable:sub", regHandle);
+
+        const auto baseline = ReadSchemeChangeRecords(runtime);
+
+        // Park the operation after the coordinator assigns its plan step but
+        // before it completes: TCreateTable reaches ProposedWaitParts and
+        // waits on TEvSchemaChanged.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 opTxId = ++txId;
+        TestCreateTable(runtime, opTxId, "/MyRoot", R"(
+            Name: "Durable"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_C(!schemeshard->InFlightByPlanStep.empty(),
+            "precondition: the op must be in flight WITH a plan step assigned");
+
+        // Restart inside that window.
+        runtime.SetObserverFunc(prevObserver);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Let the restored operation finish.
+        env.TestWaitNotification(runtime, opTxId);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_C(entries.size() > baseline.size(),
+            "a DDL that survived a propose->done reboot must still emit its record; had "
+                << baseline.size() << " records, now " << entries.size());
+
+        bool sawDurable = false;
+        for (const auto& rec : entries) {
+            if (AnyPathContains(rec, "Durable")) {
+                sawDurable = true;
+                UNIT_ASSERT_VALUES_EQUAL_C(rec.OperationType,
+                    (ui32)NKikimrSchemeOp::ESchemeOpCreateTable,
+                    "the restored record must carry its real operation type");
+                UNIT_ASSERT_C(rec.PlanStep != 0,
+                    "the restored record must carry a usable PlanStep");
+            }
+        }
+        UNIT_ASSERT_C(sawDurable,
+            "the record for the rebooted operation must be present and identifiable");
+    }
+
+    // A multi-target op rebooted between propose and done must restore ALL
+    // targets from table 144, not just a subset: finalisation cannot re-read
+    // anything else from the DB once InitOperationSchema's snapshot pass has
+    // moved on, so a partial restore here would permanently truncate the
+    // record.
+    Y_UNIT_TEST(MultiTargetPathsSurviveReboot) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "multitarget:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src1"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src2"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Src3"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Positive companion: the identical operation without a reboot, run
+        // first so its target set is the oracle the rebooted run is compared
+        // against below.
+        const ui64 baselineTxId = ++txId;
+        TestConsistentCopyTables(runtime, baselineTxId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src1"
+                DstPath: "/MyRoot/DstBaseline1"
+            }
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src2"
+                DstPath: "/MyRoot/DstBaseline2"
+            }
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src3"
+                DstPath: "/MyRoot/DstBaseline3"
+            }
+        )");
+        env.TestWaitNotification(runtime, baselineTxId);
+
+        auto baselineEntries = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* baselineFound = nullptr;
+        for (const auto& e : baselineEntries) {
+            if (AnyPathContains(e, "DstBaseline1")) {
+                baselineFound = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(baselineFound, "baseline (non-rebooted) copy must produce a record");
+        UNIT_ASSERT_VALUES_EQUAL_C(baselineFound->Targets.size(), 3u,
+            "baseline run must record all 3 targets, got " << baselineFound->Targets.size()
+                << ": " << AllTargetPaths(*baselineFound));
+
+        THashMap<TString, TString> baselineDstToSrc;
+        for (const auto& target : baselineFound->Targets) {
+            UNIT_ASSERT_VALUES_EQUAL_C(target.SourcePaths.size(), 1u,
+                "each baseline copy target must have exactly one source, got "
+                    << target.SourcePaths.size() << " for " << target.Path);
+            baselineDstToSrc[target.Path] = target.SourcePaths[0];
+        }
+
+        // Park the rebooted operation after the coordinator assigns its plan
+        // step but before it completes, mirroring RecordSurvivesProposeToDoneReboot.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 opTxId = ++txId;
+        TestConsistentCopyTables(runtime, opTxId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src1"
+                DstPath: "/MyRoot/Dst1"
+            }
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src2"
+                DstPath: "/MyRoot/Dst2"
+            }
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Src3"
+                DstPath: "/MyRoot/Dst3"
+            }
+        )");
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_C(!schemeshard->InFlightByPlanStep.empty(),
+            "precondition: the multi-target op must be in flight WITH a plan step assigned");
+
+        // Restart inside that window: targets must be rebuilt from table 144.
+        runtime.SetObserverFunc(prevObserver);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Let the restored operation finish.
+        env.TestWaitNotification(runtime, opTxId);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* found = nullptr;
+        for (const auto& e : entries) {
+            if (AnyPathContains(e, "Dst1") && !AnyPathContains(e, "DstBaseline1")) {
+                found = &e;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found,
+            "the rebooted multi-target op must still produce a record");
+        UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 3u,
+            "ALL targets must survive the reboot, not a subset; got "
+                << found->Targets.size() << ": " << AllTargetPaths(*found));
+
+        THashMap<TString, TString> dstToSrc;
+        for (const auto& target : found->Targets) {
+            UNIT_ASSERT_C(!target.Path.empty(), "restored target Path must not be empty");
+            UNIT_ASSERT_VALUES_EQUAL_C(target.SourcePaths.size(), 1u,
+                "restored target's SourcePaths must survive intact (not empty, not "
+                "truncated), got " << target.SourcePaths.size() << " for " << target.Path);
+            dstToSrc[target.Path] = target.SourcePaths[0];
+        }
+        UNIT_ASSERT_C(dstToSrc.contains("Dst1"), "missing Dst1 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_C(dstToSrc.contains("Dst2"), "missing Dst2 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_C(dstToSrc.contains("Dst3"), "missing Dst3 in " << AllTargetPaths(*found));
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst1"], "Src1",
+            "Dst1's restored target must record Src1 as its source");
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst2"], "Src2",
+            "Dst2's restored target must record Src2 as its source");
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst3"], "Src3",
+            "Dst3's restored target must record Src3 as its source");
+
+        // The rebooted run's target SET (paths database-relative, dst->src
+        // mapping) must match the non-rebooted baseline exactly, proving the
+        // reboot degraded nothing relative to normal operation.
+        UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc.size(), baselineDstToSrc.size(),
+            "rebooted target count must match the baseline's");
+    }
+
+    // A force-drop that aborts an in-flight CreateTable via AbortUnsafe must
+    // not leave the outbox reporting StatusSuccess for an object that was
+    // never actually created.
+    Y_UNIT_TEST(ForceAbortedOperationIsNotRecordedAsSuccess) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "abort:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto dirDesc = DescribePath(runtime, "/MyRoot/DirA");
+        const ui64 dirLocalPathId = dirDesc.GetPathId();
+
+        // Park the CreateTable in flight, then force-drop its parent
+        // directory concurrently: NForceDrop::AbortRelatedOperations calls
+        // AbortUnsafe on the in-flight part, which completes it via
+        // DoneOperation without ever creating the table.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 createTxId = ++txId;
+        AsyncCreateTable(runtime, createTxId, "/MyRoot/DirA", R"(
+            Name: "Aborted"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        const ui64 dropTxId = ++txId;
+        AsyncForceDropUnsafe(runtime, dropTxId, dirLocalPathId);
+
+        runtime.SetObserverFunc(prevObserver);
+        for (auto& ev : suppressed) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        suppressed.clear();
+        env.TestWaitNotification(runtime, {createTxId, dropTxId});
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* abortedEntry = nullptr;
+        for (const auto& e : entries) {
+            if (e.TxId == createTxId) {
+                abortedEntry = &e;
+            }
+        }
+        UNIT_ASSERT_C(abortedEntry, "the force-aborted CreateTable must still produce a record "
+            "so the stream advances past it");
+        // Positive companion: an ordinary completed op in the same run really
+        // does get StatusSuccess, so this isn't a status field that is always
+        // something else.
+        bool sawOrdinarySuccess = false;
+        for (const auto& e : entries) {
+            if (e.TxId != createTxId && e.Status == (ui32)NKikimrScheme::StatusSuccess) {
+                sawOrdinarySuccess = true;
+            }
+        }
+        UNIT_ASSERT_C(sawOrdinarySuccess,
+            "precondition: a genuinely completed op (the MkDir) must show StatusSuccess");
+        UNIT_ASSERT_C(abortedEntry->Status != (ui32)NKikimrScheme::StatusSuccess,
+            "a force-aborted CreateTable must not be recorded as StatusSuccess; "
+            "the table was never actually created");
+    }
+
+    // A force-drop must not leave the fetch stream stuck behind the in-flight
+    // record it aborted: AbortRelatedOperations completes every part via
+    // AbortUnsafe, so the operation reaches DoneTransactions and its record
+    // gets finalised instead of stranding at CompletedAtUs = 0 forever.
+    Y_UNIT_TEST(ForceDropDoesNotStrandInFlightRecord) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "forcedrop:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirB");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto dirDesc = DescribePath(runtime, "/MyRoot/DirB");
+        const ui64 dirLocalPathId = dirDesc.GetPathId();
+
+        // Park a CreateTable in flight under the subtree, then force-drop the
+        // subtree: the in-flight op is aborted via AbortUnsafe.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 createTxId = ++txId;
+        AsyncCreateTable(runtime, createTxId, "/MyRoot/DirB", R"(
+            Name: "StrandedCandidate"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        const ui64 dropTxId = ++txId;
+        AsyncForceDropUnsafe(runtime, dropTxId, dirLocalPathId);
+
+        runtime.SetObserverFunc(prevObserver);
+        for (auto& ev : suppressed) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        suppressed.clear();
+        env.TestWaitNotification(runtime, {createTxId, dropTxId});
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // The aborted op's own record must be finalised (not stuck at 0).
+        auto entries = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* abortedEntry = nullptr;
+        for (const auto& e : entries) {
+            if (e.TxId == createTxId) {
+                abortedEntry = &e;
+            }
+        }
+        UNIT_ASSERT_C(abortedEntry, "the force-dropped in-flight op must still produce a record");
+        UNIT_ASSERT_C(abortedEntry->CompletedAtUs != 0,
+            "a force-dropped in-flight record must not strand at CompletedAtUs = 0; "
+            "that would wedge the fetch stream behind it permanently");
+
+        // Positive companion: a subsequent normal DDL's record is delivered
+        // afterwards, proving the stream genuinely made progress and was not
+        // just empty or already broken before the force-drop.
+        TestMkDir(runtime, ++txId, "/MyRoot", "AfterForceDrop");
+        env.TestWaitNotification(runtime, txId);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "forcedrop:sub", 0, 1000, fetchHandle);
+        bool sawAfter = false;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            const auto& targets = fetch->Record.GetEntries(i).GetTargets();
+            if (targets.size() == 1 && targets[0].GetPath() == "AfterForceDrop") {
+                sawAfter = true;
+            }
+        }
+        UNIT_ASSERT_C(sawAfter,
+            "a normal DDL issued after the force-drop must still be delivered to the "
+            "subscriber; the stream must not stop dead at the aborted operation's order");
+    }
+
+    // A TolerateOrphanedPaths recovery removes an in-flight tx's rows
+    // without finalising its already-reserved outbox row. That row must not
+    // stay at CompletedAtUs = 0 forever, or the fetch stream wedges behind
+    // it permanently -- with a healthy tablet and no way to recover other
+    // than discarding everything above it.
+    Y_UNIT_TEST(OrphanedInFlightRecordDoesNotWedgeStreamForever) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "orphan:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Orphaned");
+        env.TestWaitNotification(runtime, txId);
+        TestMkDir(runtime, ++txId, "/MyRoot", "After");
+        env.TestWaitNotification(runtime, txId);
+
+        auto before = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* orphanedEntry = nullptr;
+        for (const auto& e : before) {
+            if (SinglePathEquals(e, "Orphaned")) {
+                orphanedEntry = &e;
+            }
+        }
+        UNIT_ASSERT_C(orphanedEntry, "precondition: the row to be orphaned must exist and be finalised");
+        UNIT_ASSERT_C(orphanedEntry->CompletedAtUs != 0,
+            "precondition: the row must start out finalised (visible), or reverting it "
+            "to CompletedAtUs = 0 proves nothing about recovery");
+        const ui64 orphanedOrder = orphanedEntry->Order;
+
+        // Reproduce exactly the state a TolerateOrphanedPaths orphan leaves
+        // behind: a table-141 row stuck at CompletedAtUs = 0, plus its
+        // table-144 pending-record row, for a txId with no operation left
+        // anywhere that could ever finalise it (PersistRemoveTx already
+        // dropped the tx). This isolates the damage from finding 6 without
+        // needing to fabricate a live in-flight coordinated op or a
+        // corrupted PathsById to reach the orphan-skip branch itself.
+        const ui64 ghostTxId = 999999;
+        NKikimrMiniKQL::TResult result;
+        TString err;
+        const auto status = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, Sprintf(R"(
+            (
+                (let recKey '('('Order (Uint64 '%lu))))
+                (let recUpdate '('('CompletedAtUs (Uint64 '0))))
+                (let pendingKey '('('TxId (Uint64 '%lu)) '('RequestIdx (Uint32 '0))))
+                (let pendingUpdate '('('Order (Uint64 '%lu)) '('Path (String '"/MyRoot/Orphaned"))))
+                (return (AsList
+                    (UpdateRow 'SchemeChangeRecords recKey recUpdate)
+                    (UpdateRow 'SchemeChangePendingRecords pendingKey pendingUpdate)
+                ))
+            )
+        )", orphanedOrder, ghostTxId, orphanedOrder), result, err);
+        UNIT_ASSERT_VALUES_EQUAL_C(status, NKikimrProto::EReplyStatus::OK, err);
+
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // The orphaned row must not stay a permanent barrier: a fetch must
+        // still be able to reach records above it, the way it would if the
+        // row had been finalised normally.
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetch = FetchSchemeChangeRecords(runtime, "orphan:sub", 0, 100, fetchHandle);
+        bool sawAfter = false;
+        for (size_t i = 0; i < static_cast<size_t>(fetch->Record.EntriesSize()); ++i) {
+            const auto& afterTargets = fetch->Record.GetEntries(i).GetTargets();
+            if (afterTargets.size() == 1 && afterTargets[0].GetPath() == "After") {
+                sawAfter = true;
+            }
+        }
+        UNIT_ASSERT_C(sawAfter,
+            "a row orphaned by a TolerateOrphanedPaths recovery must not permanently block "
+            "the fetch stream behind it; the record for a later, unrelated DDL "
+            "(After) must still be reachable");
+    }
+
+    // TTxInit folds every restored tx's PlanStep into the closure index before
+    // the TolerateOrphanedPaths check runs. The orphan-skip branch then erases
+    // the tx without removing its entry, so the refcount leaks and
+    // ClosedThroughPlanStep is pinned below that step forever -- on a healthy
+    // tablet, with no way back short of another orphan-free reboot.
+    //
+    // The existing OrphanedInFlightRecordDoesNotWedgeStreamForever deliberately
+    // fabricates the *outbox row* state and never reaches the orphan-skip
+    // branch, so it cannot see this.
+    Y_UNIT_TEST(OrphanedInFlightTxDoesNotPinClosureBound) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "orphanpin:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir1");
+        env.TestWaitNotification(runtime, txId);
+
+        // Fabricate the row a half-finished operation leaves behind: an
+        // in-flight tx carrying a real PlanStep whose target path element is
+        // gone. Fabricated rather than driven, because orphaning a live
+        // operation's target means erasing its Paths row, which trips the
+        // non-tolerant Tables verify at schemeshard__init.cpp:1947 long before
+        // the TxInFlight loop is reached. Nothing else references this row.
+        const ui64 ghostTxId = 999998;
+        const ui64 ghostPlanStep = 1000;
+        const ui64 ghostLocalPathId = 999999;
+        NKikimrMiniKQL::TResult mkqlResult;
+        TString mkqlErr;
+        const auto status = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, Sprintf(R"(
+            (
+                (let key '('('TxId (Uint64 '%lu)) '('TxPartId (Uint32 '0))))
+                (let update '(
+                    '('TargetOwnerPathId (Uint64 '%lu))
+                    '('TargetPathId (Uint64 '%lu))
+                    '('MinStep (Uint64 '0))
+                    '('PlanStep (Uint64 '%lu))))
+                (return (AsList (UpdateRow 'TxInFlightV2 key update)))
+            )
+        )", ghostTxId, (ui64)TTestTxConfig::SchemeShard, ghostLocalPathId, ghostPlanStep),
+            mkqlResult, mkqlErr);
+        UNIT_ASSERT_VALUES_EQUAL_C(status, NKikimrProto::EReplyStatus::OK, mkqlErr);
+
+        TControlBoard::SetValue(1, runtime.GetAppData().Icb->SchemeShardControls.TolerateOrphanedPaths);
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(schemeshard->InFlightByPlanStep.empty(),
+            "the skipped orphan's PlanStep leaked into the closure index: "
+            << schemeshard->InFlightByPlanStep.size() << " entry(ies) remain, first step "
+            << (schemeshard->InFlightByPlanStep.empty() ? 0 : schemeshard->InFlightByPlanStep.begin()->first));
+
+        UNIT_ASSERT_C(
+            schemeshard->GetClosedThroughPlanStep() >= schemeshard->LastAssignedPlanStep,
+            "ClosedThroughPlanStep is pinned below the ceiling by a tx that no longer exists: "
+                << schemeshard->GetClosedThroughPlanStep()
+                << " < " << schemeshard->LastAssignedPlanStep);
+    }
+
+    // A redelivered plan step (mediator reconnect) must not double-count in
+    // the closure index, or ClosedThroughPlanStep freezes below the ceiling
+    // forever and no subscriber can ever close that window again.
+    Y_UNIT_TEST(RedeliveredPlanStepDoesNotFreezeClosureBound) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "redelivery:sub", regHandle);
+
+        // Park the operation after the coordinator assigns its plan step but
+        // before it completes, same as ClosureBoundHeldBackByInFlightOp: it
+        // reaches ProposedWaitParts and waits on TEvSchemaChanged. Capture
+        // the assigned step and txId while parked.
+        TVector<THolder<IEventHandle>> suppressedSchemaChanged;
+        auto prevObserver = SetSuppressObserver(runtime, suppressedSchemaChanged,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 opTxId = ++txId;
+        TestCreateTable(runtime, opTxId, "/MyRoot", R"(
+            Name: "Redelivered"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(!schemeshard->InFlightByPlanStep.empty(),
+            "precondition: the op must be in flight WITH a plan step assigned");
+        const ui64 assignedStep = schemeshard->InFlightByPlanStep.begin()->first;
+
+        // Redeliver the plan step in memory, exactly as the mediator would
+        // resend it on pipe reconnect: a fresh TEvPlanStep for the same
+        // step/txId, sent directly to the schemeshard actor.
+        NKikimrTx::TEvMediatorPlanStep record;
+        record.SetStep(assignedStep);
+        auto* txRecord = record.AddTransactions();
+        txRecord->SetTxId(opTxId);
+        txRecord->SetCoordinator(ui64(TTestTxConfig::Coordinator));
+        ActorIdToProto(runtime.AllocateEdgeActor(), txRecord->MutableAckTo());
+
+        auto duplicate = MakeHolder<TEvTxProcessing::TEvPlanStep>();
+        duplicate->Record = record;
+        runtime.Send(new IEventHandle(schemeshard->SelfId(), runtime.AllocateEdgeActor(), duplicate.Release()),
+            0, false);
+        runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        // Release the held op and let it finish.
+        runtime.SetObserverFunc(prevObserver);
+        for (auto& ev : suppressedSchemaChanged) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        suppressedSchemaChanged.clear();
+        env.TestWaitNotification(runtime, opTxId);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->InFlightByPlanStep.size(), 0u,
+            "the op completed, so the index must not still show it in flight");
+        UNIT_ASSERT_C(schemeshard->GetClosedThroughPlanStep() >= schemeshard->LastAssignedPlanStep,
+            "the redelivered step must not leave a phantom refcount behind: closed="
+                << schemeshard->GetClosedThroughPlanStep()
+                << " ceiling=" << schemeshard->LastAssignedPlanStep);
+    }
+
+    Y_UNIT_TEST(RecordIsWrittenAtProposeTime) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "early:sub", regHandle);
+
+        const auto baseline = ReadSchemeChangeRecords(runtime);
+
+        // Hold the op in ProposedWaitParts: plan step assigned, not yet done.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 opTxId = ++txId;
+        TestCreateTable(runtime, opTxId, "/MyRoot", R"(
+            Name: "Early"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // The record is the durable artifact, so the row must already be on
+        // disk while the operation is still in flight.
+        auto opIt = schemeshard->Operations.find(TTxId(opTxId));
+        UNIT_ASSERT_C(opIt != schemeshard->Operations.end(),
+            "precondition: the operation must still be in flight, otherwise this "
+            "test measures nothing");
+        UNIT_ASSERT_VALUES_EQUAL_C(opIt->second->SchemeChangeSlots.size(), 1u,
+            "propose must have reserved exactly one outbox row for this DDL");
+        const ui64 reservedOrder = opIt->second->SchemeChangeSlots[0].Order;
+        UNIT_ASSERT_C(reservedOrder != 0, "a reserved order must be a real order");
+
+        // Physical presence, read by explicit order so the subscriber cursor
+        // cannot mask the answer.
+        auto present = ProbeRecordOrdersPresent(runtime, "early:sub", {reservedOrder});
+        UNIT_ASSERT_VALUES_EQUAL_C(present.size(), 1u,
+            "the record must be persisted at propose, not deferred to completion; "
+            "order " << reservedOrder << " is not on disk");
+
+        // Physically present is not the same as deliverable: an un-finalised
+        // row must not be fetchable yet, or an ack could advance the cursor
+        // past a record that never got its contents.
+        auto inFlight = ReadSchemeChangeRecords(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(inFlight.size(), baseline.size(),
+            "a reserved-but-unfinalised row must not be handed to subscribers");
+
+        // Release and let it finish; the same row must then carry the fields
+        // that are only knowable at completion.
+        runtime.SetObserverFunc(prevObserver);
+        for (auto& ev : suppressed) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        suppressed.clear();
+        env.TestWaitNotification(runtime, opTxId);
+
+        auto settled = ReadSchemeChangeRecords(runtime);
+        const TSchemeChangeRecordEntry* done = nullptr;
+        for (const auto& rec : settled) {
+            if (AnyPathContains(rec, "Early")) {
+                done = &rec;
+            }
+        }
+        UNIT_ASSERT_C(done, "the record must become visible once the operation completes");
+        UNIT_ASSERT_VALUES_EQUAL_C(done->Order, reservedOrder,
+            "completion must finalise the row reserved at propose, not a new one");
+        UNIT_ASSERT_VALUES_EQUAL_C(done->OperationType,
+            (ui32)NKikimrSchemeOp::ESchemeOpCreateTable,
+            "the operation type known at propose must survive finalisation");
+        UNIT_ASSERT_C(done->PlanStep != 0,
+            "completion must finalise PlanStep on the existing row");
+        UNIT_ASSERT_C(done->PathLocalId != 0,
+            "completion must finalise the resolved PathId on the existing row");
+        UNIT_ASSERT_VALUES_EQUAL_C(settled.size(), baseline.size() + 1,
+            "finalising must UPDATE the reserved row, not append a second one");
+    }
+
+    // A reserved order is not a consumed one: "the tail" must mean the visible
+    // tail, or a cursor silently swallows records still in flight.
+    Y_UNIT_TEST(SubscriberRegisteredMidDdlStillReceivesThatRecord) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        // Someone must be subscribed at propose or nothing is reserved at all.
+        TAutoPtr<IEventHandle> firstHandle;
+        RegisterSubscriber(runtime, "first:sub", firstHandle);
+
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(runtime, suppressed,
+            TEvDataShard::TEvSchemaChanged::EventType);
+
+        const ui64 opTxId = ++txId;
+        TestCreateTable(runtime, opTxId, "/MyRoot", R"(
+            Name: "MidDdl"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        auto opIt = schemeshard->Operations.find(TTxId(opTxId));
+        UNIT_ASSERT_C(opIt != schemeshard->Operations.end(),
+            "precondition: the operation must still be in flight");
+        UNIT_ASSERT_VALUES_EQUAL_C(opIt->second->SchemeChangeSlots.size(), 1u,
+            "precondition: propose must have reserved a row to be missed");
+
+        // The late subscriber registers here, with the row reserved but not yet
+        // finalised: defaulting to the reserved tail would put its cursor above it.
+        TAutoPtr<IEventHandle> lateHandle;
+        RegisterSubscriber(runtime, "late:sub", lateHandle);
+
+        runtime.SetObserverFunc(prevObserver);
+        for (auto& ev : suppressed) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        suppressed.clear();
+        env.TestWaitNotification(runtime, opTxId);
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetched = FetchSchemeChangeRecords(runtime, "late:sub", 0, 100, fetchHandle);
+        UNIT_ASSERT_VALUES_EQUAL_C(fetched->Record.EntriesSize(), 1u,
+            "a subscriber that registered while the DDL was in flight must still "
+            "receive its record once it finalises");
+        bool midDdlSeen = false;
+        for (const auto& t : fetched->Record.GetEntries(0).GetTargets()) {
+            if (t.GetPath().Contains("MidDdl")) {
+                midDdlSeen = true;
+            }
+        }
+        UNIT_ASSERT_C(midDdlSeen,
+            "and it must be that DDL's record");
+
+        UNIT_ASSERT_VALUES_EQUAL_C(fetched->Record.GetSkippedEntries(), 0u,
+            "nothing was swept, so nothing may be reported as skipped");
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)fetched->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "a subscriber that lost nothing must not be marked Lost");
+    }
+
+    // A consumer that stops acking must wedge DDL, not get its records
+    // quietly discarded. The only way past a broken consumer is an explicit
+    // admin action.
+    Y_UNIT_TEST(BrokenConsumerWedgesDdlUntilAdminOverride) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        // Small cap so the wedge is reachable in a unit test.
+        ApplySchemeShardConfig(runtime, {.MaxSchemeChangeRecords = 2});
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "broken:sub", regHandle);
+
+        // The consumer never acks. Fill the outbox to the cap.
+        for (int i = 0; i < 2; ++i) {
+            TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                Name: "w2t%d"
+                Columns { Name: "key" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // DDL must now be REFUSED rather than silently making room.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "wedged"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )", {NKikimrScheme::StatusResourceExhausted});
+
+        // The backlog must still be on disk: "rejected" is only the right
+        // behaviour if the records it was protecting actually survived.
+        auto present = ProbeRecordOrdersPresent(runtime, "broken:sub", {1, 2});
+        UNIT_ASSERT_VALUES_EQUAL_C(present.size(), 2u,
+            "the unacked records must be retained, not discarded to unblock DDL");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribersLost"), 0u,
+            "nothing was discarded, so nobody may be marked Lost");
+        UNIT_ASSERT_C(
+            GetCumulativeCounter(runtime, "SchemeShard/SchemeChangeDdlRejectedByOutbox") > 0,
+            "the wedge firing must be visible to monitoring");
+
+        // The admin override is the one and only release valve.
+        TAutoPtr<IEventHandle> advHandle;
+        ForceAdvanceSubscriber(runtime, "broken:sub", advHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "released"
+            Columns { Name: "key" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetSimpleCounter(runtime, "SchemeShard/SchemeChangeSubscribersLost"), 1u,
+            "the admin override discarded records, so the subscriber must now be Lost");
+    }
+
+    // DDL stops on a broken consumer rather than self-healing, so an operator
+    // must be able to see the depth climbing before it reaches the wedge.
+    // Asserted through the real exported tablet counters, the same numbers a
+    // production dashboard reads.
+    // Description is serialized into the local-DB redo log on every DDL, so it
+    // must not carry anything that scales with the object's size. Two tables
+    // identical except for partition count must produce similarly sized
+    // descriptions.
+    Y_UNIT_TEST(DescriptionDoesNotGrowWithPartitionCount) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "w1:sub", regHandle);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "single"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 1
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "spread"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 64
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        size_t single = 0;
+        size_t spread = 0;
+        for (const auto& rec : ReadSchemeChangeRecordsFull(runtime).Entries) {
+            if (AnyPathContains(rec, "single")) {
+                single = rec.Description.size();
+            } else if (AnyPathContains(rec, "spread")) {
+                spread = rec.Description.size();
+            }
+        }
+
+        // "Small" must not be "absent": a fix that stopped capturing
+        // Description would otherwise pass this test.
+        UNIT_ASSERT_C(single > 0, "the 1-partition table's description must still be captured");
+        UNIT_ASSERT_C(spread > 0, "the 64-partition table's description must still be captured");
+
+        UNIT_ASSERT_C(spread < single + 256,
+            "Description must not grow with partition count: 1 partition -> " << single
+                << " bytes, 64 partitions -> " << spread << " bytes");
+    }
+
+    // The order counter must be rewound when a propose is rejected after it
+    // has already reserved outbox rows, or the reserved order is never
+    // written while the in-memory counter has moved past it, leaving a
+    // permanent hole that fetch's gap detection reports as record loss.
+    //
+    // The source table is created before the subscriber registers so
+    // NextSchemeChangeOrder stays at 0 and the aborted propose is the first
+    // one that reserves.
+    Y_UNIT_TEST(AbortedFirstProposeDoesNotFakeRecordLoss) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        // The redo-size limit is the only check that rejects a propose after
+        // IgniteOperation has run, so it's the only way to reach
+        // AbortOperationPropose with rows already reserved.
+        TControlWrapper maxCommitRedoMB;
+        {
+            TControlBoard::RegisterSharedControl(
+                maxCommitRedoMB, runtime.GetAppData().Icb->TabletControls.MaxCommitRedoMB);
+            maxCommitRedoMB.Reset(200, 1, 4096);
+        }
+
+        // No subscriber yet, so this reserves nothing and the counter stays 0.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "src"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "w0:sub", regHandle);
+
+        // Reserves an order, then gets rejected: the DB is rolled back but the
+        // in-memory counter is not.
+        {
+            maxCommitRedoMB = 1;
+            AsyncCopyTable(runtime, ++txId, "/MyRoot", "src-copy", "/MyRoot/src");
+            TestModificationResults(runtime, txId, {{NKikimrScheme::StatusSchemeError,
+                "local tx commit redo size generated by IgniteOperation() is more than allowed limit"}});
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // ...so this one reserves the NEXT order, and the skipped one exists nowhere.
+        {
+            maxCommitRedoMB = 200;
+            AsyncCopyTable(runtime, ++txId, "/MyRoot", "src-copy", "/MyRoot/src");
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TAutoPtr<IEventHandle> fetchHandle;
+        auto* fetched = FetchSchemeChangeRecords(runtime, "w0:sub", 0, 100, fetchHandle);
+
+        // Absence of loss must not be absence of data.
+        UNIT_ASSERT_VALUES_EQUAL_C(fetched->Record.EntriesSize(), 1u,
+            "the successful CopyTable must have produced exactly one record");
+        UNIT_ASSERT_VALUES_EQUAL_C(fetched->Record.GetSkippedEntries(), 0u,
+            "an aborted propose must not leave a hole in the order sequence; "
+            "this subscriber lost nothing but was told it did");
+        UNIT_ASSERT_VALUES_EQUAL_C((ui32)fetched->Record.GetState(),
+            (ui32)NKikimrSchemeShard::TSchemeChangeSubscriberState::STATE_READY,
+            "a subscriber that lost nothing must not be marked Lost");
+    }
+
+    // DeleteAckedSchemeChangeRecords selects [oldMinOrder+1, newMinOrder]
+    // rather than a one-sided GreaterOrEqual. This test pins the part that can
+    // regress: the upper bound is inclusive. A LessOrEqual -> Less slip would
+    // strand the boundary record forever, since the next pass starts above it.
+
+    Y_UNIT_TEST(CleanupDeletesThroughTheBoundaryButNotPastIt) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "boundary:sub", regHandle);
+
+        const ui32 total = 6;
+        for (ui32 i = 0; i < total; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Dir%u", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail >= total, "precondition: records must exist");
+
+        const ui64 boundary = 3;
+
+        // The rows are physically present beforehand, so a later "gone" is meaningful.
+        auto before = ProbeRecordOrdersPresent(runtime, "boundary:sub", {boundary, boundary + 1});
+        UNIT_ASSERT_VALUES_EQUAL_C(before.size(), 2u,
+            "both the boundary record and the one above it must exist first");
+
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "boundary:sub", boundary, ackHandle);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        auto after = ProbeRecordOrdersPresent(runtime, "boundary:sub", {boundary, boundary + 1});
+        UNIT_ASSERT_VALUES_EQUAL_C(after.size(), 1u,
+            "exactly one of the two must survive the sweep");
+        UNIT_ASSERT_VALUES_EQUAL_C(after[0], boundary + 1,
+            "the acked boundary record must be deleted and the record above it "
+            "kept; a stranded boundary row is never revisited");
+    }
+
+    // Deleted outbox rows remain as tombstones until compaction, so a cleanup
+    // that restarts at order 1 re-seeks the whole dead prefix on every batch.
+    // The floor records how far deletion has physically reached and must
+    // survive a reboot, or the quadratic drain silently returns.
+
+    Y_UNIT_TEST(CleanupFloorAdvancesAndSurvivesReboot) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "floor:sub", regHandle);
+
+        for (ui32 i = 0; i < 6; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Dir%u", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->SchemeChangeFloorOrder, 0u,
+            "precondition: nothing deleted yet, so the floor must still be 0");
+
+        const ui64 acked = 3;
+        TAutoPtr<IEventHandle> ackHandle;
+        AckSchemeChangeRecords(runtime, "floor:sub", acked, ackHandle);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->SchemeChangeFloorOrder, acked,
+            "the floor must advance to the last row actually deleted");
+
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(schemeshard->SchemeChangeFloorOrder, acked,
+            "the floor must be reloaded at TTxInit; resetting to 0 would send "
+            "every later cleanup batch back over the tombstoned prefix");
+    }
+
+    // Fetching bodies must cost |Orders|, not the span they cover: point
+    // lookups instead of walking [min(Orders), max(Orders)].
+    Y_UNIT_TEST(FetchBodiesCostTracksRequestedCountNotTheirSpan) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "span:sub", regHandle);
+
+        const ui32 total = 40;
+        for (ui32 i = 0; i < total; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Dir%u", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail >= total, "precondition: records must exist");
+
+        // Two orders at opposite ends of the outbox: minimal request, maximal span.
+        const TVector<ui64> orders = {1, tail - 1};
+
+        const ui64 before = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangeOutboxRowsScanned");
+        TAutoPtr<IEventHandle> bodiesHandle;
+        auto* bodies = FetchSchemeChangeRecordBodies(runtime, "span:sub", orders, bodiesHandle);
+        const ui64 scanned = GetCumulativeCounter(runtime, "SchemeShard/SchemeChangeOutboxRowsScanned") - before;
+
+        // The cheap path must still return the data, not just satisfy the
+        // scan bound with an empty reply.
+        UNIT_ASSERT_VALUES_EQUAL_C(bodies->Record.EntriesSize(), 2u,
+            "both requested records must come back; a cheap-but-empty reply "
+            "would satisfy the bound below for the wrong reason");
+
+        // 2 metadata lookups + up to 2 detail lookups, generous headroom.
+        UNIT_ASSERT_C(scanned <= 8,
+            "fetching 2 bodies must not scan the span between them: scanned "
+                << scanned << " rows across an outbox of " << tail);
+    }
+
+    Y_UNIT_TEST(FetchBodiesRejectsOversizedRequestRatherThanTruncating) {
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "flood:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TVector<ui64> orders;
+        for (ui64 i = 1; i <= 1001; ++i) {
+            orders.push_back(i);
+        }
+
+        // The plain helper asserts STATUS_SUCCESS, so rejection needs the Expect variant.
+        TAutoPtr<IEventHandle> bodiesHandle;
+        auto* bodies = FetchSchemeChangeRecordBodiesExpect(runtime, "flood:sub", orders,
+            NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_INVALID_REQUEST, bodiesHandle);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(bodies->Record.EntriesSize(), 0u,
+            "a refused request must not carry a partial result");
+    }
+
+    Y_UNIT_TEST(RedactedFieldsEmptyWhenNothingSensitive) {
+        // Guards against a walker that reports every field it visits, not
+        // just the ones actually cleared.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableSchemeChangeRecords(true));
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "plain:sub", regHandle);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "Dir");
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        bool sawMkDir = false;
+        for (const auto& rec : entries) {
+            if (rec.OperationType == (ui32)NKikimrSchemeOp::ESchemeOpMkDir) {
+                sawMkDir = true;
+                UNIT_ASSERT_C(rec.RedactedFields.empty(),
+                    "a record with nothing sensitive must have an empty RedactedFields");
+            }
+        }
+        UNIT_ASSERT_C(sawMkDir,
+            "the MkDir op must itself be among the records checked");
+    }
+
+    Y_UNIT_TEST(RedactionDisabledPersistsSensitiveFields) {
+        // With the flag off, credentials are persisted in the outbox body and
+        // served to every subscriber over a protocol with no authentication
+        // (removed deliberately; subscriber-side auth does not exist yet).
+        // The flag is only safe once that exists.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        opts.InitYdbDriver(true);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "unredacted:sub", regHandle);
+
+        ApplySchemeShardConfig(runtime, TSchemeShardConfigOverrides{
+            .RedactSensitiveSchemeChangeFields = false,
+        });
+
+        const TString password = "s3cr3t-replication-pwd";
+        TestCreateReplication(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            Name: "Replication"
+            Config {
+              SrcConnectionParams {
+                StaticCredentials {
+                  User: "user"
+                  Password: "%s"
+                }
+              }
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )", password.c_str()));
+        env.TestWaitNotification(runtime, txId);
+
+        auto entries = ReadSchemeChangeRecords(runtime);
+        bool sawReplicationOp = false;
+        for (const auto& rec : entries) {
+            if (rec.OperationType != (ui32)NKikimrSchemeOp::ESchemeOpCreateReplication) {
+                continue;
+            }
+            sawReplicationOp = true;
+            TString serializedBody;
+            UNIT_ASSERT(rec.Body.SerializeToString(&serializedBody));
+            UNIT_ASSERT_C(!serializedBody.empty(),
+                "the CreateReplication record must carry a non-empty body for this test to mean anything");
+            UNIT_ASSERT_C(serializedBody.Contains(password),
+                "with redaction disabled the plaintext password must be present in the body");
+            UNIT_ASSERT_C(rec.RedactedFields.empty(),
+                "with redaction disabled nothing was cleared, so RedactedFields must be empty");
+        }
+        UNIT_ASSERT_C(sawReplicationOp,
+            "the CreateReplication op must itself be among the records checked");
+    }
+
+    // DeleteAckedSchemeChangeRecords used to accept an oldMinOrder watermark
+    // from the caller and resume above it. But the subscriber's LastAckedOrder
+    // (which feeds oldMinOrder on the *next* call) advances immediately, even
+    // when the batch limit stops physical deletion short. A second call with a
+    // higher watermark then starts above the undeleted gap and never revisits
+    // it: the rows are orphaned forever. SchemeChangeFloorOrder -- what was
+    // actually deleted -- is the only sound resume point.
+    Y_UNIT_TEST(CleanupNeverOrphansRowsAcrossSuccessiveWatermarkAdvances) {
+        TSchemeShard* schemeshard = nullptr;
+        auto ssFactory = [&schemeshard](const TActorId& tablet, TTabletStorageInfo* info) {
+            schemeshard = new TSchemeShard(tablet, info);
+            return schemeshard;
+        };
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableSchemeChangeRecords(true);
+        TTestEnv env(runtime, opts, ssFactory);
+        ui64 txId = 100;
+
+        TAutoPtr<IEventHandle> regHandle;
+        RegisterSubscriber(runtime, "gap:sub", regHandle);
+
+        const ui32 total = 10;
+        for (ui32 i = 0; i < total; ++i) {
+            TestMkDir(runtime, ++txId, "/MyRoot", Sprintf("Dir%u", i));
+            env.TestWaitNotification(runtime, txId);
+        }
+        const ui64 tail = schemeshard->NextSchemeChangeOrder;
+        UNIT_ASSERT_C(tail >= total, "precondition: records must exist");
+
+        // Small enough that a single Ack's inline delete pass cannot drain a
+        // 5-row range in one shot.
+        schemeshard->SchemeChangeCleanupBatchSize = 2;
+
+        // Rows [1..5] and [6..7] are both physically present beforehand.
+        auto before = ProbeRecordOrdersPresent(runtime, "gap:sub", {1, 2, 3, 4, 5, 6, 7});
+        UNIT_ASSERT_VALUES_EQUAL_C(before.size(), 7u,
+            "all seven probed rows must exist before any cleanup runs");
+
+        // First Ack: deletes only the first batch (orders 1-2) inline, then
+        // stops with hasMore=true. No SimulateSleep is called here, so the
+        // scheduled follow-up cleanup tx (10ms later) has not run yet and
+        // cannot mask the bug by draining the gap on its own before the
+        // second Ack below observes the (already advanced) watermark.
+        TAutoPtr<IEventHandle> ack1Handle;
+        AckSchemeChangeRecords(runtime, "gap:sub", 5, ack1Handle);
+
+        // Positive companion: orders 3-5 are still physically present right
+        // after the first, batch-capped Ack -- the gap this bug orphans.
+        auto midGap = ProbeRecordOrdersPresent(runtime, "gap:sub", {3, 4, 5});
+        UNIT_ASSERT_VALUES_EQUAL_C(midGap.size(), 3u,
+            "precondition: the batch limit must actually leave 3-5 undeleted "
+            "after the first Ack, or this test proves nothing");
+
+        // Second Ack: LastAckedOrder is already 5 from the call above, so the
+        // buggy code would resume cleanup at order 6, permanently skipping
+        // whatever remains undeleted in [3..5].
+        TAutoPtr<IEventHandle> ack2Handle;
+        AckSchemeChangeRecords(runtime, "gap:sub", 7, ack2Handle);
+
+        // Let any remaining scheduled continuations finish draining. This
+        // cannot paper over the bug: once the buggy Ack(7) call above jumps
+        // the floor straight to 7, rows 3-5 are below the floor and no later
+        // pass -- scheduled or not -- ever selects them again.
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        auto after = ProbeRecordOrdersPresent(runtime, "gap:sub", {1, 2, 3, 4, 5, 6, 7});
+        UNIT_ASSERT_C(after.empty(),
+            "every acked row through order 7 must eventually be deleted; "
+            << after.size() << " still present");
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records/ya.make
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records/ya.make
@@ -2,9 +2,9 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
-# Runs every op in this suite through the scheme change outbox and fails the
-# test if any of them cannot resolve a target path.
-ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+IF (WITH_VALGRIND)
+    SPLIT_FACTOR(20)
+ENDIF()
 
 SIZE(MEDIUM)
 
@@ -12,16 +12,17 @@ PEERDIR(
     library/cpp/getopt
     library/cpp/regex/pcre
     library/cpp/svnversion
-    ydb/core/metering
-    ydb/core/testlib/default
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/pg
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers
+    yql/essentials/public/udf/service/exception_policy
 )
 
 YQL_LAST_ABI_VERSION()
 
 SRCS(
-    ut_column_build.cpp
+    ut_scheme_change_records.cpp
 )
 
 END()

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records_reboots/ut_scheme_change_records_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records_reboots/ut_scheme_change_records_reboots.cpp
@@ -1,0 +1,324 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/tx/schemeshard/schemeshard_tx_infly.h>
+#include <ydb/core/tx/schemeshard/ut_scheme_change_records/ut_scheme_change_records_helpers.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+using NSchemeChangeRecordTestHelpers::ReadSchemeChangeRecords;
+
+namespace {
+
+void RegisterSubscriber(TTestActorRuntime& runtime, const TString& subscriberId) {
+    auto sender = runtime.AllocateEdgeActor();
+    auto req = MakeHolder<TEvSchemeShard::TEvRegisterSubscriber>();
+    req->Record.SetSubscriberId(subscriberId);
+    ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, req.Release());
+    TAutoPtr<IEventHandle> handle;
+    auto result = runtime.GrabEdgeEvent<TEvSchemeShard::TEvRegisterSubscriberResult>(handle);
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL((ui32)result->Record.GetStatus(), (ui32)NKikimrSchemeShard::TSchemeChangeRecordsStatus::STATUS_SUCCESS);
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(TSchemeChangeRecordsReboots) {
+
+    Y_UNIT_TEST_WITH_REBOOTS(CreateTableWithReboots) {
+        t.GetTestEnvOptions().EnableSchemeChangeRecords(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                RegisterSubscriber(runtime, "test:sub");
+            }
+
+            t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                "Name: \"Table1\""
+                "Columns { Name: \"key\"   Type: \"Uint64\" }"
+                "Columns { Name: \"value\" Type: \"Utf8\" }"
+                "KeyColumnNames: [\"key\"]"),
+                {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                 NKikimrScheme::StatusMultipleModifications});
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/Table1"),
+                    {NLs::Finished, NLs::IsTable});
+
+                auto entries = ReadSchemeChangeRecords(runtime);
+                bool found = false;
+                for (const auto& e : entries) {
+                    if (e.Body.GetCreateTable().GetName() == "Table1") {
+                        found = true;
+                        UNIT_ASSERT(e.Order > 0);
+                        break;
+                    }
+                }
+                UNIT_ASSERT_C(found, "Scheme change record for Table1 not found");
+            }
+        });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(MultipleCreateTablesWithReboots) {
+        t.GetTestEnvOptions().EnableSchemeChangeRecords(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                RegisterSubscriber(runtime, "test:sub");
+                t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                    "Name: \"T1\""
+                    "Columns { Name: \"key\" Type: \"Uint64\" }"
+                    "KeyColumnNames: [\"key\"]"),
+                    {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                     NKikimrScheme::StatusMultipleModifications});
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                "Name: \"T2\""
+                "Columns { Name: \"key\" Type: \"Uint64\" }"
+                "KeyColumnNames: [\"key\"]"),
+                {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                 NKikimrScheme::StatusMultipleModifications});
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/T1"),
+                    {NLs::Finished, NLs::IsTable});
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/T2"),
+                    {NLs::Finished, NLs::IsTable});
+
+                auto entries = ReadSchemeChangeRecords(runtime);
+
+                // T1 was created in inactive zone -- its entry must exist
+                bool foundT1 = false;
+                for (const auto& e : entries) {
+                    if (e.Body.GetCreateTable().GetName() == "T1") {
+                        foundT1 = true;
+                        UNIT_ASSERT(e.Order > 0);
+                    }
+                }
+                UNIT_ASSERT_C(foundT1, "Scheme change record for T1 not found");
+
+                // Verify monotonic sequence IDs across all entries
+                for (size_t i = 1; i < entries.size(); ++i) {
+                    UNIT_ASSERT_C(entries[i].Order > entries[i-1].Order,
+                        "Orders must be strictly monotonic");
+                }
+            }
+        });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(AlterTableWithReboots) {
+        t.GetTestEnvOptions().EnableSchemeChangeRecords(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                RegisterSubscriber(runtime, "test:sub");
+                t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                    "Name: \"Table1\""
+                    "Columns { Name: \"key\"   Type: \"Uint64\" }"
+                    "Columns { Name: \"value\" Type: \"Utf8\" }"
+                    "KeyColumnNames: [\"key\"]"),
+                    {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                     NKikimrScheme::StatusMultipleModifications});
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            TestAlterTable(runtime, ++t.TxId, "/MyRoot", R"(
+                Name: "Table1"
+                Columns { Name: "extra" Type: "Uint32" }
+            )");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/Table1"),
+                    {NLs::Finished, NLs::IsTable,
+                     NLs::CheckColumns("Table1", {"key", "value", "extra"}, {}, {"key"})});
+
+                auto entries = ReadSchemeChangeRecords(runtime);
+
+                // CREATE was done in inactive zone -- its entry must exist
+                bool foundCreate = false;
+                for (const auto& e : entries) {
+                    if (e.Body.HasCreateTable()
+                        && e.Body.GetCreateTable().GetName() == "Table1") {
+                        foundCreate = true;
+                        UNIT_ASSERT(e.Order > 0);
+                    }
+                }
+                UNIT_ASSERT_C(foundCreate, "CREATE TABLE entry not found in notification log");
+
+                // Verify monotonic sequence IDs across all entries
+                for (size_t i = 1; i < entries.size(); ++i) {
+                    UNIT_ASSERT_C(entries[i].Order > entries[i-1].Order,
+                        "Orders must be strictly monotonic");
+                }
+            }
+        });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(OrderCounterSurvivesReboot) {
+        t.GetTestEnvOptions().EnableSchemeChangeRecords(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                RegisterSubscriber(runtime, "test:sub");
+                t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                    "Name: \"T1\""
+                    "Columns { Name: \"key\" Type: \"Uint64\" }"
+                    "KeyColumnNames: [\"key\"]"),
+                    {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                     NKikimrScheme::StatusMultipleModifications});
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            // Create T2 in active zone -- reboots injected here.
+            t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                "Name: \"T2\""
+                "Columns { Name: \"key\" Type: \"Uint64\" }"
+                "KeyColumnNames: [\"key\"]"),
+                {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                 NKikimrScheme::StatusMultipleModifications});
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/T1"),
+                    {NLs::Finished, NLs::IsTable});
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/T2"),
+                    {NLs::Finished, NLs::IsTable});
+
+                auto entries = ReadSchemeChangeRecords(runtime);
+
+                // T1 was created in inactive zone -- its entry must exist
+                ui64 t1Order = 0;
+                for (const auto& e : entries) {
+                    if (e.Body.GetCreateTable().GetName() == "T1") t1Order = e.Order;
+                }
+                UNIT_ASSERT_C(t1Order > 0, "T1 entry not found in notification log");
+
+                // If T2's entry exists, verify counter continuity
+                for (const auto& e : entries) {
+                    if (e.Body.GetCreateTable().GetName() == "T2") {
+                        UNIT_ASSERT_C(e.Order > t1Order,
+                            "T2 Order (" << e.Order
+                                << ") must be greater than T1 Order (" << t1Order << ")");
+                    }
+                }
+
+                // Verify monotonic sequence IDs across all entries
+                for (size_t i = 1; i < entries.size(); ++i) {
+                    UNIT_ASSERT_C(entries[i].Order > entries[i-1].Order,
+                        "Orders must be strictly monotonic");
+                }
+            }
+        });
+    }
+
+    // A multi-target op's N (Path, SourcePaths) targets are carried in
+    // TSchemeChangeSlot in memory, backed by table 144 for recovery -- reboot
+    // mid-operation and confirm all N targets AND their sources survive, not
+    // just the destination paths.
+    Y_UNIT_TEST_WITH_REBOOTS(MultiTargetPathsSurviveReboot) {
+        t.GetTestEnvOptions().EnableSchemeChangeRecords(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                RegisterSubscriber(runtime, "test:sub");
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "Src1"
+                    Columns { Name: "key" Type: "Uint64" }
+                    KeyColumnNames: ["key"]
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "Src2"
+                    Columns { Name: "key" Type: "Uint64" }
+                    KeyColumnNames: ["key"]
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            TestConsistentCopyTables(runtime, ++t.TxId, "/MyRoot", R"(
+                CopyTableDescriptions {
+                    SrcPath: "/MyRoot/Src1"
+                    DstPath: "/MyRoot/Dst1"
+                }
+                CopyTableDescriptions {
+                    SrcPath: "/MyRoot/Src2"
+                    DstPath: "/MyRoot/Dst2"
+                }
+            )");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst1"), {NLs::Finished, NLs::IsTable});
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst2"), {NLs::Finished, NLs::IsTable});
+
+                auto entries = ReadSchemeChangeRecords(runtime);
+                const NSchemeChangeRecordTestHelpers::TSchemeChangeRecordEntry* found = nullptr;
+                for (const auto& e : entries) {
+                    if (e.Body.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables) {
+                        found = &e;
+                        break;
+                    }
+                }
+                UNIT_ASSERT_C(found, "CreateConsistentCopyTables entry not found after reboot");
+                UNIT_ASSERT_VALUES_EQUAL_C(found->Targets.size(), 2u,
+                    "both copy targets must survive a reboot, got " << found->Targets.size());
+                THashMap<TString, TString> dstToSrc;
+                for (const auto& target : found->Targets) {
+                    UNIT_ASSERT_VALUES_EQUAL_C(target.SourcePaths.size(), 1u,
+                        "each target's source must survive a reboot, got "
+                            << target.SourcePaths.size() << " for " << target.Path);
+                    dstToSrc[target.Path] = target.SourcePaths[0];
+                }
+                UNIT_ASSERT_C(dstToSrc.contains("Dst1"), "Dst1 missing after reboot");
+                UNIT_ASSERT_C(dstToSrc.contains("Dst2"), "Dst2 missing after reboot");
+                UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst1"], "Src1", "Dst1's source must survive a reboot");
+                UNIT_ASSERT_VALUES_EQUAL_C(dstToSrc["Dst2"], "Src2", "Dst2's source must survive a reboot");
+            }
+        });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(SchemeChangeRecordsSurviveReboot) {
+        t.GetTestEnvOptions().EnableSchemeChangeRecords(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                RegisterSubscriber(runtime, "test:sub");
+            }
+
+            t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId, "/MyRoot",
+                "Name: \"T1\""
+                "Columns { Name: \"key\" Type: \"Uint64\" }"
+                "KeyColumnNames: [\"key\"]"),
+                {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists,
+                 NKikimrScheme::StatusMultipleModifications});
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto entries = ReadSchemeChangeRecords(runtime);
+                bool found = false;
+                for (const auto& e : entries) {
+                    if (e.Body.GetCreateTable().GetName() == "T1") {
+                        found = true;
+                        break;
+                    }
+                }
+                UNIT_ASSERT_C(found, "Scheme change record for T1 not found after reboot");
+            }
+        });
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_scheme_change_records_reboots/ya.make
+++ b/ydb/core/tx/schemeshard/ut_scheme_change_records_reboots/ya.make
@@ -2,18 +2,20 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
-IF (WITH_VALGRIND)
-    SPLIT_FACTOR(20)
-ENDIF()
+SPLIT_FACTOR(6)
 
-SIZE(MEDIUM)
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    SIZE(LARGE)
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
 
 PEERDIR(
     library/cpp/getopt
     library/cpp/regex/pcre
     library/cpp/svnversion
-    ydb/core/kqp/ut/common
-    ydb/core/testlib/pg
+    ydb/core/testlib/default
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers
     yql/essentials/public/udf/service/exception_policy
@@ -22,9 +24,7 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 SRCS(
-    ut_scheme_change_records.cpp
-    ut_scheme_change_records_protocol.cpp
-    ut_scheme_change_records_subscriber.cpp
+    ut_scheme_change_records_reboots.cpp
 )
 
 END()

--- a/ydb/core/tx/schemeshard/ut_sequence/ya.make
+++ b/ydb/core/tx/schemeshard/ut_sequence/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SPLIT_FACTOR(2)
 
 IF (SANITIZER_TYPE == "thread")

--- a/ydb/core/tx/schemeshard/ut_view/ya.make
+++ b/ydb/core/tx/schemeshard/ut_view/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
+# Runs every op in this suite through the scheme change outbox and fails the
+# test if any of them cannot resolve a target path.
+ENV(YDB_SCHEME_CHANGE_CORPUS=1)
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -44,6 +44,7 @@ RECURSE_FOR_TESTS(
     ut_metrics
     ut_move
     ut_move_reboots
+    ut_scheme_change_records
     ut_olap
     ut_olap_reboots
     ut_partition_stats
@@ -118,6 +119,7 @@ SRCS(
     schemeshard__monitoring.cpp
     schemeshard__monitoring.h
     schemeshard__notify.cpp
+    schemeshard__scheme_change_records.cpp
     schemeshard__op_traits.h
     schemeshard__operation.cpp
     schemeshard__operation.h

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -120,6 +120,8 @@ SRCS(
     schemeshard__monitoring.h
     schemeshard__notify.cpp
     schemeshard__scheme_change_records.cpp
+    schemeshard__scheme_change_records_cleanup.cpp
+    schemeshard__scheme_change_records_fetch.cpp
     schemeshard__op_traits.h
     schemeshard__operation.cpp
     schemeshard__operation.h

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -10768,6 +10768,68 @@
         }
     },
     {
+        "TableId": 142,
+        "TableName": "SchemeChangeSubscribers",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "SubscriberId",
+                "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "LastAckedOrder",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "LastActivityAtUs",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "State",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "StartOrder",
+                "ColumnType": "Uint64"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
         "TableId": 143,
         "TableName": "SchemeChangeRecordDetails",
         "TableKey": [

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -10638,5 +10638,234 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 141,
+        "TableName": "SchemeChangeRecords",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "Order",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "TxId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "OperationType",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "PathOwnerId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "PathLocalId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 6,
+                "ColumnName": "Path",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 7,
+                "ColumnName": "ObjectType",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 8,
+                "ColumnName": "Status",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 9,
+                "ColumnName": "UserSID",
+                "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 10,
+                "ColumnName": "SchemaVersion",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 11,
+                "ColumnName": "CompletedAtUs",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "PlanStep",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 13,
+                "ColumnName": "BodySizeBytes",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 14,
+                "ColumnName": "Description",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 15,
+                "ColumnName": "PositionKind",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 16,
+                "ColumnName": "RedactedFields",
+                "ColumnType": "Utf8"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 143,
+        "TableName": "SchemeChangeRecordDetails",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "Order",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "Body",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 144,
+        "TableName": "SchemeChangePendingRecords",
+        "TableKey": [
+            1,
+            2
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "TxId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "RequestIdx",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "Order",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "Path",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    4,
+                    5
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
### Changelog entry

SchemeShard exports outbox gauges (subscriber count, backlog depth) and a monitoring page.

### Description for reviewers

Stacked on #51176 — diffed against `main`, so it contains the earlier slices too.

Adds the gauge refresh in the finalisation loop and its counters. The gauge definitions and the monitoring page ship with the protocol slice; this PR is what makes them move.

210 tests. Redaction follows in the last PR.