### PR TITLE
Remove Invoke() calls which were deprecated in gtest 1.18

### DIFF
--- a/ydb/core/kesus/tablet/quoter_resource_tree_ut.cpp
+++ b/ydb/core/kesus/tablet/quoter_resource_tree_ut.cpp
@@ -254,10 +254,10 @@ public:
         auto& updateSend =
             EXPECT_CALL(*session.Sink, OnSend(_, 0.0, _))
                 .After(oldSettingsAllocation)
-                .WillOnce(Invoke([](ui64, double, const NKikimrKesus::TStreamingQuoterResource* props) {
+                .WillOnce([](ui64, double, const NKikimrKesus::TStreamingQuoterResource* props) {
                     UNIT_ASSERT(props != nullptr);
                     UNIT_ASSERT_DOUBLES_EQUAL(props->GetHierarchicalDRRResourceConfig().GetMaxUnitsPerSecond(), 400, 0.001);
-                }));
+                });
         EXPECT_CALL(*session.Sink, OnSend(_, DoubleNear(40, 0.01), nullptr))
             .After(updateSend);
 

--- a/ydb/core/quoter/kesus_quoter_ut.cpp
+++ b/ydb/core/quoter/kesus_quoter_ut.cpp
@@ -282,14 +282,14 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -301,7 +301,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         size_t resCounter = 0;
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
             .Times(3)
-            .WillRepeatedly(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillRepeatedly([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), TStringBuilder() << "res" << resCounter);
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
@@ -309,7 +309,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
                 FillResult(ans.AddResults(), 42 + resCounter, 5.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
                 ++resCounter;
-            }));
+            });
 
         auto session = setup.ProxyRequest("res0");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -319,11 +319,11 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 44);
 
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
+            .WillOnce([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesInfoSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResourcesInfo(0).GetResourceId(), 43);
                 UNIT_ASSERT(record.GetResourcesInfo(0).GetConsumeResource());
-            }));
+            });
 
         setup.SendProxyStats({TEvQuota::TProxyStat(43, 1, 0, {}, 3, 5.0, 0, 0)});
         setup.WaitEvent<NKesus::TEvKesus::TEvUpdateConsumptionState>();
@@ -334,7 +334,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         // second pipe
         auto* pipe2 = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe2, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 3);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res0");
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(1).GetResourcePath(), "res1");
@@ -347,7 +347,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
                     FillResult(ans.AddResults(), 42 + res, 5.0);
                 }
                 pipe2->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         setup.WaitEvent<NKesus::TEvKesus::TEvSubscribeOnResources>();
     }
@@ -359,14 +359,14 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         setup.SendProxyRequest("res");
 
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         // Connected
         setup.SendConnected(pipe);
@@ -378,14 +378,14 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -394,19 +394,19 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
 
         auto& startSession =
             EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
-                .WillOnce(Invoke([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
+                .WillOnce([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
                     UNIT_ASSERT_VALUES_EQUAL(record.ResourcesInfoSize(), 1);
                     UNIT_ASSERT_VALUES_EQUAL(record.GetResourcesInfo(0).GetResourceId(), 42);
                     UNIT_ASSERT(record.GetResourcesInfo(0).GetConsumeResource());
-                }));
+                });
 
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
             .After(startSession)
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
+            .WillOnce([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesInfoSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResourcesInfo(0).GetResourceId(), 42);
                 UNIT_ASSERT(!record.GetResourcesInfo(0).GetConsumeResource());
-            }));
+            });
 
         setup.WaitEvent<NKesus::TEvKesus::TEvUpdateConsumptionState>();
         setup.SendCloseSession("res", 42);
@@ -420,24 +420,24 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillRepeatedly(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillRepeatedly([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 5.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
 
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
+            .WillOnce([&](const NKikimrKesus::TEvUpdateConsumptionState& record, ui64) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesInfoSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResourcesInfo(0).GetResourceId(), 42);
                 UNIT_ASSERT(record.GetResourcesInfo(0).GetConsumeResource());
-            }));
+            });
 
         setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 0, {}, 3, 5.0, 0, 0)});
         setup.WaitEvent<NKesus::TEvKesus::TEvUpdateConsumptionState>();
@@ -448,7 +448,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         // second pipe
         auto* pipe2 = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe2, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(record.GetResources(0).GetStartConsuming());
@@ -459,7 +459,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
                     FillResultNotFound(ans.AddResults());
                 }
                 pipe2->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         for (size_t i = 0; i < 5; ++i) {
             // Error request. If second ProxySession was sent, it will arrive first.
@@ -482,14 +482,14 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -503,14 +503,14 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 UNIT_ASSERT(!record.GetResources(0).GetStartConsuming());
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -533,13 +533,13 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -551,13 +551,13 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         setup.GetPipeFactory().ExpectTabletPipeCreation(); // Expect second pipe. Without connecting.
 
@@ -576,13 +576,13 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         setup.GetPipeFactory().ExpectTabletPipeCreation(); // Expect second pipe. Without connecting.
 
@@ -601,12 +601,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -648,12 +648,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -709,12 +709,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -742,12 +742,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -790,12 +790,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto session = setup.ProxyRequest("res");
         UNIT_ASSERT_VALUES_EQUAL(session->Get()->ResourceId, 42);
@@ -825,13 +825,13 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(record.GetResources(0).GetResourcePath(), "res");
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults());
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
 
         auto* pipe2 = setup.GetPipeFactory().ExpectTabletPipeCreation(); // Expect second pipe. Without connecting.
 
@@ -856,12 +856,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0); // speed=100, BucketMax=20
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
             .Times(AnyNumber());
 
@@ -894,12 +894,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
             .Times(AnyNumber());
 
@@ -928,12 +928,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
             .Times(AnyNumber());
 
@@ -967,12 +967,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
             .Times(AnyNumber());
 
@@ -1002,12 +1002,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         TKesusProxyTestSetup setup;
         auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
         EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+            .WillOnce([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
                 UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
                 NKikimrKesus::TEvSubscribeOnResourcesResult ans;
                 FillResult(ans.AddResults(), 42, 100.0);
                 pipe->SendSubscribeOnResourceResult(ans, cookie);
-            }));
+            });
         EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
             .Times(AnyNumber());
 

--- a/ydb/core/quoter/ut_memory/quoter_memory_ut.cpp
+++ b/ydb/core/quoter/ut_memory/quoter_memory_ut.cpp
@@ -68,7 +68,7 @@ Y_UNIT_TEST(MeasureProxyMemoryWith100kResources) {
 
     ui64 nextResId = 1;
     EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
-        .WillRepeatedly(Invoke([pipe, &nextResId](
+        .WillRepeatedly([pipe, &nextResId](
             const NKikimrKesus::TEvSubscribeOnResources& req, ui64 cookie) {
             NKikimrKesus::TEvSubscribeOnResourcesResult result;
             result.SetProtocolVersion(1);
@@ -81,7 +81,7 @@ Y_UNIT_TEST(MeasureProxyMemoryWith100kResources) {
                 props->MutableHierarchicalDRRResourceConfig()->SetMaxUnitsPerSecond(100);
             }
             pipe->SendSubscribeOnResourceResult(result, cookie);
-        }));
+        });
 
     EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _)).Times(AnyNumber());
 

--- a/ydb/core/testlib/mock_pq_metacache.h
+++ b/ydb/core/testlib/mock_pq_metacache.h
@@ -61,7 +61,7 @@ public:
         };
 
         EXPECT_CALL(*this, HandleDescribeTopics(_, _))
-            .WillOnce(Invoke(handle));
+            .WillOnce(handle);
     }
 
     void SetDescribeTopicsByNameAnswer(
@@ -86,7 +86,7 @@ public:
         };
 
         EXPECT_CALL(*this, HandleDescribeTopicsByName(_, _))
-            .WillOnce(Invoke(handle));
+            .WillOnce(handle);
     }
 };
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/read_session_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/read_session_ut.cpp
@@ -926,7 +926,7 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
                 }
             });
         EXPECT_CALL(*setup.MockProcessor, OnInitRequest(_))
-            .WillOnce(Invoke([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::InitRequest& req) {
+            .WillOnce([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::InitRequest& req) {
                 UNIT_ASSERT_STRINGS_EQUAL(req.consumer(), "TestConsumer");
                 UNIT_ASSERT_VALUES_EQUAL(req.max_lag_duration_ms(), 32000);
                 UNIT_ASSERT_VALUES_EQUAL(req.start_from_written_at_ms(), 42000);
@@ -936,7 +936,7 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
                 UNIT_ASSERT_VALUES_EQUAL(req.topics_read_settings(0).partition_group_ids_size(), 2);
                 UNIT_ASSERT_VALUES_EQUAL(req.topics_read_settings(0).partition_group_ids(0), 100);
                 UNIT_ASSERT_VALUES_EQUAL(req.topics_read_settings(0).partition_group_ids(1), 101);
-            }));
+            });
         setup.GetSession()->Start();
         setup.MockProcessorFactory->Wait();
 
@@ -1100,14 +1100,14 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
             UNIT_ASSERT(stream);
 
             EXPECT_CALL(*setup.MockProcessor, OnStartReadRequest(_))
-                .WillOnce(Invoke([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::StartRead& req) {
+                .WillOnce([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::StartRead& req) {
                     UNIT_ASSERT_STRINGS_EQUAL(req.topic().path(), "TestTopic");
                     UNIT_ASSERT_STRINGS_EQUAL(req.cluster(), "TestCluster");
                     UNIT_ASSERT_VALUES_EQUAL(req.partition(), 1);
                     UNIT_ASSERT_VALUES_EQUAL(req.assign_id(), 1);
                     UNIT_ASSERT_VALUES_EQUAL(req.read_offset(), 13);
                     UNIT_ASSERT_VALUES_EQUAL(req.commit_offset(), 31);
-                }));
+                });
 
             event.Confirm(13, 31);
         }
@@ -1140,12 +1140,12 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
             UNIT_ASSERT_EQUAL(destroyEvent.GetPartitionStream(), stream);
 
             EXPECT_CALL(*setup.MockProcessor, OnReleasedRequest(_))
-                .WillOnce(Invoke([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Released& req) {
+                .WillOnce([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Released& req) {
                     UNIT_ASSERT_STRINGS_EQUAL(req.topic().path(), "TestTopic");
                     UNIT_ASSERT_STRINGS_EQUAL(req.cluster(), "TestCluster");
                     UNIT_ASSERT_VALUES_EQUAL(req.partition(), 1);
                     UNIT_ASSERT_VALUES_EQUAL(req.assign_id(), 1);
-                }));
+                });
 
             destroyEvent.Confirm();
         }
@@ -1319,7 +1319,7 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
         THashSet<ui64> committedCookies;
         THashSet<ui64> committedOffsets;
         EXPECT_CALL(*setup.MockProcessor, OnCommitRequest(_))
-            .WillRepeatedly(Invoke([&committedCookies, &committedOffsets](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Commit& req) {
+            .WillRepeatedly([&committedCookies, &committedOffsets](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Commit& req) {
                 for (const auto& commit : req.cookies()) {
                     committedCookies.insert(commit.partition_cookie());
                 }
@@ -1329,7 +1329,7 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
                         committedOffsets.insert(i);
                     }
                 }
-            }));
+            });
 
         for (ui64 i = 1; i <= serverBatchesCount; ++i) {
             TMockReadSessionProcessor::TServerReadInfo resp;
@@ -1512,12 +1512,12 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
         setup.SuccessfulInit();
         TPartitionStream::TPtr stream = setup.CreatePartitionStream();
         EXPECT_CALL(*setup.MockProcessor, OnStatusRequest(_))
-            .WillOnce(Invoke([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Status& req) {
+            .WillOnce([](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Status& req) {
                 UNIT_ASSERT_VALUES_EQUAL(req.topic().path(), "TestTopic");
                 UNIT_ASSERT_VALUES_EQUAL(req.cluster(), "TestCluster");
                 UNIT_ASSERT_VALUES_EQUAL(req.partition(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(req.assign_id(), 1);
-            }));
+            });
         // Another assign id.
         setup.MockProcessor->AddServerResponse(TMockReadSessionProcessor::TServerReadInfo()
                                                .PartitionStreamStatus(11, 34, TInstant::Seconds(4), "TestTopic", "TestCluster", 1 /*partition*/, 13/*assign id to ignore*/));
@@ -1558,7 +1558,7 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
         bool has1 = false;
         bool has2 = false;
         EXPECT_CALL(*setup.MockProcessor, OnCommitRequest(_))
-            .WillRepeatedly(Invoke([&](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Commit& req) {
+            .WillRepeatedly([&](const Ydb::PersQueue::V1::MigrationStreamingReadClientMessage::Commit& req) {
                 Cerr << "Got commit req " << req << "\n";
                 for (const auto& commit : req.cookies()) {
                     if (commit.partition_cookie() == 1) {
@@ -1575,7 +1575,7 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
                     else if (range.start_offset() == 0 && range.end_offset() == 3) has2 = true;
                     else UNIT_ASSERT(false);
                 }
-            }));
+            });
 
         for (int i = 0; i < 2; ) {
             std::optional<TReadSessionEvent::TEvent> event = setup.EventsQueue->GetEvent(true);

--- a/ydb/public/sdk/cpp/tests/integration/topic/direct_read_it.cpp
+++ b/ydb/public/sdk/cpp/tests/integration/topic/direct_read_it.cpp
@@ -1040,7 +1040,7 @@ void SuccessfulInitImpl(bool thenTimeout) {
             });
 
         EXPECT_CALL(*setup.MockReadProcessor, OnInitRequest(_))
-            .WillOnce(Invoke([&setup](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
+            .WillOnce([&setup](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
                 ASSERT_EQ(req.consumer(), setup.ReadSessionSettings.ConsumerName_);
                 ASSERT_TRUE(req.direct_read());
                 ASSERT_EQ(req.topics_read_settings_size(), 1);
@@ -1049,7 +1049,7 @@ void SuccessfulInitImpl(bool thenTimeout) {
                 ASSERT_EQ(req.topics_read_settings(0).partition_ids_size(), 2);
                 ASSERT_EQ(req.topics_read_settings(0).partition_ids(0), 100);
                 ASSERT_EQ(req.topics_read_settings(0).partition_ids(1), 101);
-            }));
+            });
 
         EXPECT_CALL(*setup.MockReadProcessor, OnReadRequest(_));
     }
@@ -1098,20 +1098,20 @@ TEST_F(DirectReadWithControlSession, StopPartitionSessionGracefully) {
                 });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnInitRequest(_))
-                .WillOnce(Invoke([&](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
+                .WillOnce([&](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
                     ASSERT_TRUE(req.direct_read());
                     ASSERT_EQ(req.topics_read_settings_size(), 1);
                     ASSERT_EQ(req.topics_read_settings(0).path(), setup.ReadSessionSettings.Topics_[0].Path_);
                     ASSERT_EQ(req.topics_read_settings(0).partition_ids_size(), 1);
                     ASSERT_EQ(req.topics_read_settings(0).partition_ids(0), startPartitionSessionRequest.PartitionId);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnReadRequest(_));
 
             EXPECT_CALL(*setup.MockReadProcessor, OnStartPartitionSessionResponse(_))
-                .WillOnce(Invoke([&startPartitionSessionRequest](const Ydb::Topic::StreamReadMessage::StartPartitionSessionResponse& resp) {
+                .WillOnce([&startPartitionSessionRequest](const Ydb::Topic::StreamReadMessage::StartPartitionSessionResponse& resp) {
                     ASSERT_EQ(static_cast<std::uint64_t>(resp.partition_session_id()), startPartitionSessionRequest.PartitionSessionId);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnDirectReadAck(_))
                 .Times(4);
@@ -1129,18 +1129,18 @@ TEST_F(DirectReadWithControlSession, StopPartitionSessionGracefully) {
                 });
 
             EXPECT_CALL(*setup.MockDirectReadProcessor, OnInitRequest(_))
-                .WillOnce(Invoke([&setup](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
+                .WillOnce([&setup](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
                     ASSERT_EQ(req.session_id(), SERVER_SESSION_ID);
                     ASSERT_EQ(static_cast<std::size_t>(req.topics_read_settings_size()), setup.ReadSessionSettings.Topics_.size());
                     ASSERT_EQ(req.topics_read_settings(0).path(), setup.ReadSessionSettings.Topics_[0].Path_);
                     ASSERT_EQ(req.consumer(), setup.ReadSessionSettings.ConsumerName_);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockDirectReadProcessor, OnStartDirectReadPartitionSessionRequest(_))
-                .WillOnce(Invoke([&startPartitionSessionRequest](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& request) {
+                .WillOnce([&startPartitionSessionRequest](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& request) {
                     ASSERT_EQ(static_cast<std::uint64_t>(request.partition_session_id()), startPartitionSessionRequest.PartitionSessionId);
                     ASSERT_EQ(request.generation(), startPartitionSessionRequest.Generation);
-                }));
+                });
 
             // Expect OnReadRequest in case it is called before the test ends.
             // TODO(qyryq) Fix number, not 10.
@@ -1246,20 +1246,20 @@ TEST_F(DirectReadWithControlSession, StopPartitionSession) {
                 });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnInitRequest(_))
-                .WillOnce(Invoke([&](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
+                .WillOnce([&](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
                     ASSERT_TRUE(req.direct_read());
                     ASSERT_EQ(req.topics_read_settings_size(), 1);
                     ASSERT_EQ(req.topics_read_settings(0).path(), setup.ReadSessionSettings.Topics_[0].Path_);
                     ASSERT_EQ(req.topics_read_settings(0).partition_ids_size(), 1);
                     ASSERT_EQ(req.topics_read_settings(0).partition_ids(0), startPartitionSessionRequest.PartitionId);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnReadRequest(_));
 
             EXPECT_CALL(*setup.MockReadProcessor, OnStartPartitionSessionResponse(_))
-                .WillOnce(Invoke([&startPartitionSessionRequest](const Ydb::Topic::StreamReadMessage::StartPartitionSessionResponse& resp) {
+                .WillOnce([&startPartitionSessionRequest](const Ydb::Topic::StreamReadMessage::StartPartitionSessionResponse& resp) {
                     ASSERT_EQ(static_cast<std::uint64_t>(resp.partition_session_id()), startPartitionSessionRequest.PartitionSessionId);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnDirectReadAck(_))
                 .Times(4);
@@ -1277,18 +1277,18 @@ TEST_F(DirectReadWithControlSession, StopPartitionSession) {
                 });
 
             EXPECT_CALL(*setup.MockDirectReadProcessor, OnInitRequest(_))
-                .WillOnce(Invoke([&setup](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
+                .WillOnce([&setup](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
                     ASSERT_EQ(req.session_id(), SERVER_SESSION_ID);
                     ASSERT_EQ(static_cast<std::size_t>(req.topics_read_settings_size()), setup.ReadSessionSettings.Topics_.size());
                     ASSERT_EQ(req.topics_read_settings(0).path(), setup.ReadSessionSettings.Topics_[0].Path_);
                     ASSERT_EQ(req.consumer(), setup.ReadSessionSettings.ConsumerName_);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockDirectReadProcessor, OnStartDirectReadPartitionSessionRequest(_))
-                .WillOnce(Invoke([&startPartitionSessionRequest](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& request) {
+                .WillOnce([&startPartitionSessionRequest](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& request) {
                     ASSERT_EQ(static_cast<std::uint64_t>(request.partition_session_id()), startPartitionSessionRequest.PartitionSessionId);
                     ASSERT_EQ(request.generation(), startPartitionSessionRequest.Generation);
-                }));
+                });
 
             // Expect OnReadRequest in case it is called before the test ends.
             // TODO(qyryq) Fix number, not 10.
@@ -1421,28 +1421,28 @@ TEST_F(DirectReadWithControlSession, EmptyDirectReadResponse) {
                 });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnInitRequest(_))
-                .WillOnce(Invoke([&](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
+                .WillOnce([&](const Ydb::Topic::StreamReadMessage::InitRequest& req) {
                     ASSERT_TRUE(req.direct_read());
                     ASSERT_EQ(req.topics_read_settings_size(), 1);
                     ASSERT_EQ(req.topics_read_settings(0).path(), setup.ReadSessionSettings.Topics_[0].Path_);
                     ASSERT_EQ(req.topics_read_settings(0).partition_ids_size(), 1);
                     ASSERT_EQ(req.topics_read_settings(0).partition_ids(0), startPartitionSessionRequest.PartitionId);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnReadRequest(_));
 
             EXPECT_CALL(*setup.MockReadProcessor, OnStartPartitionSessionResponse(_))
-                .WillOnce(Invoke([&startPartitionSessionRequest](const Ydb::Topic::StreamReadMessage::StartPartitionSessionResponse& resp) {
+                .WillOnce([&startPartitionSessionRequest](const Ydb::Topic::StreamReadMessage::StartPartitionSessionResponse& resp) {
                     ASSERT_EQ(static_cast<std::uint64_t>(resp.partition_session_id()), startPartitionSessionRequest.PartitionSessionId);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockReadProcessor, OnDirectReadAck(_))
                 .Times(1);
 
             EXPECT_CALL(*setup.MockReadProcessor, OnReadRequest(_))
-                .WillOnce(Invoke([&](const Ydb::Topic::StreamReadMessage::ReadRequest& req) {
+                .WillOnce([&](const Ydb::Topic::StreamReadMessage::ReadRequest& req) {
                     ASSERT_EQ(req.bytes_size(), bytesSize);
-                }));
+                });
         }
 
         // There are two sequences, because OnCreateProcessor from the second sequence may be called
@@ -1457,18 +1457,18 @@ TEST_F(DirectReadWithControlSession, EmptyDirectReadResponse) {
                 });
 
             EXPECT_CALL(*setup.MockDirectReadProcessor, OnInitRequest(_))
-                .WillOnce(Invoke([&setup](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
+                .WillOnce([&setup](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
                     ASSERT_EQ(req.session_id(), SERVER_SESSION_ID);
                     ASSERT_EQ(static_cast<std::size_t>(req.topics_read_settings_size()), setup.ReadSessionSettings.Topics_.size());
                     ASSERT_EQ(req.topics_read_settings(0).path(), setup.ReadSessionSettings.Topics_[0].Path_);
                     ASSERT_EQ(req.consumer(), setup.ReadSessionSettings.ConsumerName_);
-                }));
+                });
 
             EXPECT_CALL(*setup.MockDirectReadProcessor, OnStartDirectReadPartitionSessionRequest(_))
-                .WillOnce(Invoke([&startPartitionSessionRequest](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& request) {
+                .WillOnce([&startPartitionSessionRequest](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& request) {
                     ASSERT_EQ(static_cast<std::uint64_t>(request.partition_session_id()), startPartitionSessionRequest.PartitionSessionId);
                     ASSERT_EQ(request.generation(), startPartitionSessionRequest.Generation);
-                }));
+                });
         }
     }
 
@@ -1539,16 +1539,16 @@ TEST_F(DirectReadSession, InitAndStartPartitionSession) {
             .WillOnce([&]() { setup.MockDirectReadProcessorFactory->CreateProcessor(setup.MockDirectReadProcessor); });
 
         EXPECT_CALL(*setup.MockDirectReadProcessor, OnInitRequest(_))
-            .WillOnce(Invoke([&](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
+            .WillOnce([&](const Ydb::Topic::StreamDirectReadMessage::InitRequest& req) {
                 ASSERT_EQ(req.session_id(), SERVER_SESSION_ID);
                 ASSERT_EQ(req.consumer(), setup.ReadSessionSettings.ConsumerName_);
-            }));
+            });
 
         EXPECT_CALL(*setup.MockDirectReadProcessor, OnStartDirectReadPartitionSessionRequest(_))
-            .WillOnce(Invoke([&](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& req) {
+            .WillOnce([&](const Ydb::Topic::StreamDirectReadMessage::StartDirectReadPartitionSessionRequest& req) {
                 ASSERT_EQ(req.partition_session_id(), static_cast<std::int64_t>(partitionSessionId));
                 gotStart.SetValue();
-            }));
+            });
     }
 
     session->Start();


### PR DESCRIPTION
### Description for reviewers 

Update landed in https://github.com/ydb-platform/ydb/commit/80ee610301844cce5c5d99e6bf8ab23d16bfc703

See also:
https://a.yandex-team.ru/review/15282879/files/1
https://a.yandex-team.ru/review/15256691/files/1
https://st.yandex-team.ru/IGNIETFERRO-2208