### PR TITLE
YQ-5644 basic exactly once topic writing support

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -1266,6 +1266,7 @@ private:
         const auto generation = context->CurrentExecutionGeneration;
         Y_VALIDATE(generation, "Missing current execution generation");
 
+        TasksGraph.GetMeta().AllowCheckpoints = true;
         CheckpointCoordinatorId = Register(MakeCheckpointCoordinator(
             ::NFq::TCoordinatorId(checkpointId, generation),
             NYql::NDq::MakeCheckpointStorageID(),

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1945,6 +1945,12 @@ void TKqpTasksGraph::SerializeTaskToProto(const TTask& task, NYql::NDqProto::TDq
         (*result->MutableTaskParams())[taskParam] = actorIdProto.SerializeAsString();
     }
 
+    if (const auto executionGeneration = GetMeta().UserRequestContext->CurrentExecutionGeneration) {
+        auto& params = *result->MutableTaskParams();
+        params["current_execution_generation"] = ToString(executionGeneration);
+        params["checkpoints_enabled"] = ToString(GetMeta().AllowCheckpoints);
+    }
+
     SerializeCtxToMap(*GetMeta().UserRequestContext, *result->MutableRequestContext());
 
     result->SetDisableMetering(!enableMetering);

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -222,6 +222,7 @@ struct TGraphMeta {
     bool StreamResult = false;
     Ydb::Table::QueryStatsCollection::Mode StatsMode = Ydb::Table::QueryStatsCollection::STATS_COLLECTION_NONE;
     bool CollectAffectedRows = false;
+    bool AllowCheckpoints = false;
 
     // TODO: stuff about shards on nodes should be private or protected.
     using TShardToNodeMap = TMap<ui64 /* shardId */, ui64 /* nodeId */>;

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -2986,7 +2986,7 @@ private:
         Callbacks->OnAsyncOutputStateCommitted(OutputIndex, checkpoint);
     }
 
-    void LoadState(const NYql::NDq::TSinkState&) final {}
+    void LoadState(const NYql::NDq::TSinkState&, const NYql::NDqProto::TCheckpoint&) final {}
 
     ui64 GetOutputIndex() const final {
         return OutputIndex;
@@ -6615,7 +6615,7 @@ private:
     }
 
     void CommitState(const NYql::NDqProto::TCheckpoint&) final {};
-    void LoadState(const NYql::NDq::TSinkState&) final {};
+    void LoadState(const NYql::NDq::TSinkState&, const NYql::NDqProto::TCheckpoint&) final {};
 
     ui64 GetOutputIndex() const final {
         return OutputIndex;

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
@@ -5827,8 +5827,6 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             featureFlags.SetEnableStreamingQueriesPqSinkDeduplication(true);
         }
 
-        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
-
         constexpr char inputTopicName[] = "deliveryGuarantyWriteSettingDisabledInputTopic";
         constexpr char outputTopicName[] = "deliveryGuarantyWriteSettingDisabledOutputTopic";
         CreateTopic(inputTopicName);
@@ -5851,20 +5849,6 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             "output_topic"_a = outputTopicName
         ), EStatus::GENERIC_ERROR, "Authorization is required for setting `DELIVERY_GUARANTEE` = 'exactly_once'");
 
-        constexpr char queryName[] = "deliveryGuarantyWriteSetting";
-        ExecQuery(fmt::format(R"(
-            CREATE STREAMING QUERY `{query_name}` AS
-            DO BEGIN
-                INSERT INTO `{pq_source}`.`{output_topic}` WITH (
-                    DELIVERY_GUARANTEE = "exactly_once"
-                ) SELECT * FROM `{pq_source}`.`{input_topic}`
-            END DO;)",
-            "pq_source"_a = pqSourceName,
-            "input_topic"_a = inputTopicName,
-            "output_topic"_a = outputTopicName,
-            "query_name"_a = queryName
-        ));
-
         ExecQuery(fmt::format(R"(
             CREATE STREAMING QUERY deliveryGuarantyWriteSettingWithDeduplication AS
             DO BEGIN
@@ -5877,19 +5861,6 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             "input_topic"_a = inputTopicName,
             "output_topic"_a = outputTopicName
         ), EStatus::GENERIC_ERROR, "`DELIVERY_GUARANTEE` = 'exactly_once' is not supported with enabled deduplication");
-
-        Sleep(TDuration::Seconds(1));
-
-        {
-            const auto& result = ExecQuery(fmt::format(R"(
-                SELECT Issues FROM `.sys/streaming_queries` WHERE Path = "/Root/{query_name}")",
-                "query_name"_a = queryName
-            ));
-            UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
-            CheckScriptResult(result[0], 1, 1, [&](TResultSetParser& resultSet) {
-                UNIT_ASSERT_STRING_CONTAINS(resultSet.ColumnParser("Issues").GetOptionalUtf8().value_or(""), "Deferred publications is not supported");
-            });
-        }
 
         ExecQuery(fmt::format(R"(
             INSERT INTO `{pq_source}`.`{output_topic}` WITH (

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
@@ -947,15 +947,18 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         auto newSeqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
         UNIT_ASSERT_VALUES_EQUAL(newSeqNo, seqNo); // No checkpoints due to checkpointing interval
 
-        const auto pqCountersExtractor = [&](const ui64 nodeIndex) -> ::NMonitoring::TDynamicCounters::TCounterPtr {
+        const auto pqCountersExtractor = [&](const ui64 nodeIndex) -> std::function<ui64()> {
             const NMonitoring::TDynamicCounterPtr kqpCounters = GetCounters("kqp", nodeIndex);
             const auto sourceTracker = kqpCounters->GetSubgroup("subsystem", "DqSinkTracker");
             const auto sourceCounters = sourceTracker->GetSubgroup("sink", "PqSink");
             const auto inflyData = sourceCounters->GetCounter("InFlyData");
             const auto inFlyCheckpoints = sourceCounters->GetCounter("InFlyCheckpoints");
+            const auto inFlyPendingAckCheckpoints = sourceCounters->GetCounter("InFlyPendingAckCheckpoints");
 
             if (inflyData->Val() != 0) {
-                return inFlyCheckpoints;
+                return [inFlyCheckpoints, inFlyPendingAckCheckpoints]() {
+                    return inFlyCheckpoints->Val() + inFlyPendingAckCheckpoints->Val();
+                };
             }
 
             return nullptr;
@@ -966,7 +969,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             counters = pqCountersExtractor(/* nodeIndex */ 1);
         }
         UNIT_ASSERT_C(counters, "Counters not found for PQ sink");
-        UNIT_ASSERT_VALUES_EQUAL(counters->Val(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(counters(), 0);
 
         WaitFor(CHECKPOINT_INTERVAL, "checkpoint propagation", [&](TString& error) {
             if (GetLastCheckpointSeqNo(checkpointId) == seqNo) {
@@ -974,7 +977,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 return false;
             }
 
-            return counters->Val() == 1;
+            return counters() == 1;
         });
 
         newSeqNo = GetLastCheckpointSeqNo(checkpointId);

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_deferrd_commit_write_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_deferrd_commit_write_ut.cpp
@@ -442,7 +442,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesWithDeferredCommits) {
             ) AS
             DO BEGIN
                 PRAGMA ydb.OptValidateStreamingCheckpoints = "FALSE"; -- Enable `LIMIT` operator in at-least-once semantic
-                PRAGMA ydb.MaxTasksPerStage = "2"; -- Ensure configuration where one of chanels will be remote, and one local
+                PRAGMA ydb.MaxTasksPerStage = "2"; -- Ensure configuration where one of channels will be remote, and one local
                 PRAGMA ydb.OverridePlanner = @@ [
                     {{ "tx": 0, "stage": 0, "tasks": 2 }}
                 ] @@;

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_deferrd_commit_write_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_deferrd_commit_write_ut.cpp
@@ -1,16 +1,39 @@
 #include "common.h"
 
+#include <ydb/core/kqp/ut/federated_query/common/common.h>
+
+#include <fmt/format.h>
+
 namespace NKikimr::NKqp {
 
+using namespace fmt::literals;
+using namespace NFederatedQueryTest;
+using namespace NTestUtils;
 using namespace NYdb;
 using namespace NYdb::NTopic;
 
 Y_UNIT_TEST_SUITE(KqpStreamingQueriesWithDeferredCommits) {
+    template <typename TClient>
+    TDeferredPublication CreatePublication(const TString& extId, const TString& writerIdentity, TClient& client) {
+        const auto result = client.BeginPublication(extId, TBeginPublicationSettings().WriterIdentity(writerIdentity)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+        auto publication = result.GetPublication();
+        UNIT_ASSERT(publication.ExtPublicationId);
+        UNIT_ASSERT_VALUES_EQUAL(*publication.ExtPublicationId, extId);
+        return publication;
+    }
+
+    template <typename TClient>
+    void CommitPublication(const ui64 intId, TClient& client) {
+        const auto result = client.Publish(TDeferredPublication(intId)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+    }
+
     Y_UNIT_TEST_TWIN_F(PqGatewayApiForDeferredCommits, LocalTopics, TStreamingTestFixture) {
         LogSettings.AddLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_DEBUG);
         SetupAppConfig().MutableFeatureFlags()->SetEnableTopicDeferredPublish(true);
 
-        constexpr char outputTopicName[] = "pqGatewayApiForDeferredCommitsOutputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
         CreateTopic(outputTopicName, std::nullopt, LocalTopics);
 
         constexpr char pqSourceName[] = "pqSourceName";
@@ -43,14 +66,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesWithDeferredCommits) {
 
         constexpr char publicationExtId[] = "publicationId";
         constexpr char publicationWriter[] = "testWriter";
-        TDeferredPublication publication;
-        {
-            const auto result = publishClient->BeginPublication(publicationExtId, TBeginPublicationSettings().WriterIdentity(publicationWriter)).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
-            publication = result.GetPublication();
-            UNIT_ASSERT(publication.ExtPublicationId);
-            UNIT_ASSERT_VALUES_EQUAL(*publication.ExtPublicationId, publicationExtId);
-        }
+        TDeferredPublication publication = CreatePublication(publicationExtId, publicationWriter, *publishClient);
 
         // Validate creation via sdk client
         const std::shared_ptr<TDeferredPublishClient> sdkClient = GetDeferredPublishClient(LocalTopics, testUser);
@@ -112,24 +128,8 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesWithDeferredCommits) {
 
         Sleep(TDuration::Seconds(1));
 
-        // Validate messages are not published
-        {
-            const std::shared_ptr<TTopicClient> topicClient = GetTopicClient(LocalTopics);
-            const auto result = topicClient->DescribeTopic(outputTopicName, TDescribeTopicSettings().IncludeStats(true)).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
-            const auto& partitions = result.GetTopicDescription().GetPartitions();
-            UNIT_ASSERT_VALUES_EQUAL(partitions.size(), 1);
-            const auto& stats = partitions[0].GetPartitionStats();
-            UNIT_ASSERT(stats);
-            UNIT_ASSERT_VALUES_EQUAL(stats->GetStartOffset(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats->GetEndOffset(), 0);
-        }
-
-        // Do publish
-        {
-            const auto result = publishClient->Publish(publication).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
-        }
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 0, LocalTopics);
+        CommitPublication(publication.IntPublicationId, *publishClient);
 
         // Validate messages are published
         ReadTopicMessage(outputTopicName, "test_data", disposition, LocalTopics);
@@ -141,9 +141,1346 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesWithDeferredCommits) {
         }
 
         DropTopic(outputTopicName, LocalTopics);
-        if constexpr (!LocalTopics) {
-            DropSource(pqSourceName);
+    }
+
+    std::vector<TPublicationSummary> ValidatePublicationsCount(const ui64 count, const TString& queryName, TDeferredPublishClient& client) {
+        const auto result = client.ListPublications().ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+
+        std::vector<TPublicationSummary> found;
+        found.reserve(count);
+        for (const auto& publication : result.GetPublications()) {
+            if (publication.ExtPublicationId.contains(queryName)) {
+                found.emplace_back(publication);
+                UNIT_ASSERT_STRING_CONTAINS(publication.WriterIdentity.value_or(""), queryName);
+            }
         }
+
+        if (found.size() != count) {
+            TStringBuilder description;
+            for (const auto& publication : found) {
+                description << "{" << publication.IntPublicationId << " = " << publication.ExtPublicationId << "} " << Endl;
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(found.size(), count, description);
+        }
+
+        return found;
+    }
+
+    Y_UNIT_TEST_TWIN_F(StreamingQueryWithDeferredComitPublicationCreation, LocalTopics, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto firstOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName1";
+        const auto secondOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName2";
+        CreateTopic(inputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(firstOutputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(secondOutputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                $data = SELECT * FROM {pq_source}`{input_topic}`;
+
+                INSERT INTO {pq_source}`{first_output_topic}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT Data || "-first" FROM $data;
+
+                INSERT INTO {pq_source}`{second_output_topic}` SELECT Data || "-second" FROM $data;
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "first_output_topic"_a = firstOutputTopicName,
+            "second_output_topic"_a = secondOutputTopicName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds()
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        constexpr ui64 TESTS_COUNT = 2;
+        for (ui64 i = 0; i < TESTS_COUNT; ++i) {
+            const auto disposition = TInstant::Now();
+            WriteTopicMessage(inputTopicName, TStringBuilder() << "test-" << i, /* partition */ 0, LocalTopics);
+            ReadTopicMessage(secondOutputTopicName, TStringBuilder() << "test-" << i << "-second", disposition, LocalTopics);
+
+            CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+            ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+            EnsureTopicEndOffset(firstOutputTopicName, /* endOffset */ i, LocalTopics);
+
+            WaitCheckpointUpdate(checkpointId);
+            ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+            ReadTopicMessage(firstOutputTopicName, TStringBuilder() << "test-" << i << "-first", disposition, LocalTopics);
+        }
+
+        const auto disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "test-f", /* partition */ 0, LocalTopics);
+        ReadTopicMessage(secondOutputTopicName, "test-f-second", disposition, LocalTopics);
+
+        Sleep(TDuration::Seconds(1));
+
+        ExecQuery(fmt::format(R"(
+            DROP STREAMING QUERY `{query_name}`;)",
+            "query_name"_a = queryName
+        ));
+
+        EnsureTopicEndOffset(firstOutputTopicName, /* endOffset */ TESTS_COUNT, LocalTopics);
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(firstOutputTopicName, LocalTopics);
+        DropTopic(secondOutputTopicName, LocalTopics);
+    }
+
+    // Test what for graph without checkpoints exactly once write tx commited on finish
+    Y_UNIT_TEST_TWIN_F(StreamingQueryDeferredComitPublicationWithoutCheckpoints, LocalTopics, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                PRAGMA ydb.DisableCheckpoints = "TRUE";
+                INSERT INTO {pq_source}`{output_topic}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT * FROM {pq_source}`{input_topic}`
+                LIMIT 2;
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "message1", /* partition */ 0, LocalTopics);
+
+        Sleep(TDuration::Seconds(2));
+
+        ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 0, LocalTopics);
+
+        WriteTopicMessage(inputTopicName, "message2", /* partition */ 0, LocalTopics);
+        ReadTopicMessages(outputTopicName, {"message1", "message2"}, disposition, /* sort */ false, LocalTopics);
+        ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+
+        Sleep(TDuration::Seconds(1));
+        CheckScriptExecutionsCount(1, 0);
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(outputTopicName, LocalTopics);
+    }
+
+    // If some exactly once egress task has no checkpoint dependencies, it effect should be commited on subgraph finish
+    Y_UNIT_TEST_TWIN_F(StreamingQuerySubgraphWithoutCheckpoints, LocalTopics, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        const auto finiteOutputTopicName = TStringBuilder() << Name_ << "OutputTopicNameFinite";
+        CreateTopic(inputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(finiteOutputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char tableName[] = "streamingQuerySubgraphWithoutCheckpointsInputTable";
+        ExecQuery(fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Data String NOT NULL,
+                    PRIMARY KEY (Data)
+                );
+            )",
+            "table_name"_a = tableName
+        ));
+        ExecQuery(fmt::format(R"(
+                UPSERT INTO `{table_name}` (Data) VALUES ("finite_message1"), ("finite_message2");
+            )",
+            "table_name"_a = tableName
+        ));
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        if constexpr (!LocalTopics) {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+        }
+
+        const auto disposition = TInstant::Now();
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                INSERT INTO {pq_source}`{output_topic}` SELECT * FROM {pq_source}`{input_topic}`;
+
+                INSERT INTO {pq_source}`{finite_output_topic}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT * FROM {table};
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName,
+            "finite_output_topic"_a = finiteOutputTopicName,
+            "table"_a = tableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        WriteTopicMessage(inputTopicName, "message1", /* partition */ 0, LocalTopics);
+        ReadTopicMessage(outputTopicName, "message1", disposition, LocalTopics);
+        ReadTopicMessages(finiteOutputTopicName, {"finite_message1", "finite_message2"}, disposition, /* sort */ true, LocalTopics);
+
+        ValidateStreamingQueryAst(queryName, AstChecker(/* txCount */ 1, /* stagesCount */ 2));
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(outputTopicName, LocalTopics);
+        DropTopic(finiteOutputTopicName, LocalTopics);
+    }
+
+    // When query has checkpoints, finite results must be published only on final checkpoint
+    Y_UNIT_TEST_QUAD_F(StreamingQueryWithFiniteResultAndCheckpoints, LocalTopics, ModernChannels, TStreamingWithSchemaSecretsTestFixture) {
+        NodeCount = 2;
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto firstOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName1";
+        const auto secondOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName2";
+        CreateTopic(inputTopicName, TCreateTopicSettings().PartitioningSettings(2, 2), LocalTopics);
+        CreateTopic(firstOutputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(secondOutputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char tableName[] = "outputTable";
+        ExecQuery(fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Data String NOT NULL,
+                    PRIMARY KEY (Data)
+                );
+            )",
+            "table_name"_a = tableName
+        ));
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                PRAGMA ydb.OptValidateStreamingCheckpoints = "FALSE"; -- Enable `LIMIT` operator in at-least-once semantic
+                PRAGMA ydb.MaxTasksPerStage = "2"; -- Ensure configuration where one of chanels will be remote, and one local
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 0, "tasks": 2 }}
+                ] @@;
+
+                $data = SELECT * FROM {pq_source}`{input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        time String NOT NULL,
+                        event String
+                    )
+                ) LIMIT 2;
+
+                $grouped = SELECT
+                    event,
+                    CAST(SOME(time) AS String) AS time,
+                    CAST(COUNT(*) AS String) AS count
+                FROM $data
+                GROUP BY
+                    HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"),
+                    event;
+
+                $processed = SELECT Unwrap(event || "-" || time || "-" || count) AS Data FROM $grouped;
+
+                INSERT INTO {pq_source}`{first_output_topic}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT * FROM $processed;
+
+                INSERT INTO {pq_source}`{second_output_topic}` SELECT * FROM $processed;
+
+                UPSERT INTO `{table}` SELECT * FROM $processed;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "first_output_topic"_a = firstOutputTopicName,
+            "second_output_topic"_a = secondOutputTopicName,
+            "table"_a = tableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto disposition = TInstant::Now();
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        WriteTopicMessage(inputTopicName, R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})", /* partition */ 0, LocalTopics);
+        WriteTopicMessage(inputTopicName, R"({"time": "2025-08-25T00:00:00.000000Z", "event": "A"})", /* partition */ 1, LocalTopics);
+        ReadTopicMessages(secondOutputTopicName, {"A-2025-08-24T00:00:00.000000Z-1", "A-2025-08-25T00:00:00.000000Z-1"}, disposition, /* sort */ true, LocalTopics);
+
+        // Check table data (should be flushed on finish)
+        {
+            Sleep(TDuration::Seconds(1));
+            const auto& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{table_name}` ORDER BY Data;)",
+                "table_name"_a = tableName
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+            ui64 index = 0;
+            const std::vector expected = {"A-2025-08-24T00:00:00.000000Z-1", "A-2025-08-25T00:00:00.000000Z-1"};
+            CheckScriptResult(results[0], 1, 2, [&](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), expected[index++]);
+            });
+        }
+
+        // Expected graph state now:
+        // [source stage, finished] -> [limit stage, finished] -> [group by stage + 2x PQ sinks, waiting sink{1}] -> [table sink stage, finished]
+        // Checkpoint will be injected into source stage and must pass all stages
+
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        EnsureTopicEndOffset(firstOutputTopicName, /* endOffset */ 0, LocalTopics);
+
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+        ReadTopicMessages(firstOutputTopicName, {"A-2025-08-24T00:00:00.000000Z-1", "A-2025-08-25T00:00:00.000000Z-1"}, disposition, /* sort */ true, LocalTopics);
+
+        Sleep(TDuration::Seconds(1));
+        CheckScriptExecutionsCount(1, 0);
+
+        ValidateStreamingQueryAst(queryName, AstChecker(/* txCount */ 1, /* stagesCount */ 4));
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(firstOutputTopicName, LocalTopics);
+        DropTopic(secondOutputTopicName, LocalTopics);
+    }
+
+    Y_UNIT_TEST_TWIN_F(ExactlyOnceWritingWithMultipleSinks, LocalTopics, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName1 = TStringBuilder() << Name_ << "OutputTopicName1";
+        const auto outputTopicName2 = TStringBuilder() << Name_ << "OutputTopicName2";
+        const auto outputTopicName3 = TStringBuilder() << Name_ << "OutputTopicName3";
+        CreateTopic(inputTopicName, TCreateTopicSettings().PartitioningSettings(2, 2), LocalTopics);
+        CreateTopic(outputTopicName1, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName2, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName3, std::nullopt, LocalTopics);
+
+        constexpr char tableName[] = "exactlyOnceWritingWithMultipleSinkOutputTable";
+        ExecQuery(fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Data String NOT NULL,
+                    PRIMARY KEY (Data)
+                );
+            )",
+            "table_name"_a = tableName
+        ));
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                PRAGMA ydb.MaxTasksPerStage = "2";
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 0, "tasks": 2 }}
+                ] @@;
+
+                $data = SELECT * FROM {pq_source}`{input_topic}`;
+
+                INSERT INTO {pq_source}`{output_topic1}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT * FROM $data;
+
+                INSERT INTO {pq_source}`{output_topic2}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT * FROM $data;
+
+                INSERT INTO {pq_source}`{output_topic3}` SELECT * FROM $data;
+
+                UPSERT INTO `{table}` SELECT * FROM $data;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "output_topic1"_a = outputTopicName1,
+            "output_topic2"_a = outputTopicName2,
+            "output_topic3"_a = outputTopicName3,
+            "table"_a = tableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        const auto disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "message1", /* partition */ 0, LocalTopics);
+        WriteTopicMessage(inputTopicName, "message2", /* partition */ 1, LocalTopics);
+        ReadTopicMessages(outputTopicName3, {"message1", "message2"}, disposition, /* sort */ true, LocalTopics);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        ValidatePublicationsCount(/* count */ 4, queryName, *sdkClient);
+
+        EnsureTopicEndOffset(outputTopicName1, /* endOffset */ 0, LocalTopics);
+        EnsureTopicEndOffset(outputTopicName2, /* endOffset */ 0, LocalTopics);
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+
+        ReadTopicMessages(outputTopicName1, {"message1", "message2"}, disposition, /* sort */ true, LocalTopics);
+        ReadTopicMessages(outputTopicName2, {"message1", "message2"}, disposition, /* sort */ true, LocalTopics);
+
+        const auto& results = ExecQuery(fmt::format(R"(
+            SELECT * FROM `{table_name}` ORDER BY Data;)",
+            "table_name"_a = tableName
+        ));
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+        ui64 index = 0;
+        CheckScriptResult(results[0], 1, 2, [&](TResultSetParser& resultSet) {
+            UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), TStringBuilder() << "message" << ++index);
+        });
+
+        ValidateStreamingQueryAst(queryName, AstChecker(/* txCount */ 1, /* stagesCount */ 2));
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(outputTopicName1, LocalTopics);
+        DropTopic(outputTopicName2, LocalTopics);
+        DropTopic(outputTopicName3, LocalTopics);
+    }
+
+    Y_UNIT_TEST_F(ExactlyOnceWritingWithMultipleSinksAndSameTopic, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName, TCreateTopicSettings().PartitioningSettings(2, 2));
+        CreateTopic(outputTopicName);
+
+        constexpr char tableName[] = "exactlyOnceWritingWithMultipleSinksAndSameTopicOutputTable";
+        ExecQuery(fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Data String NOT NULL,
+                    PRIMARY KEY (Data)
+                );
+            )",
+            "table_name"_a = tableName
+        ));
+
+        constexpr char pqSourceName1[] = "pqSourceName1";
+        constexpr char pqSourceName2[] = "pqSourceName2";
+        constexpr char pqSourceName3[] = "pqSourceName3";
+        CreatePqSourceBasicAuth(pqSourceName1, /* useSchemaSecrets  */ true);
+        CreatePqSourceBasicAuth(pqSourceName2, /* useSchemaSecrets  */ true, /* createSecrets  */ false);
+        CreatePqSourceBasicAuth(pqSourceName3, /* useSchemaSecrets  */ true, /* createSecrets  */ false);
+        std::shared_ptr<TDeferredPublishClient> sdkClient = GetDeferredPublishClient(/* local */ false, "", NYdb::CreateLoginCredentialsProviderFactory({
+            .User = "root",
+            .Password = "1234"
+        }));
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                PRAGMA ydb.MaxTasksPerStage = "2";
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 0, "tasks": 2 }}
+                ] @@;
+
+                $data = SELECT * FROM `{pq_source1}`.`{input_topic}`;
+
+                INSERT INTO `{pq_source1}`.`{output_topic}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT Data || "-1" FROM $data;
+
+                INSERT INTO `{pq_source2}`.`{output_topic}` WITH (
+                    DELIVERY_GUARANTEE = "exactly_once"
+                ) SELECT Data || "-2" FROM $data;
+
+                INSERT INTO `{pq_source3}`.`{output_topic}` SELECT * FROM $data;
+
+                UPSERT INTO `{table}` SELECT * FROM $data;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source1"_a = pqSourceName1,
+            "pq_source2"_a = pqSourceName2,
+            "pq_source3"_a = pqSourceName3,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName,
+            "table"_a = tableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        const auto disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "message1", /* partition */ 0);
+        WriteTopicMessage(inputTopicName, "message2", /* partition */ 1);
+        ReadTopicMessages(outputTopicName, {"message1", "message2"}, disposition, /* sort */ true);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        ValidatePublicationsCount(/* count */ 4, queryName, *sdkClient);
+
+        EnsureTopicEndOffset(outputTopicName, /* endOffset  */ 2);
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+
+        ReadTopicMessages(outputTopicName, {"message1", "message2", "message1-1", "message2-1", "message1-2", "message2-2"}, disposition, /* sort */ true);
+
+        const auto& results = ExecQuery(fmt::format(R"(
+            SELECT * FROM `{table_name}` ORDER BY Data;)",
+            "table_name"_a = tableName
+        ));
+        UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+        ui64 index = 0;
+        CheckScriptResult(results[0], 1, 2, [&](TResultSetParser& resultSet) {
+            UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), TStringBuilder() << "message" << ++index);
+        });
+
+        ValidateStreamingQueryAst(queryName, AstChecker(/* txCount */ 1, /* stagesCount */ 2));
+
+        DropTopic(inputTopicName);
+        DropTopic(outputTopicName);
+    }
+
+    Y_UNIT_TEST_QUAD_F(RestartStreamingQueryWithExactlyOnceWriting, LocalTopics, ModernChannels, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto firstOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName1";
+        const auto secondOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName2";
+        CreateTopic(inputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(firstOutputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(secondOutputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                -- Test that offsets are recovered
+                $pq_source = SELECT * FROM {pq_source}`{input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        time String NOT NULL,
+                        event String
+                    )
+                );
+
+                -- Test that state also recovered
+                $grouped = SELECT
+                    event,
+                    CAST(SOME(time) AS String) AS time,
+                    CAST(COUNT(*) AS String) AS count
+                FROM $pq_source
+                GROUP BY
+                    HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"),
+                    event;
+
+                INSERT INTO {pq_source}`{first_output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT Unwrap(event || "-" || time || "-" || count) FROM $grouped;
+
+                INSERT INTO {pq_source}`{second_output_topic}`
+                SELECT Unwrap(event || "-" || time || "-" || count) FROM $grouped;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "first_output_topic"_a = firstOutputTopicName,
+            "second_output_topic"_a = secondOutputTopicName
+        ));
+
+        TInstant dispositionFirst = TInstant::Now();
+        TInstant dispositionSecond = TInstant::Now();
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        // Write and read first message
+        {
+            WriteTopicMessages(inputTopicName, {
+                R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})",
+                R"({"time": "2025-08-25T00:00:00.000000Z", "event": "A"})",
+            }, /* partition */ 0, LocalTopics);
+            ReadTopicMessage(secondOutputTopicName, "A-2025-08-24T00:00:00.000000Z-1", dispositionSecond, LocalTopics);
+            dispositionSecond = TInstant::Now();
+
+            CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+            ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+            EnsureTopicEndOffset(firstOutputTopicName, /* endOffset */ 0, LocalTopics);
+
+            WaitCheckpointUpdate(checkpointId);
+            ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+            ReadTopicMessage(firstOutputTopicName, "A-2025-08-24T00:00:00.000000Z-1", dispositionFirst, LocalTopics);
+            dispositionFirst = TInstant::Now();
+        }
+
+        Sleep(TDuration::Seconds(1));
+        const ui64 checkpointSeqNo = GetLastCheckpointSeqNo(checkpointId);
+
+        // Write second message
+        {
+            WriteTopicMessage(inputTopicName, R"({"time": "2025-08-26T00:00:00.000000Z", "event": "A"})", /* partition */ 0, LocalTopics);
+            ReadTopicMessage(secondOutputTopicName, "A-2025-08-25T00:00:00.000000Z-1", dispositionSecond, LocalTopics);
+            dispositionSecond = TInstant::Now();
+
+            CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 4);
+            ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+            EnsureTopicEndOffset(firstOutputTopicName, /* endOffset */ 1, LocalTopics);
+        }
+
+        ExecQuery(fmt::format(R"(
+            ALTER STREAMING QUERY `{query_name}` SET (
+                RUN = FALSE
+            );)",
+            "query_name"_a = queryName
+        ));
+        CheckScriptExecutionsCount(1, 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetLastCheckpointSeqNo(checkpointId), checkpointSeqNo);
+
+        Sleep(TDuration::Seconds(1));
+        WriteTopicMessage(inputTopicName, R"({"time": "2025-08-26T00:00:00.000000Z", "event": "B"})", /* partition */ 0, LocalTopics);
+
+        ExecQuery(fmt::format(R"(
+            ALTER STREAMING QUERY `{query_name}` SET (
+                RUN = TRUE
+            );)",
+            "query_name"_a = queryName
+        ));
+        CheckScriptExecutionsCount(2, 1);
+        Sleep(TDuration::Seconds(1));
+
+        // Write and read third message
+        {
+            WriteTopicMessage(inputTopicName, R"({"time": "2025-08-27T00:00:00.000000Z", "event": "A"})", /* partition */ 0, LocalTopics);
+            ReadTopicMessages(secondOutputTopicName, {
+                "A-2025-08-25T00:00:00.000000Z-1", // Duplicated
+                "A-2025-08-26T00:00:00.000000Z-1",
+                "B-2025-08-26T00:00:00.000000Z-1"
+            }, dispositionSecond, /* sort */ true, LocalTopics);
+
+            CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+            ValidatePublicationsCount(/* count */ 2, queryName, *sdkClient);
+            EnsureTopicEndOffset(firstOutputTopicName, /* endOffset */ 1, LocalTopics);
+
+            WaitCheckpointUpdate(checkpointId);
+            ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+            ReadTopicMessages(firstOutputTopicName, {
+                "A-2025-08-25T00:00:00.000000Z-1",
+                "A-2025-08-26T00:00:00.000000Z-1",
+                "B-2025-08-26T00:00:00.000000Z-1"
+            }, dispositionFirst, /* sort */ true, LocalTopics);
+        }
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(firstOutputTopicName, LocalTopics);
+        DropTopic(secondOutputTopicName, LocalTopics);
+    }
+
+    Y_UNIT_TEST_F(RecoveryStreamingQueryWithExactlyOnceWriting, TStreamingWithSchemaSecretsTestFixture) {
+        SetupAppConfig().MutableFeatureFlags()->SetEnableExactlyOnceTopicsWriting(true);
+
+        auto pqGateway = SetupMockPqGateway();
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopic = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopic = TStringBuilder() << Name_ << "OutputTopicName";
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreateTopic(inputTopic);
+        CreateTopic(outputTopic);
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM `{pq_source}`.`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopic,
+            "output_topic"_a = outputTopic
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+
+        const auto readSession = pqGateway->WaitReadSession(inputTopic);
+        auto writeSession = pqGateway->WaitWriteSession(outputTopic);
+        auto& publicationController = pqGateway->GetDeferredPublishClientController();
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        readSession->AddDataReceivedEvent(0, "test_message1");
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->EnsureEmpty();
+
+        WaitCheckpointUpdate(checkpointId);
+        publicationController.EnsureOpenedPublications(/* count */ 0, queryName);
+        writeSession->ExpectMessage("test_message1");
+
+        readSession->AddDataReceivedEvent(0, "test_message2");
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->EnsureEmpty();
+
+        readSession->AddCloseSessionEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")});
+
+        pqGateway->WaitReadSession(inputTopic)->AddDataReceivedEvent(0, "test_message3");
+        writeSession = pqGateway->WaitWriteSession(outputTopic);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 2, queryName);
+        writeSession->EnsureEmpty();
+
+        WaitCheckpointUpdate(checkpointId);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->ExpectMessage("test_message3");
+
+        DropTopic(inputTopic);
+        DropTopic(outputTopic);
+    }
+
+    Y_UNIT_TEST_TWIN_F(CommitRetryOnStreamingQueryRecovery, CloseReadSession, TStreamingWithSchemaSecretsTestFixture) {
+        SetupAppConfig().MutableFeatureFlags()->SetEnableExactlyOnceTopicsWriting(true);
+
+        auto pqGateway = SetupMockPqGateway();
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopic = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopic = TStringBuilder() << Name_ << "OutputTopicName";
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreateTopic(inputTopic);
+        CreateTopic(outputTopic);
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM `{pq_source}`.`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopic,
+            "output_topic"_a = outputTopic
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+
+        const auto readSession = pqGateway->WaitReadSession(inputTopic);
+        auto writeSession = pqGateway->WaitWriteSession(outputTopic);
+        auto& publicationController = pqGateway->GetDeferredPublishClientController();
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        publicationController.LockCommits();
+
+        readSession->AddDataReceivedEvent(0, "test_message1");
+        const auto seqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+
+        publicationController.WaitCommits(/* count */ 1);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL, seqNo); // Checkpoint waits for publication commit
+        publicationController.ClearCommits();
+        writeSession->EnsureEmpty();
+
+        if constexpr (CloseReadSession) {
+            readSession->AddCloseSessionEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")});
+            readSession->ExpectSessionClosed();
+        } else {
+            writeSession->AddCloseSessionEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")});
+            writeSession->ExpectSessionClosed();
+        }
+
+        // Commit must be retried with correct publication id
+        publicationController.WaitCommits(/* count */ 1);
+        publicationController.UnlockCommits();
+        publicationController.EnsureOpenedPublications(/* count */ 0, queryName);
+        writeSession->ExpectMessage("test_message1");
+
+        // Check that checkpointing works for restarted query
+        pqGateway->WaitReadSession(inputTopic)->AddDataReceivedEvent(0, "test_message2");
+        writeSession = pqGateway->WaitWriteSession(outputTopic);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 4);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->EnsureEmpty();
+
+        WaitCheckpointUpdate(checkpointId);
+        publicationController.EnsureOpenedPublications(/* count */ 0, queryName);
+        writeSession->ExpectMessage("test_message2");
+
+        Sleep(TDuration::Seconds(1));
+
+        {
+            const auto& issues = GetStreamingQueryIssues(queryName);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Test pq session failure");
+
+            if constexpr (CloseReadSession) {
+                UNIT_ASSERT_STRING_CONTAINS(issues, TStringBuilder() << "Read session to topic \\\"" << inputTopic << "\\\" was closed");
+            } else {
+                UNIT_ASSERT_STRING_CONTAINS(issues, TStringBuilder() << "Write session to topic \\\"" << outputTopic << "\\\" was closed. Status: UNAVAILABLE");
+            }
+        }
+
+        DropTopic(inputTopic);
+        DropTopic(outputTopic);
+    }
+
+    Y_UNIT_TEST_TWIN_F(DeferredPublicationCreationFailure, LocalTopics, TStreamingWithSchemaSecretsTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO {pq_source}`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM {pq_source}`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        TInstant disposition = TInstant::Now();
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        WriteTopicMessage(inputTopicName, "message1", /* partition */ 0, LocalTopics);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        const std::vector<TPublicationSummary>& publications = ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 0, LocalTopics);
+
+        // Externally create publication with next seq-no
+        TString testExtId;
+        {
+            const TStringBuf extId = publications[0].ExtPublicationId;
+            const auto sepPos = extId.rfind(":");
+            UNIT_ASSERT(sepPos != TStringBuf::npos);
+            UNIT_ASSERT_LE(sepPos + 1, extId.size());
+
+            testExtId = TStringBuilder() << extId.SubString(0, sepPos) << ":" << FromString<ui64>(extId.SubString(sepPos + 1, extId.size() - sepPos)) + 1;
+            CreatePublication(testExtId, testExtId, *sdkClient);
+            ValidatePublicationsCount(/* count */ 2, queryName, *sdkClient);
+            ValidatePublicationsCount(/* count */ 1, testExtId, *sdkClient);
+        }
+
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        ValidatePublicationsCount(/* count */ 1, testExtId, *sdkClient);
+        ReadTopicMessage(outputTopicName, "message1", disposition, LocalTopics);
+
+        disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "message2", /* partition */ 0, LocalTopics);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        ValidatePublicationsCount(/* count */ 2, queryName, *sdkClient);
+        ValidatePublicationsCount(/* count */ 1, testExtId, *sdkClient);
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 1, LocalTopics);
+
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        ValidatePublicationsCount(/* count */ 1, testExtId, *sdkClient);
+        ReadTopicMessage(outputTopicName, "message2", disposition, LocalTopics);
+
+        {
+            const auto& issues = GetStreamingQueryIssues(queryName);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Failed to create deferred publication. Status: ALREADY_EXISTS");
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Conflict with existing key.");
+        }
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(outputTopicName, LocalTopics);
+    }
+
+    Y_UNIT_TEST_TWIN_F(DeferredPublicationDoubleCommitIsOk, LocalTopics, TStreamingTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        {
+            auto& featureFlags = *SetupAppConfig().MutableFeatureFlags();
+            featureFlags.SetEnableExactlyOnceTopicsWriting(true);
+            featureFlags.SetEnableTopicDeferredPublish(true);
+        }
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        std::shared_ptr<TDeferredPublishClient> sdkClient;
+        if constexpr (LocalTopics) {
+            sdkClient = GetDeferredPublishClient(LocalTopics, BUILTIN_ACL_ROOT);
+        } else {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+            sdkClient = GetDeferredPublishClient(LocalTopics, "", NYdb::CreateLoginCredentialsProviderFactory({
+                .User = "root",
+                .Password = "1234"
+            }));
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO {pq_source}`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM {pq_source}`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        TInstant disposition = TInstant::Now();
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+
+        WriteTopicMessage(inputTopicName, "message1", /* partition */ 0, LocalTopics);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        const std::vector<TPublicationSummary>& publications = ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 0, LocalTopics);
+
+        // Commit publication in front of query
+        {
+            const auto checkpointSeqNo = GetLastCheckpointSeqNo(checkpointId);
+            CommitPublication(publications[0].IntPublicationId, *sdkClient);
+            ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+            ReadTopicMessage(outputTopicName, "message1", disposition, LocalTopics);
+            UNIT_ASSERT_EQUAL(GetLastCheckpointSeqNo(checkpointId), checkpointSeqNo);
+        }
+
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 1, LocalTopics);
+
+        disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "message2", /* partition */ 0, LocalTopics);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        ValidatePublicationsCount(/* count */ 1, queryName, *sdkClient);
+        EnsureTopicEndOffset(outputTopicName, /* endOffset */ 1, LocalTopics);
+
+        WaitCheckpointUpdate(checkpointId);
+        ValidatePublicationsCount(/* count */ 0, queryName, *sdkClient);
+        ReadTopicMessage(outputTopicName, "message2", disposition, LocalTopics);
+
+        // Query should not fail on double publication commit
+        UNIT_ASSERT_VALUES_EQUAL(GetStreamingQueryIssues(queryName), "{}");
+
+        DropTopic(inputTopicName, LocalTopics);
+        DropTopic(outputTopicName, LocalTopics);
+    }
+
+    Y_UNIT_TEST_F(DeferredPublicationCommitFailure, TStreamingWithSchemaSecretsTestFixture) {
+        SetupAppConfig().MutableFeatureFlags()->SetEnableExactlyOnceTopicsWriting(true);
+        const auto pqGateway = SetupMockPqGateway();
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM `{pq_source}`.`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        auto& publicationController = pqGateway->GetDeferredPublishClientController();
+
+        publicationController.LockCommits();
+        pqGateway->WaitReadSession(inputTopicName)->AddDataReceivedEvent(0, "message1");
+        const auto seqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+
+        publicationController.WaitCommits(/* count */ 1);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL, seqNo); // Checkpoint waits for publication commit
+        auto writeSession = pqGateway->ExtractWriteSession(outputTopicName);
+        writeSession->EnsureEmpty();
+        publicationController.AcceptCommits(EStatus::UNAVAILABLE, {NIssue::TIssue("Test commit failure")});
+
+        // Commit must be retried after query restart with correct publication id
+        publicationController.WaitCommits(/* count */ 1);
+        publicationController.UnlockCommits();
+        publicationController.EnsureOpenedPublications(/* count */ 0, queryName);
+        writeSession->ExpectMessage("message1");
+        writeSession->ExpectSessionClosed();
+
+        // Check that checkpointing works for restarted query
+        pqGateway->WaitReadSession(inputTopicName)->AddDataReceivedEvent(0, "message2");
+        writeSession = pqGateway->WaitWriteSession(outputTopicName);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 4);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->EnsureEmpty();
+
+        WaitCheckpointUpdate(checkpointId);
+        publicationController.EnsureOpenedPublications(/* count */ 0, queryName);
+        writeSession->ExpectMessage("message2");
+
+        {
+            const auto& issues = GetStreamingQueryIssues(queryName);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Failed to commit deferred publication #1. Status: UNAVAILABLE");
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Test commit failure");
+        }
+
+        DropTopic(inputTopicName);
+        DropTopic(outputTopicName);
+    }
+
+    Y_UNIT_TEST_F(MessageWriteFailure, TStreamingWithSchemaSecretsTestFixture) {
+        SetupAppConfig().MutableFeatureFlags()->SetEnableExactlyOnceTopicsWriting(true);
+        const auto pqGateway = SetupMockPqGateway(TMockPqGatewaySettings{.LockWritingByDefault = true});
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM `{pq_source}`.`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        auto& publicationController = pqGateway->GetDeferredPublishClientController();
+
+        pqGateway->WaitReadSession(inputTopicName)->AddDataReceivedEvent(0, "message1");
+        const auto seqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+
+        auto writeSession = pqGateway->WaitWriteSession(outputTopicName);
+        writeSession->LockAcks();
+        writeSession->Unlock();
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL, seqNo); // Checkpoint waits for acks
+        writeSession->EnsureEmpty();
+        writeSession->UnlockAcks(TWriteSessionEvent::TWriteAck::EES_DISCARDED);
+
+        // Check that checkpointing works for restarted query
+        pqGateway->WaitReadSession(inputTopicName)->AddDataReceivedEvent(0, "message2");
+        auto newWriteSession = pqGateway->WaitWriteSession(outputTopicName);
+        newWriteSession->Unlock();
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 4);
+        publicationController.EnsureOpenedPublications(/* count */ 2, queryName);
+        newWriteSession->EnsureEmpty();
+
+        WaitCheckpointUpdate(checkpointId);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        newWriteSession->ExpectMessage("message2");
+        writeSession->EnsureEmpty(); // There is no commits on failed publication
+
+        UNIT_ASSERT_STRING_CONTAINS(GetStreamingQueryIssues(queryName), "Message with seqNo 0 was discarded");
+
+        DropTopic(inputTopicName);
+        DropTopic(outputTopicName);
+    }
+
+    Y_UNIT_TEST_F(DeferredPublicationRefreshOnCheckpoint, TStreamingWithSchemaSecretsTestFixture) {
+        SetupAppConfig().MutableFeatureFlags()->SetEnableExactlyOnceTopicsWriting(true);
+        const auto pqGateway = SetupMockPqGateway(TMockPqGatewaySettings{.LockWritingByDefault = true});
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}` WITH (DELIVERY_GUARANTEE = "exactly_once")
+                SELECT * FROM `{pq_source}`.`{input_topic}`;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        auto& publicationController = pqGateway->GetDeferredPublishClientController();
+
+        const auto readSession = pqGateway->WaitReadSession(inputTopicName);
+        readSession->AddDataReceivedEvent(0, "message1");
+        auto seqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+
+        const auto writeSession = pqGateway->WaitWriteSession(outputTopicName);
+        writeSession->LockAcks();
+        writeSession->Unlock();
+        writeSession->WaitAcks(/* count */ 1);
+        writeSession->EnsureEmpty();
+
+        writeSession->Lock();
+        readSession->AddDataReceivedEvent(1, "message2");
+        readSession->AddDataReceivedEvent(2, "message3");
+        writeSession->WaitAcks(/* count */ 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetLastCheckpointSeqNo(checkpointId), seqNo);
+
+        // Wait for new checkpoint start
+        WaitFor(CHECKPOINT_INTERVAL, "checkpoint start", [&]() {
+            return GetLastCheckpointSeqNo(checkpointId) != seqNo;
+        });
+
+        Sleep(TDuration::Seconds(1));
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->EnsureEmpty();
+
+        // Add few messages after pending checkpoint
+        readSession->AddDataReceivedEvent(3, "message4");
+        readSession->AddDataReceivedEvent(4, "message5");
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL, seqNo);
+
+        publicationController.LockCommits();
+        writeSession->UnlockAcks();
+        writeSession->Unlock();
+        publicationController.WaitCommits(/* count */ 1);
+        publicationController.EnsureOpenedPublications(/* count */ 2, queryName); // There should be another publication for new messages
+        seqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL, seqNo);
+        writeSession->EnsureEmpty();
+
+        publicationController.AcceptCommits(EStatus::SUCCESS);
+        publicationController.WaitCommits(/* count */ 1);
+        publicationController.EnsureOpenedPublications(/* count */ 1, queryName);
+        writeSession->ExpectMessages({"message1", "message2", "message3"});
+        UNIT_ASSERT(GetLastCheckpointSeqNo(checkpointId) == seqNo + 1);
+
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL, seqNo);
+        publicationController.UnlockCommits();
+        publicationController.EnsureOpenedPublications(/* count */ 0, queryName);
+        writeSession->ExpectMessages({"message4", "message5"});
+
+        DropTopic(inputTopicName);
+        DropTopic(outputTopicName);
     }
 }
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -178,7 +178,10 @@ struct IDqComputeActorAsyncOutput {
     // Apply side effects related to this checkpoint. Should call ICallbacks::OnAsyncOutputStateCommitted() when state was committed.
     // Function CommitState() must be idempotent, and may be called multiple times, in case of checkpoint restoration, for same sink.
     virtual void CommitState(const NDqProto::TCheckpoint& checkpoint) = 0;
-    virtual void LoadState(const TSinkState& state) = 0;
+
+    // Load state from specific checkpoint.
+    // If checkpoint used for restoration was in pending commit state, next will be called CommitState() on the same checkpoint.
+    virtual void LoadState(const TSinkState& state, const NDqProto::TCheckpoint& checkpoint) = 0;
 
     virtual TMaybe<google::protobuf::Any> ExtraData() { return {}; }
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -313,6 +313,7 @@ public:
         IRandomProvider *const RandomProvider;
         NWilson::TTraceId TraceId;
         ::NMonitoring::TDynamicCounterPtr TaskCounters;
+        bool HasCheckpoints = false;
     };
 
     struct TInputTransformArguments {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp
@@ -459,10 +459,10 @@ void TDqComputeActorCheckpoints::Handle(TEvDqCompute::TEvGetTaskStateResult::TPt
     RestoringTaskRunnerForCheckpoint = checkpoint;
     RestoringTaskRunnerForEvent = ev->Cookie;
     if (StateLoadPlan.GetStateType() == NDqProto::NDqStateLoadPlan::STATE_TYPE_OWN) {
-        ComputeActor->LoadState(std::move(ev->Get()->States[0]));
+        ComputeActor->LoadState(std::move(ev->Get()->States[0]), checkpoint);
     } else if (StateLoadPlan.GetStateType() == NDqProto::NDqStateLoadPlan::STATE_TYPE_FOREIGN) {
         TComputeActorState state = CombineForeignState(StateLoadPlan, ev->Get()->States, taskIds);
-        ComputeActor->LoadState(std::move(state));
+        ComputeActor->LoadState(std::move(state), checkpoint);
     } else {
         Y_ABORT("Unprocessed state type %s (%d)",
             NDqProto::NDqStateLoadPlan::EStateType_Name(StateLoadPlan.GetStateType()).c_str(),

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.h
@@ -123,7 +123,7 @@ public:
         virtual void Stop() = 0;
         virtual void ResumeExecution(EResumeSource source) = 0;
 
-        virtual void LoadState(TComputeActorState&& state) = 0;
+        virtual void LoadState(TComputeActorState&& state, const NDqProto::TCheckpoint& checkpoint) = 0;
 
         virtual ~ICallbacks() = default;
     };

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -938,7 +938,7 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
 protected:
     virtual void DoLoadRunnerState(TString&& blob) = 0;
 
-    void LoadState(TComputeActorState&& state) override final {
+    void LoadState(TComputeActorState&& state, const NDqProto::TCheckpoint& checkpoint) override final {
         CA_LOG_D("Load state");
         TMaybe<TString> error = Nothing();
         const TMiniKqlProgramState& mkqlProgramState = *state.MiniKqlProgram;
@@ -959,7 +959,7 @@ protected:
                 TAsyncOutputInfoBase* sink = SinksMap.FindPtr(sinkState.OutputIndex);
                 YQL_ENSURE(sink, "Failed to load state. Sink with output index " << sinkState.OutputIndex << " was not found");
                 YQL_ENSURE(sink->AsyncOutput, "Sink[" << sinkState.OutputIndex << "] is not created");
-                sink->AsyncOutput->LoadState(sinkState);
+                sink->AsyncOutput->LoadState(sinkState, checkpoint);
             }
         } catch (const std::exception& e) {
             error = e.what();

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -2183,6 +2183,7 @@ protected:
                         .RandomProvider = randomProvider,
                         .TraceId = ComputeActorSpan.GetTraceId(),
                         .TaskCounters = TaskCounters,
+                        .HasCheckpoints = GetTaskCheckpointingMode(Task) != NYql::NDqProto::CHECKPOINTING_MODE_DISABLED,
                     });
             } catch (const std::exception& ex) {
                 throw yexception() << "Failed to create sink " << outputDesc.GetSink().GetType() << ": " << ex.what();

--- a/ydb/library/yql/dq/actors/compute/ut/dq_sync_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_sync_compute_actor_ut.cpp
@@ -247,7 +247,7 @@ private:
         State->OnCommitState(SelfId());
     }
 
-    void LoadState(const TSinkState&) override {
+    void LoadState(const TSinkState&, const NDqProto::TCheckpoint&) override {
     }
 
     void PassAway() override {

--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
@@ -139,10 +139,10 @@ void TFakeCASetup::LoadSource(const TSourceState& state) {
     });
 }
 
-void TFakeCASetup::LoadSink(const TSinkState& state) {
-    Execute([&state](TFakeActor& actor) {
+void TFakeCASetup::LoadSink(const TSinkState& state, const NDqProto::TCheckpoint& checkpoint) {
+    Execute([&state, &checkpoint](TFakeActor& actor) {
         Y_ASSERT(actor.DqAsyncOutput);
-        actor.DqAsyncOutput->LoadState(state);
+        actor.DqAsyncOutput->LoadState(state, checkpoint);
     });
 }
 

--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
@@ -261,7 +261,7 @@ struct TFakeCASetup {
     void SaveSourceState(NDqProto::TCheckpoint checkpoint, TSourceState& state);
 
     void LoadSource(const TSourceState& state);
-    void LoadSink(const TSinkState& state);
+    void LoadSink(const TSinkState& state, const NDqProto::TCheckpoint& checkpoint);
 
     void Execute(TCallback callback);
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
@@ -597,7 +597,9 @@ std::pair<IDqComputeActorAsyncOutput*, NActors::IActor*> CreateDqPqWriteActor(
     IPqStaticGateway::TPtr pqGateway,
     bool enableStreamingQueriesCounters,
     i64 freeSpace,
-    bool enableStreamingQueriesPqSinkDeduplicationFeatureFlag)
+    i64 currentExecutionGeneration,
+    bool enableStreamingQueriesPqSinkDeduplicationFeatureFlag,
+    bool hasCheckpoints)
 {
     const TString& tokenName = settings.GetToken().GetName();
     const TString token = secureParams.Value(tokenName, TString());
@@ -614,9 +616,12 @@ std::pair<IDqComputeActorAsyncOutput*, NActors::IActor*> CreateDqPqWriteActor(
         callbacks,
         counters,
         freeSpace,
+        currentExecutionGeneration,
         pqGateway,
         enableStreamingQueriesCounters,
-        enableStreamingQueriesPqSinkDeduplicationFeatureFlag);
+        enableStreamingQueriesPqSinkDeduplicationFeatureFlag,
+        hasCheckpoints
+    );
     return {actor, actor};
 }
 
@@ -627,9 +632,18 @@ void RegisterDqPqWriteActorFactory(TDqAsyncIoFactory& factory, NYdb::TDriver dri
             IDqAsyncIoFactory::TSinkArguments&& args)
         {
             auto txId = args.TxId;
-            auto taskParamsIt = args.TaskParams.find("query_path");
-            if (taskParamsIt != args.TaskParams.end()) {
-                txId = taskParamsIt->second;
+            if (const auto it = args.TaskParams.find("query_path"); it != args.TaskParams.end()) {
+                txId = it->second;
+            }
+
+            i64 currentExecutionGeneration = 0;
+            if (const auto it = args.TaskParams.find("current_execution_generation"); it != args.TaskParams.end()) {
+                currentExecutionGeneration = FromString<i64>(it->second);
+            }
+
+            bool hasCheckpoints = false;
+            if (const auto it = args.TaskParams.find("checkpoints_enabled"); it != args.TaskParams.end()) {
+                hasCheckpoints = FromString<bool>(it->second) && args.HasCheckpoints;
             }
             NLwTraceMonPage::ProbeRegistry().AddProbesList(LWTRACE_GET_PROBES(DQ_PQ_PROVIDER));
             return CreateDqPqWriteActor(
@@ -646,7 +660,9 @@ void RegisterDqPqWriteActorFactory(TDqAsyncIoFactory& factory, NYdb::TDriver dri
                 pqGateway,
                 enableStreamingQueriesCounters,
                 DqPqDefaultFreeSpace,
-                enableStreamingQueriesPqSinkDeduplicationFeatureFlag
+                currentExecutionGeneration,
+                enableStreamingQueriesPqSinkDeduplicationFeatureFlag,
+                hasCheckpoints
             );
         });
 }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
@@ -1,8 +1,7 @@
 #include "dq_pq_write_actor.h"
 #include "probes.h"
 
-#include <ydb/core/base/appdata_fwd.h>
-
+#include <ydb/library/accessor/accessor.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
@@ -15,6 +14,7 @@
 #include <ydb/library/yql/providers/pq/common/pq_events_processor.h>
 #include <ydb/library/yql/providers/pq/proto/dq_io_state.pb.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/public/sdk/cpp/adapters/issue/issue.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/federated_topic/federated_topic.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
@@ -35,41 +35,18 @@
 #include <queue>
 #include <variant>
 
-#define LOG_T(s) \
-    LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, s)
-#define LOG_D(s) \
-    LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, s)
-#define LOG_I(s) \
-    LOG_INFO_S(*NActors::TlsActivationContext,  NKikimrServices::KQP_COMPUTE, s)
-#define LOG_W(s) \
-    LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, s)
-#define LOG_N(s) \
-    LOG_NOTICE_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, s)
-#define LOG_E(s) \
-    LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, s)
-#define LOG_C(s) \
-    LOG_CRIT_S(*NActors::TlsActivationContext,  NKikimrServices::KQP_COMPUTE, s)
-#define LOG_PRIO(prio, s) \
-    LOG_LOG_S(*NActors::TlsActivationContext, prio, NKikimrServices::KQP_COMPUTE, s)
-
-
-#define SINK_LOG_T(s) LOG_T(LogPrefix << s)
-#define SINK_LOG_D(s) LOG_D(LogPrefix << s)
-#define SINK_LOG_I(s) LOG_I(LogPrefix << s)
-#define SINK_LOG_W(s) LOG_W(LogPrefix << s)
-#define SINK_LOG_N(s) LOG_N(LogPrefix << s)
-#define SINK_LOG_E(s) LOG_E(LogPrefix << s)
-#define SINK_LOG_C(s) LOG_C(LogPrefix << s)
-#define SINK_LOG_PRIO(prio, s) LOG_PRIO(prio, LogPrefix << s)
+#define SINK_LOG_T(s) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
+#define SINK_LOG_D(s) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
+#define SINK_LOG_I(s) LOG_INFO_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
+#define SINK_LOG_N(s) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
+#define SINK_LOG_W(s) LOG_WARN_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
+#define SINK_LOG_E(s) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
+#define SINK_LOG_C(s) LOG_CRIT_S(*TlsActivationContext,  NKikimrServices::KQP_COMPUTE, LogPrefix() << s)
 
 namespace NYql::NDq {
 
 using namespace NActors;
-using namespace NLog;
 using namespace NKikimr::NMiniKQL;
-
-constexpr ui32 StateVersion = 1;
-constexpr ui32 MaxMessageSize = 1_MB;
 
 namespace {
 
@@ -78,299 +55,788 @@ LWTRACE_USING(DQ_PQ_PROVIDER);
 struct TEvPrivate {
     // Event ids
     enum EEv : ui32 {
-        EvBegin = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+        EvBegin = EventSpaceBegin(TEvents::ES_PRIVATE),
 
         EvPqEventsReady = EvBegin,
         EvExecuteTopicEvent,
+        EvDeferredPublicationCreated,
+        EvDeferredPublicationCommitted,
 
         EvEnd
     };
 
-    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+    static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
 
     // Events
 
-    struct TEvPqEventsReady : public TEventLocal<TEvPqEventsReady, EvPqEventsReady> {};
+    struct TEvPqEventsReady : public TEventLocal<TEvPqEventsReady, EvPqEventsReady> {
+    };
 
     struct TEvExecuteTopicEvent : public TTopicEventBase<TEvExecuteTopicEvent, EvExecuteTopicEvent> {
         using TTopicEventBase::TTopicEventBase;
     };
+
+    template <typename TResult, ui32 EEventId>
+    struct TEvApiResult : public TEventLocal<TEvApiResult<TResult, EEventId>, EEventId> {
+        explicit TEvApiResult(TResult result, const TInstant startedAt)
+            : Result(std::move(result))
+            , Latency(TInstant::Now() - startedAt)
+        {}
+
+        const TResult Result;
+        const TDuration Latency;
+    };
+
+    using TEvDeferredPublicationCreated = TEvApiResult<NYdb::NTopic::TBeginPublicationResult, EvDeferredPublicationCreated>;
+    using TEvDeferredPublicationCommitted = TEvApiResult<NYdb::NTopic::TPublishResult, EvDeferredPublicationCommitted>;
 };
 
-TString MakeStringForLog(const NDqProto::TCheckpoint& checkpoint) {
-    return TStringBuilder() << "[Checkpoint " << checkpoint.GetGeneration() << "." << checkpoint.GetId() << "] ";
-}
+class TDqPqWriteActor final : public TActor<TDqPqWriteActor>, public IActorExceptionHandler, public IDqComputeActorAsyncOutput, TTopicEventProcessor<TEvPrivate::TEvExecuteTopicEvent> {
+    static constexpr ui32 STATE_VERSION = 1;
+    static constexpr ui32 MAX_MESSAGE_SIZE = 1_MB;
+    static constexpr TDuration SLOW_CHECKPOINT_DURATION = TDuration::Minutes(1);
 
-} // anonymous namespace
+    using TBase = TActor<TDqPqWriteActor>;
 
-class TDqPqWriteActor : public NActors::TActor<TDqPqWriteActor>, public IDqComputeActorAsyncOutput, TTopicEventProcessor<TEvPrivate::TEvExecuteTopicEvent> {
     struct TMetrics {
         TMetrics(
-            const TTxId& txId,
-            ui64 taskId,
-            const ::NMonitoring::TDynamicCounterPtr& counters,
-            bool enableStreamingQueriesCounters,
-            bool enableCountersPerTask = false)
-            : TxId(std::visit([](auto arg) { return ToString(arg); }, txId))
-            , Counters(counters) {
-            if (Counters) {
-                SubGroup = Counters->GetSubgroup("sink", "PqSink");
-            } else {
-                SubGroup = MakeIntrusive<::NMonitoring::TDynamicCounters>();
-            }
+            const TTxId& txId, const ui64 taskId, NMonitoring::TDynamicCounterPtr counters, const bool enableStreamingQueriesCounters,
+            const bool enableCountersPerTask, const bool enableDeferredPublication
+        )
+            : TxId(std::visit([](const auto& arg) {
+                return ToString(arg);
+            }, txId))
+            , SubGroup(counters ? counters->GetSubgroup("sink", "PqSink") : MakeIntrusive<NMonitoring::TDynamicCounters>())
+        {
             auto task = SubGroup;
+
             if (enableStreamingQueriesCounters) {
                 task = task->GetSubgroup("tx_id", TxId);
+
                 if (enableCountersPerTask) {
                     task = task->GetSubgroup("task_id", ToString(taskId));
                 }
             }
+
             LastAckLatency = task->GetCounter("LastAckLatencyMs");
             InFlyCheckpoints = task->GetCounter("InFlyCheckpoints");
+            InFlyPendingAckCheckpoints = task->GetCounter("InFlyPendingAckCheckpoints");
+            InFlyPendingCommitCheckpoints = task->GetCounter("InFlyPendingCommitCheckpoints");
             InFlyData = task->GetCounter("InFlyData");
             AlreadyWritten = task->GetCounter("AlreadyWritten");
             FirstContinuationTokenMs = task->GetCounter("FirstContinuationTokenMs");
             EgressDataRate = task->GetCounter("EgressDataRate", true);
+
+            if (enableDeferredPublication) {
+                LastBeginPublicationLatency = task->GetCounter("DeferredPublication/LastBeginLatencyMs");
+                LastPublishLatency = task->GetCounter("DeferredPublication/LastPublishLatencyMs");
+                LastPublicationActiveDuration = task->GetCounter("DeferredPublication/LastActiveDurationMs");
+                InFlyActivePublications = task->GetCounter("DeferredPublication/InFlyActive");
+                InFlyPendingCommitPublications = task->GetCounter("DeferredPublication/InFlyPendingCommit");
+                UnpublishedDataSize = task->GetCounter("DeferredPublication/UnpublishedDataSize");
+            }
         }
 
         ~TMetrics() {
             SubGroup->RemoveSubgroup("tx_id", TxId);
         }
 
-        TString TxId;
-        ::NMonitoring::TDynamicCounterPtr Counters;
-        ::NMonitoring::TDynamicCounterPtr SubGroup;
-        ::NMonitoring::TDynamicCounters::TCounterPtr LastAckLatency;
-        ::NMonitoring::TDynamicCounters::TCounterPtr InFlyCheckpoints;
-        ::NMonitoring::TDynamicCounters::TCounterPtr InFlyData;
-        ::NMonitoring::TDynamicCounters::TCounterPtr AlreadyWritten;
-        ::NMonitoring::TDynamicCounters::TCounterPtr FirstContinuationTokenMs;
-        ::NMonitoring::TDynamicCounters::TCounterPtr EgressDataRate;
+        void ReportFirstContinuationToken() const {
+            if (*FirstContinuationTokenMs == 0) {
+                FirstContinuationTokenMs->Set((TInstant::Now() - StartTime).MilliSeconds());
+            }
+        }
+
+        // Common counters
+        NMonitoring::TDynamicCounters::TCounterPtr LastAckLatency;
+        NMonitoring::TDynamicCounters::TCounterPtr InFlyCheckpoints;
+        NMonitoring::TDynamicCounters::TCounterPtr InFlyPendingAckCheckpoints;
+        NMonitoring::TDynamicCounters::TCounterPtr InFlyPendingCommitCheckpoints;
+        NMonitoring::TDynamicCounters::TCounterPtr InFlyData;
+        NMonitoring::TDynamicCounters::TCounterPtr AlreadyWritten;
+        NMonitoring::TDynamicCounters::TCounterPtr EgressDataRate;
+
+        // Deferred publication counters
+        NMonitoring::TDynamicCounters::TCounterPtr LastBeginPublicationLatency;
+        NMonitoring::TDynamicCounters::TCounterPtr LastPublishLatency;
+        NMonitoring::TDynamicCounters::TCounterPtr LastPublicationActiveDuration;
+        NMonitoring::TDynamicCounters::TCounterPtr InFlyActivePublications;
+        NMonitoring::TDynamicCounters::TCounterPtr InFlyPendingCommitPublications;
+        NMonitoring::TDynamicCounters::TCounterPtr UnpublishedDataSize;
+
+    private:
+        const TInstant StartTime = TInstant::Now();
+        const TString TxId;
+        const NMonitoring::TDynamicCounterPtr SubGroup;
+
+        NMonitoring::TDynamicCounters::TCounterPtr FirstContinuationTokenMs;
     };
 
-    struct TAckInfo {
-        TAckInfo(i64 messageSize, const TInstant& startTime, ui64 seqNo)
-            : MessageSize(messageSize)
-            , StartTime(startTime)
-            , SeqNo(seqNo)
+    // Store for messages to write and acks for inflight writes into topic
+    class TDataBuffer {
+        struct TAckInfo {
+            TAckInfo(const i64 messageSize, const ui64 seqNo)
+                : MessageSize(messageSize)
+                , SeqNo(seqNo)
+            {}
+
+            const i64 MessageSize = 0;
+            const ui64 SeqNo = 0;
+            const TInstant StartTime = TInstant::Now();
+        };
+
+    public:
+        TDataBuffer(TDqAsyncStats& egressStats, const TMetrics& metrics, const bool enableDeduplication)
+            : Metrics(metrics)
+            , EnableDeduplication(enableDeduplication)
+            , EgressStats(egressStats)
         {}
 
-        i64 MessageSize = 0;
-        TInstant StartTime;
-        ui64 SeqNo = 0;
+        bool Empty() const {
+            return Messages.empty() && Inflight.empty();
+        }
+
+        ui64 GetLastSentMessageSeqNo() const {
+            Y_VALIDATE(NextMessageSeqNo > 0, "Unexpected next message seq no: " << NextMessageSeqNo);
+            return NextMessageSeqNo - 1;
+        }
+
+        ui64 GetLastBufferedSeqNo() const {
+            return GetLastSentMessageSeqNo() + Messages.size();
+        }
+
+        void PushMessage(TString&& message) {
+            Messages.emplace(std::move(message));
+            Metrics.InFlyData->Inc();
+        }
+
+        std::pair<std::optional<uint64_t>, TString> PopMessage() {
+            Y_VALIDATE(!Messages.empty(), "Unexpected empty messages queue");
+            auto message = std::move(Messages.front());
+            Messages.pop();
+
+            const std::optional<uint64_t> seqNo = EnableDeduplication ? std::optional(NextMessageSeqNo) : std::nullopt;
+            const auto itemSize = GetItemSize(message);
+            Inflight.emplace(itemSize, NextMessageSeqNo++);
+            EgressStats.Bytes += itemSize;
+            Metrics.EgressDataRate->Add(itemSize);
+            return {seqNo, std::move(message)};
+        }
+
+        TAckInfo PopAck() {
+            Y_VALIDATE(!Inflight.empty(), "Unexpected empty inflight messages queue");
+            auto ackInfo = Inflight.front();
+            Inflight.pop();
+
+            Metrics.LastAckLatency->Set((TInstant::Now() - ackInfo.StartTime).MilliSeconds());
+            Metrics.InFlyData->Dec();
+
+            // Use seqNo stored on our side because without deduplication we do not specify SeqNo on Write().
+            // We expecting that acks comes from server in strictly same order as sent messages.
+            Y_VALIDATE(ackInfo.SeqNo == ConfirmedSeqNo + 1, "Unexpected ack seq no: " << ackInfo.SeqNo << " expected: " << ConfirmedSeqNo + 1);
+            ConfirmedSeqNo = ackInfo.SeqNo;
+
+            return ackInfo;
+        }
+
+        // Called on state restoration from checkpoint
+        void LoadConfirmedSeqNo(const ui64 confirmedSeqNo) {
+            Y_VALIDATE(NextMessageSeqNo == 1, "Unexpected load state after sending some data");
+            ConfirmedSeqNo = confirmedSeqNo;
+            NextMessageSeqNo = ConfirmedSeqNo + 1;
+        }
+
+    private:
+        const TMetrics& Metrics;
+        const bool EnableDeduplication = false;
+        TDqAsyncStats& EgressStats;
+
+        YDB_READONLY_DEF(std::queue<TString>, Messages);
+        YDB_READONLY_DEF(std::queue<TAckInfo>, Inflight);
+        YDB_READONLY(ui64, ConfirmedSeqNo, 0);
+        ui64 NextMessageSeqNo = 1;
+    };
+
+    // Store for pending checkpoints and their states. Checkpoint handle phases:
+    // 1. Receive checkpoint from input, save seq no range for messages, which was in buffer before this checkpoint
+    // 2. Wait for sending all messages with SeqNo <= WaitConfirmedSeqNo and then reset deferred publication, save egress stats
+    // 3. Wait for receiving acks on all messages with SeqNo <= WaitConfirmedSeqNo, then save checkpoint state
+    // 4. Wait for checkpoint commit request, then perform deferred publication commit
+    class TCheckpointsState {
+    public:
+        struct TCheckpointInfo {
+            TCheckpointInfo(const ui64 waitConfirmedSeqNo, NDqProto::TCheckpoint checkpoint, const ui64 deferredPublicationIntId = 0)
+                : WaitConfirmedSeqNo(waitConfirmedSeqNo)
+                , Checkpoint(std::move(checkpoint))
+                , DeferredPublicationIntId(deferredPublicationIntId)
+            {}
+
+            bool Equal(const NDqProto::TCheckpoint& checkpointBound) const {
+                return Checkpoint.GetGeneration() == checkpointBound.GetGeneration() && Checkpoint.GetId() == checkpointBound.GetId();
+            }
+
+            const ui64 WaitConfirmedSeqNo = 0; // Checkpoint state should be saved after getting acks on all messages with SeqNo <= WaitConfirmedSeqNo
+            const NDqProto::TCheckpoint Checkpoint;
+            const TInstant StartTime = TInstant::Now();
+            ui64 EgressBytes = 0;
+            ui64 DataSizeUnderCheckpoint = 0;
+            ui64 DeferredPublicationIntId = 0;
+            bool AllDataSent = false;
+            bool AllAcksReceived = false;
+        };
+
+        TCheckpointsState(const TDqAsyncStats& egressStats, const TMetrics& metrics)
+            : Metrics(metrics)
+            , EgressStats(egressStats)
+        {}
+
+        bool Empty() const {
+            return !PendingCheckpoint;
+        }
+
+        TString GetSlowCheckpointDiagnostics(const ui64 sentSeqNo, const ui64 confirmedSeqNo) const {
+            Y_VALIDATE(SelfId && SlowCheckpointMonitoringStarted, "Slow checkpoint monitoring is not started");
+            TActivationContext::Schedule(SLOW_CHECKPOINT_DURATION, new IEventHandle(SelfId, SelfId, new TEvents::TEvWakeup()));
+
+            if (!PendingCheckpoint) {
+                return "";
+            }
+
+            const auto duration = TInstant::Now() - PendingCheckpoint->StartTime;
+            if (duration < SLOW_CHECKPOINT_DURATION) {
+                return "";
+            }
+
+            const auto& info = *PendingCheckpoint;
+            const auto waitConfirmedSeqNo = info.WaitConfirmedSeqNo;
+            auto result = TStringBuilder() << CheckpointLogString(info.Checkpoint)
+                << " Slow PQ sink checkpoint. Duration: " << duration.Seconds() << 's'
+                << ". Checkpoint seq no: " << waitConfirmedSeqNo
+                << (info.DeferredPublicationIntId ? TStringBuilder() << ". Deferred publication internal id: " << info.DeferredPublicationIntId : TStringBuilder())
+                << ". Checkpoint data size: " << info.DataSizeUnderCheckpoint;
+
+            if (!info.AllDataSent) {
+                result << ". Waiting for writing seq no range [" << sentSeqNo + 1 << ", " << waitConfirmedSeqNo << "]";
+            } else if (!info.AllAcksReceived) {
+                result << ". Waiting acks for seq no range [" << confirmedSeqNo + 1 << ", " << waitConfirmedSeqNo << "]";
+            } else {
+                result << ". Waiting commit request from checkpoint coordinator, last checkpoint bound: " << CheckpointLogString(LastCommitCheckpointBound);
+            }
+
+            return result;
+        }
+
+        void PushCheckpoint(const ui64 waitConfirmedSeqNo, NDqProto::TCheckpoint checkpoint) {
+            Y_VALIDATE(!PendingCheckpoint, "Multiple checkpoint inflight is not supported");
+            Y_VALIDATE(!LastCommitCheckpointBound || (
+                LastCommitCheckpointBound->GetGeneration() < checkpoint.GetGeneration() || (
+                    LastCommitCheckpointBound->GetGeneration() == checkpoint.GetGeneration() &&
+                    LastCommitCheckpointBound->GetId() < checkpoint.GetId()
+                )
+            ), "Unexpected new checkpoint: " << CheckpointLogString(checkpoint) << " for last commit checkpoint bound: " << CheckpointLogString(*LastCommitCheckpointBound));
+            PendingCheckpoint.emplace(waitConfirmedSeqNo, std::move(checkpoint));
+
+            if (!SlowCheckpointMonitoringStarted) {
+                SlowCheckpointMonitoringStarted = true;
+                TActivationContext::Schedule(SLOW_CHECKPOINT_DURATION, new IEventHandle(SelfId, SelfId, new TEvents::TEvWakeup()));
+            }
+
+            Metrics.InFlyCheckpoints->Inc();
+        }
+
+        bool AdvanceSentSeqNo(const ui64 sentSeqNo, ui64 deferredPublicationIntId) {
+            if (!PendingCheckpoint || PendingCheckpoint->AllDataSent || PendingCheckpoint->WaitConfirmedSeqNo > sentSeqNo) {
+                return false;
+            }
+
+            // For correct deferred publication reset, sent message seq no must advance strictly one by one
+            Y_VALIDATE(PendingCheckpoint->WaitConfirmedSeqNo == sentSeqNo, "Unexpected sent seq no: " << sentSeqNo << ". Wait confirmed seq no: " << PendingCheckpoint->WaitConfirmedSeqNo);
+
+            PendingCheckpoint->AllDataSent = true;
+            PendingCheckpoint->DeferredPublicationIntId = deferredPublicationIntId;
+            PendingCheckpoint->EgressBytes = EgressStats.Bytes;
+            PendingCheckpoint->DataSizeUnderCheckpoint = EgressStats.Bytes - std::exchange(WrittenDataUnderCheckpoint, EgressStats.Bytes);
+            Metrics.InFlyCheckpoints->Dec();
+            Metrics.InFlyPendingAckCheckpoints->Inc();
+            return true;
+        }
+
+        // Returns checkpoint which state should be saved if any
+        std::optional<TCheckpointInfo> AdvanceConfirmedSeqNo(const ui64 confirmedSeqNo) {
+            if (!PendingCheckpoint || PendingCheckpoint->AllAcksReceived || PendingCheckpoint->WaitConfirmedSeqNo > confirmedSeqNo) {
+                return std::nullopt;
+            }
+
+            PendingCheckpoint->AllAcksReceived = true;
+            Metrics.InFlyPendingAckCheckpoints->Dec();
+
+            if (PendingCheckpoint->DeferredPublicationIntId) {
+                Metrics.InFlyPendingCommitCheckpoints->Inc();
+                return PendingCheckpoint;
+            }
+
+            // There is no need to track checkpoints without deferred publications
+            return std::exchange(PendingCheckpoint, std::nullopt);
+        }
+
+        // Returns checkpoint which state should be committed if any
+        std::optional<TCheckpointInfo> CommitCheckpoints(const NDqProto::TCheckpoint& checkpointBound) {
+            LastCommitCheckpointBound = checkpointBound;
+
+            if (RestoredCheckpoint && RestoredCheckpoint->Equal(checkpointBound)) {
+                return *std::exchange(RestoredCheckpoint, std::nullopt);
+            }
+
+            // We already committed future checkpoint, so restored checkpoint was committed
+            RestoredCheckpoint.reset();
+
+            if (!PendingCheckpoint) {
+                return std::nullopt;
+            }
+
+            // Checkpoint for commit must be either restored or pending checkpoint
+            Y_VALIDATE(PendingCheckpoint->Equal(checkpointBound), "Unexpected checkpoint bound: " << CheckpointLogString(checkpointBound) << ", pending checkpoint: " << (PendingCheckpoint ? CheckpointLogString(PendingCheckpoint->Checkpoint) : "<null>"));
+            Y_VALIDATE(PendingCheckpoint->AllDataSent && PendingCheckpoint->AllAcksReceived, "Pending checkpoint is not ready for commit");
+            Metrics.InFlyPendingCommitCheckpoints->Dec();
+            return std::exchange(PendingCheckpoint, std::nullopt);
+        }
+
+        // Called on state restoration from checkpoint
+        void LoadPendingCommitCheckpoint(const ui64 confirmedSeqNo, NDqProto::TCheckpoint checkpoint, const ui64 deferredPublicationIntId) {
+            Y_VALIDATE(!RestoredCheckpoint, "Cannot load state twice");
+            RestoredCheckpoint.emplace(confirmedSeqNo, std::move(checkpoint), deferredPublicationIntId);
+        }
+
+    private:
+        const TMetrics& Metrics;
+        const TDqAsyncStats& EgressStats;
+        YDB_ACCESSOR_DEF(TActorId, SelfId);
+
+        std::optional<TCheckpointInfo> PendingCheckpoint;
+        std::optional<TCheckpointInfo> RestoredCheckpoint;
+        YDB_ACCESSOR(ui64, WrittenDataUnderCheckpoint, 0);
+        bool SlowCheckpointMonitoringStarted = false;
+        std::optional<NDqProto::TCheckpoint> LastCommitCheckpointBound;
+    };
+
+    // Deferred publication lifecycle:
+    // 1. Created when first message arrived and work until all data for current checkpoint was not written
+    // 2. When checkpoint receive commit request publication will be committed
+    // 3. After successful commit checkpoint marked as committed
+    class TDeferredPublishState {
+        struct TInflightPublicationInfo {
+            TInflightPublicationInfo(const ui64 publicationIntId, std::optional<NDqProto::TCheckpoint> checkpoint, const ui64 unpublishedDataSize)
+                : PublicationIntId(publicationIntId)
+                , Checkpoint(std::move(checkpoint))
+                , UnpublishedDataSize(unpublishedDataSize)
+            {}
+
+            const ui64 PublicationIntId = 0;
+            const std::optional<NDqProto::TCheckpoint> Checkpoint; // Checkpoint what was associated with data in committing publication (empty when write actor finishing without checkpoints)
+            const ui64 UnpublishedDataSize = 0;
+            const TInstant StartTime = TInstant::Now();
+        };
+
+    public:
+        TDeferredPublishState(const i64 currentExecutionGeneration, const ui64 taskId, const ui64 outputIndex, const NPq::NProto::TDqPqTopicSink& sinkParams, const TMetrics& metrics)
+            : Metrics(metrics)
+            , WriterIdentity(!sinkParams.GetDeferredPublicationExtIdPrefix().empty() ? TStringBuilder() << sinkParams.GetDeferredPublicationExtIdPrefix() << ":" << taskId << ":" << outputIndex << ":" << currentExecutionGeneration : TStringBuilder())
+        {}
+
+        operator bool() const {
+            return !WriterIdentity.empty();
+        }
+
+        bool Empty() const {
+            return !InflightPublicationCommit;
+        }
+
+        bool NeedToCreatePublication() const {
+            return WriterIdentity && !DeferredPublicationIntId;
+        }
+
+        ui64 GetCommittingPublicationIntId() const {
+            Y_VALIDATE(InflightPublicationCommit, "No committing publication");
+            return InflightPublicationCommit->PublicationIntId;
+        }
+
+        TString GetSlowPublicationDiagnostics() const {
+            TStringBuilder result;
+            const auto now = TInstant::Now();
+            if (PublicationCreationStartTime && now - PublicationCreationStartTime > SLOW_CHECKPOINT_DURATION) {
+                result << "Slow PQ sink publication creation. Duration: " << (now - PublicationCreationStartTime).Seconds() << "s. ";
+            }
+
+            if (!InflightPublicationCommit) {
+                return result;
+            }
+
+            const auto& info = *InflightPublicationCommit;
+            const auto duration = now - info.StartTime;
+            if (duration <= SLOW_CHECKPOINT_DURATION) {
+                return result;
+            }
+
+            return result << CheckpointLogString(info.Checkpoint)
+                << " Slow PQ sink publication #" << info.PublicationIntId << " commit. Duration: " << duration.Seconds() << 's'
+                << ". Checkpoint data size: " << info.UnpublishedDataSize;
+        }
+
+        void ResetCurrentPublication() {
+            DeferredPublicationIntId = 0;
+
+            if (PublicationStartTime) {
+                Metrics.InFlyActivePublications->Dec();
+                Metrics.InFlyPendingCommitPublications->Inc();
+                Metrics.LastPublicationActiveDuration->Set((TInstant::Now() - PublicationStartTime).MilliSeconds());
+                PublicationStartTime = TInstant::Zero();
+            }
+        }
+
+        void CreatePublication(IDeferredPublishClient& client) {
+            Y_VALIDATE(SelfId, "Deferred publish state is not initialized");
+            Y_VALIDATE(NeedToCreatePublication(), "Unexpected publication creation");
+
+            if (std::exchange(PublicationCreationStartTime, TInstant::Now())) {
+                return;
+            }
+
+            NYdb::NTopic::TBeginPublicationSettings settings;
+            settings.WriterIdentity(WriterIdentity);
+            const auto publicationExtId = TStringBuilder() << WriterIdentity << ":" << PublicationSeqNo++;
+
+            const auto* actorSystem = TActivationContext::ActorSystem();
+            client.BeginPublication(publicationExtId, settings).Subscribe([actorSystem, selfId = SelfId, startedAt = PublicationCreationStartTime](const NYdb::NTopic::TAsyncBeginPublicationResult& result) {
+                actorSystem->Send(selfId, new TEvPrivate::TEvDeferredPublicationCreated(result.GetValue(), startedAt));
+            });
+        }
+
+        void OnPublicationCreated(const ui64 publicationIntId) {
+            Y_VALIDATE(PublicationCreationStartTime && !DeferredPublicationIntId, "Unexpected publication creation");
+            Y_VALIDATE(publicationIntId > 0, "Expected positive publication internal id");
+            DeferredPublicationIntId = publicationIntId;
+            PublicationStartTime = TInstant::Now();
+            PublicationCreationStartTime = TInstant::Zero();
+            Metrics.InFlyActivePublications->Inc();
+        }
+
+        void CommitPublication(const ui64 publicationIntId, std::optional<NDqProto::TCheckpoint> checkpoint, const ui64 unpublishedDataSize, IDeferredPublishClient& client) {
+            Y_VALIDATE(SelfId && WriterIdentity, "Deferred publication are disabled or not initialized");
+            Y_VALIDATE(publicationIntId, "Publication is not initialised for checkpoint " << CheckpointLogString(checkpoint));
+            Y_VALIDATE(!InflightPublicationCommit, "Parallel publications commit is not supported");
+
+            InflightPublicationCommit.emplace(publicationIntId, std::move(checkpoint), unpublishedDataSize);
+
+            const auto* actorSystem = TActivationContext::ActorSystem();
+            client.Publish(NYdb::NTopic::TDeferredPublication(publicationIntId)).Subscribe([actorSystem, selfId = SelfId, startedAt = InflightPublicationCommit->StartTime](const NYdb::NTopic::TAsyncPublishResult& result) {
+                actorSystem->Send(selfId, new TEvPrivate::TEvDeferredPublicationCommitted(result.GetValue(), startedAt));
+            });
+        }
+
+        TInflightPublicationInfo OnPublicationCommitted() {
+            Y_VALIDATE(InflightPublicationCommit, "Unexpected committed publication");
+
+            if (const auto dataSize = InflightPublicationCommit->UnpublishedDataSize) {
+                // Account only publications what was created for current write session
+                Metrics.InFlyPendingCommitPublications->Dec();
+                Metrics.UnpublishedDataSize->Sub(dataSize);
+            }
+
+            return *std::exchange(InflightPublicationCommit, std::nullopt);
+        }
+
+    private:
+        const TMetrics& Metrics;
+        const TString WriterIdentity;
+        YDB_ACCESSOR_DEF(TActorId, SelfId);
+
+        YDB_READONLY(ui64, DeferredPublicationIntId, 0);
+        ui64 PublicationSeqNo = 0;
+        TInstant PublicationStartTime;
+        TInstant PublicationCreationStartTime;
+        std::optional<TInflightPublicationInfo> InflightPublicationCommit;
+    };
+
+    struct TTopicEventProcessor {
+        explicit TTopicEventProcessor(TDqPqWriteActor& self)
+            : Self(self)
+        {}
+
+        bool operator()(const NYdb::NTopic::TSessionClosedEvent& ev) {
+            Self.Fail(ev, TStringBuilder() << "Write session to topic \"" << Self.SinkParams.GetTopicPath() << "\" was closed");
+            return false;
+        }
+
+        bool operator()(NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent& ev) {
+            SINK_LOG_T("Received continuation token, buffer size: " << Self.Buffer.GetMessages().size());
+            Self.Metrics.ReportFirstContinuationToken();
+            Self.ContinuationToken = std::move(ev.ContinuationToken);
+            return true;
+        }
+
+        bool operator()(const NYdb::NTopic::TWriteSessionEvent::TAcksEvent& ev) {
+            const auto& acks = ev.Acks;
+            SINK_LOG_T("Got acks #" << acks.size());
+
+            for (const auto& sdkAck : ev.Acks) {
+                const auto sdkAckSeqNo = sdkAck.SeqNo;
+                const auto state = sdkAck.State;
+                SINK_LOG_T("Ack seq no (from TAcksEvent) " << sdkAckSeqNo << ", state: " << state);
+
+                if (state == NYdb::NTopic::TWriteSessionEvent::TWriteAck::EEventState::EES_DISCARDED) {
+                    Self.Fail(TStringBuilder() << "Message with seqNo " << sdkAckSeqNo << " was discarded");
+                    return false;
+                }
+
+                if (state == NYdb::NTopic::TWriteSessionEvent::TWriteAck::EEventState::EES_ALREADY_WRITTEN) {
+                    Self.Metrics.AlreadyWritten->Inc();
+                }
+
+                Y_VALIDATE(!Self.Buffer.GetInflight().empty(), "Got unexpected ack with seq no: " << sdkAckSeqNo);
+                const auto& ackInfo = Self.Buffer.PopAck();
+                Self.FreeSpace += ackInfo.MessageSize;
+                SINK_LOG_T("Ack seq no (from inflight ack) " << ackInfo.SeqNo << ", message size: " << ackInfo.MessageSize << ", free space: " << Self.FreeSpace);
+            }
+
+            return true;
+        }
+
+    private:
+        TString LogPrefix() const {
+            return TStringBuilder() << Self.LogPrefix() << "[TTopicEventProcessor] ";
+        }
+
+        TDqPqWriteActor& Self;
     };
 
 public:
-    TDqPqWriteActor(
-        ui64 outputIndex,
-        TCollectStatsLevel statsLevel,
-        const TTxId& txId,
-        ui64 taskId,
-        NPq::NProto::TDqPqTopicSink&& sinkParams,
-        NYdb::TDriver driver,
-        std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory,
-        IDqComputeActorAsyncOutput::ICallbacks* callbacks,
-        const ::NMonitoring::TDynamicCounterPtr& counters,
-        i64 freeSpace,
-        const IPqStaticGateway::TPtr& pqGateway,
-        bool enableStreamingQueriesCounters,
-        bool enableStreamingQueriesPqSinkDeduplicationFeatureFlag)
-        : TActor<TDqPqWriteActor>(&TDqPqWriteActor::StateFunc)
-        , OutputIndex(outputIndex)
-        , TxId(txId)
-        , Metrics(txId, taskId, counters, enableStreamingQueriesCounters)
-        , SinkParams(std::move(sinkParams))
-        , Driver(std::move(driver))
-        , CredentialsProviderFactory(credentialsProviderFactory)
-        , Callbacks(callbacks)
-        , LogPrefix(TStringBuilder() << "SelfId: " << this->SelfId() << ", TxId: " << TxId << ", TaskId: " << taskId << ", PQ sink. ")
-        , FreeSpace(freeSpace)
-        , PqGateway(pqGateway)
-        , TaskId(taskId)
-        , EnableDeduplication(enableStreamingQueriesPqSinkDeduplicationFeatureFlag && SinkParams.GetEnableDeduplication())
-    {
-        EgressStats.Level = statsLevel;
-
-        if (SinkParams.GetDeferredPublicationExtIdPrefix()) {
-            YQL_ENSURE(!EnableDeduplication, "Deferred publications cannot be used with deduplication");
-            YQL_ENSURE(false, "Deferred publications is not supported");
-        }
-    }
-
     static constexpr char ActorName[] = "DQ_PQ_WRITE_ACTOR";
 
-public:
-    void SendData(
-        NKikimr::NMiniKQL::TUnboxedValueBatch&& batch,
-        i64 dataSize,
-        const TMaybe<NDqProto::TCheckpoint>& checkpoint,
-        bool finished) override
+    TDqPqWriteActor(
+        const ui64 outputIndex, const TCollectStatsLevel statsLevel, TTxId txId, const ui64 taskId, NPq::NProto::TDqPqTopicSink&& sinkParams,
+        NYdb::TDriver driver, std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory, IDqComputeActorAsyncOutput::ICallbacks* const callbacks,
+        ::NMonitoring::TDynamicCounterPtr counters, const i64 freeSpace, const i64 currentExecutionGeneration, IPqStaticGateway::TPtr pqGateway,
+        const bool enableStreamingQueriesCounters, const bool enableStreamingQueriesPqSinkDeduplicationFeatureFlag, const bool hasCheckpoints
+    )
+        : TActor<TDqPqWriteActor>(&TDqPqWriteActor::StateFunc)
+        , OutputIndex(outputIndex)
+        , TaskId(taskId)
+        , TxId(std::move(txId))
+        , SinkParams(std::move(sinkParams))
+        , Callbacks(callbacks)
+        , PqGateway(std::move(pqGateway))
+        , CredentialsProviderFactory(std::move(credentialsProviderFactory))
+        , Driver(std::move(driver))
+        , Metrics(TxId, TaskId, std::move(counters), enableStreamingQueriesCounters, /* enableCountersPerTask */ false, !SinkParams.GetDeferredPublicationExtIdPrefix().empty())
+        , EnableDeduplication(enableStreamingQueriesPqSinkDeduplicationFeatureFlag && SinkParams.GetEnableDeduplication())
+        , HasCheckpoints(hasCheckpoints)
+        , FreeSpace(freeSpace)
+        , Buffer(EgressStats, Metrics, EnableDeduplication)
+        , CheckpointsState(EgressStats, Metrics)
+        , DeferredPublishState(currentExecutionGeneration, TaskId, OutputIndex, SinkParams, Metrics)
     {
-        SINK_LOG_T("SendData. Batch: " << batch.RowCount()
-            << ". Checkpoint: " << checkpoint.Defined()
-            << ". Finished: " << finished);
+        Y_VALIDATE(Callbacks, "Missing callbacks");
+        Y_VALIDATE(!EnableDeduplication || !DeferredPublishState, "Deferred publications can not be used with deduplication");
+
+        EgressStats.Level = statsLevel;
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvPrivate::TEvExecuteTopicEvent, HandleTopicEvent);
+        hFunc(TEvPrivate::TEvPqEventsReady, Handle);
+        hFunc(TEvPrivate::TEvDeferredPublicationCreated, Handle);
+        hFunc(TEvPrivate::TEvDeferredPublicationCommitted, Handle);
+        hFunc(TEvents::TEvWakeup, Handle);
+    )
+
+private:
+    // IActor
+
+    void Registered(TActorSystem* sys, const TActorId& owner) final {
+        TBase::Registered(sys, owner);
+        OwnerId = owner;
+        CheckpointsState.SetSelfId(SelfId());
+        DeferredPublishState.SetSelfId(SelfId());
+    }
+
+    void PassAway() final { // Is called from Compute Actor, implements IActor & IDqComputeActorAsyncOutput
+        if (WriteSession) {
+            WriteSession->Close(/* closeTimeout */ TDuration::Zero());
+        }
+
+        TBase::PassAway();
+    }
+
+    // IActorExceptionHandler
+
+    bool OnUnhandledException(const std::exception& e) final {
+        Fail(NDqProto::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Unexpected exception: " << e.what());
+        return true;
+    }
+
+    // IDqComputeActorAsyncOutput
+
+    ui64 GetOutputIndex() const final {
+        return OutputIndex;
+    }
+
+    i64 GetFreeSpace() const final {
+        return FreeSpace;
+    }
+
+    const TDqAsyncStats& GetEgressStats() const final {
+        return EgressStats;
+    }
+
+    void SendData(TUnboxedValueBatch&& batch, const i64 dataSize, const TMaybe<NDqProto::TCheckpoint>& checkpoint, const bool finished) final {
+        SINK_LOG_T("SendData. Batch: " << batch.RowCount() << ". Has checkpoint: " << checkpoint.Defined() << ". Finished: " << finished);
         Y_UNUSED(dataSize);
 
         if (finished) {
             Finished = true;
         }
 
-        CreateSessionIfNotExists();
+        const auto initialFreeSpace = FreeSpace;
 
-        Y_ABORT_UNLESS(!batch.IsWide(), "Wide batch is not supported");
-        if (!batch.ForEachRow([&](const auto& value) {
+        Y_VALIDATE(!batch.IsWide(), "Wide batch is not supported");
+        if (!batch.ForEachRow([&](const NUdf::TUnboxedValue& value) {
             if (!value.IsBoxed()) {
                 Fail("Struct with single field was expected");
                 return false;
             }
 
             const NUdf::TUnboxedValue dataCol = value.GetElement(0);
-
             if (!dataCol.IsString() && !dataCol.IsEmbedded()) {
-                Fail(TStringBuilder() << "Non string value could not be written to YDS stream");
+                Fail("Non string value could not be written to YDS stream");
                 return false;
             }
 
             TString data(dataCol.AsStringRef());
 
-            LWPROBE(PqWriteDataToSend, TString(TStringBuilder() << TxId), SinkParams.GetTopicPath(), data);
+            LWPROBE(PqWriteDataToSend, ToString(TxId), SinkParams.GetTopicPath(), data);
             SINK_LOG_T("Received data for sending: " << data);
 
             const auto messageSize = GetItemSize(data);
-            if (messageSize > MaxMessageSize) {
-                Fail(TStringBuilder() << "Max message size for YDS is " << MaxMessageSize
+            if (messageSize > MAX_MESSAGE_SIZE) {
+                Fail(TStringBuilder() << "Max message size for YDS is " << MAX_MESSAGE_SIZE
                     << " bytes but received message with size of " << messageSize << " bytes");
                 return false;
             }
 
             FreeSpace -= messageSize;
-            Metrics.InFlyData->Inc();
-            Buffer.push(std::move(data));
+            Buffer.PushMessage(std::move(data));
             return true;
         })) {
             return;
         }
 
         if (checkpoint) {
-            if (Buffer.empty() && WaitingAcks.empty()) {
-                SINK_LOG_D(MakeStringForLog(*checkpoint) << "Send checkpoint state immediately");
-                Callbacks->OnAsyncOutputStateSaved(BuildState(*checkpoint), OutputIndex, *checkpoint);
-            } else {
-                ui64 seqNo = NextSeqNo + Buffer.size() - 1;
-                SINK_LOG_D(MakeStringForLog(*checkpoint) << "Defer sending the checkpoint, seqNo: " << seqNo);
-                Metrics.InFlyCheckpoints->Inc();
-                DeferredCheckpoints.emplace(seqNo, *checkpoint);
-            }
+            const auto lastBufferedSeqNo = Buffer.GetLastBufferedSeqNo();
+            SINK_LOG_D(CheckpointLogString(*checkpoint) << " Register checkpoint for seq no: " << lastBufferedSeqNo);
+            CheckpointsState.PushCheckpoint(lastBufferedSeqNo, *checkpoint);
         }
 
-        if (!Buffer.empty() && ContinuationToken) {
-            WriteNextMessage(std::move(*ContinuationToken));
-            ContinuationToken = std::nullopt;
+        if (initialFreeSpace > 0 && FreeSpace <= 0) {
+            SINK_LOG_D("Sink paused by free space: " << initialFreeSpace << " -> " << FreeSpace);
         }
 
-        while (HandleNewPQEvents()) {} // Write messages while new continuationTokens are arriving
+        Process();
+    }
 
-        if (FreeSpace <= 0) {
-            ShouldNotifyNewFreeSpace = true;
+    void CommitState(const NDqProto::TCheckpoint& checkpoint) final {
+        SINK_LOG_D("Commit state: " << CheckpointLogString(checkpoint));
+
+        if (const auto& info = CheckpointsState.CommitCheckpoints(checkpoint); info && info->DeferredPublicationIntId) {
+            SINK_LOG_D("Commit deferred publication " << info->DeferredPublicationIntId << " on checkpoint " << CheckpointLogString(checkpoint));
+            DeferredPublishState.CommitPublication(info->DeferredPublicationIntId, checkpoint, info->DataSizeUnderCheckpoint, GetDeferredPublishClient());
+        } else {
+            SINK_LOG_D("Commit checkpoint immediately " << CheckpointLogString(checkpoint));
+            Callbacks->OnAsyncOutputStateCommitted(OutputIndex, checkpoint);
         }
-    };
 
-    void LoadState(const TSinkState& state) override {
-        Y_ABORT_UNLESS(NextSeqNo == 1);
+        Process();
+    }
+
+    void LoadState(const TSinkState& state, const NDqProto::TCheckpoint& checkpoint) final {
         const auto& data = state.Data;
-        if (data.Version == StateVersion) { // Current version
-            NPq::NProto::TDqPqTopicSinkState stateProto;
-            YQL_ENSURE(stateProto.ParseFromString(data.Blob), "Serialized state is corrupted");
-            SINK_LOG_D("Load state: " << stateProto);
-            SourceId = stateProto.GetSourceId();
-            ConfirmedSeqNo = stateProto.GetConfirmedSeqNo();
-            NextSeqNo = ConfirmedSeqNo + 1;
-            EgressStats.Bytes = stateProto.GetEgressBytes();
-            return;
-        }
-        ythrow yexception() << "Invalid state version " << data.Version;
+        Y_VALIDATE(data.Version == STATE_VERSION, "Invalid state version " << data.Version);
+
+        NPq::NProto::TDqPqTopicSinkState stateProto;
+        YQL_ENSURE(stateProto.ParseFromString(data.Blob), "Serialized state is corrupted");
+        SINK_LOG_D("Load state: " << stateProto);
+
+        SourceId = stateProto.GetSourceId();
+        EgressStats.Bytes = stateProto.GetEgressBytes();
+        CheckpointsState.SetWrittenDataUnderCheckpoint(EgressStats.Bytes);
+
+        const auto confirmedSeqNo = stateProto.GetConfirmedSeqNo();
+        Buffer.LoadConfirmedSeqNo(confirmedSeqNo);
+
+        // Register checkpoint for committing in case of restoring from partially saved checkpoint
+        CheckpointsState.LoadPendingCommitCheckpoint(confirmedSeqNo, checkpoint, stateProto.GetDeferredPublicationIntId());
     }
 
-    void CommitState(const NDqProto::TCheckpoint& checkpoint) override {
-        Callbacks->OnAsyncOutputStateCommitted(OutputIndex, checkpoint);
-    }
-
-    i64 GetFreeSpace() const override {
-        return FreeSpace;
-    }
-
-    ui64 GetOutputIndex() const override {
-        return OutputIndex;
-    }
-
-    const TDqAsyncStats& GetEgressStats() const override {
-        return EgressStats;
-    }
-
-private:
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvPrivate::TEvPqEventsReady, Handle);
-        hFunc(TEvPrivate::TEvExecuteTopicEvent, HandleTopicEvent);
-    )
+    // Events
 
     void Handle(TEvPrivate::TEvPqEventsReady::TPtr&) {
         SINK_LOG_T("New PQ write session events arrived");
-
-        if (!Inited) {
-            Init();
-            Inited = true;
-        }
-
-        while (HandleNewPQEvents()) {}
-
+        Process();
         SubscribeOnNextEvent();
     }
 
-    void Init() {
-        LogPrefix = TStringBuilder() << "SelfId: " << this->SelfId() << ", TxId: " << TxId << ", TaskId: " << TaskId << ", PQ sink. ";
-    }
+    void Handle(TEvPrivate::TEvDeferredPublicationCreated::TPtr& ev) {
+        Metrics.LastBeginPublicationLatency->Set(ev->Get()->Latency.MilliSeconds());
 
-    // IActor & IDqComputeActorAsyncOutput
-    void PassAway() override { // Is called from Compute Actor
-        if (WriteSession) {
-            WriteSession->Close(TDuration::Zero());
+        const auto& result = ev->Get()->Result;
+        if (!result.IsSuccess()) {
+            Fail(result, "Failed to create deferred publication");
+            return;
         }
-        TActor<TDqPqWriteActor>::PassAway();
+
+        const auto intPublicationId = result.GetIntPublicationId();
+        SINK_LOG_D("Publication created, internal id: " << intPublicationId << ", external id: " << result.GetPublication().ExtPublicationId.value_or("<null>"));
+        DeferredPublishState.OnPublicationCreated(intPublicationId);
+
+        Process();
     }
 
-private:
-    const TString& GetSourceId() {
-        if (!SourceId) {
-            SourceId = CreateGuidAsString(); // Not loaded from state, so this is the first run.
+    void Handle(TEvPrivate::TEvDeferredPublicationCommitted::TPtr& ev) {
+        Metrics.LastPublishLatency->Set(ev->Get()->Latency.MilliSeconds());
+
+        const auto publicationIntId = DeferredPublishState.GetCommittingPublicationIntId();
+        const auto& result = ev->Get()->Result;
+        if (!result.IsSuccess() && result.GetStatus() != NYdb::EStatus::NOT_FOUND) {
+            Fail(result, TStringBuilder() << "Failed to commit deferred publication #" << publicationIntId);
+            return;
         }
-        return SourceId;
-    }
 
-    NYdb::NTopic::TWriteSessionSettings GetWriteSessionSettings() {
-        auto settings = NYdb::NTopic::TWriteSessionSettings()
-            .Path(SinkParams.GetTopicPath())
-            .TraceId(LogPrefix)
-            .MaxMemoryUsage(FreeSpace)
-            .Codec(SinkParams.GetClusterType() == NPq::NProto::DataStreams
-                ? NYdb::NTopic::ECodec::RAW
-                : NYdb::NTopic::ECodec::GZIP);
-
-        settings.DeduplicationEnabled(EnableDeduplication);
-        if (EnableDeduplication) {
-            settings.ProducerId(GetSourceId());
-            settings.MessageGroupId(GetSourceId());
+        if (result.IsSuccess()) {
+            SINK_LOG_D("Publication #" << publicationIntId << " committed");
+        } else {
+            SINK_LOG_I("Publication #" << publicationIntId << " not found, considering as committed");
         }
-        return settings;
-    }
 
-    IFederatedTopicClient& GetFederatedTopicClient() {
-        if (!FederatedTopicClient) {
-            FederatedTopicClient = PqGateway->GetFederatedTopicClient(Driver, GetFederatedTopicClientSettings());
+        if (const auto& info = DeferredPublishState.OnPublicationCommitted(); info.Checkpoint) {
+            Callbacks->OnAsyncOutputStateCommitted(OutputIndex, *info.Checkpoint);
         }
-        return *FederatedTopicClient;
+
+        Process();
     }
 
-    NYdb::NFederatedTopic::TFederatedTopicClientSettings GetFederatedTopicClientSettings() {
+    void Handle(TEvents::TEvWakeup::TPtr&) {
+        if (const auto& diagnostics = CheckpointsState.GetSlowCheckpointDiagnostics(Buffer.GetLastSentMessageSeqNo(), Buffer.GetConfirmedSeqNo())) {
+            SINK_LOG_W(diagnostics);
+        }
+
+        if (const auto& diagnostics = DeferredPublishState.GetSlowPublicationDiagnostics()) {
+            SINK_LOG_W(diagnostics);
+        }
+    }
+
+    // Initialization
+
+    NYdb::NFederatedTopic::TFederatedTopicClientSettings GetFederatedTopicClientSettings() { // Must be called after actor registration
+        Y_VALIDATE(OwnerId, "Can not create federated topic client settings before actor registration");
         NYdb::NFederatedTopic::TFederatedTopicClientSettings opts = PqGateway->GetFederatedTopicClientSettings();
 
         if (SinkParams.GetUseActorSystemThreadsInTopicClient()) {
@@ -385,27 +851,114 @@ private:
         return opts;
     }
 
-    static i64 GetItemSize(const TString& item) {
-        return std::max(static_cast<i64>(item.size()), static_cast<i64>(1));
+    IFederatedTopicClient& GetFederatedTopicClient() {
+        if (!FederatedTopicClient) {
+            FederatedTopicClient = PqGateway->GetFederatedTopicClient(Driver, GetFederatedTopicClientSettings());
+            Y_VALIDATE(FederatedTopicClient, "Failed to create federated topic client");
+        }
+
+        return *FederatedTopicClient;
+    }
+
+    IDeferredPublishClient& GetDeferredPublishClient() {
+        if (!DeferredPublishClient) {
+            DeferredPublishClient = PqGateway->GetDeferredPublishClient(Driver, NYdb::TCommonClientSettings()
+                .Database(SinkParams.GetDatabase())
+                .DiscoveryEndpoint(SinkParams.GetEndpoint())
+                .SslCredentials(NYdb::TSslCredentials(SinkParams.GetUseSsl()))
+                .CredentialsProviderFactory(CredentialsProviderFactory)
+            );
+            Y_VALIDATE(DeferredPublishClient, "Failed to create deferred publish client");
+        }
+
+        return *DeferredPublishClient;
+    }
+
+    const TString& GetSourceId() { // Must be called after state loading
+        if (!SourceId) {
+            SourceId = CreateGuidAsString(); // Not loaded from state, so this is the first run.
+            SINK_LOG_D("Created new source id: " << SourceId);
+        }
+
+        return SourceId;
+    }
+
+    NYdb::NTopic::TWriteSessionSettings GetWriteSessionSettings() {
+        auto settings = NYdb::NTopic::TWriteSessionSettings()
+            .Path(SinkParams.GetTopicPath())
+            .TraceId(LogPrefix())
+            .MaxMemoryUsage(FreeSpace)
+            .DeduplicationEnabled(EnableDeduplication)
+            .Codec(SinkParams.GetClusterType() == NPq::NProto::DataStreams
+                ? NYdb::NTopic::ECodec::RAW
+                : NYdb::NTopic::ECodec::GZIP);
+
+        if (EnableDeduplication) {
+            const auto& sourceId = GetSourceId();
+            settings.ProducerId(sourceId);
+            settings.MessageGroupId(sourceId);
+        }
+
+        return settings;
     }
 
     void CreateSessionIfNotExists() {
         if (!WriteSession) {
-            SINK_LOG_T("Create new PQ write session");
+            SINK_LOG_D("Create new PQ write session");
             WriteSession = GetFederatedTopicClient().CreateWriteSession(GetWriteSessionSettings());
             SubscribeOnNextEvent();
         }
     }
 
-    void SubscribeOnNextEvent() {
+    // Message processing
+
+    void Process() {
+        if (Failed) {
+            // Skip iteration, fail status was already sent to compute actor
+            return;
+        }
+
+        CreateSessionIfNotExists();
+
+        for (bool canSend = true; canSend;) {
+            if (!HandleNewPQEvents()) {
+                // Write session returned error
+                return;
+            }
+
+            canSend = !Buffer.GetMessages().empty() && ContinuationToken && !DeferredPublishState.NeedToCreatePublication();
+
+            if (canSend) {
+                WriteNextMessage(std::move(*ContinuationToken));
+                ContinuationToken.reset();
+            }
+
+            if (CheckpointsState.AdvanceSentSeqNo(Buffer.GetLastSentMessageSeqNo(), DeferredPublishState.GetDeferredPublicationIntId())) {
+                DeferredPublishState.ResetCurrentPublication();
+            }
+        }
+
+        if (const auto& info = CheckpointsState.AdvanceConfirmedSeqNo(Buffer.GetConfirmedSeqNo())) {
+            SINK_LOG_D(CheckpointLogString(info->Checkpoint) << " Save state for deferred checkpoint with seq no: " << info->WaitConfirmedSeqNo);
+            Callbacks->OnAsyncOutputStateSaved(BuildState(*info), OutputIndex, info->Checkpoint);
+        }
+
+        if (!Buffer.GetMessages().empty() && DeferredPublishState.NeedToCreatePublication()) {
+            SINK_LOG_D("Creating new deferred publication");
+            DeferredPublishState.CreatePublication(GetDeferredPublishClient());
+        }
+
+        CheckFinished();
+    }
+
+    void SubscribeOnNextEvent() const {
         if (!WriteSession) {
             return;
         }
 
         SINK_LOG_T("Subscribe on next event");
-
-        NActors::TActorSystem* actorSystem = NActors::TActivationContext::ActorSystem();
-        EventFuture = WriteSession->WaitEvent().Subscribe([actorSystem, selfId = SelfId()](const auto&){
+        const auto* actorSystem = TActivationContext::ActorSystem();
+        WriteSession->WaitEvent().Subscribe([actorSystem, selfId = SelfId()](const auto&) {
             actorSystem->Send(selfId, new TEvPrivate::TEvPqEventsReady());
         });
     }
@@ -416,174 +969,169 @@ private:
         }
 
         auto events = WriteSession->GetEvents();
-        SINK_LOG_T("Extracted #" << events.size() << " PQ write session events");
+        const auto initialFreeSpace = FreeSpace;
+        SINK_LOG_T("Extracted #" << events.size() << " PQ write session events, free space: " << initialFreeSpace);
 
         for (auto& event : events) {
-            auto issues = std::visit(TTopicEventProcessor{*this}, event);
-            if (issues) {
-                WriteSession->Close(TDuration::Zero());
-                WriteSession.reset();
-                Callbacks->OnAsyncOutputError(OutputIndex, *issues, NYql::NDqProto::StatusIds::EXTERNAL_ERROR);
-                break;
-            }
-
-            if (ShouldNotifyNewFreeSpace && FreeSpace > 0) {
-                Callbacks->ResumeExecution();
-                ShouldNotifyNewFreeSpace = false;
+            if (!std::visit(TTopicEventProcessor{*this}, event)) {
+                return false;
             }
         }
 
-        CheckFinished();
-        return !events.empty();
-    }
+        if (initialFreeSpace <= 0 && FreeSpace > 0) {
+            SINK_LOG_D("Sink resumed by free space: " << initialFreeSpace << " -> " << FreeSpace);
+            Callbacks->ResumeExecution();
+        }
 
-    TSinkState BuildState(const NDqProto::TCheckpoint& checkpoint) {
-        NPq::NProto::TDqPqTopicSinkState stateProto;
-        stateProto.SetSourceId(GetSourceId());
-        stateProto.SetConfirmedSeqNo(ConfirmedSeqNo);
-        stateProto.SetEgressBytes(EgressStats.Bytes);
-        TString serializedState;
-        YQL_ENSURE(stateProto.SerializeToString(&serializedState));
-
-        TSinkState sinkState;
-        auto& data = sinkState.Data;
-        data.Version = StateVersion;
-        data.Blob = serializedState;
-        SINK_LOG_T("Save checkpoint " << checkpoint << " state: " << stateProto);
-        return sinkState;
+        return true;
     }
 
     void WriteNextMessage(NYdb::NTopic::TContinuationToken&& token) {
-        std::optional<uint64_t> seqNo;
-        if (EnableDeduplication) {
-            seqNo = NextSeqNo;
+        if (!WriteSession) {
+            return;
         }
-        SINK_LOG_T("Write message into PQ session: " << Buffer.front());
-        WriteSession->Write(std::move(token), Buffer.front(), seqNo);
-        auto itemSize = GetItemSize(Buffer.front());
-        WaitingAcks.emplace(itemSize, TInstant::Now(), NextSeqNo);
-        NextSeqNo++;
-        EgressStats.Bytes += itemSize;
-        Metrics.EgressDataRate->Add(itemSize);
-        Buffer.pop();
+
+        const auto& [seqNo, messageData] = Buffer.PopMessage();
+        SINK_LOG_T("Write message into PQ session: " << messageData);
+
+        NYdb::NTopic::TWriteMessage message(messageData);
+        message.SeqNo(seqNo);
+
+        if (const auto deferredPublicationIntId = DeferredPublishState.GetDeferredPublicationIntId()) {
+            message.DeferredPublication(NYdb::NTopic::TDeferredPublication(deferredPublicationIntId));
+            Metrics.UnpublishedDataSize->Add(GetItemSize(messageData));
+        } else {
+            Y_VALIDATE(!DeferredPublishState, "Unexpected deferred publication state");
+        }
+
+        WriteSession->Write(std::move(token), std::move(message));
     }
 
-    void Fail(TString message) {
-        TIssues issues;
-        issues.AddIssue(message);
-        Callbacks->OnAsyncOutputError(OutputIndex, issues, NYql::NDqProto::StatusIds::EXTERNAL_ERROR);
+    TSinkState BuildState(const TCheckpointsState::TCheckpointInfo& info) {
+        NPq::NProto::TDqPqTopicSinkState stateProto;
+        stateProto.SetSourceId(GetSourceId());
+        stateProto.SetConfirmedSeqNo(info.WaitConfirmedSeqNo);
+        stateProto.SetEgressBytes(info.EgressBytes);
+        stateProto.SetDeferredPublicationIntId(info.DeferredPublicationIntId);
+
+        TSinkState sinkState;
+        auto& data = sinkState.Data;
+        data.Version = STATE_VERSION;
+        YQL_ENSURE(stateProto.SerializeToString(&data.Blob));
+        SINK_LOG_T("Save checkpoint " << info.Checkpoint << " state: " << stateProto);
+
+        return sinkState;
     }
-
-    struct TTopicEventProcessor {
-        std::optional<TIssues> operator()(NYdb::NTopic::TSessionClosedEvent& ev) {
-            TIssues issues;
-            issues.AddIssue(TStringBuilder() << "Write session to topic \"" << Self.SinkParams.GetTopicPath() << "\" was closed: " << ev.DebugString());
-            return issues;
-        }
-
-        std::optional<TIssues> operator()(NYdb::NTopic::TWriteSessionEvent::TAcksEvent& ev) {
-            if (ev.Acks.empty()) {
-                LOG_D(Self.LogPrefix << "Empty ack");
-                return std::nullopt;
-            }
-
-            //Y_ABORT_UNLESS(Self.ConfirmedSeqNo == 0 || ev.Acks.front().SeqNo == Self.ConfirmedSeqNo + 1);
-
-            for (auto it = ev.Acks.begin(); it != ev.Acks.end(); ++it) {
-                //Y_ABORT_UNLESS(it == ev.Acks.begin() || it->SeqNo == std::prev(it)->SeqNo + 1);
-                LOG_T(Self.LogPrefix << "Ack seq no (from TAcksEvent) " << it->SeqNo);
-                if (it->State == NYdb::NTopic::TWriteSessionEvent::TWriteAck::EEventState::EES_DISCARDED) {
-                    TIssues issues;
-                    issues.AddIssue(TStringBuilder() << "Message with seqNo " << it->SeqNo << " was discarded");
-                    return issues;
-                }
-
-                if (it->State == NYdb::NTopic::TWriteSessionEvent::TWriteAck::EEventState::EES_ALREADY_WRITTEN) {
-                    Self.Metrics.AlreadyWritten->Inc();
-                }
-
-                Y_VALIDATE(!Self.WaitingAcks.empty(), "Got unexpected ack with seq no: " << it->SeqNo);
-                const auto& ackInfo = Self.WaitingAcks.front();
-                Self.Metrics.LastAckLatency->Set((TInstant::Now() - ackInfo.StartTime).MilliSeconds());
-                Self.Metrics.InFlyData->Dec();
-                Self.FreeSpace += ackInfo.MessageSize;
-                ui64 seqNo = ackInfo.SeqNo;        // use seqNo stored on our side because without deduplication we do not specify SeqNo on Write().
-                LOG_T(Self.LogPrefix << "Ack seq no (from WaitingAcks) " << seqNo);
-                Self.WaitingAcks.pop();
-
-                if (!Self.DeferredCheckpoints.empty() && std::get<0>(Self.DeferredCheckpoints.front()) == seqNo) {
-                    Self.ConfirmedSeqNo = seqNo;
-                    const auto& checkpoint = std::get<1>(Self.DeferredCheckpoints.front());
-                    LOG_D(Self.LogPrefix << MakeStringForLog(checkpoint) << "Send a deferred checkpoint, seqNo: " << seqNo);
-                    Self.Callbacks->OnAsyncOutputStateSaved(Self.BuildState(checkpoint), Self.OutputIndex, checkpoint);
-                    Self.DeferredCheckpoints.pop();
-                    Self.Metrics.InFlyCheckpoints->Dec();
-                }
-            }
-            Self.ConfirmedSeqNo = ev.Acks.back().SeqNo;
-
-            return std::nullopt;
-        }
-
-        std::optional<TIssues> operator()(NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent& ev) {
-            //Y_ABORT_UNLESS(!Self.ContinuationToken);
-            LOG_T(Self.LogPrefix << "Received continuation token, buffer size: " << Self.Buffer.size());
-
-            if (*Self.Metrics.FirstContinuationTokenMs == 0) {
-                Self.Metrics.FirstContinuationTokenMs->Set((TInstant::Now() - Self.StartTime).MilliSeconds());
-            }
-
-            if (!Self.Buffer.empty()) {
-                Self.WriteNextMessage(std::move(ev.ContinuationToken));
-                return std::nullopt;
-            }
-
-            Self.ContinuationToken = std::move(ev.ContinuationToken);
-            return std::nullopt;
-        }
-
-        TDqPqWriteActor& Self;
-    };
 
     void CheckFinished() {
-        if (Finished && Buffer.empty() && WaitingAcks.empty()) {
-            SINK_LOG_T("Notify PQ sink finished");
-            Callbacks->OnAsyncOutputFinished(OutputIndex);
+        if (!Finished || !Buffer.Empty() || !CheckpointsState.Empty() || !DeferredPublishState.Empty()) {
+            return;
         }
+
+        if (const auto publicationIntId = DeferredPublishState.GetDeferredPublicationIntId()) {
+            if (HasCheckpoints) {
+                SINK_LOG_T("Waiting for one checkpoint after last write");
+                return;
+            }
+
+            // In case of disabled checkpoints, publications should be committed once on finish
+            SINK_LOG_I("Commit publication " << publicationIntId << " after finish without checkpoints");
+            DeferredPublishState.ResetCurrentPublication();
+            DeferredPublishState.CommitPublication(publicationIntId, /* checkpoint */ std::nullopt, EgressStats.Bytes - CheckpointsState.GetWrittenDataUnderCheckpoint(), GetDeferredPublishClient());
+            return;
+        }
+
+        SINK_LOG_D("Notify PQ sink finished");
+        Callbacks->OnAsyncOutputFinished(OutputIndex);
     }
 
-private:
-    TInstant StartTime = TInstant::Now();
-    const ui64 OutputIndex;
-    TDqAsyncStats EgressStats;
+    // Common
+
+    void Fail(const NDqProto::StatusIds::StatusCode status, const TIssues& issues) {
+        Failed = true;
+
+        if (WriteSession) {
+            WriteSession->Close(TDuration::Zero());
+            WriteSession.reset();
+        }
+
+        Y_VALIDATE(!IsIn({NDqProto::StatusIds::SUCCESS, NDqProto::StatusIds::UNSPECIFIED}, status), "Invalid fail status: " << status);
+        SINK_LOG_W("Fail. Status: " << NDqProto::StatusIds::StatusCode_Name(status) << ". Issues: " << issues.ToOneLineString());
+        Callbacks->OnAsyncOutputError(OutputIndex, issues, status);
+    }
+
+    void Fail(const NDqProto::StatusIds::StatusCode status, const TString& message) {
+        Fail(status, {TIssue(message)});
+    }
+
+    void Fail(const TString& message) {
+        Fail(NDqProto::StatusIds::EXTERNAL_ERROR, message);
+    }
+
+    void Fail(const NYdb::TStatus& status, const TString& message) {
+        Y_VALIDATE(!status.IsSuccess(), "Unexpected success status for fail");
+
+        TIssue rootIssue(TStringBuilder() << message << ". Status: " << status.GetStatus());
+        for (const auto& issue : status.GetIssues()) {
+            rootIssue.AddSubIssue(MakeIntrusive<TIssue>(NYdb::NAdapters::ToYqlIssue(issue)));
+        }
+
+        Fail(NDqProto::StatusIds::EXTERNAL_ERROR, {rootIssue});
+    }
+
+    TString LogPrefix() const {
+        auto prefix = TStringBuilder() << "[" << ActorName << "] ";
+
+        if (OwnerId) {
+            prefix << "OwnerId: " << *OwnerId << ". ActorId: " << SelfId() << ". ";
+        }
+
+        return prefix << "TxId: " << TxId << ". TaskId: " << TaskId << ". OutputIndex: " << OutputIndex << ". ";
+    }
+
+    static i64 GetItemSize(const TString& item) {
+        return std::max(static_cast<i64>(item.size()), static_cast<i64>(1));
+    }
+
+    static TString CheckpointLogString(const NDqProto::TCheckpoint& checkpoint) {
+        return TStringBuilder() << "[Checkpoint " << checkpoint.GetGeneration() << "." << checkpoint.GetId() << "]";
+    }
+
+    static TString CheckpointLogString(const std::optional<NDqProto::TCheckpoint>& checkpoint) {
+        return checkpoint ? CheckpointLogString(*checkpoint) : "[Checkpoint <null>]";
+    }
+
+    const ui64 OutputIndex = 0;
+    const ui64 TaskId;
     const TTxId TxId;
-    TMetrics Metrics;
     const NPq::NProto::TDqPqTopicSink SinkParams;
-    NYdb::TDriver Driver;
-    std::shared_ptr<NYdb::ICredentialsProviderFactory> CredentialsProviderFactory;
-    IDqComputeActorAsyncOutput::ICallbacks* const Callbacks;
-    TString LogPrefix;
+    IDqComputeActorAsyncOutput::ICallbacks* const Callbacks = nullptr;
+    const IPqStaticGateway::TPtr PqGateway;
+    const NYdb::TCredentialsProviderFactoryPtr CredentialsProviderFactory;
+    const NYdb::TDriver Driver;
+    const TMetrics Metrics;
+    const bool EnableDeduplication = false;
+    const bool HasCheckpoints = false;
+
+    std::optional<TActorId> OwnerId;
+    TDqAsyncStats EgressStats;
+    TString SourceId;
+    IFederatedTopicClient::TPtr FederatedTopicClient;
+    IDeferredPublishClient::TPtr DeferredPublishClient;
+    std::shared_ptr<NYdb::NTopic::IWriteSession> WriteSession;
+
     i64 FreeSpace = 0;
     bool Finished = false;
-
-    IFederatedTopicClient::TPtr FederatedTopicClient;
-    std::shared_ptr<NYdb::NTopic::IWriteSession> WriteSession;
-    TString SourceId;
-    ui64 NextSeqNo = 1;
-    ui64 ConfirmedSeqNo = 0;
+    bool Failed = false;
+    TDataBuffer Buffer;
+    TCheckpointsState CheckpointsState;
+    TDeferredPublishState DeferredPublishState;
     std::optional<NYdb::NTopic::TContinuationToken> ContinuationToken;
-    NThreading::TFuture<void> EventFuture;
-    bool ShouldNotifyNewFreeSpace = false;
-    std::queue<TString> Buffer;
-    std::queue<TAckInfo> WaitingAcks; // Size of items which are waiting for acks (used to update free space)
-    std::queue<std::tuple<ui64, NDqProto::TCheckpoint>> DeferredCheckpoints;
-    IPqStaticGateway::TPtr PqGateway;
-    ui64 TaskId;
-    bool Inited = false;
-    bool EnableDeduplication = false;
 };
 
-std::pair<IDqComputeActorAsyncOutput*, NActors::IActor*> CreateDqPqWriteActor(
+} // anonymous namespace
+
+std::pair<IDqComputeActorAsyncOutput*, IActor*> CreateDqPqWriteActor(
     NPq::NProto::TDqPqTopicSink&& settings,
     ui64 outputIndex,
     TCollectStatsLevel statsLevel,
@@ -645,6 +1193,7 @@ void RegisterDqPqWriteActorFactory(TDqAsyncIoFactory& factory, NYdb::TDriver dri
             if (const auto it = args.TaskParams.find("checkpoints_enabled"); it != args.TaskParams.end()) {
                 hasCheckpoints = FromString<bool>(it->second) && args.HasCheckpoints;
             }
+
             NLwTraceMonPage::ProbeRegistry().AddProbesList(LWTRACE_GET_PROBES(DQ_PQ_PROVIDER));
             return CreateDqPqWriteActor(
                 std::move(settings),
@@ -664,7 +1213,8 @@ void RegisterDqPqWriteActorFactory(TDqAsyncIoFactory& factory, NYdb::TDriver dri
                 enableStreamingQueriesPqSinkDeduplicationFeatureFlag,
                 hasCheckpoints
             );
-        });
+        }
+    );
 }
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.h
@@ -32,7 +32,9 @@ std::pair<IDqComputeActorAsyncOutput*, NActors::IActor*> CreateDqPqWriteActor(
     IPqStaticGateway::TPtr pqGateway,
     bool enableStreamingQueriesCounters,
     i64 freeSpace = DqPqDefaultFreeSpace,
-    bool enableStreamingQueriesPqSinkDeduplicationFeatureFlag = true);
+    i64 currentExecutionGeneration = 0,
+    bool enableStreamingQueriesPqSinkDeduplicationFeatureFlag = true,
+    bool hasCheckpoints = false);
 
 void RegisterDqPqWriteActorFactory(
     TDqAsyncIoFactory& factory,

--- a/ydb/library/yql/providers/pq/async_io/ya.make
+++ b/ydb/library/yql/providers/pq/async_io/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     ydb/core/fq/libs/graph_params/proto
     ydb/core/fq/libs/protos
     ydb/core/fq/libs/row_dispatcher
+    ydb/library/accessor
     ydb/library/actors/log_backend
     ydb/library/yql/dq/actors/compute
     ydb/library/yql/providers/common/token_accessor/client

--- a/ydb/library/yql/providers/pq/proto/dq_io_state.proto
+++ b/ydb/library/yql/providers/pq/proto/dq_io_state.proto
@@ -28,4 +28,5 @@ message TDqPqTopicSinkState {
     string SourceId = 1;
     uint64 ConfirmedSeqNo = 2;
     uint64 EgressBytes = 3;
+    uint64 DeferredPublicationIntId = 4;
 }

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -583,7 +583,7 @@ private:
         Callbacks->OnAsyncOutputStateCommitted(OutputIndex, checkpoint);
     }
 
-    void LoadState(const TSinkState&) final {}
+    void LoadState(const TSinkState&, const NDqProto::TCheckpoint&) final {}
 
     ui64 GetOutputIndex() const final {
         return OutputIndex;

--- a/ydb/library/yql/providers/solomon/actors/dq_solomon_write_actor.cpp
+++ b/ydb/library/yql/providers/solomon/actors/dq_solomon_write_actor.cpp
@@ -176,7 +176,7 @@ public:
     // idempotent and there is no way to roll back a partially-sent batch.
     // Silently ignore checkpoint calls so the actor can coexist with
     // checkpoint-enabled pipelines.
-    void LoadState(const TSinkState&) override {}
+    void LoadState(const TSinkState&, const NDqProto::TCheckpoint&) override {}
 
     void CommitState(const NDqProto::TCheckpoint& checkpoint) override {
         Callbacks->OnAsyncOutputStateCommitted(OutputIndex, checkpoint);

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_write_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_write_actor_ut.cpp
@@ -78,6 +78,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
         PQCreateStream(topicName);
 
         TSinkState state1;
+        NDqProto::TCheckpoint checkpoint;
         {
             TPqIoTestFixture setup;
             setup.InitAsyncOutput(topicName);
@@ -86,7 +87,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
             setup.AsyncOutputWrite(data1);
 
             const std::vector<TString> data2 = { "2", "3" };
-            auto checkpoint = CreateCheckpoint();
+            checkpoint = CreateCheckpoint();
             auto future = setup.CaSetup->AsyncOutputPromises->StateSaved.GetFuture();
             setup.AsyncOutputWrite(data2, checkpoint);
 
@@ -97,7 +98,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
         {
             TPqIoTestFixture setup;
             setup.InitAsyncOutput(topicName);
-            setup.LoadSink(state1);
+            setup.LoadSink(state1, checkpoint);
 
             const std::vector<TString> data3 = { "4", "5" };
             setup.AsyncOutputWrite(data3);
@@ -110,7 +111,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
         {
             TPqIoTestFixture setup;
             setup.InitAsyncOutput(topicName);
-            setup.LoadSink(state1);
+            setup.LoadSink(state1, checkpoint);
 
             const std::vector<TString> data4 = { "4", "5" };
             setup.AsyncOutputWrite(data4); // This write should be deduplicated

--- a/ydb/tests/fq/pq_async_io/ut_helpers.h
+++ b/ydb/tests/fq/pq_async_io/ut_helpers.h
@@ -88,8 +88,8 @@ struct TPqIoTestFixture : public NUnitTest::TBaseFixture {
         InitAsyncOutput(BuildPqTopicSinkSettings(topic), freeSpace);
     }
 
-    void LoadSink(const TSinkState& state) {
-        CaSetup->LoadSink(state);
+    void LoadSink(const TSinkState& state, const NDqProto::TCheckpoint& checkpoint) {
+        CaSetup->LoadSink(state, checkpoint);
     }
 
     void AsyncOutputWrite(std::vector<TString> data, TMaybe<NDqProto::TCheckpoint> checkpoint = Nothing());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported exactly once write into local/external topics

### Description for reviewers <!-- (optional) description for those who read this PR -->

Now out of scoupe:

- Support for federative writing
- Cleanup not committed publications 