### PR TITLE
Fix documentation PR label synchronization

### DIFF
--- a/.github/workflows/docs_label.yaml
+++ b/.github/workflows/docs_label.yaml
@@ -1,29 +1,53 @@
 name: Label documentation PR
 
 # SECURITY: this workflow runs in the privileged `pull_request_target` context
-# but does NOT check out PR-controlled code. It only adds the `documentation`
-# label using the GITHUB_TOKEN. The actual documentation build is intentionally
-# split out into `docs_build.yaml`, which runs in the fork-isolated
-# `pull_request` context.
+# but does NOT check out PR-controlled code. It only synchronizes the
+# `documentation` label using the GITHUB_TOKEN. The actual documentation build
+# is intentionally split out into `docs_build.yaml`, which runs in the
+# fork-isolated `pull_request` context.
 
 on:
   pull_request_target:
-    paths:
-      - 'ydb/docs/**'
+    types: [opened, reopened, synchronize]
 
 jobs:
-  add-label:
+  sync-label:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Add documentation label
+      - name: Synchronize documentation label
         uses: actions/github-script@v8
         with:
           script: |
-            await github.rest.issues.addLabels({
-              issue_number: context.payload.pull_request.number,
+            const pullNumber = context.payload.pull_request.number;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['documentation']
+              pull_number: pullNumber,
+              per_page: 100,
             });
+            const hasDocs = files.some((file) => file.filename.startsWith('ydb/docs/'));
+
+            if (hasDocs) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                labels: ['documentation'],
+              });
+              return;
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                name: 'documentation',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }


### PR DESCRIPTION
### What changed

- replace the `paths` trigger filter with explicit PR lifecycle events;
- inspect the PR's current file list through the GitHub API;
- add the `documentation` label only when the current diff contains `ydb/docs/**`;
- remove a stale `documentation` label when documentation changes disappear.

### Why

After a rebase, GitHub's path filter can match documentation files introduced by the rewritten base even when the final PR diff contains no documentation. This happened in #51120. The old workflow also never removed stale labels.

### Validation

- YAML syntax check;
- `git diff --check`.
