### PR TITLE
shared reading: support structued parsing for Variant type: pushdown for Variant accessor

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -235,33 +235,7 @@ public:
         }
     }
 
-    bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional, bool isQuiet = false) const {
-        Y_ENSURE(HolderFactory); // should be already verified by ParseNestedType
-        simdjson::builtin::ondemand::json_type cellType;
-        CHECK_JSON_ERROR(jsonValue.type().get(cellType)) {
-            SetParsingError(error, jsonValue, "determine json value type", status, isQuiet);
-            return false;
-        }
-
-        if (cellType == simdjson::builtin::ondemand::json_type::null) {
-            bool isNull;
-            CHECK_JSON_ERROR(jsonValue.is_null().get(isNull)) {
-                SetParsingError(error, jsonValue, "parse as null", status, isQuiet);
-                return false;
-            }
-            if (isOptional) {
-                resultValue = NYql::NUdf::TUnboxedValuePod();
-                return true;
-            }
-            if (IsNullableType(type, resultValue)) {
-                return true;
-            }
-            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
-            return false;
-        }
-
-        switch (type->GetKind()) {
-            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
+    bool ParseVariantValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
                 auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
                 const auto alternativesCount = variantType->GetAlternativesCount();
                 simdjson::ondemand::parser parser;
@@ -324,25 +298,9 @@ public:
                     status.AddParentIssue(TStringBuilder() << "Failed to parse as Variant type");
                 }
                 return false;
-            }
+    }
 
-            case NKikimr::NMiniKQL::TTypeBase::EKind::Data: {
-                auto maybeDataSlot = AS_TYPE(NKikimr::NMiniKQL::TDataType, type)->GetDataSlot();
-                Y_ENSURE(maybeDataSlot);
-                auto dataSlot = *maybeDataSlot;
-                if (dataSlot != NYql::NUdf::EDataSlot::Json) {
-                    return ParseDataType(std::move(jsonValue), resultValue, status, dataSlot, isOptional, NYql::NUdf::GetDataTypeInfo(dataSlot).Name, isQuiet);
-                } else {
-                    return ParseJsonType(std::move(jsonValue), resultValue, status, isQuiet);
-                }
-            }
-
-            case NKikimr::NMiniKQL::TTypeBase::EKind::Optional: {
-                Y_ENSURE(!isOptional);
-                return ParseNestedValue(std::move(jsonValue), resultValue, status, AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), true, isQuiet);
-            }
-
-            case NKikimr::NMiniKQL::TTypeBase::EKind::List: {
+    bool ParseListValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
                 if (cellType != simdjson::builtin::ondemand::json_type::array) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
                     return false;
@@ -371,10 +329,10 @@ public:
                     listBuilder->Add(std::move(value));
                 }
                 resultValue = listBuilder->Build();
-                break;
-            }
+                return true;
+    }
 
-            case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple: {
+    bool ParseTupleValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
                 if (cellType != simdjson::builtin::ondemand::json_type::array) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
                     return false;
@@ -414,10 +372,10 @@ public:
                     }
                 }
                 resultValue = std::move(tuple);
-                break;
-            }
+                return true;
+    }
 
-            case NKikimr::NMiniKQL::TTypeBase::EKind::Struct: {
+    bool ParseStructValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
                 if (cellType != simdjson::builtin::ondemand::json_type::object) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
                     return false;
@@ -472,10 +430,10 @@ public:
                     }
                 }
                 resultValue = std::move(structValue);
-                break;
-            }
+                return true;
+    }
 
-            case NKikimr::NMiniKQL::TTypeBase::EKind::Dict: {
+    bool ParseDictValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
                 if (cellType != simdjson::builtin::ondemand::json_type::object) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
                     return false;
@@ -541,7 +499,64 @@ public:
                     return true;
                 }
                 return false;
+    }
+
+    bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional, bool isQuiet = false) const {
+        Y_ENSURE(HolderFactory); // should be already verified by ParseNestedType
+        simdjson::builtin::ondemand::json_type cellType;
+        CHECK_JSON_ERROR(jsonValue.type().get(cellType)) {
+            SetParsingError(error, jsonValue, "determine json value type", status, isQuiet);
+            return false;
+        }
+
+        if (cellType == simdjson::builtin::ondemand::json_type::null) {
+            bool isNull;
+            CHECK_JSON_ERROR(jsonValue.is_null().get(isNull)) {
+                SetParsingError(error, jsonValue, "parse as null", status, isQuiet);
+                return false;
             }
+            if (isOptional) {
+                resultValue = NYql::NUdf::TUnboxedValuePod();
+                return true;
+            }
+            if (IsNullableType(type, resultValue)) {
+                return true;
+            }
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
+            return false;
+        }
+
+        switch (type->GetKind()) {
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant:
+                return ParseVariantValue(jsonValue, resultValue, status, type, isQuiet, cellType);
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Data: {
+                auto maybeDataSlot = AS_TYPE(NKikimr::NMiniKQL::TDataType, type)->GetDataSlot();
+                Y_ENSURE(maybeDataSlot);
+                auto dataSlot = *maybeDataSlot;
+                if (dataSlot != NYql::NUdf::EDataSlot::Json) {
+                    return ParseDataType(std::move(jsonValue), resultValue, status, dataSlot, isOptional, NYql::NUdf::GetDataTypeInfo(dataSlot).Name, isQuiet);
+                } else {
+                    return ParseJsonType(std::move(jsonValue), resultValue, status, isQuiet);
+                }
+            }
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Optional: {
+                Y_ENSURE(!isOptional);
+                return ParseNestedValue(std::move(jsonValue), resultValue, status, AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), true, isQuiet);
+            }
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::List:
+                return ParseListValue(jsonValue, resultValue, status, type, isQuiet, cellType);
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple:
+                return ParseTupleValue(jsonValue, resultValue, status, type, isQuiet, cellType);
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Struct:
+                return ParseStructValue(jsonValue, resultValue, status, type, isQuiet, cellType);
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Dict:
+                return ParseDictValue(jsonValue, resultValue, status, type, isQuiet, cellType);
 
             default:
                 // should've been handled in ParseNestedType

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -227,7 +227,7 @@ public:
                 auto tupleType = AS_TYPE(NKikimr::NMiniKQL::TTupleType, type);
                 auto elementsCount = tupleType->GetElementsCount();
                 NYql::NUdf::TUnboxedValue *resultValues;
-                auto tuple = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
+                NYql::NUdf::TUnboxedValue tuple = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
                 size_t idx = 0;
                 array.reset();
                 for (auto elt : array) {
@@ -270,7 +270,7 @@ public:
                 Y_ENSURE(memberNames.size() == membersCount);
 
                 NYql::NUdf::TUnboxedValue *resultValues;
-                auto structValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
+                NYql::NUdf::TUnboxedValue structValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
                 object.reset();
                 for (auto elt : object) {
                     std::string_view name;
@@ -338,7 +338,7 @@ public:
                 GetDictionaryKeyTypes(keyType, keyTypes, isTuple, encoded, useIHash);
                 Y_ENSURE(!(isTuple || encoded || useIHash));
                 status = TStatus::Success();
-                auto dictValue = HolderFactory->CreateDirectHashedDictHolder(
+                NYql::NUdf::TUnboxedValue dictValue = HolderFactory->CreateDirectHashedDictHolder(
                     [&, this](auto& map) {
                         for (auto elt : jsonObject) {
                             std::string_view name;

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -168,6 +168,7 @@ public:
                         resultValue = HolderFactory->CreateVariantHolder(resultValue, index);
                         return true;
                     }
+                    resultValue = NYql::NUdf::TUnboxedValue();
                 }
                 if (status.IsSuccess()) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse Variant type");
@@ -226,7 +227,7 @@ public:
                 auto tupleType = AS_TYPE(NKikimr::NMiniKQL::TTupleType, type);
                 auto elementsCount = tupleType->GetElementsCount();
                 NYql::NUdf::TUnboxedValue *resultValues;
-                resultValue = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
+                auto tuple = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
                 size_t idx = 0;
                 array.reset();
                 for (auto elt : array) {
@@ -250,6 +251,7 @@ public:
                         return false;
                     }
                 }
+                resultValue = std::move(tuple);
                 break;
             }
 
@@ -268,7 +270,7 @@ public:
                 Y_ENSURE(memberNames.size() == membersCount);
 
                 NYql::NUdf::TUnboxedValue *resultValues;
-                resultValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
+                auto structValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
                 object.reset();
                 for (auto elt : object) {
                     std::string_view name;
@@ -301,6 +303,7 @@ public:
                         return false;
                     }
                 }
+                resultValue = std::move(structValue);
                 break;
             }
 
@@ -335,7 +338,7 @@ public:
                 GetDictionaryKeyTypes(keyType, keyTypes, isTuple, encoded, useIHash);
                 Y_ENSURE(!(isTuple || encoded || useIHash));
                 status = TStatus::Success();
-                resultValue = HolderFactory->CreateDirectHashedDictHolder(
+                auto dictValue = HolderFactory->CreateDirectHashedDictHolder(
                     [&, this](auto& map) {
                         for (auto elt : jsonObject) {
                             std::string_view name;
@@ -358,7 +361,11 @@ public:
                         }
                     },
                     keyTypes, false, true, nullptr, nullptr, nullptr);
-                return status.IsSuccess();
+                if (status.IsSuccess()) {
+                    resultValue = std::move(dictValue);
+                    return true;
+                }
+                return false;
             }
 
             default:

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -151,10 +151,33 @@ public:
                 return true;
             }
             status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
-            return false;
+            if (type->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Variant) {
+                return false;
+            }
+            // if Variant type has optional component, json null may be accepted
         }
 
         switch (type->GetKind()) {
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
+                auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
+                const auto alternativesCount = variantType->GetAlternativesCount();
+                for (ui32 index = 0; index != alternativesCount; ++index) {
+                    auto alternativeType = variantType->GetAlternativeType(index);
+                    status = TStatus::Success();
+                    if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false)) {
+                        resultValue = HolderFactory->CreateVariantHolder(resultValue, index);
+                        return true;
+                    }
+                }
+                if (alternativesCount == 0) {
+                    return true;
+                }
+                if (status.IsSuccess()) {
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse Variant type");
+                }
+                return false;
+            }
+
             case NKikimr::NMiniKQL::TTypeBase::EKind::Data: {
                 auto maybeDataSlot = AS_TYPE(NKikimr::NMiniKQL::TDataType, type)->GetDataSlot();
                 Y_ENSURE(maybeDataSlot);
@@ -172,14 +195,16 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::List: {
-                if (cellType != simdjson::builtin::ondemand::json_type::array) {
+                simdjson::ondemand::array array;
+                if (jsonValue.get_array().get(array)) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (List), expected array, but got " << JsonTypeToString(cellType));
                     return false;
                 }
                 auto listType = AS_TYPE(NKikimr::NMiniKQL::TListType, type);
                 auto itemType = listType->GetItemType();
                 auto listBuilder = HolderFactory->NewList();
-                for (auto elt : jsonValue.get_array()) {
+                array.reset();
+                for (auto elt : array) {
                     simdjson::builtin::ondemand::value eltValue;
                     CHECK_JSON_ERROR(elt.get(eltValue)) {
                         SetParsingError(error, jsonValue, "parse as array", status);
@@ -196,7 +221,8 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple: {
-                if (cellType != simdjson::builtin::ondemand::json_type::array) {
+                simdjson::ondemand::array array;
+                if (jsonValue.get_array().get(array)) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Tuple), expected array, but got " << JsonTypeToString(cellType));
                     return false;
                 }
@@ -205,7 +231,8 @@ public:
                 NYql::NUdf::TUnboxedValue *resultValues;
                 resultValue = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
                 size_t idx = 0;
-                for (auto elt : jsonValue.get_array()) {
+                array.reset();
+                for (auto elt : array) {
                     if (idx == elementsCount) {
                         break;
                     }
@@ -230,7 +257,8 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Struct: {
-                if (cellType != simdjson::builtin::ondemand::json_type::object) {
+                simdjson::ondemand::object object;
+                if (jsonValue.get_object().get(object)) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Struct), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
@@ -244,7 +272,8 @@ public:
 
                 NYql::NUdf::TUnboxedValue *resultValues;
                 resultValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
-                for (auto elt : jsonValue.get_object()) {
+                object.reset();
+                for (auto elt : object) {
                     std::string_view name;
                     {
                         CHECK_JSON_ERROR(elt.escaped_key().get(name)) {
@@ -279,11 +308,12 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Dict: {
-                if (cellType != simdjson::builtin::ondemand::json_type::object) {
+                simdjson::ondemand::object jsonObject;
+                if (jsonValue.get_object().get(jsonObject)) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Dict), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
-                auto jsonObject = jsonValue.get_object();
+                jsonObject.reset();
                 {
                     bool isEmpty;
                     CHECK_JSON_ERROR(jsonObject.is_empty().get(isEmpty)) {
@@ -512,6 +542,21 @@ private:
                 }
                 break;
             }
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
+                auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
+                auto alternativeCount = variantType->GetAlternativesCount();
+                auto index = value.GetVariantIndex();
+                if (!(index < alternativeCount)) {
+                    Y_DEBUG_ABORT();
+                    return false;
+                }
+                auto variantItem = value.GetVariantItem();
+                if (!ValidateObjectRefs(variantType->GetAlternativeType(index), variantItem, 2)) { // two refs expected: one from object, one from variantItem
+                    Y_DEBUG_ABORT();
+                    return false;
+                }
+                break;
+            }
             default:
                 Y_ABORT();
         }
@@ -592,6 +637,19 @@ private:
                 break;
             }
 
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
+                auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
+                const auto alternativesCount = variantType->GetAlternativesCount();
+                for (ui32 index = 0; index != alternativesCount; ++index) {
+                    auto alternativeType = variantType->GetAlternativeType(index);
+                    auto success = ParseNestedType(alternativeType);
+                    if (!success) {
+                        return success;
+                    }
+                }
+                break;
+            }
+
             default: {
                 return TStatus::Fail(EStatusId::UNSUPPORTED, TStringBuilder() << "Unsupported type kind: " << type->GetKindAsStr());
             }
@@ -618,6 +676,7 @@ private:
                 IsOptional = true;
                 return ExtractDataSlot(AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType());
             }
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Dict:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Struct:

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -319,7 +319,7 @@ public:
                 }
                 if (status.IsSuccess()) {
                     // Note: we try to keep error from last alternative, but this won't work if tail is rejected by early json type mismatch check. So, just ensure some error is reported
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse as Variant type");
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse as Variant type" << ", json type: " << JsonTypeToString(cellType) << ", current token: '" << TruncateString(jsonValue.raw_json_token()) << "'");
                 } else if (!isQuiet) {
                     status.AddParentIssue(TStringBuilder() << "Failed to parse as Variant type");
                 }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -939,7 +939,7 @@ private:
 
                 resultValue = NKikimr::NMiniKQL::ValueFromString(dataSlot, rawString);
                 if (Y_UNLIKELY(!resultValue)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
+                    status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
                 }
                 return resultValue.HasValue();
             }
@@ -1022,7 +1022,7 @@ private:
 
         TJsonNumber number = jsonNumber.value();
         if (Y_UNLIKELY(number < std::numeric_limits<TResult>::min() || std::numeric_limits<TResult>::max() < number)) {
-            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Number is out of range [" << ToString(std::numeric_limits<TResult>::min()) << ", " << ToString(std::numeric_limits<TResult>::max()) << "]");
+            status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Number is out of range [" << ToString(std::numeric_limits<TResult>::min()) << ", " << ToString(std::numeric_limits<TResult>::max()) << "]");
             return;
         }
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -137,11 +137,11 @@ public:
         return Status;
     }
 
-    bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional) const {
+    bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional, bool isQuiet = false) const {
         Y_ENSURE(HolderFactory); // should be already verified by ParseNestedType
         simdjson::builtin::ondemand::json_type cellType;
         CHECK_JSON_ERROR(jsonValue.type().get(cellType)) {
-            SetParsingError(error, jsonValue, "determine json value type", status);
+            SetParsingError(error, jsonValue, "determine json value type", status, isQuiet);
             return false;
         }
 
@@ -150,7 +150,7 @@ public:
                 resultValue = NYql::NUdf::TUnboxedValuePod();
                 return true;
             }
-            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
             if (type->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Variant) {
                 return false;
             }
@@ -164,7 +164,7 @@ public:
                 for (ui32 index = 0; index != alternativesCount; ++index) {
                     auto alternativeType = variantType->GetAlternativeType(index);
                     status = TStatus::Success();
-                    if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false)) {
+                    if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false, index + 1 != alternativesCount || isQuiet)) {
                         resultValue = HolderFactory->CreateVariantHolder(resultValue, index);
                         return true;
                     }
@@ -173,7 +173,7 @@ public:
                     return true;
                 }
                 if (status.IsSuccess()) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse Variant type");
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse Variant type");
                 }
                 return false;
             }
@@ -183,21 +183,21 @@ public:
                 Y_ENSURE(maybeDataSlot);
                 auto dataSlot = *maybeDataSlot;
                 if (dataSlot != NYql::NUdf::EDataSlot::Json) {
-                    return ParseDataType(std::move(jsonValue), resultValue, status, dataSlot, isOptional, NYql::NUdf::GetDataTypeInfo(dataSlot).Name);
+                    return ParseDataType(std::move(jsonValue), resultValue, status, dataSlot, isOptional, NYql::NUdf::GetDataTypeInfo(dataSlot).Name, isQuiet);
                 } else {
-                    return ParseJsonType(std::move(jsonValue), resultValue, status);
+                    return ParseJsonType(std::move(jsonValue), resultValue, status, isQuiet);
                 }
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Optional: {
                 Y_ENSURE(!isOptional);
-                return ParseNestedValue(std::move(jsonValue), resultValue, status, AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), true);
+                return ParseNestedValue(std::move(jsonValue), resultValue, status, AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), true, isQuiet);
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::List: {
                 simdjson::ondemand::array array;
                 if (jsonValue.get_array().get(array)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (List), expected array, but got " << JsonTypeToString(cellType));
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (List), expected array, but got " << JsonTypeToString(cellType));
                     return false;
                 }
                 auto listType = AS_TYPE(NKikimr::NMiniKQL::TListType, type);
@@ -207,11 +207,11 @@ public:
                 for (auto elt : array) {
                     simdjson::builtin::ondemand::value eltValue;
                     CHECK_JSON_ERROR(elt.get(eltValue)) {
-                        SetParsingError(error, jsonValue, "parse as array", status);
+                        SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
                         return false;
                     }
                     NYql::NUdf::TUnboxedValue value;
-                    if (!ParseNestedValue(std::move(eltValue), value, status, itemType, false)) {
+                    if (!ParseNestedValue(std::move(eltValue), value, status, itemType, false, isQuiet)) {
                         return false;
                     }
                     listBuilder->Add(std::move(value));
@@ -223,7 +223,7 @@ public:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple: {
                 simdjson::ondemand::array array;
                 if (jsonValue.get_array().get(array)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Tuple), expected array, but got " << JsonTypeToString(cellType));
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Tuple), expected array, but got " << JsonTypeToString(cellType));
                     return false;
                 }
                 auto tupleType = AS_TYPE(NKikimr::NMiniKQL::TTupleType, type);
@@ -238,10 +238,10 @@ public:
                     }
                     simdjson::builtin::ondemand::value eltValue;
                     CHECK_JSON_ERROR(elt.get(eltValue)) {
-                        SetParsingError(error, jsonValue, "parse as array (tuple)", status);
+                        SetParsingError(error, jsonValue, "parse as array (tuple)", status, isQuiet);
                         return false;
                     }
-                    if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, tupleType->GetElementType(idx), false)) {
+                    if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, tupleType->GetElementType(idx), false, isQuiet)) {
                         return false;
                     }
                     ++idx;
@@ -259,7 +259,7 @@ public:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Struct: {
                 simdjson::ondemand::object object;
                 if (jsonValue.get_object().get(object)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Struct), expected object, but got " << JsonTypeToString(cellType));
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Struct), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
                 auto structType = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
@@ -277,7 +277,7 @@ public:
                     std::string_view name;
                     {
                         CHECK_JSON_ERROR(elt.escaped_key().get(name)) {
-                            SetParsingError(error, jsonValue, "parse as object", status);
+                            SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                             return false;
                         }
                     }
@@ -289,18 +289,18 @@ public:
 
                     simdjson::builtin::ondemand::value eltValue;
                     CHECK_JSON_ERROR(elt.value().get(eltValue)) {
-                        SetParsingError(error, jsonValue, "parse as object", status);
+                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                         return false;
                     }
 
-                    if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, structType->GetMemberType(idx), false)) {
+                    if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, structType->GetMemberType(idx), false, isQuiet)) {
                         return false;
                     }
                 }
 
                 for (ui32 idx = 0; idx != membersCount; ++idx) {
                     if (!resultValues[idx] && structType->GetMemberType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
-                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Struct), expected non-optional field " << structType->GetMemberName(idx));
+                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Struct), expected non-optional field " << structType->GetMemberName(idx));
                         return false;
                     }
                 }
@@ -310,14 +310,14 @@ public:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Dict: {
                 simdjson::ondemand::object jsonObject;
                 if (jsonValue.get_object().get(jsonObject)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Dict), expected object, but got " << JsonTypeToString(cellType));
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Dict), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
                 jsonObject.reset();
                 {
                     bool isEmpty;
                     CHECK_JSON_ERROR(jsonObject.is_empty().get(isEmpty)) {
-                        SetParsingError(error, jsonValue, "parse as object", status);
+                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                         return false;
                     }
                     if (isEmpty) {
@@ -344,17 +344,17 @@ public:
                             std::string_view name;
                             {
                                 CHECK_JSON_ERROR(elt.escaped_key().get(name)) {
-                                    SetParsingError(error, jsonValue, "parse as object", status);
+                                    SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                                     return;
                                 }
                             }
                             simdjson::builtin::ondemand::value eltValue;
                             CHECK_JSON_ERROR(elt.value().get(eltValue)) {
-                                SetParsingError(error, jsonValue, "parse as object", status);
+                                SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                                 return;
                             }
                             NYql::NUdf::TUnboxedValue payload;
-                            if (!ParseNestedValue(std::move(eltValue), payload, status, payloadType, false)) {
+                            if (!ParseNestedValue(std::move(eltValue), payload, status, payloadType, false, isQuiet)) {
                                 return;
                             }
                             map.emplace(NKikimr::NMiniKQL::ValueFromString(*keyDataSlot, name), std::move(payload));
@@ -366,7 +366,7 @@ public:
 
             default:
                 // should've been handled in ParseNestedType
-                status = TStatus::Fail(EStatusId::UNSUPPORTED, TStringBuilder() << "Unsupported type kind: " << type->GetKindAsStr());
+                status = TStatus::Fail(EStatusId::UNSUPPORTED, isQuiet ? TString() : TStringBuilder() << "Unsupported type kind: " << type->GetKindAsStr());
                 return false;
         }
         return true;
@@ -695,10 +695,10 @@ private:
         return ParseDataType(jsonValue, resultValue, status, DataSlot, IsOptional, DataTypeName);
     }
 
-    Y_FORCE_INLINE bool ParseDataType(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, NYql::NUdf::EDataSlot dataSlot, bool isOptional, const TStringBuf dataTypeName) const {
+    Y_FORCE_INLINE bool ParseDataType(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, NYql::NUdf::EDataSlot dataSlot, bool isOptional, const TStringBuf dataTypeName, bool isQuiet = false) const {
         simdjson::builtin::ondemand::json_type cellType;
         CHECK_JSON_ERROR(jsonValue.type().get(cellType)) {
-            SetParsingError(error, jsonValue, "determine json value type", status);
+            SetParsingError(error, jsonValue, "determine json value type", status, isQuiet);
             return false;
         }
 
@@ -706,43 +706,43 @@ private:
             case simdjson::builtin::ondemand::json_type::number: {
                 switch (dataSlot) {
                     case NYql::NUdf::EDataSlot::Int8:
-                        ParseJsonNumber<i8>(jsonValue.get_int64(), resultValue, status);
+                        ParseJsonNumber<i8>(jsonValue.get_int64(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Int16:
-                        ParseJsonNumber<i16>(jsonValue.get_int64(), resultValue, status);
+                        ParseJsonNumber<i16>(jsonValue.get_int64(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Int32:
-                        ParseJsonNumber<i32>(jsonValue.get_int64(), resultValue, status);
+                        ParseJsonNumber<i32>(jsonValue.get_int64(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Int64:
-                        ParseJsonNumber<i64>(jsonValue.get_int64(), resultValue, status);
+                        ParseJsonNumber<i64>(jsonValue.get_int64(), resultValue, status, isQuiet);
                         break;
 
                     case NYql::NUdf::EDataSlot::Uint8:
-                        ParseJsonNumber<ui8>(jsonValue.get_uint64(), resultValue, status);
+                        ParseJsonNumber<ui8>(jsonValue.get_uint64(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Uint16:
-                        ParseJsonNumber<ui16>(jsonValue.get_uint64(), resultValue, status);
+                        ParseJsonNumber<ui16>(jsonValue.get_uint64(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Uint32:
-                        ParseJsonNumber<ui32>(jsonValue.get_uint64(), resultValue, status);
+                        ParseJsonNumber<ui32>(jsonValue.get_uint64(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Uint64:
-                        ParseJsonNumber<ui64>(jsonValue.get_uint64(), resultValue, status);
+                        ParseJsonNumber<ui64>(jsonValue.get_uint64(), resultValue, status, isQuiet);
                         break;
 
                     case NYql::NUdf::EDataSlot::Double:
-                        ParseJsonDouble<double>(jsonValue.get_double(), resultValue, status);
+                        ParseJsonDouble<double>(jsonValue.get_double(), resultValue, status, isQuiet);
                         break;
                     case NYql::NUdf::EDataSlot::Float:
-                        ParseJsonDouble<float>(jsonValue.get_double(), resultValue, status);
+                        ParseJsonDouble<float>(jsonValue.get_double(), resultValue, status, isQuiet);
                         break;
 
                     default:
-                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Number value is not expected for data type " << dataTypeName);
+                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Number value is not expected for data type " << dataTypeName);
                         break;
                 }
-                if (Y_UNLIKELY(status.IsFail())) {
+                if (Y_UNLIKELY(status.IsFail()) && !isQuiet) {
                     status.AddParentIssue(TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json number (raw: '" << TruncateString(jsonValue.raw_json_token()) << "')");
                 }
                 return resultValue.HasValue();
@@ -751,13 +751,13 @@ private:
             case simdjson::builtin::ondemand::json_type::string: {
                 std::string_view rawString;
                 CHECK_JSON_ERROR(jsonValue.get_string(rawString)) {
-                    SetParsingError(error, jsonValue, "extract json string", status);
+                    SetParsingError(error, jsonValue, "extract json string", status, isQuiet);
                     return false;
                 }
 
                 resultValue = NKikimr::NMiniKQL::ValueFromString(dataSlot, rawString);
                 if (Y_UNLIKELY(!resultValue)) {
-                    status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
+                    status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
                 }
                 return resultValue.HasValue();
             }
@@ -766,22 +766,22 @@ private:
             case simdjson::builtin::ondemand::json_type::object: {
                 std::string_view rawJson;
                 CHECK_JSON_ERROR(jsonValue.raw_json().get(rawJson)) {
-                    SetParsingError(error, jsonValue, "extract json value", status);
+                    SetParsingError(error, jsonValue, "extract json value", status, isQuiet);
                     return false;
                 }
-                status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Found unexpected nested value (raw: '" << TruncateString(rawJson) << "'), expected data type " << dataTypeName << ", please use Json type for nested values");
+                status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected nested value (raw: '" << TruncateString(rawJson) << "'), expected data type " << dataTypeName << ", please use Json type for nested values");
                 return false;
             }
 
             case simdjson::builtin::ondemand::json_type::boolean: {
                 if (Y_UNLIKELY(dataSlot != NYql::NUdf::EDataSlot::Bool)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Found unexpected bool value, expected data type " << dataTypeName);
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected bool value, expected data type " << dataTypeName);
                     return false;
                 }
 
                 bool boolValue;
                 CHECK_JSON_ERROR(jsonValue.get_bool().get(boolValue)) {
-                    SetParsingError(error, jsonValue, "extract json bool", status);
+                    SetParsingError(error, jsonValue, "extract json bool", status, isQuiet);
                     return false;
                 }
 
@@ -791,7 +791,7 @@ private:
 
             case simdjson::builtin::ondemand::json_type::null: {
                 if (Y_UNLIKELY(!isOptional)) {
-                    status =  TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Found unexpected null value, expected non optional data type " << dataTypeName);
+                    status =  TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional data type " << dataTypeName);
                     return false;
                 }
 
@@ -801,24 +801,24 @@ private:
             case simdjson::builtin::ondemand::json_type::unknown: {
                 std::string_view rawString;
                 CHECK_JSON_ERROR(jsonValue.get_string(rawString)) {
-                    SetParsingError(error, jsonValue, "extract json string", status);
+                    SetParsingError(error, jsonValue, "extract json string", status, isQuiet);
                     return false;
                 }
-                status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
+                status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
                 return false;
             }
         }
     }
 
-    Y_FORCE_INLINE bool ParseJsonType(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status) const {
+    Y_FORCE_INLINE bool ParseJsonType(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, bool isQuiet = false) const {
         std::string_view rawJson;
         CHECK_JSON_ERROR(jsonValue.raw_json().get(rawJson)) {
-            SetParsingError(error, jsonValue, "extract json value", status);
+            SetParsingError(error, jsonValue, "extract json value", status, isQuiet);
             return false;
         }
 
         if (Y_UNLIKELY(!NYql::NDom::IsValidJson(rawJson))) {
-            status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Found bad json value: '" << TruncateString(rawJson) << "'");
+            status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Found bad json value: '" << TruncateString(rawJson) << "'");
             return false;
         }
 
@@ -827,15 +827,15 @@ private:
     }
 
     template <typename TResult, typename TJsonNumber>
-    Y_FORCE_INLINE static void ParseJsonNumber(simdjson::simdjson_result<TJsonNumber> jsonNumber, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status) {
+    Y_FORCE_INLINE static void ParseJsonNumber(simdjson::simdjson_result<TJsonNumber> jsonNumber, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, bool isQuiet = false) {
         CHECK_JSON_ERROR(jsonNumber.error()) {
-            status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to extract json integer number, error: " << simdjson::error_message(error));
+            status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to extract json integer number, error: " << simdjson::error_message(error));
             return;
         }
 
         TJsonNumber number = jsonNumber.value();
         if (Y_UNLIKELY(number < std::numeric_limits<TResult>::min() || std::numeric_limits<TResult>::max() < number)) {
-            status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Number is out of range [" << ToString(std::numeric_limits<TResult>::min()) << ", " << ToString(std::numeric_limits<TResult>::max()) << "]");
+            status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Number is out of range [" << ToString(std::numeric_limits<TResult>::min()) << ", " << ToString(std::numeric_limits<TResult>::max()) << "]");
             return;
         }
 
@@ -843,17 +843,17 @@ private:
     }
 
     template <typename TResult>
-    Y_FORCE_INLINE static void ParseJsonDouble(simdjson::simdjson_result<double> jsonNumber, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status) {
+    Y_FORCE_INLINE static void ParseJsonDouble(simdjson::simdjson_result<double> jsonNumber, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, bool isQuiet = false) {
         CHECK_JSON_ERROR(jsonNumber.error()) {
-            status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to extract json float number, error: " << simdjson::error_message(error));
+            status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to extract json float number, error: " << simdjson::error_message(error));
             return;
         }
 
         resultValue = NYql::NUdf::TUnboxedValuePod(static_cast<TResult>(jsonNumber.value()));
     }
 
-    static void SetParsingError(simdjson::error_code error, simdjson::builtin::ondemand::value jsonValue, const TString& description, TStatus& status) {
-        status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to " << description << ", current token: '" << TruncateString(jsonValue.raw_json_token()) << "', error: " << simdjson::error_message(error));
+    static void SetParsingError(simdjson::error_code error, simdjson::builtin::ondemand::value jsonValue, const TString& description, TStatus& status, bool isQuiet = false) {
+        status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to " << description << ", current token: '" << TruncateString(jsonValue.raw_json_token()) << "', error: " << simdjson::error_message(error));
     }
 
 private:

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -1,3 +1,6 @@
+#ifndef NDEBUG
+#define SIMDJSON_DEVELOPMENT_CHECKS 1
+#endif
 #include "json_parser.h"
 
 #include "parser_base.h"

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -195,7 +195,7 @@ public:
                     auto alternativeType = variantType->GetAlternativeType(index);
                     status = TStatus::Success();
                     if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false, index + 1 != alternativesCount || isQuiet)) {
-                        resultValue = HolderFactory->CreateVariantHolder(resultValue, index);
+                        resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
                         return true;
                     }
                     resultValue = NYql::NUdf::TUnboxedValue();

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -140,6 +140,28 @@ public:
         return Status;
     }
 
+    bool IsNullableType(const NKikimr::NMiniKQL::TType* type, NYql::NUdf::TUnboxedValue& resultValue) const {
+        Y_DEBUG_ABORT_UNLESS(!resultValue);
+        switch(type->GetKind()) {
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Optional:
+                return true;
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
+                auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
+                auto alternativeCount = variantType->GetAlternativesCount();
+                for (ui32 index = 0; index != alternativeCount; ++index) {
+                    if (IsNullableType(variantType->GetAlternativeType(index), resultValue)) {
+                        // nullable alternative found, wrap in holder
+                        resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
+                        return true;
+                    }
+                }
+                [[fallthrough]];
+            }
+            default:
+                return false;
+        }
+    }
+
     bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional, bool isQuiet = false) const {
         Y_ENSURE(HolderFactory); // should be already verified by ParseNestedType
         simdjson::builtin::ondemand::json_type cellType;
@@ -149,15 +171,20 @@ public:
         }
 
         if (cellType == simdjson::builtin::ondemand::json_type::null) {
-            if (isOptional || type->GetKind() == NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
+            bool isNull;
+            CHECK_JSON_ERROR(jsonValue.is_null().get(isNull)) {
+                SetParsingError(error, jsonValue, "parse as null", status, isQuiet);
+                return false;
+            }
+            if (isOptional) {
                 resultValue = NYql::NUdf::TUnboxedValuePod();
                 return true;
             }
-            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
-            if (type->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Variant) {
-                return false;
+            if (IsNullableType(type, resultValue)) {
+                return true;
             }
-            // if Variant type has optional component, json null may be accepted
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional type " << GetTypeName(type));
+            return false;
         }
 
         switch (type->GetKind()) {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -480,9 +480,9 @@ public:
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
-                simdjson::ondemand::object jsonObject;
+                simdjson::ondemand::object object;
                 {
-                    CHECK_JSON_ERROR(jsonValue.get_object().get(jsonObject)) {
+                    CHECK_JSON_ERROR(jsonValue.get_object().get(object)) {
                         SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                         return false;
                     }
@@ -490,7 +490,7 @@ public:
 
                 {
                     bool isEmpty;
-                    CHECK_JSON_ERROR(jsonObject.is_empty().get(isEmpty)) {
+                    CHECK_JSON_ERROR(object.is_empty().get(isEmpty)) {
                         SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                         return false;
                     }
@@ -499,7 +499,7 @@ public:
                         return true;
                     }
                 }
-                jsonObject.reset();
+                object.reset();
                 auto dictType = AS_TYPE(NKikimr::NMiniKQL::TDictType, type);
                 auto keyType = dictType->GetKeyType();
                 Y_ENSURE(keyType->GetKind() == NKikimr::NMiniKQL::TTypeBase::EKind::Data); // should be already verified, not user-data-error
@@ -515,7 +515,7 @@ public:
                 status = TStatus::Success();
                 NYql::NUdf::TUnboxedValue dictValue = HolderFactory->CreateDirectHashedDictHolder(
                     [&, this](auto& map) {
-                        for (auto elt : jsonObject) {
+                        for (auto elt : object) {
                             std::string_view name;
                             {
                                 CHECK_JSON_ERROR(elt.escaped_key().get(name)) {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -308,6 +308,10 @@ public:
                         return true;
                     }
                     if (doc.error() != simdjson::error_code::UNINITIALIZED) {
+                        if (!doc->is_alive()) {
+                            // json parsing error, unrecoverable, not safe to continue
+                            break;
+                        }
                         doc.rewind();
                     }
                     resultValue = NYql::NUdf::TUnboxedValue();

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -236,269 +236,269 @@ public:
     }
 
     bool ParseVariantValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
-                auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
-                const auto alternativesCount = variantType->GetAlternativesCount();
-                simdjson::ondemand::parser parser;
-                simdjson::simdjson_result<simdjson::ondemand::document> doc;
-                // we need to know validAlternativesLimit to
-                // 1) check if non-scalar alternative is last possible (then we can avoid re-parsing);
-                // 2) return error from last failed alternative;
-                // tc is O(sum alternativesCount) anyway
-                ui32 validAlternativesLimit = alternativesCount;
-                while (validAlternativesLimit > 0) {
-                    auto alternativeType = variantType->GetAlternativeType(validAlternativesLimit - 1);
-                    if (ValidateJsonType(alternativeType, cellType, jsonValue)) {
-                        break;
-                    }
-                    --validAlternativesLimit;
+        auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
+        const auto alternativesCount = variantType->GetAlternativesCount();
+        simdjson::ondemand::parser parser;
+        simdjson::simdjson_result<simdjson::ondemand::document> doc;
+        // we need to know validAlternativesLimit to
+        // 1) check if non-scalar alternative is last possible (then we can avoid re-parsing);
+        // 2) return error from last failed alternative;
+        // tc is O(sum alternativesCount) anyway
+        ui32 validAlternativesLimit = alternativesCount;
+        while (validAlternativesLimit > 0) {
+            auto alternativeType = variantType->GetAlternativeType(validAlternativesLimit - 1);
+            if (ValidateJsonType(alternativeType, cellType, jsonValue)) {
+                break;
+            }
+            --validAlternativesLimit;
+        }
+        auto innerJsonValue = jsonValue;
+        for (ui32 index = 0; index != validAlternativesLimit; ++index) {
+            auto alternativeType = variantType->GetAlternativeType(index);
+            if (!ValidateJsonType(alternativeType, cellType, jsonValue)) {
+                continue;
+            }
+            if (doc.error() == simdjson::error_code::UNINITIALIZED && !jsonValue.is_scalar() && index + 1 != validAlternativesLimit) {
+                // With non-scalar types we must use re-parsing
+                // With scalar types, we cannot do reparsing (and it would be inefficient)
+                // Note that scalar case relies on repeated calls `value.get_string(consumer)`, which is not exactly documented (and, on the contrary, `sv = value.get_string()` does NOT work, in a very nasty way -- it triggers OOB writes)
+                // Also note that we cannot just (easily) reparse scalar values, as
+                // we cannot .get(value) from scalar document
+                std::string_view rawJson;
+                CHECK_JSON_ERROR(jsonValue.raw_json().get(rawJson)) {
+                    SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
+                    return false;
                 }
-                auto innerJsonValue = jsonValue;
-                for (ui32 index = 0; index != validAlternativesLimit; ++index) {
-                    auto alternativeType = variantType->GetAlternativeType(index);
-                    if (!ValidateJsonType(alternativeType, cellType, jsonValue)) {
-                        continue;
-                    }
-                    if (doc.error() == simdjson::error_code::UNINITIALIZED && !jsonValue.is_scalar() && index + 1 != validAlternativesLimit) {
-                        // With non-scalar types we must use re-parsing
-                        // With scalar types, we cannot do reparsing (and it would be inefficient)
-                        // Note that scalar case relies on repeated calls `value.get_string(consumer)`, which is not exactly documented (and, on the contrary, `sv = value.get_string()` does NOT work, in a very nasty way -- it triggers OOB writes)
-                        // Also note that we cannot just (easily) reparse scalar values, as
-                        // we cannot .get(value) from scalar document
-                        std::string_view rawJson;
-                        CHECK_JSON_ERROR(jsonValue.raw_json().get(rawJson)) {
-                            SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
-                            return false;
-                        }
-                        doc = parser.iterate(simdjson::padded_string_view(rawJson, rawJson.size() + simdjson::SIMDJSON_PADDING)); // as rawJson points to original document, we *know* padding is present
-                    }
-                    if (doc.error() != simdjson::error_code::UNINITIALIZED) {
-                        CHECK_JSON_ERROR(doc.get(innerJsonValue)) {
-                            SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
-                            return false;
-                        }
-                    }
-                    status = TStatus::Success();
-                    if (ParseNestedValue(innerJsonValue, resultValue, status, alternativeType, false, index + 1 != validAlternativesLimit || isQuiet)) {
-                        resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
-                        return true;
-                    }
-                    if (doc.error() != simdjson::error_code::UNINITIALIZED) {
-                        if (!doc->is_alive()) {
-                            // json parsing error, unrecoverable, not safe to continue
-                            break;
-                        }
-                        doc.rewind();
-                    }
-                    resultValue = NYql::NUdf::TUnboxedValue();
+                doc = parser.iterate(simdjson::padded_string_view(rawJson, rawJson.size() + simdjson::SIMDJSON_PADDING)); // as rawJson points to original document, we *know* padding is present
+            }
+            if (doc.error() != simdjson::error_code::UNINITIALIZED) {
+                CHECK_JSON_ERROR(doc.get(innerJsonValue)) {
+                    SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
+                    return false;
                 }
-                if (status.IsSuccess()) {
-                    // Note: we try to keep error from last alternative, but this won't work if tail is rejected by early json type mismatch check. So, just ensure some error is reported
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse as Variant type" << ", json type: " << JsonTypeToString(cellType) << ", current token: '" << TruncateString(jsonValue.raw_json_token()) << "'");
-                } else if (!isQuiet) {
-                    status.AddParentIssue(TStringBuilder() << "Failed to parse as Variant type");
+            }
+            status = TStatus::Success();
+            if (ParseNestedValue(innerJsonValue, resultValue, status, alternativeType, false, index + 1 != validAlternativesLimit || isQuiet)) {
+                resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
+                return true;
+            }
+            if (doc.error() != simdjson::error_code::UNINITIALIZED) {
+                if (!doc->is_alive()) {
+                    // json parsing error, unrecoverable, not safe to continue
+                    break;
                 }
-                return false;
+                doc.rewind();
+            }
+            resultValue = NYql::NUdf::TUnboxedValue();
+        }
+        if (status.IsSuccess()) {
+            // Note: we try to keep error from last alternative, but this won't work if tail is rejected by early json type mismatch check. So, just ensure some error is reported
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse as Variant type" << ", json type: " << JsonTypeToString(cellType) << ", current token: '" << TruncateString(jsonValue.raw_json_token()) << "'");
+        } else if (!isQuiet) {
+            status.AddParentIssue(TStringBuilder() << "Failed to parse as Variant type");
+        }
+        return false;
     }
 
     bool ParseListValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
-                if (cellType != simdjson::builtin::ondemand::json_type::array) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
-                    return false;
-                }
-                simdjson::ondemand::array array;
-                {
-                    CHECK_JSON_ERROR(jsonValue.get_array().get(array)) {
-                        SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
-                        return false;
-                    }
-                }
-                auto listType = AS_TYPE(NKikimr::NMiniKQL::TListType, type);
-                auto itemType = listType->GetItemType();
-                auto listBuilder = HolderFactory->NewList();
-                array.reset();
-                for (auto elt : array) {
-                    simdjson::builtin::ondemand::value eltValue;
-                    CHECK_JSON_ERROR(elt.get(eltValue)) {
-                        SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
-                        return false;
-                    }
-                    NYql::NUdf::TUnboxedValue value;
-                    if (!ParseNestedValue(std::move(eltValue), value, status, itemType, false, isQuiet)) {
-                        return false;
-                    }
-                    listBuilder->Add(std::move(value));
-                }
-                resultValue = listBuilder->Build();
-                return true;
+        if (cellType != simdjson::builtin::ondemand::json_type::array) {
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
+            return false;
+        }
+        simdjson::ondemand::array array;
+        {
+            CHECK_JSON_ERROR(jsonValue.get_array().get(array)) {
+                SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
+                return false;
+            }
+        }
+        auto listType = AS_TYPE(NKikimr::NMiniKQL::TListType, type);
+        auto itemType = listType->GetItemType();
+        auto listBuilder = HolderFactory->NewList();
+        array.reset();
+        for (auto elt : array) {
+            simdjson::builtin::ondemand::value eltValue;
+            CHECK_JSON_ERROR(elt.get(eltValue)) {
+                SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
+                return false;
+            }
+            NYql::NUdf::TUnboxedValue value;
+            if (!ParseNestedValue(std::move(eltValue), value, status, itemType, false, isQuiet)) {
+                return false;
+            }
+            listBuilder->Add(std::move(value));
+        }
+        resultValue = listBuilder->Build();
+        return true;
     }
 
     bool ParseTupleValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
-                if (cellType != simdjson::builtin::ondemand::json_type::array) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
-                    return false;
-                }
-                simdjson::ondemand::array array;
-                {
-                    CHECK_JSON_ERROR(jsonValue.get_array().get(array)) {
-                        SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
-                        return false;
-                    }
-                }
-                auto tupleType = AS_TYPE(NKikimr::NMiniKQL::TTupleType, type);
-                auto elementsCount = tupleType->GetElementsCount();
-                NYql::NUdf::TUnboxedValue *resultValues;
-                NYql::NUdf::TUnboxedValue tuple = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
-                size_t idx = 0;
-                array.reset();
-                for (auto elt : array) {
-                    if (idx == elementsCount) {
-                        break;
-                    }
-                    simdjson::builtin::ondemand::value eltValue;
-                    CHECK_JSON_ERROR(elt.get(eltValue)) {
-                        SetParsingError(error, jsonValue, "parse as array (tuple)", status, isQuiet);
-                        return false;
-                    }
-                    if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, tupleType->GetElementType(idx), false, isQuiet)) {
-                        return false;
-                    }
-                    ++idx;
-                }
-                for (; idx != elementsCount; ++idx) {
-                    // tail must be optional
-                    if (tupleType->GetElementType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
-                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), short json array at index " << idx << ", expected non optional type " << GetTypeName(tupleType->GetElementType(idx)));
-                        return false;
-                    }
-                }
-                resultValue = std::move(tuple);
-                return true;
+        if (cellType != simdjson::builtin::ondemand::json_type::array) {
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
+            return false;
+        }
+        simdjson::ondemand::array array;
+        {
+            CHECK_JSON_ERROR(jsonValue.get_array().get(array)) {
+                SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
+                return false;
+            }
+        }
+        auto tupleType = AS_TYPE(NKikimr::NMiniKQL::TTupleType, type);
+        auto elementsCount = tupleType->GetElementsCount();
+        NYql::NUdf::TUnboxedValue *resultValues;
+        NYql::NUdf::TUnboxedValue tuple = HolderFactory->CreateDirectArrayHolder(elementsCount, resultValues);
+        size_t idx = 0;
+        array.reset();
+        for (auto elt : array) {
+            if (idx == elementsCount) {
+                break;
+            }
+            simdjson::builtin::ondemand::value eltValue;
+            CHECK_JSON_ERROR(elt.get(eltValue)) {
+                SetParsingError(error, jsonValue, "parse as array (tuple)", status, isQuiet);
+                return false;
+            }
+            if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, tupleType->GetElementType(idx), false, isQuiet)) {
+                return false;
+            }
+            ++idx;
+        }
+        for (; idx != elementsCount; ++idx) {
+            // tail must be optional
+            if (tupleType->GetElementType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
+                status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), short json array at index " << idx << ", expected non optional type " << GetTypeName(tupleType->GetElementType(idx)));
+                return false;
+            }
+        }
+        resultValue = std::move(tuple);
+        return true;
     }
 
     bool ParseStructValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
-                if (cellType != simdjson::builtin::ondemand::json_type::object) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
+        if (cellType != simdjson::builtin::ondemand::json_type::object) {
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
+            return false;
+        }
+        simdjson::ondemand::object object;
+        {
+            CHECK_JSON_ERROR(jsonValue.get_object().get(object)) {
+                SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
+                return false;
+            }
+        }
+        auto structType = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
+        auto membersCount = structType->GetMembersCount();
+
+        auto it = StructMembers.find(structType);
+        Y_ENSURE(it != StructMembers.end());
+        const auto& memberNames = it->second;
+        Y_ENSURE(memberNames.size() == membersCount);
+
+        NYql::NUdf::TUnboxedValue *resultValues;
+        NYql::NUdf::TUnboxedValue structValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
+        object.reset();
+        for (auto elt : object) {
+            std::string_view name;
+            {
+                CHECK_JSON_ERROR(elt.escaped_key().get(name)) {
+                    SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
                     return false;
                 }
-                simdjson::ondemand::object object;
-                {
-                    CHECK_JSON_ERROR(jsonValue.get_object().get(object)) {
-                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                        return false;
-                    }
-                }
-                auto structType = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
-                auto membersCount = structType->GetMembersCount();
+            }
+            auto itName = memberNames.find(name);
+            if (itName == memberNames.end()) {
+                continue;
+            }
+            auto idx = itName->second;
 
-                auto it = StructMembers.find(structType);
-                Y_ENSURE(it != StructMembers.end());
-                const auto& memberNames = it->second;
-                Y_ENSURE(memberNames.size() == membersCount);
+            simdjson::builtin::ondemand::value eltValue;
+            CHECK_JSON_ERROR(elt.value().get(eltValue)) {
+                SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
+                return false;
+            }
 
-                NYql::NUdf::TUnboxedValue *resultValues;
-                NYql::NUdf::TUnboxedValue structValue = HolderFactory->CreateDirectArrayHolder(membersCount, resultValues);
-                object.reset();
+            if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, structType->GetMemberType(idx), false, isQuiet)) {
+                return false;
+            }
+        }
+
+        for (ui32 idx = 0; idx != membersCount; ++idx) {
+            if (!resultValues[idx] && structType->GetMemberType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
+                status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected non-optional field " << structType->GetMemberName(idx));
+                return false;
+            }
+        }
+        resultValue = std::move(structValue);
+        return true;
+    }
+
+    bool ParseDictValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
+        if (cellType != simdjson::builtin::ondemand::json_type::object) {
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
+            return false;
+        }
+        simdjson::ondemand::object object;
+        {
+            CHECK_JSON_ERROR(jsonValue.get_object().get(object)) {
+                SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
+                return false;
+            }
+        }
+
+        {
+            bool isEmpty;
+            CHECK_JSON_ERROR(object.is_empty().get(isEmpty)) {
+                SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
+                return false;
+            }
+            if (isEmpty) {
+                resultValue = HolderFactory->GetEmptyContainerLazy();
+                return true;
+            }
+        }
+        object.reset();
+        auto dictType = AS_TYPE(NKikimr::NMiniKQL::TDictType, type);
+        auto keyType = dictType->GetKeyType();
+        Y_ENSURE(keyType->GetKind() == NKikimr::NMiniKQL::TTypeBase::EKind::Data); // should be already verified, not user-data-error
+        auto keyDataSlot = AS_TYPE(NKikimr::NMiniKQL::TDataType, keyType)->GetDataSlot();
+        Y_ENSURE(keyDataSlot); // should be already verified, not user-data-error
+        auto payloadType = dictType->GetPayloadType();
+        NKikimr::NMiniKQL::TKeyTypes keyTypes;
+        bool isTuple;
+        bool encoded;
+        bool useIHash;
+        GetDictionaryKeyTypes(keyType, keyTypes, isTuple, encoded, useIHash);
+        Y_ENSURE(!(isTuple || encoded || useIHash));
+        status = TStatus::Success();
+        NYql::NUdf::TUnboxedValue dictValue = HolderFactory->CreateDirectHashedDictHolder(
+            [&, this](auto& map) {
                 for (auto elt : object) {
                     std::string_view name;
                     {
                         CHECK_JSON_ERROR(elt.escaped_key().get(name)) {
                             SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                            return false;
+                            return;
                         }
                     }
-                    auto itName = memberNames.find(name);
-                    if (itName == memberNames.end()) {
-                        continue;
-                    }
-                    auto idx = itName->second;
-
                     simdjson::builtin::ondemand::value eltValue;
                     CHECK_JSON_ERROR(elt.value().get(eltValue)) {
                         SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                        return false;
+                        return;
                     }
-
-                    if (!ParseNestedValue(std::move(eltValue), resultValues[idx], status, structType->GetMemberType(idx), false, isQuiet)) {
-                        return false;
+                    NYql::NUdf::TUnboxedValue payload;
+                    if (!ParseNestedValue(std::move(eltValue), payload, status, payloadType, false, isQuiet)) {
+                        return;
                     }
+                    map.emplace(NKikimr::NMiniKQL::ValueFromString(*keyDataSlot, name), std::move(payload));
                 }
-
-                for (ui32 idx = 0; idx != membersCount; ++idx) {
-                    if (!resultValues[idx] && structType->GetMemberType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
-                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected non-optional field " << structType->GetMemberName(idx));
-                        return false;
-                    }
-                }
-                resultValue = std::move(structValue);
-                return true;
-    }
-
-    bool ParseDictValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isQuiet, simdjson::builtin::ondemand::json_type cellType) const {
-                if (cellType != simdjson::builtin::ondemand::json_type::object) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
-                    return false;
-                }
-                simdjson::ondemand::object object;
-                {
-                    CHECK_JSON_ERROR(jsonValue.get_object().get(object)) {
-                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                        return false;
-                    }
-                }
-
-                {
-                    bool isEmpty;
-                    CHECK_JSON_ERROR(object.is_empty().get(isEmpty)) {
-                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                        return false;
-                    }
-                    if (isEmpty) {
-                        resultValue = HolderFactory->GetEmptyContainerLazy();
-                        return true;
-                    }
-                }
-                object.reset();
-                auto dictType = AS_TYPE(NKikimr::NMiniKQL::TDictType, type);
-                auto keyType = dictType->GetKeyType();
-                Y_ENSURE(keyType->GetKind() == NKikimr::NMiniKQL::TTypeBase::EKind::Data); // should be already verified, not user-data-error
-                auto keyDataSlot = AS_TYPE(NKikimr::NMiniKQL::TDataType, keyType)->GetDataSlot();
-                Y_ENSURE(keyDataSlot); // should be already verified, not user-data-error
-                auto payloadType = dictType->GetPayloadType();
-                NKikimr::NMiniKQL::TKeyTypes keyTypes;
-                bool isTuple;
-                bool encoded;
-                bool useIHash;
-                GetDictionaryKeyTypes(keyType, keyTypes, isTuple, encoded, useIHash);
-                Y_ENSURE(!(isTuple || encoded || useIHash));
-                status = TStatus::Success();
-                NYql::NUdf::TUnboxedValue dictValue = HolderFactory->CreateDirectHashedDictHolder(
-                    [&, this](auto& map) {
-                        for (auto elt : object) {
-                            std::string_view name;
-                            {
-                                CHECK_JSON_ERROR(elt.escaped_key().get(name)) {
-                                    SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                                    return;
-                                }
-                            }
-                            simdjson::builtin::ondemand::value eltValue;
-                            CHECK_JSON_ERROR(elt.value().get(eltValue)) {
-                                SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
-                                return;
-                            }
-                            NYql::NUdf::TUnboxedValue payload;
-                            if (!ParseNestedValue(std::move(eltValue), payload, status, payloadType, false, isQuiet)) {
-                                return;
-                            }
-                            map.emplace(NKikimr::NMiniKQL::ValueFromString(*keyDataSlot, name), std::move(payload));
-                        }
-                    },
-                    keyTypes, false, true, nullptr, nullptr, nullptr);
-                if (status.IsSuccess()) {
-                    resultValue = std::move(dictValue);
-                    return true;
-                }
-                return false;
+            },
+            keyTypes, false, true, nullptr, nullptr, nullptr);
+        if (status.IsSuccess()) {
+            resultValue = std::move(dictValue);
+            return true;
+        }
+        return false;
     }
 
     bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional, bool isQuiet = false) const {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -162,6 +162,78 @@ public:
         }
     }
 
+    static bool ValidateJsonType(const NKikimr::NMiniKQL::TType* type, simdjson::builtin::ondemand::json_type cellType, simdjson::builtin::ondemand::value& jsonValue) {
+        switch(type->GetKind()) {
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Optional:
+                // null are handled separately
+                return ValidateJsonType(AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), cellType, jsonValue);
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
+                auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
+                const auto alternativesCount = variantType->GetAlternativesCount();
+                for (ui32 index = 0; index != alternativesCount; ++index) {
+                    if (ValidateJsonType(AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), cellType, jsonValue)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Data: {
+                auto maybeDataSlot = AS_TYPE(NKikimr::NMiniKQL::TDataType, type)->GetDataSlot();
+                Y_ENSURE(maybeDataSlot);
+                auto dataSlot = *maybeDataSlot;
+                switch (dataSlot) {
+                    case NYql::NUdf::EDataSlot::Int8:
+                    case NYql::NUdf::EDataSlot::Int16:
+                    case NYql::NUdf::EDataSlot::Int32:
+                    case NYql::NUdf::EDataSlot::Int64:
+                        if (cellType != simdjson::builtin::ondemand::json_type::number) {
+                            return false;
+                        }
+                        return jsonValue.is_integer();
+                    case NYql::NUdf::EDataSlot::Uint8:
+                    case NYql::NUdf::EDataSlot::Uint16:
+                    case NYql::NUdf::EDataSlot::Uint32:
+                    case NYql::NUdf::EDataSlot::Uint64:
+                        if (cellType != simdjson::builtin::ondemand::json_type::number) {
+                            return false;
+                        }
+                        if (jsonValue.is_negative()) {
+                            return false;
+                        }
+                        return jsonValue.is_integer();
+                    case NYql::NUdf::EDataSlot::Double:
+                    case NYql::NUdf::EDataSlot::Float:
+                        return cellType == simdjson::builtin::ondemand::json_type::number;
+                    case NYql::NUdf::EDataSlot::String:
+                    case NYql::NUdf::EDataSlot::Utf8:
+                        return cellType == simdjson::builtin::ondemand::json_type::string;
+                    case NYql::NUdf::EDataSlot::Bool:
+                        return cellType == simdjson::builtin::ondemand::json_type::boolean;
+                    case NYql::NUdf::EDataSlot::Json:
+                        return true;
+                    default:
+                        // Note: we cannot distinguish between various subtypes
+                        // E.g. string may be parsable as Datetime, but first alternative
+                        // is Interval; parsing will fail as a result
+                        return cellType == simdjson::builtin::ondemand::json_type::string;
+                }
+            }
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Struct:
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Dict:
+                return cellType == simdjson::builtin::ondemand::json_type::object;
+
+            case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple:
+            case NKikimr::NMiniKQL::TTypeBase::EKind::List:
+                return cellType == simdjson::builtin::ondemand::json_type::array;
+
+            default:
+                Y_DEBUG_ABORT();
+                return true;
+        }
+    }
+
     bool ParseNestedValue(simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue, TStatus& status, const NKikimr::NMiniKQL::TType* type, bool isOptional, bool isQuiet = false) const {
         Y_ENSURE(HolderFactory); // should be already verified by ParseNestedType
         simdjson::builtin::ondemand::json_type cellType;
@@ -191,16 +263,44 @@ public:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
                 auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
                 const auto alternativesCount = variantType->GetAlternativesCount();
+                simdjson::ondemand::parser parser;
+                simdjson::simdjson_result<simdjson::ondemand::document> doc;
                 for (ui32 index = 0; index != alternativesCount; ++index) {
                     auto alternativeType = variantType->GetAlternativeType(index);
                     status = TStatus::Success();
+                    if (!ValidateJsonType(alternativeType, cellType, jsonValue)) {
+                        continue;
+                    }
+                    if (doc.error() == simdjson::error_code::UNINITIALIZED && !jsonValue.is_scalar()) {
+                        // With non-scalar types we must use re-parsing
+                        // With scalar types, we cannot do reparsing (and it would be inefficient)
+                        // Note that scalar case relies on repeated calls `value.get_string(consumer)`, which is not exactly documented (and, on the contrary, `sv = value.get_string()` does NOT work, in a very nasty way -- it triggers OOB writes)
+                        // Also note that we cannot just (easily) reparse scalar values, as
+                        // we cannot .get(value) from scalar document
+                        std::string_view rawJson;
+                        CHECK_JSON_ERROR(jsonValue.raw_json().get(rawJson)) {
+                            SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
+                            return false;
+                        }
+                        doc = parser.iterate(simdjson::padded_string_view(rawJson, rawJson.size() + simdjson::SIMDJSON_PADDING)); // as rawJson points to original document, we *know* padding is present
+                    }
+                    if (doc.error() != simdjson::error_code::UNINITIALIZED) {
+                        CHECK_JSON_ERROR(doc.get(jsonValue)) {
+                            SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
+                            return false;
+                        }
+                    }
                     if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false, index + 1 != alternativesCount || isQuiet)) {
                         resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
                         return true;
                     }
+                    if (doc.error() != simdjson::error_code::UNINITIALIZED) {
+                        doc.rewind();
+                    }
                     resultValue = NYql::NUdf::TUnboxedValue();
                 }
                 if (status.IsSuccess()) {
+                    // Note: we try to keep error from last alternative, but this won't work if tail is rejected by early json type mismatch check. So, just ensure some error is reported
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse Variant type");
                 }
                 return false;
@@ -343,7 +443,6 @@ public:
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Dict), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
-                jsonObject.reset();
                 {
                     bool isEmpty;
                     CHECK_JSON_ERROR(jsonObject.is_empty().get(isEmpty)) {
@@ -355,6 +454,7 @@ public:
                         return true;
                     }
                 }
+                jsonObject.reset();
                 auto dictType = AS_TYPE(NKikimr::NMiniKQL::TDictType, type);
                 auto keyType = dictType->GetKeyType();
                 Y_ENSURE(keyType->GetKind() == NKikimr::NMiniKQL::TTypeBase::EKind::Data); // should be already verified, not user-data-error

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -827,6 +827,11 @@ private:
             }
 
             case simdjson::builtin::ondemand::json_type::null: {
+                bool isNull;
+                CHECK_JSON_ERROR(jsonValue.is_null().get(isNull)) {
+                    SetParsingError(error, jsonValue, "parse as null", status, isQuiet);
+                    return false;
+                }
                 if (Y_UNLIKELY(!isOptional)) {
                     status =  TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Found unexpected null value, expected non optional data type " << dataTypeName);
                     return false;

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -575,7 +575,7 @@ public:
     }
 private:
 
-    bool ValidateObjectRefs(const NKikimr::NMiniKQL::TType* type, const NYql::NUdf::TUnboxedValue& value, i32 expectedRefs = 1) {
+    bool ValidateObjectRefs(const NKikimr::NMiniKQL::TType* type, const NYql::NUdf::TUnboxedValuePod& value, i32 expectedRefs = 1) {
         if (value.RefCount() == -1) { // NULL/POD/Embedded String
             return true;
         }
@@ -654,7 +654,7 @@ private:
                 auto listIterator = value.GetListIterator();
 
                 for(NYql::NUdf::TUnboxedValue itemValue; listIterator.Next(itemValue); ) {
-                    if (!ValidateObjectRefs(itemType, itemValue, 2)) { // two refs expected: one from object, one from itemValue
+                    if (!ValidateObjectRefs(itemType, itemValue.Release())) {
                         Y_DEBUG_ABORT();
                         return false;
                     }
@@ -680,11 +680,11 @@ private:
                 auto dictIterator = value.GetDictIterator();
 
                 for(NYql::NUdf::TUnboxedValue keyValue, payload; dictIterator.NextPair(keyValue, payload); ) {
-                    if (!ValidateObjectRefs(keyType, keyValue, 2)) { // two refs expected: one from object, one from keyValue
+                    if (!ValidateObjectRefs(keyType, keyValue.Release())) {
                         Y_DEBUG_ABORT();
                         return false;
                     }
-                    if (!ValidateObjectRefs(valueType, payload, 2)) { // two refs expected: one from object, one from payload
+                    if (!ValidateObjectRefs(valueType, payload.Release())) {
                         Y_DEBUG_ABORT();
                         return false;
                     }
@@ -700,7 +700,7 @@ private:
                     return false;
                 }
                 auto variantItem = value.GetVariantItem();
-                if (!ValidateObjectRefs(variantType->GetAlternativeType(index), variantItem, 2)) { // two refs expected: one from object, one from variantItem
+                if (!ValidateObjectRefs(variantType->GetAlternativeType(index), variantItem.Release())) {
                     Y_DEBUG_ABORT();
                     return false;
                 }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -343,10 +343,16 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::List: {
-                simdjson::ondemand::array array;
-                if (jsonValue.get_array().get(array)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (List), expected array, but got " << JsonTypeToString(cellType));
+                if (cellType != simdjson::builtin::ondemand::json_type::array) {
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
                     return false;
+                }
+                simdjson::ondemand::array array;
+                {
+                    CHECK_JSON_ERROR(jsonValue.get_array().get(array)) {
+                        SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
+                        return false;
+                    }
                 }
                 auto listType = AS_TYPE(NKikimr::NMiniKQL::TListType, type);
                 auto itemType = listType->GetItemType();
@@ -369,10 +375,16 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Tuple: {
-                simdjson::ondemand::array array;
-                if (jsonValue.get_array().get(array)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Tuple), expected array, but got " << JsonTypeToString(cellType));
+                if (cellType != simdjson::builtin::ondemand::json_type::array) {
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected array, but got " << JsonTypeToString(cellType));
                     return false;
+                }
+                simdjson::ondemand::array array;
+                {
+                    CHECK_JSON_ERROR(jsonValue.get_array().get(array)) {
+                        SetParsingError(error, jsonValue, "parse as array", status, isQuiet);
+                        return false;
+                    }
                 }
                 auto tupleType = AS_TYPE(NKikimr::NMiniKQL::TTupleType, type);
                 auto elementsCount = tupleType->GetElementsCount();
@@ -397,7 +409,7 @@ public:
                 for (; idx != elementsCount; ++idx) {
                     // tail must be optional
                     if (tupleType->GetElementType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
-                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (Tuple), short json array at index " << idx << ", expected non optional type " << GetTypeName(tupleType->GetElementType(idx)));
+                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), short json array at index " << idx << ", expected non optional type " << GetTypeName(tupleType->GetElementType(idx)));
                         return false;
                     }
                 }
@@ -406,10 +418,16 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Struct: {
-                simdjson::ondemand::object object;
-                if (jsonValue.get_object().get(object)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Struct), expected object, but got " << JsonTypeToString(cellType));
+                if (cellType != simdjson::builtin::ondemand::json_type::object) {
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
                     return false;
+                }
+                simdjson::ondemand::object object;
+                {
+                    CHECK_JSON_ERROR(jsonValue.get_object().get(object)) {
+                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
+                        return false;
+                    }
                 }
                 auto structType = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
                 auto membersCount = structType->GetMembersCount();
@@ -449,7 +467,7 @@ public:
 
                 for (ui32 idx = 0; idx != membersCount; ++idx) {
                     if (!resultValues[idx] && structType->GetMemberType(idx)->GetKind() != NKikimr::NMiniKQL::TTypeBase::EKind::Optional) {
-                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Struct), expected non-optional field " << structType->GetMemberName(idx));
+                        status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected non-optional field " << structType->GetMemberName(idx));
                         return false;
                     }
                 }
@@ -458,11 +476,18 @@ public:
             }
 
             case NKikimr::NMiniKQL::TTypeBase::EKind::Dict: {
-                simdjson::ondemand::object jsonObject;
-                if (jsonValue.get_object().get(jsonObject)) {
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (Dict), expected object, but got " << JsonTypeToString(cellType));
+                if (cellType != simdjson::builtin::ondemand::json_type::object) {
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse nested json value (" << type->GetKindAsStr() << "), expected object, but got " << JsonTypeToString(cellType));
                     return false;
                 }
+                simdjson::ondemand::object jsonObject;
+                {
+                    CHECK_JSON_ERROR(jsonValue.get_object().get(jsonObject)) {
+                        SetParsingError(error, jsonValue, "parse as object", status, isQuiet);
+                        return false;
+                    }
+                }
+
                 {
                     bool isEmpty;
                     CHECK_JSON_ERROR(jsonObject.is_empty().get(isEmpty)) {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -278,6 +278,7 @@ public:
                     }
                     --validAlternativesLimit;
                 }
+                auto innerJsonValue = jsonValue;
                 for (ui32 index = 0; index != validAlternativesLimit; ++index) {
                     auto alternativeType = variantType->GetAlternativeType(index);
                     if (!ValidateJsonType(alternativeType, cellType, jsonValue)) {
@@ -297,13 +298,13 @@ public:
                         doc = parser.iterate(simdjson::padded_string_view(rawJson, rawJson.size() + simdjson::SIMDJSON_PADDING)); // as rawJson points to original document, we *know* padding is present
                     }
                     if (doc.error() != simdjson::error_code::UNINITIALIZED) {
-                        CHECK_JSON_ERROR(doc.get(jsonValue)) {
+                        CHECK_JSON_ERROR(doc.get(innerJsonValue)) {
                             SetParsingError(error, jsonValue, "reparse as json", status, isQuiet);
                             return false;
                         }
                     }
                     status = TStatus::Success();
-                    if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false, index + 1 != validAlternativesLimit || isQuiet)) {
+                    if (ParseNestedValue(innerJsonValue, resultValue, status, alternativeType, false, index + 1 != validAlternativesLimit || isQuiet)) {
                         resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
                         return true;
                     }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -172,7 +172,8 @@ public:
                 auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
                 const auto alternativesCount = variantType->GetAlternativesCount();
                 for (ui32 index = 0; index != alternativesCount; ++index) {
-                    if (ValidateJsonType(AS_TYPE(NKikimr::NMiniKQL::TOptionalType, type)->GetItemType(), cellType, jsonValue)) {
+                    auto alternativeType = variantType->GetAlternativeType(index);
+                    if (ValidateJsonType(alternativeType, cellType, jsonValue)) {
                         return true;
                     }
                 }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -169,9 +169,6 @@ public:
                         return true;
                     }
                 }
-                if (alternativesCount == 0) {
-                    return true;
-                }
                 if (status.IsSuccess()) {
                     status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse Variant type");
                 }
@@ -640,6 +637,9 @@ private:
             case NKikimr::NMiniKQL::TTypeBase::EKind::Variant: {
                 auto variantType = AS_TYPE(NKikimr::NMiniKQL::TVariantType, type);
                 const auto alternativesCount = variantType->GetAlternativesCount();
+                if (alternativesCount == 0) {
+                    return TStatus::Fail(EStatusId::UNSUPPORTED, TStringBuilder() << "Variant with zero alternatives");
+                }
                 for (ui32 index = 0; index != alternativesCount; ++index) {
                     auto alternativeType = variantType->GetAlternativeType(index);
                     auto success = ParseNestedType(alternativeType);

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -914,7 +914,7 @@ private:
 
                 resultValue = NKikimr::NMiniKQL::ValueFromString(dataSlot, rawString);
                 if (Y_UNLIKELY(!resultValue)) {
-                    status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse data type " << dataTypeName << " from json string: '" << TruncateString(rawString) << "'");
                 }
                 return resultValue.HasValue();
             }
@@ -997,7 +997,7 @@ private:
 
         TJsonNumber number = jsonNumber.value();
         if (Y_UNLIKELY(number < std::numeric_limits<TResult>::min() || std::numeric_limits<TResult>::max() < number)) {
-            status = TStatus::Fail(EStatusId::BAD_REQUEST, isQuiet ? TString() : TStringBuilder() << "Number is out of range [" << ToString(std::numeric_limits<TResult>::min()) << ", " << ToString(std::numeric_limits<TResult>::max()) << "]");
+            status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Number is out of range [" << ToString(std::numeric_limits<TResult>::min()) << ", " << ToString(std::numeric_limits<TResult>::max()) << "]");
             return;
         }
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -266,13 +266,24 @@ public:
                 const auto alternativesCount = variantType->GetAlternativesCount();
                 simdjson::ondemand::parser parser;
                 simdjson::simdjson_result<simdjson::ondemand::document> doc;
-                for (ui32 index = 0; index != alternativesCount; ++index) {
+                // we need to know validAlternativesLimit to
+                // 1) check if non-scalar alternative is last possible (then we can avoid re-parsing);
+                // 2) return error from last failed alternative;
+                // tc is O(sum alternativesCount) anyway
+                ui32 validAlternativesLimit = alternativesCount;
+                while (validAlternativesLimit > 0) {
+                    auto alternativeType = variantType->GetAlternativeType(validAlternativesLimit - 1);
+                    if (ValidateJsonType(alternativeType, cellType, jsonValue)) {
+                        break;
+                    }
+                    --validAlternativesLimit;
+                }
+                for (ui32 index = 0; index != validAlternativesLimit; ++index) {
                     auto alternativeType = variantType->GetAlternativeType(index);
-                    status = TStatus::Success();
                     if (!ValidateJsonType(alternativeType, cellType, jsonValue)) {
                         continue;
                     }
-                    if (doc.error() == simdjson::error_code::UNINITIALIZED && !jsonValue.is_scalar()) {
+                    if (doc.error() == simdjson::error_code::UNINITIALIZED && !jsonValue.is_scalar() && index + 1 != validAlternativesLimit) {
                         // With non-scalar types we must use re-parsing
                         // With scalar types, we cannot do reparsing (and it would be inefficient)
                         // Note that scalar case relies on repeated calls `value.get_string(consumer)`, which is not exactly documented (and, on the contrary, `sv = value.get_string()` does NOT work, in a very nasty way -- it triggers OOB writes)
@@ -291,7 +302,8 @@ public:
                             return false;
                         }
                     }
-                    if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false, index + 1 != alternativesCount || isQuiet)) {
+                    status = TStatus::Success();
+                    if (ParseNestedValue(jsonValue, resultValue, status, alternativeType, false, index + 1 != validAlternativesLimit || isQuiet)) {
                         resultValue = HolderFactory->CreateVariantHolder(std::move(resultValue.Release()), index);
                         return true;
                     }
@@ -302,7 +314,9 @@ public:
                 }
                 if (status.IsSuccess()) {
                     // Note: we try to keep error from last alternative, but this won't work if tail is rejected by early json type mismatch check. So, just ensure some error is reported
-                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse Variant type");
+                    status = TStatus::Fail(EStatusId::PRECONDITION_FAILED, isQuiet ? TString() : TStringBuilder() << "Failed to parse as Variant type");
+                } else if (!isQuiet) {
+                    status.AddParentIssue(TStringBuilder() << "Failed to parse as Variant type");
                 }
                 return false;
             }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_parser_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_parser_ut.cpp
@@ -453,7 +453,7 @@ Y_UNIT_TEST_SUITE(TestJsonParser) {
                 auto var = result[0][1];
                 UNIT_ASSERT(var.GetVariantIndex() == 1);
                 auto val = var.GetVariantItem();
-                UNIT_ASSERT_VALUES_EQUAL(2, val.Get<i64>());
+                UNIT_ASSERT_VALUES_EQUAL(2, val.Get<i8>());
             }
             UNIT_ASSERT_VALUES_EQUAL("hello2", TString(result[1][1].AsStringRef()));
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_parser_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_parser_ut.cpp
@@ -432,6 +432,57 @@ Y_UNIT_TEST_SUITE(TestJsonParser) {
         });
     }
 
+    Y_UNIT_TEST_F(NestedVariantTypes, TJsonParserFixture) {
+        ExpectedBatches = 1;
+
+        CheckSuccess(MakeParser({{"nested", "[VariantType; [StructType;[[a; [DataType; String]]; [b; [OptionalType; [DataType; Int8]]]; [c; [OptionalType; [DataType; Int64]]]]]]"}, {"a1", "[DataType; String]"}}, [&](ui64 numberRows, TVector<std::span<NYql::NUdf::TUnboxedValue>> result) {
+            UNIT_ASSERT_VALUES_EQUAL(4, numberRows);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+            UNIT_ASSERT(result[0][0]);
+            {
+                auto var = result[0][0];
+                UNIT_ASSERT(var.GetVariantIndex() == 0);
+                auto val = var.GetVariantItem();
+                UNIT_ASSERT_VALUES_EQUAL("key1", TString(val.AsStringRef()));
+            }
+            UNIT_ASSERT_VALUES_EQUAL("hello1", TString(result[1][0].AsStringRef()));
+
+            UNIT_ASSERT(result[0][1]);
+            {
+                auto var = result[0][1];
+                UNIT_ASSERT(var.GetVariantIndex() == 1);
+                auto val = var.GetVariantItem();
+                UNIT_ASSERT_VALUES_EQUAL(2, val.Get<i64>());
+            }
+            UNIT_ASSERT_VALUES_EQUAL("hello2", TString(result[1][1].AsStringRef()));
+
+            UNIT_ASSERT(result[0][2]);
+            {
+                auto var = result[0][2];
+                UNIT_ASSERT(var.GetVariantIndex() == 2);
+                auto val = var.GetVariantItem();
+                UNIT_ASSERT_VALUES_EQUAL(2222, val.Get<i64>());
+            }
+            UNIT_ASSERT_VALUES_EQUAL("hello3", TString(result[1][2].AsStringRef()));
+
+            {
+                auto var = result[0][3];
+                UNIT_ASSERT(var.GetVariantIndex() == 1);
+                auto val = var.GetVariantItem();
+                UNIT_ASSERT(!val);
+            }
+            UNIT_ASSERT_VALUES_EQUAL("hello4", TString(result[1][3].AsStringRef()));
+        }));
+
+        Parser->ParseMessages({
+            GetMessage(FIRST_OFFSET, R"({"a1": "hello1", "nested": "key1"})"),
+            GetMessage(FIRST_OFFSET + 1, R"({"a1": "hello2", "nested": 2})"),
+            GetMessage(FIRST_OFFSET + 2, R"({"a1": "hello3", "nested": 2222})"),
+            GetMessage(FIRST_OFFSET + 3, R"({"a1": "hello4", "nested": null})"),
+        });
+    }
+
     Y_UNIT_TEST_F(NestedStructTypes, TJsonParserFixture) {
         ExpectedBatches = 1;
 

--- a/ydb/library/yql/providers/common/pushdown/collection.cpp
+++ b/ydb/library/yql/providers/common/pushdown/collection.cpp
@@ -240,6 +240,13 @@ private:
         return false;
     }
 
+    bool IsSupportedGuess(const TCoGuess& guess) {
+        if (Settings.IsEnabled(EFlag::StructOperators)) {
+            return CheckExpressionNodeForPushdown(guess.Variant());
+        }
+        return false;
+    }
+
     bool IsMemberColumn(const TExprBase& node) {
         if (const auto member = node.Maybe<TCoMember>()) {
             return IsMemberColumn(member.Cast());
@@ -346,6 +353,9 @@ public:
         }
         if (auto maybeNth = node.Maybe<TCoNth>()) {
             return IsSupportedNth(maybeNth.Cast());
+        }
+        if (auto maybeGuess = node.Maybe<TCoGuess>()) {
+            return IsSupportedGuess(maybeGuess.Cast());
         }
         if (auto maybeSafeCast = node.Maybe<TCoSafeCast>()) {
             return IsSupportedSafeCast(maybeSafeCast.Cast());

--- a/ydb/library/yql/providers/common/pushdown/collection.cpp
+++ b/ydb/library/yql/providers/common/pushdown/collection.cpp
@@ -247,13 +247,6 @@ private:
         return false;
     }
 
-    bool IsMemberColumn(const TExprBase& node) {
-        if (const auto member = node.Maybe<TCoMember>()) {
-            return IsMemberColumn(member.Cast());
-        }
-        return false;
-    }
-
     bool IsSupportedSafeCast(const TCoSafeCast& cast) {
         if (!Settings.IsEnabled(EFlag::CastExpression)) {
             return false;
@@ -675,7 +668,18 @@ private:
     }
 
     bool ExistsCanBePushed(const TCoExists& exists) {
-        return IsMemberColumn(exists.Optional());
+        const auto& node = exists.Optional();
+
+        if (const auto member = node.Maybe<TCoMember>()) {
+            return IsMemberColumn(member.Cast());
+        }
+        if (auto maybeNth = node.Maybe<TCoNth>()) {
+            return IsSupportedNth(maybeNth.Cast());
+        }
+        if (auto maybeGuess = node.Maybe<TCoGuess>()) {
+            return IsSupportedGuess(maybeGuess.Cast());
+        }
+        return false;
     }
 
     bool UdfCanBePushed(const TCoUdf& udf, const TExprNode::TListType& children) {

--- a/ydb/library/yql/providers/generic/connector/api/service/protos/connector.proto
+++ b/ydb/library/yql/providers/generic/connector/api/service/protos/connector.proto
@@ -397,6 +397,11 @@ message TExpression {
         uint64 field = 2;
     }
 
+    message TVariantGuess {
+        TExpression operand = 1;
+        string field = 2;
+    }
+
     oneof payload {
         // A scalar value
         Ydb.TypedValue typed_value = 1;
@@ -426,6 +431,8 @@ message TExpression {
         TStructMember struct_member = 13;
 
         TTupleNth tuple_nth = 14;
+
+        TVariantGuess variant_guess = 15;
     }
 }
 

--- a/ydb/library/yql/providers/generic/provider/yql_generic_predicate_pushdown.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_predicate_pushdown.cpp
@@ -695,7 +695,7 @@ namespace NYql {
     }
 
     TString FormatStructMember(const TExpression::TStructMember& structMember) {
-        return TStringBuilder() << '(' << FormatExpression(structMember.operand()) << ')' << "." << NFq::EncloseAndEscapeString(structMember.field(), '`');
+        return TStringBuilder() << '(' << FormatExpression(structMember.operand()) << ')' << '.' << FormatColumn(structMember.field());
     }
 
     TString FormatTupleNth(const TExpression::TTupleNth& tupleNth) {
@@ -703,7 +703,7 @@ namespace NYql {
     }
 
     TString FormatVariantGuess(const TExpression::TVariantGuess& variantGuess) {
-        return TStringBuilder() << '(' << FormatExpression(variantGuess.operand()) << ')' << ".`" << variantGuess.field() << "`";
+        return TStringBuilder() << '(' << FormatExpression(variantGuess.operand()) << ')' << '.' << FormatColumn(variantGuess.field());
     }
 
     TString FormatValue(const Ydb::Value& value) {

--- a/ydb/library/yql/providers/generic/provider/yql_generic_predicate_pushdown.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_predicate_pushdown.cpp
@@ -30,6 +30,7 @@ namespace NYql {
     TString FormatUnwrap(const TExpression::TUnwrap& unwrap);
     TString FormatStructMember(const TExpression::TStructMember& structMember);
     TString FormatTupleNth(const TExpression::TTupleNth& tupleNth);
+    TString FormatVariantGuess(const TExpression::TVariantGuess& variantGuess);
     TString FormatMinOf(const TExpression::TMinOf& minOf);
     TString FormatMaxOf(const TExpression::TMaxOf& maxOf);
     TString FormatCurrentUtcTimestamp(const TExpression::TCurrentUtcTimestamp& currentUtcTimestamp);
@@ -78,6 +79,12 @@ namespace NYql {
             }
             tupleNth->set_field(*index);
             return SerializeExpression(nth.Tuple(), tupleNth->mutable_operand(), ctx, depth + 1);
+        }
+
+        bool SerializeGuess(const TCoGuess& guess, TExpression* proto, TSerializationContext& ctx, ui64 depth) {
+            auto variantGuess = proto->mutable_variant_guess();
+            variantGuess->set_field(guess.Index().StringValue());
+            return SerializeExpression(guess.Variant(), variantGuess->mutable_operand(), ctx, depth + 1);
         }
 
         bool SerializeLambdaArgument(const TExprBase& node, TExpression* proto, TSerializationContext& ctx) {
@@ -320,6 +327,9 @@ namespace NYql {
             }
             if (auto nth = expression.Maybe<TCoNth>()) {
                 return SerializeNth(nth.Cast(), proto, ctx, depth);
+            }
+            if (auto guess = expression.Maybe<TCoGuess>()) {
+                return SerializeGuess(guess.Cast(), proto, ctx, depth);
             }
             if (auto coalesce = expression.Maybe<TCoCoalesce>()) {
                 return SerializeCoalesceExpression(coalesce.Cast(), proto, ctx, depth);
@@ -584,6 +594,10 @@ namespace NYql {
             return SerializeNth(nth, proto->mutable_bool_expression()->mutable_value(), ctx, depth);
         }
 
+        bool SerializeGuess(const TCoGuess& guess, TPredicate* proto, TSerializationContext& ctx, ui64 depth) {
+            return SerializeGuess(guess, proto->mutable_bool_expression()->mutable_value(), ctx, depth);
+        }
+
         bool SerializeRegexp(const TCoUdf& regexp, const TExprNode::TListType& children, TPredicate* proto, TSerializationContext& ctx, ui64 depth) {
             if (children.size() != 2) {
                 ctx.Err << "expected exactly one argument for UDF function Re2.Grep, but got: " << children.size() - 1;
@@ -645,6 +659,9 @@ namespace NYql {
             if (auto nth = predicate.Maybe<TCoNth>()) {
                 return SerializeNth(nth.Cast(), proto, ctx, depth);
             }
+            if (auto guess = predicate.Maybe<TCoGuess>()) {
+                return SerializeGuess(guess.Cast(), proto, ctx, depth);
+            }
             if (auto exists = predicate.Maybe<TCoExists>()) {
                 return SerializeExists(exists.Cast(), proto, ctx, false, depth);
             }
@@ -683,6 +700,10 @@ namespace NYql {
 
     TString FormatTupleNth(const TExpression::TTupleNth& tupleNth) {
         return TStringBuilder() << '(' << FormatExpression(tupleNth.operand()) << ')' << ".`" << tupleNth.field() << "`";
+    }
+
+    TString FormatVariantGuess(const TExpression::TVariantGuess& variantGuess) {
+        return TStringBuilder() << '(' << FormatExpression(variantGuess.operand()) << ')' << ".`" << variantGuess.field() << "`";
     }
 
     TString FormatValue(const Ydb::Value& value) {
@@ -888,6 +909,8 @@ namespace NYql {
                 return FormatStructMember(expression.struct_member());
             case TExpression::kTupleNth:
                 return FormatTupleNth(expression.tuple_nth());
+            case TExpression::kVariantGuess:
+                return FormatVariantGuess(expression.variant_guess());
             case TExpression::kMinOf:
                 return FormatMinOf(expression.min_of());
             case TExpression::kMaxOf:

--- a/ydb/library/yql/providers/generic/pushdown/yql_generic_match_predicate.cpp
+++ b/ydb/library/yql/providers/generic/pushdown/yql_generic_match_predicate.cpp
@@ -63,6 +63,7 @@ namespace NYql::NGenericPushDown {
                 case NYql::NConnector::NApi::TExpression::kPredicate:
                 case NYql::NConnector::NApi::TExpression::kStructMember:
                 case NYql::NConnector::NApi::TExpression::kTupleNth:
+                case NYql::NConnector::NApi::TExpression::kVariantGuess:
                 case NYql::NConnector::NApi::TExpression::PAYLOAD_NOT_SET:
                     return false;
             }
@@ -86,6 +87,7 @@ namespace NYql::NGenericPushDown {
                 case NYql::NConnector::NApi::TExpression::kPredicate:
                 case NYql::NConnector::NApi::TExpression::kStructMember:
                 case NYql::NConnector::NApi::TExpression::kTupleNth:
+                case NYql::NConnector::NApi::TExpression::kVariantGuess:
                 case NYql::NConnector::NApi::TExpression::PAYLOAD_NOT_SET:
                     return false;
             }
@@ -311,6 +313,7 @@ namespace NYql::NGenericPushDown {
                 case NYql::NConnector::NApi::TExpression::kPredicate:
                 case NYql::NConnector::NApi::TExpression::kStructMember:
                 case NYql::NConnector::NApi::TExpression::kTupleNth:
+                case NYql::NConnector::NApi::TExpression::kVariantGuess:
                 case NYql::NConnector::NApi::TExpression::PAYLOAD_NOT_SET:
                     return Triple::Unknown;
             }

--- a/ydb/library/yql/providers/pq/gateway/clients/file/yql_pq_file_topic_client.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/file/yql_pq_file_topic_client.cpp
@@ -34,9 +34,9 @@ public:
         : File(std::move(file))
         , Session(std::move(session))
         , ProducerId(producerId)
-        , FilePoller([this]() { PollFileForChanges(); })
         , CancelOnFileFinish(cancelOnFileFinish)
         , StartFuture(startFuture)
+        , FilePoller([this]() { PollFileForChanges(); })
     {
         Pool.Start(1);
     }
@@ -179,13 +179,13 @@ private:
     const TFile File;
     const TPartitionSession::TPtr Session;
     const TString ProducerId;
-    std::thread FilePoller;
     const bool CancelOnFileFinish = false;
     TEQueue EventsQ = TEQueue(4_MB);
+    NThreading::TFuture<TConfirmSessionInfo> StartFuture;
+    std::thread FilePoller;
     TThreadPool Pool;
     size_t MsgOffset = 0;
     ui64 SeqNo = 0;
-    NThreading::TFuture<TConfirmSessionInfo> StartFuture;
 };
 
 class TFileTopicWriteSession final : public IWriteSession, private TContinuationTokenIssuer {
@@ -351,11 +351,11 @@ private:
     }
 
     const TFile File;
-    std::thread FileWriter;
     TMsgQueue EventsMsgQ = TMsgQueue(4_MB);
     TEQueue EventsQ = TEQueue(128_KB);
     TThreadPool Pool;
     uint64_t SeqNo = 0;
+    std::thread FileWriter;
 };
 
 struct TDummyPartitionSession final : public TPartitionSessionControl {

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1825,14 +1825,28 @@ FROM `{table_name}`"""
                             bar: String?,
                             baz: List<Int>?,
                             bat: Tuple<Int, String?>?,
-                            bet: Dict<String, Int>?>?,
+                            bet: Dict<String, Int>?,
+                            bum: Variant<
+                                a: Tuple<Int, String>?,
+                                b: List<Int>,
+                                c: bool,
+                                d: Int8,
+                                e: Int64,
+                                f: Dict<String,Int?>
+                            >
+                        >?,
                         test String
                     )
                 )
                 WHERE foo.bar regexp "lunch" and foo.bat.`0` > 0
                       {comment_for_pushdown} OR ListLength(foo.baz) > 5
                 ;
-                $in = SELECT foo.bar AS bar, foo.baz AS baz, foo.bat AS bat, foo.bet AS bet, test FROM $in;
+                $in = SELECT * FROM $in FLATTEN COLUMNS; -- expand foo
+                $in = SELECT
+                        i.*,
+                        bum.a AS ua, bum.b AS ub, bum.c AS uc, bum.d AS ud, bum.e AS ue, bum.f AS uf
+                      WITHOUT bum
+                      FROM $in AS i;
                 -- $in = SELECT * FROM $in FLATTEN LIST BY baz; -- prevents pushdown
                 INSERT INTO {out} SELECT UNWRAP(Yson::SerializeJson(Yson::From(TableRow()))) FROM $in;
             END DO;'''
@@ -1852,14 +1866,20 @@ FROM `{table_name}`"""
 
         longstr = '23456789876543212345678987654321'  # so that it won't fit SSO/embedded
         data = [
-            '{"foo":{"bar":"before lunch", "bat":[0]}}',
-            '{"foo":{"bar":"lunch time", "baz":[1,2], "bat":[1,"{longstr}"],"bet":{"a":1,"b{longstr}c":2}},"test":"xy{longstr}z"}',
-            '{"foo":{"bar":"after lunch", "baz":[], "bat":[2,"t{longstr}a"],"bet":{"a":2,"c{longstr}d":3}},"test":"x{longstr}yz"}',
+            '{"foo":{"bar":"before lunch", "bat":[0], "bum":null}}',
+            '{"foo":{"bar":"lunch time", "baz":[1,2], "bat":[1,"{longstr}"],"bet":{"a":1,"b{longstr}c":2},"bum":[123,456]},"test":"xy{longstr}z"}',
+            '{"foo":{"bar":"after lunch", "baz":[], "bat":[2,"t{longstr}a"],"bet":{"a":2,"c{longstr}d":3},"bum":[789,"foo"]},"test":"x{longstr}yz"}',
+            '{"foo":{"bar":"is lunch over", "bat":[3],"bum":true},"test":"x{longstr}yz"}',
+            '{"foo":{"bar":"lunch was yummy", "bat":[4,null,"that"],"bum":1234},"test":"x{longstr}yz"}',
+            '{"foo":{"bar":"lunch time again", "bat":[5],"bum":{"foo": 12356789,"bar":987654321,"xyz":null}},"test":"x{longstr}yz"}',
         ]
         data = [*map(lambda x: x.replace('{longstr}', longstr), data)]
         expected_data = [
-            '{"bar":"lunch time","bat":[1,"{longstr}"],"baz":[1,2],"bet":{"a":1,"b{longstr}c":2},"test":"xy{longstr}z"}',
-            '{"bar":"after lunch","bat":[2,"t{longstr}a"],"baz":[],"bet":{"a":2,"c{longstr}d":3},"test":"x{longstr}yz"}',
+            '{"bar":"lunch time","bat":[1,"{longstr}"],"baz":[1,2],"bet":{"a":1,"b{longstr}c":2},"test":"xy{longstr}z","ua":null,"ub":[123,456],"uc":null,"ud":null,"ue":null,"uf":null}',
+            '{"bar":"after lunch","bat":[2,"t{longstr}a"],"baz":[],"bet":{"a":2,"c{longstr}d":3},"test":"x{longstr}yz","ua":[789,"foo"],"ub":null,"uc":null,"ud":null,"ue":null,"uf":null}',
+            '{"bar":"is lunch over","bat":[3,null],"baz":null,"bet":null,"test":"x{longstr}yz","ua":null,"ub":null,"uc":true,"ud":null,"ue":null,"uf":null}',
+            '{"bar":"lunch was yummy","bat":[4,null],"baz":null,"bet":null,"test":"x{longstr}yz","ua":null,"ub":null,"uc":null,"ud":null,"ue":1234,"uf":null}',
+            '{"bar":"lunch time again","bat":[5,null],"baz":null,"bet":null,"test":"x{longstr}yz","ua":null,"ub":null,"uc":null,"ud":null,"ue":null,"uf":{"bar":987654321,"foo":12356789,"xyz":null}}',
         ] * 2
         expected_data = [*map(lambda x: x.replace('{longstr}', longstr), expected_data)]
 

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1829,7 +1829,7 @@ FROM `{table_name}`"""
                             bum: Variant<
                                 a: Tuple<Int, String>?,
                                 b: List<Int>,
-                                c: bool,
+                                c: Bool,
                                 d: Int8,
                                 e: Int64,
                                 f: Dict<String,Int?>

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1829,8 +1829,10 @@ FROM `{table_name}`"""
                             bum: Variant<
                                 a: Tuple<Int, String>?,
                                 b: List<Int>,
-                                c: Bool,
-                                d: Int8,
+                                cd: Variant<
+                                    c: Bool,
+                                    d: Int8
+                                >,
                                 e: Int64,
                                 f: Dict<String,Int?>
                             >
@@ -1844,7 +1846,7 @@ FROM `{table_name}`"""
                 $in = SELECT * FROM $in FLATTEN COLUMNS; -- expand foo
                 $in = SELECT
                         i.*,
-                        bum.a AS ua, bum.b AS ub, bum.c AS uc, bum.d AS ud, bum.e AS ue, bum.f AS uf
+                        bum.a AS ua, bum.b AS ub, bum.cd.c AS uc, bum.cd.d AS ud, bum.e AS ue, bum.f AS uf
                       WITHOUT bum
                       FROM $in AS i;
                 -- $in = SELECT * FROM $in FLATTEN LIST BY baz; -- prevents pushdown

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -2006,6 +2006,108 @@ FROM `{table_name}`"""
         sql = R'''DROP STREAMING QUERY `{query_name}`;'''
         kikimr.ydb_client.query(sql.format(query_name=query_name))
 
+    @pytest.mark.parametrize("local_topics", [False])
+    @pytest.mark.parametrize("kikimr", [{"enable_shared_reading_structured_json_parsing": True}], indirect=["kikimr"])
+    def test_read_topic_shared_reading_nested_variant_parsing(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], local_topics: bool) -> None:
+        inp, out, endpoint = self.get_io_names(
+            kikimr,
+            f"nested_variant_json{local_topics!s:.1}",
+            local_topics,
+            entity_name,
+            partitions_count=1,
+            shared=True,
+        )
+
+        query_name = f"test_nested_variant_json_{local_topics!s:.1}"
+
+        sql = Rf'''
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                $i =
+                SELECT
+                        foo.`0` as f0, foo.`1` as f1, foo.`2` as f2,
+                        bar, baz,
+                        Way(bar.`0`) AS barw,
+                        Way(baz) AS bazw,
+                        Way(foo) as w, Way(foo.1) as w1, Way(foo.`1`.`1`) as w11,
+                        case when foo.`1`.`3` IS NOT NULL THEN Way(Unwrap(foo.`1`.`3`)) ELSE NULL END AS w13
+                  FROM {inp} WITH (
+                    STREAMING = "TRUE",
+                    FORMAT = "json_each_row",
+                    SCHEMA = (
+                        foo Variant<
+                                Bool,
+                                Variant<Int,
+                                    Variant<
+                                        List<Int>,
+                                        Tuple<String, String>,
+                                        List<String>,
+                                        String>,
+                                    List<List<Int>>,
+                                    Variant<
+                                        List<Tuple<Bool, String>>,
+                                        List<Tuple<String>>>?>,
+                                Tuple<Int,String>>,
+                        bar Variant<Variant<
+                                {",".join(["Tuple<String>"]*70)},
+                                Tuple<Int>, Variant<Tuple<Bool>, Bool>
+                        >>,
+                        baz Variant<
+                                {",".join(["Tuple<String>"]*70)},
+                                Tuple<Int>, Variant<Tuple<Bool>, Bool>
+                        >
+                    )
+                )
+                WHERE foo.`1` IS DISTINCT FROM NULL OR foo.`0` IS NOT NULL
+                    OR foo.`2`.`0` IS NOT NULL OR (foo.`1`.`0` = 5)
+                    --OR foo.`2`[0] IS NOT NULL
+                ;
+                INSERT INTO {out}
+                SELECT ToBytes(Unwrap(Yson2::SerializeJson(Yson::From(TableRow()))))
+                FROM $i
+            END DO;'''
+        kikimr.ydb_client.query(sql)
+        path = f"/Root/{query_name}"
+        self.wait_completed_checkpoints(kikimr, path)
+
+        # Check that streaming.query.tasks.count metric exists for both queries
+        self.wait_streaming_query_metric(kikimr, path, "streaming.query.tasks.count", expected_value=1)
+
+        data = [
+            R'{"foo":"bar","bar":["1stringstringstring"],"baz":["2stringstringstring"]}',
+            R'{"foo":[1],"bar":["str1"],"baz":["str2"]}',
+            R'{"foo":["1\"strstrstrstrstrstrstrstrstrstr\u0022str"],"bar":[1234],"baz":[5678]}',
+            R'{"foo":["2strstrstrstrstrstrstrstrstr\u0022str","22strstrstrstrstrstrstrstrstr\u0022str"],"bar":[true],"baz":[false]}',
+            R'{"foo":[123,"3strstrstrstrstrstrstrstrstrstrstr"],"bar":false,"baz":true}',
+            R'{"foo":["4strstrstrstrstrstrstrstr\u0022strstr","42strstrstrstrstrstrstrstrstrstr","44strstrstrstrstrstrstrstrstr\u0022strstr"]}',
+            R'{"foo":[[1]]}',
+            R'{"foo":[["1\u0022xxxxxxxxxxxxxxxxxxxxx"]]}',
+            R'{"foo":[]}',
+            R'{"foo":[[]]}',
+            R'{"foo":[[true, "xyz"]]}',
+            R'{"foo":123}',
+        ]
+        expected_data = [
+            R'{"bar":["1stringstringstring"],"barw":0,"baz":["2stringstringstring"],"bazw":0,"f0":null,"f1":"bar","f2":null,"w":1,"w1":1,"w11":3,"w13":null}',
+            R'{"bar":["str1"],"barw":0,"baz":["str2"],"bazw":0,"f0":null,"f1":[1],"f2":null,"w":1,"w1":1,"w11":0,"w13":null}',
+            R'{"bar":[1234],"barw":70,"baz":[5678],"bazw":70,"f0":null,"f1":["1\"strstrstrstrstrstrstrstrstrstr\"str"],"f2":null,"w":1,"w1":1,"w11":2,"w13":null}',
+            R'{"bar":[true],"barw":71,"baz":[false],"bazw":71,"f0":null,"f1":["2strstrstrstrstrstrstrstrstr\"str","22strstrstrstrstrstrstrstrstr\"str"],"f2":null,"w":1,"w1":1,"w11":1,"w13":null}',
+            R'{"bar":false,"barw":71,"baz":true,"bazw":71,"f0":null,"f1":null,"f2":[123,"3strstrstrstrstrstrstrstrstrstrstr"],"w":2,"w1":null,"w11":null,"w13":null}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":["4strstrstrstrstrstrstrstr\"strstr","42strstrstrstrstrstrstrstrstrstr"],"f2":null,"w":1,"w1":1,"w11":1,"w13":null}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":[[1]],"f2":null,"w":1,"w1":2,"w11":null,"w13":null}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":[["1\"xxxxxxxxxxxxxxxxxxxxx"]],"f2":null,"w":1,"w1":3,"w11":null,"w13":1}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":[],"f2":null,"w":1,"w1":1,"w11":0,"w13":null}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":[[]],"f2":null,"w":1,"w1":2,"w11":null,"w13":null}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":[[true,"xyz"]],"f2":null,"w":1,"w1":3,"w11":null,"w13":0}',
+            R'{"bar":null,"barw":null,"baz":null,"bazw":null,"f0":null,"f1":123,"f2":null,"w":1,"w1":0,"w11":null,"w13":null}',
+        ]
+
+        self.write_stream(data, endpoint=endpoint)
+        assert sorted(self.read_stream(len(expected_data), topic_path=self.output_topic, endpoint=endpoint)) == sorted(expected_data)
+
+        sql = R'''DROP STREAMING QUERY `{query_name}`;'''
+        kikimr.ydb_client.query(sql.format(query_name=query_name))
+
     @pytest.mark.parametrize("local_topics", [True, False])
     @pytest.mark.parametrize("kikimr", [{"enable_discovery": False, "lease_duration_sec": "30"}], indirect=["kikimr"])
     def test_streaming_query_stop_after_restart(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], local_topics: bool) -> None:

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1842,7 +1842,7 @@ FROM `{table_name}`"""
                 )
                 WHERE foo.bar regexp "lunch" and foo.bat.`0` > 0
                       {comment_for_pushdown} OR ListLength(foo.baz) > 5
-                      OR foo.bum.b IS NOT NULL OR foo.bum.d IS DISTINCT FROM NULL OR foo.bum.c
+                      OR foo.bum.b IS NOT NULL OR foo.bum.cd.d IS DISTINCT FROM NULL OR foo.bum.cd.c
                 ;
                 $in = SELECT * FROM $in FLATTEN COLUMNS; -- expand foo
                 $in = SELECT
@@ -1913,8 +1913,8 @@ FROM `{table_name}`"""
                     assert "`bar`" in filter
                     assert "`bat`" in filter
                     assert "((`foo`).`bum`).`b`" in filter
-                    assert "((`foo`).`bum`).`c`" in filter
-                    assert "((`foo`).`bum`).`d`" in filter
+                    assert "(((`foo`).`bum`).`cd`).`c`" in filter
+                    assert "(((`foo`).`bum`).`cd`).`d`" in filter
                     sources += 1
         assert sources > 0
 

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1930,6 +1930,80 @@ FROM `{table_name}`"""
         kikimr.ydb_client.query(sql.format(query_name=query_name1))
         kikimr.ydb_client.query(sql.format(query_name=query_name2))
 
+    @pytest.mark.parametrize("local_topics", [False])
+    @pytest.mark.parametrize("kikimr", [{"enable_shared_reading_structured_json_parsing": True}], indirect=["kikimr"])
+    def test_read_topic_shared_reading_variant_parsing(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], local_topics: bool) -> None:
+        inp, out, endpoint = self.get_io_names(
+            kikimr,
+            f"variant_json{local_topics!s:.1}",
+            local_topics,
+            entity_name,
+            partitions_count=1,
+            shared=True,
+        )
+
+        sql = R'''
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                $in = SELECT * FROM {inp}
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(
+                        foo Struct<
+                            bar: Variant<
+                                Tuple<Bool>,
+                                Tuple<Variant<
+                                Timestamp, Timestamp, Timestamp, Timestamp, Timestamp,
+                                Timestamp, Timestamp, Timestamp, Timestamp, Interval,
+                                Interval, Interval, Interval, Interval, Interval,
+                                Interval, String>>>,
+                            baz: Variant<
+                                Dict<String, Int>,
+                                Struct<x:Variant<
+                                Timestamp, Timestamp, Timestamp, Timestamp, Timestamp,
+                                Timestamp, Timestamp, Timestamp, Timestamp, Interval,
+                                Interval, Interval, Interval, Interval, Interval,
+                                Interval, Interval, String>>>
+                        >?,
+                        t String
+                    )
+                )
+                ;
+                $in = SELECT * FROM $in FLATTEN COLUMNS; -- expand foo
+                $in = SELECT
+                        Way(bar.`1`.`0`) as barway, CAST(bar.`1`.`0`.`9` AS String) AS bar9, CAST(bar.`1`.`0`.`16` AS String) AS bar16,
+                        Way(baz.`1`.`x`) as bazway, CAST(baz.`1`.`x`.`9` AS String) AS baz9, CAST(baz.`1`.`x`.`17` AS String) AS baz17,
+                        t
+                      FROM $in AS i;
+                INSERT INTO {out} SELECT UNWRAP(Yson::SerializeJson(Yson::From(TableRow()))) FROM $in;
+            END DO;'''
+
+        query_name = f"test_variant_json_{local_topics!s:.1}"
+        kikimr.ydb_client.query(sql.format(query_name=query_name, inp=inp, out=out, comment_for_pushdown='--'))
+        path = f"/Root/{query_name}"
+        self.wait_completed_checkpoints(kikimr, path)
+
+        # Check that streaming.query.tasks.count metric exists for both queries
+        self.wait_streaming_query_metric(kikimr, path, "streaming.query.tasks.count", expected_value=1)
+
+        longstr = '23456789876543212345678987654321'  # so that it won't fit SSO/embedded
+        data = [
+            R'{"foo":{"bar":["xa{longstr}\u0022a\"s\"d"], "baz":{"x":"PT3600S"}},"t":"1"}',
+            R'{"foo":{"bar":["PT60S"],"baz":{"x":"xa{longstr}a\u0022s\"d"}},"t":"2"}',
+        ]
+        data = [*map(lambda x: x.replace('{longstr}', longstr), data)]
+        expected_data = [
+            R'{"bar16":"xa{longstr}\"a\"s\"d","bar9":null,"barway":16,"baz17":null,"baz9":"PT1H","bazway":9,"t":"1"}',
+            R'{"bar16":null,"bar9":"PT1M","barway":9,"baz17":"xa{longstr}a\"s\"d","baz9":null,"bazway":17,"t":"2"}',
+        ]
+        expected_data = [*map(lambda x: x.replace('{longstr}', longstr), expected_data)]
+
+        self.write_stream(data, endpoint=endpoint)
+        assert sorted(self.read_stream(len(expected_data), topic_path=self.output_topic, endpoint=endpoint)) == sorted(expected_data)
+
+        sql = R'''DROP STREAMING QUERY `{query_name}`;'''
+        kikimr.ydb_client.query(sql.format(query_name=query_name))
+
     @pytest.mark.parametrize("local_topics", [True, False])
     @pytest.mark.parametrize("kikimr", [{"enable_discovery": False, "lease_duration_sec": "30"}], indirect=["kikimr"])
     def test_streaming_query_stop_after_restart(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], local_topics: bool) -> None:

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1842,6 +1842,7 @@ FROM `{table_name}`"""
                 )
                 WHERE foo.bar regexp "lunch" and foo.bat.`0` > 0
                       {comment_for_pushdown} OR ListLength(foo.baz) > 5
+                      OR foo.bum.b IS NOT NULL OR foo.bum.d IS DISTINCT FROM NULL OR foo.bum.c
                 ;
                 $in = SELECT * FROM $in FLATTEN COLUMNS; -- expand foo
                 $in = SELECT
@@ -1906,10 +1907,14 @@ FROM `{table_name}`"""
         for source in collect_plan_nodes(json.loads(result_sets[0].rows[0]["Plan"])["Plan"], "Source"):
             for operator in source.get("Operators", []):
                 if operator.get("SourceType", None) == "pq":
+                    logger.debug(operator)
                     assert pushdown_key in operator
                     filter = operator[pushdown_key]
                     assert "`bar`" in filter
                     assert "`bat`" in filter
+                    assert "((`foo`).`bum`).`b`" in filter
+                    assert "((`foo`).`bum`).`c`" in filter
+                    assert "((`foo`).`bum`).`d`" in filter
                     sources += 1
         assert sources > 0
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

YQ-5635, should be rebased/merged after #51129
Adds support for `Variant` accessor yql function (`Guess`)