### PR TITLE
Fix united executor pool accounting and wakeups

### DIFF
--- a/ydb/library/actors/core/cpu_manager.cpp
+++ b/ydb/library/actors/core/cpu_manager.cpp
@@ -29,7 +29,7 @@ namespace NActors {
         ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::SetupShared");
         bool hasSharedThread = false;
         for (TBasicExecutorPoolConfig& cfg : Config.Basic) {
-            if (cfg.HasSharedThread || cfg.AllThreadsAreShared) {
+            if (cfg.HasSharedThread) {
                 hasSharedThread = true;
                 break;
             }
@@ -53,11 +53,7 @@ namespace NActors {
 
         for (ui32 i = 0; i < Config.Basic.size(); ++i) {
             auto &cfg = Config.Basic[poolIds[i]];
-            i16 sharedThreadCount = cfg.AllThreadsAreShared
-                ? (cfg.DefaultThreadCount
-                    ? cfg.DefaultThreadCount
-                    : static_cast<i16>(Min<ui32>(cfg.Threads, Max<i16>())))
-                : cfg.MaxThreadCount ? 1 : 0;
+            i16 sharedThreadCount = cfg.AllThreadsAreShared ? cfg.DefaultThreadCount : cfg.MaxThreadCount ? 1 : 0;
             poolInfos.push_back(TPoolShortInfo{
                 .PoolId = static_cast<i16>(Config.Basic[poolIds[i]].PoolId),
                 .SharedThreadCount = sharedThreadCount,

--- a/ydb/library/actors/core/cpu_manager.cpp
+++ b/ydb/library/actors/core/cpu_manager.cpp
@@ -29,7 +29,7 @@ namespace NActors {
         ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::SetupShared");
         bool hasSharedThread = false;
         for (TBasicExecutorPoolConfig& cfg : Config.Basic) {
-            if (cfg.HasSharedThread) {
+            if (cfg.HasSharedThread || cfg.AllThreadsAreShared) {
                 hasSharedThread = true;
                 break;
             }
@@ -53,7 +53,11 @@ namespace NActors {
 
         for (ui32 i = 0; i < Config.Basic.size(); ++i) {
             auto &cfg = Config.Basic[poolIds[i]];
-            i16 sharedThreadCount = cfg.AllThreadsAreShared ? cfg.DefaultThreadCount : cfg.MaxThreadCount ? 1 : 0;
+            i16 sharedThreadCount = cfg.AllThreadsAreShared
+                ? (cfg.DefaultThreadCount
+                    ? cfg.DefaultThreadCount
+                    : static_cast<i16>(Min<ui32>(cfg.Threads, Max<i16>())))
+                : cfg.MaxThreadCount ? 1 : 0;
             poolInfos.push_back(TPoolShortInfo{
                 .PoolId = static_cast<i16>(Config.Basic[poolIds[i]].PoolId),
                 .SharedThreadCount = sharedThreadCount,

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -138,9 +138,34 @@ namespace NActors {
         Y_UNUSED(Jail, SoftProcessingDurationTs);
 
         if (cfg.AllThreadsAreShared) {
-            DefaultFullThreadCount = 0;
-            MinFullThreadCount = 0;
-            MaxFullThreadCount = 0;
+            ui32 sharedThreads = DefaultThreadCount;
+            ui32 threads = ThreadCount;
+            if (sharedThreads && threads) {
+                threads = threads - sharedThreads;
+            }
+            if (cfg.AllThreadsAreShared) {
+                threads = 0;
+            }
+
+            if constexpr (NFeatures::TSpinFeatureFlags::CalcPerThread) {
+                for (ui32 idx = 0; idx < threads; ++idx) {
+                    SpinThresholdCyclesPerThread[idx].store(0);
+                }
+            }
+            if constexpr (NFeatures::TSpinFeatureFlags::UsePseudoMovingWindow) {
+                MovingWaitingStats.Reset(new TWaitingStats<double>[threads]);
+            }
+
+            i16 limit = Min(threads, (ui32)Max<i16>());
+            DefaultFullThreadCount = Min<i16>(DefaultFullThreadCount - sharedThreads, limit);
+
+            MaxFullThreadCount = Min(Max<i16>(MaxFullThreadCount - sharedThreads, DefaultFullThreadCount), limit);
+
+            if (MinFullThreadCount) {
+                MinFullThreadCount = Min<i16>(MinFullThreadCount - sharedThreads, DefaultFullThreadCount);
+            } else {
+                MinFullThreadCount = DefaultFullThreadCount;
+            }
         } else {
             ui32 threads = ThreadCount;
             if (HasOwnSharedThread && threads) {
@@ -178,26 +203,17 @@ namespace NActors {
         semaphore.CurrentThreadCount = ThreadCount;
         Semaphore = semaphore.ConvertToI64();
 
-        if (cfg.AllThreadsAreShared) {
-            const i16 defaultThreadCount = cfg.DefaultThreadCount
-                ? cfg.DefaultThreadCount
-                : static_cast<i16>(Min<ui32>(cfg.Threads, Max<i16>()));
-            DefaultThreadCount = defaultThreadCount;
-            MaxThreadCount = Max(cfg.MaxThreadCount, defaultThreadCount);
-            MinThreadCount = cfg.MinThreadCount ? Min(cfg.MinThreadCount, defaultThreadCount) : defaultThreadCount;
-        } else {
-            DefaultThreadCount = DefaultFullThreadCount + HasOwnSharedThread;
-            MinThreadCount = MinFullThreadCount + HasOwnSharedThread;
-            MaxThreadCount = MaxFullThreadCount + HasOwnSharedThread;
-        }
+        DefaultThreadCount = DefaultFullThreadCount + HasOwnSharedThread;
+        MinThreadCount = MinFullThreadCount + HasOwnSharedThread;
+        MaxThreadCount = MaxFullThreadCount + HasOwnSharedThread;
 
-        if (SharedOnly && !cfg.AllThreadsAreShared) {
+        if (SharedOnly) {
             MaxThreadCount = cfg.ForcedForeignSlotCount + 1;
         }
 
         Threads.Reset(new NThreading::TPadded<TExecutorThreadCtx>[MaxFullThreadCount]);
         if (EnableWaker) {
-            Y_ABORT_UNLESS(!HasOwnSharedThread && !SharedOnly && !cfg.AllThreadsAreShared,
+            Y_ABORT_UNLESS(!HasOwnSharedThread && !SharedOnly,
                 "EnableWaker is supported only for non-shared Basic executor pools");
             Waker = std::make_unique<TWaker>(this);
         }

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -138,34 +138,9 @@ namespace NActors {
         Y_UNUSED(Jail, SoftProcessingDurationTs);
 
         if (cfg.AllThreadsAreShared) {
-            ui32 sharedThreads = DefaultThreadCount;
-            ui32 threads = ThreadCount;
-            if (sharedThreads && threads) {
-                threads = threads - sharedThreads;
-            }
-            if (cfg.AllThreadsAreShared) {
-                threads = 0;
-            }
-
-            if constexpr (NFeatures::TSpinFeatureFlags::CalcPerThread) {
-                for (ui32 idx = 0; idx < threads; ++idx) {
-                    SpinThresholdCyclesPerThread[idx].store(0);
-                }
-            }
-            if constexpr (NFeatures::TSpinFeatureFlags::UsePseudoMovingWindow) {
-                MovingWaitingStats.Reset(new TWaitingStats<double>[threads]);
-            }
-
-            i16 limit = Min(threads, (ui32)Max<i16>());
-            DefaultFullThreadCount = Min<i16>(DefaultFullThreadCount - sharedThreads, limit);
-
-            MaxFullThreadCount = Min(Max<i16>(MaxFullThreadCount - sharedThreads, DefaultFullThreadCount), limit);
-
-            if (MinFullThreadCount) {
-                MinFullThreadCount = Min<i16>(MinFullThreadCount - sharedThreads, DefaultFullThreadCount);
-            } else {
-                MinFullThreadCount = DefaultFullThreadCount;
-            }
+            DefaultFullThreadCount = 0;
+            MinFullThreadCount = 0;
+            MaxFullThreadCount = 0;
         } else {
             ui32 threads = ThreadCount;
             if (HasOwnSharedThread && threads) {
@@ -203,17 +178,26 @@ namespace NActors {
         semaphore.CurrentThreadCount = ThreadCount;
         Semaphore = semaphore.ConvertToI64();
 
-        DefaultThreadCount = DefaultFullThreadCount + HasOwnSharedThread;
-        MinThreadCount = MinFullThreadCount + HasOwnSharedThread;
-        MaxThreadCount = MaxFullThreadCount + HasOwnSharedThread;
+        if (cfg.AllThreadsAreShared) {
+            const i16 defaultThreadCount = cfg.DefaultThreadCount
+                ? cfg.DefaultThreadCount
+                : static_cast<i16>(Min<ui32>(cfg.Threads, Max<i16>()));
+            DefaultThreadCount = defaultThreadCount;
+            MaxThreadCount = Max(cfg.MaxThreadCount, defaultThreadCount);
+            MinThreadCount = cfg.MinThreadCount ? Min(cfg.MinThreadCount, defaultThreadCount) : defaultThreadCount;
+        } else {
+            DefaultThreadCount = DefaultFullThreadCount + HasOwnSharedThread;
+            MinThreadCount = MinFullThreadCount + HasOwnSharedThread;
+            MaxThreadCount = MaxFullThreadCount + HasOwnSharedThread;
+        }
 
-        if (SharedOnly) {
+        if (SharedOnly && !cfg.AllThreadsAreShared) {
             MaxThreadCount = cfg.ForcedForeignSlotCount + 1;
         }
 
         Threads.Reset(new NThreading::TPadded<TExecutorThreadCtx>[MaxFullThreadCount]);
         if (EnableWaker) {
-            Y_ABORT_UNLESS(!HasOwnSharedThread && !SharedOnly,
+            Y_ABORT_UNLESS(!HasOwnSharedThread && !SharedOnly && !cfg.AllThreadsAreShared,
                 "EnableWaker is supported only for non-shared Basic executor pools");
             Waker = std::make_unique<TWaker>(this);
         }

--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -102,10 +102,9 @@ namespace NActors {
         , DefaultSpinThresholdCycles(cfg.SpinThreshold * NHPTimer::GetCyclesPerSecond() * 0.000001) // convert microseconds to cycles
         , PoolName("Shared")
         , SoftProcessingDurationTs(cfg.SoftProcessingDurationTs)
-        , United(cfg.United)
         , Threads(new NThreading::TPadded<TSharedExecutorThreadCtx>[PoolThreads])
-        , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<i64>>[poolInfos.size()])
-        , ForeignThreadSlots(new NThreading::TPadded<std::atomic<i64>>[poolInfos.size()])
+        , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
+        , ForeignThreadSlots(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , LocalThreads(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , LocalNotifications(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , SpinThresholdCycles(DefaultSpinThresholdCycles)
@@ -124,9 +123,8 @@ namespace NActors {
         }
         for (ui64 i = 0; i < PoolManager.PoolInfos.size(); ++i) {
             auto &poolInfo = PoolManager.PoolInfos[i];
-            const i16 foreignSlots = Max<i16>(0, poolInfo.ForeignSlots);
-            ForeignThreadsAllowedByPool[i].store(foreignSlots, std::memory_order_release);
-            ForeignThreadSlots[i].store(foreignSlots, std::memory_order_release);
+            ForeignThreadsAllowedByPool[i].store(poolInfo.ForeignSlots, std::memory_order_release);
+            ForeignThreadSlots[i].store(poolInfo.ForeignSlots, std::memory_order_release);
             LocalThreads[i].store(poolInfo.SharedThreadCount, std::memory_order_release);
             LocalNotifications[i].store(0, std::memory_order_release);
         }
@@ -160,7 +158,7 @@ namespace NActors {
                 adj = true;
             }
 
-            if (ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire) <= 0 && !adj) {
+            if (ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire) == 0 && !adj) {
                 EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "don't have leases; OwnerPoolId == ", thread.OwnerPoolId);
                 continue;
             }
@@ -174,7 +172,7 @@ namespace NActors {
                 return i;
             }
 
-            i64 slots = ForeignThreadSlots[i].load(std::memory_order_acquire);
+            ui64 slots = ForeignThreadSlots[i].load(std::memory_order_acquire);
 
             while (true) {
                 if (slots <= 0) {
@@ -194,7 +192,7 @@ namespace NActors {
         TWorkerId workerId = TlsThreadContext->WorkerId();
         TlsThreadContext->ExecutionStats->UpdateThreadTime();
         if (Threads[workerId].CurrentPoolId != poolId && !CheckPoolAdjacency(PoolManager, Threads[workerId].OwnerPoolId, Threads[workerId].CurrentPoolId)) {
-            i64 slots = ForeignThreadSlots[Threads[workerId].CurrentPoolId].fetch_add(1, std::memory_order_acq_rel);
+            ui64 slots = ForeignThreadSlots[Threads[workerId].CurrentPoolId].fetch_add(1, std::memory_order_acq_rel);
             EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Lease, "return lease; ownerPoolId == ", Threads[workerId].OwnerPoolId, " currentPoolId == ", Threads[workerId].CurrentPoolId, " poolId = ", poolId, " slots == ", slots, " -> ", slots + 1);
         }
         Threads[workerId].CurrentPoolId = poolId;
@@ -498,18 +496,11 @@ namespace NActors {
     }
 
     bool TSharedExecutorPool::WakeUpGlobalThreads(i16 ownerPoolId) {
-        const bool canUseForeignThreads =
-            ForeignThreadsAllowedByPool[ownerPoolId].load(std::memory_order_acquire) > 0 &&
-            ForeignThreadSlots[ownerPoolId].load(std::memory_order_acquire) > 0;
-        bool hasAdjacentThreads = false;
-        for (i16 poolId : PoolManager.PriorityOrder) {
-            const auto& range = PoolManager.PoolThreadRanges[poolId];
-            if (poolId != ownerPoolId && range.Begin != range.End && CheckPoolAdjacency(PoolManager, poolId, ownerPoolId)) {
-                hasAdjacentThreads = true;
-                break;
-            }
+        if (ForeignThreadsAllowedByPool[ownerPoolId].load(std::memory_order_acquire) == 0) {
+            return false;
         }
-        if (!canUseForeignThreads && !hasAdjacentThreads) {
+        ui64 slots = ForeignThreadSlots[ownerPoolId].load(std::memory_order_acquire);
+        if (slots <= 0) {
             return false;
         }
 
@@ -539,24 +530,13 @@ namespace NActors {
             return false;
         }
 
-        for (bool adjacentOnly : {true, false}) {
-            if (!adjacentOnly && !canUseForeignThreads) {
-                break;
-            }
-            for (i16 i = static_cast<i16>(PoolManager.PriorityOrder.size()) - 1; i >= 0; --i) {
-                i16 poolId = PoolManager.PriorityOrder[i];
-                if (poolId == ownerPoolId) {
-                    continue;
-                }
-                if (CheckPoolAdjacency(PoolManager, poolId, ownerPoolId) != adjacentOnly) {
-                    continue;
-                }
-                for (i16 threadId = PoolManager.PoolThreadRanges[poolId].Begin; threadId < PoolManager.PoolThreadRanges[poolId].End; ++threadId) {
-                    auto &thread = Threads[threadId];
-                    if (thread.WakeUp()) {
-                        EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "wakeup from other pool; ownerPoolId == ", ownerPoolId, " poolId == ", poolId, " threadId == ", threadId);
-                        return true;
-                    }
+        for (i16 i = static_cast<i16>(PoolManager.PriorityOrder.size()) - 1; i >= 0; --i) {
+            i16 poolId = PoolManager.PriorityOrder[i];
+            for (i16 threadId = PoolManager.PoolThreadRanges[poolId].Begin; threadId < PoolManager.PoolThreadRanges[poolId].End; ++threadId) {
+                auto &thread = Threads[threadId];
+                if (thread.WakeUp()) {
+                    EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "wakeup from other pool; ownerPoolId == ", ownerPoolId, " poolId == ", poolId, " threadId == ", threadId);
+                    return true;
                 }
             }
         }
@@ -567,7 +547,7 @@ namespace NActors {
     void TSharedExecutorPool::FillForeignThreadsAllowed(std::vector<i16>& foreignThreadsAllowed) const {
         foreignThreadsAllowed.resize(PoolManager.PoolInfos.size());
         for (ui64 i = 0; i < foreignThreadsAllowed.size(); ++i) {
-            foreignThreadsAllowed[i] = static_cast<i16>(ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire));
+            foreignThreadsAllowed[i] = ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire);
         }
     }
 
@@ -596,15 +576,12 @@ namespace NActors {
         if (auto forcedSlots = GetForcedForeignSlots(PoolManager, poolId)) {
             return;
         }
-        slots = Max<i16>(0, slots);
-        i64 current = ForeignThreadsAllowedByPool[poolId].load(std::memory_order_acquire);
+        i16 current = ForeignThreadsAllowedByPool[poolId].load(std::memory_order_acquire);
         if (current == slots) {
             return;
         }
-        // Availability is the admission gate. Update it before publishing the new
-        // limit so a concurrent decrease cannot grant leases above that limit.
-        ForeignThreadSlots[poolId].fetch_add(static_cast<i64>(slots) - current, std::memory_order_acq_rel);
         ForeignThreadsAllowedByPool[poolId].store(slots, std::memory_order_release);
+        ForeignThreadSlots[poolId].fetch_add(slots - current, std::memory_order_relaxed);
     }
 
     void TSharedExecutorPool::SetBasicPool(TBasicExecutorPool* pool) {

--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -102,9 +102,10 @@ namespace NActors {
         , DefaultSpinThresholdCycles(cfg.SpinThreshold * NHPTimer::GetCyclesPerSecond() * 0.000001) // convert microseconds to cycles
         , PoolName("Shared")
         , SoftProcessingDurationTs(cfg.SoftProcessingDurationTs)
+        , United(cfg.United)
         , Threads(new NThreading::TPadded<TSharedExecutorThreadCtx>[PoolThreads])
-        , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
-        , ForeignThreadSlots(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
+        , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<i64>>[poolInfos.size()])
+        , ForeignThreadSlots(new NThreading::TPadded<std::atomic<i64>>[poolInfos.size()])
         , LocalThreads(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , LocalNotifications(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , SpinThresholdCycles(DefaultSpinThresholdCycles)
@@ -123,8 +124,9 @@ namespace NActors {
         }
         for (ui64 i = 0; i < PoolManager.PoolInfos.size(); ++i) {
             auto &poolInfo = PoolManager.PoolInfos[i];
-            ForeignThreadsAllowedByPool[i].store(poolInfo.ForeignSlots, std::memory_order_release);
-            ForeignThreadSlots[i].store(poolInfo.ForeignSlots, std::memory_order_release);
+            const i16 foreignSlots = Max<i16>(0, poolInfo.ForeignSlots);
+            ForeignThreadsAllowedByPool[i].store(foreignSlots, std::memory_order_release);
+            ForeignThreadSlots[i].store(foreignSlots, std::memory_order_release);
             LocalThreads[i].store(poolInfo.SharedThreadCount, std::memory_order_release);
             LocalNotifications[i].store(0, std::memory_order_release);
         }
@@ -158,7 +160,7 @@ namespace NActors {
                 adj = true;
             }
 
-            if (ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire) == 0 && !adj) {
+            if (ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire) <= 0 && !adj) {
                 EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "don't have leases; OwnerPoolId == ", thread.OwnerPoolId);
                 continue;
             }
@@ -172,7 +174,7 @@ namespace NActors {
                 return i;
             }
 
-            ui64 slots = ForeignThreadSlots[i].load(std::memory_order_acquire);
+            i64 slots = ForeignThreadSlots[i].load(std::memory_order_acquire);
 
             while (true) {
                 if (slots <= 0) {
@@ -192,7 +194,7 @@ namespace NActors {
         TWorkerId workerId = TlsThreadContext->WorkerId();
         TlsThreadContext->ExecutionStats->UpdateThreadTime();
         if (Threads[workerId].CurrentPoolId != poolId && !CheckPoolAdjacency(PoolManager, Threads[workerId].OwnerPoolId, Threads[workerId].CurrentPoolId)) {
-            ui64 slots = ForeignThreadSlots[Threads[workerId].CurrentPoolId].fetch_add(1, std::memory_order_acq_rel);
+            i64 slots = ForeignThreadSlots[Threads[workerId].CurrentPoolId].fetch_add(1, std::memory_order_acq_rel);
             EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Lease, "return lease; ownerPoolId == ", Threads[workerId].OwnerPoolId, " currentPoolId == ", Threads[workerId].CurrentPoolId, " poolId = ", poolId, " slots == ", slots, " -> ", slots + 1);
         }
         Threads[workerId].CurrentPoolId = poolId;
@@ -496,11 +498,18 @@ namespace NActors {
     }
 
     bool TSharedExecutorPool::WakeUpGlobalThreads(i16 ownerPoolId) {
-        if (ForeignThreadsAllowedByPool[ownerPoolId].load(std::memory_order_acquire) == 0) {
-            return false;
+        const bool canUseForeignThreads =
+            ForeignThreadsAllowedByPool[ownerPoolId].load(std::memory_order_acquire) > 0 &&
+            ForeignThreadSlots[ownerPoolId].load(std::memory_order_acquire) > 0;
+        bool hasAdjacentThreads = false;
+        for (i16 poolId : PoolManager.PriorityOrder) {
+            const auto& range = PoolManager.PoolThreadRanges[poolId];
+            if (poolId != ownerPoolId && range.Begin != range.End && CheckPoolAdjacency(PoolManager, poolId, ownerPoolId)) {
+                hasAdjacentThreads = true;
+                break;
+            }
         }
-        ui64 slots = ForeignThreadSlots[ownerPoolId].load(std::memory_order_acquire);
-        if (slots <= 0) {
+        if (!canUseForeignThreads && !hasAdjacentThreads) {
             return false;
         }
 
@@ -530,13 +539,24 @@ namespace NActors {
             return false;
         }
 
-        for (i16 i = static_cast<i16>(PoolManager.PriorityOrder.size()) - 1; i >= 0; --i) {
-            i16 poolId = PoolManager.PriorityOrder[i];
-            for (i16 threadId = PoolManager.PoolThreadRanges[poolId].Begin; threadId < PoolManager.PoolThreadRanges[poolId].End; ++threadId) {
-                auto &thread = Threads[threadId];
-                if (thread.WakeUp()) {
-                    EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "wakeup from other pool; ownerPoolId == ", ownerPoolId, " poolId == ", poolId, " threadId == ", threadId);
-                    return true;
+        for (bool adjacentOnly : {true, false}) {
+            if (!adjacentOnly && !canUseForeignThreads) {
+                break;
+            }
+            for (i16 i = static_cast<i16>(PoolManager.PriorityOrder.size()) - 1; i >= 0; --i) {
+                i16 poolId = PoolManager.PriorityOrder[i];
+                if (poolId == ownerPoolId) {
+                    continue;
+                }
+                if (CheckPoolAdjacency(PoolManager, poolId, ownerPoolId) != adjacentOnly) {
+                    continue;
+                }
+                for (i16 threadId = PoolManager.PoolThreadRanges[poolId].Begin; threadId < PoolManager.PoolThreadRanges[poolId].End; ++threadId) {
+                    auto &thread = Threads[threadId];
+                    if (thread.WakeUp()) {
+                        EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "wakeup from other pool; ownerPoolId == ", ownerPoolId, " poolId == ", poolId, " threadId == ", threadId);
+                        return true;
+                    }
                 }
             }
         }
@@ -547,7 +567,7 @@ namespace NActors {
     void TSharedExecutorPool::FillForeignThreadsAllowed(std::vector<i16>& foreignThreadsAllowed) const {
         foreignThreadsAllowed.resize(PoolManager.PoolInfos.size());
         for (ui64 i = 0; i < foreignThreadsAllowed.size(); ++i) {
-            foreignThreadsAllowed[i] = ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire);
+            foreignThreadsAllowed[i] = static_cast<i16>(ForeignThreadsAllowedByPool[i].load(std::memory_order_acquire));
         }
     }
 
@@ -576,12 +596,15 @@ namespace NActors {
         if (auto forcedSlots = GetForcedForeignSlots(PoolManager, poolId)) {
             return;
         }
-        i16 current = ForeignThreadsAllowedByPool[poolId].load(std::memory_order_acquire);
+        slots = Max<i16>(0, slots);
+        i64 current = ForeignThreadsAllowedByPool[poolId].load(std::memory_order_acquire);
         if (current == slots) {
             return;
         }
+        // Availability is the admission gate. Update it before publishing the new
+        // limit so a concurrent decrease cannot grant leases above that limit.
+        ForeignThreadSlots[poolId].fetch_add(static_cast<i64>(slots) - current, std::memory_order_acq_rel);
         ForeignThreadsAllowedByPool[poolId].store(slots, std::memory_order_release);
-        ForeignThreadSlots[poolId].fetch_add(slots - current, std::memory_order_relaxed);
     }
 
     void TSharedExecutorPool::SetBasicPool(TBasicExecutorPool* pool) {

--- a/ydb/library/actors/core/executor_pool_shared.h
+++ b/ydb/library/actors/core/executor_pool_shared.h
@@ -80,15 +80,15 @@ namespace NActors {
         const ui64 DefaultSpinThresholdCycles;
         const TString PoolName;
         const ui64 SoftProcessingDurationTs;
-        const bool United = false;
+        const bool United;
 
         char Barrier[64];
 
         TArrayHolder<NThreading::TPadded<TSharedExecutorThreadCtx>> Threads;
         static_assert(sizeof(std::decay_t<decltype(Threads[0])>) == PLATFORM_CACHE_LINE);
 
-        alignas(64) TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> ForeignThreadsAllowedByPool;
-        TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> ForeignThreadSlots;
+        alignas(64) TArrayHolder<NThreading::TPadded<std::atomic<i64>>> ForeignThreadsAllowedByPool;
+        TArrayHolder<NThreading::TPadded<std::atomic<i64>>> ForeignThreadSlots;
         TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> LocalThreads;
         TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> LocalNotifications;
         alignas(64) std::atomic<ui64> SpinThresholdCycles;

--- a/ydb/library/actors/core/executor_pool_shared.h
+++ b/ydb/library/actors/core/executor_pool_shared.h
@@ -80,15 +80,15 @@ namespace NActors {
         const ui64 DefaultSpinThresholdCycles;
         const TString PoolName;
         const ui64 SoftProcessingDurationTs;
-        const bool United;
+        const bool United = false;
 
         char Barrier[64];
 
         TArrayHolder<NThreading::TPadded<TSharedExecutorThreadCtx>> Threads;
         static_assert(sizeof(std::decay_t<decltype(Threads[0])>) == PLATFORM_CACHE_LINE);
 
-        alignas(64) TArrayHolder<NThreading::TPadded<std::atomic<i64>>> ForeignThreadsAllowedByPool;
-        TArrayHolder<NThreading::TPadded<std::atomic<i64>>> ForeignThreadSlots;
+        alignas(64) TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> ForeignThreadsAllowedByPool;
+        TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> ForeignThreadSlots;
         TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> LocalThreads;
         TArrayHolder<NThreading::TPadded<std::atomic<ui64>>> LocalNotifications;
         alignas(64) std::atomic<ui64> SpinThresholdCycles;

--- a/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
+++ b/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
@@ -137,8 +137,8 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             IsStarvedPresent = true;
         }
 
-        bool hasSharedThread = sharedInfo.OwnedThreads[poolIdx] != -1;
-        float expectedThreadCount = pool.GetFullThreadCount() + (hasSharedThread ? 1 : 0) + 0.5;
+        i16 ownedThreadCount = Max<i16>(0, sharedInfo.OwnedThreads[poolIdx]);
+        float expectedThreadCount = pool.GetFullThreadCount() + ownedThreadCount + 0.5;
         bool isMoreThanExpected = (PoolConsumption[poolIdx].NeedyWindowCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].NeedyWindowCpu >= currentFullThreadCount - 1);
         bool isMoreThanExpectedLastSecond = (PoolConsumption[poolIdx].LastSecondCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].LastSecondCpu >= currentFullThreadCount - 1);
         bool hasCurrentCpuDemand = (PoolConsumption[poolIdx].LastSecondCpu >= currentThreadCount || isMoreThanExpectedLastSecond);
@@ -153,7 +153,7 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             NeedyPools.push_back(poolIdx);
         }
 
-        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + hasSharedThread) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + hasSharedThread);
+        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + ownedThreadCount) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + ownedThreadCount);
         if (isHoggish) {
             float freeCpu = std::min(currentFullThreadCount - PoolFullThreadConsumption[poolIdx].Elapsed, currentFullThreadCount - PoolFullThreadConsumption[poolIdx].LastSecondElapsed);
             HoggishPools.push_back({poolIdx, freeCpu});

--- a/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
+++ b/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
@@ -137,8 +137,8 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             IsStarvedPresent = true;
         }
 
-        i16 ownedThreadCount = Max<i16>(0, sharedInfo.OwnedThreads[poolIdx]);
-        float expectedThreadCount = pool.GetFullThreadCount() + ownedThreadCount + 0.5;
+        bool hasSharedThread = sharedInfo.OwnedThreads[poolIdx] != -1;
+        float expectedThreadCount = pool.GetFullThreadCount() + (hasSharedThread ? 1 : 0) + 0.5;
         bool isMoreThanExpected = (PoolConsumption[poolIdx].NeedyWindowCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].NeedyWindowCpu >= currentFullThreadCount - 1);
         bool isMoreThanExpectedLastSecond = (PoolConsumption[poolIdx].LastSecondCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].LastSecondCpu >= currentFullThreadCount - 1);
         bool hasCurrentCpuDemand = (PoolConsumption[poolIdx].LastSecondCpu >= currentThreadCount || isMoreThanExpectedLastSecond);
@@ -153,7 +153,7 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             NeedyPools.push_back(poolIdx);
         }
 
-        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + ownedThreadCount) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + ownedThreadCount);
+        bool isHoggish = !isNeedy && IsHoggish(PoolConsumption[poolIdx].Elapsed, currentFullThreadCount + hasSharedThread) && IsHoggish(PoolConsumption[poolIdx].LastSecondElapsed, currentFullThreadCount + hasSharedThread);
         if (isHoggish) {
             float freeCpu = std::min(currentFullThreadCount - PoolFullThreadConsumption[poolIdx].Elapsed, currentFullThreadCount - PoolFullThreadConsumption[poolIdx].LastSecondElapsed);
             HoggishPools.push_back({poolIdx, freeCpu});

--- a/ydb/library/actors/core/harmonizer/harmonizer.cpp
+++ b/ydb/library/actors/core/harmonizer/harmonizer.cpp
@@ -136,11 +136,11 @@ void THarmonizer::ProcessWaitingStats() {
 
 void THarmonizer::SetForeignThreadSlotsForCurrentFullThreadCount(ui16 poolIdx) {
     if (Shared) {
-        i16 ownedThreadCount = Max<i16>(0, SharedInfo.OwnedThreads[poolIdx]);
+        bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
         i16 currentFullThreadCount = Pools[poolIdx]->GetFullThreadCount();
-        i16 slots = Max<i16>(0, Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - ownedThreadCount);
-        i16 maxSlots = Max<i16>(0, Shared->GetSharedThreadCount() - ownedThreadCount);
-        Shared->SetForeignThreadSlots(poolIdx, Min(slots, maxSlots));
+        i16 slots = Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - hasOwnSharedThread;
+        i16 maxSlots = Shared->GetSharedThreadCount() - hasOwnSharedThread;
+        Shared->SetForeignThreadSlots(poolIdx, Min<i16>(slots, maxSlots));
     }
 }
 
@@ -157,7 +157,7 @@ void THarmonizer::ProcessStarvedState() {
         if (CpuConsumption.PoolConsumption[poolIdx].Elapsed > pool.GetThreadCount()) {
             continue;
         }
-        i16 maxSharedCpuQuota = Max<i16>(0, SharedInfo.OwnedThreads[poolIdx]) + SharedInfo.ForeignThreadsAllowed[poolIdx];
+        i16 maxSharedCpuQuota = i16(SharedInfo.OwnedThreads[poolIdx] != -1) + SharedInfo.ForeignThreadsAllowed[poolIdx];
         if (SharedInfo.CpuConsumption[poolIdx].CpuQuota > maxSharedCpuQuota) {
             continue;
         }
@@ -346,8 +346,8 @@ void THarmonizer::HarmonizeImpl(ui64 ts) {
 
         float possibleMaxSharedQuota = 0.0f;
         if (Shared) {
-            i16 ownedThreadCount = Max<i16>(0, SharedInfo.OwnedThreads[poolIdx]);
-            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + ownedThreadCount, SharedInfo.ThreadCount);
+            bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
+            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + hasOwnSharedThread, SharedInfo.ThreadCount);
             float poolSharedElapsedCpu = SharedInfo.CpuConsumption[poolIdx].Elapsed;
             possibleMaxSharedQuota = std::min<float>(poolSharedElapsedCpu + freeSharedCpu, sharedThreads);
         }
@@ -464,12 +464,10 @@ void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ign
     poolInfo.Priority = pool->GetPriority();
     pool->SetFullThreadCount(poolInfo.DefaultFullThreadCount);
     if (Shared) {
-        TVector<i16> ownedThreads;
+        TVector<i16> ownedThreads(Pools.size(), -1);
         Shared->FillOwnedThreads(ownedThreads);
-        i16 ownedThreadCount = Max<i16>(0, ownedThreads[pool->PoolId]);
-        i16 slotsByPoolLimit = Max<i16>(0, static_cast<i16>(poolInfo.MaxThreadCount) - ownedThreadCount);
-        i16 slotsBySharedLimit = Max<i16>(0, Shared->GetSharedThreadCount() - ownedThreadCount);
-        Shared->SetForeignThreadSlots(pool->PoolId, Min(slotsByPoolLimit, slotsBySharedLimit));
+        bool hasOwnSharedThread = ownedThreads[pool->PoolId] != -1;
+        Shared->SetForeignThreadSlots(pool->PoolId, Min<i16>(poolInfo.MaxThreadCount, Shared->GetSharedThreadCount()) - hasOwnSharedThread);
     }
     if (pingInfo) {
         poolInfo.AvgPingCounter = pingInfo->AvgPingCounter;

--- a/ydb/library/actors/core/harmonizer/harmonizer.cpp
+++ b/ydb/library/actors/core/harmonizer/harmonizer.cpp
@@ -136,11 +136,11 @@ void THarmonizer::ProcessWaitingStats() {
 
 void THarmonizer::SetForeignThreadSlotsForCurrentFullThreadCount(ui16 poolIdx) {
     if (Shared) {
-        bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
+        i16 ownedThreadCount = Max<i16>(0, SharedInfo.OwnedThreads[poolIdx]);
         i16 currentFullThreadCount = Pools[poolIdx]->GetFullThreadCount();
-        i16 slots = Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - hasOwnSharedThread;
-        i16 maxSlots = Shared->GetSharedThreadCount() - hasOwnSharedThread;
-        Shared->SetForeignThreadSlots(poolIdx, Min<i16>(slots, maxSlots));
+        i16 slots = Max<i16>(0, Pools[poolIdx]->MaxThreadCount - currentFullThreadCount - ownedThreadCount);
+        i16 maxSlots = Max<i16>(0, Shared->GetSharedThreadCount() - ownedThreadCount);
+        Shared->SetForeignThreadSlots(poolIdx, Min(slots, maxSlots));
     }
 }
 
@@ -157,7 +157,7 @@ void THarmonizer::ProcessStarvedState() {
         if (CpuConsumption.PoolConsumption[poolIdx].Elapsed > pool.GetThreadCount()) {
             continue;
         }
-        i16 maxSharedCpuQuota = i16(SharedInfo.OwnedThreads[poolIdx] != -1) + SharedInfo.ForeignThreadsAllowed[poolIdx];
+        i16 maxSharedCpuQuota = Max<i16>(0, SharedInfo.OwnedThreads[poolIdx]) + SharedInfo.ForeignThreadsAllowed[poolIdx];
         if (SharedInfo.CpuConsumption[poolIdx].CpuQuota > maxSharedCpuQuota) {
             continue;
         }
@@ -346,8 +346,8 @@ void THarmonizer::HarmonizeImpl(ui64 ts) {
 
         float possibleMaxSharedQuota = 0.0f;
         if (Shared) {
-            bool hasOwnSharedThread = SharedInfo.OwnedThreads[poolIdx] != -1;
-            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + hasOwnSharedThread, SharedInfo.ThreadCount);
+            i16 ownedThreadCount = Max<i16>(0, SharedInfo.OwnedThreads[poolIdx]);
+            i16 sharedThreads = std::min<i16>(SharedInfo.ForeignThreadsAllowed[poolIdx] + ownedThreadCount, SharedInfo.ThreadCount);
             float poolSharedElapsedCpu = SharedInfo.CpuConsumption[poolIdx].Elapsed;
             possibleMaxSharedQuota = std::min<float>(poolSharedElapsedCpu + freeSharedCpu, sharedThreads);
         }
@@ -464,10 +464,12 @@ void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ign
     poolInfo.Priority = pool->GetPriority();
     pool->SetFullThreadCount(poolInfo.DefaultFullThreadCount);
     if (Shared) {
-        TVector<i16> ownedThreads(Pools.size(), -1);
+        TVector<i16> ownedThreads;
         Shared->FillOwnedThreads(ownedThreads);
-        bool hasOwnSharedThread = ownedThreads[pool->PoolId] != -1;
-        Shared->SetForeignThreadSlots(pool->PoolId, Min<i16>(poolInfo.MaxThreadCount, Shared->GetSharedThreadCount()) - hasOwnSharedThread);
+        i16 ownedThreadCount = Max<i16>(0, ownedThreads[pool->PoolId]);
+        i16 slotsByPoolLimit = Max<i16>(0, static_cast<i16>(poolInfo.MaxThreadCount) - ownedThreadCount);
+        i16 slotsBySharedLimit = Max<i16>(0, Shared->GetSharedThreadCount() - ownedThreadCount);
+        Shared->SetForeignThreadSlots(pool->PoolId, Min(slotsByPoolLimit, slotsBySharedLimit));
     }
     if (pingInfo) {
         poolInfo.AvgPingCounter = pingInfo->AvgPingCounter;

--- a/ydb/library/actors/core/harmonizer/ut/cpu_count_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/cpu_count_ut.cpp
@@ -82,4 +82,37 @@ Y_UNIT_TEST_SUITE(CpuCountTest) {
         pool.SetFullThreadCount(0);
         UNIT_ASSERT_DOUBLES_EQUAL(pool.GetThreadCount(), 0.3, 1e-6);
     }
+
+    Y_UNIT_TEST(TestWithAllThreadsShared) {
+        TBasicExecutorPoolConfig config;
+        config.MinThreadCount = 1;
+        config.DefaultThreadCount = 2;
+        config.MaxThreadCount = 3;
+        config.Threads = 3;
+        config.AllThreadsAreShared = true;
+
+        TBasicExecutorPool pool(config, nullptr, nullptr);
+
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetFullThreadCount(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetDefaultFullThreadCount(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetMinFullThreadCount(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetMaxFullThreadCount(), 0);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetThreadCount(), 0, 1e-6);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetDefaultThreadCount(), 2, 1e-6);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMinThreadCount(), 1, 1e-6);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMaxThreadCount(), 3, 1e-6);
+    }
+
+    Y_UNIT_TEST(TestWithAllThreadsSharedAndImplicitDefaultThreadCount) {
+        TBasicExecutorPoolConfig config;
+        config.Threads = 3;
+        config.AllThreadsAreShared = true;
+
+        TBasicExecutorPool pool(config, nullptr, nullptr);
+
+        UNIT_ASSERT_VALUES_EQUAL(pool.GetFullThreadCount(), 0);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetDefaultThreadCount(), 3, 1e-6);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMinThreadCount(), 3, 1e-6);
+        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMaxThreadCount(), 3, 1e-6);
+    }
 }

--- a/ydb/library/actors/core/harmonizer/ut/cpu_count_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/cpu_count_ut.cpp
@@ -82,37 +82,4 @@ Y_UNIT_TEST_SUITE(CpuCountTest) {
         pool.SetFullThreadCount(0);
         UNIT_ASSERT_DOUBLES_EQUAL(pool.GetThreadCount(), 0.3, 1e-6);
     }
-
-    Y_UNIT_TEST(TestWithAllThreadsShared) {
-        TBasicExecutorPoolConfig config;
-        config.MinThreadCount = 1;
-        config.DefaultThreadCount = 2;
-        config.MaxThreadCount = 3;
-        config.Threads = 3;
-        config.AllThreadsAreShared = true;
-
-        TBasicExecutorPool pool(config, nullptr, nullptr);
-
-        UNIT_ASSERT_VALUES_EQUAL(pool.GetFullThreadCount(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(pool.GetDefaultFullThreadCount(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(pool.GetMinFullThreadCount(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(pool.GetMaxFullThreadCount(), 0);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetThreadCount(), 0, 1e-6);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetDefaultThreadCount(), 2, 1e-6);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMinThreadCount(), 1, 1e-6);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMaxThreadCount(), 3, 1e-6);
-    }
-
-    Y_UNIT_TEST(TestWithAllThreadsSharedAndImplicitDefaultThreadCount) {
-        TBasicExecutorPoolConfig config;
-        config.Threads = 3;
-        config.AllThreadsAreShared = true;
-
-        TBasicExecutorPool pool(config, nullptr, nullptr);
-
-        UNIT_ASSERT_VALUES_EQUAL(pool.GetFullThreadCount(), 0);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetDefaultThreadCount(), 3, 1e-6);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMinThreadCount(), 3, 1e-6);
-        UNIT_ASSERT_DOUBLES_EQUAL(pool.GetMaxThreadCount(), 3, 1e-6);
-    }
 }

--- a/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
@@ -195,41 +195,6 @@ Y_UNIT_TEST_SUITE(HarmonizerTests) {
         UNIT_ASSERT_VALUES_EQUAL(stats.DecreasingThreadsByStarvedState, 0);
     }
 
-    Y_UNIT_TEST(TestUnitedPoolUsesOwnedThreadCountForForeignSlots) {
-        ui64 currentTs = 1'000'000;
-        std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));
-        TSharedExecutorPool sharedPool(TSharedExecutorPoolConfig{
-            .United = true,
-        }, std::vector<TPoolShortInfo>{
-            TPoolShortInfo{
-                .PoolId = 0,
-                .SharedThreadCount = 4,
-                .InPriorityOrder = true,
-            },
-            TPoolShortInfo{
-                .PoolId = 1,
-                .SharedThreadCount = 2,
-                .InPriorityOrder = true,
-            },
-        });
-        harmonizer->SetSharedPool(&sharedPool);
-
-        TMockExecutorPoolParams params {
-            .DefaultFullThreadCount = 0,
-            .MinFullThreadCount = 0,
-            .MaxFullThreadCount = 0,
-            .DefaultThreadCount = 4,
-            .MinThreadCount = 4,
-            .MaxThreadCount = 8,
-        };
-        auto pool = std::make_unique<TMockExecutorPool>(params);
-        harmonizer->AddPool(pool.get());
-
-        std::vector<i16> foreignThreadsAllowed;
-        sharedPool.FillForeignThreadsAllowed(foreignThreadsAllowed);
-        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed[0], 2);
-    }
-
     Y_UNIT_TEST(TestHarmonize) {
         ui64 currentTs = 1000000;
         std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));

--- a/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
@@ -195,6 +195,41 @@ Y_UNIT_TEST_SUITE(HarmonizerTests) {
         UNIT_ASSERT_VALUES_EQUAL(stats.DecreasingThreadsByStarvedState, 0);
     }
 
+    Y_UNIT_TEST(TestUnitedPoolUsesOwnedThreadCountForForeignSlots) {
+        ui64 currentTs = 1'000'000;
+        std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));
+        TSharedExecutorPool sharedPool(TSharedExecutorPoolConfig{
+            .United = true,
+        }, std::vector<TPoolShortInfo>{
+            TPoolShortInfo{
+                .PoolId = 0,
+                .SharedThreadCount = 4,
+                .InPriorityOrder = true,
+            },
+            TPoolShortInfo{
+                .PoolId = 1,
+                .SharedThreadCount = 2,
+                .InPriorityOrder = true,
+            },
+        });
+        harmonizer->SetSharedPool(&sharedPool);
+
+        TMockExecutorPoolParams params {
+            .DefaultFullThreadCount = 0,
+            .MinFullThreadCount = 0,
+            .MaxFullThreadCount = 0,
+            .DefaultThreadCount = 4,
+            .MinThreadCount = 4,
+            .MaxThreadCount = 8,
+        };
+        auto pool = std::make_unique<TMockExecutorPool>(params);
+        harmonizer->AddPool(pool.get());
+
+        std::vector<i16> foreignThreadsAllowed;
+        sharedPool.FillForeignThreadsAllowed(foreignThreadsAllowed);
+        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed[0], 2);
+    }
+
     Y_UNIT_TEST(TestHarmonize) {
         ui64 currentTs = 1000000;
         std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));

--- a/ydb/library/actors/core/ut/actor_shared_threads.cpp
+++ b/ydb/library/actors/core/ut/actor_shared_threads.cpp
@@ -13,6 +13,7 @@
 
 #include <util/generic/algorithm.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
+#include <util/system/event.h>
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
 
@@ -24,6 +25,64 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
     using TActorBenchmark = ::NActors::NTests::TActorBenchmark<>;
     using TSettings = TActorBenchmark::TSettings;
     using TSendReceiveActorParams = TActorBenchmark::TSendReceiveActorParams;
+
+    class TSignalActor : public TActorBootstrapped<TSignalActor> {
+    public:
+        explicit TSignalActor(TManualEvent* done)
+            : Done(done)
+        {}
+
+        void Bootstrap() {
+            Done->Signal();
+            PassAway();
+        }
+
+    private:
+        TManualEvent* const Done;
+    };
+
+    class TDelayedSignalActor : public TActorBootstrapped<TDelayedSignalActor> {
+    public:
+        TDelayedSignalActor(TManualEvent* scheduled, TManualEvent* done)
+            : Scheduled(scheduled)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            Become(&TDelayedSignalActor::StateFunc);
+            Schedule(TDuration::MilliSeconds(500), new TEvents::TEvWakeup());
+            Scheduled->Signal();
+        }
+
+        STFUNC(StateFunc) {
+            Y_UNUSED(ev);
+            Done->Signal();
+            PassAway();
+        }
+
+    private:
+        TManualEvent* const Scheduled;
+        TManualEvent* const Done;
+    };
+
+    class TStartAdjacentActor : public TActorBootstrapped<TStartAdjacentActor> {
+    public:
+        TStartAdjacentActor(ui32 adjacentPoolId, TManualEvent* scheduled, TManualEvent* done)
+            : AdjacentPoolId(adjacentPoolId)
+            , Scheduled(scheduled)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            Register(new TDelayedSignalActor(Scheduled, Done), TMailboxType::HTSwap, AdjacentPoolId);
+            PassAway();
+        }
+
+    private:
+        const ui32 AdjacentPoolId;
+        TManualEvent* const Scheduled;
+        TManualEvent* const Done;
+    };
 
     class TAliveCounterDecorator : public TDecorator {
     public:
@@ -203,6 +262,62 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
 
         Cerr << "Completed " << 1e9 * elapsedTime << Endl;
         Cerr << "Elapsed " << Ts2Us(aggregated.ElapsedTicks) << "us" << Endl;
+    }
+
+    Y_UNIT_TEST(AllThreadsSharedRunWithoutLegacySharedFlag) {
+        THolder<TActorSystemSetup> setup = TActorBenchmark::GetActorSystemSetup();
+        setup->CpuManager.Shared.United = true;
+        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
+            .PoolId = 0,
+            .PoolName = "UnitedPool",
+            .Threads = 2,
+            .SpinThreshold = 0,
+            .AllThreadsAreShared = true,
+        });
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TManualEvent done;
+        actorSystem.Register(new TSignalActor(&done), TMailboxType::HTSwap, 0);
+        bool completed = done.WaitT(TDuration::Seconds(5));
+
+        actorSystem.Stop();
+        UNIT_ASSERT_C(completed, "actor was not executed by the united pool");
+    }
+
+    Y_UNIT_TEST(AdjacentPoolWakesSleepingOwnerThreadWithoutForeignSlots) {
+        THolder<TActorSystemSetup> setup = TActorBenchmark::GetActorSystemSetup();
+        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
+            .PoolId = 0,
+            .PoolName = "OwnerPool",
+            .Threads = 1,
+            .SpinThreshold = 0,
+            .MinThreadCount = 1,
+            .MaxThreadCount = 1,
+            .DefaultThreadCount = 1,
+            .HasSharedThread = true,
+            .AdjacentPools = {1},
+        });
+        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
+            .PoolId = 1,
+            .PoolName = "AdjacentPool",
+            .Threads = 0,
+            .SpinThreshold = 0,
+        });
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TManualEvent scheduled;
+        TManualEvent adjacentDone;
+        actorSystem.Register(new TStartAdjacentActor(1, &scheduled, &adjacentDone), TMailboxType::HTSwap, 0);
+        bool wasScheduled = scheduled.WaitT(TDuration::Seconds(5));
+        bool adjacentCompleted = adjacentDone.WaitT(TDuration::Seconds(5));
+
+        actorSystem.Stop();
+        UNIT_ASSERT_C(wasScheduled, "delayed event was not scheduled from the adjacent pool");
+        UNIT_ASSERT_C(adjacentCompleted, "sleeping owner thread was not woken for its adjacent pool");
     }
 
     Y_UNIT_TEST(RegistrationAndPassingAwayActorsCommon) {

--- a/ydb/library/actors/core/ut/actor_shared_threads.cpp
+++ b/ydb/library/actors/core/ut/actor_shared_threads.cpp
@@ -13,7 +13,6 @@
 
 #include <util/generic/algorithm.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
-#include <util/system/event.h>
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
 
@@ -25,64 +24,6 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
     using TActorBenchmark = ::NActors::NTests::TActorBenchmark<>;
     using TSettings = TActorBenchmark::TSettings;
     using TSendReceiveActorParams = TActorBenchmark::TSendReceiveActorParams;
-
-    class TSignalActor : public TActorBootstrapped<TSignalActor> {
-    public:
-        explicit TSignalActor(TManualEvent* done)
-            : Done(done)
-        {}
-
-        void Bootstrap() {
-            Done->Signal();
-            PassAway();
-        }
-
-    private:
-        TManualEvent* const Done;
-    };
-
-    class TDelayedSignalActor : public TActorBootstrapped<TDelayedSignalActor> {
-    public:
-        TDelayedSignalActor(TManualEvent* scheduled, TManualEvent* done)
-            : Scheduled(scheduled)
-            , Done(done)
-        {}
-
-        void Bootstrap() {
-            Become(&TDelayedSignalActor::StateFunc);
-            Schedule(TDuration::MilliSeconds(500), new TEvents::TEvWakeup());
-            Scheduled->Signal();
-        }
-
-        STFUNC(StateFunc) {
-            Y_UNUSED(ev);
-            Done->Signal();
-            PassAway();
-        }
-
-    private:
-        TManualEvent* const Scheduled;
-        TManualEvent* const Done;
-    };
-
-    class TStartAdjacentActor : public TActorBootstrapped<TStartAdjacentActor> {
-    public:
-        TStartAdjacentActor(ui32 adjacentPoolId, TManualEvent* scheduled, TManualEvent* done)
-            : AdjacentPoolId(adjacentPoolId)
-            , Scheduled(scheduled)
-            , Done(done)
-        {}
-
-        void Bootstrap() {
-            Register(new TDelayedSignalActor(Scheduled, Done), TMailboxType::HTSwap, AdjacentPoolId);
-            PassAway();
-        }
-
-    private:
-        const ui32 AdjacentPoolId;
-        TManualEvent* const Scheduled;
-        TManualEvent* const Done;
-    };
 
     class TAliveCounterDecorator : public TDecorator {
     public:
@@ -262,62 +203,6 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
 
         Cerr << "Completed " << 1e9 * elapsedTime << Endl;
         Cerr << "Elapsed " << Ts2Us(aggregated.ElapsedTicks) << "us" << Endl;
-    }
-
-    Y_UNIT_TEST(AllThreadsSharedRunWithoutLegacySharedFlag) {
-        THolder<TActorSystemSetup> setup = TActorBenchmark::GetActorSystemSetup();
-        setup->CpuManager.Shared.United = true;
-        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
-            .PoolId = 0,
-            .PoolName = "UnitedPool",
-            .Threads = 2,
-            .SpinThreshold = 0,
-            .AllThreadsAreShared = true,
-        });
-
-        TActorSystem actorSystem(setup);
-        actorSystem.Start();
-
-        TManualEvent done;
-        actorSystem.Register(new TSignalActor(&done), TMailboxType::HTSwap, 0);
-        bool completed = done.WaitT(TDuration::Seconds(5));
-
-        actorSystem.Stop();
-        UNIT_ASSERT_C(completed, "actor was not executed by the united pool");
-    }
-
-    Y_UNIT_TEST(AdjacentPoolWakesSleepingOwnerThreadWithoutForeignSlots) {
-        THolder<TActorSystemSetup> setup = TActorBenchmark::GetActorSystemSetup();
-        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
-            .PoolId = 0,
-            .PoolName = "OwnerPool",
-            .Threads = 1,
-            .SpinThreshold = 0,
-            .MinThreadCount = 1,
-            .MaxThreadCount = 1,
-            .DefaultThreadCount = 1,
-            .HasSharedThread = true,
-            .AdjacentPools = {1},
-        });
-        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
-            .PoolId = 1,
-            .PoolName = "AdjacentPool",
-            .Threads = 0,
-            .SpinThreshold = 0,
-        });
-
-        TActorSystem actorSystem(setup);
-        actorSystem.Start();
-
-        TManualEvent scheduled;
-        TManualEvent adjacentDone;
-        actorSystem.Register(new TStartAdjacentActor(1, &scheduled, &adjacentDone), TMailboxType::HTSwap, 0);
-        bool wasScheduled = scheduled.WaitT(TDuration::Seconds(5));
-        bool adjacentCompleted = adjacentDone.WaitT(TDuration::Seconds(5));
-
-        actorSystem.Stop();
-        UNIT_ASSERT_C(wasScheduled, "delayed event was not scheduled from the adjacent pool");
-        UNIT_ASSERT_C(adjacentCompleted, "sleeping owner thread was not woken for its adjacent pool");
     }
 
     Y_UNIT_TEST(RegistrationAndPassingAwayActorsCommon) {

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -220,6 +220,34 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
+    Y_UNIT_TEST(UnitedConfigurationAndForcedSlots) {
+        TSharedExecutorPool sharedPool(TSharedExecutorPoolConfig{
+            .United = true,
+        }, std::vector<TPoolShortInfo>{
+            TPoolShortInfo{
+                .PoolId = 0,
+                .SharedThreadCount = 2,
+                .ForeignSlots = 2,
+                .InPriorityOrder = true,
+                .ForcedForeignSlots = true,
+            }
+        });
+
+        UNIT_ASSERT(sharedPool.IsUnited());
+        UNIT_ASSERT_VALUES_EQUAL(sharedPool.GetSharedThreadCount(), 2);
+
+        std::vector<i16> ownedThreads;
+        sharedPool.FillOwnedThreads(ownedThreads);
+        UNIT_ASSERT_VALUES_EQUAL(ownedThreads.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ownedThreads[0], 2);
+
+        sharedPool.SetForeignThreadSlots(0, 0);
+        std::vector<i16> foreignThreadsAllowed;
+        sharedPool.FillForeignThreadsAllowed(foreignThreadsAllowed);
+        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed[0], 2);
+    }
+
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1
@@ -538,7 +566,103 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[1], 0), mailboxes[3]);
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), mailboxes[2]);
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), mailboxes[2]);
-        // worker 0 can't take task from pool 4, because it has only 1 foreign slot and it already acquired by worker 1
+        // worker 0 can't take a task from pool 3 because its only foreign slot is held by worker 1
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), mailboxes[4]);
+    }
+
+    Y_UNIT_TEST(ReducingForeignSlotsBelowActiveLeasesDoesNotWrap) {
+        std::unique_ptr<TSharedExecutorPool> sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
+            .Threads = 5,
+            .United = true,
+        }, std::vector<TPoolShortInfo>{
+            TPoolShortInfo{
+                .PoolId = 0,
+                .SharedThreadCount = 1,
+                .InPriorityOrder = true,
+                .PoolName = "WorkerPool0",
+            },
+            TPoolShortInfo{
+                .PoolId = 1,
+                .SharedThreadCount = 1,
+                .InPriorityOrder = true,
+                .PoolName = "WorkerPool1",
+            },
+            TPoolShortInfo{
+                .PoolId = 2,
+                .SharedThreadCount = 1,
+                .InPriorityOrder = true,
+                .PoolName = "WorkerPool2",
+            },
+            TPoolShortInfo{
+                .PoolId = 3,
+                .SharedThreadCount = 1,
+                .ForeignSlots = 2,
+                .InPriorityOrder = true,
+                .PoolName = "TargetPool",
+            },
+            TPoolShortInfo{
+                .PoolId = 4,
+                .SharedThreadCount = 1,
+                .ForeignSlots = 1,
+                .InPriorityOrder = true,
+                .PoolName = "FallbackPool",
+            },
+        });
+
+        std::vector<std::unique_ptr<TBasicExecutorPool>> pools;
+        for (ui32 i = 0; i < 5; ++i) {
+            pools.push_back(std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
+                .PoolId = i,
+                .PoolName = "Pool" + ToString(i),
+                .Threads = 1,
+                .HasSharedThread = true,
+            }, nullptr));
+        }
+
+        TieBasicPoolsAndSharedPool(pools, sharedPool.get());
+        PreparePools(pools);
+        PreparePool(sharedPool.get());
+
+        std::vector<IExecutorPool*> poolsForEmulator;
+        for (const auto& pool : pools) {
+            poolsForEmulator.push_back(pool.get());
+        }
+        TThreadEmulator emulator(poolsForEmulator, sharedPool.get());
+
+        std::vector<TWorkerIdentity> workers {
+            {sharedPool.get(), 0},
+            {sharedPool.get(), 1},
+            {sharedPool.get(), 2},
+            {sharedPool.get(), 3},
+            {sharedPool.get(), 4},
+        };
+
+        TMailbox* targetMailbox = pools[3]->GetMailboxTable()->Allocate();
+        TMailbox* fallbackMailbox = pools[4]->GetMailboxTable()->Allocate();
+        for (ui64 counter = 0; counter < 3; ++counter) {
+            emulator.ScheduleActivation(workers[3], pools[3].get(), targetMailbox, counter);
+        }
+        emulator.ScheduleActivation(workers[4], pools[4].get(), fallbackMailbox, 0);
+
+        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), targetMailbox);
+        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[1], 0), targetMailbox);
+
+        sharedPool->SetForeignThreadSlots(3, 1);
+
+        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[2], 0), fallbackMailbox);
+
+        {
+            TThreadContextGuard guard(emulator.GetContext(workers[0]));
+            sharedPool->SwitchToPool(0, 0);
+        }
+        UNIT_ASSERT_EQUAL(
+            emulator.GetReadyActivation(workers[0], 0, TOverriddenThreadContext{.IsNeededToWaitNextActivation = false}),
+            nullptr);
+
+        {
+            TThreadContextGuard guard(emulator.GetContext(workers[1]));
+            sharedPool->SwitchToPool(1, 0);
+        }
+        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), targetMailbox);
     }
 }

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -220,34 +220,6 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
-    Y_UNIT_TEST(UnitedConfigurationAndForcedSlots) {
-        TSharedExecutorPool sharedPool(TSharedExecutorPoolConfig{
-            .United = true,
-        }, std::vector<TPoolShortInfo>{
-            TPoolShortInfo{
-                .PoolId = 0,
-                .SharedThreadCount = 2,
-                .ForeignSlots = 2,
-                .InPriorityOrder = true,
-                .ForcedForeignSlots = true,
-            }
-        });
-
-        UNIT_ASSERT(sharedPool.IsUnited());
-        UNIT_ASSERT_VALUES_EQUAL(sharedPool.GetSharedThreadCount(), 2);
-
-        std::vector<i16> ownedThreads;
-        sharedPool.FillOwnedThreads(ownedThreads);
-        UNIT_ASSERT_VALUES_EQUAL(ownedThreads.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(ownedThreads[0], 2);
-
-        sharedPool.SetForeignThreadSlots(0, 0);
-        std::vector<i16> foreignThreadsAllowed;
-        sharedPool.FillForeignThreadsAllowed(foreignThreadsAllowed);
-        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(foreignThreadsAllowed[0], 2);
-    }
-
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1
@@ -566,103 +538,7 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[1], 0), mailboxes[3]);
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), mailboxes[2]);
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), mailboxes[2]);
-        // worker 0 can't take a task from pool 3 because its only foreign slot is held by worker 1
+        // worker 0 can't take task from pool 4, because it has only 1 foreign slot and it already acquired by worker 1
         UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), mailboxes[4]);
-    }
-
-    Y_UNIT_TEST(ReducingForeignSlotsBelowActiveLeasesDoesNotWrap) {
-        std::unique_ptr<TSharedExecutorPool> sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
-            .Threads = 5,
-            .United = true,
-        }, std::vector<TPoolShortInfo>{
-            TPoolShortInfo{
-                .PoolId = 0,
-                .SharedThreadCount = 1,
-                .InPriorityOrder = true,
-                .PoolName = "WorkerPool0",
-            },
-            TPoolShortInfo{
-                .PoolId = 1,
-                .SharedThreadCount = 1,
-                .InPriorityOrder = true,
-                .PoolName = "WorkerPool1",
-            },
-            TPoolShortInfo{
-                .PoolId = 2,
-                .SharedThreadCount = 1,
-                .InPriorityOrder = true,
-                .PoolName = "WorkerPool2",
-            },
-            TPoolShortInfo{
-                .PoolId = 3,
-                .SharedThreadCount = 1,
-                .ForeignSlots = 2,
-                .InPriorityOrder = true,
-                .PoolName = "TargetPool",
-            },
-            TPoolShortInfo{
-                .PoolId = 4,
-                .SharedThreadCount = 1,
-                .ForeignSlots = 1,
-                .InPriorityOrder = true,
-                .PoolName = "FallbackPool",
-            },
-        });
-
-        std::vector<std::unique_ptr<TBasicExecutorPool>> pools;
-        for (ui32 i = 0; i < 5; ++i) {
-            pools.push_back(std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
-                .PoolId = i,
-                .PoolName = "Pool" + ToString(i),
-                .Threads = 1,
-                .HasSharedThread = true,
-            }, nullptr));
-        }
-
-        TieBasicPoolsAndSharedPool(pools, sharedPool.get());
-        PreparePools(pools);
-        PreparePool(sharedPool.get());
-
-        std::vector<IExecutorPool*> poolsForEmulator;
-        for (const auto& pool : pools) {
-            poolsForEmulator.push_back(pool.get());
-        }
-        TThreadEmulator emulator(poolsForEmulator, sharedPool.get());
-
-        std::vector<TWorkerIdentity> workers {
-            {sharedPool.get(), 0},
-            {sharedPool.get(), 1},
-            {sharedPool.get(), 2},
-            {sharedPool.get(), 3},
-            {sharedPool.get(), 4},
-        };
-
-        TMailbox* targetMailbox = pools[3]->GetMailboxTable()->Allocate();
-        TMailbox* fallbackMailbox = pools[4]->GetMailboxTable()->Allocate();
-        for (ui64 counter = 0; counter < 3; ++counter) {
-            emulator.ScheduleActivation(workers[3], pools[3].get(), targetMailbox, counter);
-        }
-        emulator.ScheduleActivation(workers[4], pools[4].get(), fallbackMailbox, 0);
-
-        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), targetMailbox);
-        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[1], 0), targetMailbox);
-
-        sharedPool->SetForeignThreadSlots(3, 1);
-
-        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[2], 0), fallbackMailbox);
-
-        {
-            TThreadContextGuard guard(emulator.GetContext(workers[0]));
-            sharedPool->SwitchToPool(0, 0);
-        }
-        UNIT_ASSERT_EQUAL(
-            emulator.GetReadyActivation(workers[0], 0, TOverriddenThreadContext{.IsNeededToWaitNextActivation = false}),
-            nullptr);
-
-        {
-            TThreadContextGuard guard(emulator.GetContext(workers[1]));
-            sharedPool->SwitchToPool(1, 0);
-        }
-        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workers[0], 0), targetMailbox);
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improved reliability of united executor pools during configuration changes and cross-pool task scheduling.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Preserves logical thread limits for all-shared pools, propagates united mode, accounts for every owned shared thread, and keeps foreign-slot and adjacent wake-up behavior bounded. Adds regression coverage for these configurations.