### PR TITLE
schemeshard: make datashard stats events cheaper to handle

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -646,7 +646,7 @@ enum EPercentileCounters {
         Ranges: { Value: 512      Name: "512"   }
         Ranges: { Value: 1024     Name: "1024"  }
         Ranges: { Value: 2048     Name: "2048"  }  // used as initial arena size
-        Ranges: { Value: 3072     Name: "3072"  }  // middle step be more accurate in the area of interest
+        Ranges: { Value: 3072     Name: "3072"  }  // middle step to be more accurate in the area of interest
         Ranges: { Value: 4096     Name: "4096"  }
         Ranges: { Value: 8192     Name: "8192"  }
         Ranges: { Value: 16384    Name: "16384" }
@@ -660,7 +660,7 @@ enum EPercentileCounters {
         Ranges: { Value: 1024     Name: "1024"   }
         Ranges: { Value: 2048     Name: "2048"   }
         Ranges: { Value: 4096     Name: "4096"   }  // used as initial arena size
-        Ranges: { Value: 5120     Name: "5120"   }  // several middle steps be more accurate in the area of interest
+        Ranges: { Value: 5120     Name: "5120"   }  // several middle steps to be more accurate in the area of interest
         Ranges: { Value: 6144     Name: "6144"   }
         Ranges: { Value: 7168     Name: "7168"   }
         Ranges: { Value: 8192     Name: "8192"   }

--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -306,7 +306,7 @@ enum ESimpleCounters {
     COUNTER_TEST_SHARD_COUNT = 236                         [(CounterOpts) = {Name: "TestShardCount"}];
     COUNTER_IN_FLIGHT_OPS_TxCreateTestShardSet = 237      [(CounterOpts) = {Name: "InFlightOps/CreateTestShardSet"}];
     COUNTER_IN_FLIGHT_OPS_TxDropTestShardSet = 238        [(CounterOpts) = {Name: "InFlightOps/DropTestShardSet"}];
-    
+
     COUNTER_RUNNING_STREAMING_QUERY_COUNT = 239           [(CounterOpts) = {Name: "RunningStreamingQueryCount"}];
 }
 
@@ -635,6 +635,39 @@ enum EPercentileCounters {
         Ranges: { Value: 200000      Name: "200 ms"       }
         Ranges: { Value: 500000      Name: "500 ms"       }
         Ranges: { Value: 1000000     Name: "1000 ms"      }
+    }];
+
+    // google::protobuf::Arena::SpaceUsed() of the arena-backed event record, bytes.
+    // Used to check the InitialBlockSize/MaxBlockSize choice on the event's TEventPBWithArena.
+    COUNTER_PERIODIC_TABLE_STATS_ARENA_SPACE_USED = 7 [(CounterOpts) = {
+        Name: "PeriodicTableStatsArenaSpaceUsed",
+        Integral: true,
+        Ranges: { Value: 256      Name: "256"   }
+        Ranges: { Value: 512      Name: "512"   }
+        Ranges: { Value: 1024     Name: "1024"  }
+        Ranges: { Value: 2048     Name: "2048"  }  // used as initial arena size
+        Ranges: { Value: 3072     Name: "3072"  }  // middle step be more accurate in the area of interest
+        Ranges: { Value: 4096     Name: "4096"  }
+        Ranges: { Value: 8192     Name: "8192"  }
+        Ranges: { Value: 16384    Name: "16384" }
+        Ranges: { Value: 32768    Name: "32768" }
+    }];
+
+    COUNTER_GET_TABLE_STATS_RESULT_ARENA_SPACE_USED = 8 [(CounterOpts) = {
+        Name: "GetTableStatsResultArenaSpaceUsed",
+        Integral: true,
+        Ranges: { Value: 512      Name: "512"    }
+        Ranges: { Value: 1024     Name: "1024"   }
+        Ranges: { Value: 2048     Name: "2048"   }
+        Ranges: { Value: 4096     Name: "4096"   }  // used as initial arena size
+        Ranges: { Value: 5120     Name: "5120"   }  // several middle steps be more accurate in the area of interest
+        Ranges: { Value: 6144     Name: "6144"   }
+        Ranges: { Value: 7168     Name: "7168"   }
+        Ranges: { Value: 8192     Name: "8192"   }
+        Ranges: { Value: 16384    Name: "16384"  }
+        Ranges: { Value: 32768    Name: "32768"  }
+        Ranges: { Value: 65536    Name: "65536"  }
+        Ranges: { Value: 131072   Name: "131072" }
     }];
 }
 

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -909,9 +909,28 @@ namespace TEvDataShard {
         }
     };
 
-    struct TEvGetTableStatsResult : public TEventPB<TEvGetTableStatsResult,
+    // Arena avoids a per-submessage heap alloc/free (histogram buckets, part-owner entries,
+    // TabletMetrics' repeated fields).
+    // That is important for the schemeshard (receiver) side.
+    //
+    // In-memory footprint after parsing (not wire size): ~1-2KB base (scalar counters,
+    // part-owner lists, TabletMetrics), plus two independently-sized pieces:
+    //  - RowCountHistogram (always) and DataSizeHistogram (unless dropHistogram is on):
+    //    bucket count follows the request, 10 typical, capped at 500 (MaxBuckets in
+    //    datashard__stats.cpp), ~40B/bucket each.
+    //  - KeyAccessSample (unless dropHistogram is on): a FIXED-size reservoir sample, 100
+    //    entries by default (TKeyAccessSample::SampleCount in flat_stat_table.h) -- not
+    //    affected by the histogram bucket count above; entry size depends on the table's key
+    //    columns.
+    // ~4096 typical covers 10-bucket histograms plus a 100-entry key sample on a narrow key.
+    // A 500-bucket request just overflows into extra 32KB blocks, not a hard cap. (Once
+    // dropHistogram defaults on, DataSizeHistogram/KeyAccessSample are replaced by
+    // SplitBySizeSuggestedKey/SplitByLoadSuggestedKey -- serialized key prefixes, sized by the
+    // key, not by bucket/sample count.)
+    struct TEvGetTableStatsResult : public TEventPBWithArena<TEvGetTableStatsResult,
                                                         NKikimrTxDataShard::TEvGetTableStatsResult,
-                                                        TEvDataShard::EvGetTableStatsResult> {
+                                                        TEvDataShard::EvGetTableStatsResult,
+                                                        4096, 32*1024> {
         TEvGetTableStatsResult() = default;
         TEvGetTableStatsResult(ui64 datashardId, ui64 tableOwnerId, ui64 tableLocalId) {
             Record.SetDatashardId(datashardId);
@@ -920,9 +939,17 @@ namespace TEvDataShard {
         }
     };
 
-    struct TEvPeriodicTableStats : public TEventPB<TEvPeriodicTableStats,
+    // Arena avoids a per-submessage heap alloc/free (per-channel TChannelStats, TabletMetrics'
+    // per-channel throughput/iops lists, part-owner entries).
+    // That is important for the schemeshard (receiver) side.
+    //
+    // Histograms never set here (that's TEvGetTableStatsResult); size scales with channel
+    // count instead -- ~1-2KB typical at 3 channels. A 256-channel report just overflows into
+    // extra 8KB blocks, not a hard cap.
+    struct TEvPeriodicTableStats : public TEventPBWithArena<TEvPeriodicTableStats,
                                                         NKikimrTxDataShard::TEvPeriodicTableStats,
-                                                        TEvDataShard::EvPeriodicTableStats> {
+                                                        TEvDataShard::EvPeriodicTableStats,
+                                                        2048, 8192> {
         TEvPeriodicTableStats() = default;
         TEvPeriodicTableStats(ui64 datashardId, ui64 tableOwnerId, ui64 tableLocalId) {
             Record.SetDatashardId(datashardId);

--- a/ydb/core/tx/schemeshard/schemeshard__stats.h
+++ b/ydb/core/tx/schemeshard/schemeshard__stats.h
@@ -20,7 +20,7 @@ struct TStatsId {
     }
 
     bool operator==(const TStatsId& rhs) const {
-        return PathId == rhs.PathId && Datashard == rhs.Datashard & FollowerId == rhs.FollowerId;
+        return PathId == rhs.PathId && Datashard == rhs.Datashard && FollowerId == rhs.FollowerId;
     }
 
     struct THash {

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -745,7 +745,10 @@ void TTxStoreTableStats::ScheduleNextBatch(const TActorContext& ctx) {
 }
 
 void TSchemeShard::Handle(TEvDataShard::TEvPeriodicTableStats::TPtr& ev, const TActorContext& ctx) {
-    const auto& rec = ev->Get()->Record;
+    auto* msg = ev->Get();
+    const auto& rec = msg->Record;
+
+    TabletCounters->Percentile()[COUNTER_PERIODIC_TABLE_STATS_ARENA_SPACE_USED].IncrementFor(msg->Arena->Get()->SpaceUsed());
 
     auto datashardId = TTabletId(rec.GetDatashardId());
     const ui32 followerId = rec.GetFollowerId();

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
@@ -188,7 +188,10 @@ public:
 
 
 void TSchemeShard::Handle(TEvDataShard::TEvGetTableStatsResult::TPtr& ev, const TActorContext& ctx) {
-    const auto& rec = ev->Get()->Record;
+    auto* msg = ev->Get();
+    const auto& rec = msg->Record;
+
+    TabletCounters->Percentile()[COUNTER_GET_TABLE_STATS_RESULT_ARENA_SPACE_USED].IncrementFor(msg->Arena->Get()->SpaceUsed());
 
     auto datashardId = TTabletId(rec.GetDatashardId());
     ui64 dataSize = rec.GetTableStats().GetDataSize();

--- a/ydb/core/tx/schemeshard/ut_stats_bench/b_table_stats_arena.cpp
+++ b/ydb/core/tx/schemeshard/ut_stats_bench/b_table_stats_arena.cpp
@@ -1,0 +1,325 @@
+// Benchmarks the arena block sizes chosen for TEvDataShard::TEvPeriodicTableStats and
+// TEvGetTableStatsResult (see ydb/core/tx/datashard/datashard.h) against a non-arena baseline
+// over the same protobuf messages. Both sides go through the real TEventPBBase::Load() path
+// (parse from a serialized buffer), which is what the schemeshard actually pays on every
+// stats report from a datashard.
+
+#include <library/cpp/testing/gbenchmark/benchmark.h>
+
+#include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/protos/table_stats.pb.h>
+#include <ydb/core/protos/tablet.pb.h>
+#include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/core/events.h>
+
+using namespace NKikimr;
+using namespace NActors;
+
+namespace {
+
+    // Non-arena baselines over the same wire format as the production events, to isolate the
+    // arena's effect on Load() from everything else (parsing logic, message shape).
+    struct TEvGetTableStatsResultNoArena
+        : public TEventPB<TEvGetTableStatsResultNoArena,
+                           NKikimrTxDataShard::TEvGetTableStatsResult,
+                           EventSpaceBegin(TEvents::ES_PRIVATE) + 0> {
+    };
+
+    struct TEvPeriodicTableStatsNoArena
+        : public TEventPB<TEvPeriodicTableStatsNoArena,
+                           NKikimrTxDataShard::TEvPeriodicTableStats,
+                           EventSpaceBegin(TEvents::ES_PRIVATE) + 1> {
+    };
+
+    NKikimrTableStats::THistogram MakeHistogram(size_t buckets) {
+        NKikimrTableStats::THistogram hist;
+        for (size_t i = 0; i < buckets; ++i) {
+            auto* bucket = hist.AddBuckets();
+            bucket->SetKey(TString("key_") + ToString(i));
+            bucket->SetValue(i * 1000);
+        }
+        return hist;
+    }
+
+    // Scalar counters both TEvGetTableStatsResult and TEvPeriodicTableStats fill on their shared
+    // NKikimrTableStats::TTableStats submessage, outside of the histogram/suggested-key and
+    // per-channel fields that differ between the two event types.
+    void FillCommonTableStats(NKikimrTableStats::TTableStats* stats) {
+        stats->SetDataSize(123456789);
+        stats->SetRowCount(987654);
+        stats->SetIndexSize(45678);
+        stats->SetByKeyFilterSize(4096);
+        stats->SetInMemSize(890);
+        stats->SetLastAccessTime(1700000000000ull);
+        stats->SetLastUpdateTime(1700000000000ull);
+        stats->SetPartCount(7);
+        stats->SetSearchHeight(3);
+        stats->SetHasSchemaChanges(false);
+        stats->SetLastFullCompactionTs(1699999000ull);
+        stats->SetHasLoanedParts(false);
+    }
+
+    // A shard always reports at least itself as a user table part owner; right after a
+    // split/merge or copy, this list carries several historical owners. Templated because
+    // TEvGetTableStatsResult and TEvPeriodicTableStats are unrelated proto messages that happen
+    // to expose the same AddUserTablePartOwners/AddSysTablesPartOwners methods.
+    template <typename TRec>
+    void FillPartOwners(TRec& rec, size_t partOwners) {
+        for (ui64 i = 0; i < partOwners; ++i) {
+            rec.AddUserTablePartOwners(123456789 + i);
+        }
+        rec.AddSysTablesPartOwners(100);
+        rec.AddSysTablesPartOwners(101);
+    }
+
+    // TabletMetrics submessage (resourceMetrics->Fill), shared verbatim between both event types:
+    // aggregate CPU/Memory/Network/Storage plus one group read/write throughput+iops record per
+    // channel.
+    void FillTabletMetrics(NKikimrTabletBase::TMetrics* metrics, size_t channels) {
+        metrics->SetCPU(1234567);
+        metrics->SetMemory(89012345);
+        metrics->SetNetwork(345678);
+        metrics->SetStorage(999888777);
+        for (size_t channel = 0; channel < channels; ++channel) {
+            auto* readTp = metrics->AddGroupReadThroughput();
+            readTp->SetChannel(channel);
+            readTp->SetGroupID(2181038080 + channel);
+            readTp->SetThroughput(10000 + channel);
+
+            auto* writeTp = metrics->AddGroupWriteThroughput();
+            writeTp->SetChannel(channel);
+            writeTp->SetGroupID(2181038080 + channel);
+            writeTp->SetThroughput(5000 + channel);
+
+            auto* readIops = metrics->AddGroupReadIops();
+            readIops->SetChannel(channel);
+            readIops->SetGroupID(2181038080 + channel);
+            readIops->SetIops(100 + channel);
+
+            auto* writeIops = metrics->AddGroupWriteIops();
+            writeIops->SetChannel(channel);
+            writeIops->SetGroupID(2181038080 + channel);
+            writeIops->SetIops(50 + channel);
+        }
+    }
+
+    // KeyAccessSample is a fixed-size reservoir sample (TKeyAccessSample::SampleCount in
+    // flat_stat_table.h), not affected by the requested histogram bucket count -- see
+    // TEvGetTableStatsResult's definition comment in datashard.h.
+    constexpr size_t KeyAccessSampleSize = 100;
+
+    // Shape mirrors a real TEvGetTableStatsResult report as built by
+    // TDataShard::TTxGetTableStats::Execute() (ydb/core/tx/datashard/datashard__stats.cpp): base
+    // fields, part-owner lists (`partOwners` entries), the full scalar counter set the real
+    // handler fills when stats are ready, a TabletMetrics submessage (resourceMetrics->Fill), and
+    // RowCountHistogram (`buckets` entries -- unconditional, filled regardless of split-protocol
+    // version).
+    //
+    // `useSuggestedKey` selects the split-protocol variant (FillSplitBySize/FillSplitByLoad):
+    // DataSizeHistogram+KeyAccessSample and SplitBySizeSuggestedKey/SplitByLoadSuggestedKey are
+    // both gated by the same dropHistogram flag, so a report carries exactly one of the two
+    // shapes, never both --
+    //   false: protocol version 0/1 (today's default) -- DataSizeHistogram (`buckets` entries)
+    //          + KeyAccessSample (fixed `KeyAccessSampleSize` entries), no suggested-key fields.
+    //   true:  protocol version 3 (dropHistogram on -- the near-future default) -- no
+    //          DataSizeHistogram/KeyAccessSample, instead SplitBySizeSuggestedKey/
+    //          SplitByLoadSuggestedKey.
+    // See TEvGetTableStatsResult's definition comment in datashard.h for the full footprint
+    // breakdown and the 500-bucket cap.
+    TString MakeGetTableStatsResultPayload(size_t buckets, bool useSuggestedKey, size_t partOwners) {
+        NKikimrTxDataShard::TEvGetTableStatsResult rec;
+        rec.SetDatashardId(123456789);
+        rec.SetTableOwnerId(111);
+        rec.SetTableLocalId(222);
+        rec.SetShardState(2);
+        rec.SetFullStatsReady(true);
+        rec.SetFollowerId(0);
+
+        auto* stats = rec.MutableTableStats();
+        if (useSuggestedKey) {
+            stats->SetSplitProtocolVersion(3);
+            // Serialized single-column split key, same order of magnitude as a real
+            // TSerializedCellVec::Serialize() of one key column.
+            stats->SetSplitBySizeSuggestedKey(TString(12, 'k'));
+            stats->SetSplitByLoadSuggestedKey(TString(12, 'k'));
+        } else {
+            stats->SetSplitProtocolVersion(0);
+            *stats->MutableDataSizeHistogram() = MakeHistogram(buckets);
+            *stats->MutableKeyAccessSample() = MakeHistogram(KeyAccessSampleSize);
+        }
+
+        FillCommonTableStats(stats);
+        *stats->MutableRowCountHistogram() = MakeHistogram(buckets);
+
+        FillPartOwners(rec, partOwners);
+        FillTabletMetrics(rec.MutableTabletMetrics(), /* channels */ 3);
+
+        TString out;
+        Y_ENSURE(rec.SerializeToString(&out));
+        return out;
+    }
+
+    // Shape mirrors a real TEvPeriodicTableStats report as built by SendPeriodicTableStats
+    // (ydb/core/tx/datashard/datashard_impl.h): single table, no histograms (per the comment at
+    // its definition, those are only ever set on TEvGetTableStatsResult), but with per-channel
+    // stats (`channels` entries — typically 3, up to 256), non-empty part-owner lists
+    // (`partOwners` entries — always at least the shard itself; more after a split/merge or
+    // copy), the full set of scalar counters SendPeriodicTableStats always fills (tx/lock/row
+    // counters, timestamps, part/search-height), and a TabletMetrics submessage
+    // (resourceMetrics->Fill) with per-channel throughput/iops records — one group per channel,
+    // same `channels` count, since that's what a real shard with that many channels reports. No
+    // nested `Tables` entries: a periodic report is normally for one table, so that dimension
+    // isn't representative of steady-state traffic.
+    TString MakePeriodicTableStatsPayload(size_t channels, size_t partOwners) {
+        NKikimrTxDataShard::TEvPeriodicTableStats rec;
+        rec.SetDatashardId(123456789);
+        rec.SetTableOwnerId(111);
+        rec.SetTableLocalId(222);
+        rec.SetFollowerId(0);
+        rec.SetGeneration(3);
+        rec.SetRound(42);
+        rec.SetShardState(2);
+        rec.SetNodeId(17);
+        rec.SetStartTime(1700000000000ull);
+
+        auto* stats = rec.MutableTableStats();
+        FillCommonTableStats(stats);
+
+        for (size_t channel = 0; channel < channels; ++channel) {
+            auto* item = stats->AddChannels();
+            item->SetChannel(channel);
+            item->SetDataSize(1000000 + channel * 137);
+            item->SetIndexSize(50000 + channel * 11);
+        }
+
+        stats->SetImmediateTxCompleted(123456);
+        stats->SetPlannedTxCompleted(7890);
+        stats->SetTxRejectedByOverload(12);
+        stats->SetTxRejectedBySpace(0);
+        stats->SetTxCompleteLagMsec(5);
+        stats->SetInFlightTxCount(2);
+
+        stats->SetRowUpdates(456789);
+        stats->SetRowDeletes(1234);
+        stats->SetRowReads(987654321);
+        stats->SetRangeReads(54321);
+        stats->SetRangeReadRows(6543210);
+
+        stats->SetLocksAcquired(321);
+        stats->SetLocksWholeShard(2);
+        stats->SetLocksBroken(1);
+
+        FillPartOwners(rec, partOwners);
+        FillTabletMetrics(rec.MutableTabletMetrics(), channels);
+
+        TString out;
+        Y_ENSURE(rec.SerializeToString(&out));
+        return out;
+    }
+
+    template <typename TEv>
+    void BenchLoad(benchmark::State& state, const TString& payload) {
+        size_t bytes = 0;
+        for (auto _ : state) {
+            TEventSerializedData data(TString(payload), TEventSerializationInfo{});
+            THolder<TEv> ev(TEv::Load(&data));
+            benchmark::DoNotOptimize(ev.Get());
+            bytes += payload.size();
+        }
+        state.SetBytesProcessed(bytes);
+    }
+
+    // Isolates destruction cost: parsing happens outside the timed region (PauseTiming), so what's
+    // measured is exactly freeing the parsed message tree — one arena block free vs. individually
+    // destructing every submessage (histogram buckets, nested tables).
+    template <typename TEv>
+    void BenchDestroy(benchmark::State& state, const TString& payload) {
+        for (auto _ : state) {
+            state.PauseTiming();
+            TEventSerializedData data(TString(payload), TEventSerializationInfo{});
+            TEv* ev = TEv::Load(&data);
+            state.ResumeTiming();
+            delete ev;
+        }
+    }
+
+    // range(0) = histogram bucket count, range(1) = split-protocol variant (0 = DataSizeHistogram
+    // + KeyAccessSample, 1 = SplitBySizeSuggestedKey/SplitByLoadSuggestedKey), range(2) =
+    // UserTablePartOwners count (1 = steady state, 4 = representative post-split, 32 = deep
+    // split-chain worst case).
+    void LoadGetTableStatsResultArena(benchmark::State& state) {
+        const TString payload = MakeGetTableStatsResultPayload(state.range(0), state.range(1), state.range(2));
+        BenchLoad<TEvDataShard::TEvGetTableStatsResult>(state, payload);
+    }
+
+    void LoadGetTableStatsResultNoArena(benchmark::State& state) {
+        const TString payload = MakeGetTableStatsResultPayload(state.range(0), state.range(1), state.range(2));
+        BenchLoad<TEvGetTableStatsResultNoArena>(state, payload);
+    }
+
+    // range(0) = channel count, range(1) = UserTablePartOwners count (see LoadGetTableStatsResult*).
+    void LoadPeriodicTableStatsArena(benchmark::State& state) {
+        const TString payload = MakePeriodicTableStatsPayload(state.range(0), state.range(1));
+        BenchLoad<TEvDataShard::TEvPeriodicTableStats>(state, payload);
+    }
+
+    void LoadPeriodicTableStatsNoArena(benchmark::State& state) {
+        const TString payload = MakePeriodicTableStatsPayload(state.range(0), state.range(1));
+        BenchLoad<TEvPeriodicTableStatsNoArena>(state, payload);
+    }
+
+    // range(0)/(1)/(2) as in LoadGetTableStatsResult*.
+    void DestroyGetTableStatsResultArena(benchmark::State& state) {
+        const TString payload = MakeGetTableStatsResultPayload(state.range(0), state.range(1), state.range(2));
+        BenchDestroy<TEvDataShard::TEvGetTableStatsResult>(state, payload);
+    }
+
+    void DestroyGetTableStatsResultNoArena(benchmark::State& state) {
+        const TString payload = MakeGetTableStatsResultPayload(state.range(0), state.range(1), state.range(2));
+        BenchDestroy<TEvGetTableStatsResultNoArena>(state, payload);
+    }
+
+    // range(0)/(1) as in LoadPeriodicTableStats*.
+    void DestroyPeriodicTableStatsArena(benchmark::State& state) {
+        const TString payload = MakePeriodicTableStatsPayload(state.range(0), state.range(1));
+        BenchDestroy<TEvDataShard::TEvPeriodicTableStats>(state, payload);
+    }
+
+    void DestroyPeriodicTableStatsNoArena(benchmark::State& state) {
+        const TString payload = MakePeriodicTableStatsPayload(state.range(0), state.range(1));
+        BenchDestroy<TEvPeriodicTableStatsNoArena>(state, payload);
+    }
+
+    // Bucket count: 0, 10 (typical), 50, 500 (the documented worst case) x split-protocol variant
+    // (0 = DataSizeHistogram+KeyAccessSample, 1 = SplitBySizeSuggestedKey/SplitByLoadSuggestedKey)
+    // x UserTablePartOwners count (1 = steady state, 4 = representative post-split, 32 = deep
+    // split-chain worst case).
+    BENCHMARK(LoadGetTableStatsResultArena)
+        ->ArgsProduct({{0, 10, 50, 500}, {0, 1}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+    BENCHMARK(LoadGetTableStatsResultNoArena)
+        ->ArgsProduct({{0, 10, 50, 500}, {0, 1}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+    BENCHMARK(DestroyGetTableStatsResultArena)
+        ->ArgsProduct({{0, 10, 50, 500}, {0, 1}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+    BENCHMARK(DestroyGetTableStatsResultNoArena)
+        ->ArgsProduct({{0, 10, 50, 500}, {0, 1}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+
+    // Channel count: 1 (single-channel table), 3 (typical), 256 (documented worst case) x
+    // UserTablePartOwners count (see LoadGetTableStatsResult*).
+    BENCHMARK(LoadPeriodicTableStatsArena)
+        ->ArgsProduct({{1, 3, 256}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+    BENCHMARK(LoadPeriodicTableStatsNoArena)
+        ->ArgsProduct({{1, 3, 256}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+    BENCHMARK(DestroyPeriodicTableStatsArena)
+        ->ArgsProduct({{1, 3, 256}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+    BENCHMARK(DestroyPeriodicTableStatsNoArena)
+        ->ArgsProduct({{1, 3, 256}, {1, 4, 32}})
+        ->Unit(benchmark::kMicrosecond);
+
+} // namespace

--- a/ydb/core/tx/schemeshard/ut_stats_bench/ya.make
+++ b/ydb/core/tx/schemeshard/ut_stats_bench/ya.make
@@ -1,0 +1,21 @@
+G_BENCHMARK(ut_stats_bench)
+
+TAG(ya:manual)
+
+SIZE(MEDIUM)
+
+# Run the binary directly (or with a larger --benchmark_min_time) when comparing numbers
+# before and after a change.
+BENCHMARK_OPTS(--benchmark_min_time=0.05s)
+
+SRCS(
+    b_table_stats_arena.cpp
+)
+
+PEERDIR(
+    ydb/core/tx/datashard
+    ydb/core/protos
+    ydb/library/actors/core
+)
+
+END()


### PR DESCRIPTION
Schemeshard now parses `TEvPeriodicTableStats`/`TEvGetTableStatsResult` via protobuf arenas instead of per-submessage heap allocs (histogram buckets, per-channel stats, part owners, TabletMetrics), cutting CPU on the datashard-stats receive path.

Initial arena block sizes are picked per event from typical message shape. Added two percentile counters logging `Arena->SpaceUsed()` per message to check block-size fit against real traffic over time.

Manual bench (`ut_stats_bench`) confirms arena wins across configurations:
- `TEvPeriodicTableStats`
	- full parse-destroy `1.34x` faster
	- destroy `1.72x` faster  (up to `25-34x` for high-channel-count reports)
- `TEvGetTableStatsResult`
	- full parse-destroy `1.33-1.52x` faster
	- destroy `2.03-2.83x` faster
