### PR TITLE
Support SpaceDataKind for restore-get queries

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -676,6 +676,22 @@ struct TEvBlobStorage {
         std::shared_ptr<TExecutionRelay> ExecutionRelay;
         std::optional<ui32> ForceGroupGeneration;
 
+        // Admission hint deciding whether the write this request performs -- the put itself, or the
+        // restore a MustRestoreFirst read triggers -- is still accepted when the group is low on
+        // space. It is never stored along with the blob.
+        NKikimrBlobStorage::TDataKind::E DataKind = NKikimrBlobStorage::TDataKind::USER;
+
+        TEvRequestCommon() = default;
+
+        explicit TEvRequestCommon(NKikimrBlobStorage::TDataKind::E dataKind)
+            : DataKind(dataKind)
+        {}
+
+        // A clone keeps the admission hint, but starts its own restart counter and execution relay.
+        TEvRequestCommon(TCloneEventPolicy, const TEvRequestCommon& origin)
+            : DataKind(origin.DataKind)
+        {}
+
         static TString GetRequestName(ui32 eventType) {
             switch (eventType) {
             case EvPut:
@@ -747,7 +763,6 @@ struct TEvBlobStorage {
         const NKikimrBlobStorage::EPutHandleClass HandleClass;
         const ETactic Tactic;
         const TWriteSource WriteSource;
-        const NKikimrBlobStorage::TDataKind::E DataKind = NKikimrBlobStorage::TDataKind::USER;
         const bool IssueKeepFlag = false;
         const bool IgnoreBlock = false;
         const bool AlreadyEncrypted = false; // when set to true, no encryption is required
@@ -779,13 +794,13 @@ struct TEvBlobStorage {
         // so a new field of TEvPut cannot be silently lost by a caller that only needs to flip this
         // one flag.
         TEvPut(TCloneEventPolicy, const TEvPut& origin, std::optional<bool> reduceInterpileTraffic = std::nullopt)
-            : Id(origin.Id)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , Id(origin.Id)
             , Buffer(origin.Buffer)
             , Deadline(origin.Deadline)
             , HandleClass(origin.HandleClass)
             , Tactic(origin.Tactic)
             , WriteSource(origin.WriteSource)
-            , DataKind(origin.DataKind)
             , IssueKeepFlag(origin.IssueKeepFlag)
             , IgnoreBlock(origin.IgnoreBlock)
             , AlreadyEncrypted(origin.AlreadyEncrypted)
@@ -797,13 +812,13 @@ struct TEvBlobStorage {
         {}
 
         TEvPut(TParameters parameters)
-            : Id(parameters.BlobId)
+            : TEvRequestCommon(parameters.DataKind)
+            , Id(parameters.BlobId)
             , Buffer(std::move(parameters.Buffer))
             , Deadline(parameters.Deadline)
             , HandleClass(parameters.HandleClass)
             , Tactic(parameters.Tactic)
             , WriteSource(parameters.WriteSource)
-            , DataKind(parameters.DataKind)
             , IssueKeepFlag(parameters.IssueKeepFlag)
             , IgnoreBlock(parameters.IgnoreBlock)
             , AlreadyEncrypted(parameters.AlreadyEncrypted)
@@ -1019,7 +1034,8 @@ struct TEvBlobStorage {
         std::optional<TForceBlockTabletData> ForceBlockTabletData;
 
         TEvGet(TCloneEventPolicy, const TEvGet& origin)
-            : QuerySize(origin.QuerySize)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , QuerySize(origin.QuerySize)
             , Queries(new TQuery[QuerySize])
             , Deadline(origin.Deadline)
             , MustRestoreFirst(origin.MustRestoreFirst)
@@ -1085,6 +1101,9 @@ struct TEvBlobStorage {
             Y_UNUSED(isFull);
             TStringStream str;
             str << "TEvGet {MustRestoreFirst# " << (MustRestoreFirst ? "true" : "false");
+            if (DataKind != NKikimrBlobStorage::TDataKind::USER) {
+                str << " DataKind# " << NKikimrBlobStorage::TDataKind::E_Name(DataKind);
+            }
             str << " GetHandleClass# " << NKikimrBlobStorage::EGetHandleClass_Name(GetHandleClass);
             str << " IsVerboseNoDataEnabled# " << (IsVerboseNoDataEnabled ? "true" : "false");
             str << " Deadline# " << Deadline.MilliSeconds();
@@ -1257,7 +1276,8 @@ struct TEvBlobStorage {
         bool OmitDataInfoUnlessError;
 
         TEvCheckIntegrity(TCloneEventPolicy, const TEvCheckIntegrity& origin)
-            : Id(origin.Id)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , Id(origin.Id)
             , Deadline(origin.Deadline)
             , GetHandleClass(origin.GetHandleClass)
             , SingleLine(origin.SingleLine)
@@ -1393,7 +1413,8 @@ struct TEvBlobStorage {
         const TInstant Deadline;
 
         TEvGetBlock(TCloneEventPolicy, const TEvGetBlock& origin)
-            : TabletId(origin.TabletId)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , TabletId(origin.TabletId)
             , Deadline(origin.Deadline)
         {}
 
@@ -1465,7 +1486,8 @@ struct TEvBlobStorage {
         bool IsMonitored = true;
 
         TEvBlock(TCloneEventPolicy, const TEvBlock& origin)
-            : TabletId(origin.TabletId)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , TabletId(origin.TabletId)
             , Generation(origin.Generation)
             , Deadline(origin.Deadline)
             , IssuerGuid(origin.IssuerGuid)
@@ -1592,7 +1614,8 @@ struct TEvBlobStorage {
         mutable NLWTrace::TOrbit Orbit;
 
         TEvPatch(TCloneEventPolicy, const TEvPatch& origin)
-            : OriginalGroupId(origin.OriginalGroupId)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , OriginalGroupId(origin.OriginalGroupId)
             , OriginalId(origin.OriginalId)
             , PatchedId(origin.PatchedId)
             , MaskForCookieBruteForcing(origin.MaskForCookieBruteForcing)
@@ -1876,7 +1899,8 @@ struct TEvBlobStorage {
         const bool FromLeader;
 
         TEvDiscover(TCloneEventPolicy, const TEvDiscover& origin)
-            : TabletId(origin.TabletId)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , TabletId(origin.TabletId)
             , MinGeneration(origin.MinGeneration)
             , Deadline(origin.Deadline)
             , ReadBody(origin.ReadBody)
@@ -1906,6 +1930,9 @@ struct TEvBlobStorage {
             str << " ForceBlockedGeneration# " << ForceBlockedGeneration;
             str << " FromLeader# " << (FromLeader ? "true" : "false");
             str << " Deadline# " << Deadline.MilliSeconds();
+            if (DataKind != NKikimrBlobStorage::TDataKind::USER) {
+                str << " DataKind# " << NKikimrBlobStorage::TDataKind::E_Name(DataKind);
+            }
             str << "}";
             return str.Str();
         }
@@ -1993,7 +2020,8 @@ struct TEvBlobStorage {
         bool Decommission = false;
 
         TEvRange(TCloneEventPolicy, const TEvRange& origin)
-            : TabletId(origin.TabletId)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , TabletId(origin.TabletId)
             , From(origin.From)
             , To(origin.To)
             , Deadline(origin.Deadline)
@@ -2022,6 +2050,9 @@ struct TEvBlobStorage {
             str << " To# " << To.ToString();
             str << " Deadline# " << Deadline.MilliSeconds();
             str << " MustRestoreFirst# " << (MustRestoreFirst ? "true" : "false");
+            if (DataKind != NKikimrBlobStorage::TDataKind::USER) {
+                str << " DataKind# " << NKikimrBlobStorage::TDataKind::E_Name(DataKind);
+            }
             if (ForceBlockedGeneration)
                 str << " ForceBlock: " << ForceBlockedGeneration;
             str << "}";
@@ -2142,7 +2173,8 @@ struct TEvBlobStorage {
         const TWriteSource WriteSource;
 
         TEvCollectGarbage(TCloneEventPolicy, const TEvCollectGarbage& origin)
-            : TabletId(origin.TabletId)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , TabletId(origin.TabletId)
             , RecordGeneration(origin.RecordGeneration)
             , PerGenerationCounter(origin.PerGenerationCounter)
             , Channel(origin.Channel)
@@ -2322,7 +2354,8 @@ struct TEvBlobStorage {
         const TInstant Deadline;
 
         TEvStatus(TCloneEventPolicy, const TEvStatus& origin)
-            : Deadline(origin.Deadline)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , Deadline(origin.Deadline)
         {}
 
         TEvStatus(TInstant deadline)
@@ -2393,7 +2426,8 @@ struct TEvBlobStorage {
         bool Reverse;
 
         TEvAssimilate(TCloneEventPolicy, const TEvAssimilate& origin)
-            : SkipBlocksUpTo(origin.SkipBlocksUpTo)
+            : TEvRequestCommon(CloneEventPolicy, origin)
+            , SkipBlocksUpTo(origin.SkipBlocksUpTo)
             , SkipBarriersUpTo(origin.SkipBarriersUpTo)
             , SkipBlobsUpTo(origin.SkipBlobsUpTo)
             , IgnoreDecommitState(origin.IgnoreDecommitState)

--- a/ydb/core/blob_depot/agent/agent_impl.h
+++ b/ydb/core/blob_depot/agent/agent_impl.h
@@ -491,6 +491,7 @@ namespace NKikimr::NBlobDepot {
                 ui64 Tag = 0;
                 std::optional<TEvBlobStorage::TEvGet::TReaderTabletData> ReaderTabletData;
                 TString Key; // the key we are reading -- this is used for retries when we are getting NODATA
+                NKikimrBlobStorage::TDataKind::E DataKind = NKikimrBlobStorage::TDataKind::USER;
             };
             struct TCheckContext;
 

--- a/ydb/core/blob_depot/agent/blob_mapping_cache.cpp
+++ b/ydb/core/blob_depot/agent/blob_mapping_cache.cpp
@@ -111,7 +111,7 @@ namespace NKikimr::NBlobDepot {
     }
 
     const TResolvedValue *TBlobDepotAgent::TBlobMappingCache::ResolveKey(TString key, TQuery *query,
-            TRequestContext::TPtr context, bool mustRestoreFirst) {
+            TRequestContext::TPtr context, bool mustRestoreFirst, NKikimrBlobStorage::TDataKind::E dataKind) {
         // obtain entry in the cache
         const TStringBuf keyBuf = key;
         const auto [it, inserted] = Cache.try_emplace(std::move(key), keyBuf);
@@ -151,6 +151,10 @@ namespace NKikimr::NBlobDepot {
             if (mustRestoreFirst != item->GetMustRestoreFirst()) {
                 item->SetMustRestoreFirst(mustRestoreFirst);
             }
+            // A pending resolve is shared with the queries that arrive while it is in flight, but a
+            // cache entry is a blob id and thus belongs to a single tablet, so every query sharing
+            // it carries the same data kind.
+            msg.SetDataKind(dataKind);
 
             Agent.Issue(std::move(msg), this, std::make_unique<TResolveContext>(TString(keyBuf), mustRestoreFirst));
             ++(mustRestoreFirst ? entry.MustRestoreFirstResolvePending : entry.OrdinaryResolvePending);

--- a/ydb/core/blob_depot/agent/blob_mapping_cache.h
+++ b/ydb/core/blob_depot/agent/blob_mapping_cache.h
@@ -30,7 +30,8 @@ namespace NKikimr::NBlobDepot {
         {}
 
         void HandleResolveResult(ui64 tag, const NKikimrBlobDepot::TEvResolveResult& msg, TRequestContext::TPtr context);
-        const TResolvedValue *ResolveKey(TString key, TQuery *query, TRequestContext::TPtr context, bool mustRestoreFirst);
+        const TResolvedValue *ResolveKey(TString key, TQuery *query, TRequestContext::TPtr context, bool mustRestoreFirst,
+            NKikimrBlobStorage::TDataKind::E dataKind);
 
     private:
         void ProcessResponse(ui64 tag, TRequestContext::TPtr /*context*/, TResponse response) override;

--- a/ydb/core/blob_depot/agent/read.cpp
+++ b/ydb/core/blob_depot/agent/read.cpp
@@ -204,6 +204,7 @@ namespace NKikimr::NBlobDepot {
 
             auto event = std::make_unique<TEvBlobStorage::TEvGet>(q, sz, TInstant::Max(), context->ReadArg.GetHandleClass);
             event->ReaderTabletData = context->ReadArg.ReaderTabletData;
+            event->DataKind = context->ReadArg.DataKind;
             YDB_LOG_DEBUG("Issuing TEvGet",
                 {"marker", "BDA39"},
                 {"agentId", Agent.LogId},
@@ -277,6 +278,7 @@ namespace NKikimr::NBlobDepot {
                 auto *item = resolve.AddItems();
                 item->SetExactKey(readContext.ReadArg.Key);
                 item->SetMustRestoreFirst(readContext.ReadArg.MustRestoreFirst);
+                resolve.SetDataKind(readContext.ReadArg.DataKind);
                 YDB_LOG_DEBUG("Issuing extra resolve",
                     {"marker", "BDA48"},
                     {"agent", Agent.LogId},

--- a/ydb/core/blob_depot/agent/storage_check_integrity.cpp
+++ b/ydb/core/blob_depot/agent/storage_check_integrity.cpp
@@ -25,7 +25,7 @@ namespace NKikimr::NBlobDepot {
                 TString blobId = Request.Id.AsBinaryString();
 
                 if (const TResolvedValue *value = Agent.BlobMappingCache.ResolveKey(blobId, this,
-                        std::make_shared<TRequestContext>(), false)) {
+                        std::make_shared<TRequestContext>(), false, Request.DataKind)) {
                     ProcessResolveResult(value);
                 } else {
                     YDB_LOG_DEBUG("Resolve pending",
@@ -57,6 +57,7 @@ namespace NKikimr::NBlobDepot {
                         0,
                         std::nullopt,
                         Request.Id.AsBinaryString(),
+                        Request.DataKind,
                     };
                     IssueCheckIntegrity(std::move(arg));
                 }

--- a/ydb/core/blob_depot/agent/storage_discover.cpp
+++ b/ydb/core/blob_depot/agent/storage_discover.cpp
@@ -60,6 +60,7 @@ namespace NKikimr::NBlobDepot {
                 range->SetReverse(true);
                 item->SetTabletId(Request.TabletId);
                 item->SetMustRestoreFirst(true);
+                Resolve.SetDataKind(Request.DataKind);
             }
 
             void IssueResolve() {
@@ -139,6 +140,7 @@ namespace NKikimr::NBlobDepot {
                                 0,
                                 {},
                                 item.GetKey(),
+                                Request.DataKind,
                             };
                             TString error;
                             if (!IssueRead(std::move(arg), error)) {

--- a/ydb/core/blob_depot/agent/storage_get.cpp
+++ b/ydb/core/blob_depot/agent/storage_get.cpp
@@ -75,7 +75,7 @@ namespace NKikimr::NBlobDepot {
 
                     TString blobId = query.Id.AsBinaryString();
                     if (const TResolvedValue *value = Agent.BlobMappingCache.ResolveKey(blobId, this,
-                            std::make_shared<TResolveKeyContext>(i), Request.MustRestoreFirst)) {
+                            std::make_shared<TResolveKeyContext>(i), Request.MustRestoreFirst, Request.DataKind)) {
                         if (!ProcessSingleResult(i, value)) {
                             return; // error occured
                         }
@@ -126,6 +126,7 @@ namespace NKikimr::NBlobDepot {
                         queryIdx,
                         Request.ReaderTabletData,
                         Request.Queries[queryIdx].Id.AsBinaryString(),
+                        Request.DataKind,
                     };
                     TString error;
                     const bool success = IssueRead(std::move(arg), error);

--- a/ydb/core/blob_depot/agent/storage_range.cpp
+++ b/ydb/core/blob_depot/agent/storage_range.cpp
@@ -56,6 +56,7 @@ namespace NKikimr::NBlobDepot {
                 range->SetReverse(Reverse);
                 item->SetTabletId(Request.TabletId);
                 item->SetMustRestoreFirst(Request.MustRestoreFirst);
+                resolve.SetDataKind(Request.DataKind);
 
                 Agent.Issue(std::move(resolve), this, nullptr);
             }
@@ -112,6 +113,7 @@ namespace NKikimr::NBlobDepot {
                             tag,
                             {},
                             key.GetKey(),
+                            Request.DataKind,
                         };
                         ++ReadsInFlight;
                         TString error;

--- a/ydb/core/blob_depot/data_decommit.cpp
+++ b/ydb/core/blob_depot/data_decommit.cpp
@@ -423,14 +423,15 @@ namespace NKikimr::NBlobDepot {
                     {"cookie", Ev->Cookie},
                     {"key", key},
                     {"blobId", id});
-                // DataKind is deliberately left at USER: this copies user payload out of the group
-                // being decommitted, and stalling that while the destination is short of space is
-                // the wanted behaviour.
+                // This is the restore the MustRestoreFirst read asked for, so it inherits the kind of
+                // the reader: the payload is user data, but a tablet reading its own log during boot
+                // cannot get up until this copy lands.
                 SendToBSProxy(SelfId(), channel.GroupId, new TEvBlobStorage::TEvPut(TEvBlobStorage::TEvPut::TParameters{
                         .BlobId = id,
                         .Buffer = TRope(TRcBuf(buffer)),
                         .Deadline = TInstant::Max(),
                         .WriteSource = TWriteSource::BlobDepotPut,
+                        .DataKind = Ev->Get()->Record.GetDataKind(),
                     }), (ui64)keep | (ui64)doNotKeep << 1);
                 const bool inserted = channel.AssimilatedBlobsInFlight.insert(value).second; // prevent from barrier advancing
                 Y_ABORT_UNLESS(inserted);

--- a/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
+++ b/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
@@ -94,6 +94,9 @@ namespace NKikimr {
             size_t RestoreIndex = Max<size_t>();
             bool IsRestoring = false;
             bool MustRestoreFirst = false;
+            // Restoring a blob into a pile which lacks it is a write made on behalf of the original
+            // request, so it is admitted the same way that request would be.
+            NKikimrBlobStorage::TDataKind::E DataKind = NKikimrBlobStorage::TDataKind::USER;
             NKikimrBlobStorage::EGetHandleClass GetHandleClass = NKikimrBlobStorage::FastRead;
 
             TDynBitMap Processed; // a set of piles we already got main reply from
@@ -109,6 +112,8 @@ namespace NKikimr {
                 Y_ABORT_UNLESS(Info);
                 Y_ABORT_UNLESS(Info->Group);
                 Y_ABORT_UNLESS(Info->Group->HasBridgeGroupState());
+
+                DataKind = request->DataKind;
 
                 if constexpr (std::is_same_v<TEvRequest, TEvBlobStorage::TEvGet>) {
                     Y_ABORT_UNLESS(!request->PhantomCheck);
@@ -403,8 +408,10 @@ namespace NKikimr {
                     if (item.Buffer && item.Buffer.size() == item.Id.BlobSize()) {
                         IssueRestorePut(self, RestoreIndex);
                     } else {
-                        self.SendQuery(shared_from_this(), item.ReadFrom, std::make_unique<TEvBlobStorage::TEvGet>(
-                            item.Id, 0, 0, TInstant::Max(), GetHandleClass), {.Index = RestoreIndex});
+                        auto get = std::make_unique<TEvBlobStorage::TEvGet>(item.Id, 0, 0, TInstant::Max(),
+                            GetHandleClass);
+                        get->DataKind = DataKind;
+                        self.SendQuery(shared_from_this(), item.ReadFrom, std::move(get), {.Index = RestoreIndex});
                         IsRestoring = true;
                     }
 
@@ -455,6 +462,7 @@ namespace NKikimr {
                             .HandleClass = handleClass,
                             .Tactic = TEvBlobStorage::TEvPut::TacticDefault,
                             .WriteSource = TWriteSource::BridgeProxyRestorePut,
+                            .DataKind = DataKind,
                             .IssueKeepFlag = item.IssueKeepFlag,
                             .IgnoreBlock = true,
                         }), {.Index = index});

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -212,6 +212,14 @@ public:
     };
 
 public:
+    // The batched put path builds the actor out of a queue of events instead of a single one and
+    // leaves Event unset; each of those events keeps its own kind, so the request-wide one is never
+    // consulted there.
+    template<typename TEv>
+    static NKikimrBlobStorage::TDataKind::E DataKindOf(const TEv *ev) {
+        return ev ? ev->DataKind : NKikimrBlobStorage::TDataKind::USER;
+    }
+
     template<typename TGroupRequestParameters>
     TBlobStorageGroupRequestActor(TGroupRequestParameters& params)
         : TActor(&TThis::InitialStateFunc, params.TypeSpecific.Activity)
@@ -222,6 +230,7 @@ public:
         , LogCtx(params.TypeSpecific.LogComponent, params.Common.LogAccEnabled)
         , ParentSpan(TWilson::BlobStorage, std::move(params.Common.TraceId), params.TypeSpecific.Name)
         , RestartCounter(params.Common.RestartCounter)
+        , DataKind(DataKindOf(params.Common.Event))
         , CostModel(GroupQueues->CostModel)
         , RequestStartTime(params.Common.Now)
         , Source(params.Common.Source)
@@ -334,6 +343,10 @@ protected:
     ui32 GeneratedSubrequestBytes = 0;
     bool Dead = false;
     const ui32 RestartCounter = 0;
+    // Admission hint of the request being served; it has to reach every write this request makes on
+    // its own -- notably the parts a MustRestoreFirst read rewrites -- and every internal request it
+    // spawns on the way there.
+    const NKikimrBlobStorage::TDataKind::E DataKind = NKikimrBlobStorage::TDataKind::USER;
     std::shared_ptr<const TCostModel> CostModel;
     const TMonotonic RequestStartTime;
     THashMap<ui32, TActorId> NodeSubscriptions;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
@@ -324,7 +324,7 @@ void TGetImpl::PrepareVPuts(TLogContext &logCtx, TDeque<std::unique_ptr<TEvBlobS
         const bool checksumming = EnableChecksumCalcAndValidationOnDsProxy && Blackboard.GroupQueues->ChecksumExpected(Info->GetTopology(), vdiskId,
             TGroupQueues::TVDisk::TQueues::VDiskQueueId(Blackboard.PutHandleClass));
         auto vput = std::make_unique<TEvBlobStorage::TEvVPut>(put.Id, put.Buffer, vdiskId, true, nullptr, Deadline,
-            Blackboard.PutHandleClass, checksumming, TWriteSource::DSProxyGetAccelerate);
+            Blackboard.PutHandleClass, checksumming, TWriteSource::DSProxyGetAccelerate, DataKind);
         DSP_LOG_DEBUG_SX(logCtx, "BPG15", "Send put to orderNumber# " << put.OrderNumber << " vput# " << vput->ToString());
         History.AddVPutToWaitingList(put.Id, put.OrderNumber);
         outVPuts.push_back(std::move(vput));

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
@@ -28,6 +28,7 @@ class TGetImpl {
     const bool IsVerboseNoDataEnabled;
     const bool CollectDebugInfo;
     const bool MustRestoreFirst;
+    const NKikimrBlobStorage::TDataKind::E DataKind;
     const bool ReportDetailedPartMap;
     const bool EnableChecksumCalcAndValidationOnDsProxy;
     std::optional<TEvBlobStorage::TEvGet::TForceBlockTabletData> ForceBlockTabletData;
@@ -79,6 +80,7 @@ public:
         , IsVerboseNoDataEnabled(ev->IsVerboseNoDataEnabled)
         , CollectDebugInfo(ev->CollectDebugInfo)
         , MustRestoreFirst(ev->MustRestoreFirst)
+        , DataKind(ev->DataKind)
         , ReportDetailedPartMap(ev->ReportDetailedPartMap)
         , EnableChecksumCalcAndValidationOnDsProxy(enableChecksumCalcAndValidationOnDsProxy)
         , ForceBlockTabletData(ev->ForceBlockTabletData)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -803,6 +803,15 @@ namespace NKikimr {
             auto q = RestartQuery(RestartCounter + 1);
             if (q->Type() != TEvBlobStorage::EvBunchOfEvents) {
                 SetExecutionRelay(*q, std::exchange(ExecutionRelay, {}));
+                // Restarting rebuilds the request field by field, so carry the admission hint over
+                // here rather than in each RestartQuery: a request must not become user data just
+                // because it raced with a group reconfiguration. The put path is exempt because it
+                // restarts as a bunch of events, each already carrying its own kind.
+                auto *common = dynamic_cast<TEvBlobStorage::TEvRequestCommon*>(q.get());
+                Y_DEBUG_ABORT_UNLESS(common);
+                if (common) {
+                    common->DataKind = DataKind;
+                }
             }
             ++*Mon->NodeMon->RestartHisto[Min<size_t>(Mon->NodeMon->RestartHisto.size() - 1, RestartCounter)];
             const TActorId& proxyId = MakeBlobStorageProxyID(Info->GroupID);
@@ -915,9 +924,10 @@ namespace NKikimr {
     }
 
     void TBlobStorageGroupRequestActor::SendToProxy(std::unique_ptr<IEventBase> event, ui64 cookie, NWilson::TTraceId traceId) {
-        if (ForceGroupGeneration) {
+        if (ForceGroupGeneration || DataKind != NKikimrBlobStorage::TDataKind::USER) {
             if (auto *common = dynamic_cast<TEvBlobStorage::TEvRequestCommon*>(event.get())) {
                 common->ForceGroupGeneration = ForceGroupGeneration;
+                common->DataKind = DataKind;
             }
         }
         Send(ProxyActorId, event.release(), 0, cookie, std::move(traceId));

--- a/ydb/core/blobstorage/ut_blobstorage/blob_depot.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/blob_depot.cpp
@@ -364,4 +364,64 @@ Y_UNIT_TEST_SUITE(BlobDepot) {
             }
         }
     }
+
+    // A read that asks for MustRestoreFirst turns into a resolve, and in decommission mode the
+    // tablet answers it by copying the blob into its own storage. The kind of the read is the only
+    // thing that can tell that copy whether it is allowed to happen in a group short of space, so
+    // it has to travel with the resolve.
+    Y_UNIT_TEST(DataKindReachesTheResolve) {
+        ui32 seed;
+        LoadSeed(seed);
+        TBlobDepotTestEnvironment tenv(seed);
+        auto& env = *tenv.Env;
+
+        ui64 tabletId = 100600;
+        for (const auto dataKind : {NKikimrBlobStorage::TDataKind::USER, NKikimrBlobStorage::TDataKind::SYSTEM}) {
+            const TString data = "hello";
+            const TLogoBlobID id(tabletId, 1, 1, 0, data.size(), 0);
+            const TActorId sender = env.Runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+            env.Runtime->WrapInActorContext(sender, [&] {
+                SendToBSProxy(sender, tenv.BlobDepot, new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+            });
+            auto putRes = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender, false);
+            UNIT_ASSERT_VALUES_EQUAL(putRes->Get()->Status, NKikimrProto::OK);
+
+            // A range resolve names the tablet it scans, which keeps unrelated resolves -- the agent
+            // issues them for its own housekeeping too -- out of the measurement.
+            std::vector<NKikimrBlobStorage::TDataKind::E> seen;
+            env.Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+                if (ev->GetTypeRewrite() == TEvBlobDepot::EvResolve) {
+                    const auto& record = ev->Get<TEvBlobDepot::TEvResolve>()->Record;
+                    for (const auto& item : record.GetItems()) {
+                        if (item.GetTabletId() == tabletId) {
+                            seen.push_back(record.GetDataKind());
+                        }
+                    }
+                }
+                return true;
+            };
+
+            const TLogoBlobID from(tabletId, 0, 0, 0, 0, 0);
+            const TLogoBlobID to(tabletId, Max<ui32>(), Max<ui32>(), TLogoBlobID::MaxChannel,
+                TLogoBlobID::MaxBlobSize, TLogoBlobID::MaxCookie);
+            env.Runtime->WrapInActorContext(sender, [&] {
+                auto range = std::make_unique<TEvBlobStorage::TEvRange>(tabletId, from, to,
+                    true /*mustRestoreFirst*/, TInstant::Max(), false /*isIndexOnly*/);
+                range->DataKind = dataKind;
+                SendToBSProxy(sender, tenv.BlobDepot, range.release());
+            });
+            auto rangeRes = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvRangeResult>(sender, false);
+            UNIT_ASSERT_VALUES_EQUAL(rangeRes->Get()->Status, NKikimrProto::OK);
+            UNIT_ASSERT_VALUES_EQUAL(rangeRes->Get()->Responses.size(), 1);
+
+            env.Runtime->FilterFunction = nullptr;
+
+            UNIT_ASSERT_C(!seen.empty(), "the read did not resolve anything, so it proves nothing");
+            for (const auto kind : seen) {
+                UNIT_ASSERT_EQUAL(kind, dataKind);
+            }
+
+            ++tabletId;
+        }
+    }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/bridge_data_kind.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bridge_data_kind.cpp
@@ -157,4 +157,68 @@ Y_UNIT_TEST_SUITE(BridgeDataKind) {
         }
     }
 
+    // A MustRestoreFirst read of a blob that only one pile has makes the bridge proxy copy it into
+    // the other piles. That copy is a write the reader cannot avoid, so it has to be admitted the
+    // same way the read itself is -- otherwise a system tablet cannot boot off a bridged group that
+    // is short of space.
+    Y_UNIT_TEST(RestorePutInheritsTheKindOfTheRead) {
+        TEnvironmentSetup env{{
+            .NodeCount = 8 * 3,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+            .LocationGenerator = GetLocation,
+            .SelfManagementConfig = true,
+            .NumPiles = 3,
+            .AutomaticBootstrap = true,
+        }};
+        env.CreatePool();
+        const ui32 groupId = env.GetGroups().front();
+        auto info = env.GetGroupInfo(groupId);
+
+        const TActorId sender = env.Runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+        const TString data = "hello";
+
+        ui32 step = 1;
+        for (const auto dataKind : {NKikimrBlobStorage::TDataKind::USER, NKikimrBlobStorage::TDataKind::SYSTEM}) {
+            // Write straight into the group backing the first pile, leaving the other two without
+            // the blob.
+            const TLogoBlobID id(100500, 1, step++, 0, data.size(), 0);
+            env.Runtime->WrapInActorContext(sender, [&] {
+                auto put = std::make_unique<TEvBlobStorage::TEvPut>(id, data, TInstant::Max());
+                put->ForceGroupGeneration = 1;
+                SendToBSProxy(sender, groupId + 1, put.release());
+            });
+            auto putRes = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender, false);
+            UNIT_ASSERT_VALUES_EQUAL(putRes->Get()->Status, NKikimrProto::OK);
+
+            std::vector<NKikimrBlobStorage::TDataKind::E> seen;
+            env.Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+                if (ev->GetTypeRewrite() == TEvBlobStorage::EvPut) {
+                    const auto& put = *ev->Get<TEvBlobStorage::TEvPut>();
+                    if (put.WriteSource == TWriteSource::BridgeProxyRestorePut) {
+                        seen.push_back(put.DataKind);
+                    }
+                }
+                return true;
+            };
+
+            env.Runtime->WrapInActorContext(sender, [&] {
+                auto get = std::make_unique<TEvBlobStorage::TEvGet>(id, 0, 0, TInstant::Max(),
+                    NKikimrBlobStorage::FastRead, true /*mustRestoreFirst*/);
+                get->DataKind = dataKind;
+                SendToBSProxy(sender, info->GroupID, get.release());
+            });
+            auto getRes = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender, false);
+            UNIT_ASSERT_VALUES_EQUAL(getRes->Get()->Status, NKikimrProto::OK);
+            UNIT_ASSERT_VALUES_EQUAL(getRes->Get()->ResponseSz, 1);
+            UNIT_ASSERT_VALUES_EQUAL(getRes->Get()->Responses[0].Status, NKikimrProto::OK);
+
+            env.Runtime->FilterFunction = nullptr;
+
+            UNIT_ASSERT_C(!seen.empty(), "the read restored nothing, so it proves nothing");
+            for (const auto kind : seen) {
+                UNIT_ASSERT_EQUAL(kind, dataKind);
+            }
+        }
+    }
+
 }

--- a/ydb/core/blobstorage/ut_blobstorage/space_data_kind.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/space_data_kind.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_space_color.h>
 #include <ydb/core/base/blobstorage_data_kind.h>
+#include <ydb/core/base/blobstorage_write_source.h>
 
 #include <util/random/random.h>
 
@@ -70,6 +71,80 @@ struct TSpaceColorEnv {
             status = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(edge)->Get()->Record.GetStatus();
         });
         return status;
+    }
+};
+
+// Leaves a blob in the group with only its data parts written, so that reading it back with
+// MustRestoreFirst makes DSProxy reconstruct and write out the parities.
+struct TPartialBlobEnv {
+    TEnvironmentSetup Env;
+    TIntrusivePtr<TBlobStorageGroupInfo> Info;
+    TString Data;
+    ui32 NextStep = 1;
+
+    TPartialBlobEnv()
+        : Env(TEnvironmentSetup::TSettings{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        })
+    {
+        Env.CreateBoxAndPool(1, 1);
+        Env.Sim(TDuration::Minutes(1));
+
+        auto groups = Env.GetGroups();
+        UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
+        Info = Env.GetGroupInfo(groups.front());
+
+        Data.resize(1024);
+        for (size_t i = 0; i < Data.size(); ++i) {
+            Data[i] = RandomNumber<ui8>();
+        }
+    }
+
+    TLogoBlobID WriteDataPartsOnly() {
+        const TLogoBlobID fullId(1, 1, NextStep++, 0, Data.size(), 0);
+
+        TDataPartSet partSet;
+        Info->Type.SplitData((TErasureType::ECrcMode)fullId.CrcMode(), Data, partSet);
+
+        for (ui32 part = 1; part <= Info->Type.DataParts(); ++part) {
+            const TVDiskID vdiskId = Info->CreateVDiskID(Info->GetTopology().GetVDiskInSubgroup(part - 1,
+                fullId.Hash()));
+            Env.PutBlob(vdiskId, TLogoBlobID(fullId, part),
+                partSet.Parts[part - 1].OwnedString.ConvertToString());
+        }
+
+        return fullId;
+    }
+
+    // Reads the blob back through DSProxy and returns the data kind of every write the read
+    // provoked.
+    std::vector<TDataKind::E> RestoreWriteKinds(TLogoBlobID id, TDataKind::E dataKind) {
+        std::vector<TDataKind::E> kinds;
+        Env.Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::EvVPut) {
+                const auto& record = ev->Get<TEvBlobStorage::TEvVPut>()->Record;
+                if (WriteSourceFromProto(record.GetWriteSourceOp()) == TWriteSource::DSProxyGetAccelerate) {
+                    kinds.push_back(record.GetDataKind());
+                }
+            }
+            return true;
+        };
+
+        const TActorId sender = Env.Runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+        Env.Runtime->WrapInActorContext(sender, [&] {
+            auto ev = std::make_unique<TEvBlobStorage::TEvGet>(id, 0, 0, TInstant::Max(),
+                NKikimrBlobStorage::EGetHandleClass::FastRead, true /*mustRestoreFirst*/);
+            ev->DataKind = dataKind;
+            SendToBSProxy(sender, Info->GroupID, ev.release());
+        });
+        auto res = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender, false);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->ResponseSz, 1);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Responses[0].Buffer.ConvertToString(), Data);
+
+        Env.Runtime->FilterFunction = nullptr;
+        return kinds;
     }
 };
 
@@ -147,6 +222,20 @@ Y_UNIT_TEST_SUITE(SpaceDataKind) {
         // still be able to come up at RED, otherwise nobody can delete anything.
         UNIT_ASSERT_VALUES_EQUAL(env.Put(TDataKind::SYSTEM, true), NKikimrProto::OK);
         UNIT_ASSERT_VALUES_EQUAL(env.Put(TDataKind::USER, true), NKikimrProto::OUT_OF_SPACE);
+    }
+
+    // A tablet reading its own log during boot asks for MustRestoreFirst, and DSProxy answers by
+    // writing the parts it could not find. That write has to be admitted like the tablet's own
+    // writes, or a system tablet cannot get up in a group that has run out of space.
+    Y_UNIT_TEST(RestoreWriteInheritsTheKindOfTheRead) {
+        TPartialBlobEnv env;
+        for (const auto dataKind : {TDataKind::USER, TDataKind::SYSTEM}) {
+            const auto kinds = env.RestoreWriteKinds(env.WriteDataPartsOnly(), dataKind);
+            UNIT_ASSERT_C(!kinds.empty(), "the read restored nothing, so it proves nothing");
+            for (const auto kind : kinds) {
+                UNIT_ASSERT_EQUAL(kind, dataKind);
+            }
+        }
     }
 
     Y_UNIT_TEST(BlackStopsEverything) {

--- a/ydb/core/protos/blob_depot.proto
+++ b/ydb/core/protos/blob_depot.proto
@@ -1,5 +1,6 @@
 import "ydb/core/protos/blob_depot_config.proto";
 import "ydb/core/protos/base.proto";
+import "ydb/core/protos/blobstorage_base.proto";
 import "ydb/core/protos/blobstorage_disk_color.proto";
 
 package NKikimrBlobDepot;
@@ -233,6 +234,11 @@ message TEvResolve {
     }
 
     repeated TItem Items = 1;
+
+    // Admission hint of the request this resolve serves: in decommission mode a MustRestoreFirst
+    // item makes BlobDepot copy the blob into its own storage, and that write must be admitted the
+    // same way the requesting tablet's own writes are, or the tablet cannot boot.
+    optional NKikimrBlobStorage.TDataKind.E DataKind = 2;
 }
 
 message TEvResolveResult {

--- a/ydb/core/tablet/tablet_req_findlatest.cpp
+++ b/ydb/core/tablet/tablet_req_findlatest.cpp
@@ -1,4 +1,5 @@
 #include "tablet_impl.h"
+#include <ydb/core/base/blobstorage_data_kind.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 
@@ -12,6 +13,7 @@ class TTabletReqFindLatestLogEntry : public TActorBootstrapped<TTabletReqFindLat
     const ui32 BlockedGeneration;
     const bool Leader;
     TIntrusivePtr<TTabletStorageInfo> Info;
+    const NKikimrBlobStorage::TDataKind::E DataKind;
     const TTabletChannelInfo *ChannelInfo;
     ui64 CurrentHistoryIndex;
 
@@ -28,6 +30,10 @@ class TTabletReqFindLatestLogEntry : public TActorBootstrapped<TTabletReqFindLat
         const ui32 group = ChannelInfo->History[CurrentHistoryIndex].GroupID;
         const ui32 minGeneration = ChannelInfo->History[CurrentHistoryIndex].FromGeneration;
         auto request = MakeHolder<TEvBlobStorage::TEvDiscover>(Info->TabletID, minGeneration, ReadBody, true, TInstant::Max(), BlockedGeneration, Leader);
+        // With ReadBody set this discover reads the entry back with MustRestoreFirst, which makes
+        // BlobStorage rewrite the parts it is missing; the tablet cannot boot if that write is
+        // rejected, so it is admitted as whatever the tablet itself writes.
+        request->DataKind = DataKind;
         SendToBSProxy(SelfId(), group, request.Release());
     }
 
@@ -74,6 +80,7 @@ public:
         , BlockedGeneration(blockedGeneration)
         , Leader(leader)
         , Info(info)
+        , DataKind(DataKindByTabletType(info->TabletType))
         , ChannelInfo(Info->ChannelInfo(0))
         , CurrentHistoryIndex(ChannelInfo->History.size())
     {

--- a/ydb/core/tablet/tablet_req_rebuildhistory.cpp
+++ b/ydb/core/tablet/tablet_req_rebuildhistory.cpp
@@ -1,4 +1,5 @@
 #include "tablet_impl.h"
+#include <ydb/core/base/blobstorage_data_kind.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/core/tablet/tablet_metrics.h>
@@ -188,6 +189,9 @@ class TTabletReqRebuildHistoryGraph : public TActorBootstrapped<TTabletReqRebuil
 
     const TActorId Owner;
     TIntrusivePtr<TTabletStorageInfo> Info;
+    // Restoring what these reads find is a write the tablet cannot avoid on its way up, so it is
+    // admitted as whatever the tablet itself writes.
+    const NKikimrBlobStorage::TDataKind::E DataKind;
     const ui32 BlockedGen;
 
     std::pair<ui32, ui32> LatestKnownStep;
@@ -396,7 +400,10 @@ class TTabletReqRebuildHistoryGraph : public TActorBootstrapped<TTabletReqRebuil
             const TLogoBlobID fromId(tabletId, from.first, from.second, 0, 0, 0);
             const TLogoBlobID toId(tabletId, lastGen ? to.first : toGen - 1, lastGen ? to.second : Max<ui32>(), 0, TLogoBlobID::MaxBlobSize, TLogoBlobID::MaxCookie);
 
-            SendToBSProxy(SelfId(), group, new TEvBlobStorage::TEvRange(tabletId, fromId, toId, mustRestoreFirst, TInstant::Max(), false, BlockedGen));
+            auto request = std::make_unique<TEvBlobStorage::TEvRange>(tabletId, fromId, toId, mustRestoreFirst,
+                TInstant::Max(), false, BlockedGen);
+            request->DataKind = DataKind;
+            SendToBSProxy(SelfId(), group, request.release());
             RangesToDiscover.insert(toId);
             if (IntrospectionTrace) {
                 IntrospectionTrace->Attach(MakeHolder<NTracing::TOnDiscoverRangeRequest>(group, fromId, toId));
@@ -565,9 +572,11 @@ class TTabletReqRebuildHistoryGraph : public TActorBootstrapped<TTabletReqRebuil
             for (ui64 i = 0; i < count; ++i) {
                 q[i].Set(refs[i + firstRequestIdx] /*must be index read*/);
             }
-            SendToBSProxy(SelfId(), group, new TEvBlobStorage::TEvGet(q, (ui32)count, TInstant::Max(),
+            auto request = std::make_unique<TEvBlobStorage::TEvGet>(q, (ui32)count, TInstant::Max(),
                 NKikimrBlobStorage::EGetHandleClass::FastRead, true, true, TEvBlobStorage::TEvGet::TForceBlockTabletData(
-                    Info->TabletID, refs[firstRequestIdx].Generation())));
+                    Info->TabletID, refs[firstRequestIdx].Generation()));
+            request->DataKind = DataKind;
+            SendToBSProxy(SelfId(), group, request.release());
             ++RequestsLeft;
 
             firstRequestIdx = endRequestIdx;
@@ -948,6 +957,7 @@ public:
     TTabletReqRebuildHistoryGraph(const TActorId &owner, TTabletStorageInfo *info, ui32 blockedGen, NTracing::ITrace *trace, ui64 followerCookie)
         : Owner(owner)
         , Info(info)
+        , DataKind(DataKindByTabletType(info->TabletType))
         , BlockedGen(blockedGen)
         , RequestsLeft(0)
         , IntrospectionTrace(trace)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support SpaceDataKind for restore-get queries

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows to specify DataKind for any kind of queries (nest egg for the future), and currently implements support of DataKind for get queries involving writes (get with restore, range, discover, etc).
