### PR TITLE
chore: assign local-ydb acceptance test ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,6 +135,7 @@
 /ydb/tools/stress_tool @ydb-platform/blobstorage
 
 /ydb/apps/ydb @ydb-platform/cli
+/ydb/ci/local-ydb/tests/ @ydb-platform/appteam
 /ydb/public/lib/ydb_cli @ydb-platform/cli
 /ydb/public/lib/ydb_cli/dump @ydb-platform/core
 /ydb/public/sdk/cpp @ydb-platform/cpp-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,7 +135,7 @@
 /ydb/tools/stress_tool @ydb-platform/blobstorage
 
 /ydb/apps/ydb @ydb-platform/cli
-/ydb/ci/local-ydb/tests/ @ydb-platform/appteam
+/ydb/ci/local-ydb/ @ydb-platform/appteam
 /ydb/public/lib/ydb_cli @ydb-platform/cli
 /ydb/public/lib/ydb_cli/dump @ydb-platform/core
 /ydb/public/sdk/cpp @ydb-platform/cpp-sdk


### PR DESCRIPTION
## Summary

- assign `@ydb-platform/appteam` as the code owner for `ydb/ci/local-ydb/`
- ensure changes to the local-ydb Docker acceptance suite request AppTeam review

## Validation

- `git diff --check`
