### PR TITLE
Fix united shared pool mode reporting

### DIFF
--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -102,6 +102,7 @@ namespace NActors {
         , DefaultSpinThresholdCycles(cfg.SpinThreshold * NHPTimer::GetCyclesPerSecond() * 0.000001) // convert microseconds to cycles
         , PoolName("Shared")
         , SoftProcessingDurationTs(cfg.SoftProcessingDurationTs)
+        , United(cfg.United)
         , Threads(new NThreading::TPadded<TSharedExecutorThreadCtx>[PoolThreads])
         , ForeignThreadsAllowedByPool(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])
         , ForeignThreadSlots(new NThreading::TPadded<std::atomic<ui64>>[poolInfos.size()])

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -220,6 +220,17 @@ void TieBasicPoolsAndSharedPool(const std::vector<std::unique_ptr<TBasicExecutor
 
 Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
 
+    Y_UNIT_TEST(SharedPoolReportsUnitedMode) {
+        for (const bool united : {false, true}) {
+            TSharedExecutorPoolConfig config;
+            config.United = united;
+
+            const TSharedExecutorPool sharedPool(config, {});
+
+            UNIT_ASSERT_VALUES_EQUAL(sharedPool.IsUnited(), united);
+        }
+    }
+
     Y_UNIT_TEST(ReceiveActivationForEachRevolvingCounter) {
         std::unique_ptr<IExecutorPool> pool = std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
             .Threads = 1


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed United shared pools being treated as legacy shared pools by the CPU harmonizer.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Initialize `TSharedExecutorPool` United flag from its config and cover both default and enabled modes.