### PR TITLE
ANALYZE: equi-height histograms

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -408,6 +408,8 @@ bool FillMultiColumnStatisticsDesc(TTableDescProto& tableDesc,
         for (const auto& type : statistics.Types) {
             if (type == "COUNT_MIN_SKETCH") {
                 statisticsDesc->AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH);
+            } else if (type == "EQ_HEIGHT_HISTOGRAM") {
+                statisticsDesc->AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM);
             } else {
                 code = Ydb::StatusIds::BAD_REQUEST;
                 error = TStringBuilder() << "Unknown multi-column statistics type: " << type;

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -3015,6 +3015,8 @@ public:
                                 const auto typeName = to_upper(TString(type.Value()));
                                 if (typeName == "COUNT_MIN_SKETCH") {
                                     add_statistics->add_types(Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH);
+                                } else if (typeName == "EQ_HEIGHT_HISTOGRAM") {
+                                    add_statistics->add_types(Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM);
                                 } else {
                                     ctx.AddError(TIssue(ctx.GetPosition(type.Pos()),
                                         TStringBuilder() << "Unknown statistic type: " << TString(type.Value())));

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -476,6 +476,9 @@ struct TMultiColumnStatisticsDescription {
                 case NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH:
                     Types.push_back("COUNT_MIN_SKETCH");
                     break;
+                case NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM:
+                    Types.push_back("EQ_HEIGHT_HISTOGRAM");
+                    break;
                 default:
                     break;
             }

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -4,6 +4,7 @@
 #include "yql_kikimr_type_ann_pg.h"
 
 #include <ydb/core/base/fulltext.h>
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>
 #include <ydb/core/base/kmeans_clusters.h>
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/docapi/traits.h>
@@ -54,6 +55,30 @@ static const TSet<TString> REPLICATION_AND_TRANSFER_SECRETS_SETTINGS = [] {
 // Its value must never be supplied by the user, so DML may not name it explicitly.
 bool IsSystemGeneratedColumn(const std::string_view name) {
     return name == NKikimr::NTableIndex::NFulltext::RowIdColumn;
+}
+
+bool CheckEqHeightHistogramColumnTypes(
+    const TVector<TString>& columnNames,
+    const TMap<TString, TKikimrColumnMetadata>& columns,
+    TPositionHandle pos,
+    TExprContext& ctx)
+{
+    for (const auto& name : columnNames) {
+        auto it = columns.find(name);
+        if (it == columns.end()) {
+            ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
+                << "Statistics column: " << name << " was not found in the table"));
+            return false;
+        }
+        const auto& col = it->second;
+        if (!NKikimr::NScheme::NTypeIds::IsPresortEncodable(col.TypeInfo.GetTypeId())) {
+            ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
+                << "EQ_HEIGHT_HISTOGRAM is not supported for column '" << name
+                << "' of type " << col.Type));
+            return false;
+        }
+    }
+    return true;
 }
 
 void MaybeAutoBindRowIdSequence(NYql::TKikimrTableMetadata& meta) {
@@ -1892,12 +1917,17 @@ private:
             }
             for (const auto& type : statistics.Types()) {
                 const auto typeName = to_upper(TString(type.Value()));
-                if (typeName != "COUNT_MIN_SKETCH") {
+                if (typeName != "COUNT_MIN_SKETCH" && typeName != "EQ_HEIGHT_HISTOGRAM") {
                     ctx.AddError(TIssue(ctx.GetPosition(type.Pos()), TStringBuilder()
                         << "Unknown statistic type: " << TString(type.Value())));
                     return TStatus::Error;
                 }
                 statisticsDesc.Types.push_back(typeName);
+            }
+            if (IsIn(statisticsDesc.Types, "EQ_HEIGHT_HISTOGRAM")
+                    && !CheckEqHeightHistogramColumnTypes(
+                        statisticsDesc.Columns, meta->Columns, statistics.Pos(), ctx)) {
+                return TStatus::Error;
             }
 
             meta->MultiColumnStatistics.push_back(statisticsDesc);
@@ -2555,12 +2585,54 @@ private:
                         "Column FAMILY is not supported for column tables"));
                     return TStatus::Error;
                 }
+            } else if (name == "addStatistics") {
+                if (!SessionCtx->Config().FeatureFlags.GetEnableColumnStatistics()) {
+                    ctx.AddError(TIssue(ctx.GetPosition(action.Pos()),
+                        "Multi-column statistics support is disabled"));
+                    return TStatus::Error;
+                }
+                auto listNode = action.Value().Cast<TExprList>();
+                TVector<TString> columnNames;
+                TVector<TString> typeNames;
+                TPositionHandle columnsPos = action.Pos();
+                for (size_t i = 0; i < listNode.Size(); ++i) {
+                    auto item = listNode.Item(i).Cast<TExprList>();
+                    auto itemName = TString(item.Item(0).Cast<TCoAtom>().Value());
+                    if (itemName == "statisticsColumns") {
+                        auto columnList = item.Item(1).Cast<TCoAtomList>();
+                        columnsPos = columnList.Pos();
+                        for (auto column : columnList) {
+                            TString columnName(column.Value());
+                            if (!table->Metadata->Columns.contains(columnName)) {
+                                ctx.AddError(TIssue(ctx.GetPosition(column.Pos()), TStringBuilder()
+                                    << "Statistics column: " << columnName << " was not found in the table"));
+                                return TStatus::Error;
+                            }
+                            columnNames.push_back(std::move(columnName));
+                        }
+                    } else if (itemName == "statisticsTypes") {
+                        auto typeList = item.Item(1).Cast<TCoAtomList>();
+                        for (auto type : typeList) {
+                            const auto typeName = to_upper(TString(type.Value()));
+                            if (typeName != "COUNT_MIN_SKETCH" && typeName != "EQ_HEIGHT_HISTOGRAM") {
+                                ctx.AddError(TIssue(ctx.GetPosition(type.Pos()), TStringBuilder()
+                                    << "Unknown statistic type: " << TString(type.Value())));
+                                return TStatus::Error;
+                            }
+                            typeNames.push_back(typeName);
+                        }
+                    }
+                }
+                if (IsIn(typeNames, "EQ_HEIGHT_HISTOGRAM")
+                        && !CheckEqHeightHistogramColumnTypes(
+                            columnNames, table->Metadata->Columns, columnsPos, ctx)) {
+                    return TStatus::Error;
+                }
             } else if (name != "setTableSettings"
                     && name != "addChangefeed"
                     && name != "dropChangefeed"
                     && name != "renameIndexTo"
                     && name != "alterIndex"
-                    && name != "addStatistics"
                     && name != "dropStatistics"
                     && name != "rebuildIndex"
                     && name != "compact")

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -407,6 +407,225 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
     }
 
+    Y_UNIT_TEST(CreateTableWithEqHeightHistogram) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableColumnStatistics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/Orders` (
+                    order_id Uint64,
+                    customer_id Uint64,
+                    order_date Date,
+                    status Utf8,
+                    PRIMARY KEY (order_id),
+                    STATISTICS orders_hist ON (customer_id, order_date) WITH (EQ_HEIGHT_HISTOGRAM)
+                );
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto describe = session.DescribeTable("/Root/Orders").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            const auto statistics = describe.GetTableDescription().GetMultiColumnStatisticsDescriptions();
+            UNIT_ASSERT_VALUES_EQUAL(statistics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetName(), "orders_hist");
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetColumns().size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetColumns()[0], "customer_id");
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetColumns()[1], "order_date");
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetTypes().size(), 1);
+            UNIT_ASSERT(statistics[0].GetTypes()[0] == EMultiColumnStatisticsType::EqHeightHistogram);
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                ALTER TABLE `/Root/Orders`
+                    ADD STATISTICS status_hist ON (status) WITH (EQ_HEIGHT_HISTOGRAM);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto describe = session.DescribeTable("/Root/Orders").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            const auto statistics = describe.GetTableDescription().GetMultiColumnStatisticsDescriptions();
+            UNIT_ASSERT_VALUES_EQUAL(statistics.size(), 2);
+            TSet<std::string> names;
+            for (const auto& s : statistics) {
+                names.insert(s.GetName());
+                UNIT_ASSERT_VALUES_EQUAL(s.GetTypes().size(), 1);
+                UNIT_ASSERT(s.GetTypes()[0] == EMultiColumnStatisticsType::EqHeightHistogram);
+            }
+            UNIT_ASSERT(names.contains("orders_hist"));
+            UNIT_ASSERT(names.contains("status_hist"));
+        }
+
+        {
+            auto qSession = kikimr.GetQueryClient().GetSession().GetValueSync().GetSession();
+            auto showResult = qSession.ExecuteQuery(
+                "SHOW CREATE TABLE `/Root/Orders`;",
+                NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(showResult.GetStatus(), EStatus::SUCCESS, showResult.GetIssues().ToString());
+            UNIT_ASSERT(!showResult.GetResultSets().empty());
+            NYdb::TResultSetParser parser(showResult.GetResultSet(0));
+            UNIT_ASSERT_C(parser.TryNextRow(), "SHOW CREATE must return at least one row");
+            TString createText = parser.ColumnParser(0).GetOptionalUtf8().value_or("");
+            UNIT_ASSERT_C(createText.Contains("EQ_HEIGHT_HISTOGRAM"),
+                "SHOW CREATE should render EQ_HEIGHT_HISTOGRAM, got: " << createText);
+            UNIT_ASSERT_C(createText.Contains("orders_hist") && createText.Contains("status_hist"),
+                "SHOW CREATE should list both histograms, got: " << createText);
+        }
+    }
+
+    Y_UNIT_TEST(EqHeightHistogramRejectsUnencodableType) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableColumnStatistics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/Orders` (
+                    order_id Uint64,
+                    payload Json,
+                    PRIMARY KEY (order_id),
+                    STATISTICS payload_hist ON (payload) WITH (EQ_HEIGHT_HISTOGRAM)
+                );
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_C(TString(result.GetIssues().ToString()).Contains(
+                "EQ_HEIGHT_HISTOGRAM is not supported for column 'payload' of type Json"),
+                result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/Orders` (
+                    order_id Uint64,
+                    payload Json,
+                    status Utf8,
+                    PRIMARY KEY (order_id)
+                );
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                ALTER TABLE `/Root/Orders`
+                    ADD STATISTICS payload_hist ON (payload) WITH (EQ_HEIGHT_HISTOGRAM);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_C(TString(result.GetIssues().ToString()).Contains(
+                "EQ_HEIGHT_HISTOGRAM is not supported for column 'payload' of type Json"),
+                result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/ColumnOrders` (
+                    order_id Uint64 NOT NULL,
+                    payload Json,
+                    PRIMARY KEY (order_id),
+                    STATISTICS payload_hist ON (payload) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                WITH (STORE = COLUMN);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_C(TString(result.GetIssues().ToString()).Contains(
+                "EQ_HEIGHT_HISTOGRAM is not supported for column 'payload' of type Json"),
+                result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/ColumnOrders` (
+                    order_id Uint64 NOT NULL,
+                    payload Json,
+                    PRIMARY KEY (order_id)
+                )
+                WITH (STORE = COLUMN);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                ALTER TABLE `/Root/ColumnOrders`
+                    ADD STATISTICS payload_hist ON (payload) WITH (EQ_HEIGHT_HISTOGRAM);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_C(TString(result.GetIssues().ToString()).Contains(
+                "EQ_HEIGHT_HISTOGRAM is not supported for column 'payload' of type Json"),
+                result.GetIssues().ToString());
+        }
+    }
+
+    Y_UNIT_TEST(CreateColumnTableWithEqHeightHistogram) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableColumnStatistics(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/ColumnOrders` (
+                    order_id Uint64 NOT NULL,
+                    customer_id Uint64,
+                    order_date Date,
+                    PRIMARY KEY (order_id),
+                    STATISTICS orders_hist ON (customer_id, order_date) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                WITH (STORE = COLUMN);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto describe = session.DescribeTable("/Root/ColumnOrders").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            const auto statistics = describe.GetTableDescription().GetMultiColumnStatisticsDescriptions();
+            UNIT_ASSERT_VALUES_EQUAL(statistics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetName(), "orders_hist");
+            UNIT_ASSERT_VALUES_EQUAL(statistics[0].GetTypes().size(), 1);
+            UNIT_ASSERT(statistics[0].GetTypes()[0] == EMultiColumnStatisticsType::EqHeightHistogram);
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                ALTER TABLE `/Root/ColumnOrders`
+                    ADD STATISTICS date_hist ON (order_date) WITH (EQ_HEIGHT_HISTOGRAM);
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto describe = session.DescribeTable("/Root/ColumnOrders").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(describe.GetTableDescription().GetMultiColumnStatisticsDescriptions().size(), 2);
+        }
+
+        {
+            auto qSession = kikimr.GetQueryClient().GetSession().GetValueSync().GetSession();
+            auto showResult = qSession.ExecuteQuery(
+                "SHOW CREATE TABLE `/Root/ColumnOrders`;",
+                NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(showResult.GetStatus(), EStatus::SUCCESS, showResult.GetIssues().ToString());
+            UNIT_ASSERT(!showResult.GetResultSets().empty());
+            NYdb::TResultSetParser parser(showResult.GetResultSet(0));
+            UNIT_ASSERT_C(parser.TryNextRow(), "SHOW CREATE must return at least one row");
+            TString createText = parser.ColumnParser(0).GetOptionalUtf8().value_or("");
+            UNIT_ASSERT_C(createText.Contains("EQ_HEIGHT_HISTOGRAM"),
+                "SHOW CREATE should render EQ_HEIGHT_HISTOGRAM, got: " << createText);
+        }
+    }
+
     Y_UNIT_TEST(ColumnTableMultiColumnStatisticsWithoutWithMeansAllTypes) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableColumnStatistics(true);

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3392,6 +3392,15 @@ message TStatisticsConfig {
     // Column tables smaller than or equal to this size are scanned as a whole table
     // rather than per shard. 0 disables the optimization (always per-shard).
     optional uint64 AnalyzeWholeTableScanMaxBytes = 9 [default = 10737418240]; // 10 GiB
+
+    // Auto-collect PK equi-height histogram on ANALYZE. Declared stats ignore this.
+    optional bool AnalyzeCollectPrimaryKeyHistogram = 10 [default = false];
+
+    // Extra samples per histogram bucket. Clamped to [1, 256].
+    optional uint32 AnalyzeHistogramOversampleFactor = 11 [default = 8];
+
+    // Intermediate-state byte budget. Clamped to MaxStatisticSize (8 MB).
+    optional uint64 AnalyzeHistogramMaxStateBytes = 12 [default = 4194304];
 };
 
 message TSystemTabletBackupConfig {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -612,6 +612,7 @@ message TOlapIndexDescription {
 enum EMultiColumnStatisticsType {
     MULTI_COLUMN_STATISTICS_UNSPECIFIED = 0;
     COUNT_MIN_SKETCH = 1;
+    EQ_HEIGHT_HISTOGRAM = 2;
 }
 
 // Multi-column table statistics

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -1190,11 +1190,21 @@ void TStatisticsAggregator::PersistTraversal(NIceDb::TNiceDb& db) {
 
 void TStatisticsAggregator::StartAnalyzeActor(const TActorContext& ctx, const TString& operationId,
         const TString& database, const TPathId& pathId, const TVector<ui32>& columnTags) {
+    // Clamp oversample to [1, 256] and maxStateBytes to (0, MaxStatisticSize].
+    const ui32 oversampleFactor = std::max<ui32>(1, std::min<ui32>(
+        StatisticsConfig.GetAnalyzeHistogramOversampleFactor(),
+        TAnalyzeActor::MaxHistogramOversampleFactor));
+    const ui64 maxStateBytes = std::max<ui64>(1, std::min<ui64>(
+        StatisticsConfig.GetAnalyzeHistogramMaxStateBytes(),
+        TAnalyzeActor::MaxStatisticSize));
     auto analyzeActorConfig = TAnalyzeActor::TConfig{
         .MaxTotalScanActorsInFlight = StatisticsConfig.GetAnalyzeMaxTotalScanActorsInFlight(),
         .MaxPerNodeScanActorsInFlight = StatisticsConfig.GetAnalyzeMaxPerNodeScanActorsInFlight(),
         .WholeTableScanMaxBytes = StatisticsConfig.GetAnalyzeWholeTableScanMaxBytes(),
         .TableBytesSize = GetTableBytesSize(pathId),
+        .CollectPrimaryKeyHistogram = StatisticsConfig.GetAnalyzeCollectPrimaryKeyHistogram(),
+        .HistogramOversampleFactor = oversampleFactor,
+        .HistogramMaxStateBytes = maxStateBytes,
     };
     AnalyzeActorId = ctx.Register(new TAnalyzeActor(
         SelfId(), operationId, database, pathId, columnTags, analyzeActorConfig),

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -4,7 +4,10 @@
 #include <ydb/core/base/request_types.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/scheme/scheme_type_info.h>
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>
 #include <util/generic/size_literals.h>
+#include <util/generic/algorithm.h>
 #include <util/string/vector.h>
 #include <algorithm>
 
@@ -12,7 +15,6 @@
 
 namespace NKikimr::NStat {
 
-static constexpr ui64 MAX_STATISTIC_SIZE = 8_MB;
 static constexpr ui64 MAX_STATISTICS_SIZE_IN_SINGLE_SCAN = 40_MB;
 
 namespace {
@@ -23,7 +25,11 @@ std::optional<EStatType> ConvertMultiColumnStatType(NKikimrSchemeOp::EMultiColum
         return std::nullopt;
     case NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH:
         return EStatType::COUNT_MIN_SKETCH;
+    case NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM:
+        return EStatType::EQ_HEIGHT_HISTOGRAM;
     }
+    // Unknown protobuf value from a newer schemeshard: skip rather than fail ANALYZE.
+    return std::nullopt;
 }
 
 } // anonymous namespace
@@ -265,12 +271,16 @@ void TAnalyzeActor::HandleResolveDatabase(const NSchemeCache::TSchemeCacheNaviga
 
 void TAnalyzeActor::HandleNavigateResult() {
     THashMap<ui32, TSysTables::TTableColumnInfo> tag2Column;
+    std::vector<std::pair<TString, ui32>> keyColumns;
     for (const auto& col : NavigateColumns) {
         tag2Column[col.second.Id] = col.second;
 
         if (col.second.KeyOrder >= 0) {
             KeyColumnTypes.resize(Max<size_t>(KeyColumnTypes.size(), col.second.KeyOrder + 1));
             KeyColumnTypes[col.second.KeyOrder] = col.second.PType;
+
+            keyColumns.resize(Max<size_t>(keyColumns.size(), col.second.KeyOrder + 1));
+            keyColumns[col.second.KeyOrder] = {col.second.Name, col.second.Id};
         }
     }
 
@@ -293,22 +303,96 @@ void TAnalyzeActor::HandleNavigateResult() {
             continue;
         }
 
-        if (desc.ColumnIds.size() < 2) {
-            // A 1-column multi-column statistic is degenerate: its column_tags key would collide
-            // with the single-column stat's key in .metadata/statistics_v2, and single-column CMS
-            // already covers it. Skip gathering it.
-            continue;
-        }
+        auto addType = [&](EStatType statType) {
+            if (Find(desc.Types, statType) != desc.Types.end()) {
+                return;
+            }
+            // A 1-column COUNT_MIN_SKETCH would collide with the single-column sketch's
+            // (column_tags, stat_type) key, and is already covered by it. Other types have their own
+            // stat_type and cannot collide.
+            if (desc.ColumnIds.size() < 2 && statType == EStatType::COUNT_MIN_SKETCH) {
+                return;
+            }
+            if (statType == EStatType::EQ_HEIGHT_HISTOGRAM) {
+                TStringBuilder issue;
+                issue << "EQ_HEIGHT_HISTOGRAM '" << desc.Name
+                      << "' has a column type that PresortKey cannot encode";
+                bool anyUnsupported = false;
+                for (ui32 id : desc.ColumnIds) {
+                    const auto& col = tag2Column.at(id);
+                    if (!NScheme::NTypeIds::IsPresortEncodable(col.PType.GetTypeId())) {
+                        issue << (anyUnsupported ? ", " : ": ")
+                              << "column '" << col.Name << "' of type "
+                              << NScheme::TypeName(col.PType, col.PTypeMod);
+                        anyUnsupported = true;
+                    }
+                }
+                if (anyUnsupported) {
+                    // Skip this type only. Covers persisted descriptors and
+                    // STATISTICS without WITH; explicit WITH is rejected at DDL.
+                    YDB_LOG_WARN("Skipping EQ_HEIGHT_HISTOGRAM: column type is not encodable by PresortKey",
+                        {"operationId", OperationId.Quote()},
+                        {"pathId", PathId},
+                        {"details", TString(issue)});
+                    return;
+                }
+            }
+            desc.Types.push_back(statType);
+        };
 
-        for (auto type : def.GetTypes()) {
-            auto statType = ConvertMultiColumnStatType(
-                static_cast<NKikimrSchemeOp::EMultiColumnStatisticsType>(type));
-            if (statType) {
-                desc.Types.push_back(*statType);
+        if (def.GetTypes().empty()) {
+            // No WITH clause: collect every supported multi-column type.
+            for (auto type : IMultiColumnStatisticEval::SupportedMultiColumnTypes()) {
+                addType(type);
+            }
+        } else {
+            for (auto type : def.GetTypes()) {
+                auto statType = ConvertMultiColumnStatType(
+                    static_cast<NKikimrSchemeOp::EMultiColumnStatisticsType>(type));
+                if (statType) {
+                    addType(*statType);
+                }
             }
         }
         if (!desc.Types.empty()) {
             MultiColumnStatDescs.push_back(std::move(desc));
+        }
+    }
+
+    if (Config.CollectPrimaryKeyHistogram && !keyColumns.empty()) {
+        // Skip auto-PK histogram if a dropped key column left a gap in KeyOrder.
+        const bool hasDroppedKeyColumn = AnyOf(keyColumns, [](const auto& kc) {
+            return kc.first.empty();
+        });
+        const bool hasUnsupportedKeyType = AnyOf(keyColumns, [&](const auto& kc) {
+            auto it = tag2Column.find(kc.second);
+            return it == tag2Column.end() || !NScheme::NTypeIds::IsPresortEncodable(it->second.PType.GetTypeId());
+        });
+        if (hasDroppedKeyColumn) {
+            YDB_LOG_WARN("Skipping auto-PK EQ_HEIGHT_HISTOGRAM: key columns are not contiguous",
+                {"operationId", OperationId.Quote()},
+                {"pathId", PathId});
+        } else if (hasUnsupportedKeyType) {
+            YDB_LOG_WARN("Skipping auto-PK EQ_HEIGHT_HISTOGRAM: a key column type is not encodable by PresortKey",
+                {"operationId", OperationId.Quote()},
+                {"pathId", PathId});
+        } else {
+            TMultiColumnStatDesc pk;
+            pk.Name = "__pk";
+            for (const auto& [name, id] : keyColumns) {
+                pk.ColumnNames.push_back(name);
+                pk.ColumnIds.push_back(id);
+            }
+            pk.Types = {EStatType::EQ_HEIGHT_HISTOGRAM};
+
+            // Declared PK histogram (explicit WITH or no WITH) wins over auto-PK.
+            const bool alreadyDeclared = AnyOf(MultiColumnStatDescs, [&](const auto& d) {
+                return d.ColumnIds == pk.ColumnIds
+                    && Find(d.Types, EStatType::EQ_HEIGHT_HISTOGRAM) != d.Types.end();
+            });
+            if (!alreadyDeclared) {
+                MultiColumnStatDescs.push_back(std::move(pk));
+            }
         }
     }
 
@@ -651,12 +735,21 @@ void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
                         == supportedMultiColumnTypes.end()) {
                     continue;
                 }
+                IMultiColumnStatisticEval::THistogramSizing sizing;
+                sizing.OversampleFactor = Config.HistogramOversampleFactor;
+                sizing.MaxStateBytes = Config.HistogramMaxStateBytes;
                 auto statEval = IMultiColumnStatisticEval::MaybeCreate(
-                    type, def.ColumnNames, def.ColumnIds, RowCount.value());
+                    type, def.ColumnNames, def.ColumnIds, RowCount.value(), sizing);
                 if (!statEval) {
                     continue;
                 }
-                if (statEval->EstimateSize() > MAX_STATISTIC_SIZE) {
+                if (statEval->EstimateSize() > TAnalyzeActor::MaxStatisticSize) {
+                    YDB_LOG_WARN("Skipping multi-column statistic: estimated size exceeds MaxStatisticSize",
+                        {"operationId", OperationId.Quote()},
+                        {"pathId", PathId},
+                        {"statType", static_cast<int>(type)},
+                        {"estimatedSize", statEval->EstimateSize()},
+                        {"maxStatisticSize", TAnalyzeActor::MaxStatisticSize});
                     continue;
                 }
                 PendingTasks.push(TColumnStatEvalTask{
@@ -684,7 +777,13 @@ void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
                 if (!statEval) {
                     continue;
                 }
-                if (statEval->EstimateSize() > MAX_STATISTIC_SIZE) {
+                if (statEval->EstimateSize() > TAnalyzeActor::MaxStatisticSize) {
+                    YDB_LOG_WARN("Skipping stage-2 statistic: estimated size exceeds MaxStatisticSize",
+                        {"operationId", OperationId.Quote()},
+                        {"pathId", PathId},
+                        {"statType", static_cast<int>(type)},
+                        {"estimatedSize", statEval->EstimateSize()},
+                        {"maxStatisticSize", TAnalyzeActor::MaxStatisticSize});
                     continue;
                 }
                 PendingTasks.push(TColumnStatEvalTask{
@@ -699,10 +798,13 @@ void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
                 task.Stage2StatEval->GetType(),
                 task.Stage2StatEval->ExtractData(result.AggColumns));
         } else {
-            resultItems.emplace_back(
-                task.MultiStatEval->GetColumnIds(),
-                task.MultiStatEval->GetType(),
-                task.MultiStatEval->ExtractData(result.AggColumns));
+            auto data = task.MultiStatEval->ExtractData(result.AggColumns);
+            if (data) {
+                resultItems.emplace_back(
+                    task.MultiStatEval->GetColumnIds(),
+                    task.MultiStatEval->GetType(),
+                    std::move(*data));
+            }
         }
     }
 

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -17,11 +17,17 @@ namespace NKikimr::NStat {
 
 class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 public:
+    static constexpr ui64 MaxStatisticSize = 8ull << 20;
+    static constexpr ui32 MaxHistogramOversampleFactor = 256;
+
     struct TConfig {
         ui64 MaxTotalScanActorsInFlight = 100;
         i64 MaxPerNodeScanActorsInFlight = 1;
         ui64 WholeTableScanMaxBytes = 10ULL << 30; // 10 GiB
         std::optional<ui64> TableBytesSize;
+        bool CollectPrimaryKeyHistogram = false;
+        ui32 HistogramOversampleFactor = 8;
+        ui64 HistogramMaxStateBytes = 4u << 20;
     };
 
 private:

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -7,6 +7,8 @@
 #include <ydb/library/actors/core/log.h>
 #include <yql/essentials/core/minsketch/count_min_sketch.h>
 #include <yql/essentials/core/histogram/eq_width_histogram.h>
+#include <yql/essentials/core/histogram/eq_height_histogram.h>
+#include <yql/essentials/core/histogram/eq_height_histogram_reader.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
 
 #include <numbers>
@@ -314,13 +316,13 @@ public:
 
     void AddAggregations(TSelectBuilder& builder) final {
         Sketch.OnAdded(
-            builder.AddUDAFAggregationTuple(ColumnNames, "CMS", Sketch.GetWidth(), Sketch.GetDepth()),
+            builder.AddUDAFAggregationTuple(ColumnNames, ETupleEncoding::StablePickle, "CMS", Sketch.GetWidth(), Sketch.GetDepth()),
             builder.IsIntermediateAggregation());
     }
 
     void Merge(const TVector<NYdb::TValue>& aggColumns) final { Sketch.Merge(aggColumns); }
 
-    TString ExtractData(const TVector<NYdb::TValue>& aggColumns) final { return Sketch.ExtractData(aggColumns); }
+    std::optional<TString> ExtractData(const TVector<NYdb::TValue>& aggColumns) final { return Sketch.ExtractData(aggColumns); }
 };
 
 struct TBorder {
@@ -330,6 +332,30 @@ struct TBorder {
     template<typename T>
     explicit TBorder(T val) : Val(val), YqlVal(val) {}
 };
+
+// Bucket-count limits shared by equi-width and equi-height histograms.
+// The upper bound leaves room for the histogram object's own bookkeeping
+// fields (see TEqWidthHistogram).
+constexpr ui32 MAX_BUCKETS = 524288;
+constexpr ui32 MIN_BUCKETS = 1;
+
+// Buckets for a column with n rows and ndv distinct values. Shared by equi-width and equi-height.
+// Preserves the existing MIN_BUCKETS / MAX_BUCKETS - 24 clamping.
+static ui32 EstimateBucketCount(double n, double ndv) {
+    const double cbrtN = std::cbrt(n);
+    const double numBucketsEstimate = std::ceil(
+        std::min(std::sqrt(n), cbrtN * n / ndv));
+    ui32 numBuckets = (numBucketsEstimate <= std::numeric_limits<ui32>::max()
+        ? numBucketsEstimate
+        : std::numeric_limits<ui32>::max());
+    if (numBuckets == 0) {
+        numBuckets = MIN_BUCKETS;
+    } else if (numBuckets > MAX_BUCKETS - 24) {
+        // to accommodate for the other class variables' memory consumption.
+        numBuckets = MAX_BUCKETS - 24;
+    }
+    return numBuckets;
+}
 
 class TEWHEval : public IStage2ColumnStatisticEval {
     NScheme::TTypeInfo ColumnType;
@@ -350,10 +376,6 @@ private:
         };
         return NAggFuncs::TEWHAggFunc::CreateState(ColumnType.GetTypeId(), params);
     }
-
-    // current upper limit is 4_MB per columnar statistics
-    static constexpr ui32 MAX_BUCKETS = 524288;
-    static constexpr ui32 MIN_BUCKETS = 1;
 
 public:
     TEWHEval(NScheme::TTypeInfo columnType, ui32 numBuckets, TBorder rangeStart, TBorder rangeEnd)
@@ -449,18 +471,7 @@ public:
         const double n = simpleStats.GetCount();
         const double ndv = simpleStats.GetCountDistinct();
 
-        const double cbrtN = std::cbrt(n);
-        const double numBucketsEstimate = std::ceil(
-            std::min(std::sqrt(n), cbrtN * n / ndv));
-        ui32 numBuckets = (numBucketsEstimate <= std::numeric_limits<ui32>::max()
-            ? numBucketsEstimate
-            : std::numeric_limits<ui32>::max());
-        if (numBuckets == 0) {
-            numBuckets = MIN_BUCKETS;
-        } else if (numBuckets > MAX_BUCKETS - 24) {
-            // to accommodate for the other class variables' memory consumption.
-            numBuckets = MAX_BUCKETS - 24;
-        }
+        ui32 numBuckets = EstimateBucketCount(n, ndv);
 
         auto domainRange = GetDomainRange(
             *histType, simpleStats.GetMin(), simpleStats.GetMax(), &numBuckets);
@@ -540,9 +551,127 @@ bool IStage2ColumnStatisticEval::AreMinMaxNeeded(const NScheme::TTypeInfo& typeI
     return TEWHEval::GetHistogramType(typeInfo.GetTypeId()).Defined();
 }
 
+// Eq-height histogram collection has three integration paths:
+//
+// 1. DataShard PK (sorted input): keys arrive in PK order → AddSorted fast path
+//    → RankUncertainty == 0 (exact). Finalize runs in the YQL query; no actor-side merge.
+//
+// 2. DataShard non-PK (unsorted input): keys arrive in PK order but the histogram
+//    is over non-PK columns → staging buffer → InterleaveInto → RankUncertainty > 0
+//    (bounded approximate). Finalize runs in the YQL query; no actor-side merge.
+//
+// 3. ColumnShard (per-shard): each shard runs Serialize in the YQL query,
+//    returning an intermediate state. The actor merges them here via
+//    IntermediateState->Merge(), then calls Finalize() to produce the final blob.
+//    IntermediateState is created only for this path (IsIntermediateAggregation).
+class TMultiColumnEqHeightHistogramEval : public IMultiColumnStatisticEval {
+    std::vector<TString> ColumnNames;
+    std::vector<ui32> ColumnIds;
+    TEqHeightHistogramBuilder::TParams Params;
+    std::optional<ui32> Seq;
+    std::unique_ptr<TEqHeightHistogramBuilder> IntermediateState;
+
+public:
+    TMultiColumnEqHeightHistogramEval(std::vector<TString> columnNames, std::vector<ui32> columnIds,
+                                     TEqHeightHistogramBuilder::TParams params)
+        : ColumnNames(std::move(columnNames))
+        , ColumnIds(std::move(columnIds))
+        , Params(std::move(params))
+    {}
+
+    static TPtr MaybeCreate(std::vector<TString> columnNames, std::vector<ui32> columnIds,
+                            ui64 rowCount, const THistogramSizing& sizing) {
+        if (rowCount == 0) {
+            return TPtr{};   // empty table
+        }
+        // Same bucket-count formula as equi-width. No tuple NDV estimate exists (as for
+        // multi-column CMS), so ndv == n, which reduces the formula to ceil(cbrt(n)) -- exactly
+        // right for a PK tuple. Finalize() then clamps to the observed distinct count.
+        const ui32 numBuckets = EstimateBucketCount(rowCount, rowCount);
+        // Compute EmissionRate in ui64 to avoid a ui32 overflow (e.g. 524264 * 10000
+        // wraps), then clamp to ui32. A factor of 0 would make
+        // Staging.size() >= EmissionRate always true and flush on every row, so
+        // force a minimum of 1.
+        const ui64 emissionRate64 = static_cast<ui64>(numBuckets) * sizing.OversampleFactor;
+        const ui32 emissionRate = static_cast<ui32>(
+            std::max<ui64>(1, std::min<ui64>(emissionRate64, std::numeric_limits<ui32>::max())));
+        return std::make_unique<TMultiColumnEqHeightHistogramEval>(
+            std::move(columnNames), std::move(columnIds),
+            TEqHeightHistogramBuilder::TParams{
+                .NumBuckets = numBuckets,
+                .EmissionRate = emissionRate,
+                .MaxStateBytes = sizing.MaxStateBytes,
+            });
+        // Deliberately no width-based rejection here: key width is unknown until the scan runs,
+        // so the MIN_ENTRIES guard lives in Finalize().
+    }
+
+    EStatType GetType() const final { return EStatType::EQ_HEIGHT_HISTOGRAM; }
+    const std::vector<ui32>& GetColumnIds() const final { return ColumnIds; }
+
+    // Bounds the intermediate state crossing the scan result row (what
+    // MAX_STATISTICS_SIZE_IN_SINGLE_SCAN budgets).  Add/Merge compact to
+    // MaxStateBytes/2, and Finalize further trims, but Serialize() adds a
+    // small header plus MinKey.  Returning MaxStateBytes is a conservative
+    // estimate rather than a key-width guess.
+    size_t EstimateSize() const final { return Params.MaxStateBytes; }
+
+    void AddAggregations(TSelectBuilder& builder) final {
+        Seq = builder.AddUDAFAggregationTuple(ColumnNames, ETupleEncoding::PresortKey, "EQH",
+            Ui32Literal(Params.NumBuckets), Ui32Literal(Params.EmissionRate),
+            Ui64Literal(Params.MaxStateBytes));
+        if (builder.IsIntermediateAggregation()) {
+            IntermediateState = std::make_unique<TEqHeightHistogramBuilder>(Params);
+        }
+    }
+
+    void Merge(const TVector<NYdb::TValue>& aggColumns) final {
+        Y_ENSURE(IntermediateState);
+        NYdb::TValueParser val(aggColumns.at(Seq.value()));
+        val.OpenOptional();
+        if (val.IsNull()) {
+            return;
+        }
+        const auto& bytes = val.GetBytes();
+        TEqHeightHistogramIntermediateState state;
+        Y_ENSURE(state.ParseFromArray(bytes.data(), bytes.size()),
+            "truncated or malformed EQ_HEIGHT_HISTOGRAM intermediate state");
+        IntermediateState->Merge(TEqHeightHistogramBuilder(state));
+    }
+
+    std::optional<TString> ExtractData(const TVector<NYdb::TValue>& aggColumns) final {
+        if (IntermediateState) {
+            Merge(aggColumns);
+            auto result = IntermediateState->Finalize();
+            return result.Defined()
+                ? std::optional(result->SerializeAsString())
+                : std::nullopt;
+        }
+        NYdb::TValueParser val(aggColumns.at(Seq.value()));
+        val.OpenOptional();
+        if (val.IsNull()) {
+            return std::nullopt;
+        }
+        const auto& bytes = val.GetBytes();
+        // Row tables finalize inside the query, so this already is the final blob; empty means
+        // TEQHAggFunc::FinalizeState saw a nullopt.
+        if (bytes.empty()) {
+            return std::nullopt;
+        }
+        TEqHeightHistogramResult result;
+        Y_ENSURE(result.ParseFromArray(bytes.data(), bytes.size()),
+            "truncated or malformed EQ_HEIGHT_HISTOGRAM result");
+        TEqHeightHistogram parsed(result);
+        Y_ENSURE(parsed.GetNumBuckets() > 0,
+            "EQ_HEIGHT_HISTOGRAM result parsed to an empty histogram");
+        return TString(bytes.data(), bytes.size());
+    }
+};
+
 TVector<EStatType> IMultiColumnStatisticEval::SupportedMultiColumnTypes() {
     return {
         EStatType::COUNT_MIN_SKETCH,
+        EStatType::EQ_HEIGHT_HISTOGRAM,
     };
 }
 
@@ -550,11 +679,15 @@ IMultiColumnStatisticEval::TPtr IMultiColumnStatisticEval::MaybeCreate(
         EStatType statType,
         std::vector<TString> columnNames,
         std::vector<ui32> columnIds,
-        ui64 rowCount) {
+        ui64 rowCount,
+        const THistogramSizing& sizing) {
     switch (statType) {
     case EStatType::COUNT_MIN_SKETCH:
         return TMultiColumnCountMinSketchEval::MaybeCreate(
             std::move(columnNames), std::move(columnIds), rowCount);
+    case EStatType::EQ_HEIGHT_HISTOGRAM:
+        return TMultiColumnEqHeightHistogramEval::MaybeCreate(
+            std::move(columnNames), std::move(columnIds), rowCount, sizing);
     default:
         return TPtr{};
     }

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -11,6 +11,8 @@
 #include <yql/essentials/core/histogram/eq_height_histogram_reader.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
 
+#include <algorithm>
+#include <cmath>
 #include <numbers>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::STATISTICS
@@ -342,6 +344,8 @@ constexpr ui32 MIN_BUCKETS = 1;
 // Buckets for a column with n rows and ndv distinct values. Shared by equi-width and equi-height.
 // Preserves the existing MIN_BUCKETS / MAX_BUCKETS - 24 clamping.
 static ui32 EstimateBucketCount(double n, double ndv) {
+    n = std::max(n, 0.0);
+    ndv = std::max(ndv, 1.0);
     const double cbrtN = std::cbrt(n);
     const double numBucketsEstimate = std::ceil(
         std::min(std::sqrt(n), cbrtN * n / ndv));
@@ -609,12 +613,14 @@ public:
     EStatType GetType() const final { return EStatType::EQ_HEIGHT_HISTOGRAM; }
     const std::vector<ui32>& GetColumnIds() const final { return ColumnIds; }
 
-    // Bounds the intermediate state crossing the scan result row (what
-    // MAX_STATISTICS_SIZE_IN_SINGLE_SCAN budgets).  Add/Merge compact to
-    // MaxStateBytes/2, and Finalize further trims, but Serialize() adds a
-    // small header plus MinKey.  Returning MaxStateBytes is a conservative
-    // estimate rather than a key-width guess.
-    size_t EstimateSize() const final { return Params.MaxStateBytes; }
+    // Scan-batch budget: typical serialized summary is ~EmissionRate entries.
+    // Cap at MaxStateBytes (Compact's hard ceiling).
+    size_t EstimateSize() const final {
+        constexpr size_t assumedAverageKeyWidth = 128;
+        const size_t typical =
+            static_cast<size_t>(std::max(Params.NumBuckets, Params.EmissionRate)) * assumedAverageKeyWidth;
+        return std::min(typical, static_cast<size_t>(Params.MaxStateBytes));
+    }
 
     void AddAggregations(TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregationTuple(ColumnNames, ETupleEncoding::PresortKey, "EQH",

--- a/ydb/core/statistics/aggregator/column_statistic_eval.h
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.h
@@ -60,19 +60,27 @@ class IMultiColumnStatisticEval {
 public:
     using TPtr = std::unique_ptr<IMultiColumnStatisticEval>;
 
+    // Sizing knobs from NKikimrConfig::TStatisticsConfig; ignored by types that do not need them.
+    struct THistogramSizing {
+        ui32 OversampleFactor = 8;      // f, so C = f * B
+        ui64 MaxStateBytes = 4u << 20;
+    };
+
     static TVector<EStatType> SupportedMultiColumnTypes();
     static TPtr MaybeCreate(
         EStatType,
         std::vector<TString> columnNames,
         std::vector<ui32> columnIds,
-        ui64 rowCount);
+        ui64 rowCount,
+        const THistogramSizing& sizing);
 
     virtual EStatType GetType() const = 0;
     virtual const std::vector<ui32>& GetColumnIds() const = 0;
     virtual size_t EstimateSize() const = 0;
     virtual void AddAggregations(TSelectBuilder&) = 0;
     virtual void Merge(const TVector<NYdb::TValue>& aggColumns) = 0;
-    virtual TString ExtractData(const TVector<NYdb::TValue>& aggColumns) = 0;
+    // nullopt == "no statistic for this table"; the caller stores no row at all.
+    virtual std::optional<TString> ExtractData(const TVector<NYdb::TValue>& aggColumns) = 0;
     virtual ~IMultiColumnStatisticEval() = default;
 };
 

--- a/ydb/core/statistics/aggregator/select_builder.cpp
+++ b/ydb/core/statistics/aggregator/select_builder.cpp
@@ -79,7 +79,10 @@ TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> table
         if (agg.UdafFactory) {
             res << "AGGREGATE_BY(";
             if (agg.TupleColumnNames) {
-                res << "StablePickle(AsTuple(";
+                res << (agg.TupleEncoding == ETupleEncoding::PresortKey
+                            ? "Udf(StatisticsInternal::PresortKey)"
+                            : "StablePickle")
+                    << "(AsTuple(";
                 bool firstCol = true;
                 for (const auto& columnName : *agg.TupleColumnNames) {
                     if (firstCol) {

--- a/ydb/core/statistics/aggregator/select_builder.h
+++ b/ydb/core/statistics/aggregator/select_builder.h
@@ -3,9 +3,30 @@
 #include <util/generic/string.h>
 #include <util/generic/hash.h>
 #include <util/generic/vector.h>
+#include <util/string/builder.h>
 #include <util/string/join.h>
 
 namespace NKikimr::NStat {
+
+// YQL literal for a ui64 value, e.g. 1000000ul.  Join(',', ...) calls Out on each
+// parameter, so we return a TString to use the existing Out<TString> overload.
+inline TString Ui64Literal(ui64 v) {
+    return TString(TStringBuilder() << v << "ul");
+}
+
+// YQL literal for a ui32 value, e.g. 1000000u.  Without the suffix YQL infers a
+// bare integer literal as Int32, while the UDAF's CreateState reads it with
+// Get<ui32>(); the mismatch is harmless at today's magnitudes but wrong if the
+// value ever crosses 2^31.
+inline TString Ui32Literal(ui32 v) {
+    return TString(TStringBuilder() << v << "u");
+}
+
+// How a tuple of columns is encoded before being fed to a UDAF.
+enum class ETupleEncoding {
+    StablePickle, // canonical bytes: equal values -> equal bytes. For hash sketches.
+    PresortKey,  // memcomparable bytes: memcmp == value order. For histograms.
+};
 
 // Class that is used to build internal SELECT queries used to calculate column statistics.
 class TSelectBuilder {
@@ -25,10 +46,12 @@ public:
     template<typename... TArgs>
     ui32 AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params);
 
-    // Aggregates StablePickle(AsTuple(columnNames...)) instead of a single column,
-    // for statistics computed over a tuple of columns.
+    // Aggregates a tuple of columns instead of a single column, for statistics computed
+    // over a tuple of columns.  The encoding controls how the tuple is serialised before
+    // being passed to the UDAF.
     template<typename... TArgs>
-    ui32 AddUDAFAggregationTuple(std::vector<TString> columnNames, const TStringBuf& udafName, TArgs&&... params);
+    ui32 AddUDAFAggregationTuple(std::vector<TString> columnNames, ETupleEncoding encoding,
+                                 const TStringBuf& udafName, TArgs&&... params);
 
     TString Build(const TStringBuf& table, std::optional<ui64> tabletId) const;
 
@@ -58,6 +81,7 @@ private:
         ui32 Seq = 0;
         std::optional<TString> ColumnName;
         std::optional<std::vector<TString>> TupleColumnNames;
+        ETupleEncoding TupleEncoding = ETupleEncoding::StablePickle;
         std::optional<TString> AggName;
         std::optional<ui32> UdafFactory;
         TString Params;
@@ -93,10 +117,12 @@ ui32 TSelectBuilder::AddUDAFAggregation(TString columnName, const TStringBuf& ud
 }
 
 template<typename... TArgs>
-ui32 TSelectBuilder::AddUDAFAggregationTuple(std::vector<TString> columnNames, const TStringBuf& udafName, TArgs&&... params) {
+ui32 TSelectBuilder::AddUDAFAggregationTuple(std::vector<TString> columnNames, ETupleEncoding encoding,
+                                             const TStringBuf& udafName, TArgs&&... params) {
     auto factory = AddFactory(udafName, sizeof...(params));
     return PushColumn(TAggColumn{
         .TupleColumnNames = std::move(columnNames),
+        .TupleEncoding = encoding,
         .UdafFactory = factory,
         // TODO: parameters escaping/binding
         .Params = Join(',', params...),

--- a/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze.cpp
@@ -13,6 +13,8 @@
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/statistics/service/service.h>
 
+#include <util/string/cast.h>
+
 namespace NKikimr {
 namespace NStat {
 
@@ -38,6 +40,324 @@ Y_UNIT_TEST_SUITE(AnalyzeStatistics) {
         Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
 
         CheckMultiColumnStatisticsProbes(env, runtime, tableInfo.PathId, {2, 3});
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogram, ColumnShard) {
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeCollectPrimaryKeyHistogram(true);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareMultiColumnTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        // Auto-PK over Key. DataShard: exact (PARTITION_AT_KEYS). ColumnShard: within 2N/(f·B).
+        const bool optionalKey = !ColumnShard;
+        std::vector<TString> sourceKeys;
+        sourceKeys.reserve(ColumnTableRowsNumber);
+        for (ui64 i = 0; i < ColumnTableRowsNumber; ++i) {
+            sourceKeys.push_back(MakeUint64PresortKey(i, optionalKey));
+        }
+        std::vector<TEqHeightHistogramProbe> probes;
+        if (optionalKey) {
+            probes.push_back({MakeNullPresortKey(), 0});
+        }
+        probes.push_back({MakeUint64PresortKey(ColumnTableRowsNumber - 1, optionalKey), ColumnTableRowsNumber});
+        probes.push_back({MakeUint64PresortKey(ColumnTableRowsNumber, optionalKey), ColumnTableRowsNumber});
+        CheckEqHeightHistogram(runtime, tableInfo.PathId, {1},
+            ColumnTableRowsNumber,
+            /*expectedMinBuckets=*/4,
+            probes,
+            ColumnShard ? std::optional<bool>() : std::optional<bool>(true),
+            sourceKeys,
+            ColumnShard ? std::optional<ui64>(EqHeightDesignRankErrorBound()) : std::nullopt);
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeMultiColumnEqHeightHistogram, ColumnShard) {
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareMultiColumnEqHeightTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        std::vector<TString> sourceKeys;
+        sourceKeys.reserve(ColumnTableRowsNumber);
+        constexpr bool optionalValues = true; // Value1/Value2 are nullable on both table types.
+        for (ui64 i = 0; i < ColumnTableRowsNumber; ++i) {
+            sourceKeys.push_back(MakeStringTuplePresortKey(
+                {ToString(i % 10), ToString(i % 20)}, optionalValues));
+        }
+        std::vector<TEqHeightHistogramProbe> probes = {
+            {MakeNullStringTuplePresortKey(2), 0},
+            {MakeStringTuplePresortKey({"zz", "zz"}, optionalValues), ColumnTableRowsNumber},
+        };
+        CheckEqHeightHistogram(runtime, tableInfo.PathId, {2, 3},
+            ColumnTableRowsNumber,
+            /*expectedMinBuckets=*/1,
+            probes,
+            /*requireExact=*/std::nullopt,
+            sourceKeys,
+            EqHeightDesignRankErrorBound());
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramDeclaredPkDedup, ColumnShard) {
+        // Declared WITH (EQ_HEIGHT_HISTOGRAM) on the PK plus the auto-PK config
+        // must produce exactly one stored histogram (the declared descriptor wins).
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeCollectPrimaryKeyHistogram(true);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareDeclaredPkEqHeightTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        const bool optionalKey = !ColumnShard;
+        std::vector<TString> sourceKeys;
+        sourceKeys.reserve(ColumnTableRowsNumber);
+        for (ui64 i = 0; i < ColumnTableRowsNumber; ++i) {
+            sourceKeys.push_back(MakeUint64PresortKey(i, optionalKey));
+        }
+        CheckEqHeightHistogram(runtime, tableInfo.PathId, {1},
+            ColumnTableRowsNumber,
+            /*expectedMinBuckets=*/4,
+            std::nullopt,
+            ColumnShard ? std::optional<bool>() : std::optional<bool>(true),
+            sourceKeys,
+            ColumnShard ? std::optional<ui64>(EqHeightDesignRankErrorBound()) : std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(
+            CountStatisticsV2Rows(env, "Database", tableInfo.PathId, EStatType::EQ_HEIGHT_HISTOGRAM, "1"),
+            1);
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramCompositePk, ColumnShard) {
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeCollectPrimaryKeyHistogram(true);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareCompositePkTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        const bool optionalKey = !ColumnShard;
+        std::vector<TString> sourceKeys;
+        sourceKeys.reserve(ColumnTableRowsNumber);
+        for (ui64 i = 0; i < ColumnTableRowsNumber; ++i) {
+            sourceKeys.push_back(MakeUint64StringPresortKey(i, ToString(i % 10), optionalKey));
+        }
+        CheckEqHeightHistogram(runtime, tableInfo.PathId, {1, 2},
+            ColumnTableRowsNumber,
+            /*expectedMinBuckets=*/4,
+            std::nullopt,
+            ColumnShard ? std::optional<bool>() : std::optional<bool>(true),
+            sourceKeys,
+            ColumnShard ? std::optional<ui64>(EqHeightDesignRankErrorBound()) : std::nullopt);
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramJsonRejectedAtDdl, ColumnShard) {
+        // Declared EQ_HEIGHT_HISTOGRAM on Json must fail at CREATE, not at ANALYZE.
+        TTestEnv env(1, 1);
+        CreateDatabase(env, "Database");
+
+        const char* script = ColumnShard
+            ? R"(
+                CREATE TABLE `Root/Database/Table` (
+                    Key Uint64 NOT NULL,
+                    Js Json,
+                    PRIMARY KEY (Key),
+                    STATISTICS js_hist ON (Js) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                PARTITION BY HASH(Key)
+                WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
+            )"
+            : R"(
+                CREATE TABLE `Root/Database/Table` (
+                    Key Uint64,
+                    Js Json,
+                    PRIMARY KEY (Key),
+                    STATISTICS js_hist ON (Js) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                WITH ( UNIFORM_PARTITIONS = 4 );
+            )";
+
+        auto status = ExecuteYqlScript(env, script, /*mustSucceed=*/false);
+        UNIT_ASSERT_VALUES_UNEQUAL_C(status, Ydb::StatusIds::SUCCESS,
+            "EQ_HEIGHT_HISTOGRAM on Json must be rejected at DDL");
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramJsonColumnOk, ColumnShard) {
+        // A Json column on the table must not prevent ANALYZE or a histogram
+        // over a different, encodable column.
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+
+        if constexpr (ColumnShard) {
+            ExecuteYqlScript(env, R"(
+                CREATE TABLE `Root/Database/Table` (
+                    Key Uint64 NOT NULL,
+                    Js Json,
+                    Value String,
+                    PRIMARY KEY (Key),
+                    STATISTICS val_hist ON (Value) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                PARTITION BY HASH(Key)
+                WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
+            )");
+            runtime.SimulateSleep(TDuration::Seconds(1));
+        } else {
+            ExecuteYqlScript(env, R"(
+                CREATE TABLE `Root/Database/Table` (
+                    Key Uint64,
+                    Js Json,
+                    Value String,
+                    PRIMARY KEY (Key),
+                    STATISTICS val_hist ON (Value) WITH (EQ_HEIGHT_HISTOGRAM)
+                )
+                WITH ( UNIFORM_PARTITIONS = 4 );
+            )");
+        }
+
+        TTableInfo tableInfo;
+        tableInfo.Path = "/Root/Database/Table";
+        tableInfo.PathId = ResolvePathId(
+            runtime, tableInfo.Path, &tableInfo.DomainKey, &tableInfo.SaTabletId);
+
+        InsertDataIntoTable(env, "Database", "Table", ColumnTableRowsNumber, {
+            {
+                .Name = "Js",
+                .TypeId = NScheme::NTypeIds::Json,
+                .AddValue = [](ui64 /*key*/, Ydb::Value& row) {
+                    row.add_items()->set_text_value("{}");
+                },
+            },
+            {
+                .Name = "Value",
+                .TypeId = NScheme::NTypeIds::String,
+                .AddValue = [](ui64 key, Ydb::Value& row) {
+                    row.add_items()->set_bytes_value(ToString(key % 10));
+                },
+            },
+        });
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        auto responses = GetStatisticsMultiColumn(
+            runtime, tableInfo.PathId, EStatType::EQ_HEIGHT_HISTOGRAM, {3});
+        UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
+        UNIT_ASSERT(responses[0].Success);
+        UNIT_ASSERT(responses[0].EqHeightHistogram.Data);
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramConfigOff, ColumnShard) {
+        // When AnalyzeCollectPrimaryKeyHistogram is false (the default),
+        // the auto-PK eq-height histogram must NOT be collected.
+        TTestEnv env(1, 1); // default: AnalyzeCollectPrimaryKeyHistogram = false
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareMultiColumnTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        // The PK eq-height histogram should not be present.
+        // GetStatistics for EQ_HEIGHT_HISTOGRAM on the PK column (tag 1) should
+        // return an empty response (no histogram stored), which is indicated by
+        // Success = false (see CheckCountMinSketch for the same convention).
+        auto responses = GetStatisticsMultiColumn(runtime, tableInfo.PathId, EStatType::EQ_HEIGHT_HISTOGRAM, {1});
+        UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
+        for (const auto& resp : responses) {
+            UNIT_ASSERT_C(!resp.Success,
+                          "EQ_HEIGHT_HISTOGRAM should not be collected when "
+                          "AnalyzeCollectPrimaryKeyHistogram is false");
+            UNIT_ASSERT_C(!resp.EqHeightHistogram.Data,
+                          "EQ_HEIGHT_HISTOGRAM should not be collected when "
+                          "AnalyzeCollectPrimaryKeyHistogram is false");
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEmptyTableEqHeightHistogram, ColumnShard) {
+        // With AnalyzeCollectPrimaryKeyHistogram enabled, an empty table
+        // should produce no eq-height histogram: Finalize() returns nullopt
+        // when TotalCount == 0, so no histogram is stored.
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetAnalyzeCollectPrimaryKeyHistogram(true);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = CreateEmptyTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        // No eq-height histogram should be stored for an empty table.
+        auto responses = GetStatisticsMultiColumn(runtime, tableInfo.PathId, EStatType::EQ_HEIGHT_HISTOGRAM, {1});
+        UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
+        for (const auto& resp : responses) {
+            UNIT_ASSERT_C(!resp.Success,
+                          "EQ_HEIGHT_HISTOGRAM should not be collected for an empty table");
+            UNIT_ASSERT_C(!resp.EqHeightHistogram.Data,
+                          "EQ_HEIGHT_HISTOGRAM should not be collected for an empty table");
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramWithoutWith, ColumnShard) {
+        // STATISTICS without WITH: collect CMS and EQ_HEIGHT (auto-PK off).
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareMultiColumnAllTypesTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        CheckMultiColumnStatisticsProbes(env, runtime, tableInfo.PathId, {2, 3});
+
+        std::vector<TString> sourceKeys;
+        sourceKeys.reserve(ColumnTableRowsNumber);
+        constexpr bool optionalValues = true;
+        for (ui64 i = 0; i < ColumnTableRowsNumber; ++i) {
+            sourceKeys.push_back(MakeStringTuplePresortKey(
+                {ToString(i % 10), ToString(i % 20)}, optionalValues));
+        }
+        std::vector<TEqHeightHistogramProbe> probes = {
+            {MakeNullStringTuplePresortKey(2), 0},
+            {MakeStringTuplePresortKey({"zz", "zz"}, optionalValues), ColumnTableRowsNumber},
+        };
+        CheckEqHeightHistogram(runtime, tableInfo.PathId, {2, 3},
+            ColumnTableRowsNumber,
+            /*expectedMinBuckets=*/1,
+            probes,
+            /*requireExact=*/std::nullopt,
+            sourceKeys,
+            EqHeightDesignRankErrorBound());
+    }
+
+    Y_UNIT_TEST_TWIN(AnalyzeEqHeightHistogramWithoutWithOnPk, ColumnShard) {
+        // STATISTICS on PK with no WITH, auto-PK off: still collect the PK histogram.
+        TTestEnv env(1, 1); // AnalyzeCollectPrimaryKeyHistogram = false
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareDeclaredPkAllTypesTable(env, "Database", "Table", ColumnShard);
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        const bool optionalKey = !ColumnShard;
+        std::vector<TString> sourceKeys;
+        sourceKeys.reserve(ColumnTableRowsNumber);
+        for (ui64 i = 0; i < ColumnTableRowsNumber; ++i) {
+            sourceKeys.push_back(MakeUint64PresortKey(i, optionalKey));
+        }
+        CheckEqHeightHistogram(runtime, tableInfo.PathId, {1},
+            ColumnTableRowsNumber,
+            /*expectedMinBuckets=*/4,
+            std::nullopt,
+            ColumnShard ? std::optional<bool>() : std::optional<bool>(true),
+            sourceKeys,
+            ColumnShard ? std::optional<ui64>(EqHeightDesignRankErrorBound()) : std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(
+            CountStatisticsV2Rows(env, "Database", tableInfo.PathId, EStatType::EQ_HEIGHT_HISTOGRAM, "1"),
+            1);
     }
 
     Y_UNIT_TEST_TWIN(AnalyzeTwoTables, ColumnShard) {

--- a/ydb/core/statistics/aggregator/ut/ya.make
+++ b/ydb/core/statistics/aggregator/ut/ya.make
@@ -18,9 +18,11 @@ PEERDIR(
     ydb/library/yql/udfs/statistics_internal
     ydb/core/kqp/node_service
     ydb/core/protos
+    ydb/core/scheme
     ydb/core/testlib/default
     ydb/core/statistics/ut_common
     ydb/core/tx/conveyor_composite/usage
+    yql/essentials/core/histogram
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/hyperloglog
 )

--- a/ydb/core/statistics/aggregator/ya.make
+++ b/ydb/core/statistics/aggregator/ya.make
@@ -35,6 +35,7 @@ PEERDIR(
     ydb/core/tablet_flat
     ydb/core/statistics/database
     ydb/library/yql/udfs/statistics_internal
+    yql/essentials/core/histogram
     yql/essentials/core/minsketch
 )
 

--- a/ydb/core/statistics/events.h
+++ b/ydb/core/statistics/events.h
@@ -8,13 +8,25 @@
 #include <ydb/library/actors/core/events.h>
 #include <yql/essentials/public/issue/yql_issue.h>
 
+#include <bit>
 #include <variant>
 
 
 namespace NKikimr {
 
+// Count-min sketch and equi-width histogram blobs are serialized in native
+// byte order and persisted in .metadata/statistics_v2, then read back by other
+// nodes. That pins those stored formats to little-endian architectures.
+// Equi-height histograms use protobuf (endian-independent).
+// The count-min sketch additionally pins struct layout (member order, padding,
+// sizeof) since its blob is the in-memory object reinterpreted directly, so a
+// byte-swap layer alone would not unblock a big-endian port.
+static_assert(std::endian::native == std::endian::little,
+              "statistics blobs in .metadata/statistics_v2 are little-endian");
+
 class TCountMinSketch;
 class TEqWidthHistogram;
+class TEqHeightHistogram;
 
 namespace NStat {
 
@@ -35,6 +47,10 @@ struct TStatEqWidthHistogram {
     std::shared_ptr<TEqWidthHistogram> Data;
 };
 
+struct TStatEqHeightHistogram {
+    std::shared_ptr<TEqHeightHistogram> Data;
+};
+
 struct TStatTableSummary {
     std::optional<NKikimrStat::TTableSummaryStatistics> Data;
 };
@@ -52,6 +68,8 @@ enum class EStatType {
     EQ_WIDTH_HISTOGRAM = 3,
     // Correct table row count calculated during ANALYZE.
     TABLE_SUMMARY = 4,
+    // Equi-height histogram over a tuple of columns (multi-column).
+    EQ_HEIGHT_HISTOGRAM = 5,
 };
 
 // Absent for SIMPLE/TABLE_SUMMARY stats;
@@ -92,6 +110,7 @@ struct TResponse {
     TStatSimpleColumn SimpleColumn;
     TStatCountMinSketch CountMinSketch;
     TStatEqWidthHistogram EqWidthHistogram;
+    TStatEqHeightHistogram EqHeightHistogram;
     TStatTableSummary TableSummary;
 };
 

--- a/ydb/core/statistics/service/service_impl.cpp
+++ b/ydb/core/statistics/service/service_impl.cpp
@@ -22,6 +22,7 @@
 #include <ydb/library/actors/core/log.h>
 #include <yql/essentials/core/minsketch/count_min_sketch.h>
 #include <yql/essentials/core/histogram/eq_width_histogram.h>
+#include <yql/essentials/core/histogram/eq_height_histogram_reader.h>
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
@@ -572,9 +573,35 @@ private:
                     TCountMinSketch::FromString(msg->Data->data(), msg->Data->size()));
                 break;
             case EStatType::EQ_WIDTH_HISTOGRAM:
-                response.Success = true;
-                response.EqWidthHistogram.Data =
-                    std::make_shared<TEqWidthHistogram>(msg->Data->data(), msg->Data->size());
+                try {
+                    response.Success = true;
+                    response.EqWidthHistogram.Data =
+                        std::make_shared<TEqWidthHistogram>(msg->Data->data(), msg->Data->size());
+                } catch (const std::exception& ex) {
+                    YDB_LOG_ERROR("Failed to parse EQ_WIDTH_HISTOGRAM blob",
+                        {"requestId", requestId},
+                        {"error", ex.what()});
+                    response.Success = false;
+                }
+                break;
+            case EStatType::EQ_HEIGHT_HISTOGRAM:
+                try {
+                    TEqHeightHistogramResult result;
+                    Y_ENSURE(result.ParseFromArray(msg->Data->data(), msg->Data->size()));
+                    response.Success = true;
+                    response.EqHeightHistogram.Data =
+                        std::make_shared<TEqHeightHistogram>(result);
+                } catch (const std::exception& ex) {
+                    // Malformed blobs throw from TEqHeightHistogram; report failure
+                    // rather than propagating the exception out of the handler.
+                    // Protobuf unknown fields from a newer writer are skipped, not
+                    // thrown — this catch is for YQL_ENSURE validation, not version
+                    // skew.
+                    YDB_LOG_ERROR("Failed to parse EQ_HEIGHT_HISTOGRAM blob",
+                        {"requestId", requestId},
+                        {"error", ex.what()});
+                    response.Success = false;
+                }
                 break;
             case EStatType::TABLE_SUMMARY: {
                 NKikimrStat::TTableSummaryStatistics data;
@@ -784,6 +811,7 @@ private:
                     << ", SIMPLE_COLUMN: " << counts[EStatType::SIMPLE_COLUMN]
                     << ", COUNT_MIN_SKETCH: " << counts[EStatType::COUNT_MIN_SKETCH]
                     << ", EQ_WIDTH_HISTOGRAM: " << counts[EStatType::EQ_WIDTH_HISTOGRAM]
+                    << ", EQ_HEIGHT_HISTOGRAM: " << counts[EStatType::EQ_HEIGHT_HISTOGRAM]
                     << ", TABLE_SUMMARY: " << counts[EStatType::TABLE_SUMMARY]
                     << "]" << Endl;
             }

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -8,6 +8,8 @@
 #include <ydb/core/statistics/service/service.h>
 #include <ydb/core/protos/statistics.pb.h>
 
+#include <yql/essentials/core/histogram/eq_height_histogram_reader.h>
+
 #include <type_traits>
 
 namespace NKikimr::NStat {
@@ -362,6 +364,41 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
         UNIT_ASSERT(histogram->GetType() == EHistogramValueType::Int64);
         auto estimator = TEqWidthHistogramEstimator(histogram);
         UNIT_ASSERT_VALUES_EQUAL(estimator.EstimateLess<i64>(0), 500);
+    }
+
+    Y_UNIT_TEST(EqHeightHistogram) {
+        // Service-level EQ_HEIGHT over (Value1, Value2). Only boundary probes:
+        // merge/compaction is not exact (see eq_height_histogram_ut.cpp).
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareMultiColumnEqHeightColumnTable(env, "Database", "Table1");
+
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        // Fetch the histogram via the stat service using the multi-column
+        // variant (the single-column GetStatistics would construct a
+        // TColumnTags(ui32) that only collides with the multi-column key by
+        // coincidence of SerializeColumnTags).
+        auto responses = GetStatisticsMultiColumn(
+            runtime, tableInfo.PathId, EStatType::EQ_HEIGHT_HISTOGRAM, {2, 3});
+        UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
+
+        const auto& resp = responses.at(0);
+        UNIT_ASSERT(resp.Success);
+        const auto& histogram = resp.EqHeightHistogram.Data;
+        UNIT_ASSERT(histogram);
+        UNIT_ASSERT_VALUES_EQUAL(histogram->GetTotalCount(), ColumnTableRowsNumber);
+        UNIT_ASSERT(histogram->GetNumBuckets() >= 1);
+
+        // Optional-null String tuple sorts first. "zz" is above all digit-only values.
+        UNIT_ASSERT_VALUES_EQUAL(
+            histogram->EstimateLessOrEqual(MakeNullStringTuplePresortKey(2)), 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            histogram->EstimateLessOrEqual(
+                MakeStringTuplePresortKey({"zz", "zz"}, /*isOptional=*/true)),
+            ColumnTableRowsNumber);
     }
 
     Y_UNIT_TEST(ManyColumns) {

--- a/ydb/core/statistics/service/ya.make
+++ b/ydb/core/statistics/service/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     ydb/core/tablet_flat
     ydb/core/statistics/database    
     yql/essentials/core/minsketch
+    yql/essentials/core/histogram
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/statistics/ut/presort_key_agreement_ut.cpp
+++ b/ydb/core/statistics/ut/presort_key_agreement_ut.cpp
@@ -53,6 +53,11 @@ struct TTypedValue {
 
 using TTypedTuple = std::vector<TTypedValue>;
 
+struct TColDesc {
+    NScheme::TTypeId TypeId;
+    bool IsOptional = false;
+};
+
 // Cell bytes → TUnboxedValuePod for TPresortEncoder::Encode().
 TUnboxedValue MakePod(const TTypedValue& v) {
     if (v.IsNull) {

--- a/ydb/core/statistics/ut/presort_key_agreement_ut.cpp
+++ b/ydb/core/statistics/ut/presort_key_agreement_ut.cpp
@@ -1,0 +1,550 @@
+// memcmp(TPresortEncoder(key)) must agree with CompareTypedCellVectors.
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <yql/essentials/minikql/computation/presort.h>
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/mkql_string_util.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/core/scheme/scheme_types_defs.h>
+#include <ydb/core/scheme_types/scheme_decimal_type.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/utility.h>
+#include <util/system/unaligned_mem.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace {
+
+using namespace NKikimr;
+using namespace NYql::NUdf;
+
+// A typed value: the raw bytes of a TCell plus the type id.
+struct TTypedValue {
+    NScheme::TTypeId TypeId;
+    bool IsNull = false;
+    bool IsOptional = false;
+    TString Data; // TCell payload
+
+    TCell ToCell() const {
+        if (IsNull) {
+            return TCell();
+        }
+        return TCell(Data.data(), Data.size());
+    }
+
+    NScheme::TTypeInfoOrder TypeInfoOrder() const {
+        // Decimal needs TDecimalType; TypeId alone is not enough.
+        if (TypeId == NScheme::NTypeIds::Decimal) {
+            return NScheme::TTypeInfoOrder(NScheme::TTypeInfo(NScheme::TDecimalType::Default()));
+        }
+        return NScheme::TTypeInfoOrder(NScheme::TTypeInfo(TypeId));
+    }
+};
+
+using TTypedTuple = std::vector<TTypedValue>;
+
+// Cell bytes → TUnboxedValuePod for TPresortEncoder::Encode().
+TUnboxedValue MakePod(const TTypedValue& v) {
+    if (v.IsNull) {
+        return TUnboxedValuePod();
+    }
+
+    const auto slot = GetDataSlot(v.TypeId);
+    TUnboxedValue pod;
+
+    switch (slot) {
+        case EDataSlot::Bool:
+            pod = TUnboxedValuePod(v.Data.empty() ? false : ReadUnaligned<bool>(v.Data.data()));
+            break;
+        case EDataSlot::Int8:
+            pod = TUnboxedValuePod(ReadUnaligned<i8>(v.Data.data()));
+            break;
+        case EDataSlot::Uint8:
+            pod = TUnboxedValuePod(ReadUnaligned<ui8>(v.Data.data()));
+            break;
+        case EDataSlot::Int16:
+            pod = TUnboxedValuePod(ReadUnaligned<i16>(v.Data.data()));
+            break;
+        case EDataSlot::Uint16:
+        case EDataSlot::Date:
+            pod = TUnboxedValuePod(ReadUnaligned<ui16>(v.Data.data()));
+            break;
+        case EDataSlot::Int32:
+        case EDataSlot::Date32:
+            pod = TUnboxedValuePod(ReadUnaligned<i32>(v.Data.data()));
+            break;
+        case EDataSlot::Uint32:
+        case EDataSlot::Datetime:
+            pod = TUnboxedValuePod(ReadUnaligned<ui32>(v.Data.data()));
+            break;
+        case EDataSlot::Int64:
+        case EDataSlot::Interval:
+        case EDataSlot::Interval64:
+        case EDataSlot::Datetime64:
+        case EDataSlot::Timestamp64:
+            pod = TUnboxedValuePod(ReadUnaligned<i64>(v.Data.data()));
+            break;
+        case EDataSlot::Uint64:
+        case EDataSlot::Timestamp:
+            pod = TUnboxedValuePod(ReadUnaligned<ui64>(v.Data.data()));
+            break;
+        case EDataSlot::Float:
+            pod = TUnboxedValuePod(ReadUnaligned<float>(v.Data.data()));
+            break;
+        case EDataSlot::Double:
+            pod = TUnboxedValuePod(ReadUnaligned<double>(v.Data.data()));
+            break;
+        case EDataSlot::Decimal: {
+            NYql::NDecimal::TInt128 val;
+            std::memcpy(&val, v.Data.data(), sizeof(val));
+            pod = TUnboxedValuePod(val);
+            break;
+        }
+        case EDataSlot::String:
+        case EDataSlot::Utf8:
+        case EDataSlot::DyNumber:
+        case EDataSlot::Json:
+        case EDataSlot::Yson:
+        case EDataSlot::Uuid: {
+            pod = NMiniKQL::MakeString(TStringRef(v.Data.data(), v.Data.size()));
+            break;
+        }
+        default:
+            pod = NMiniKQL::MakeString(TStringRef(v.Data.data(), v.Data.size()));
+            break;
+    }
+
+    if (v.IsOptional) {
+        return TUnboxedValue(pod.MakeOptional());
+    }
+    return pod;
+}
+
+TString EncodeTuple(const TTypedTuple& t) {
+    NMiniKQL::TPresortEncoder enc;
+    for (const auto& v : t) {
+        const auto slot = GetDataSlot(v.TypeId);
+        enc.AddType(slot, v.IsOptional, /*isDesc=*/false);
+    }
+    enc.Start();
+    for (const auto& v : t) {
+        enc.Encode(MakePod(v));
+    }
+    const TStringBuf buf = enc.Finish();
+    return TString(buf.data(), buf.size());
+}
+
+int CompareEncoded(const TString& a, const TString& b) {
+    const int c = memcmp(a.data(), b.data(), Min(a.size(), b.size()));
+    if (c != 0) {
+        return c < 0 ? -1 : 1;
+    }
+    if (a.size() < b.size()) {
+        return -1;
+    }
+    if (a.size() > b.size()) {
+        return 1;
+    }
+    return 0;
+}
+
+int CompareWithYdb(const TTypedTuple& a, const TTypedTuple& b) {
+    TVector<TCell> cellsA, cellsB;
+    TVector<NScheme::TTypeInfoOrder> types;
+    for (const auto& v : a) {
+        cellsA.push_back(v.ToCell());
+        types.push_back(v.TypeInfoOrder());
+    }
+    for (const auto& v : b) {
+        cellsB.push_back(v.ToCell());
+    }
+    return CompareTypedCellVectors(
+        cellsA.data(), cellsB.data(), types.data(),
+        static_cast<ui32>(Min(cellsA.size(), cellsB.size())));
+}
+
+int Sign(int x) {
+    return (x > 0) - (x < 0);
+}
+
+TTypedTuple SingleElem(NScheme::TTypeId typeId, bool isNull, TString data,
+                       bool isOptional = false) {
+    return {{typeId, isNull, isOptional, std::move(data)}};
+}
+
+} // namespace
+
+struct TPresortKeyAgreementFixture : public NUnitTest::TBaseTestCase {
+    NMiniKQL::TScopedAlloc Alloc{__LOCATION__};
+};
+
+Y_UNIT_TEST_SUITE_F(PresortKeyAgreement, TPresortKeyAgreementFixture) {
+
+Y_UNIT_TEST(NullBeforePresent) {
+    TTypedTuple a = SingleElem(NScheme::NTypeIds::Int32, true, {}, true);
+    TTypedTuple b = SingleElem(NScheme::NTypeIds::Int32, false, TString(4, '\x00'), true);
+
+    int ydbCmp = CompareWithYdb(a, b);
+    int encCmp = CompareEncoded(EncodeTuple(a), EncodeTuple(b));
+
+    UNIT_ASSERT_VALUES_EQUAL(Sign(ydbCmp), -1);
+    UNIT_ASSERT_VALUES_EQUAL(Sign(encCmp), -1);
+}
+
+Y_UNIT_TEST(SignedIntegers) {
+    std::vector<i32> vals = {-100, -1, 0, 1, 100, 12345, -12345};
+    for (size_t i = 0; i + 1 < vals.size(); ++i) {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::Int32, false,
+            TString(reinterpret_cast<const char*>(&vals[i]), sizeof(i32)));
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::Int32, false,
+            TString(reinterpret_cast<const char*>(&vals[i + 1]), sizeof(i32)));
+
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "Int32 " << vals[i] << " vs " << vals[i + 1]
+                     << ": ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+}
+
+Y_UNIT_TEST(UnsignedIntegers) {
+    std::vector<ui64> vals = {0, 1, 127, 128, 255, 256, 65535, 65536, UINT64_MAX / 2};
+    for (size_t i = 0; i + 1 < vals.size(); ++i) {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::Uint64, false,
+            TString(reinterpret_cast<const char*>(&vals[i]), sizeof(ui64)));
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::Uint64, false,
+            TString(reinterpret_cast<const char*>(&vals[i + 1]), sizeof(ui64)));
+
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "Uint64 " << vals[i] << " vs " << vals[i + 1]
+                      << ": ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+}
+
+Y_UNIT_TEST(Floats) {
+    std::vector<float> vals = {
+        -std::numeric_limits<float>::infinity(),
+        -1.0f,
+        0.0f,
+        1.0f,
+        std::numeric_limits<float>::infinity(),
+    };
+    for (size_t i = 0; i + 1 < vals.size(); ++i) {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::Float, false,
+            TString(reinterpret_cast<const char*>(&vals[i]), sizeof(float)));
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::Float, false,
+            TString(reinterpret_cast<const char*>(&vals[i + 1]), sizeof(float)));
+
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "Float " << vals[i] << " vs " << vals[i + 1]
+                     << ": ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+}
+
+// -0.0 and +0.0 must encode identically (YDB reports them equal).
+Y_UNIT_TEST(MinusZeroVsPlusZero) {
+    float negZero = -0.0f;
+    float posZero = +0.0f;
+    TTypedTuple a = SingleElem(NScheme::NTypeIds::Float, false,
+        TString(reinterpret_cast<const char*>(&negZero), sizeof(float)));
+    TTypedTuple b = SingleElem(NScheme::NTypeIds::Float, false,
+        TString(reinterpret_cast<const char*>(&posZero), sizeof(float)));
+
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareWithYdb(a, b)), 0);
+    UNIT_ASSERT_VALUES_EQUAL(EncodeTuple(a), EncodeTuple(b));
+
+    double negZeroD = -0.0;
+    double posZeroD = +0.0;
+    TTypedTuple ad = SingleElem(NScheme::NTypeIds::Double, false,
+        TString(reinterpret_cast<const char*>(&negZeroD), sizeof(double)));
+    TTypedTuple bd = SingleElem(NScheme::NTypeIds::Double, false,
+        TString(reinterpret_cast<const char*>(&posZeroD), sizeof(double)));
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareWithYdb(ad, bd)), 0);
+    UNIT_ASSERT_VALUES_EQUAL(EncodeTuple(ad), EncodeTuple(bd));
+}
+
+// Not in RandomAgreement: YDB float `<` is not an order on NaN. Presort puts NaN above +inf.
+Y_UNIT_TEST(NanPlacement) {
+    float nan = std::numeric_limits<float>::quiet_NaN();
+    float posInf = std::numeric_limits<float>::infinity();
+    TTypedTuple a = SingleElem(NScheme::NTypeIds::Float, false,
+        TString(reinterpret_cast<const char*>(&nan), sizeof(float)));
+    TTypedTuple b = SingleElem(NScheme::NTypeIds::Float, false,
+        TString(reinterpret_cast<const char*>(&posInf), sizeof(float)));
+
+    int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+    UNIT_ASSERT_VALUES_EQUAL_C(encCmp, 1,
+        "NaN must sort above +inf in presort, got enc=" << encCmp);
+}
+
+Y_UNIT_TEST(Strings) {
+    std::vector<TString> vals = {"", "a", "aa", "ab", "b", "z", "9", "19"};
+    for (size_t i = 0; i + 1 < vals.size(); ++i) {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::String, false, vals[i]);
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::String, false, vals[i + 1]);
+
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "String \"" << vals[i] << "\" vs \"" << vals[i + 1]
+                       << "\": ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+}
+
+Y_UNIT_TEST(StringsWithEmbeddedNul) {
+    TString a = "a\0b";
+    TString b = "ab";
+    TTypedTuple ta = SingleElem(NScheme::NTypeIds::String, false, a);
+    TTypedTuple tb = SingleElem(NScheme::NTypeIds::String, false, b);
+
+    int ydbCmp = Sign(CompareWithYdb(ta, tb));
+    int encCmp = Sign(CompareEncoded(EncodeTuple(ta), EncodeTuple(tb)));
+    UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+        "String \"a\\0b\" vs \"ab\": ydb=" << ydbCmp << " enc=" << encCmp);
+    UNIT_ASSERT_C(encCmp < 0, "\"a\\0b\" must sort below \"ab\"");
+}
+
+// 15-byte vs 16-byte: trailing length 0x0F meets the next block marker 0x1F.
+Y_UNIT_TEST(StringBlockBoundary) {
+    TString s15(15, 'a');
+    TString s16(16, 'a');
+    TString s14(14, 'a');
+
+    {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::String, false, s14);
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::String, false, s15);
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "14-byte vs 15-byte string: ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+    {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::String, false, s15);
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::String, false, s16);
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "15-byte vs 16-byte string: ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+    {
+        TString s15a(15, 'a');
+        TString s15b(14, 'a');
+        s15b.append('b');
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::String, false, s15a);
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::String, false, s15b);
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "15-byte aaa..a vs 14a+b: ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+}
+
+Y_UNIT_TEST(MultiColumnTuples) {
+    i32 one = 1;
+    i32 two = 2;
+    TTypedTuple a = {
+        {NScheme::NTypeIds::Int32, false, false, TString(reinterpret_cast<const char*>(&one), sizeof(i32))},
+        {NScheme::NTypeIds::String, false, false, "abc"},
+    };
+    TTypedTuple b = {
+        {NScheme::NTypeIds::Int32, false, false, TString(reinterpret_cast<const char*>(&one), sizeof(i32))},
+        {NScheme::NTypeIds::String, false, false, "abd"},
+    };
+    TTypedTuple c = {
+        {NScheme::NTypeIds::Int32, false, false, TString(reinterpret_cast<const char*>(&two), sizeof(i32))},
+        {NScheme::NTypeIds::String, false, false, "aaa"},
+    };
+
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b))),
+                              Sign(CompareWithYdb(a, b)));
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(c))),
+                              Sign(CompareWithYdb(a, c)));
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareEncoded(EncodeTuple(b), EncodeTuple(c))),
+                              Sign(CompareWithYdb(b, c)));
+}
+
+Y_UNIT_TEST(NullInSecondColumn) {
+    i32 five = 5;
+    i32 zero = 0;
+    TTypedTuple a = {
+        {NScheme::NTypeIds::Int32, false, false, TString(reinterpret_cast<const char*>(&five), sizeof(i32))},
+        {NScheme::NTypeIds::Int32, true, true, {}},
+    };
+    TTypedTuple b = {
+        {NScheme::NTypeIds::Int32, false, false, TString(reinterpret_cast<const char*>(&five), sizeof(i32))},
+        {NScheme::NTypeIds::Int32, false, true, TString(reinterpret_cast<const char*>(&zero), sizeof(i32))},
+    };
+
+    int ydbCmp = Sign(CompareWithYdb(a, b));
+    int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+    UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+        "NULL in second column: ydb=" << ydbCmp << " enc=" << encCmp);
+    UNIT_ASSERT_C(encCmp < 0, "NULL must sort before present value");
+}
+
+// Ordinary decimals only (YQL Inf/NaN/error are outside YDB's pair<ui64,i64> cell).
+Y_UNIT_TEST(Decimal) {
+    auto makeDecimal = [](i64 high, ui64 low) -> TTypedValue {
+        TTypedValue v;
+        v.TypeId = NScheme::NTypeIds::Decimal;
+        v.IsNull = false;
+        std::pair<ui64, i64> p{low, high};
+        v.Data = TString(reinterpret_cast<const char*>(&p), sizeof(p));
+        return v;
+    };
+
+    std::vector<std::pair<i64, ui64>> vals = {
+        {0, 0},
+        {0, 1},
+        {0, 100},
+        {1, 0},
+        {-1, 0},
+        {0, 0},
+    };
+    std::vector<TTypedTuple> tuples;
+    for (auto& [high, low] : vals) {
+        tuples.push_back({makeDecimal(high, low)});
+    }
+
+    // Compare each pair.
+    for (size_t i = 0; i < tuples.size(); ++i) {
+        for (size_t j = i + 1; j < tuples.size(); ++j) {
+            int ydbCmp = Sign(CompareWithYdb(tuples[i], tuples[j]));
+            int encCmp = Sign(CompareEncoded(EncodeTuple(tuples[i]), EncodeTuple(tuples[j])));
+            UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+                "Decimal (" << vals[i].first << "," << vals[i].second << ") vs ("
+                << vals[j].first << "," << vals[j].second
+                << "): ydb=" << ydbCmp << " enc=" << encCmp);
+        }
+    }
+}
+
+Y_UNIT_TEST(Uuid) {
+    TString a(16, '\x00');
+    TString b(16, '\x00');
+    b[15] = 1;
+    TString c(16, '\xFF');
+
+    TTypedTuple ta = SingleElem(NScheme::NTypeIds::Uuid, false, a);
+    TTypedTuple tb = SingleElem(NScheme::NTypeIds::Uuid, false, b);
+    TTypedTuple tc = SingleElem(NScheme::NTypeIds::Uuid, false, c);
+
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareEncoded(EncodeTuple(ta), EncodeTuple(tb))),
+                              Sign(CompareWithYdb(ta, tb)));
+    UNIT_ASSERT_VALUES_EQUAL(Sign(CompareEncoded(EncodeTuple(tb), EncodeTuple(tc))),
+                              Sign(CompareWithYdb(tb, tc)));
+    UNIT_ASSERT_C(Sign(CompareEncoded(EncodeTuple(ta), EncodeTuple(tb))) < 0,
+        "all-zero Uuid must sort below ...01");
+}
+
+Y_UNIT_TEST(DyNumber) {
+    std::vector<TString> vals = {"", "1", "10", "2", "a"};
+    for (size_t i = 0; i + 1 < vals.size(); ++i) {
+        TTypedTuple a = SingleElem(NScheme::NTypeIds::DyNumber, false, vals[i]);
+        TTypedTuple b = SingleElem(NScheme::NTypeIds::DyNumber, false, vals[i + 1]);
+
+        int ydbCmp = Sign(CompareWithYdb(a, b));
+        int encCmp = Sign(CompareEncoded(EncodeTuple(a), EncodeTuple(b)));
+        UNIT_ASSERT_VALUES_EQUAL_C(encCmp, ydbCmp,
+            "DyNumber \"" << vals[i] << "\" vs \"" << vals[i + 1]
+                          << "\": ydb=" << ydbCmp << " enc=" << encCmp);
+    }
+}
+
+Y_UNIT_TEST(RandomAgreement) {
+    std::mt19937 rng(12345);
+
+    auto randomInt = [&](i64 lo, i64 hi) -> i64 {
+        return std::uniform_int_distribution<i64>(lo, hi)(rng);
+    };
+
+    auto randomString = [&]() -> TString {
+        const size_t len = std::uniform_int_distribution<size_t>(0, 20)(rng);
+        TString s;
+        for (size_t i = 0; i < len; ++i) {
+            const int c = std::uniform_int_distribution<int>(0, 255)(rng);
+            s.append(static_cast<char>(c));
+        }
+        return s;
+    };
+
+    const std::vector<TColDesc> columnTypes = {
+        {NScheme::NTypeIds::Int32, true},
+        {NScheme::NTypeIds::Uint64, false},
+        {NScheme::NTypeIds::String, true},
+    };
+
+    auto randomValue = [&](const TColDesc& col) -> TTypedValue {
+        TTypedValue v;
+        v.TypeId = col.TypeId;
+        v.IsOptional = col.IsOptional;
+        // 10% chance of NULL (only meaningful for optional columns).
+        if (col.IsOptional && std::uniform_int_distribution<int>(0, 9)(rng) == 0) {
+            v.IsNull = true;
+            return v;
+        }
+        switch (col.TypeId) {
+            case NScheme::NTypeIds::Int32: {
+                i32 val = static_cast<i32>(randomInt(-100000, 100000));
+                v.Data = TString(reinterpret_cast<const char*>(&val), sizeof(i32));
+                break;
+            }
+            case NScheme::NTypeIds::Uint64: {
+                ui64 val = static_cast<ui64>(randomInt(0, std::numeric_limits<i64>::max()));
+                v.Data = TString(reinterpret_cast<const char*>(&val), sizeof(ui64));
+                break;
+            }
+            case NScheme::NTypeIds::String: {
+                v.Data = randomString();
+                break;
+            }
+            default:
+                break;
+        }
+        return v;
+    };
+
+    const int N = 200;
+    std::vector<TTypedTuple> tuples;
+    std::vector<TString> encoded;
+    for (int i = 0; i < N; ++i) {
+        TTypedTuple t;
+        for (const auto& col : columnTypes) {
+            t.push_back(randomValue(col));
+        }
+        tuples.push_back(t);
+        encoded.push_back(EncodeTuple(t));
+    }
+
+    int mismatches = 0;
+    for (int i = 0; i < N; ++i) {
+        for (int j = i + 1; j < N; ++j) {
+            int ydbCmp = Sign(CompareWithYdb(tuples[i], tuples[j]));
+            int encCmp = Sign(CompareEncoded(encoded[i], encoded[j]));
+            if (ydbCmp != encCmp) {
+                ++mismatches;
+                Cerr << "Mismatch at (" << i << "," << j << "): "
+                     << "ydb=" << ydbCmp << " enc=" << encCmp << Endl;
+            }
+        }
+    }
+    UNIT_ASSERT_VALUES_EQUAL_C(mismatches, 0,
+        "TPresortEncoder disagrees with CompareTypedCellVectors in "
+        << mismatches << " out of " << (N * (N - 1) / 2) << " pairs");
+}
+
+} // Y_UNIT_TEST_SUITE(PresortKeyAgreement)

--- a/ydb/core/statistics/ut/ya.make
+++ b/ydb/core/statistics/ut/ya.make
@@ -1,0 +1,22 @@
+UNITTEST()
+
+FORK_SUBTESTS()
+
+SIZE(SMALL)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    ydb/core/scheme
+    ydb/core/scheme_types
+    yql/essentials/minikql/computation
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg_dummy
+)
+
+SRCS(
+    presort_key_agreement_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -17,6 +17,9 @@
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 
 #include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/core/histogram/eq_height_histogram_reader.h>
+
+#include <util/generic/algorithm.h>
 
 using namespace NYdb;
 using namespace NYdb::NTable;
@@ -24,6 +27,16 @@ using namespace NYdb::NScheme;
 
 namespace NKikimr {
 namespace NStat {
+
+namespace {
+
+// Split so keys [0, n) hit all 4 shards. UNIFORM_PARTITIONS would put them in shard 0.
+TString DataShardPartitionAtKeysSetting() {
+    const ui32 n = ColumnTableRowsNumber;
+    return Sprintf("PARTITION_AT_KEYS = (%u, %u, %u)", n / 4, n / 2, 3 * n / 4);
+}
+
+} // namespace
 
 TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads,
     std::function<void(Tests::TServerSettings&)> modifySettings)
@@ -561,12 +574,191 @@ TTableInfo PrepareMultiColumnUniformTable(TTestEnv& env, const TString& database
             PRIMARY KEY (Key),
             STATISTICS multi_stat ON (Value1, Value2) WITH (COUNT_MIN_SKETCH)
         )
-        WITH ( UNIFORM_PARTITIONS = 4 );
-    )", databaseName.c_str(), tableName.c_str()));
+        WITH ( %s );
+    )", databaseName.c_str(), tableName.c_str(), DataShardPartitionAtKeysSetting().c_str()));
 
     InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
 
     return MakeTableInfo(runtime, databaseName, tableName, false);
+}
+
+TTableInfo PrepareMultiColumnEqHeightColumnTable(
+        TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount) {
+    auto fullTableName = Sprintf("Root/%s/%s", databaseName.c_str(), tableName.c_str());
+    auto& runtime = *env.GetServer().GetRuntime();
+
+    ExecuteYqlScript(env, Sprintf(R"(
+        CREATE TABLE `%s` (
+            Key Uint64 NOT NULL,
+            Value1 String,
+            Value2 String,
+            PRIMARY KEY (Key),
+            STATISTICS multi_stat ON (Value1, Value2) WITH (EQ_HEIGHT_HISTOGRAM)
+        )
+        PARTITION BY HASH(Key)
+        WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d);
+    )", fullTableName.c_str(), shardCount));
+    runtime.SimulateSleep(TDuration::Seconds(1));
+
+    InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
+
+    return MakeTableInfo(runtime, databaseName, tableName, true);
+}
+
+TTableInfo PrepareMultiColumnEqHeightUniformTable(TTestEnv& env, const TString& databaseName, const TString& tableName) {
+    auto& runtime = *env.GetServer().GetRuntime();
+
+    ExecuteYqlScript(env, Sprintf(R"(
+        CREATE TABLE `Root/%s/%s` (
+            Key Uint64,
+            Value1 String,
+            Value2 String,
+            PRIMARY KEY (Key),
+            STATISTICS multi_stat ON (Value1, Value2) WITH (EQ_HEIGHT_HISTOGRAM)
+        )
+        WITH ( %s );
+    )", databaseName.c_str(), tableName.c_str(), DataShardPartitionAtKeysSetting().c_str()));
+
+    InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
+
+    return MakeTableInfo(runtime, databaseName, tableName, false);
+}
+
+TTableInfo PrepareMultiColumnEqHeightTable(TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard) {
+    if (columnShard) {
+        return PrepareMultiColumnEqHeightColumnTable(env, databaseName, tableName);
+    }
+    return PrepareMultiColumnEqHeightUniformTable(env, databaseName, tableName);
+}
+
+TTableInfo PrepareMultiColumnAllTypesTable(
+        TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard) {
+    auto& runtime = *env.GetServer().GetRuntime();
+    if (columnShard) {
+        auto fullTableName = Sprintf("Root/%s/%s", databaseName.c_str(), tableName.c_str());
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `%s` (
+                Key Uint64 NOT NULL,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key),
+                STATISTICS multi_stat ON (Value1, Value2)
+            )
+            PARTITION BY HASH(Key)
+            WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
+        )", fullTableName.c_str()));
+        runtime.SimulateSleep(TDuration::Seconds(1));
+    } else {
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `Root/%s/%s` (
+                Key Uint64,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key),
+                STATISTICS multi_stat ON (Value1, Value2)
+            )
+            WITH ( %s );
+        )", databaseName.c_str(), tableName.c_str(), DataShardPartitionAtKeysSetting().c_str()));
+    }
+    InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
+    return MakeTableInfo(runtime, databaseName, tableName, columnShard);
+}
+
+TTableInfo PrepareDeclaredPkAllTypesTable(
+        TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard) {
+    auto& runtime = *env.GetServer().GetRuntime();
+    if (columnShard) {
+        auto fullTableName = Sprintf("Root/%s/%s", databaseName.c_str(), tableName.c_str());
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `%s` (
+                Key Uint64 NOT NULL,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key),
+                STATISTICS pk_hist ON (Key)
+            )
+            PARTITION BY HASH(Key)
+            WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
+        )", fullTableName.c_str()));
+        runtime.SimulateSleep(TDuration::Seconds(1));
+    } else {
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `Root/%s/%s` (
+                Key Uint64,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key),
+                STATISTICS pk_hist ON (Key)
+            )
+            WITH ( %s );
+        )", databaseName.c_str(), tableName.c_str(), DataShardPartitionAtKeysSetting().c_str()));
+    }
+    InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
+    return MakeTableInfo(runtime, databaseName, tableName, columnShard);
+}
+
+TTableInfo PrepareDeclaredPkEqHeightTable(
+        TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard) {
+    auto& runtime = *env.GetServer().GetRuntime();
+    if (columnShard) {
+        auto fullTableName = Sprintf("Root/%s/%s", databaseName.c_str(), tableName.c_str());
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `%s` (
+                Key Uint64 NOT NULL,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key),
+                STATISTICS pk_hist ON (Key) WITH (EQ_HEIGHT_HISTOGRAM)
+            )
+            PARTITION BY HASH(Key)
+            WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
+        )", fullTableName.c_str()));
+        runtime.SimulateSleep(TDuration::Seconds(1));
+    } else {
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `Root/%s/%s` (
+                Key Uint64,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key),
+                STATISTICS pk_hist ON (Key) WITH (EQ_HEIGHT_HISTOGRAM)
+            )
+            WITH ( %s );
+        )", databaseName.c_str(), tableName.c_str(), DataShardPartitionAtKeysSetting().c_str()));
+    }
+    InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
+    return MakeTableInfo(runtime, databaseName, tableName, columnShard);
+}
+
+TTableInfo PrepareCompositePkTable(
+        TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard) {
+    auto& runtime = *env.GetServer().GetRuntime();
+    if (columnShard) {
+        auto fullTableName = Sprintf("Root/%s/%s", databaseName.c_str(), tableName.c_str());
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `%s` (
+                Key Uint64 NOT NULL,
+                Value1 String NOT NULL,
+                Value2 String,
+                PRIMARY KEY (Key, Value1)
+            )
+            PARTITION BY HASH(Key)
+            WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 4);
+        )", fullTableName.c_str()));
+        runtime.SimulateSleep(TDuration::Seconds(1));
+    } else {
+        ExecuteYqlScript(env, Sprintf(R"(
+            CREATE TABLE `Root/%s/%s` (
+                Key Uint64,
+                Value1 String,
+                Value2 String,
+                PRIMARY KEY (Key, Value1)
+            )
+            WITH ( %s );
+        )", databaseName.c_str(), tableName.c_str(), DataShardPartitionAtKeysSetting().c_str()));
+    }
+    InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, MultiColumnValueColumns());
+    return MakeTableInfo(runtime, databaseName, tableName, columnShard);
 }
 
 TTableInfo PrepareUniformTableWithData(TTestEnv& env, const TString& databaseName, const TString& tableName) {
@@ -650,6 +842,25 @@ std::vector<TResponse> GetStatistics(
     return std::move(evResult->Get()->StatResponses);
 }
 
+std::vector<TResponse> GetStatisticsMultiColumn(
+        TTestActorRuntime& runtime, const TPathId& pathId, EStatType statType,
+        const std::vector<ui32>& columnTags, ui32 nodeIdx) {
+    auto statServiceId = NStat::MakeStatServiceID(runtime.GetNodeId(nodeIdx));
+
+    auto evGet = std::make_unique<TEvStatistics::TEvGetStatistics>();
+    evGet->StatType = statType;
+    TRequest req{ .PathId = pathId, .ColumnTags = TColumnTags(columnTags) };
+    evGet->StatRequests.push_back(std::move(req));
+
+    auto sender = runtime.AllocateEdgeActor(nodeIdx);
+    runtime.Send(statServiceId, sender, evGet.release(), nodeIdx, true);
+    auto evResult = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvGetStatisticsResult>(sender);
+
+    UNIT_ASSERT(evResult);
+    UNIT_ASSERT(evResult->Get());
+    return std::move(evResult->Get()->StatResponses);
+}
+
 
 void CheckCountMinSketch(
         TTestActorRuntime& runtime, const TPathId& pathId,
@@ -678,6 +889,122 @@ void CheckCountMinSketch(
             UNIT_ASSERT(!stat.Success);
         }
     }
+}
+
+void CheckEqHeightHistogram(
+        TTestActorRuntime& runtime, const TPathId& pathId,
+        const std::vector<ui32>& columnTags,
+        std::optional<ui64> expectedTotalCount,
+        std::optional<size_t> expectedMinBuckets,
+        std::optional<std::vector<TEqHeightHistogramProbe>> probes,
+        std::optional<bool> requireExact,
+        std::optional<std::vector<TString>> sourceKeys,
+        std::optional<ui64> maxTrueRankError) {
+    auto statServiceId = NStat::MakeStatServiceID(runtime.GetNodeId(1));
+
+    auto evGet = std::make_unique<TEvStatistics::TEvGetStatistics>();
+    evGet->StatType = EStatType::EQ_HEIGHT_HISTOGRAM;
+    evGet->StatRequests.push_back(TRequest{ .PathId = pathId, .ColumnTags = TColumnTags(columnTags) });
+
+    auto sender = runtime.AllocateEdgeActor(1);
+    runtime.Send(statServiceId, sender, evGet.release(), 1, true);
+    auto evResult = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvGetStatisticsResult>(sender);
+
+    UNIT_ASSERT(evResult);
+    UNIT_ASSERT(evResult->Get());
+    auto& responses = evResult->Get()->StatResponses;
+    UNIT_ASSERT_VALUES_EQUAL(responses.size(), 1);
+    const auto& stat = responses[0];
+
+    UNIT_ASSERT(stat.Success);
+    const auto& histogram = stat.EqHeightHistogram.Data;
+    UNIT_ASSERT(histogram);
+
+    if (expectedTotalCount) {
+        UNIT_ASSERT_VALUES_EQUAL(histogram->GetTotalCount(), *expectedTotalCount);
+    }
+    if (expectedMinBuckets) {
+        UNIT_ASSERT(histogram->GetNumBuckets() >= *expectedMinBuckets);
+    }
+    if (probes) {
+        for (const auto& probe : *probes) {
+            auto estimate = histogram->EstimateLessOrEqual(probe.Key);
+            UNIT_ASSERT_VALUES_EQUAL_C(estimate, probe.Expected,
+                "EstimateLessOrEqual returned " << estimate << ", expected " << probe.Expected);
+        }
+    }
+    if (requireExact) {
+        UNIT_ASSERT_VALUES_EQUAL_C(histogram->IsExact(), *requireExact,
+            "IsExact()=" << histogram->IsExact() << " MaxRankError=" << histogram->GetMaxRankError());
+    }
+    if (sourceKeys) {
+        std::vector<TString> sorted = *sourceKeys;
+        Sort(sorted);
+        for (size_t i = 0; i < histogram->GetNumBuckets(); ++i) {
+            const auto bucket = histogram->GetBucket(i);
+            auto it = UpperBound(sorted.begin(), sorted.end(), bucket.UpperBound,
+                [](TStringBuf value, const TString& elem) { return value < TStringBuf(elem); });
+            const ui64 trueRank = static_cast<ui64>(it - sorted.begin());
+            const ui64 actual = bucket.CumulativeCount;
+            const ui64 diff = (actual > trueRank) ? (actual - trueRank) : (trueRank - actual);
+            UNIT_ASSERT_C(diff <= histogram->GetMaxRankError(),
+                "bucket " << i << " cumulative " << actual
+                << " deviates from true rank " << trueRank << " by " << diff
+                << " > MaxRankError " << histogram->GetMaxRankError());
+            if (maxTrueRankError) {
+                UNIT_ASSERT_C(diff <= *maxTrueRankError,
+                    "bucket " << i << " cumulative " << actual
+                    << " deviates from true rank " << trueRank << " by " << diff
+                    << " > 2N/(f·B) bound " << *maxTrueRankError);
+            }
+            if (requireExact && *requireExact) {
+                UNIT_ASSERT_VALUES_EQUAL_C(actual, trueRank,
+                    "bucket " << i << " cumulative " << actual
+                    << " != true rank " << trueRank << " on an exact histogram");
+            }
+        }
+    }
+}
+
+ui64 CountStatisticsV2Rows(
+        TTestEnv& env, const TString& databaseName, const TPathId& pathId,
+        EStatType statType, const TString& columnTags) {
+    TStringBuilder script;
+    script << "SELECT COUNT(*) FROM `/Root/" << databaseName << "/.metadata/statistics_v2` "
+        << "WHERE owner_id = " << pathId.OwnerId
+        << " AND local_path_id = " << pathId.LocalPathId
+        << " AND stat_type = " << static_cast<ui32>(statType)
+        << " AND column_tags = \"" << columnTags << "\";";
+
+    auto& runtime = *env.GetServer().GetRuntime();
+    using TEvExecuteYqlRequest = NGRpcService::TGrpcRequestOperationCall<
+        Ydb::Scripting::ExecuteYqlRequest,
+        Ydb::Scripting::ExecuteYqlResponse>;
+
+    Ydb::Scripting::ExecuteYqlRequest request;
+    request.set_script(script);
+
+    auto future = NRpcService::DoLocalRpc<TEvExecuteYqlRequest>(
+        std::move(request), "", "", runtime.GetActorSystem(0));
+    auto response = runtime.WaitFuture(std::move(future));
+
+    UNIT_ASSERT(response.operation().ready());
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        response.operation().status(), Ydb::StatusIds::SUCCESS,
+        GetIssuesString(response.operation()));
+
+    Ydb::Scripting::ExecuteYqlResult result;
+    UNIT_ASSERT(response.operation().result().UnpackTo(&result));
+    UNIT_ASSERT_VALUES_EQUAL(result.result_sets_size(), 1);
+    const auto& resultSet = result.result_sets(0);
+    UNIT_ASSERT_VALUES_EQUAL(resultSet.rows_size(), 1);
+    const auto& cell = resultSet.rows(0).items(0);
+    if (cell.has_uint64_value()) {
+        return cell.uint64_value();
+    }
+    UNIT_ASSERT_C(cell.has_int64_value(), "COUNT(*) did not return an integer");
+    UNIT_ASSERT_C(cell.int64_value() >= 0, "COUNT(*) was negative");
+    return static_cast<ui64>(cell.int64_value());
 }
 
 static TString ExecuteYqlScriptFetchBytes(TTestEnv& env, const TString& script) {

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -5,11 +5,16 @@
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/protos/analyze_operation.pb.h>
 
+#include <yql/essentials/minikql/computation/presort.h>
+#include <yql/essentials/public/udf/udf_value.h>
+
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
 
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <cmath>
 
 namespace NKikimrStat {
     class TTable;
@@ -19,6 +24,12 @@ namespace NKikimr {
 namespace NStat {
 
 static constexpr ui32 ColumnTableRowsNumber = 1000;
+
+// Rank-error bound for approximate EQ_HEIGHT: 2 * n / (oversampleFactor * ceil(cbrt(n))).
+inline ui64 EqHeightDesignRankErrorBound(ui64 n = ColumnTableRowsNumber, ui32 oversampleFactor = 8) {
+    const ui32 b = static_cast<ui32>(std::ceil(std::cbrt(static_cast<double>(n))));
+    return 2 * n / (static_cast<ui64>(oversampleFactor) * b);
+}
 
 class TTestEnv {
 public:
@@ -131,9 +142,28 @@ TTableInfo PrepareColumnTableWithIndexes(TTestEnv& env, const TString& databaseN
 TTableInfo PrepareMultiColumnColumnTable(
     TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount = 4);
 
-// Create a datashard table with 4 uniform shards and a two-column COUNT_MIN_SKETCH
-// multi-column statistic (see MultiColumnValueColumns), and insert ColumnTableRowsNumber rows.
+// DataShard table split at PARTITION_AT_KEYS (4 shards), two-column COUNT_MIN_SKETCH.
 TTableInfo PrepareMultiColumnUniformTable(TTestEnv& env, const TString& databaseName, const TString& tableName);
+
+// Create a column table with a two-column EQ_HEIGHT_HISTOGRAM multi-column statistic
+// (see MultiColumnValueColumns) and insert ColumnTableRowsNumber rows.
+TTableInfo PrepareMultiColumnEqHeightColumnTable(
+    TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount = 4);
+
+// DataShard table split at PARTITION_AT_KEYS (4 shards), two-column EQ_HEIGHT_HISTOGRAM.
+TTableInfo PrepareMultiColumnEqHeightUniformTable(TTestEnv& env, const TString& databaseName, const TString& tableName);
+
+// Create a table of the requested type with a two-column EQ_HEIGHT_HISTOGRAM
+// multi-column statistic and insert ColumnTableRowsNumber rows.
+TTableInfo PrepareMultiColumnEqHeightTable(TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard);
+
+// STATISTICS without WITH on (Value1, Value2).
+TTableInfo PrepareMultiColumnAllTypesTable(
+    TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard);
+
+// STATISTICS without WITH on the primary key.
+TTableInfo PrepareDeclaredPkAllTypesTable(
+    TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard);
 
 // Create a datashard table with 4 uniform shards and insert ColumnTableRowsNumber rows
 // (Value = key % 10, matching PrepareColumnTable's data pattern).
@@ -184,6 +214,15 @@ std::vector<TResponse> GetStatistics(
     TTestActorRuntime&, const TPathId&, EStatType,
     const std::vector<std::optional<ui32>>& columnTags, ui32 nodeIdx = 1);
 
+// Multi-column variant: requests a single statistic under a multi-column
+// TColumnTags(vector<ui32>), which serializes to a comma-joined key. Use this
+// for multi-column statistics (e.g. EQ_HEIGHT_HISTOGRAM) where the single-column
+// GetStatistics above would construct a TColumnTags(ui32) that only collides
+// with the multi-column key by coincidence of SerializeColumnTags.
+std::vector<TResponse> GetStatisticsMultiColumn(
+    TTestActorRuntime&, const TPathId&, EStatType,
+    const std::vector<ui32>& columnTags, ui32 nodeIdx = 1);
+
 struct TCountMinSketchProbes {
     struct TProbe {
         TString Value;
@@ -198,6 +237,120 @@ struct TCountMinSketchProbes {
 void CheckCountMinSketch(
     TTestActorRuntime& runtime, const TPathId& pathId,
     const std::vector<TCountMinSketchProbes>& expected);
+
+// A probe for EQ_HEIGHT_HISTOGRAM: `Key` is a pre-built presort key (use
+// MakeUint64PresortKey for a single Uint64 column), and `Expected` is the exact
+// value EstimateLessOrEqual must return.
+struct TEqHeightHistogramProbe {
+    TString Key;
+    ui64 Expected;
+};
+
+// Build a presort key for a single Uint64 column value using TPresortEncoder.
+// The encoding is memcomparable: memcmp on the result equals value order.
+// isOptional must match what PresortKey sees in the ANALYZE query: YQL wraps
+// nullable column references in Optional (DataShard PK columns in these tests),
+// while ColumnShard NOT NULL PK columns are encoded as non-optional.
+inline TString MakeUint64PresortKey(ui64 value, bool isOptional = true) {
+    NMiniKQL::TPresortEncoder enc;
+    enc.AddType(NYql::NUdf::EDataSlot::Uint64, isOptional, /*isDesc=*/false);
+    enc.Start();
+    auto pod = NYql::NUdf::TUnboxedValuePod(value);
+    enc.Encode(isOptional ? pod.MakeOptional() : pod);
+    TStringBuf buf = enc.Finish();
+    return TString(buf.data(), buf.size());
+}
+
+// Optional NULL for a single Uint64 column. Not valid for NOT NULL columns.
+inline TString MakeNullPresortKey() {
+    NMiniKQL::TPresortEncoder enc;
+    enc.AddType(NYql::NUdf::EDataSlot::Uint64, /*isOptional=*/true, /*isDesc=*/false);
+    enc.Start();
+    enc.Encode(NYql::NUdf::TUnboxedValuePod()); // empty == NULL
+    TStringBuf buf = enc.Finish();
+    return TString(buf.data(), buf.size());
+}
+
+// Optional-null tuple of `n` String columns. Do not use MakeNullPresortKey() here.
+inline TString MakeNullStringTuplePresortKey(size_t n) {
+    UNIT_ASSERT_C(n > 0, "MakeNullStringTuplePresortKey: empty tuple");
+    NMiniKQL::TPresortEncoder enc;
+    for (size_t i = 0; i < n; ++i) {
+        enc.AddType(NYql::NUdf::EDataSlot::String, /*isOptional=*/true, /*isDesc=*/false);
+    }
+    enc.Start();
+    for (size_t i = 0; i < n; ++i) {
+        enc.Encode(NYql::NUdf::TUnboxedValuePod());
+    }
+    TStringBuf buf = enc.Finish();
+    return TString(buf.data(), buf.size());
+}
+
+// Presort key for a String tuple. isOptional follows column nullability
+// (same as MakeUint64PresortKey). Strings must fit in Embedded (<= 14 bytes).
+inline TString MakeStringTuplePresortKey(const std::vector<TStringBuf>& values, bool isOptional = true) {
+    NMiniKQL::TPresortEncoder enc;
+    for (size_t i = 0; i < values.size(); ++i) {
+        enc.AddType(NYql::NUdf::EDataSlot::String, isOptional, /*isDesc=*/false);
+    }
+    enc.Start();
+    for (auto value : values) {
+        // TUnboxedValuePod::Embedded stores strings up to 14 bytes inline.
+        // Longer strings require a heap-backed TStringValue, which needs a
+        // TScopedAlloc; guard against silent corruption if a future test
+        // uses a longer probe string.
+        UNIT_ASSERT_C(value.size() <= 14,
+            "MakeStringTuplePresortKey: string of " << value.size()
+            << " bytes exceeds the 14-byte Embedded limit");
+        auto pod = NYql::NUdf::TUnboxedValuePod::Embedded(
+            NYql::NUdf::TStringRef(value.data(), value.size()));
+        enc.Encode(isOptional ? pod.MakeOptional() : pod);
+    }
+    TStringBuf buf = enc.Finish();
+    return TString(buf.data(), buf.size());
+}
+
+inline TString MakeUint64StringPresortKey(ui64 key, TStringBuf value, bool isOptional = true) {
+    NMiniKQL::TPresortEncoder enc;
+    enc.AddType(NYql::NUdf::EDataSlot::Uint64, isOptional, /*isDesc=*/false);
+    enc.AddType(NYql::NUdf::EDataSlot::String, isOptional, /*isDesc=*/false);
+    enc.Start();
+    auto keyPod = NYql::NUdf::TUnboxedValuePod(key);
+    enc.Encode(isOptional ? keyPod.MakeOptional() : keyPod);
+    UNIT_ASSERT_C(value.size() <= 14,
+        "MakeUint64StringPresortKey: string of " << value.size()
+        << " bytes exceeds the 14-byte Embedded limit");
+    auto valuePod = NYql::NUdf::TUnboxedValuePod::Embedded(
+        NYql::NUdf::TStringRef(value.data(), value.size()));
+    enc.Encode(isOptional ? valuePod.MakeOptional() : valuePod);
+    TStringBuf buf = enc.Finish();
+    return TString(buf.data(), buf.size());
+}
+
+// Fetch EQ_HEIGHT via the stat service. Optional args add assertions
+// (count, min buckets, probes, IsExact, true-rank vs sourceKeys).
+void CheckEqHeightHistogram(
+    TTestActorRuntime& runtime, const TPathId& pathId,
+    const std::vector<ui32>& columnTags,
+    std::optional<ui64> expectedTotalCount = std::nullopt,
+    std::optional<size_t> expectedMinBuckets = std::nullopt,
+    std::optional<std::vector<TEqHeightHistogramProbe>> probes = std::nullopt,
+    std::optional<bool> requireExact = std::nullopt,
+    std::optional<std::vector<TString>> sourceKeys = std::nullopt,
+    std::optional<ui64> maxTrueRankError = std::nullopt);
+
+// Count rows in `.metadata/statistics_v2` for one (path, type, column_tags) key.
+ui64 CountStatisticsV2Rows(
+    TTestEnv& env, const TString& databaseName, const TPathId& pathId,
+    EStatType statType, const TString& columnTags);
+
+// Table with a declared EQ_HEIGHT_HISTOGRAM on the primary key column (Key).
+TTableInfo PrepareDeclaredPkEqHeightTable(
+    TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard);
+
+// Table with PRIMARY KEY (Key, Value1) and ColumnTableRowsNumber rows.
+TTableInfo PrepareCompositePkTable(
+    TTestEnv& env, const TString& databaseName, const TString& tableName, bool columnShard);
 
 // Checks the multi-column count-min sketch produced from data inserted via
 // MultiColumnValueColumns: the present pair ("0","0") should have count

--- a/ydb/core/statistics/ut_common/ya.make
+++ b/ydb/core/statistics/ut_common/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     ydb/core/protos
     ydb/core/statistics
     ydb/core/statistics/common
+    yql/essentials/minikql/computation
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/statistics/ya.make
+++ b/ydb/core/statistics/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     ydb/library/actors/core
     ydb/library/query_actor
     yql/essentials/core/minsketch
+    yql/essentials/core/histogram
     ydb/core/protos
     ydb/core/scheme
 )
@@ -27,4 +28,5 @@ RECURSE_FOR_TESTS(
     aggregator/ut
     database/ut
     service/ut
+    ut
 )

--- a/ydb/core/sys_view/show_create/create_table_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_table_formatter.cpp
@@ -836,6 +836,9 @@ void TCreateTableFormatter::Format(const Ydb::Table::TableMultiColumnStatistics&
                 case Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH:
                     Stream << "COUNT_MIN_SKETCH";
                     break;
+                case Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM:
+                    Stream << "EQ_HEIGHT_HISTOGRAM";
+                    break;
                 default:
                     ythrow TFormatFail(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected Ydb::Table::TableMultiColumnStatistics statistic type");
             }
@@ -867,6 +870,9 @@ void TCreateTableFormatter::Format(const NKikimrSchemeOp::TMultiColumnStatistics
             switch (statistics.GetTypes(i)) {
                 case NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH:
                     Stream << "COUNT_MIN_SKETCH";
+                    break;
+                case NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM:
+                    Stream << "EQ_HEIGHT_HISTOGRAM";
                     break;
                 default:
                     ythrow TFormatFail(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected NKikimrSchemeOp::TMultiColumnStatisticsDescription statistic type");

--- a/ydb/core/sys_view/ut_show_create.cpp
+++ b/ydb/core/sys_view/ut_show_create.cpp
@@ -782,6 +782,46 @@ Y_UNIT_TEST(TableWithMultiColumnStatistics) {
     );
 }
 
+Y_UNIT_TEST(TableWithEqHeightHistogram) {
+    TTestEnv env(1, 4, {.StoragePools = 3, .ShowCreateTable = true});
+
+    TShowCreateChecker checker(env);
+
+    checker.CheckShowCreateTable(
+        R"(
+            CREATE TABLE test_show_create (
+                Key Uint64,
+                a Uint64,
+                b Utf8,
+                PRIMARY KEY (Key),
+                STATISTICS s ON (a, b) WITH (EQ_HEIGHT_HISTOGRAM)
+            );
+        )", "test_show_create",
+        R"(
+            CREATE TABLE `test_show_create` (
+                `Key` Uint64,
+                `a` Uint64,
+                `b` Utf8,
+                STATISTICS `s` ON (`a`, `b`) WITH (EQ_HEIGHT_HISTOGRAM),
+                PRIMARY KEY (`Key`)
+            );
+        )"
+    );
+
+    checker.CheckShowCreateTable(
+        R"(
+            CREATE TABLE test_show_create (
+                Key Uint64 NOT NULL,
+                a Uint64,
+                b Utf8,
+                PRIMARY KEY (Key),
+                STATISTICS s ON (a, b) WITH (EQ_HEIGHT_HISTOGRAM)
+            )
+            WITH (STORE = COLUMN);
+        )", "test_show_create"
+    );
+}
+
 Y_UNIT_TEST(TableWithMultiColumnStatisticsWithoutWith) {
     TTestEnv env(1, 4, {.StoragePools = 3, .ShowCreateTable = true});
 

--- a/ydb/core/tx/schemeshard/olap/statistics/schema.cpp
+++ b/ydb/core/tx/schemeshard/olap/statistics/schema.cpp
@@ -1,7 +1,10 @@
 #include "schema.h"
 
+#include <ydb/core/scheme/scheme_type_info.h>
 #include <ydb/core/tx/schemeshard/olap/schema/schema.h>
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>
 
+#include <util/generic/algorithm.h>
 #include <util/system/yassert.h>
 
 namespace NKikimr::NSchemeShard {
@@ -69,9 +72,32 @@ bool TOlapMultiColumnStatisticsSchema::ApplyUpsert(const TOlapSchema& currentSch
                 errors.AddError(NKikimrScheme::StatusInvalidParameter, TStringBuilder() << "MultiColumnStatistics '" << Name << "' type must be specified");
                 return false;
             case NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH:
+            case NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM:
                 break;
+            default:
+                errors.AddError(NKikimrScheme::StatusInvalidParameter, TStringBuilder() << "Unknown statistic type: " << static_cast<ui32>(rawType));
+                return false;
         }
         Types.emplace_back(type);
+    }
+
+    if (AnyOf(Types, [](auto t) {
+            return t == NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM;
+        })) {
+        for (const auto& columnName : ColumnNames) {
+            const auto* column = currentSchema.GetColumns().GetByName(columnName);
+            if (!column) {
+                errors.AddError(NKikimrScheme::StatusSchemeError,
+                    TStringBuilder() << "Undefined column: " << columnName);
+                return false;
+            }
+            if (!NScheme::NTypeIds::IsPresortEncodable(column->GetType().GetTypeId())) {
+                errors.AddError(NKikimrScheme::StatusInvalidParameter, TStringBuilder()
+                    << "EQ_HEIGHT_HISTOGRAM is not supported for column '" << columnName
+                    << "' of type " << NScheme::TypeName(column->GetType()));
+                return false;
+            }
+        }
     }
 
     return true;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -16,6 +16,7 @@
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
+#include <ydb/core/scheme/scheme_type_info.h>
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 #include <ydb/core/util/pb.h>
@@ -911,6 +912,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                 desc->AddColumnNames(colName);
                 desc->AddColumnIds(it->second);
             }
+            bool hasEqHeightHistogram = false;
             for (const auto rawType : add.GetTypes()) {
                 const auto type = static_cast<NKikimrSchemeOp::EMultiColumnStatisticsType>(rawType);
                 switch (type) {
@@ -919,11 +921,37 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                         return nullptr;
                     case NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH:
                         break;
+                    case NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM:
+                        hasEqHeightHistogram = true;
+                        break;
                     default:
                         errStr = TStringBuilder() << "Unknown statistic type: " << rawType;
                         return nullptr;
                 }
                 desc->AddTypes(type);
+            }
+            if (hasEqHeightHistogram) {
+                for (const auto& colName : add.GetColumnNames()) {
+                    const ui32 colId = colName2Id.at(colName);
+                    const TColumn* column = nullptr;
+                    if (auto it = alterData->Columns.find(colId); it != alterData->Columns.end()) {
+                        column = &it->second;
+                    } else if (source) {
+                        if (auto it = source->Columns.find(colId); it != source->Columns.end()) {
+                            column = &it->second;
+                        }
+                    }
+                    if (!column || column->IsDropped()) {
+                        errStr = TStringBuilder() << "Undefined column: " << colName;
+                        return nullptr;
+                    }
+                    if (!NScheme::NTypeIds::IsPresortEncodable(column->PType.GetTypeId())) {
+                        errStr = TStringBuilder()
+                            << "EQ_HEIGHT_HISTOGRAM is not supported for column '" << colName
+                            << "' of type " << NScheme::TypeName(column->PType, column->PTypeMod);
+                        return nullptr;
+                    }
+                }
             }
         }
     }

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -4980,6 +4980,72 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
             {NLs::PathExist, NLs::Finished, checkMultiColumnStatistics("s2")});
     }
 
+    Y_UNIT_TEST(MultiColumnStatisticsEqHeightHistogram) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "a"   Type: "Uint64" }
+            Columns { Name: "b"   Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            MultiColumnStatistics { Name: "h1" ColumnNames: "a" ColumnNames: "b" Types: EQ_HEIGHT_HISTOGRAM }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/EqHeightTable"),
+            {NLs::PathExist, NLs::Finished,
+             NLs::CheckMultiColumnStatistics("h1", {"a", "b"},
+                 {NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM})});
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/EqHeightTable"),
+            {NLs::PathExist, NLs::Finished,
+             NLs::CheckMultiColumnStatistics("h1", {"a", "b"},
+                 {NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM})});
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightTable"
+            MultiColumnStatistics { Name: "h2" ColumnNames: "a" Types: EQ_HEIGHT_HISTOGRAM }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/EqHeightTable"),
+            {NLs::PathExist, NLs::Finished,
+             NLs::CheckMultiColumnStatistics("h1", {"a", "b"},
+                 {NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM}),
+             NLs::CheckMultiColumnStatistics("h2", {"a"},
+                 {NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM})});
+    }
+
+    Y_UNIT_TEST(MultiColumnStatisticsEqHeightHistogramRejectsJson) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightJsonTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "js"  Type: "Json" }
+            KeyColumnNames: ["key"]
+            MultiColumnStatistics { Name: "h1" ColumnNames: "js" Types: EQ_HEIGHT_HISTOGRAM }
+        )", {NKikimrScheme::StatusSchemeError});
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightJsonTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "js"  Type: "Json" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightJsonTable"
+            MultiColumnStatistics { Name: "h1" ColumnNames: "js" Types: EQ_HEIGHT_HISTOGRAM }
+        )", {NKikimrScheme::StatusInvalidParameter});
+    }
+
     Y_UNIT_TEST(AlterTableDropColumnReCreateSplit) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -765,6 +765,87 @@ Y_UNIT_TEST_SUITE(TOlap) {
         checkMultiColumnStatistics("s2");
     }
 
+    Y_UNIT_TEST(MultiColumnStatisticsEqHeightHistogram) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        auto checkEqHeight = [&](const TSet<TString>& expectedNames) {
+            auto descr = DescribePrivatePath(runtime, "/MyRoot/EqHeightColumnTable");
+            const auto& tableDesc = descr.GetPathDescription().GetColumnTableDescription();
+            TSet<TString> names;
+            for (const auto& stat : tableDesc.GetMultiColumnStatistics()) {
+                names.insert(stat.GetName());
+                UNIT_ASSERT_VALUES_EQUAL(stat.ColumnNamesSize(), stat.ColumnIdsSize());
+                UNIT_ASSERT(stat.ColumnNamesSize() > 0);
+                UNIT_ASSERT(stat.TypesSize() > 0);
+                for (const auto type : stat.GetTypes()) {
+                    UNIT_ASSERT_EQUAL(
+                        static_cast<NKikimrSchemeOp::EMultiColumnStatisticsType>(type),
+                        NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM);
+                }
+            }
+            UNIT_ASSERT_VALUES_EQUAL(names, expectedNames);
+        };
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightColumnTable"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "key1" Type: "Uint32" }
+                Columns { Name: "data" Type: "Utf8" }
+                KeyColumnNames: [ "timestamp" ]
+            }
+            MultiColumnStatistics { Name: "h1" ColumnNames: "key1" ColumnNames: "data" Types: EQ_HEIGHT_HISTOGRAM }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        checkEqHeight({"h1"});
+
+        GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+        checkEqHeight({"h1"});
+
+        TestAlterColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightColumnTable"
+            UpsertMultiColumnStatistics { Name: "h2" ColumnNames: "data" Types: EQ_HEIGHT_HISTOGRAM }
+        )", {NKikimrScheme::StatusSuccess});
+        env.TestWaitNotification(runtime, txId);
+        checkEqHeight({"h1", "h2"});
+    }
+
+    Y_UNIT_TEST(MultiColumnStatisticsEqHeightHistogramRejectsJson) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightJsonColumnTable"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "js" Type: "Json" }
+                KeyColumnNames: [ "timestamp" ]
+            }
+            MultiColumnStatistics { Name: "h1" ColumnNames: "js" Types: EQ_HEIGHT_HISTOGRAM }
+        )", {NKikimrScheme::StatusSchemeError, NKikimrScheme::StatusInvalidParameter});
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightJsonColumnTable"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "js" Type: "Json" }
+                KeyColumnNames: [ "timestamp" ]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "EqHeightJsonColumnTable"
+            UpsertMultiColumnStatistics { Name: "h1" ColumnNames: "js" Types: EQ_HEIGHT_HISTOGRAM }
+        )", {NKikimrScheme::StatusSchemeError, NKikimrScheme::StatusInvalidParameter});
+    }
+
     Y_UNIT_TEST(CreateTable) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -760,6 +760,9 @@ bool BuildAlterTableModifyScheme(const TString& path, const Ydb::Table::AlterTab
                     case Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH:
                         statisticsDesc->AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH);
                         break;
+                    case Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM:
+                        statisticsDesc->AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM);
+                        break;
                     default:
                         code = Ydb::StatusIds::BAD_REQUEST;
                         error = "Unknown statistic type";
@@ -1602,6 +1605,9 @@ bool BuildAlterColumnTableModifyScheme(const TString& path, const Ydb::Table::Al
                     case Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH:
                         statisticsDesc->AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH);
                         break;
+                    case Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM:
+                        statisticsDesc->AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM);
+                        break;
                     default:
                         status = Ydb::StatusIds::BAD_REQUEST;
                         error = "Unknown statistic type";
@@ -2160,6 +2166,9 @@ void FillMultiColumnStatisticsDescriptionImpl(TYdbProto& out,
                 case NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH:
                     outMultiColumnStatistics->add_types(Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH);
                     break;
+                case NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM:
+                    outMultiColumnStatistics->add_types(Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM);
+                    break;
                 default:
                     break;
             }
@@ -2187,6 +2196,9 @@ void FillMultiColumnStatistics(NKikimrSchemeOp::TMultiColumnStatisticsDescriptio
         switch (type) {
             case Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH:
                 out.AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::COUNT_MIN_SKETCH);
+                break;
+            case Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM:
+                out.AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::EQ_HEIGHT_HISTOGRAM);
                 break;
             default:
                 out.AddTypes(NKikimrSchemeOp::EMultiColumnStatisticsType::MULTI_COLUMN_STATISTICS_UNSPECIFIED);

--- a/ydb/library/yql/udfs/statistics_internal/all_agg_funcs.h
+++ b/ydb/library/yql/udfs/statistics_internal/all_agg_funcs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cms_agg_func.h"
+#include "eqh_agg_func.h"
 #include "ewh_agg_func.h"
 #include "hll_agg_func.h"
 
@@ -9,6 +10,7 @@ namespace NKikimr::NStat::NAggFuncs {
 using TAllAggFuncsList = TTypeList<
     TCMSAggFunc,
     TEWHAggFunc,
+    TEQHAggFunc,
     THLLAggFunc
 >;
 

--- a/ydb/library/yql/udfs/statistics_internal/eqh_agg_func.h
+++ b/ydb/library/yql/udfs/statistics_internal/eqh_agg_func.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "common.h"
+
+#include <yql/essentials/core/histogram/eq_height_histogram.h>
+
+namespace NKikimr::NStat::NAggFuncs {
+
+// UDAF computing an equi-height histogram over memcomparable keys produced by
+// StatisticsInternal::PresortKey. The item type is always String, so the column
+// type id is ignored.
+class TEQHAggFunc {
+public:
+  static constexpr std::string_view GetName() { return "EQH"; }
+
+  using TState = NKikimr::TEqHeightHistogramBuilder;
+
+  static constexpr size_t ParamsCount =
+      3; // numBuckets, emissionRate, maxStateBytes
+
+  static TState
+  CreateState(TTypeId, const std::span<const TValue, ParamsCount> &params) {
+    return TState(TState::TParams{
+        .NumBuckets = params[0].Get<ui32>(),
+        .EmissionRate = params[1].Get<ui32>(),
+        .MaxStateBytes = params[2].Get<ui64>(),
+    });
+  }
+
+  static auto CreateStateUpdater(TTypeId) {
+    return [](TState &state, const TValue &val) {
+      const auto ref = val.AsStringRef();
+      state.Add(TStringBuf(ref.Data(), ref.Size()));
+    };
+  }
+
+  static void MergeStates(const TState &left, TState &right) {
+    right.Merge(left);
+  }
+
+  static TString SerializeState(const TState &state) {
+    return state.Serialize().SerializeAsString();
+  }
+
+  static TState DeserializeState(const char *data, size_t size) {
+    TEqHeightHistogramIntermediateState state;
+    Y_ENSURE(state.ParseFromArray(data, size));
+    return TState(state);
+  }
+
+  // Empty means "no histogram"; TMultiColumnEqHeightHistogramEval turns that
+  // into a skipped row.
+  static TString FinalizeState(const TState &state) {
+    auto result = state.Finalize();
+    return result.Defined() ? result->SerializeAsString() : TString();
+  }
+};
+
+} // namespace NKikimr::NStat::NAggFuncs

--- a/ydb/library/yql/udfs/statistics_internal/presort_key_udf.h
+++ b/ydb/library/yql/udfs/statistics_internal/presort_key_udf.h
@@ -4,6 +4,8 @@
 #include <yql/essentials/public/udf/udf_helpers.h>
 #include <yql/essentials/public/udf/udf_type_inspection.h>
 
+#include <util/system/yassert.h>
+
 namespace NKikimr::NStat::NAggFuncs {
 
 // Scalar UDF: StatisticsInternal::PresortKey(AsTuple(a, b, ...)) -> String
@@ -19,11 +21,17 @@ class TPresortKeyFunc : public NYql::NUdf::TBoxedValue {
     TVector<TElementDesc> Elements_;
     bool IsTuple_ = false;
     NYql::NUdf::TSourcePosition Pos_;
+    mutable NMiniKQL::TPresortEncoder Encoder_;
 
 public:
     explicit TPresortKeyFunc(TVector<TElementDesc> elements, bool isTuple,
                              NYql::NUdf::TSourcePosition pos)
-        : Elements_(std::move(elements)), IsTuple_(isTuple), Pos_(pos) {}
+        : Elements_(std::move(elements)), IsTuple_(isTuple), Pos_(pos)
+    {
+        for (const auto& e : Elements_) {
+            Encoder_.AddType(e.Slot, e.IsOptional, /*isDesc=*/false);
+        }
+    }
 
     static NYql::NUdf::TStringRef Name() {
         static const TString name = "PresortKey";
@@ -133,31 +141,18 @@ private:
     Run(const NYql::NUdf::IValueBuilder *valueBuilder,
         const NYql::NUdf::TUnboxedValuePod *args) const override {
         try {
-            // Build the encoder per call. AddType just appends to a small vector, so
-            // this is cheap, and it avoids the stale-encoder hazard of a thread_local
-            // cache keyed by `this`: the implementation object is owned by the
-            // function registry and dies when the query ends, so a later query can
-            // allocate a new TPresortKeyFunc at the same address with a different
-            // Elements_ list and silently reuse the wrong encoder.
-            NMiniKQL::TPresortEncoder encoder;
-            for (const auto &e : Elements_) {
-                encoder.AddType(e.Slot, e.IsOptional, /*isDesc=*/false);
-            }
+            Y_DEBUG_ABORT_UNLESS(!Elements_.empty());
+            Y_DEBUG_ABORT_UNLESS(IsTuple_ || Elements_.size() == 1);
 
-            encoder.Start();
+            Encoder_.Start();
             for (size_t i = 0; i < Elements_.size(); ++i) {
-                // Encode() takes const TUnboxedValuePod& and handles the optional
-                // itself: it writes the has-value byte inline and returns early when
-                // the value is empty, so no unwrapping is needed here.  TUnboxedValue
-                // derives from TUnboxedValuePod, so both branches bind directly to the
-                // base reference without any explicit cast.
                 if (IsTuple_) {
-                    encoder.Encode(args[0].GetElement(i));
+                    Encoder_.Encode(args[0].GetElement(i));
                 } else {
-                    encoder.Encode(args[0]);
+                    Encoder_.Encode(args[0]);
                 }
             }
-            const TStringBuf encoded = encoder.Finish(); // borrowed -- copy before next Start()
+            const TStringBuf encoded = Encoder_.Finish();
             return valueBuilder->NewString(
                 NYql::NUdf::TStringRef(encoded.data(), encoded.size()));
         } catch (const std::exception &ex) {

--- a/ydb/library/yql/udfs/statistics_internal/presort_key_udf.h
+++ b/ydb/library/yql/udfs/statistics_internal/presort_key_udf.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <yql/essentials/minikql/computation/presort.h>
+#include <yql/essentials/public/udf/udf_helpers.h>
+#include <yql/essentials/public/udf/udf_type_inspection.h>
+
+namespace NKikimr::NStat::NAggFuncs {
+
+// Scalar UDF: StatisticsInternal::PresortKey(AsTuple(a, b, ...)) -> String
+// Encodes a tuple of values into memcomparable byte keys using
+// NMiniKQL::TPresortEncoder. The result preserves the intended value order under
+// memcmp.
+class TPresortKeyFunc : public NYql::NUdf::TBoxedValue {
+    struct TElementDesc {
+        NYql::NUdf::EDataSlot Slot = NYql::NUdf::EDataSlot::Bool;
+        bool IsOptional = false;
+    };
+
+    TVector<TElementDesc> Elements_;
+    bool IsTuple_ = false;
+    NYql::NUdf::TSourcePosition Pos_;
+
+public:
+    explicit TPresortKeyFunc(TVector<TElementDesc> elements, bool isTuple,
+                             NYql::NUdf::TSourcePosition pos)
+        : Elements_(std::move(elements)), IsTuple_(isTuple), Pos_(pos) {}
+
+    static NYql::NUdf::TStringRef Name() {
+        static const TString name = "PresortKey";
+        return name;
+    }
+
+    static bool DeclareSignature(const NYql::NUdf::TStringRef &name,
+                                 NYql::NUdf::TType *userType,
+                                 NYql::NUdf::IFunctionTypeInfoBuilder &builder,
+                                 bool typesOnly) {
+        if (name != Name()) {
+            return false;
+        }
+
+        if (!userType) {
+            builder.SetError("User type is not specified");
+            return true;
+        }
+        builder.UserType(userType);
+
+        auto typeHelper = builder.TypeInfoHelper();
+        auto userTypeInspector =
+            NYql::NUdf::TTupleTypeInspector(*typeHelper, userType);
+        if (!userTypeInspector || userTypeInspector.GetElementsCount() < 1) {
+            builder.SetError("Invalid user type");
+            return true;
+        }
+
+        // The userType is a tuple of (args_tuple, optional return type).
+        // args_tuple is the first element; unwrap it to get the single argument.
+        auto argsTupleType = userTypeInspector.GetElementType(0);
+        auto argsTupleInspector =
+            NYql::NUdf::TTupleTypeInspector(*typeHelper, argsTupleType);
+        if (!argsTupleInspector || argsTupleInspector.GetElementsCount() != 1) {
+            builder.SetError("PresortKey expects exactly one argument");
+            return true;
+        }
+        auto argType = argsTupleInspector.GetElementType(0);
+        builder.Args()->Add(argType);
+        builder.Returns<char *>();
+
+        // Validate even when typesOnly, so Json fails annotation not Encode().
+        TVector<TElementDesc> elements;
+        bool isTuple = false;
+
+        auto addElement = [&](const NYql::NUdf::TType* elemType) -> bool {
+            TElementDesc desc;
+            auto optInspector =
+                NYql::NUdf::TOptionalTypeInspector(*typeHelper, elemType);
+            if (optInspector) {
+                desc.IsOptional = true;
+                elemType = optInspector.GetItemType();
+            }
+            auto dataInspector =
+                NYql::NUdf::TDataTypeInspector(*typeHelper, elemType);
+            if (!dataInspector) {
+                return false;
+            }
+            auto slot = NYql::NUdf::FindDataSlot(dataInspector.GetTypeId());
+            if (!slot) {
+                return false;
+            }
+            desc.Slot = *slot;
+            // Encode() has no case for these.
+            switch (desc.Slot) {
+            case NYql::NUdf::EDataSlot::Json:
+            case NYql::NUdf::EDataSlot::Yson:
+            case NYql::NUdf::EDataSlot::JsonDocument:
+                return false;
+            default:
+                break;
+            }
+            elements.push_back(desc);
+            return true;
+        };
+
+        // If argType is a Tuple, walk its elements; otherwise treat it as a
+        // 1-element tuple.
+        auto argTupleInspector =
+            NYql::NUdf::TTupleTypeInspector(*typeHelper, argType);
+        if (argTupleInspector) {
+            isTuple = true;
+            for (ui32 i = 0; i < argTupleInspector.GetElementsCount(); ++i) {
+                if (!addElement(argTupleInspector.GetElementType(i))) {
+                    builder.SetError("Unsupported element type in PresortKey");
+                    return true;
+                }
+            }
+            if (elements.empty()) {
+                builder.SetError("PresortKey expects a non-empty tuple");
+                return true;
+            }
+        } else if (!addElement(argType)) {
+            builder.SetError("Unsupported argument type in PresortKey");
+            return true;
+        }
+
+        if (!typesOnly) {
+            builder.Implementation(new TPresortKeyFunc(std::move(elements), isTuple,
+                                                     GetSourcePosition(builder)));
+        }
+        return true;
+    }
+
+private:
+    NYql::NUdf::TUnboxedValue
+    Run(const NYql::NUdf::IValueBuilder *valueBuilder,
+        const NYql::NUdf::TUnboxedValuePod *args) const override {
+        try {
+            // Build the encoder per call. AddType just appends to a small vector, so
+            // this is cheap, and it avoids the stale-encoder hazard of a thread_local
+            // cache keyed by `this`: the implementation object is owned by the
+            // function registry and dies when the query ends, so a later query can
+            // allocate a new TPresortKeyFunc at the same address with a different
+            // Elements_ list and silently reuse the wrong encoder.
+            NMiniKQL::TPresortEncoder encoder;
+            for (const auto &e : Elements_) {
+                encoder.AddType(e.Slot, e.IsOptional, /*isDesc=*/false);
+            }
+
+            encoder.Start();
+            for (size_t i = 0; i < Elements_.size(); ++i) {
+                // Encode() takes const TUnboxedValuePod& and handles the optional
+                // itself: it writes the has-value byte inline and returns early when
+                // the value is empty, so no unwrapping is needed here.  TUnboxedValue
+                // derives from TUnboxedValuePod, so both branches bind directly to the
+                // base reference without any explicit cast.
+                if (IsTuple_) {
+                    encoder.Encode(args[0].GetElement(i));
+                } else {
+                    encoder.Encode(args[0]);
+                }
+            }
+            const TStringBuf encoded = encoder.Finish(); // borrowed -- copy before next Start()
+            return valueBuilder->NewString(
+                NYql::NUdf::TStringRef(encoded.data(), encoded.size()));
+        } catch (const std::exception &ex) {
+            TStringBuilder sb;
+            APPEND_SOURCE_LOCATION(sb, valueBuilder, Pos_)
+            sb << ex.what();
+            UdfTerminate(sb.c_str());
+        }
+    }
+};
+
+} // namespace NKikimr::NStat::NAggFuncs

--- a/ydb/library/yql/udfs/statistics_internal/test/canondata/result.json
+++ b/ydb/library/yql/udfs/statistics_internal/test/canondata/result.json
@@ -8,5 +8,10 @@
         {
             "uri": "file://test.test_equi_width_histogram_/results.txt"
         }
+    ],
+    "test.test[eq_height_histogram]": [
+        {
+            "uri": "file://test.test_eq_height_histogram_/results.txt"
+        }
     ]
 }

--- a/ydb/library/yql/udfs/statistics_internal/test/canondata/test.test_eq_height_histogram_/results.txt
+++ b/ydb/library/yql/udfs/statistics_internal/test/canondata/test.test_eq_height_histogram_/results.txt
@@ -1,0 +1,36 @@
+[
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "column0";
+                                [
+                                    "DataType";
+                                    "Bool"
+                                ]
+                            ];
+                            [
+                                "column1";
+                                [
+                                    "DataType";
+                                    "Bool"
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        %true;
+                        %true
+                    ]
+                ]
+            }
+        ]
+    }
+]

--- a/ydb/library/yql/udfs/statistics_internal/test/cases/eq_height_histogram.sql
+++ b/ydb/library/yql/udfs/statistics_internal/test/cases/eq_height_histogram.sql
@@ -1,0 +1,25 @@
+$get_factory = ($buckets, $emission, $maxBytes) -> { return AggregationFactory(
+        "UDAF",
+        ($item, $parent) -> { return Udf(StatisticsInternal::EQHCreate, $parent as Depends)($item, $buckets, $emission, $maxBytes) },
+        ($state, $item, $parent) -> { return Udf(StatisticsInternal::EQHAddValue, $parent as Depends)($state, $item) },
+        StatisticsInternal::EQHMerge,
+        StatisticsInternal::EQHFinalize,
+        StatisticsInternal::EQHSerialize,
+        StatisticsInternal::EQHDeserialize,
+    )
+};
+
+$t1 = [
+    <|key: 1u, value: "v1"|>,
+    <|key: 2u, value: "v2"|>,
+    <|key: 3u, value: "v3"|>
+];
+
+-- Typed suffixes are load-bearing: a bare integer types as Int32, and
+-- EQHCreate reads params with Get<ui32>() / Get<ui64>(). 2147483648ul does
+-- not fit in Int32, so a missing `ul` fails this case instead of silently
+-- feeding garbage into MaxStateBytes.
+select
+    Length(Unwrap(AGGREGATE_BY(Udf(StatisticsInternal::PresortKey)(AsTuple(key)), $get_factory(4u, 32u, 2147483648ul)))) > 0,
+    Length(Unwrap(AGGREGATE_BY(Udf(StatisticsInternal::PresortKey)(AsTuple(value)), $get_factory(4u, 32u, 2147483648ul)))) > 0
+from AS_TABLE($t1);

--- a/ydb/library/yql/udfs/statistics_internal/udf.cpp
+++ b/ydb/library/yql/udfs/statistics_internal/udf.cpp
@@ -1,4 +1,5 @@
 #include <ydb/library/yql/udfs/statistics_internal/all_agg_funcs.h>
+#include <ydb/library/yql/udfs/statistics_internal/presort_key_udf.h>
 #include <yql/essentials/public/udf/udf_helpers.h>
 #include <util/string/cast.h>
 
@@ -360,6 +361,7 @@ public:
 
     void GetAllFunctions(NYql::NUdf::IFunctionsSink& sink) const final {
         (GetAllFunctionsImpl<TAggFuncList>(sink), ...);
+        sink.Add(TPresortKeyFunc::Name())->SetTypeAwareness();
     }
 
     void BuildFunctionTypeInfo(
@@ -369,8 +371,12 @@ public:
         ui32 flags,
         NYql::NUdf::IFunctionTypeInfoBuilder& builder) const override {
         try {
+            const bool typesOnly = (flags & TFlags::TypesOnly);
             bool found = (BuildFunctionTypeInfoImpl<TAggFuncList>(
                 name, userType, typeConfig, flags, builder) || ...);
+            if (!found) {
+                found = TPresortKeyFunc::DeclareSignature(name, userType, builder, typesOnly);
+            }
             if (!found) {
                 TStringBuilder sb;
                 sb << "Unknown function: " << TStringBuf(name);

--- a/ydb/library/yql/udfs/statistics_internal/ya.make
+++ b/ydb/library/yql/udfs/statistics_internal/ya.make
@@ -8,8 +8,10 @@ YQL_ABI_VERSION(
 
 SRCS(
     cms_agg_func.h
+    eqh_agg_func.h
     ewh_agg_func.h
     hll_agg_func.h
+    presort_key_udf.h
     all_agg_funcs.cpp
     all_agg_funcs.h
     common.h
@@ -20,6 +22,7 @@ PEERDIR(
     library/cpp/hyperloglog
     yql/essentials/core/minsketch
     yql/essentials/core/histogram
+    yql/essentials/minikql/computation
 )
 
 END()

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -454,6 +454,7 @@ message TableMultiColumnStatistics {
     enum MultiColumnStatisticsType {
         STATISTIC_TYPE_UNSPECIFIED = 0;
         COUNT_MIN_SKETCH = 1;
+        EQ_HEIGHT_HISTOGRAM = 2;
     }
     // Name of statistics
     string name = 1;

--- a/ydb/public/lib/scheme_types/scheme_type_id.h
+++ b/ydb/public/lib/scheme_types/scheme_type_id.h
@@ -103,6 +103,18 @@ constexpr bool IsYqlType(TTypeId typeId) {
     return IsYqlTypeImpl(typeId, 0);
 }
 
+// Json/Yson/JsonDocument are YQL types but have no TPresortEncoder::Encode() case.
+constexpr bool IsPresortEncodable(TTypeId typeId) {
+    switch (typeId) {
+    case Json:
+    case Yson:
+    case JsonDocument:
+        return false;
+    default:
+        return IsYqlType(typeId);
+    }
+}
+
 constexpr bool IsParametrizedType(TTypeId typeId) {
     return typeId == Pg
         || typeId == Decimal

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v3.22.0
 
+* Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
+
 * Added `IWriteSession::Flush` to asynchronously wait until all previously accepted topic writes are acknowledged.
 
 * Fixed query parameters with incomplete types being sent to the server; the parameter builder now reports the error locally.

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,6 +1,6 @@
-# v3.22.0
-
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
+
+# v3.22.0
 
 * Added `IWriteSession::Flush` to asynchronously wait until all previously accepted topic writes are acknowledged.
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -1046,6 +1046,7 @@ enum class EStoreType {
 enum class EMultiColumnStatisticsType {
     Unknown = 0,
     CountMinSketch = 1,
+    EqHeightHistogram = 2,
 };
 
 //! Represents multi-column table statistics description

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -3516,6 +3516,9 @@ TMultiColumnStatisticsDescription TMultiColumnStatisticsDescription::FromProto(c
         case Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH:
             types.push_back(EMultiColumnStatisticsType::CountMinSketch);
             break;
+        case Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM:
+            types.push_back(EMultiColumnStatisticsType::EqHeightHistogram);
+            break;
         default:
             types.push_back(EMultiColumnStatisticsType::Unknown);
             break;
@@ -3545,6 +3548,9 @@ void TMultiColumnStatisticsDescription::SerializeTo(Ydb::Table::TableMultiColumn
         switch (type) {
         case EMultiColumnStatisticsType::CountMinSketch:
             proto.add_types(Ydb::Table::TableMultiColumnStatistics::COUNT_MIN_SKETCH);
+            break;
+        case EMultiColumnStatisticsType::EqHeightHistogram:
+            proto.add_types(Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM);
             break;
         case EMultiColumnStatisticsType::Unknown:
             proto.add_types(Ydb::Table::TableMultiColumnStatistics::STATISTIC_TYPE_UNSPECIFIED);

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 #include <library/cpp/testing/common/network.h>
@@ -7,6 +8,7 @@
 #include <util/string/cast.h>
 
 #include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
+#include <ydb/public/api/protos/ydb_table.pb.h>
 
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
@@ -779,6 +781,29 @@ TEST(TableTest, AlterTableDroppedMetricsSettings) {
 
     ASSERT_TRUE(!tableService.LastAlterTableRequest->has_set_metrics_settings());
     ASSERT_TRUE(tableService.LastAlterTableRequest->has_drop_metrics_settings());
+}
+
+/**
+ * Verify proto round-trip for equi-height histogram multi-column statistics.
+ */
+TEST(TableTest, MultiColumnStatisticsEqHeightHistogramRoundTrip) {
+    NTable::TMultiColumnStatisticsDescription desc(
+        "h1",
+        {"a", "b"},
+        {NTable::EMultiColumnStatisticsType::EqHeightHistogram});
+
+    Ydb::Table::TableMultiColumnStatistics proto;
+    desc.SerializeTo(proto);
+    ASSERT_EQ(proto.name(), "h1");
+    ASSERT_EQ(proto.columns_size(), 2);
+    ASSERT_EQ(proto.types_size(), 1);
+    ASSERT_EQ(proto.types(0), Ydb::Table::TableMultiColumnStatistics::EQ_HEIGHT_HISTOGRAM);
+
+    auto roundTrip = TProtoAccessor::FromProto(proto);
+    ASSERT_EQ(roundTrip.GetName(), "h1");
+    ASSERT_EQ(roundTrip.GetColumns().size(), 2u);
+    ASSERT_EQ(roundTrip.GetTypes().size(), 1u);
+    ASSERT_EQ(roundTrip.GetTypes()[0], NTable::EMultiColumnStatisticsType::EqHeightHistogram);
 }
 
 /**

--- a/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     library/cpp/testing/common
     library/cpp/testing/gtest
     ydb/public/api/grpc
+    ydb/public/api/protos
     ydb/public/sdk/cpp/src/client/table
 )
 


### PR DESCRIPTION
ANALYZE can collect equi-height histograms over primary keys and declared multi-column statistics (including strings). 

This PR is **collection, persistence, and serving only** — no CBO estimator.

Equi-width histograms need arithmetic, so strings and composite keys have no histogram today. Equi-height buckets are delimited by real values and only need order. Keys are encoded with `StatisticsInternal::PresortKey` (`NMiniKQL::TPresortEncoder`) so `memcmp` matches YDB value order.

**ANALYZE**
- Automatic PK-tuple histogram when `TStatisticsConfig.AnalyzeCollectPrimaryKeyHistogram` is true (default false). Declared `WITH (EQ_HEIGHT_HISTOGRAM)` is collected regardless.
- DataShard PK: sorted disjoint ranges → exact ranks. Non-PK / ColumnShard: bounded approximate (`≤ 2N/(f·B)`).

**DDL:** 
* `CREATE TABLE … STATISTICS name ON (cols) WITH (EQ_HEIGHT_HISTOGRAM)` 

KIKIMR-26443