### PR TITLE
Check for correct tenant setting when invoking distconf configuration commands

### DIFF
--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -134,6 +134,12 @@ bool ConvertGetConfigToFetchConfigResult(
     return true;
 }
 
+bool IsDomainDatabaseOrEmpty(const TMaybe<TString>& databaseName) {
+    return !databaseName || databaseName->empty()
+        || NKikimr::CanonizePath(*databaseName)
+            == NKikimr::CanonizePath(NKikimr::AppData()->DomainsInfo->Domain->Name);
+}
+
 } // namespace
 
 namespace NKikimr::NGRpcService {
@@ -293,6 +299,13 @@ public:
         if (!NKikimr::IsAdministrator(AppData(), Request_->GetInternalToken().Get())) {
             self->Reply(Ydb::StatusIds::UNAUTHORIZED, "User is not a cluster administrator.",
                   NKikimrIssues::TIssuesIds::ACCESS_DENIED, self->ActorContext());
+            return;
+        }
+        if (!IsDomainDatabaseOrEmpty(Request_->GetDatabaseName())) {
+            self->Reply(Ydb::StatusIds::BAD_REQUEST,
+                "Cluster configuration replacement cannot be performed on a tenant database. "
+                "Specify the domain database or omit the database.",
+                NKikimrIssues::TIssuesIds::DEFAULT_ERROR, self->ActorContext());
             return;
         }
         self->Become(&TReplaceStorageConfigRequest::StateFunc);
@@ -684,6 +697,14 @@ void DoBootstrapCluster(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvide
             if (!CheckAccess()) {
                 Request().RaiseIssue(NYql::TIssue("Access denied"));
                 Reply(Ydb::StatusIds::UNAUTHORIZED, ctx);
+                return;
+            }
+
+            if (!IsDomainDatabaseOrEmpty(Request().GetDatabaseName())) {
+                Reply(Ydb::StatusIds::BAD_REQUEST,
+                    "Cluster bootstrap cannot be performed on a tenant database. "
+                    "Specify the domain database or omit the database.",
+                    NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
                 return;
             }
 

--- a/ydb/tests/functional/config/test_distconf.py
+++ b/ydb/tests/functional/config/test_distconf.py
@@ -588,6 +588,50 @@ class TestKiKiMRDistConfBasic(DistConfKiKiMRTest):
         assert_that(replace_config_response.operation.issues[0].message == "Dynamic Config V1 is disabled. Use V2 API.")
         logger.debug(replace_config_response.operation)
 
+    def test_cluster_config_replace_rejects_tenant_database(self):
+        database_path = os.path.join('/', self.cluster.domain_name, 'config_tenant')
+        self.cluster.create_database(
+            database_path,
+            storage_pool_units_count={'rot': 1},
+            timeout_seconds=60,
+        )
+        try:
+            config_to_replace = yaml.safe_load(fetch_config(self.cluster.config_client))
+            bump_config_version(config_to_replace)
+            config_to_replace = yaml.dump(config_to_replace)
+
+            domain_response = self.cluster.config_client.replace_config(
+                config_to_replace,
+                dry_run=True,
+                database=os.path.join('/', self.cluster.domain_name),
+            )
+            assert_that(domain_response.operation.status == StatusIds.SUCCESS)
+
+            tenant_response = self.cluster.config_client.replace_config(
+                config_to_replace,
+                dry_run=True,
+                database=database_path,
+            )
+            assert_that(tenant_response.operation.status == StatusIds.BAD_REQUEST)
+            assert_that(
+                tenant_response.operation.issues[0].message
+                == "Cluster configuration replacement cannot be performed on a tenant database. "
+                   "Specify the domain database or omit the database."
+            )
+
+            bootstrap_response = self.cluster.config_client.bootstrap_cluster(
+                'test-cluster',
+                database=database_path,
+            )
+            assert_that(bootstrap_response.operation.status == StatusIds.BAD_REQUEST)
+            assert_that(
+                bootstrap_response.operation.issues[0].message
+                == "Cluster bootstrap cannot be performed on a tenant database. "
+                   "Specify the domain database or omit the database."
+            )
+        finally:
+            self.cluster.remove_database(database_path)
+
     def test_dry_run_valid_config_not_applied(self):
         fetched_config = fetch_config(self.cluster.config_client)
         dumped_config = yaml.safe_load(fetched_config)

--- a/ydb/tests/library/clients/kikimr_config_client.py
+++ b/ydb/tests/library/clients/kikimr_config_client.py
@@ -69,7 +69,7 @@ class ConfigClient(object):
     def _get_invoke_callee(self, method):
         return getattr(self._stub, method)
 
-    def invoke(self, request, method):
+    def invoke(self, request, method, database=None):
         retry = self.__retry_count
         while True:
             try:
@@ -77,6 +77,8 @@ class ConfigClient(object):
                 metadata = []
                 if self._auth_token:
                     metadata.append(('x-ydb-auth-ticket', self._auth_token))
+                if database:
+                    metadata.append(('x-ydb-database', database))
                 return callee(request, metadata=metadata)
             except (RuntimeError, grpc.RpcError):
                 retry -= 1
@@ -86,11 +88,11 @@ class ConfigClient(object):
 
                 time.sleep(self.__retry_sleep_seconds)
 
-    def replace_config(self, main_config, dry_run=False):
+    def replace_config(self, main_config, dry_run=False, database=None):
         request = config_api.ReplaceConfigRequest()
         request.replace = main_config
         request.dry_run = dry_run
-        return self.invoke(request, 'ReplaceConfig')
+        return self.invoke(request, 'ReplaceConfig', database=database)
 
     def fetch_all_configs(self, transform=None):
         request = config_api.FetchConfigRequest()
@@ -107,10 +109,10 @@ class ConfigClient(object):
 
         return self.invoke(request, 'FetchConfig')
 
-    def bootstrap_cluster(self, self_assembly_uuid):
+    def bootstrap_cluster(self, self_assembly_uuid, database=None):
         request = config_api.BootstrapClusterRequest()
         request.self_assembly_uuid = self_assembly_uuid
-        return self.invoke(request, 'BootstrapCluster')
+        return self.invoke(request, 'BootstrapCluster', database=database)
 
     def close(self):
         self._channel.close()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Check for correct tenant setting when invoking distconf configuration commands

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch prevents executing configuration commands in tenant.
