### PR TITLE
Allow processing EvVBlock in VDisk running on RED

### DIFF
--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -1212,7 +1212,10 @@ namespace NKikimr {
             const ui32 gen = record.GetGeneration();
             const ui64 issuerGuid = record.GetIssuerGuid();
 
-            if (!OutOfSpaceLogic->Allow(ctx, ev)) {
+            ui32 currentGen = 0;
+            bool hasExistingEntry = Hull->GetBlocked(tabletId, &currentGen);
+
+            if (!OutOfSpaceLogic->Allow(ctx, ev, hasExistingEntry)) {
                 ReplyError(NKikimrProto::OUT_OF_SPACE, "out of space", ev, ctx, now);
                 return;
             }

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_logic.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_logic.cpp
@@ -181,7 +181,7 @@ namespace NKikimr {
             record.GetDataKind());
     }
 
-    bool TOutOfSpaceLogic::Allow(const TActorContext& /*ctx*/, TEvBlobStorage::TEvVBlock::TPtr &ev) const {
+    bool TOutOfSpaceLogic::Allow(const TActorContext& /*ctx*/, TEvBlobStorage::TEvVBlock::TPtr &ev, bool hasExistingEntry) const {
         const ESpaceColor color = GetSpaceColor();
         auto &stat = Stat->Lookup(TStat::Block, color).HandleMsg(ev->Get()->GetCachedByteSize());
         switch (color) {
@@ -195,7 +195,7 @@ namespace NKikimr {
                 return stat.Allow();
             case TSpaceColor::RED: {
                 // FIXME: handle complete removal only
-                return stat.NotAllow();
+                return stat.Pass(hasExistingEntry);
             }
             case TSpaceColor::BLACK:
                 return stat.NotAllow();

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_logic.h
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_logic.h
@@ -23,7 +23,7 @@ namespace NKikimr {
         bool AllowVPutLikeWrite(const TActorContext& ctx, bool ignoreBlock, bool isZeroEntry, ui32 size,
             NKikimrBlobStorage::TDataKind::E dataKind) const;
         bool Allow(const TActorContext &ctx, TEvBlobStorage::TEvVPut::TPtr &ev) const;
-        bool Allow(const TActorContext &ctx, TEvBlobStorage::TEvVBlock::TPtr &ev) const;
+        bool Allow(const TActorContext &ctx, TEvBlobStorage::TEvVBlock::TPtr &ev, bool hasExistingEntry) const;
         bool Allow(const TActorContext &ctx, TEvBlobStorage::TEvVCollectGarbage::TPtr &ev) const;
         bool Allow(const TActorContext &ctx, TEvLocalSyncData::TPtr &ev) const;
         bool Allow(const TActorContext &ctx, TEvAnubisOsirisPut::TPtr &ev) const;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow processing EvVBlock in VDisk running on RED

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows system tablets to boot even on VDisks in RED space state.
