### PR TITLE
PQ: ack all TEvPlanStep senders after mediator restart

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4044,7 +4044,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         TDistributedTransaction& tx = p->second;
 
         // таблетка координатора могла перезапуститься надо обновить информацию
-        tx.SendPlanStepAcksAfterCompletion(sender, std::move(ev));
+        tx.AddPlanStepSender(sender, std::move(ev));
 
         if (tx.State >= NKikimrPQ::TTransaction::EXECUTED) {
             // таблетка PQ могла отправить подтвержение, но координатор перезапустился и его не получил
@@ -4079,11 +4079,13 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
 void TPersQueue::SendPlanStepAcks(const TActorContext& ctx,
                                   const TDistributedTransaction& tx)
 {
-    if (!tx.PlanStepSender) {
+    if (tx.PlanStepSenders.empty()) {
         return;
     }
 
-    SendPlanStepAcks(ctx, tx.PlanStepSender, *tx.PlanStepEvent);
+    for (const auto& [receiver, event] : tx.PlanStepSenders) {
+        SendPlanStepAcks(ctx, receiver, *event);
+    }
 }
 
 void TPersQueue::SendPlanStepAcks(const TActorContext& ctx,

--- a/ydb/core/persqueue/pqtablet/transaction.cpp
+++ b/ydb/core/persqueue/pqtablet/transaction.cpp
@@ -394,10 +394,9 @@ void TDistributedTransaction::OnTxDone(const TEvPQ::TEvTxDone& event)
     ++PartitionRepliesCount;
 }
 
-void TDistributedTransaction::SendPlanStepAcksAfterCompletion(const TActorId& sender, std::unique_ptr<TEvTxProcessing::TEvPlanStep>&& event)
+void TDistributedTransaction::AddPlanStepSender(const TActorId& sender, std::unique_ptr<TEvTxProcessing::TEvPlanStep>&& event)
 {
-    PlanStepSender = sender;
-    PlanStepEvent = std::move(event);
+    PlanStepSenders[sender] = std::move(event);
 }
 
 auto TDistributedTransaction::GetDecision() const -> EDecision

--- a/ydb/core/persqueue/pqtablet/transaction.h
+++ b/ydb/core/persqueue/pqtablet/transaction.h
@@ -39,7 +39,7 @@ struct TDistributedTransaction {
     void OnReadSetAck(ui64 tabletId);
     void OnTxDone(const TEvPQ::TEvTxDone& event);
 
-    void SendPlanStepAcksAfterCompletion(const TActorId& sender, std::unique_ptr<TEvTxProcessing::TEvPlanStep>&& event);
+    void AddPlanStepSender(const TActorId& sender, std::unique_ptr<TEvTxProcessing::TEvPlanStep>&& event);
 
     bool GetSkipSrcIdInfo() const;
 
@@ -132,8 +132,7 @@ struct TDistributedTransaction {
 
     TMaybe<NKikimrPQ::TError> Error;
 
-    TActorId PlanStepSender;
-    std::unique_ptr<TEvTxProcessing::TEvPlanStep> PlanStepEvent;
+    THashMap<TActorId, std::unique_ptr<TEvTxProcessing::TEvPlanStep>> PlanStepSenders;
 
 private:
     NWilson::TSpan CreateSpan(const char* name, ui64 tabletId);

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -72,6 +72,7 @@ struct TProposeTransactionParams {
 struct TPlanStepParams {
     ui64 Step;
     TVector<ui64> TxIds;
+    TMaybe<TActorId> Sender;
 };
 
 struct TReadSetParams {
@@ -614,7 +615,8 @@ void TPQTabletFixture::SendPlanStep(const TPlanStepParams& params)
         ActorIdToProto(Ctx->Edge, tx->MutableAckTo());
     }
 
-    SendToPipe(Ctx->Edge,
+    const TActorId sender = params.Sender.GetOrElse(Ctx->Edge);
+    SendToPipe(sender,
                event.Release());
 }
 
@@ -2090,6 +2092,70 @@ Y_UNIT_TEST_F(PQTablet_Send_RS_With_Abort, TPQTabletFixture)
 
     tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
     WaitReadSetAck(*tablet, {.Step=100, .TxId=txId, .Source=22222, .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
+}
+
+Y_UNIT_TEST_F(PlanStep_Ack_All_Senders_After_Mediator_Restart, TPQTabletFixture)
+{
+    // The mediator tablet may restart: a TEvPlanStep from a stale mediator leader
+    // can arrive after the one from the current leader. The PQ tablet must keep
+    // all senders and ack each of them on transaction completion, not only the
+    // last one (otherwise the real mediator never gets the ack for its PlanStep).
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(22222);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    const ui64 txId = 67890;
+    const ui64 mockTabletId = 22222;
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    // The current mediator leader plans the step.
+    const TActorId realLeader = Ctx->Edge;
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    // The tx is now in WAIT_RS (a readset was sent to the mock tablet and not
+    // yet answered), so it is not yet EXECUTED — a window for a stale leader.
+    WaitReadSet(*tablet, {.Step=100, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                          .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+
+    // A stale mediator leader (a different ActorId) replays the same PlanStep.
+    // It arrives after the real leader's message but before the tx completes.
+    const TActorId staleLeader = Ctx->Runtime->AllocateEdgeActor();
+    SendPlanStep({.Step=100, .TxIds={txId}, .Sender=staleLeader});
+
+    // The mock tablet answers the readset, completing the transaction.
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=txId, .Target=Ctx->TabletId,
+                                         .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+
+    // Both leaders must receive TEvPlanStepAccepted; the coordinator (AckTo ==
+    // Ctx->Edge) must receive one TEvPlanStepAck per stored PlanStep event.
+    auto accepted1 = Ctx->Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(realLeader);
+    UNIT_ASSERT(accepted1);
+    auto accepted2 = Ctx->Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(staleLeader);
+    UNIT_ASSERT(accepted2);
+
+    auto ack1 = Ctx->Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(realLeader);
+    UNIT_ASSERT(ack1);
+    UNIT_ASSERT_VALUES_EQUAL(100, ack1->Get()->Record.GetStep());
+    UNIT_ASSERT_VALUES_EQUAL(1, ack1->Get()->Record.TxIdSize());
+    UNIT_ASSERT_VALUES_EQUAL(txId, ack1->Get()->Record.GetTxId(0));
+
+    auto ack2 = Ctx->Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(realLeader);
+    UNIT_ASSERT(ack2);
+    UNIT_ASSERT_VALUES_EQUAL(100, ack2->Get()->Record.GetStep());
+    UNIT_ASSERT_VALUES_EQUAL(1, ack2->Get()->Record.TxIdSize());
+    UNIT_ASSERT_VALUES_EQUAL(txId, ack2->Get()->Record.GetTxId(0));
+
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+    WaitReadSetAck(*tablet, {.Step=100, .TxId=txId, .Source=mockTabletId, .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
 }
 
 Y_UNIT_TEST_F(Partition_Send_Predicate_With_False, TPQTabletFixture)


### PR DESCRIPTION
## Problem

The mediator tablet may restart, and a `TEvPlanStep` from a stale mediator leader can arrive after the one from the current leader. Previously the PQ tablet stored only a single sender (`PlanStepSender`) and overwrote it on each `TEvPlanStep`. When a stale leader's message arrived last, the ack went to the stale leader and was lost — the real mediator never received the ack for its `TEvPlanStep`.

## Fix

Store **all** `TEvPlanStep` senders (deduplicated by `ActorId`) in the transaction and send acks to each of them on transaction completion. Duplicate acks are idempotent for the mediator/coordinator.

## Changes

- `transaction.h` / `transaction.cpp`: replace single `PlanStepSender` + `PlanStepEvent` with `THashMap<TActorId, std::unique_ptr<TEvPlanStep>> PlanStepSenders`; rename `SendPlanStepAcksAfterCompletion` → `AddPlanStepSender`.
- `pq_impl.cpp`: `SendPlanStepAcks(ctx, tx)` now iterates over all stored senders.
- `pqtablet_ut.cpp`: new test `PlanStep_Ack_All_Senders_After_Mediator_Restart` verifying both the real and stale leaders receive `TEvPlanStepAccepted`, and the coordinator receives one `TEvPlanStepAck` per stored event.