### PR TITLE
EnableTopicMessageLevelParallelism = true by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -238,7 +238,7 @@ message TFeatureFlags {
     optional bool EnableCompileCacheView = 209 [default = true];
     optional bool EnableSecureScriptExecutions = 210 [default = false];
     optional bool EnableColumnshardBool = 211 [default = true];
-    optional bool EnableTopicMessageLevelParallelism = 212 [default = false];
+    optional bool EnableTopicMessageLevelParallelism = 212 [default = true];
     optional bool EnableOlapRejectProbability = 213 [default = true];
     optional bool EnablePDiskLogForSmallDisks = 214 [default = false];
     optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = true, deprecated = true]; // deprecated: always true


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Shared consumers (message-level parallelism) are enabled by default. Creating a SHARED / MLP consumer no longer requires turning on the `EnableTopicMessageLevelParallelism` feature flag.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Flip the proto default of `EnableTopicMessageLevelParallelism` from `false` to `true`. The flag still gates SHARED / MLP consumer creation; clusters that need the previous behavior can set it back to `false`.