### PR TITLE
DDisk read load test must init full DDisk with zeroes

### DIFF
--- a/ydb/core/load_test/ddisk_load.cpp
+++ b/ydb/core/load_test/ddisk_load.cpp
@@ -26,6 +26,20 @@ namespace {
 constexpr size_t SimulatedBufferSizeBytes = 128ull << 20; // 128 MiB
 constexpr size_t SimulatedBufferAlignment = 4096;
 
+using TAreaProto = NKikimr::TEvLoadTestRequest::TDDiskLoad::TArea;
+
+TAreaProto::EAreaInit ResolveAreaInitType(bool isReadLoad, const TAreaProto& area) {
+    if (!isReadLoad) {
+        return area.GetInitType();
+    }
+    if (!area.HasInitType() || area.GetInitType() == TAreaProto::INIT_ZEROES_FULL) {
+        return TAreaProto::INIT_ZEROES_FULL;
+    }
+    ythrow TLoadActorException()
+        << "read load requires InitType INIT_ZEROES_FULL (omit InitType to use it); "
+        << "INIT_NONE and INIT_ZEROES_FIRST_BLOCK leave unread slots as in-memory zeros";
+}
+
 class TAlignedPayloadChunk : public IContiguousChunk {
     std::unique_ptr<char, decltype(&free)> Owner;
     char* Ptr = nullptr;
@@ -312,7 +326,7 @@ public:
                 areaSize,
                 area.GetWeight(),
                 area.GetSequential(),
-                area.GetInitType(),
+                ResolveAreaInitType(IsReadLoad, area),
                 nextBaseChunk,
                 numChunks,
                 0,

--- a/ydb/core/protos/load_test.proto
+++ b/ydb/core/protos/load_test.proto
@@ -152,16 +152,19 @@ message TEvLoadTestRequest {
             enum EAreaInit {
                 INIT_NONE = 0;
 
-                // requires ExpectedChunkSize: the idea is just to preallocate all chunks
+                // Write one zeroed IoSizeBytes block at the start of each chunk
+                // (preallocates chunks). Schema default for omitted InitType;
+                // used as-is for write loads.
                 INIT_ZEROES_FIRST_BLOCK = 1;
 
                 // Zero-fill every IoSizeBytes slot. Required for read load with
                 // checksums: DDisk serves never-written blocks as in-memory zeros
-                // and does not issue device I/O.
+                // and does not issue device I/O. The load actor treats omitted
+                // InitType as INIT_ZEROES_FULL when IsReadLoad is set.
                 INIT_ZEROES_FULL = 2;
             }
             optional uint32 AreaSize = 1; // must be a multiple of IoSizeBytes
-            optional EAreaInit InitType = 2 [default = INIT_ZEROES_FULL];
+            optional EAreaInit InitType = 2 [default = INIT_ZEROES_FIRST_BLOCK];
             optional uint32 Weight = 3 [default = 1]; // probability weight
             optional bool Sequential = 4 [default = true];
         }

--- a/ydb/core/protos/load_test.proto
+++ b/ydb/core/protos/load_test.proto
@@ -155,10 +155,13 @@ message TEvLoadTestRequest {
                 // requires ExpectedChunkSize: the idea is just to preallocate all chunks
                 INIT_ZEROES_FIRST_BLOCK = 1;
 
+                // Zero-fill every IoSizeBytes slot. Required for read load with
+                // checksums: DDisk serves never-written blocks as in-memory zeros
+                // and does not issue device I/O.
                 INIT_ZEROES_FULL = 2;
             }
             optional uint32 AreaSize = 1; // must be a multiple of IoSizeBytes
-            optional EAreaInit InitType = 2 [default = INIT_ZEROES_FIRST_BLOCK];
+            optional EAreaInit InitType = 2 [default = INIT_ZEROES_FULL];
             optional uint32 Weight = 3 [default = 1]; // probability weight
             optional bool Sequential = 4 [default = true];
         }

--- a/ydb/tools/stress_tool/README.md
+++ b/ydb/tools/stress_tool/README.md
@@ -77,6 +77,7 @@ Each `DDiskTestList` entry contains one or more `DDiskLoad` sources.
 - `ExpectedChunkSize` - expected chunk size in bytes; must be divisible by `IoSizeBytes`.
 - `IoSizeBytes` - request size for DDisk read/write I/O in bytes (default `4096`).
 - `Areas` - the set of DDisk areas used by the load source; each `AreaSize` must be divisible by `IoSizeBytes`.
+  Per-area `InitType` defaults to `INIT_ZEROES_FULL` (every slot is written before the measured load). Use `INIT_ZEROES_FIRST_BLOCK` only to preallocate chunks; with checksums enabled, unread blocks are then served from RAM as zeros and do not hit the device. `INIT_NONE` is rejected for read load.
 - `IsReadLoad` - if `true`, run read load; if `false`, run write load.
 - `SQPoll` / `IOPoll` - enable io_uring SQPOLL / IOPOLL for direct I/O.
 

--- a/ydb/tools/stress_tool/device_test_tool_ddisk_test.h
+++ b/ydb/tools/stress_tool/device_test_tool_ddisk_test.h
@@ -165,11 +165,14 @@ protected:
             const auto& cmd = baseRecord.GetDDiskLoad();
             if (cmd.GetIsReadLoad()) {
                 for (const auto& area : cmd.GetAreas()) {
-                    if (area.GetInitType() == TEvLoadTestRequest::TDDiskLoad::TArea::INIT_NONE) {
-                        Cerr << "Error: read load requires area initialization"
-                             << " (InitType != INIT_NONE) to allocate chunks before reading" << Endl;
+                    if (area.HasInitType() &&
+                            area.GetInitType() != TEvLoadTestRequest::TDDiskLoad::TArea::INIT_ZEROES_FULL) {
+                        Cerr << "Error: read load requires InitType INIT_ZEROES_FULL"
+                             << " (omit InitType to use it automatically);"
+                             << " INIT_NONE and INIT_ZEROES_FIRST_BLOCK skip device I/O for unread blocks"
+                             << Endl;
                         ASSERT_YTHROW(false,
-                            "Invalid configuration: read load requires area initialization (InitType != INIT_NONE)");
+                            "Invalid configuration: read load requires InitType INIT_ZEROES_FULL");
                     }
                 }
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
