### PR TITLE
ydb_bench: fix bundled target reachability

### DIFF
--- a/ydb/tools/ydb_bench/ya.make
+++ b/ydb/tools/ydb_bench/ya.make
@@ -85,6 +85,8 @@ PEERDIR(
 END()
 
 RECURSE(
+    background
+    memory
     process_guard
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed ydb_bench builds by making the bundled background and memory benchmark targets reachable.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The root ya.make now recurses into background and memory alongside process_guard.