### PR TITLE
Return clamping to zero in KQP predictor

### DIFF
--- a/ydb/core/kqp/query_data/kqp_predictor.cpp
+++ b/ydb/core/kqp/query_data/kqp_predictor.cpp
@@ -195,7 +195,7 @@ ui32 TStagePredictor::CalcTasksOptimalCount(const ui32 availableThreadsCount, co
     } else {
         result = (availableThreadsCount - previousStageTasksCount.value_or(0) * 0.25) * (InputDataPrediction / *LevelDataPrediction);
     }
-    if (previousStageTasksCount && *previousStageTasksCount > 0) {
+    if (previousStageTasksCount) {
         result = std::min<ui32>(result, *previousStageTasksCount);
     }
     return std::max<ui32>(1, result);


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

Zero is a known count: the caller divides the cluster-wide task count by the node count, so a stage fed by fewer tasks than there are nodes lands here.

Unknown is encoded by an empty optional. Clamping to zero is intended - the final max(1, ...) turns it into one task per node.
