### PR TITLE
Accept trailing slash on SQS HTTP database endpoint

### DIFF
--- a/ydb/core/http_proxy/http_req.cpp
+++ b/ydb/core/http_proxy/http_req.cpp
@@ -82,10 +82,7 @@ namespace NKikimr::NHttpProxy {
             SourceAddress = address;
         }
 
-        DatabasePath = Request->URL.Before('?');
-        if (DatabasePath == "/") {
-           DatabasePath = "";
-        }
+        DatabasePath = ParseDatabasePathFromRequestUrl(Request->URL);
         CgiParameters = TCgiParameters(Request->URL.After('?'));
         if (auto it = CgiParameters.Find("folderId"); it != CgiParameters.end()) {
             FolderId = it->second;

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -420,6 +420,26 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
             UNIT_ASSERT_VALUES_EQUAL(GetByPath<TString>(json, "__type"), "InvalidArgumentException");
         }
 
+        Y_UNIT_TEST_F(TestGetQueueUrlWithTrailingSlashOnEndpoint, TFixture) {
+            auto driver = MakeDriver(*this);
+            const TString topicName = "ExampleQueueName";
+            const TString consumer = "ydb-sqs-consumer";
+            Y_ENSURE(CreateTopic(driver, topicName, consumer));
+
+            const TString expectedPath = std::format(
+                "/v1/5//Root/{}/{}/{}/{}",
+                topicName.size(), topicName.c_str(), consumer.size(), consumer.c_str());
+            auto res = SendHttpRequest(
+                "/Root/",
+                "AmazonSQS.GetQueueUrl",
+                NJson::TJsonMap{{"QueueName", topicName}},
+                FormAuthorizationStr("ru-central1"));
+            UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
+            NJson::TJsonMap json;
+            UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &json, true));
+            UNIT_ASSERT_VALUES_EQUAL(expectedPath, GetPathFromQueueUrlMap(json));
+        }
+
         Y_UNIT_TEST_F(TestGetQueueUrlUsesRequestHost, TNoAuthFixture) {
             auto driver = MakeDriver(*this);
             const TString topicName = "ExampleQueueName";
@@ -559,6 +579,38 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
 
         Y_UNIT_TEST_F(TestGetQueueUrlWithLeadingSlashInConsumerNameInFederation, TNonFirstClassCitizenFixture) {
             TestGetQueueUrlWithAtSignInConsumerNameInFederationImpl(*this, "my_topic@/my/consumer");
+        }
+
+        Y_UNIT_TEST_F(TestGetQueueUrlWithTrailingSlashOnFederationEndpoint, TNonFirstClassCitizenFixture) {
+            auto driver = MakeDriver(*this);
+
+            const TString database = TString{TNonFirstClassCitizenFixture::FederationDatabase};
+            const TString topicName = "my_topic";
+            const TString topicPath = TStringBuilder() << "federation/" << topicName;
+            UNIT_ASSERT(CreateTopic(driver, topicPath, NYdb::NTopic::TCreateTopicSettings()
+                .AddAttribute("_federation_account", "account1")
+                .BeginAddSharedConsumer("my@consumer")
+                    .KeepMessagesOrder(false)
+                    .DefaultProcessingTimeout(TDuration::Seconds(20))
+                .EndAddConsumer()));
+
+            const TString expectedQueueUrl = std::format(
+                "/v1/{}/{}/{}/{}/{}/{}",
+                database.size(),
+                database.c_str(),
+                topicName.size(),
+                topicName.c_str(),
+                TStringBuf("my/consumer").size(),
+                "my/consumer");
+            auto res = SendHttpRequest(
+                database + "/",
+                "AmazonSQS.GetQueueUrl",
+                NJson::TJsonMap{{"QueueName", "my_topic@my/consumer"}},
+                FormAuthorizationStr("ru-central1"));
+            UNIT_ASSERT_VALUES_EQUAL_C(res.HttpCode, 200, res.Body);
+            NJson::TJsonMap json;
+            UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &json, true));
+            UNIT_ASSERT_VALUES_EQUAL(expectedQueueUrl, GetPathFromQueueUrlMap(json));
         }
 
         Y_UNIT_TEST_F(TestDeleteQueueInFederation, TNonFirstClassCitizenFixture) {

--- a/ydb/core/http_proxy/ut/utils_ut.cpp
+++ b/ydb/core/http_proxy/ut/utils_ut.cpp
@@ -519,3 +519,29 @@ Y_UNIT_TEST_SUITE(SqsRequestEndpoint) {
             "https://lbkx.example.net:8443");
     }
 }
+
+Y_UNIT_TEST_SUITE(DatabasePathFromRequestUrl) {
+    Y_UNIT_TEST(EmptyAndRoot) {
+        UNIT_ASSERT_VALUES_EQUAL(ParseDatabasePathFromRequestUrl(""), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseDatabasePathFromRequestUrl("/"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseDatabasePathFromRequestUrl("/?folderId=abc"), "");
+    }
+
+    Y_UNIT_TEST(StripsTrailingSlash) {
+        UNIT_ASSERT_VALUES_EQUAL(ParseDatabasePathFromRequestUrl("/Root"), "/Root");
+        UNIT_ASSERT_VALUES_EQUAL(ParseDatabasePathFromRequestUrl("/Root/"), "/Root");
+        UNIT_ASSERT_VALUES_EQUAL(ParseDatabasePathFromRequestUrl("/Root/?folderId=abc"), "/Root");
+    }
+
+    Y_UNIT_TEST(FederationEndpoint) {
+        UNIT_ASSERT_VALUES_EQUAL(
+            ParseDatabasePathFromRequestUrl("/Root/logbroker-federation/thist"),
+            "/Root/logbroker-federation/thist");
+        UNIT_ASSERT_VALUES_EQUAL(
+            ParseDatabasePathFromRequestUrl("/Root/logbroker-federation/thist/"),
+            "/Root/logbroker-federation/thist");
+        UNIT_ASSERT_VALUES_EQUAL(
+            ParseDatabasePathFromRequestUrl("/Root/federation/"),
+            "/Root/federation");
+    }
+}

--- a/ydb/core/http_proxy/utils.cpp
+++ b/ydb/core/http_proxy/utils.cpp
@@ -3,6 +3,7 @@
 #include "http_req.h"
 
 #include <library/cpp/string_utils/url/url.h>
+#include <ydb/core/base/path.h>
 #include <ydb/library/http/rfc7239_forwarded.h>
 
 #include <util/generic/maybe.h>
@@ -211,6 +212,10 @@ TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext) {
     const auto& request = *httpContext.Request;
     const bool tlsSecure = request.Endpoint && request.Endpoint->Secure;
     return MakeSqsRequestEndpoint(request.Host, request.Headers, tlsSecure);
+}
+
+TString ParseDatabasePathFromRequestUrl(TStringBuf url) {
+    return CanonizePath(TString{url.Before('?')});
 }
 
 } // namespace NKikimr::NHttpProxy

--- a/ydb/core/http_proxy/utils.h
+++ b/ydb/core/http_proxy/utils.h
@@ -26,4 +26,9 @@ TString LogHttpRequestResponseCommonInfoString(const THttpRequestContext& httpCo
 TString MakeSqsRequestEndpoint(TStringBuf host, TStringBuf headers, bool tlsSecure);
 TString MakeSqsRequestEndpoint(const THttpRequestContext& httpContext);
 
+// HTTP request path used as the SQS/Kinesis database endpoint.
+// Query string is ignored; a trailing slash is treated as equivalent to no slash.
+// "/" and empty path mean "no database".
+TString ParseDatabasePathFromRequestUrl(TStringBuf url);
+
 } // namespace NKikimr::NHttpProxy


### PR DESCRIPTION
### Changelog entry

SQS HTTP API now accepts a trailing slash on the database endpoint path (for example `/Root/logbroker-federation/thist/` is treated as `/Root/logbroker-federation/thist`).

### Description for reviewers

**Problem**

Clients that add a trailing slash to the SQS HTTP endpoint (e.g. `/Root/logbroker-federation/thist/` instead of `/Root/logbroker-federation/thist`) get an error: the request path is used as `DatabasePath` as-is, so scheme lookup and later database matching fail.

**Solution**

Canonize the HTTP request path when filling `DatabasePath` (`CanonizePath`, query string ignored). `/Root/` and `/Root` are the same database; `/` still means “no database”.

**Tests**

- `ydb/core/http_proxy/ut` — `ParseDatabasePathFromRequestUrl` (`/Root/`, federation path, query string)
- `ydb/core/http_proxy/ut/sqs_topic_ut` — `GetQueueUrl` on `/Root/` and `/Root/federation/`

```bash
./ya make --build relwithdebinfo -tA ydb/core/http_proxy/ut -F '*DatabasePathFromRequestUrl*'
./ya make --build relwithdebinfo -tA ydb/core/http_proxy/ut/sqs_topic_ut -F '*TrailingSlash*'
```