### PR TITLE
Check TPC-C tpmC and NewOrder p90 deviation from previous runs

### DIFF
--- a/ydb/tests/olap/lib/results_processor.py
+++ b/ydb/tests/olap/lib/results_processor.py
@@ -25,6 +25,21 @@ class ResultsProcessor:
             self._table = table
             self._columns = columns
 
+        @property
+        def table_path(self) -> str:
+            return os.path.join(self._db, self._table)
+
+        def execute_query(self, query: str, parameters: dict | None = None) -> list:
+            logging.info(f"[ResultsProcessor] Reading from YDB endpoint: {self._endpoint}, db: {self._db}, table: {self._table}")
+            logging.debug(f"[ResultsProcessor] Query: {query}, parameters: {parameters}")
+            with ydb.QuerySessionPool(self._driver) as pool:
+                result_sets = pool.execute_with_retries(query, parameters)
+            rows = []
+            for result_set in result_sets:
+                rows.extend(result_set.rows)
+            logging.info(f"[ResultsProcessor] Got {len(rows)} rows from {self.table_path}")
+            return rows
+
         def send_data(self, data):
             try:
                 logging.info(f"[ResultsProcessor] Sending data to YDB endpoint: {self._endpoint}, db: {self._db}, table: {self._table}")
@@ -45,6 +60,7 @@ class ResultsProcessor:
 
     send_results = external_param_is_true('send-results')
     ignore_stderr_content = external_param_is_true('ignore_stderr_content')
+    tpcc_tool = 'ydb_cli_tpcc'
     _columns_types = (
         ydb.BulkUpsertColumns()
         .add_column('Db', ydb.PrimitiveType.Utf8)
@@ -244,23 +260,98 @@ class ResultsProcessor:
                 endpoint.send_data(data)
 
     @classmethod
+    def get_tpcc_run_context(cls) -> dict:
+        """Cluster/branch/version identity of the current run.
+
+        Shared by the TPC-C results upload and the deviation check, so both
+        address history by exactly the same values.
+        """
+        cluster_info = YdbCluster.get_cluster_info()
+        cluster_name = os.getenv('CI_CLUSTER_NAME', '').replace('oltp-', '').replace('-', '') or cluster_info.get('name', '')
+        ver = cluster_info.get('version', '').split('.')
+        version = ver[-1]
+        branch = ver[0] if len(ver) > 1 else ''
+        commit_ts = 0
+        ci_git_info = os.getenv('CI_YDB_GIT_INFO')
+        if ci_git_info:
+            ci_git_info = json.loads(ci_git_info)
+            branch = ci_git_info.get('branch', branch)
+            version = ci_git_info.get('version', version)
+            commit_ts = ci_git_info.get('commit_timestamp', 0)
+        return {
+            'cluster': cluster_name,
+            'version': version,
+            'branch': f'origin/{branch}' if branch else '',
+            'commit_timestamp': commit_ts,
+        }
+
+    @staticmethod
+    def get_tpcc_metrics(results: dict) -> dict:
+        """Key TPC-C metrics of a run, keyed by the results table column names."""
+        summary = results.get('summary', {})
+        new_order = results.get('transactions', {}).get('NewOrder', {})
+        return {
+            'warehouses': summary.get('warehouses', 0),
+            'tpmC': summary.get('tpmc', 0),
+            'newOrderLatency90': new_order.get('percentiles', {}).get('90', 0),
+        }
+
+    @classmethod
+    def get_tpcc_history(cls, cluster: str, warehouses: int, run_type: str, before_ts: float, per_branch_limit: int) -> list:
+        """Up to `per_branch_limit` last runs of the same configuration, for every branch at once."""
+        endpoints = cls.get_tpcc_endpoints()
+        if not endpoints:
+            raise RuntimeError('TPC-C results table is not configured, set the results-tpcc-table param')
+        endpoint = endpoints[0]
+        query = f'''
+            DECLARE $cluster AS Utf8;
+            DECLARE $warehouses AS Uint32;
+            DECLARE $run_type AS Utf8;
+            DECLARE $tool AS Utf8;
+            DECLARE $before AS Timestamp;
+            DECLARE $limit AS Uint64;
+
+            $history = (
+                SELECT
+                    git_branch,
+                    timestamp,
+                    tpmC,
+                    newOrderLatency90,
+                    ROW_NUMBER() OVER (PARTITION BY git_branch ORDER BY timestamp DESC) AS row_num
+                FROM `{endpoint.table_path}`
+                WHERE cluster == $cluster
+                  AND warehouses == $warehouses
+                  AND run_type == $run_type
+                  AND tool == $tool
+                  AND timestamp < $before
+            );
+
+            SELECT git_branch, timestamp, tpmC, newOrderLatency90
+            FROM $history
+            WHERE row_num <= $limit
+            ORDER BY git_branch, timestamp DESC;
+        '''
+        parameters = {
+            '$cluster': (cluster, ydb.PrimitiveType.Utf8),
+            '$warehouses': (warehouses, ydb.PrimitiveType.Uint32),
+            '$run_type': (run_type, ydb.PrimitiveType.Utf8),
+            '$tool': (cls.tpcc_tool, ydb.PrimitiveType.Utf8),
+            '$before': (int(1000000 * before_ts), ydb.PrimitiveType.Timestamp),
+            '$limit': (per_branch_limit, ydb.PrimitiveType.Uint64),
+        }
+        return endpoint.execute_query(query, parameters)
+
+    @classmethod
     def upload_tpcc_results(cls, results, run_type: str, warmup_start_ts: float):
         if not cls.send_results or not cls.get_tpcc_endpoints():
             return
         with allure.step("Upload TPCC results to YDB"):
-            cluster_info = YdbCluster.get_cluster_info()
-            cluster_name = os.getenv('CI_CLUSTER_NAME', '').replace('oltp-', '').replace('-', '') or cluster_info.get('name', '')
-            ver = cluster_info.get('version', '').split('.')
-            version = ver[-1]
-            branch = ver[0] if len(ver) > 1 else ''
-            commit_ts = 0
-            ci_git_info = os.getenv('CI_YDB_GIT_INFO')
-            if ci_git_info:
-                ci_git_info = json.loads(ci_git_info)
-                branch = ci_git_info.get('branch', branch)
-                version = ci_git_info.get('version', version)
-                commit_ts = ci_git_info.get('commit_timestamp', 0)
-            branch = f'origin/{branch}' if branch else ''
+            run_context = cls.get_tpcc_run_context()
+            cluster_name = run_context['cluster']
+            version = run_context['version']
+            branch = run_context['branch']
+            commit_ts = run_context['commit_timestamp']
+            metrics = cls.get_tpcc_metrics(results)
 
             summary = results.get('summary', {})
             report_url = os.getenv('ALLURE_RESOURCE_URL', None)
@@ -306,15 +397,15 @@ class ResultsProcessor:
                 'git_commit_timestamp': 1000000 * commit_ts,
                 'git_branch': branch,
                 'run_type': run_type,
-                'tool': 'ydb_cli_tpcc',
+                'tool': cls.tpcc_tool,
                 'label': f"{datetime.fromtimestamp(commit_ts).strftime('%Y-%m-%d_%H%M%S')}_{version}_{summary.get('measure_start_ts', 0)}",
-                'warehouses': summary.get('warehouses', 0),
+                'warehouses': metrics['warehouses'],
                 'duration_seconds': summary.get('time_seconds', 0),
-                'tpmC': summary.get('tpmc', 0),
+                'tpmC': metrics['tpmC'],
                 'efficiency': summary.get('efficiency', 0),
                 'throughput': None,
                 'goodput': None,
-                'newOrderLatency90': results.get('transactions', {}).get('NewOrder', {}).get('percentiles', {}).get('90', 0),
+                'newOrderLatency90': metrics['newOrderLatency90'],
                 'json': json_string
             }
             allure.attach(json.dumps(data), 'data', allure.attachment_type.JSON)

--- a/ydb/tests/olap/lib/tpcc_deviation.py
+++ b/ydb/tests/olap/lib/tpcc_deviation.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import allure
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from math import exp, inf, log
+from ydb.tests.olap.lib.results_processor import ResultsProcessor
+from ydb.tests.olap.lib.utils import external_param_is_true, get_external_param
+
+LOGGER = logging.getLogger(__name__)
+
+MAIN_BRANCH = 'origin/main'
+
+# Baseline is the "UnixBench" aggregate of the previous runs: take the best
+# BASELINE_BEST of BASELINE_RUNS values and return their geometric mean, the way
+# TTestInfo does it in ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp.
+BASELINE_RUNS = 6
+BASELINE_BEST = 4
+# Below this the baseline is too noisy to say anything, so the check is skipped.
+MIN_BASELINE_RUNS = 2
+DEFAULT_MAX_DEVIATION_PERCENT = 5.0
+
+_STABLE_BRANCH_RE = re.compile(r'^(?:origin/)?stable-(\d+)-(\d+)(?:-(\d+))?$')
+
+
+@dataclass(frozen=True)
+class Metric:
+    column: str
+    name: str
+    higher_is_better: bool
+
+
+METRICS = (
+    Metric('tpmC', 'tpmC', True),
+    Metric('newOrderLatency90', 'NewOrder p90', False),
+)
+
+
+@dataclass
+class MetricDeviation:
+    metric: Metric
+    current: float
+    baseline: float
+    # Degradation as a fraction of the baseline: positive means worse than the baseline.
+    deviation: float
+    used_values: list[float]
+
+    @property
+    def error_message(self) -> str:
+        return (
+            f'TPC-C {self.metric.name} deviates from the baseline by {100 * self.deviation:+.2f}%: '
+            f'{self.current:.2f} vs baseline {self.baseline:.2f} '
+            f'(unixbench of {len(self.used_values)} best of the previous runs)'
+        )
+
+
+@dataclass
+class DeviationCheckResult:
+    # Non-empty when the current run must be treated as failed.
+    errors: list[str] = field(default_factory=list)
+    # Short one-line status for the Allure table, empty when the check did not run.
+    summary: str = ''
+
+
+def is_enabled() -> bool:
+    env = os.getenv('TPCC_CHECK_DEVIATION')
+    if env is not None:
+        return env.strip().lower() in ['t', 'true', 'yes', '1', 'da']
+    return external_param_is_true('tpcc-check-deviation')
+
+
+def get_max_deviation() -> float:
+    """Allowed degradation as a fraction of the baseline."""
+    raw = os.getenv('TPCC_MAX_DEVIATION_PERCENT') or get_external_param('tpcc-max-deviation-percent', '')
+    if not raw:
+        return DEFAULT_MAX_DEVIATION_PERCENT / 100.0
+    return float(raw) / 100.0
+
+
+def _stable_branch_key(branch: str):
+    """Sort key of a stable branch, newest first, or None for a non-stable branch.
+
+    The branch line itself is newer than any release cut from it, so the order is
+    stable-26-2, stable-26-2-2, stable-26-2-1, stable-26-1, stable-26-1-1, ...
+    """
+    match = _STABLE_BRANCH_RE.match(branch or '')
+    if match is None:
+        return None
+    patch = match.group(3)
+    return (-int(match.group(1)), -int(match.group(2)), -inf if patch is None else -int(patch))
+
+
+def branch_fallback_chain(current_branch: str, known_branches) -> list[str]:
+    """Branches to take the baseline from: the current one, then older ones."""
+    chain = [current_branch]
+    current_key = _stable_branch_key(current_branch)
+    if current_key is None and current_branch != MAIN_BRANCH and MAIN_BRANCH in known_branches:
+        # A branch outside of the stable numbering (a feature branch, a fork):
+        # main is the closest thing to its own history.
+        chain.append(MAIN_BRANCH)
+    stable = []
+    for branch in set(known_branches):
+        key = _stable_branch_key(branch)
+        if key is not None and branch != current_branch:
+            stable.append((key, branch))
+    for key, branch in sorted(stable):
+        # A smaller key means a newer branch, and only older ones may be a fallback.
+        if current_key is None or key > current_key:
+            chain.append(branch)
+    return chain
+
+
+def _unixbench(values: list[float], higher_is_better: bool) -> tuple[float, list[float]]:
+    """Geometric mean of the best BASELINE_BEST/BASELINE_RUNS of the values."""
+    best_count = max(1, len(values) * BASELINE_BEST // BASELINE_RUNS)
+    best = sorted(values, reverse=higher_is_better)[:best_count]
+    return exp(sum(log(value) for value in best) / len(best)), best
+
+
+def _collect_baseline_runs(history: list, chain: list[str]) -> tuple[list, list[str]]:
+    """Last BASELINE_RUNS runs, taken along the branch chain until there are enough."""
+    by_branch: dict[str, list] = {}
+    for row in history:
+        by_branch.setdefault(row['git_branch'], []).append(row)
+    runs = []
+    used_branches = []
+    for branch in chain:
+        rows = sorted(by_branch.get(branch, []), key=lambda row: row['timestamp'], reverse=True)
+        rows = rows[:BASELINE_RUNS - len(runs)]
+        if not rows:
+            continue
+        runs.extend(rows)
+        used_branches.append(f'{branch}: {len(rows)}')
+        if len(runs) >= BASELINE_RUNS:
+            break
+    return runs, used_branches
+
+
+def _check_metric(metric: Metric, current: float, runs: list, max_deviation: float) -> tuple[MetricDeviation | None, str]:
+    values = [float(row[metric.column]) for row in runs if row[metric.column] and float(row[metric.column]) > 0]
+    if len(values) < MIN_BASELINE_RUNS:
+        return None, f'{metric.name}: skipped, only {len(values)} usable previous values'
+    baseline, used_values = _unixbench(values, metric.higher_is_better)
+    deviation = (baseline - current) / baseline if metric.higher_is_better else (current - baseline) / baseline
+    result = MetricDeviation(metric, current, baseline, deviation, used_values)
+    status = 'FAILED' if deviation > max_deviation else 'ok'
+    LOGGER.info(
+        f'TPC-C deviation {status}: {metric.name} current {current}, baseline {baseline}, '
+        f'deviation {100 * deviation:+.2f}%, limit {100 * max_deviation:.2f}%, values {values}, used {used_values}'
+    )
+    report = f'{metric.name}: {100 * deviation:+.2f}% ({status})'
+    return (result if deviation > max_deviation else None), report
+
+
+def _report(lines: list[str]) -> None:
+    allure.attach('\n'.join(lines), 'TPC-C deviation check', attachment_type=allure.attachment_type.TEXT)
+
+
+def _check(results: dict, run_type: str, run_ts: float) -> DeviationCheckResult:
+    run_context = ResultsProcessor.get_tpcc_run_context()
+    metrics = ResultsProcessor.get_tpcc_metrics(results)
+    warehouses = int(metrics['warehouses'] or 0)
+    if warehouses <= 0:
+        raise ValueError(f'no warehouses count in the TPC-C results, got {metrics["warehouses"]!r}')
+    cluster = run_context['cluster']
+    branch = run_context['branch']
+    max_deviation = get_max_deviation()
+    lines = [
+        f'cluster: {cluster}, branch: {branch}, warehouses: {warehouses}, run type: {run_type}',
+        f'allowed degradation: {100 * max_deviation:.2f}%, baseline: unixbench of {BASELINE_BEST} best of {BASELINE_RUNS} previous runs',
+    ]
+
+    history = ResultsProcessor.get_tpcc_history(
+        cluster=cluster,
+        warehouses=warehouses,
+        run_type=run_type,
+        before_ts=run_ts,
+        per_branch_limit=BASELINE_RUNS,
+    )
+    chain = branch_fallback_chain(branch, {row['git_branch'] for row in history})
+    runs, used_branches = _collect_baseline_runs(history, chain)
+    lines.append(f'branches to fall back on: {", ".join(chain)}')
+    lines.append(f'previous runs taken: {", ".join(used_branches) if used_branches else "none"}')
+
+    if len(runs) < MIN_BASELINE_RUNS:
+        summary = f'skipped, only {len(runs)} previous runs found'
+        lines.append(summary)
+        _report(lines)
+        LOGGER.warning(f'TPC-C deviation check {summary}')
+        return DeviationCheckResult(summary=summary)
+
+    errors = []
+    reports = []
+    for metric in METRICS:
+        current = float(metrics[metric.column] or 0)
+        if current <= 0:
+            raise ValueError(f'no {metric.name} in the TPC-C results, got {metrics[metric.column]!r}')
+        deviation, report = _check_metric(metric, current, runs, max_deviation)
+        reports.append(report)
+        if deviation is not None:
+            errors.append(deviation.error_message)
+    lines.extend(reports)
+    _report(lines)
+    return DeviationCheckResult(errors=errors, summary=', '.join(reports))
+
+
+def check_tpcc_deviation(results: dict, run_type: str, run_ts: float) -> DeviationCheckResult:
+    """Compare the finished run against the baseline of the previous ones.
+
+    Never raises: the caller must be able to store the current results even when
+    the check itself has failed, so problems are reported as errors of the run.
+    """
+    if not is_enabled():
+        return DeviationCheckResult()
+    with allure.step('Check TPC-C results deviation'):
+        try:
+            return _check(results, run_type, run_ts)
+        except BaseException as e:
+            LOGGER.exception('TPC-C deviation check failed')
+            message = f'TPC-C deviation check failed: {e}'
+            _report([message])
+            return DeviationCheckResult(errors=[message], summary='failed')

--- a/ydb/tests/olap/lib/tpcc_deviation.py
+++ b/ydb/tests/olap/lib/tpcc_deviation.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import allure
+import html
 import logging
 import os
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
 from math import exp, inf, log
 from ydb.tests.olap.lib.results_processor import ResultsProcessor
-from ydb.tests.olap.lib.utils import external_param_is_true, get_external_param
+from ydb.tests.olap.lib.utils import get_external_param
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +25,51 @@ BASELINE_BEST = 4
 MIN_BASELINE_RUNS = 2
 DEFAULT_MAX_DEVIATION_PERCENT = 5.0
 
+_OK_COLOR = '#90EE90'
+_FAILED_COLOR = '#FA8072'
 _STABLE_BRANCH_RE = re.compile(r'^(?:origin/)?stable-(\d+)-(\d+)(?:-(\d+))?$')
+
+
+class CheckMode(StrEnum):
+    OFF = 'off'
+    REPORT = 'report'
+    FAIL = 'fail'
+
+    @staticmethod
+    def get() -> CheckMode:
+        param = os.getenv('TPCC_CHECK_DEVIATION')
+        if param is None:
+            param = get_external_param('tpcc-check-deviation', '')
+        mode = _MODE_ALIASES.get(str(param).strip().lower())
+        if mode is None:
+            raise ValueError(f'invalid TPCC_CHECK_DEVIATION {param}')
+        return mode
+
+
+_MODE_ALIASES = {
+    '': CheckMode.OFF,
+    '0': CheckMode.OFF,
+    'f': CheckMode.OFF,
+    'false': CheckMode.OFF,
+    'no': CheckMode.OFF,
+    'off': CheckMode.OFF,
+    'none': CheckMode.OFF,
+    '2': CheckMode.REPORT,
+    'report': CheckMode.REPORT,
+    'report_only': CheckMode.REPORT,
+    'warn': CheckMode.REPORT,
+    'warning': CheckMode.REPORT,
+    'soft': CheckMode.REPORT,
+    '1': CheckMode.FAIL,
+    't': CheckMode.FAIL,
+    'true': CheckMode.FAIL,
+    'yes': CheckMode.FAIL,
+    'da': CheckMode.FAIL,
+    'on': CheckMode.FAIL,
+    'fail': CheckMode.FAIL,
+    'error': CheckMode.FAIL,
+    'strict': CheckMode.FAIL,
+}
 
 
 @dataclass(frozen=True)
@@ -39,20 +86,39 @@ METRICS = (
 
 
 @dataclass
-class MetricDeviation:
+class MetricCheck:
     metric: Metric
     current: float
-    baseline: float
+    max_deviation: float
+    baseline: float | None = None
     # Degradation as a fraction of the baseline: positive means worse than the baseline.
-    deviation: float
-    used_values: list[float]
+    deviation: float | None = None
+    # Indexes of the previous runs whose values form the baseline.
+    used_runs: list[int] = field(default_factory=list)
+    skip_reason: str = ''
+
+    @property
+    def failed(self) -> bool:
+        return self.deviation is not None and self.deviation > self.max_deviation
+
+    @property
+    def status(self) -> str:
+        if self.skip_reason:
+            return 'skipped'
+        return 'FAILED' if self.failed else 'ok'
+
+    @property
+    def report_text(self) -> str:
+        if self.skip_reason:
+            return f'{self.metric.name}: skipped, {self.skip_reason}'
+        return f'{self.metric.name}: {100 * self.deviation:+.2f}% ({self.status})'
 
     @property
     def error_message(self) -> str:
         return (
-            f'TPC-C {self.metric.name} deviates from the baseline by {100 * self.deviation:+.2f}%: '
-            f'{self.current:.2f} vs baseline {self.baseline:.2f} '
-            f'(unixbench of {len(self.used_values)} best of the previous runs)'
+            f'TPC-C {self.metric.name} degraded by {100 * self.deviation:.2f}% '
+            f'(allowed {100 * self.max_deviation:.2f}%): {self.current:.2f} '
+            f'vs baseline {self.baseline:.2f}, unixbench of {len(self.used_runs)} best of the previous runs'
         )
 
 
@@ -62,13 +128,6 @@ class DeviationCheckResult:
     errors: list[str] = field(default_factory=list)
     # Short one-line status for the Allure table, empty when the check did not run.
     summary: str = ''
-
-
-def is_enabled() -> bool:
-    env = os.getenv('TPCC_CHECK_DEVIATION')
-    if env is not None:
-        return env.strip().lower() in ['t', 'true', 'yes', '1', 'da']
-    return external_param_is_true('tpcc-check-deviation')
 
 
 def get_max_deviation() -> float:
@@ -112,53 +171,114 @@ def branch_fallback_chain(current_branch: str, known_branches) -> list[str]:
     return chain
 
 
-def _unixbench(values: list[float], higher_is_better: bool) -> tuple[float, list[float]]:
-    """Geometric mean of the best BASELINE_BEST/BASELINE_RUNS of the values."""
+def _unixbench(values: list[tuple[int, float]], higher_is_better: bool) -> tuple[float, list[int]]:
+    """Geometric mean of the best BASELINE_BEST/BASELINE_RUNS of the (run index, value) pairs."""
     best_count = max(1, len(values) * BASELINE_BEST // BASELINE_RUNS)
-    best = sorted(values, reverse=higher_is_better)[:best_count]
-    return exp(sum(log(value) for value in best) / len(best)), best
+    best = sorted(values, key=lambda item: item[1], reverse=higher_is_better)[:best_count]
+    baseline = exp(sum(log(value) for _, value in best) / len(best))
+    return baseline, sorted(index for index, _ in best)
 
 
-def _collect_baseline_runs(history: list, chain: list[str]) -> tuple[list, list[str]]:
-    """Last BASELINE_RUNS runs, taken along the branch chain until there are enough."""
+def _collect_history(history: list, chain: list[str]) -> tuple[list, list]:
+    """Baseline runs and everything the branches they came from have to show.
+
+    Returns the last BASELINE_RUNS runs taken along the branch chain, and the rows
+    of the visited branches as (branch, row, index in the baseline or None).
+    """
     by_branch: dict[str, list] = {}
     for row in history:
         by_branch.setdefault(row['git_branch'], []).append(row)
     runs = []
-    used_branches = []
+    displayed = []
     for branch in chain:
-        rows = sorted(by_branch.get(branch, []), key=lambda row: row['timestamp'], reverse=True)
-        rows = rows[:BASELINE_RUNS - len(runs)]
-        if not rows:
-            continue
-        runs.extend(rows)
-        used_branches.append(f'{branch}: {len(rows)}')
         if len(runs) >= BASELINE_RUNS:
             break
-    return runs, used_branches
+        for row in sorted(by_branch.get(branch, []), key=lambda row: row['timestamp'], reverse=True):
+            index = None
+            if len(runs) < BASELINE_RUNS:
+                index = len(runs)
+                runs.append(row)
+            displayed.append((branch, row, index))
+    return runs, displayed
 
 
-def _check_metric(metric: Metric, current: float, runs: list, max_deviation: float) -> tuple[MetricDeviation | None, str]:
-    values = [float(row[metric.column]) for row in runs if row[metric.column] and float(row[metric.column]) > 0]
+def _check_metric(metric: Metric, current: float, runs: list, max_deviation: float) -> MetricCheck:
+    values = []
+    for index, row in enumerate(runs):
+        value = row[metric.column]
+        if value and float(value) > 0:
+            values.append((index, float(value)))
     if len(values) < MIN_BASELINE_RUNS:
-        return None, f'{metric.name}: skipped, only {len(values)} usable previous values'
-    baseline, used_values = _unixbench(values, metric.higher_is_better)
+        return MetricCheck(metric, current, max_deviation, skip_reason=f'only {len(values)} usable previous values')
+    baseline, used_runs = _unixbench(values, metric.higher_is_better)
     deviation = (baseline - current) / baseline if metric.higher_is_better else (current - baseline) / baseline
-    result = MetricDeviation(metric, current, baseline, deviation, used_values)
-    status = 'FAILED' if deviation > max_deviation else 'ok'
+    check = MetricCheck(metric, current, max_deviation, baseline, deviation, used_runs)
     LOGGER.info(
-        f'TPC-C deviation {status}: {metric.name} current {current}, baseline {baseline}, '
-        f'deviation {100 * deviation:+.2f}%, limit {100 * max_deviation:.2f}%, values {values}, used {used_values}'
+        f'TPC-C deviation {check.status}: {metric.name} current {current}, baseline {baseline}, '
+        f'deviation {100 * deviation:+.2f}%, limit {100 * max_deviation:.2f}%, previous values {values}'
     )
-    report = f'{metric.name}: {100 * deviation:+.2f}% ({status})'
-    return (result if deviation > max_deviation else None), report
+    return check
 
 
-def _report(lines: list[str]) -> None:
-    allure.attach('\n'.join(lines), 'TPC-C deviation check', attachment_type=allure.attachment_type.TEXT)
+def _format_timestamp(value) -> str:
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
+    try:
+        return datetime.fromtimestamp(int(value) / 1000000).strftime('%Y-%m-%d %H:%M:%S')
+    except (TypeError, ValueError, OSError, OverflowError):
+        return str(value)
 
 
-def _check(results: dict, run_type: str, run_ts: float) -> DeviationCheckResult:
+def _table(header: list[str], rows: list[list]) -> str:
+    """Cells are either a text or a (text, background color) pair."""
+    result = '<table border="1" cellpadding="2px" cellspacing="0" style="margin-bottom: 10px">'
+    result += '<tr>' + ''.join(f'<th>{html.escape(str(cell))}</th>' for cell in header) + '</tr>'
+    for row in rows:
+        result += '<tr>'
+        for cell in row:
+            text, color = cell if isinstance(cell, tuple) else (cell, None)
+            color = f' bgcolor="{color}"' if color else ''
+            result += f'<td{color}>{html.escape(str(text))}</td>'
+        result += '</tr>'
+    return result + '</table>'
+
+
+def _previous_runs_report(displayed: list, checks: list[MetricCheck]) -> str:
+    used = {check.metric.column: set(check.used_runs) for check in checks}
+    rows = []
+    for branch, row, index in displayed:
+        cells = ['-' if index is None else str(index + 1), branch, _format_timestamp(row['timestamp'])]
+        for metric in METRICS:
+            value = row[metric.column]
+            in_baseline = index is not None and index in used.get(metric.column, set())
+            cells.append(('' if value is None else value, _OK_COLOR if in_baseline else None))
+        rows.append(cells)
+    return (
+        '<h4>Previous runs</h4>'
+        '<div>The numbered ones are the baseline runs, the highlighted values are the ones it is built of.</div>'
+        + _table(['#', 'Branch', 'Timestamp'] + [metric.name for metric in METRICS], rows)
+    )
+
+
+def _baseline_report(checks: list[MetricCheck]) -> str:
+    rows = []
+    for check in checks:
+        color = _FAILED_COLOR if check.failed else _OK_COLOR if not check.skip_reason else None
+        rows.append([
+            check.metric.name,
+            f'{check.current:.2f}',
+            'n/a' if check.baseline is None else f'{check.baseline:.2f}',
+            check.skip_reason if check.deviation is None else f'{100 * check.deviation:+.2f}%',
+            f'{100 * check.max_deviation:.2f}%',
+            (check.status, color),
+        ])
+    return (
+        '<h4>Check result</h4>'
+        + _table(['Metric', 'Current', 'Baseline (unixbench)', 'Degradation', 'Allowed', 'Status'], rows)
+    )
+
+
+def _check(results: dict, run_type: str, run_ts: float, mode: CheckMode, report: list[str]) -> DeviationCheckResult:
     run_context = ResultsProcessor.get_tpcc_run_context()
     metrics = ResultsProcessor.get_tpcc_metrics(results)
     warehouses = int(metrics['warehouses'] or 0)
@@ -167,10 +287,15 @@ def _check(results: dict, run_type: str, run_ts: float) -> DeviationCheckResult:
     cluster = run_context['cluster']
     branch = run_context['branch']
     max_deviation = get_max_deviation()
-    lines = [
-        f'cluster: {cluster}, branch: {branch}, warehouses: {warehouses}, run type: {run_type}',
-        f'allowed degradation: {100 * max_deviation:.2f}%, baseline: unixbench of {BASELINE_BEST} best of {BASELINE_RUNS} previous runs',
-    ]
+    report.append(_table(['Parameter', 'Value'], [
+        ['Cluster', cluster],
+        ['Branch', branch],
+        ['Warehouses', warehouses],
+        ['Run type', run_type],
+        ['Mode', str(mode)],
+        ['Allowed degradation', f'{100 * max_deviation:.2f}%'],
+        ['Baseline', f'unixbench (geometric mean) of {BASELINE_BEST} best of {BASELINE_RUNS} previous runs'],
+    ]))
 
     history = ResultsProcessor.get_tpcc_history(
         cluster=cluster,
@@ -180,30 +305,28 @@ def _check(results: dict, run_type: str, run_ts: float) -> DeviationCheckResult:
         per_branch_limit=BASELINE_RUNS,
     )
     chain = branch_fallback_chain(branch, {row['git_branch'] for row in history})
-    runs, used_branches = _collect_baseline_runs(history, chain)
-    lines.append(f'branches to fall back on: {", ".join(chain)}')
-    lines.append(f'previous runs taken: {", ".join(used_branches) if used_branches else "none"}')
+    runs, displayed = _collect_history(history, chain)
+    report.append(f'<div>Branches to fall back on: {html.escape(", ".join(chain))}</div>')
 
     if len(runs) < MIN_BASELINE_RUNS:
         summary = f'skipped, only {len(runs)} previous runs found'
-        lines.append(summary)
-        _report(lines)
+        report.append(_previous_runs_report(displayed, []))
+        report.append(f'<h4>Check result</h4><div>{html.escape(summary)}</div>')
         LOGGER.warning(f'TPC-C deviation check {summary}')
         return DeviationCheckResult(summary=summary)
 
-    errors = []
-    reports = []
+    checks = []
     for metric in METRICS:
         current = float(metrics[metric.column] or 0)
         if current <= 0:
             raise ValueError(f'no {metric.name} in the TPC-C results, got {metrics[metric.column]!r}')
-        deviation, report = _check_metric(metric, current, runs, max_deviation)
-        reports.append(report)
-        if deviation is not None:
-            errors.append(deviation.error_message)
-    lines.extend(reports)
-    _report(lines)
-    return DeviationCheckResult(errors=errors, summary=', '.join(reports))
+        checks.append(_check_metric(metric, current, runs, max_deviation))
+    report.append(_previous_runs_report(displayed, checks))
+    report.append(_baseline_report(checks))
+    return DeviationCheckResult(
+        errors=[check.error_message for check in checks if check.failed],
+        summary=', '.join(check.report_text for check in checks),
+    )
 
 
 def check_tpcc_deviation(results: dict, run_type: str, run_ts: float) -> DeviationCheckResult:
@@ -212,13 +335,25 @@ def check_tpcc_deviation(results: dict, run_type: str, run_ts: float) -> Deviati
     Never raises: the caller must be able to store the current results even when
     the check itself has failed, so problems are reported as errors of the run.
     """
-    if not is_enabled():
+    try:
+        mode = CheckMode.get()
+    except ValueError as e:
+        LOGGER.error(f'TPC-C deviation check is misconfigured: {e}')
+        return DeviationCheckResult(errors=[str(e)], summary='failed')
+    if mode == CheckMode.OFF:
         return DeviationCheckResult()
+    report: list[str] = ['<h4>TPC-C deviation check</h4>']
     with allure.step('Check TPC-C results deviation'):
         try:
-            return _check(results, run_type, run_ts)
+            result = _check(results, run_type, run_ts, mode, report)
         except BaseException as e:
             LOGGER.exception('TPC-C deviation check failed')
             message = f'TPC-C deviation check failed: {e}'
-            _report([message])
-            return DeviationCheckResult(errors=[message], summary='failed')
+            report.append(f'<h4>Check result</h4><div bgcolor="{_FAILED_COLOR}">{html.escape(message)}</div>')
+            result = DeviationCheckResult(errors=[message], summary='failed')
+        if mode == CheckMode.REPORT and result.errors:
+            LOGGER.warning(f'TPC-C deviation check is report only, the test is not failed by: {result.errors}')
+            report.append('<div>Report only mode: this check does not fail the test.</div>')
+            result = DeviationCheckResult(summary=f'{result.summary} (report only)')
+        allure.attach('\n'.join(report), 'TPC-C deviation check', attachment_type=allure.attachment_type.HTML)
+    return result

--- a/ydb/tests/olap/lib/ya.make
+++ b/ydb/tests/olap/lib/ya.make
@@ -5,6 +5,7 @@ PY3_LIBRARY()
         compaction.py
         results_processor.py
         remote_execution.py
+        tpcc_deviation.py
         ydb_cluster.py
         utils.py
         ydb_cli.py

--- a/ydb/tests/olap/load/lib/tpcc.py
+++ b/ydb/tests/olap/load/lib/tpcc.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from time import time
 from .conftest import LoadSuiteBase
 from ydb.tests.olap.lib.results_processor import ResultsProcessor
+from ydb.tests.olap.lib.tpcc_deviation import DeviationCheckResult, check_tpcc_deviation
 from ydb.tests.olap.lib.allure_utils import time_interval_str
 from ydb.tests.olap.lib.utils import get_external_param
 from ydb.tests.olap.lib.ydb_cli import YdbCliHelper, TxMode
@@ -182,10 +183,18 @@ class TpccSuiteBase(LoadSuiteBase):
             'threads': summary.get('threads', ''),
             'warmup_seconds': summary.get('warmup_seconds', ''),
         }
-        self.process_query_result(result, 'test', True, allure_table_strings=allure_table_strings, node_errors=node_errors, verify_errors=verify_errors)
+        deviation = DeviationCheckResult()
         if result.success and 'tpcc_json' in stats:
             run_type = f'ydb_cli_{str(self.tx_mode).replace("-rw", "")}_{getenv("TPCC_RUN_TYPE", "default")}'
+            # Read the baseline before the upload, so that the current run is not part of it.
+            deviation = check_tpcc_deviation(stats['tpcc_json'], run_type, result.start_time)
+            # Results are stored regardless of the deviation check outcome.
             ResultsProcessor.upload_tpcc_results(stats['tpcc_json'], run_type, result.start_time)
+        if deviation.summary:
+            allure_table_strings['deviation_check'] = deviation.summary
+        for error in deviation.errors:
+            result.add_error(error)
+        self.process_query_result(result, 'test', True, allure_table_strings=allure_table_strings, node_errors=node_errors, verify_errors=verify_errors)
 
 
 class TestTpccW5000T0Serializable(TpccSuiteBase):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Baseline is the unixbench aggregate (geometric mean of the 4 best of the 6
previous runs) over the same cluster, warehouse count and run type, taken
from the current branch and, when it has too little history, continued from
older stable branches in order. Only degradation beyond 5% fails the test.

Enabled by TPCC_CHECK_DEVIATION, threshold by TPCC_MAX_DEVIATION_PERCENT.
The baseline is read before the upload, so the run is never part of its own
baseline, and results are stored regardless of the check outcome.

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
