### PR TITLE
Start shared pool for all-shared executors

### DIFF
--- a/ydb/library/actors/core/cpu_manager.cpp
+++ b/ydb/library/actors/core/cpu_manager.cpp
@@ -27,14 +27,14 @@ namespace NActors {
 
     void TCpuManager::SetupShared() {
         ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::SetupShared");
-        bool hasSharedThread = false;
+        bool needsSharedPool = false;
         for (TBasicExecutorPoolConfig& cfg : Config.Basic) {
-            if (cfg.HasSharedThread) {
-                hasSharedThread = true;
+            if (cfg.HasSharedThread || cfg.AllThreadsAreShared) {
+                needsSharedPool = true;
                 break;
             }
         }
-        if (!hasSharedThread) {
+        if (!needsSharedPool) {
             ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::SetupShared: no shared threads, skipping");
             return;
         }

--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -102,6 +102,7 @@ namespace NActors {
         , DefaultSpinThresholdCycles(cfg.SpinThreshold * NHPTimer::GetCyclesPerSecond() * 0.000001) // convert microseconds to cycles
         , PoolName("Shared")
         , SoftProcessingDurationTs(cfg.SoftProcessingDurationTs)
+        , United(cfg.United)
         , Threads(new NThreading::TPadded<TSharedExecutorThreadCtx>[PoolThreads])
         , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , ForeignThreadSlots(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])

--- a/ydb/library/actors/core/ut/actor_shared_threads.cpp
+++ b/ydb/library/actors/core/ut/actor_shared_threads.cpp
@@ -13,6 +13,7 @@
 
 #include <util/generic/algorithm.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
+#include <util/system/event.h>
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
 
@@ -24,6 +25,21 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
     using TActorBenchmark = ::NActors::NTests::TActorBenchmark<>;
     using TSettings = TActorBenchmark::TSettings;
     using TSendReceiveActorParams = TActorBenchmark::TSendReceiveActorParams;
+
+    class TSignalActor : public TActorBootstrapped<TSignalActor> {
+    public:
+        explicit TSignalActor(TManualEvent* done)
+            : Done(done)
+        {}
+
+        void Bootstrap() {
+            Done->Signal();
+            PassAway();
+        }
+
+    private:
+        TManualEvent* const Done;
+    };
 
     class TAliveCounterDecorator : public TDecorator {
     public:
@@ -227,6 +243,31 @@ Y_UNIT_TEST_SUITE(SharedThreads) {
 
     Y_UNIT_TEST(RegistrationAndPassingAwayActorsLazyStrictPool) {
         RunRegistrationAndPassingAwayActors<ESendingType::Lazy>(true);
+    }
+
+    Y_UNIT_TEST(AllThreadsSharedRunWithoutLegacySharedFlag) {
+        THolder<TActorSystemSetup> setup = TActorBenchmark::GetActorSystemSetup();
+        setup->CpuManager.Shared.United = true;
+        setup->CpuManager.Basic.emplace_back(TBasicExecutorPoolConfig{
+            .PoolId = 0,
+            .PoolName = "UnitedPool",
+            .Threads = 2,
+            .SpinThreshold = 0,
+            .MaxThreadCount = 2,
+            .DefaultThreadCount = 2,
+            .AllThreadsAreShared = true,
+        });
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TManualEvent done;
+        actorSystem.Register(new TSignalActor(&done), TMailboxType::HTSwap, 0);
+        const bool completed = done.WaitT(TDuration::Seconds(5));
+
+        actorSystem.Stop();
+        UNIT_ASSERT_C(completed,
+            "AllThreadsAreShared pool did not execute an actor without the legacy HasSharedThread flag");
     }
 
 } // Y_UNIT_TEST_SUITE(ActorBenchmark)

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -220,6 +220,17 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
+    Y_UNIT_TEST(SharedPoolReportsUnitedMode) {
+        for (const bool united : {false, true}) {
+            TSharedExecutorPoolConfig config;
+            config.United = united;
+
+            const TSharedExecutorPool sharedPool(config, {});
+
+            UNIT_ASSERT_VALUES_EQUAL(sharedPool.IsUnited(), united);
+        }
+    }
+
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed actor systems with all executor threads shared failing to process events unless legacy shared threads were also enabled.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51351. Treat `AllThreadsAreShared` as sufficient to create shared infrastructure; thread-count arithmetic is unchanged.