### PR TITLE
[NBS-7656] Fresh watermark persist. Show fill progress on mon page.

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.cpp
@@ -50,6 +50,19 @@ bool TBlockRangeField::Add(TBlockRange64 range)
     return erasedCount != 1 || merged != firstErased;
 }
 
+bool TBlockRangeField::Add(const TBlockRangeField& field)
+{
+    if (this == &field) {
+        return false;
+    }
+
+    bool changed = false;
+    for (const auto& range: field.Intervals) {
+        changed |= Add(range);
+    }
+    return changed;
+}
+
 bool TBlockRangeField::Remove(TBlockRange64 range)
 {
     if (Intervals.empty()) {
@@ -90,6 +103,19 @@ bool TBlockRangeField::Remove(TBlockRange64 range)
     return changed;
 }
 
+bool TBlockRangeField::Remove(const TBlockRangeField& field)
+{
+    if (this == &field) {
+        return Clear();
+    }
+
+    bool changed = false;
+    for (const auto& range: field.Intervals) {
+        changed |= Remove(range);
+    }
+    return changed;
+}
+
 bool TBlockRangeField::Clear()
 {
     const bool changed = !Intervals.empty();
@@ -112,6 +138,26 @@ bool TBlockRangeField::Overlaps(TBlockRange64 other) const
     }
 
     return it->Overlaps(other);
+}
+
+bool TBlockRangeField::Overlaps(const TBlockRangeField& other) const
+{
+    // Disjoint intervals are ordered by both Start and End, so advance the
+    // interval that lies entirely before the other one.
+    auto left = Intervals.begin();
+    auto right = other.Intervals.begin();
+
+    while (left != Intervals.end() && right != other.Intervals.end()) {
+        if (left->End < right->Start) {
+            ++left;
+        } else if (right->End < left->Start) {
+            ++right;
+        } else {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void TBlockRangeField::Enumerate(TEnumerateFunc func) const

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field.h
@@ -24,11 +24,16 @@ public:
     // Returns true if the intervals have actually changed.
     bool Add(TBlockRange64 range);
     // Returns true if the intervals have actually changed.
+    bool Add(const TBlockRangeField& field);
+    // Returns true if the intervals have actually changed.
     bool Remove(TBlockRange64 range);
+    // Returns true if the intervals have actually changed.
+    bool Remove(const TBlockRangeField& field);
     // Returns true if the intervals have actually changed.
     bool Clear();
 
     [[nodiscard]] bool Overlaps(TBlockRange64 other) const;
+    [[nodiscard]] bool Overlaps(const TBlockRangeField& other) const;
 
     void Enumerate(TEnumerateFunc func) const;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_field_ut.cpp
@@ -121,6 +121,22 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
         UNIT_ASSERT_VALUES_EQUAL(R(3, 7), v[0]);
     }
 
+    Y_UNIT_TEST(AddField)
+    {
+        TBlockRangeField f;
+        UNIT_ASSERT(f.Add(R(0, 4)));
+        UNIT_ASSERT(f.Add(R(20, 24)));
+
+        TBlockRangeField other;
+        UNIT_ASSERT(other.Add(R(5, 10)));
+        UNIT_ASSERT(other.Add(R(30, 34)));
+
+        UNIT_ASSERT(f.Add(other));
+        UNIT_ASSERT_VALUES_EQUAL("[0..10][20..24][30..34]", f.Print());
+        UNIT_ASSERT(!f.Add(other));
+        UNIT_ASSERT(!f.Add(f));
+    }
+
     // -------------------------------------------------------------------------
     // Remove – basic
 
@@ -193,6 +209,22 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
         UNIT_ASSERT_VALUES_EQUAL(R(23, 25), v[1]);
     }
 
+    Y_UNIT_TEST(RemoveField)
+    {
+        TBlockRangeField f;
+        UNIT_ASSERT(f.Add(R(0, 40)));
+
+        TBlockRangeField other;
+        UNIT_ASSERT(other.Add(R(5, 9)));
+        UNIT_ASSERT(other.Add(R(20, 29)));
+
+        UNIT_ASSERT(f.Remove(other));
+        UNIT_ASSERT_VALUES_EQUAL("[0..4][10..19][30..40]", f.Print());
+        UNIT_ASSERT(!f.Remove(other));
+        UNIT_ASSERT(f.Remove(f));
+        UNIT_ASSERT(f.Empty());
+    }
+
     // -------------------------------------------------------------------------
     // Overlaps
 
@@ -252,6 +284,25 @@ Y_UNIT_TEST_SUITE(TBlockRangeFieldTest)
         UNIT_ASSERT(!f.Overlaps(R(5, 9)));
         // [21,21] touches end but doesn't overlap.
         UNIT_ASSERT(!f.Overlaps(R(21, 25)));
+    }
+
+    Y_UNIT_TEST(OverlapsField)
+    {
+        TBlockRangeField left;
+        TBlockRangeField right;
+
+        UNIT_ASSERT(!left.Overlaps(right));
+
+        left.Add(R(0, 5));
+        left.Add(R(20, 25));
+        right.Add(R(6, 10));
+        right.Add(R(30, 35));
+        UNIT_ASSERT(!left.Overlaps(right));
+        UNIT_ASSERT(!right.Overlaps(left));
+
+        right.Add(R(24, 29));
+        UNIT_ASSERT(left.Overlaps(right));
+        UNIT_ASSERT(right.Overlaps(left));
     }
 
     // -------------------------------------------------------------------------

--- a/ydb/core/nbs/cloud/blockstore/libs/common/constants.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/constants.h
@@ -36,6 +36,9 @@ constexpr size_t DirectBlockGroupsCount = 32;
 // The size of the data copied at a time.
 constexpr ui64 CopyRangeSize = 1_MB;
 
+// The amount of copied data between copy progress notifications.
+constexpr ui64 CopyProgressSaveInterval = 8_MB;
+
 // Max allowed VChunk size.
 constexpr ui64 MaxVChunkSize = RegionSize / DirectBlockGroupsCount;
 // Max allowed VChunk block count (when block size is minimum).

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -163,15 +163,15 @@ void TBaseFixture::Init()
         UNIT_ASSERT_VALUES_EQUAL(FreshDDisk, hostIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
+        const ui64 sizeBytes = range.Size() * BlockSize;
         TString copiedData;
-        copiedData.resize(CopyRangeSize);
+        copiedData.resize(sizeBytes);
         SgListCopy(
             guardedSglist.Acquire().Get(),
             TBlockDataRef{copiedData.data(), copiedData.size()});
 
         const ui64 offsetBlocks = range.Start - ExpectedRange.Start;
         const ui64 offsetBytes = offsetBlocks * BlockSize;
-        const ui64 sizeBytes = range.Size() * BlockSize;
         TString expectedData =
             TString(RangeData.data() + offsetBytes, sizeBytes);
         UNIT_ASSERT_VALUES_EQUAL(expectedData, copiedData);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
@@ -47,6 +47,7 @@ struct TDDiskDataCopier::TCopyRangeRequestState
     TCopyRangeRequestState(
         ui64 syncId,
         TBlockRange64 range,
+        ui32 blockSize,
         TRangeLock lock,
         NWilson::TSpan span)
         : SyncId(syncId)
@@ -54,7 +55,7 @@ struct TDDiskDataCopier::TCopyRangeRequestState
         , Lock(std::move(lock))
         , Span(std::move(span))
     {
-        Data.resize(CopyRangeSize);
+        Data.resize(Range.Size() * blockSize);
         Lock.Arm();
     }
 
@@ -73,7 +74,7 @@ TDDiskDataCopier::TDDiskDataCopier(
     const TDiskDescription& diskDescription,
     const TVChunkConfig& vChunkConfig,
     IDirectBlockGroupPtr directBlockGroup,
-    TBlocksDirtyMapPtr dirtyMap,
+    IRangeSyncClient* client,
     THostIndex destination)
     : ActorSystem(actorSystem)
     , TraceService(traceService)
@@ -81,7 +82,7 @@ TDDiskDataCopier::TDDiskDataCopier(
     , VolumeConfig(partitionDirectService->GetVolumeConfig())
     , DirectBlockGroup(std::move(directBlockGroup))
     , Destination(destination)
-    , DirtyMap(std::move(dirtyMap))
+    , Client(client)
     , LogTitle{
           GetCycleCount(),
           TLogTitle::TDDiskDataCopier{
@@ -94,6 +95,7 @@ TDDiskDataCopier::TDDiskDataCopier(
     , BackoffDelayProvider(MinBackoff, MaxBackoff)
 {
     Y_ABORT_UNLESS(traceService);
+    Y_ABORT_UNLESS(Client);
     Y_ABORT_UNLESS(Destination < VChunkConfig.GetHostCount());
 }
 
@@ -134,9 +136,14 @@ TFuture<TDDiskDataCopier::EResult> TDDiskDataCopier::Stop()
     }
 }
 
+ui64 TDDiskDataCopier::GetBytesCopied() const
+{
+    return BytesCopied;
+}
+
 std::optional<TBlockRange64> TDDiskDataCopier::GetFreshRange() const
 {
-    auto freshRange = DirtyMap->GetFreshRange(Destination);
+    auto freshRange = Client->GetFreshRange(Destination);
     if (!freshRange) {
         return std::nullopt;
     }
@@ -187,7 +194,7 @@ void TDDiskDataCopier::StartCopyRange()
 
     auto timeWaitBeforeExecution = DirectBlockGroup->TakeCopyRangeBudget(
         freshRange->Size() * VolumeConfig->BlockSize);
-    auto hint = DirtyMap->BeginRangeSync(Destination, *freshRange);
+    auto hint = Client->BeginRangeSync(Destination, *freshRange);
     hint.ReadyToStart.Subscribe(
         [weakSelf = weak_from_this(),
          syncId = hint.SyncId,
@@ -241,12 +248,13 @@ void TDDiskDataCopier::CopyRange(
     auto copyRangeState = std::make_shared<TCopyRangeRequestState>(
         syncId,
         range,
-        TRangeLock(DirtyMap, range, THostMask::MakeOne(Destination)),
+        VolumeConfig->BlockSize,
+        Client->MakeDDiskRangeLock(range, THostMask::MakeOne(Destination)),
         CreateSpan(range));
 
-    auto readHint = DirtyMap->MakeReadHint(range);
+    auto readHint = Client->MakeReadHint(range);
     if (readHint.RangeHints.empty()) {
-        DirtyMap->EndRangeSync(copyRangeState->SyncId, false);
+        Client->EndRangeSync(copyRangeState->SyncId, false);
         auto waitReadyFuture = readHint.WaitReady;
         Y_ABORT_UNLESS(!waitReadyFuture.HasValue());
         waitReadyFuture.Subscribe(
@@ -321,7 +329,7 @@ void TDDiskDataCopier::OnRangeRead(
             copyRangeState->Range.Print().c_str(),
             FormatError(response.Error).Quote().c_str());
 
-        DirtyMap->EndRangeSync(copyRangeState->SyncId, false);
+        Client->EndRangeSync(copyRangeState->SyncId, false);
         if (IsNeverRetriableError(response.Error)) {
             Complete.SetValue(EResult::Error);
         } else {
@@ -372,7 +380,7 @@ void TDDiskDataCopier::OnRangeWritten(
             copyRangeState->Range.Print().c_str(),
             FormatError(response.Error).Quote().c_str());
 
-        DirtyMap->EndRangeSync(copyRangeState->SyncId, false);
+        Client->EndRangeSync(copyRangeState->SyncId, false);
         if (IsNeverRetriableError(response.Error)) {
             Complete.SetValue(EResult::Error);
         } else {
@@ -382,7 +390,15 @@ void TDDiskDataCopier::OnRangeWritten(
     }
 
     BackoffDelayProvider.Reset();
-    DirtyMap->EndRangeSync(copyRangeState->SyncId, true);
+    const ui64 rangeBytes =
+        copyRangeState->Range.Size() * VolumeConfig->BlockSize;
+    BytesCopied += rangeBytes;
+    BytesCopiedSinceLastProgress += rangeBytes;
+    Client->EndRangeSync(copyRangeState->SyncId, true);
+    if (BytesCopiedSinceLastProgress >= CopyProgressSaveInterval) {
+        BytesCopiedSinceLastProgress -= CopyProgressSaveInterval;
+        Client->OnCopyProgress(BytesCopied);
+    }
     StartCopyRange();
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
@@ -17,7 +17,22 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TBlocksDirtyMap;
+struct IRangeSyncClient
+{
+    virtual ~IRangeSyncClient() = default;
+
+    [[nodiscard]] virtual std::optional<TBlockRange64> GetFreshRange(
+        THostIndex host) const = 0;
+    [[nodiscard]] virtual TReadHint MakeReadHint(TBlockRange64 range) = 0;
+    [[nodiscard]] virtual TRangeLock MakeDDiskRangeLock(
+        TBlockRange64 range,
+        THostMask mask) = 0;
+    virtual TSyncHint BeginRangeSync(THostIndex host, TBlockRange64 range) = 0;
+    virtual void EndRangeSync(ui64 syncId, bool success) = 0;
+    virtual void OnCopyProgress(ui64 totalBytes) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 
 class TDDiskDataCopier: public std::enable_shared_from_this<TDDiskDataCopier>
 {
@@ -43,7 +58,7 @@ public:
         const TDiskDescription& diskDescription,
         const TVChunkConfig& vChunkConfig,
         IDirectBlockGroupPtr directBlockGroup,
-        TBlocksDirtyMapPtr dirtyMap,
+        IRangeSyncClient* client,
         THostIndex destination);
 
     // Starts processing from the FreshWatermark position, which is stored in
@@ -51,6 +66,8 @@ public:
     NThreading::TFuture<EResult> Start();
     // Stops processing. After stopping, the processing can be started again.
     NThreading::TFuture<EResult> Stop();
+
+    [[nodiscard]] ui64 GetBytesCopied() const;
 
 private:
     struct TCopyRangeRequestState;
@@ -77,12 +94,14 @@ private:
     const TVolumeConfigPtr VolumeConfig;
     const IDirectBlockGroupPtr DirectBlockGroup;
     const THostIndex Destination;
-    const TBlocksDirtyMapPtr DirtyMap;
+    IRangeSyncClient* const Client = nullptr;
 
     TLogTitle LogTitle;
     EState State = EState::Stopped;
     TBackoffDelayProvider BackoffDelayProvider;
     NThreading::TPromise<EResult> Complete;
+    ui64 BytesCopied = 0;
+    ui64 BytesCopiedSinceLastProgress = 0;
 };
 
 using TDDiskDataCopierPtr = std::shared_ptr<TDDiskDataCopier>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
@@ -2,6 +2,8 @@
 
 #include "base_test_fixture.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/range_locker_access.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 using namespace NKikimr;
@@ -29,9 +31,42 @@ void FinishFlushes(TBlocksDirtyMap& dirtyMap, const TFlushHints& hints)
     }
 }
 
-struct TFixture: public TBaseFixture
+struct TFixture
+    : public TBaseFixture
+    , public IRangeSyncClient
 {
     TDDiskDataCopierPtr Copier;
+    TVector<ui64> CopyProgressNotifications;
+
+    std::optional<TBlockRange64> GetFreshRange(THostIndex host) const override
+    {
+        return DirtyMap->GetFreshRange(host);
+    }
+
+    TReadHint MakeReadHint(TBlockRange64 range) override
+    {
+        return DirtyMap->MakeReadHint(range);
+    }
+
+    TRangeLock MakeDDiskRangeLock(TBlockRange64 range, THostMask mask) override
+    {
+        return TRangeLockAccess::Make(DirtyMap, range, mask);
+    }
+
+    TSyncHint BeginRangeSync(THostIndex host, TBlockRange64 range) override
+    {
+        return DirtyMap->BeginRangeSync(host, range);
+    }
+
+    void EndRangeSync(ui64 syncId, bool success) override
+    {
+        DirtyMap->EndRangeSync(syncId, success);
+    }
+
+    void OnCopyProgress(ui64 totalBytes) override
+    {
+        CopyProgressNotifications.push_back(totalBytes);
+    }
 
     void Init() override
     {
@@ -48,7 +83,7 @@ struct TFixture: public TBaseFixture
             DiskDescription,
             VChunkConfig,
             DirectBlockGroup,
-            DirtyMap,
+            this,
             FreshDDisk);
     }
 };
@@ -84,6 +119,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
 
         // Start data copy
         ExpectedRange = TBlockRange64::WithLength(0, BlocksPerCopy);
+        UNIT_ASSERT_VALUES_EQUAL(0, Copier->GetBytesCopied());
         auto complete = Copier->Start();
 
         // Should transfer all ranges. One-by-one.
@@ -114,6 +150,17 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             SetWriteResult(
                 TDBGWriteBlocksResponse{.Error = MakeError(S_OK)},
                 false);
+            UNIT_ASSERT_VALUES_EQUAL(
+                (i + 1) * CopyRangeSize,
+                Copier->GetBytesCopied());
+            UNIT_ASSERT_VALUES_EQUAL(
+                Copier->GetBytesCopied() / CopyProgressSaveInterval,
+                CopyProgressNotifications.size());
+            if (!CopyProgressNotifications.empty()) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    CopyProgressNotifications.size() * CopyProgressSaveInterval,
+                    CopyProgressNotifications.back());
+            }
 
             if (i == 5) {
                 // Check state on 5th iteration
@@ -133,6 +180,7 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         UNIT_ASSERT_VALUES_EQUAL(
             TDDiskDataCopier::EResult::Ok,
             complete.GetValue());
+        UNIT_ASSERT_VALUES_EQUAL(DefaultVChunkSize, Copier->GetBytesCopied());
 
         // All DDisk fully operational
         UNIT_ASSERT_VALUES_EQUAL(
@@ -142,6 +190,60 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             "H3*{Operational,32768};"
             "H4+{Disabled,0};",
             DirtyMap->DebugPrintDDiskState());
+    }
+
+    Y_UNIT_TEST_F(ShouldAccumulatePartialRangesForCopyProgress, TFixture)
+    {
+        Init();
+
+        const ui64 firstCopyBytes = CopyProgressSaveInterval - BlockSize;
+        const ui64 firstCopyBlocks = firstCopyBytes / BlockSize;
+        ui64 rangeStart = VChunkBlockCount - firstCopyBlocks;
+
+        DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, rangeStart * BlockSize);
+
+        ExpectedRange = TBlockRange64::WithLength(
+            rangeStart,
+            Min<ui64>(BlocksPerCopy, VChunkBlockCount - rangeStart));
+        auto complete = Copier->Start();
+
+        while (!complete.IsReady()) {
+            const ui64 rangeSize = ExpectedRange.Size();
+            SetReadResult({.Error = MakeError(S_OK)}, false);
+
+            rangeStart += rangeSize;
+            if (rangeStart < VChunkBlockCount) {
+                ExpectedRange = TBlockRange64::WithLength(
+                    rangeStart,
+                    Min<ui64>(BlocksPerCopy, VChunkBlockCount - rangeStart));
+            }
+            SetWriteResult(
+                TDBGWriteBlocksResponse{.Error = MakeError(S_OK)},
+                false);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(firstCopyBytes, Copier->GetBytesCopied());
+        UNIT_ASSERT_VALUES_EQUAL(0, CopyProgressNotifications.size());
+
+        DirtyMap->UpdateWatermarkDebugOnly(
+            FreshDDisk,
+            (VChunkBlockCount - 1) * BlockSize);
+        ExpectedRange = TBlockRange64::WithLength(VChunkBlockCount - 1, 1);
+        complete = Copier->Start();
+
+        SetReadResult({.Error = MakeError(S_OK)}, false);
+        SetWriteResult(
+            TDBGWriteBlocksResponse{.Error = MakeError(S_OK)},
+            false);
+
+        UNIT_ASSERT_VALUES_EQUAL(true, complete.IsReady());
+        UNIT_ASSERT_VALUES_EQUAL(
+            CopyProgressSaveInterval,
+            Copier->GetBytesCopied());
+        UNIT_ASSERT_VALUES_EQUAL(1, CopyProgressNotifications.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            CopyProgressSaveInterval,
+            CopyProgressNotifications.front());
     }
 
     Y_UNIT_TEST_F(ShouldRetryOnReadError, TFixture)
@@ -233,6 +335,8 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         UNIT_ASSERT_VALUES_EQUAL(
             TDDiskDataCopier::EResult::Error,
             complete.GetValue());
+        UNIT_ASSERT_VALUES_EQUAL(0, Copier->GetBytesCopied());
+        UNIT_ASSERT_VALUES_EQUAL(0, CopyProgressNotifications.size());
 
         UNIT_ASSERT_VALUES_EQUAL(
             TBlockRange64::WithLength(0, 32768),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.cpp
@@ -17,11 +17,20 @@ void TDDiskState::Init(
     BehindAheadMonitor = behindAheadMonitor;
     TotalBlockCount = totalBlockCount;
     OperationalBlockCount = operationalBlockCount;
+
+    // Mark all blocks over watermark as behind.
+    if (OperationalBlockCount < TotalBlockCount) {
+        BehindField.Add(TBlockRange64::MakeClosedInterval(
+            OperationalBlockCount,
+            TotalBlockCount - 1));
+    }
     UpdateState(true);
+    CheckInvariants();
 }
 
 void TDDiskState::Save(TDDiskStateProto* proto) const
 {
+    CheckInvariants();
     SaveBlockField(AheadField, TotalBlockCount, proto->MutableAhead());
     SaveBlockField(BehindField, TotalBlockCount, proto->MutableBehind());
 }
@@ -29,7 +38,21 @@ void TDDiskState::Save(TDDiskStateProto* proto) const
 void TDDiskState::Load(const TDDiskStateProto& proto)
 {
     LoadBlockField(proto.GetAhead(), &AheadField);
-    LoadBlockField(proto.GetBehind(), &BehindField);
+    BehindField.Remove(AheadField);
+
+    TBlockRangeField loadedBehind;
+    LoadBlockField(proto.GetBehind(), &loadedBehind);
+
+    // A non-empty persisted map is more accurate than the initial map
+    // reconstructed from the watermark. An empty persisted map may belong to
+    // an older state that did not store the initial fresh range, so keep the
+    // map prepared by Init in that case.
+    if (!loadedBehind.Empty()) {
+        BehindField.Clear();
+        BehindField.Add(loadedBehind);
+    }
+
+    CheckInvariants();
 }
 
 void TDDiskState::SwitchOffline()
@@ -38,6 +61,7 @@ void TDDiskState::SwitchOffline()
     OperationalBlockCount = 0;
     AheadField.Clear();
     BehindField.Clear();
+    CheckInvariants();
 }
 
 bool TDDiskState::IsLagging() const
@@ -155,6 +179,7 @@ void TDDiskState::RangeSynced(TBlockRange64 range)
         OperationalBlockCount = newWatermark;
     }
     UpdateState(false);
+    CheckInvariants();
 }
 
 TCountAndSize TDDiskState::GetAheadSegmentsStat() const
@@ -177,6 +202,11 @@ void TDDiskState::UpdateWatermarkDebugOnly(ui64 blockCount)
 
     OperationalBlockCount = blockCount;
     UpdateState(false);
+}
+
+void TDDiskState::CheckInvariants() const
+{
+    Y_DEBUG_ABORT_UNLESS(!BehindField.Overlaps(AheadField));
 }
 
 TString TDDiskState::DebugPrint() const
@@ -241,14 +271,17 @@ void TDDiskState::AddAhead(TBlockRange64 range)
     if (OperationalBlockCount) {
         AheadField.Remove(TBlockRange64::WithLength(0, OperationalBlockCount));
     }
+    CheckInvariants();
 }
 
 void TDDiskState::AddBehind(TBlockRange64 range)
 {
+    const bool aheadChanged = AheadField.Remove(range);
     const bool behindChanged = BehindField.Add(range);
-    if (behindChanged) {
+    if (aheadChanged || behindChanged) {
         BehindAheadMonitor->OnBehindAheadChanged();
     }
+    CheckInvariants();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state.h
@@ -91,6 +91,7 @@ public:
     [[nodiscard]] TString DebugPrintAheadBehindBrief() const;
 
 private:
+    void CheckInvariants() const;
     [[nodiscard]] bool IsFresh() const;
     void UpdateState(bool force);
     void AddAhead(TBlockRange64 range);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ddisk_state_ut.cpp
@@ -1,5 +1,7 @@
 #include "ddisk_state.h"
 
+#include "block_field_serializer.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/dirty_map.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -36,25 +38,47 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
         ddisk.Init(
             &testBlockFieldMonitor,
             /*totalBlockCount=*/100,
-            /*operationalBlockCount=*/5);
+            /*operationalBlockCount=*/40);
         UNIT_ASSERT_VALUES_EQUAL(true, ddisk.IsTrackingEnabled());
+        UNIT_ASSERT_VALUES_EQUAL("[40..99]", ddisk.DebugPrintBehind());
+
+        const auto range = TBlockRange64::WithLength(50, 10);
+        ddisk.RangeSynced(range);
+        UNIT_ASSERT_VALUES_EQUAL("[40..49][60..99]", ddisk.DebugPrintBehind());
 
         // While lagging, a missed flush marks the range as outdated (Behind).
         ddisk.StartLagging();
-        ddisk.OnRangeFlushed(
-            TBlockRange64::WithLength(10, 10),
-            TDDiskState::EFlushCompletion::Missed);
-        UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintBehind());
+        ddisk.OnRangeFlushed(range, TDDiskState::EFlushCompletion::Missed);
+        UNIT_ASSERT_VALUES_EQUAL("[40..99]", ddisk.DebugPrintBehind());
         UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintAhead());
 
         // The DDisk catches up and the same range is flushed successfully.
         // The range must leave Behind and appear in Ahead.
         ddisk.StopLagging();
-        ddisk.OnRangeFlushed(
-            TBlockRange64::WithLength(10, 10),
-            TDDiskState::EFlushCompletion::Completed);
-        UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintBehind());
-        UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintAhead());
+        ddisk.OnRangeFlushed(range, TDDiskState::EFlushCompletion::Completed);
+        UNIT_ASSERT_VALUES_EQUAL("[40..49][60..99]", ddisk.DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL("[50..59]", ddisk.DebugPrintAhead());
+    }
+
+    Y_UNIT_TEST(ShouldMoveRangeFromAheadToBehindOnMissedFlush)
+    {
+        TTestBlockFieldMonitor monitor;
+        TDDiskState ddisk;
+        ddisk.Init(
+            &monitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/40);
+
+        const auto range = TBlockRange64::WithLength(50, 10);
+        ddisk.RangeSynced(range);
+        ddisk.OnRangeFlushed(range, TDDiskState::EFlushCompletion::Completed);
+        UNIT_ASSERT_VALUES_EQUAL("[50..59]", ddisk.DebugPrintAhead());
+        UNIT_ASSERT_VALUES_EQUAL("[40..49][60..99]", ddisk.DebugPrintBehind());
+
+        ddisk.StartLagging();
+        ddisk.OnRangeFlushed(range, TDDiskState::EFlushCompletion::Missed);
+        UNIT_ASSERT_VALUES_EQUAL("", ddisk.DebugPrintAhead());
+        UNIT_ASSERT_VALUES_EQUAL("[40..99]", ddisk.DebugPrintBehind());
     }
 
     // Save() chooses a compact encoding for Ahead/Behind; Load() must restore
@@ -129,6 +153,50 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
         UNIT_ASSERT_VALUES_EQUAL("", loaded.DebugPrintAhead());
     }
 
+    Y_UNIT_TEST(ShouldPreferLoadedBehindState)
+    {
+        TBlockRangeField ahead;
+        ahead.Add(TBlockRange64::WithLength(50, 10));
+
+        TBlockRangeField behind;
+        behind.Add(TBlockRange64::WithLength(10, 10));
+
+        TDDiskStateProto proto;
+        SaveBlockField(ahead, 100, proto.MutableAhead());
+        SaveBlockField(behind, 100, proto.MutableBehind());
+
+        TTestBlockFieldMonitor monitor;
+        TDDiskState ddisk;
+        ddisk.Init(
+            &monitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/40);
+        ddisk.Load(proto);
+
+        UNIT_ASSERT_VALUES_EQUAL("[50..59]", ddisk.DebugPrintAhead());
+        UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintBehind());
+    }
+
+    Y_UNIT_TEST(ShouldKeepFreshTailWhenLoadedBehindIsEmpty)
+    {
+        TBlockRangeField ahead;
+        ahead.Add(TBlockRange64::WithLength(50, 10));
+
+        TDDiskStateProto proto;
+        SaveBlockField(ahead, 100, proto.MutableAhead());
+
+        TTestBlockFieldMonitor monitor;
+        TDDiskState ddisk;
+        ddisk.Init(
+            &monitor,
+            /*totalBlockCount=*/100,
+            /*operationalBlockCount=*/40);
+        ddisk.Load(proto);
+
+        UNIT_ASSERT_VALUES_EQUAL("[50..59]", ddisk.DebugPrintAhead());
+        UNIT_ASSERT_VALUES_EQUAL("[40..49][60..99]", ddisk.DebugPrintBehind());
+    }
+
     Y_UNIT_TEST(ShouldClearAheadAndBehindWhenSwitchedOffline)
     {
         TTestBlockFieldMonitor monitor;
@@ -147,7 +215,7 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
             TBlockRange64::WithLength(30, 5),
             TDDiskState::EFlushCompletion::Completed);
 
-        UNIT_ASSERT_VALUES_EQUAL("[10..19]", ddisk.DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL("[5..29][35..99]", ddisk.DebugPrintBehind());
         UNIT_ASSERT_VALUES_EQUAL("[30..34]", ddisk.DebugPrintAhead());
 
         ddisk.SwitchOffline();
@@ -171,7 +239,7 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
         ddisk.Init(
             &monitor,
             /*totalBlockCount=*/100,
-            /*operationalBlockCount=*/5);
+            /*operationalBlockCount=*/100);
 
         // Empty Behind – always false.
         UNIT_ASSERT_VALUES_EQUAL(
@@ -218,7 +286,7 @@ Y_UNIT_TEST_SUITE(TDDiskStateTest)
         ddisk.Init(
             &monitor,
             /*totalBlockCount=*/100,
-            /*operationalBlockCount=*/5);
+            /*operationalBlockCount=*/100);
 
         UNIT_ASSERT_VALUES_EQUAL(0u, monitor.BehindAheadGeneration);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -915,9 +915,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "H4+{Disabled,0};",
             dirtyMap->DebugPrintDDiskState());
 
-        // Nothing tracked before the flush.
+        // The unsynced tail is tracked as Behind before the flush.
         UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintAhead());
-        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "  H3: [5..32767]\n",
+            dirtyMap->DebugPrintBehind());
 
         // Write above the fresh watermark to all four DDisks.
         const THostMask requested = MakeHostMask(true, true, true, true, false);
@@ -940,7 +942,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(
             "  H3: [10..19]\n",
             dirtyMap->DebugPrintAhead());
-        UNIT_ASSERT_VALUES_EQUAL("", dirtyMap->DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "  H3: [5..9][20..32767]\n",
+            dirtyMap->DebugPrintBehind());
 
         // Drain erases so the inflight map ends clean.
         auto eraseHints = dirtyMap->MakeEraseHint(1);
@@ -2670,7 +2674,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Only Behind blocks erase; Ahead does not.
         UNIT_ASSERT_VALUES_EQUAL(
-            "  H1: [10..19]\n",
+            "  H1: [10..19]\n"
+            "  H3: [5..9][20..32767]\n",
             dirtyMap->DebugPrintBehind());
         eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
@@ -2714,7 +2719,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL("  H3: [10..19]\n", source->DebugPrintAhead());
         UNIT_ASSERT_VALUES_EQUAL(
-            "  H1: [10..19]\n",
+            "  H1: [10..19]\n"
+            "  H3: [5..9][20..32767]\n",
             source->DebugPrintBehind());
 
         const auto persisted = source->GetStateForPersist();
@@ -2726,9 +2732,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        // Before load the target has no tracked ranges.
+        // Before load the target contains the unsynced fresh tail.
         UNIT_ASSERT_VALUES_EQUAL("", target->DebugPrintAhead());
-        UNIT_ASSERT_VALUES_EQUAL("", target->DebugPrintBehind());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "  H3: [5..32767]\n",
+            target->DebugPrintBehind());
 
         target->Load(persisted);
 
@@ -2767,6 +2775,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Promote hand-off H3 to a primary DDisk so we have 4 desired DDisks.
         vchunkConfig.PromoteHost(3);
+        vchunkConfig.SetWatermark(3, std::nullopt);
 
         auto dirtyMap = std::make_shared<TBlocksDirtyMap>(
             vchunkConfig,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h
@@ -43,8 +43,8 @@ public:
 
 private:
     friend class TBlocksDirtyMap;
+    friend class TVChunk;
     friend class TRangeLockAccess;
-    friend class TDDiskDataCopier;
 
     // Lock the PBuffer record with the given id.
     TRangeLock(ILockableRangesWeakPtr lockableRanges, TPBufferKey pBufferKey);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker_ut.cpp
@@ -2,6 +2,8 @@
 
 #include "pbuffer_key_test_helpers.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/range_locker_access.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <utility>
@@ -10,26 +12,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TRangeLockAccess
-{
-public:
-    static TRangeLock Make(
-        ILockableRangesWeakPtr lockableRanges,
-        TPBufferKey pBufferKey)
-    {
-        return TRangeLock(std::move(lockableRanges), pBufferKey);
-    }
-
-    static TRangeLock Make(
-        ILockableRangesWeakPtr lockableRanges,
-        TBlockRange64 range,
-        THostMask mask)
-    {
-        return TRangeLock(std::move(lockableRanges), range, mask);
-    }
-};
-
-////////////////////////////////////////////////////////////////////////////////
+namespace {
 
 class TMockLockableRanges
     : public ILockableRanges
@@ -75,6 +58,8 @@ public:
 private:
     TLockRangeHandle NextHandle = 1000;
 };
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/range_locker_access.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/range_locker_access.cpp
@@ -1,0 +1,26 @@
+#include "range_locker_access.h"
+
+#include <utility>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TRangeLock TRangeLockAccess::Make(
+    ILockableRangesWeakPtr lockableRanges,
+    TPBufferKey pBufferKey)
+{
+    return TRangeLock(std::move(lockableRanges), pBufferKey);
+}
+
+TRangeLock TRangeLockAccess::Make(
+    ILockableRangesWeakPtr lockableRanges,
+    TBlockRange64 range,
+    THostMask mask)
+{
+    return TRangeLock(std::move(lockableRanges), range, mask);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/range_locker_access.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/range_locker_access.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRangeLockAccess
+{
+public:
+    static TRangeLock Make(
+        ILockableRangesWeakPtr lockableRanges,
+        TPBufferKey pBufferKey);
+
+    static TRangeLock Make(
+        ILockableRangesWeakPtr lockableRanges,
+        TBlockRange64 range,
+        THostMask mask);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib/ya.make
@@ -1,0 +1,11 @@
+LIBRARY()
+
+SRCS(
+    range_locker_access.cpp
+)
+
+PEERDIR(
+    ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map
+)
+
+END()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ut/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/ut/ya.make
@@ -10,6 +10,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map
+    ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib
     ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model
 
     library/cpp/testing/unittest

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -54,6 +54,7 @@ struct TTabletInfo
 {
     ui64 TabletId = 0;
     ui32 Generation = 0;
+    ui32 BlockSize = 0;
     TString DiskId;
     TString State;   // "INIT" / "WORK"
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -268,18 +268,21 @@ void RenderOverview(IOutputStream& str, const TFastPathServiceInfo& info)
     }
 }
 
-void RenderFreshPercentage(IOutputStream& str, const TDbgSnapshot& dbg)
+void RenderFreshPercentage(
+    IOutputStream& str,
+    const TDbgSnapshot& dbg,
+    ui32 blockSize)
 {
     for (const auto& [vChunkId, vChunkConfig]: dbg.VChunkConfigs) {
         TStringBuilder w;
         for (auto host: vChunkConfig.GetDDisks()) {
             if (auto watermark = vChunkConfig.GetWatermark(host)) {
-                w << PrintHostIndex(host) << ":" << *watermark;
+                w << PrintHostIndex(host) << ":" << *watermark / blockSize;
             }
         }
 
         if (w) {
-            str << vChunkId << "[" << w << "] ";
+            str << PrintVChunkId(vChunkId) << "[" << w << "] ";
         }
     }
 }
@@ -383,7 +386,10 @@ void RenderDbgList(
                             str << behindBlocks.Print(true);
                         }
                         TABLED () {
-                            RenderFreshPercentage(str, dbg);
+                            RenderFreshPercentage(
+                                str,
+                                dbg,
+                                tabletInfo.BlockSize);
                         }
                     }
                 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -188,18 +188,19 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
 
     Y_UNIT_TEST(DbgListShowsFreshDDisksByVChunk)
     {
+        constexpr ui32 BlockSize = 4096;
         auto dbg = MakeDbg(0);
         auto config = TVChunkConfig::MakeDefault(
             /*vChunkIndex*/ 17,
             /*hostCount*/ 5,
             /*primaryCount*/ 3);
         config.PromoteHost(3);
-        config.SetWatermark(3, 42);
+        config.SetWatermark(3, 42 * BlockSize);
         dbg.VChunkConfigs.emplace(config.GetVChunkIndex(), std::move(config));
 
         const TMonPageData data{
             .Page = EMonPage::Dbg,
-            .TabletInfo = {.TabletId = 42},
+            .TabletInfo = {.TabletId = 42, .BlockSize = BlockSize},
             .Dbgs = {std::move(dbg)},
         };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
@@ -135,6 +135,7 @@ TTabletInfo TPartitionActor::MakeMonTabletInfo() const
     return {
         .TabletId = TabletID(),
         .Generation = Executor()->Generation(),
+        .BlockSize = VolumeConfig.GetBlockSize(),
         .DiskId = VolumeConfig.GetDiskId(),
         .State = FastPathService ? "WORK" : "INIT",
     };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ut/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ut/ya.make
@@ -20,6 +20,7 @@ SRCS(
 PEERDIR(
     ydb/core/base
     ydb/core/blobstorage/ut_blobstorage/lib
+    ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/testlib
     ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib
     ydb/core/nbs/cloud/blockstore/libs/storage/testlib
     ydb/core/protos

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -434,6 +434,68 @@ void TVChunk::OnBelatedWriteBlocksResponse(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+std::optional<TBlockRange64> TVChunk::GetFreshRange(THostIndex host) const
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    return BlocksDirtyMap->GetFreshRange(host);
+}
+
+TReadHint TVChunk::MakeReadHint(TBlockRange64 range)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    return BlocksDirtyMap->MakeReadHint(range);
+}
+
+TRangeLock TVChunk::MakeDDiskRangeLock(TBlockRange64 range, THostMask mask)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    return TRangeLock(BlocksDirtyMap, range, mask);
+}
+
+TSyncHint TVChunk::BeginRangeSync(THostIndex host, TBlockRange64 range)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    return BlocksDirtyMap->BeginRangeSync(host, range);
+}
+
+void TVChunk::EndRangeSync(ui64 syncId, bool success)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    BlocksDirtyMap->EndRangeSync(syncId, success);
+}
+
+void TVChunk::OnCopyProgress(ui64 totalBytes)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    auto prepare = [weakSelf = weak_from_this()]()
+    {
+        if (auto self = weakSelf.lock()) {
+            auto newConfig = self->VChunkConfig;
+            for (const auto& [hostIndex, _]: self->Copiers) {
+                const auto freshRange = self->GetFreshRange(hostIndex);
+                newConfig.SetWatermark(
+                    hostIndex,
+                    freshRange ? std::optional<ui64>(
+                                     freshRange->Start * self->BlockSize)
+                               : std::nullopt);
+            }
+            return newConfig;
+        }
+        return TVChunkConfig{};
+    };
+    UpdateConfig(
+        std::move(prepare),
+        TStringBuilder() << "copy progress " << totalBytes << " bytes");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TVChunk::UpdateDirtyMap(const TDBGRestoreResponse& response)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
@@ -990,14 +1052,16 @@ void TVChunk::UpdateConfig(TPrepareConfigFunc prepareConfig, TString message)
     PendingVChunkConfigs.push_back(TPendingVChunkConfig{
         .PrepareConfig = std::move(prepareConfig),
         .Message = std::move(message)});
-    PersistNextPendingConfig();
+    if (PendingVChunkConfigs.size() == 1) {
+        PersistNextPendingConfig();
+    }
 }
 
 void TVChunk::PersistNextPendingConfig()
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
-    if (PendingVChunkConfigs.size() != 1) {
+    if (PendingVChunkConfigs.empty()) {
         return;
     }
 
@@ -1097,7 +1161,7 @@ void TVChunk::ApplyConfig(TVChunkConfig newConfig, const TString& message)
                     DiskDescription,
                     VChunkConfig,
                     DirectBlockGroup,
-                    BlocksDirtyMap,
+                    this,
                     hostIndex);
 
             newCopier->Start().Subscribe(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -31,6 +31,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 class TVChunk
     : public IWriteClient
+    , public IRangeSyncClient
     , public std::enable_shared_from_this<TVChunk>
 {
 public:
@@ -95,6 +96,17 @@ public:
     void OnBelatedWriteBlocksResponse(
         std::shared_ptr<TWriteRequestBundle> bundle,
         THostMask completedWrites) override;
+
+    // IRangeSyncClient implementation
+    [[nodiscard]] std::optional<TBlockRange64> GetFreshRange(
+        THostIndex host) const override;
+    [[nodiscard]] TReadHint MakeReadHint(TBlockRange64 range) override;
+    [[nodiscard]] TRangeLock MakeDDiskRangeLock(
+        TBlockRange64 range,
+        THostMask mask) override;
+    TSyncHint BeginRangeSync(THostIndex host, TBlockRange64 range) override;
+    void EndRangeSync(ui64 syncId, bool success) override;
+    void OnCopyProgress(ui64 totalBytes) override;
 
 private:
     friend struct TBaseFixture;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -717,6 +717,22 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         // Waiting for the copying to be completed.
         {
             DrainExecutor(DirectBlockGroup->GetExecutor());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                PartitionDirectService->UpdateConfigRequests.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                CopyProgressSaveInterval,
+                *PartitionDirectService->UpdateConfigRequests.front()
+                     .Config.GetWatermark(3));
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                PartitionDirectService->UpdateConfigRequests.size());
+            UNIT_ASSERT(!PartitionDirectService->UpdateConfigRequests.front()
+                             .Config.GetWatermark(3)
+                             .has_value());
             UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
             DrainExecutor(DirectBlockGroup->GetExecutor());
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1 Periodic persistence of the fresh-data watermark during range synchronization. Copy progress is saved every 8 MiB.
2 Show fill progress on the monitoring page 
3 strengthens Ahead/Behind dirty-map loading and invariants.

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
