### PR TITLE
Fix missing viewer fields

### DIFF
--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -493,6 +493,7 @@ message TStorageGroupInfo {
     optional double MaxVDiskRawUsage = 26;
     optional double MaxNormalizedOccupancy = 27;
     optional string CapacityAlert = 28;
+    optional uint32 GroupSizeInUnits = 29;
     repeated TStorageVDisk VDisks = 30;
 }
 

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -802,8 +802,8 @@
         }
     },
     "test.TestViewer.test_storage_groups": {
-        "FieldsAvailable": "111110111111111111111111111",
-        "FieldsRequired": "111111111111111111111111111",
+        "FieldsAvailable": "1111110111111111111111111111",
+        "FieldsRequired": "1111111111111111111111111111",
         "FoundGroups": 5,
         "StorageGroups": [
             {
@@ -814,6 +814,7 @@
                 "ErasureSpecies": "none",
                 "GroupGeneration": "1",
                 "GroupId": "0",
+                "GroupSizeInUnits": 0,
                 "LatencyGetFast": "accepted-value",
                 "LatencyPutTabletLog": "accepted-value",
                 "LatencyPutUserData": "accepted-value",
@@ -852,17 +853,19 @@
                                 "ChangeTime": "not-zero-number-text",
                                 "Device": "Green",
                                 "EnforcedDynamicSlotSize": "not-zero-number-text",
-                                "ExpectedSlotCount": 0,
+                                "ExpectedSlotCount": 16,
                                 "ExpectedSlotSize": "0",
                                 "Guid": "1",
                                 "LogTotalSize": "not-zero-number-text",
                                 "LogUsedSize": "not-zero-number-text",
                                 "NumActiveSlots": 5,
+                                "PDiskCapacityAlert": "GREEN",
                                 "PDiskId": 1,
                                 "PDiskUsage": "not-zero-number",
                                 "Path": "SectorMap:1:64",
                                 "Realtime": "Green",
                                 "SerialNumber": "",
+                                "SlotSizeInUnits": 1,
                                 "State": "Normal",
                                 "SystemSize": "not-zero-number-text",
                                 "TotalSize": "not-zero-number-text"
@@ -877,6 +880,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -915,8 +919,9 @@
                 "DiskSpace": "Green",
                 "DiskSpaceUsage": "not-zero-number",
                 "ErasureSpecies": "none",
-                "GroupGeneration": "1",
+                "GroupGeneration": "2",
                 "GroupId": "2181038080",
+                "GroupSizeInUnits": 1,
                 "Kind": "hdd",
                 "LatencyGetFast": "accepted-value",
                 "LatencyPutTabletLog": "accepted-value",
@@ -957,24 +962,26 @@
                                 "ChangeTime": "not-zero-number-text",
                                 "Device": "Green",
                                 "EnforcedDynamicSlotSize": "not-zero-number-text",
-                                "ExpectedSlotCount": 0,
+                                "ExpectedSlotCount": 16,
                                 "ExpectedSlotSize": "0",
                                 "Guid": "1",
                                 "LogTotalSize": "not-zero-number-text",
                                 "LogUsedSize": "not-zero-number-text",
                                 "NumActiveSlots": 5,
+                                "PDiskCapacityAlert": "GREEN",
                                 "PDiskId": 1,
                                 "PDiskUsage": "not-zero-number",
                                 "Path": "SectorMap:1:64",
                                 "Realtime": "Green",
                                 "SerialNumber": "",
+                                "SlotSizeInUnits": 1,
                                 "State": "Normal",
                                 "SystemSize": "not-zero-number-text",
                                 "TotalSize": "not-zero-number-text"
                             }
                         },
                         "Status": "READY",
-                        "VDiskId": "2181038080-1-0-0-0",
+                        "VDiskId": "2181038080-2-0-0-0",
                         "Whiteboard": {
                             "AllocatedSize": "0",
                             "AvailableSize": "not-zero-number-text",
@@ -982,6 +989,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -1001,7 +1009,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -1020,8 +1028,9 @@
                 "DiskSpace": "Green",
                 "DiskSpaceUsage": "not-zero-number",
                 "ErasureSpecies": "none",
-                "GroupGeneration": "1",
+                "GroupGeneration": "2",
                 "GroupId": "2181038081",
+                "GroupSizeInUnits": 1,
                 "Kind": "hdd",
                 "LatencyGetFast": "accepted-value",
                 "LatencyPutTabletLog": "accepted-value",
@@ -1062,24 +1071,26 @@
                                 "ChangeTime": "not-zero-number-text",
                                 "Device": "Green",
                                 "EnforcedDynamicSlotSize": "not-zero-number-text",
-                                "ExpectedSlotCount": 0,
+                                "ExpectedSlotCount": 16,
                                 "ExpectedSlotSize": "0",
                                 "Guid": "1",
                                 "LogTotalSize": "not-zero-number-text",
                                 "LogUsedSize": "not-zero-number-text",
                                 "NumActiveSlots": 5,
+                                "PDiskCapacityAlert": "GREEN",
                                 "PDiskId": 1,
                                 "PDiskUsage": "not-zero-number",
                                 "Path": "SectorMap:1:64",
                                 "Realtime": "Green",
                                 "SerialNumber": "",
+                                "SlotSizeInUnits": 1,
                                 "State": "Normal",
                                 "SystemSize": "not-zero-number-text",
                                 "TotalSize": "not-zero-number-text"
                             }
                         },
                         "Status": "READY",
-                        "VDiskId": "2181038081-1-0-0-0",
+                        "VDiskId": "2181038081-2-0-0-0",
                         "Whiteboard": {
                             "AllocatedSize": "0",
                             "AvailableSize": "not-zero-number-text",
@@ -1087,6 +1098,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -1106,7 +1118,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -1128,6 +1140,7 @@
                 "ErasureSpecies": "none",
                 "GroupGeneration": "2",
                 "GroupId": "2181038082",
+                "GroupSizeInUnits": 0,
                 "Kind": "hdd",
                 "LatencyGetFast": "accepted-value",
                 "LatencyPutTabletLog": "accepted-value",
@@ -1168,17 +1181,19 @@
                                 "ChangeTime": "not-zero-number-text",
                                 "Device": "Green",
                                 "EnforcedDynamicSlotSize": "not-zero-number-text",
-                                "ExpectedSlotCount": 0,
+                                "ExpectedSlotCount": 16,
                                 "ExpectedSlotSize": "0",
                                 "Guid": "1",
                                 "LogTotalSize": "not-zero-number-text",
                                 "LogUsedSize": "not-zero-number-text",
                                 "NumActiveSlots": 5,
+                                "PDiskCapacityAlert": "GREEN",
                                 "PDiskId": 1,
                                 "PDiskUsage": "not-zero-number",
                                 "Path": "SectorMap:1:64",
                                 "Realtime": "Green",
                                 "SerialNumber": "",
+                                "SlotSizeInUnits": 1,
                                 "State": "Normal",
                                 "SystemSize": "not-zero-number-text",
                                 "TotalSize": "not-zero-number-text"
@@ -1193,6 +1208,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -1234,6 +1250,7 @@
                 "ErasureSpecies": "none",
                 "GroupGeneration": "2",
                 "GroupId": "2181038083",
+                "GroupSizeInUnits": 0,
                 "Kind": "hdd",
                 "LatencyGetFast": "accepted-value",
                 "LatencyPutTabletLog": "accepted-value",
@@ -1274,17 +1291,19 @@
                                 "ChangeTime": "not-zero-number-text",
                                 "Device": "Green",
                                 "EnforcedDynamicSlotSize": "not-zero-number-text",
-                                "ExpectedSlotCount": 0,
+                                "ExpectedSlotCount": 16,
                                 "ExpectedSlotSize": "0",
                                 "Guid": "1",
                                 "LogTotalSize": "not-zero-number-text",
                                 "LogUsedSize": "not-zero-number-text",
                                 "NumActiveSlots": 5,
+                                "PDiskCapacityAlert": "GREEN",
                                 "PDiskId": 1,
                                 "PDiskUsage": "not-zero-number",
                                 "Path": "SectorMap:1:64",
                                 "Realtime": "Green",
                                 "SerialNumber": "",
+                                "SlotSizeInUnits": 1,
                                 "State": "Normal",
                                 "SystemSize": "not-zero-number-text",
                                 "TotalSize": "not-zero-number-text"
@@ -1299,6 +1318,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -4964,14 +4984,14 @@
             },
             {
                 "ErasureSpecies": "none",
-                "GroupGeneration": 1,
+                "GroupGeneration": 2,
                 "GroupID": 2181038080,
                 "NodeId": 1,
                 "StoragePoolName": "dynamic_storage_pool:1",
                 "VDiskIds": [
                     {
                         "Domain": 0,
-                        "GroupGeneration": 1,
+                        "GroupGeneration": 2,
                         "GroupID": 2181038080,
                         "Ring": 0,
                         "VDisk": 0
@@ -4983,14 +5003,14 @@
             },
             {
                 "ErasureSpecies": "none",
-                "GroupGeneration": 1,
+                "GroupGeneration": 2,
                 "GroupID": 2181038081,
                 "NodeId": 1,
                 "StoragePoolName": "dynamic_storage_pool:1",
                 "VDiskIds": [
                     {
                         "Domain": 0,
-                        "GroupGeneration": 1,
+                        "GroupGeneration": 2,
                         "GroupID": 2181038081,
                         "Ring": 0,
                         "VDisk": 0
@@ -5880,7 +5900,7 @@
                             "VDiskCategory": "0",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -5900,7 +5920,7 @@
                             "VDiskCategory": "0",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -6063,6 +6083,12 @@
                 }
             },
             "BlobStorageConfig": {
+                "InferPDiskSlotCountSettings": {
+                    "Rot": {
+                        "MaxSlots": 16,
+                        "UnitSize": "4294967296"
+                    }
+                },
                 "ServiceSet": {
                     "AvailabilityDomains": [
                         "1"
@@ -7113,6 +7139,12 @@
                 }
             },
             "BlobStorageConfig": {
+                "InferPDiskSlotCountSettings": {
+                    "Rot": {
+                        "MaxSlots": 16,
+                        "UnitSize": "4294967296"
+                    }
+                },
                 "ServiceSet": {
                     "AvailabilityDomains": [
                         "1"
@@ -8163,6 +8195,12 @@
                 }
             },
             "BlobStorageConfig": {
+                "InferPDiskSlotCountSettings": {
+                    "Rot": {
+                        "MaxSlots": 16,
+                        "UnitSize": "4294967296"
+                    }
+                },
                 "ServiceSet": {
                     "AvailabilityDomains": [
                         "1"
@@ -9174,8 +9212,8 @@
         }
     },
     "test.TestViewer.test_viewer_groups_allocation_units_without_pool_name": {
-        "FieldsAvailable": "000000100000100000100011111",
-        "FieldsRequired": "000000000000100000000000011",
+        "FieldsAvailable": "1000000100000100000100011111",
+        "FieldsRequired": "0000000000000100000000000011",
         "FoundGroups": 5,
         "StorageGroups": [
             {
@@ -9200,8 +9238,8 @@
     },
     "test.TestViewer.test_viewer_groups_group_by_capacity_alert": [
         {
-            "FieldsAvailable": "111110111111011111011110001",
-            "FieldsRequired": "100000000010000000000000001",
+            "FieldsAvailable": "1111110111111011111011110001",
+            "FieldsRequired": "0100000000010000000000000001",
             "FoundGroups": 5,
             "StorageGroupGroups": [
                 {
@@ -9220,8 +9258,8 @@
             "TotalGroups": 5
         },
         {
-            "FieldsAvailable": "111110111111011111011110001",
-            "FieldsRequired": "100000000010000000000000001",
+            "FieldsAvailable": "1111110111111011111011110001",
+            "FieldsRequired": "0100000000010000000000000001",
             "FoundGroups": 5,
             "StorageGroups": [
                 {
@@ -9250,8 +9288,8 @@
     ],
     "test.TestViewer.test_viewer_groups_group_by_pool_name": [
         {
-            "FieldsAvailable": "000000100000000000100011111",
-            "FieldsRequired": "000000000000000000000000011",
+            "FieldsAvailable": "1000000100000000000100011111",
+            "FieldsRequired": "0000000000000000000000000011",
             "FoundGroups": 5,
             "StorageGroupGroups": [
                 {
@@ -9286,8 +9324,8 @@
             "TotalGroups": 5
         },
         {
-            "FieldsAvailable": "000000100000000000100011111",
-            "FieldsRequired": "000000000000000000000000011",
+            "FieldsAvailable": "1000000100000000000100011111",
+            "FieldsRequired": "0000000000000000000000000011",
             "FoundGroups": 1,
             "StorageGroups": [
                 {
@@ -10039,18 +10077,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -10213,6 +10253,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -10252,6 +10293,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -10274,7 +10316,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -10291,6 +10333,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -10313,7 +10356,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -10330,6 +10373,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -10369,6 +10413,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -11063,18 +11108,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -11289,6 +11336,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -11328,6 +11376,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -11350,7 +11399,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -11367,6 +11416,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -11389,7 +11439,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -11406,6 +11456,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -11445,6 +11496,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -12381,7 +12433,7 @@
                 "ChangeTime": "not-zero-number-text",
                 "Device": 1,
                 "EnforcedDynamicSlotSize": "not-zero-number-text",
-                "ExpectedSlotCount": 0,
+                "ExpectedSlotCount": 16,
                 "ExpectedSlotSize": "0",
                 "Guid": "1",
                 "LogTotalSize": "not-zero-number-text",
@@ -14362,18 +14414,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -14536,6 +14590,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14575,6 +14630,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14597,7 +14653,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -14614,6 +14670,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14636,7 +14693,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -14653,6 +14710,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14692,6 +14750,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14760,18 +14819,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -14934,6 +14995,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14973,6 +15035,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -14995,7 +15058,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -15012,6 +15075,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15034,7 +15098,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -15051,6 +15115,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15090,6 +15155,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15158,18 +15224,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -15332,6 +15400,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15371,6 +15440,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15393,7 +15463,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -15410,6 +15480,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15432,7 +15503,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -15449,6 +15520,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15488,6 +15560,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15556,18 +15629,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -15730,6 +15805,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15769,6 +15845,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15791,7 +15868,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -15808,6 +15885,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15830,7 +15908,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -15847,6 +15925,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15886,6 +15965,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -15954,18 +16034,20 @@
                             "ChangeTime": "not-zero-number-text",
                             "Device": "Green",
                             "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "ExpectedSlotCount": 0,
+                            "ExpectedSlotCount": 16,
                             "ExpectedSlotSize": "0",
                             "Guid": "1",
                             "LogTotalSize": "not-zero-number-text",
                             "LogUsedSize": "not-zero-number-text",
                             "NodeId": 1,
                             "NumActiveSlots": 5,
+                            "PDiskCapacityAlert": "GREEN",
                             "PDiskId": 1,
                             "PDiskUsage": "not-zero-number",
                             "Path": "SectorMap:1:64",
                             "Realtime": "Green",
                             "SerialNumber": "",
+                            "SlotSizeInUnits": 1,
                             "State": "Normal",
                             "SystemSize": "not-zero-number-text",
                             "TotalSize": "not-zero-number-text"
@@ -16180,6 +16262,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -16219,6 +16302,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -16241,7 +16325,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038080,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -16258,6 +16342,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 1,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -16280,7 +16365,7 @@
                             "StoragePoolName": "dynamic_storage_pool:1",
                             "VDiskId": {
                                 "Domain": 0,
-                                "GroupGeneration": 1,
+                                "GroupGeneration": 2,
                                 "GroupID": 2181038081,
                                 "Ring": 0,
                                 "VDisk": 0
@@ -16297,6 +16382,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -16336,6 +16422,7 @@
                             "ChangeTime": "not-zero-number-text",
                             "DiskSpace": "Green",
                             "FrontQueues": "Green",
+                            "GroupSizeInUnits": 0,
                             "Guid": "1",
                             "HasUnreadableBlobs": false,
                             "IncarnationGuid": "not-zero-number-text",
@@ -18621,6 +18708,41 @@
                         "Flag": 1
                     }
                 },
+                "StoragePoolName": "static",
+                "VDiskId": {
+                    "Domain": 0,
+                    "GroupGeneration": 1,
+                    "GroupID": 0,
+                    "Ring": 0,
+                    "VDisk": 0
+                },
+                "VDiskSlotId": 0,
+                "VDiskState": 5
+            },
+            {
+                "AllocatedSize": "0",
+                "AvailableSize": "not-zero-number-text",
+                "ChangeTime": "not-zero-number-text",
+                "DiskSpace": 1,
+                "FrontQueues": 1,
+                "Guid": "1",
+                "HasUnreadableBlobs": false,
+                "IncarnationGuid": "not-zero-number-text",
+                "InstanceGuid": "not-zero-number-text",
+                "Kind": "0",
+                "NodeId": 1,
+                "PDiskId": 1,
+                "Replicated": true,
+                "ReplicationProgress": 1,
+                "ReplicationSecondsRemaining": 0,
+                "SatisfactionRank": {
+                    "FreshRank": {
+                        "Flag": 1
+                    },
+                    "LevelRank": {
+                        "Flag": 1
+                    }
+                },
                 "StoragePoolName": "/Root/dedicated_db:hdd",
                 "VDiskId": {
                     "Domain": 0,
@@ -18694,7 +18816,7 @@
                 "StoragePoolName": "dynamic_storage_pool:1",
                 "VDiskId": {
                     "Domain": 0,
-                    "GroupGeneration": 1,
+                    "GroupGeneration": 2,
                     "GroupID": 2181038080,
                     "Ring": 0,
                     "VDisk": 0
@@ -18726,45 +18848,10 @@
                         "Flag": 1
                     }
                 },
-                "StoragePoolName": "static",
-                "VDiskId": {
-                    "Domain": 0,
-                    "GroupGeneration": 1,
-                    "GroupID": 0,
-                    "Ring": 0,
-                    "VDisk": 0
-                },
-                "VDiskSlotId": 0,
-                "VDiskState": 5
-            },
-            {
-                "AllocatedSize": "0",
-                "AvailableSize": "not-zero-number-text",
-                "ChangeTime": "not-zero-number-text",
-                "DiskSpace": 1,
-                "FrontQueues": 1,
-                "Guid": "1",
-                "HasUnreadableBlobs": false,
-                "IncarnationGuid": "not-zero-number-text",
-                "InstanceGuid": "not-zero-number-text",
-                "Kind": "0",
-                "NodeId": 1,
-                "PDiskId": 1,
-                "Replicated": true,
-                "ReplicationProgress": 1,
-                "ReplicationSecondsRemaining": 0,
-                "SatisfactionRank": {
-                    "FreshRank": {
-                        "Flag": 1
-                    },
-                    "LevelRank": {
-                        "Flag": 1
-                    }
-                },
                 "StoragePoolName": "dynamic_storage_pool:1",
                 "VDiskId": {
                     "Domain": 0,
-                    "GroupGeneration": 1,
+                    "GroupGeneration": 2,
                     "GroupID": 2181038081,
                     "Ring": 0,
                     "VDisk": 0

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -805,6 +805,16 @@
         "FieldsAvailable": "1111110111111111111111111111",
         "FieldsRequired": "1111111111111111111111111111",
         "FoundGroups": 5,
+        "GroupSizeInUnitsChecks": {
+            "GroupSizeOnly": {
+                "AllGroupsHaveField": true,
+                "HasNestedDiskData": false
+            },
+            "WhiteboardOnly": {
+                "AllGroupsHaveNonZeroSize": true,
+                "AllGroupsMatchVDisks": true
+            }
+        },
         "StorageGroups": [
             {
                 "Available": "not-zero-number-text",

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -853,9 +853,48 @@ class TestViewer(object):
 
     @classmethod
     def test_storage_groups(cls):
-        return cls.normalize_result(cls.get_viewer("/viewer/groups", {
+        result = cls.normalize_result(cls.get_viewer("/viewer/groups", {
             'fields_required': 'all'
         }))
+
+        group_size_only = cls.get_viewer_normalized("/viewer/groups", {
+            'fields_required': 'GroupSizeInUnits',
+        })
+        group_size_only_groups = group_size_only.get('StorageGroups', [])
+        assert group_size_only_groups, group_size_only
+        assert all('GroupSizeInUnits' in group for group in group_size_only_groups), group_size_only
+        assert all('VDisks' not in group for group in group_size_only_groups), group_size_only
+
+        whiteboard_only = cls.get_viewer_normalized("/viewer/groups", {
+            'whiteboard_only': 'true',
+            'filter_group_by': 'PoolName',
+            'filter_group': 'dynamic_storage_pool:1',
+        })
+        whiteboard_only_groups = whiteboard_only.get('StorageGroups', [])
+        assert whiteboard_only_groups, whiteboard_only
+        assert all(
+            group.get('GroupSizeInUnits', 0) > 0
+            for group in whiteboard_only_groups
+        ), whiteboard_only
+        for group in whiteboard_only_groups:
+            vdisks = group.get('VDisks', [])
+            assert vdisks, group
+            assert all(
+                vdisk.get('Whiteboard', {}).get('GroupSizeInUnits') == group['GroupSizeInUnits']
+                for vdisk in vdisks
+            ), group
+
+        result['GroupSizeInUnitsChecks'] = {
+            'GroupSizeOnly': {
+                'AllGroupsHaveField': True,
+                'HasNestedDiskData': False,
+            },
+            'WhiteboardOnly': {
+                'AllGroupsHaveNonZeroSize': True,
+                'AllGroupsMatchVDisks': True,
+            },
+        }
+        return result
 
     # A strict database user is allowed to filter groups by group_id/node_id/pdisk_id, and every such
     # filter is validated against the storage of the database, so the handler has to fetch GroupId,

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -7,6 +7,8 @@ import ydb
 from ydb._topic_writer.topic_writer import PublicMessage
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.common.wait_for import retry_assertions
+from ydb.core.protos import msgbus_pb2
 import requests
 from urllib.parse import urlencode
 import time
@@ -48,6 +50,12 @@ class TestViewer(object):
             'enable_column_statistics': True,
             },
             enable_static_auth=True)
+        config.yaml_config['blob_storage_config']['infer_pdisk_slot_count_settings'] = {
+            'rot': {
+                'unit_size': 4 * 1024**3,
+                'max_slots': 16,
+            },
+        }
         config.yaml_config['domains_config']['security_config']['enforce_user_token_requirement'] = False
         config.yaml_config['domains_config']['security_config']['enforce_user_token_check_requirement'] = True
         config.yaml_config['domains_config']['security_config']['database_allowed_sids'] = ['database']
@@ -89,6 +97,7 @@ class TestViewer(object):
             'X-CSRF-Token': cls.csrf_token,
         }
         cls.wait_for_cluster_ready()
+        cls.setup_group_size_in_units()
         yield
         cls.cluster.stop()
 
@@ -390,6 +399,34 @@ class TestViewer(object):
     @classmethod
     def test_waiting_for_cluster_ready(cls):
         return {}
+
+    @classmethod
+    def setup_group_size_in_units(cls, pool_name='dynamic_storage_pool:1', size_in_units=1):
+        "Changes group_size_in_units for all groups in pool"
+        cls.cluster.client.set_auth_token(cls.root_token)
+        storage_pool = next(p for p in cls.cluster.client.read_storage_pools() if p.Name == pool_name)
+
+        request = msgbus_pb2.TBlobStorageConfigRequest(Domain=1)
+        command = request.Request.Command.add().ChangeGroupSizeInUnits
+        command.BoxId = storage_pool.BoxId
+        command.StoragePoolId = storage_pool.StoragePoolId
+        command.ItemConfigGeneration = storage_pool.ItemConfigGeneration
+        command.SizeInUnits = size_in_units
+
+        response = cls.cluster.client._send_blob_storage_config_request(request)
+        assert response.Success, response.ErrorDescription
+        assert all(status.Success for status in response.Status), response
+
+        def get_updated_groups():
+            result = cls.get_viewer_normalized("/viewer/groups", {
+                'fields_required': 'GroupSizeInUnits,PoolName',
+                'filter_group_by': 'PoolName',
+                'filter_group': pool_name
+            })
+            assert result.get('StorageGroups'), result
+            assert all(g.get('GroupSizeInUnits') == size_in_units for g in result['StorageGroups']), result
+
+        return retry_assertions(get_updated_groups)
 
     @classmethod
     def test_whoami_root(cls):

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -110,6 +110,7 @@ enum class EGroupFields : ui8 {
     MaxVDiskRawUsage,
     MaxNormalizedOccupancy,
     CapacityAlert,
+    GroupSizeInUnits,
     COUNT
 };
 
@@ -699,7 +700,8 @@ public:
     const TFieldsType FieldsAll = TFieldsType().set();
     const TFieldsType FieldsBsGroups = TFieldsType().set(+EGroupFields::GroupId)
                                                     .set(+EGroupFields::Erasure)
-                                                    .set(+EGroupFields::Latency);
+                                                    .set(+EGroupFields::Latency)
+                                                    .set(+EGroupFields::GroupSizeInUnits);
     const TFieldsType FieldsBsPools = TFieldsType().set(+EGroupFields::PoolName)
                                                    .set(+EGroupFields::Kind)
                                                    .set(+EGroupFields::MediaType)
@@ -724,7 +726,8 @@ public:
     const TFieldsType FieldsWbGroups = TFieldsType().set(+EGroupFields::GroupId)
                                                     .set(+EGroupFields::Erasure)
                                                     .set(+EGroupFields::PoolName)
-                                                    .set(+EGroupFields::Encryption);
+                                                    .set(+EGroupFields::Encryption)
+                                                    .set(+EGroupFields::GroupSizeInUnits);
     const TFieldsType FieldsWbDisks = TFieldsType().set(+EGroupFields::NodeId)
                                                    .set(+EGroupFields::PDiskId)
                                                    .set(+EGroupFields::VDisk)
@@ -833,6 +836,8 @@ public:
             result = EGroupFields::MaxNormalizedOccupancy;
         } else if (field == "MaxVDiskRawUsage") {
             result = EGroupFields::MaxVDiskRawUsage;
+        } else if (field == "GroupSizeInUnits") {
+            result = EGroupFields::GroupSizeInUnits;
         }
         return result;
     }
@@ -2199,6 +2204,7 @@ public:
             vdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kNormalizedOccupancyFieldNumber);
             vdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kVDiskRawUsageFieldNumber);
             vdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kCapacityAlertFieldNumber);
+            vdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kGroupSizeInUnitsFieldNumber);
             VDiskStateResponse.emplace(nodeId, MakeWhiteboardRequest(nodeId, vdiskRequest));
             ++VDiskStateRequestsInFlight;
         }
@@ -2206,6 +2212,8 @@ public:
             auto pdiskRequest = new TEvWhiteboard::TEvPDiskStateRequest();
             pdiskRequest->Record.MutableFieldsRequired()->CopyFrom(GetDefaultWhiteboardFields<NKikimrWhiteboard::TPDiskStateInfo>());
             pdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TPDiskStateInfo::kPDiskUsageFieldNumber);
+            pdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TPDiskStateInfo::kSlotSizeInUnitsFieldNumber);
+            pdiskRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TPDiskStateInfo::kPDiskCapacityAlertFieldNumber);
             PDiskStateResponse.emplace(nodeId, MakeWhiteboardRequest(nodeId, pdiskRequest));
             ++PDiskStateRequestsInFlight;
         }
@@ -2540,6 +2548,9 @@ public:
                 if (FieldsAvailable.test(+EGroupFields::CapacityAlert) && FieldsRequested.test(+EGroupFields::CapacityAlert)) {
                     jsonGroup.SetCapacityAlert(NKikimrBlobStorage::TPDiskSpaceColor::E_Name(group->CapacityAlert));
                 }
+                if (FieldsRequested.test(+EGroupFields::GroupSizeInUnits)) {
+                    jsonGroup.SetGroupSizeInUnits(group->GroupSizeInUnits);
+                }
             }
         } else {
             for (TGroupGroup& groupGroup : GroupGroups) {
@@ -2648,6 +2659,7 @@ public:
                           * `MaxVDiskSlotUsage `
                           * `MaxNormalizedOccupancy`
                           * `MaxVDiskRawUsage`
+                          * `GroupSizeInUnits`
                     required: false
                     type: string
                   - name: group
@@ -2667,6 +2679,7 @@ public:
                           * `State`
                           * `Latency`
                           * `CapacityAlert`
+                          * `GroupSizeInUnits`
                     required: false
                     type: string
                   - name: filter_group_by

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -2192,7 +2192,10 @@ public:
             return;
         }
         if (BSGroupStateResponse.count(nodeId) == 0) {
-            BSGroupStateResponse.emplace(nodeId, MakeWhiteboardRequest(nodeId, new TEvWhiteboard::TEvBSGroupStateRequest()));
+            auto groupRequest = new TEvWhiteboard::TEvBSGroupStateRequest();
+            groupRequest->Record.MutableFieldsRequired()->CopyFrom(GetDefaultWhiteboardFields<NKikimrWhiteboard::TBSGroupStateInfo>());
+            groupRequest->Record.AddFieldsRequired(NKikimrWhiteboard::TBSGroupStateInfo::kGroupSizeInUnitsFieldNumber);
+            BSGroupStateResponse.emplace(nodeId, MakeWhiteboardRequest(nodeId, groupRequest));
             ++BSGroupStateRequestsInFlight;
         }
     }
@@ -2683,7 +2686,6 @@ public:
                           * `State`
                           * `Latency`
                           * `CapacityAlert`
-                          * `GroupSizeInUnits`
                     required: false
                     type: string
                   - name: filter_group_by
@@ -2739,6 +2741,7 @@ public:
                           * `MaxNormalizedOccupancy`
                           * `MaxVDiskRawUsage`
                           * `CapacityAlert`
+                          * `GroupSizeInUnits`
                     required: false
                     type: string
                   - name: offset

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -2555,7 +2555,7 @@ public:
                 if (FieldsAvailable.test(+EGroupFields::CapacityAlert) && FieldsRequested.test(+EGroupFields::CapacityAlert)) {
                     jsonGroup.SetCapacityAlert(NKikimrBlobStorage::TPDiskSpaceColor::E_Name(group->CapacityAlert));
                 }
-                if (FieldsRequested.test(+EGroupFields::GroupSizeInUnits)) {
+                if (FieldsAvailable.test(+EGroupFields::GroupSizeInUnits) && FieldsRequested.test(+EGroupFields::GroupSizeInUnits)) {
                     jsonGroup.SetGroupSizeInUnits(group->GroupSizeInUnits);
                 }
             }

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -1341,6 +1341,7 @@ public:
                 case EGroupFields::MaxVDiskSlotUsage:
                 case EGroupFields::MaxNormalizedOccupancy:
                 case EGroupFields::MaxVDiskRawUsage:
+                case EGroupFields::GroupSizeInUnits:
                     break;
             }
         }
@@ -1415,6 +1416,9 @@ public:
                     break;
                 case EGroupFields::MaxVDiskRawUsage:
                     SortCollection(GroupView, [](const TGroup* group) { return group->MaxVDiskRawUsage; }, ReverseSort);
+                    break;
+                case EGroupFields::GroupSizeInUnits:
+                    SortCollection(GroupView, [](const TGroup* group) { return group->GroupSizeInUnits; }, ReverseSort);
                     break;
                 case EGroupFields::PDiskId:
                 case EGroupFields::NodeId:

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -2317,6 +2317,7 @@ public:
             request->AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kNormalizedOccupancyFieldNumber);
             request->AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kVDiskRawUsageFieldNumber);
             request->AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kCapacityAlertFieldNumber);
+            request->AddFieldsRequired(NKikimrWhiteboard::TVDiskStateInfo::kGroupSizeInUnitsFieldNumber);
         }
     }
 
@@ -2327,6 +2328,8 @@ public:
         } else {
             request->MutableFieldsRequired()->CopyFrom(GetDefaultWhiteboardFields<NKikimrWhiteboard::TPDiskStateInfo>());
             request->AddFieldsRequired(NKikimrWhiteboard::TPDiskStateInfo::kPDiskUsageFieldNumber);
+            request->AddFieldsRequired(NKikimrWhiteboard::TPDiskStateInfo::kSlotSizeInUnitsFieldNumber);
+            request->AddFieldsRequired(NKikimrWhiteboard::TPDiskStateInfo::kPDiskCapacityAlertFieldNumber);
         }
     }
 

--- a/ydb/tests/library/clients/kikimr_client.py
+++ b/ydb/tests/library/clients/kikimr_client.py
@@ -104,6 +104,10 @@ class KiKiMRMessageBusClient(object):
         self._channel = grpc.insecure_channel("%s:%s" % (self.server, self.port), options=self._options)
         self._stub = grpc_server.TGRpcServerStub(self._channel)
         self.tablet_service = StubWithRetries(grpc_tablet_service.TabletServiceStub(self._channel), timeout=self.__timeout)
+        self._auth_token = None
+
+    def set_auth_token(self, token):
+        self._auth_token = token
 
     def describe(self, path, token):
         request = msgbus.TSchemeDescribe()
@@ -212,6 +216,8 @@ class KiKiMRMessageBusClient(object):
         return self.invoke(request, 'SchemeOperationStatus')
 
     def send(self, request, method):
+        if self._auth_token and hasattr(request, 'SecurityToken') and not request.SecurityToken:
+            request.SecurityToken = self._auth_token
         return self.invoke(request, method)
 
     def ddl_exec_status(self, flat_tx_id, token=None):
@@ -300,12 +306,18 @@ class KiKiMRMessageBusClient(object):
         request.Alive = True
         return self.invoke(request, 'TabletStateRequest')
 
+    def _send_blob_storage_config_request(self, request):
+        response = self.send(request, 'BlobStorageConfig')
+        if not response.HasField('BlobStorageConfigResponse'):
+            raise RuntimeError('BlobStorageConfig request failed with status %s: %s' % (response.Status, response.ErrorReason))
+        return response.BlobStorageConfigResponse
+
     def read_host_configs(self, domain=1):
         request = msgbus.TBlobStorageConfigRequest()
         request.Domain = domain
         request.Request.Command.add().ReadHostConfig.SetInParent()
 
-        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        response = self._send_blob_storage_config_request(request)
         if not response.Success:
             raise RuntimeError('read_host_config request failed: %s' % response.ErrorDescription)
         status = response.Status[0]
@@ -320,7 +332,7 @@ class KiKiMRMessageBusClient(object):
         for host_config in host_configs:
             request.Request.Command.add().DefineHostConfig.MergeFrom(host_config)
 
-        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        response = self._send_blob_storage_config_request(request)
         if not response.Success:
             raise RuntimeError('define_host_config request failed: %s' % response.ErrorDescription)
         for i, status in enumerate(response.Status):
@@ -333,7 +345,7 @@ class KiKiMRMessageBusClient(object):
         cmd = request.Request.Command.add().ReadStoragePool
         cmd.BoxId = 0xFFFFFFFFFFFFFFFF
 
-        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        response = self._send_blob_storage_config_request(request)
         if not response.Success:
             raise RuntimeError('read_storage_pools request failed: %s' % response.ErrorDescription)
 
@@ -358,7 +370,7 @@ class KiKiMRMessageBusClient(object):
             cmd.PDiskId = pdisk.PDiskId
             cmd.Status = blobstorage_base3_pb2.EDriveStatus.ACTIVE
 
-        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        response = self._send_blob_storage_config_request(request)
 
         if not response.Success:
             raise RuntimeError('update_all_drive_status_active request failed: %s' % response.ErrorDescription)
@@ -374,7 +386,7 @@ class KiKiMRMessageBusClient(object):
         command.QueryBaseConfig.RetrieveDevices = True
         command.QueryBaseConfig.VirtualGroupsOnly = False
 
-        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        response = self._send_blob_storage_config_request(request)
         if not response.Success:
             raise RuntimeError('query_base_config failed: %s' % response.ErrorDescription)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Close #47465 

Close the viewer contract gap for storage layout values and backend capacity alerts.

- Add `GroupSizeInUnits` as a selective top-level field in `/storage/groups`.
- Request `GroupSizeInUnits`, `SlotSizeInUnits`, and `PDiskCapacityAlert` from Whiteboard in `/storage/groups` and `/viewer/nodes`.
- Keep Whiteboard requests selective and return the producer values directly.
- Support `GroupSizeInUnits` through the normal BSController path and the Whiteboard fallback path.

Tests:

- Configure inferred PDisk slot sizes and a non-default group size in the viewer fixture.
- Extend canonical coverage for all new fields in `/storage/groups` and `/viewer/nodes`.
- Verify that `fields_required=GroupSizeInUnits` returns the top-level value without nested VDisk/PDisk data.
- Verify that the Whiteboard fallback exposes the same `GroupSizeInUnits` at group and VDisk levels.
- Fix `ydb/tests/library/clients/kikimr_client.py` to handle auth and to display grpc-level errors transparently. 
