### PR TITLE
Optimize JsonValue for native columns

### DIFF
--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/constructors.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/constructors.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_binary.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/type_traits.h>
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
@@ -22,7 +23,7 @@ TBlobWithAdditionalAccessorData TBinaryDenseConstructor::DoSerializeToBlobAndMet
     const std::shared_ptr<IChunkedArray>& columnData, const TChunkConstructionData& externalInfo) const {
     AFL_VERIFY(columnData->GetType() == IChunkedArray::EType::Array)("array_type", columnData->GetType());
     const auto* trivial = static_cast<const TTrivialArray*>(columnData.get());
-    AFL_VERIFY(trivial->GetArray()->type_id() == arrow::Type::BINARY)("element_type", trivial->GetArray()->type()->ToString());
+    AFL_VERIFY(arrow::is_binary_like(trivial->GetArray()->type_id()))("element_type", trivial->GetArray()->type()->ToString());
     const auto& binary = static_cast<const arrow::BinaryArray&>(*trivial->GetArray());
     return { SerializeBinaryArray(binary, GetCompressionCodec(externalInfo)),
         std::make_shared<TEmptyAdditionalData>() };
@@ -30,7 +31,8 @@ TBlobWithAdditionalAccessorData TBinaryDenseConstructor::DoSerializeToBlobAndMet
 
 TConclusion<std::shared_ptr<IChunkedArray>> TBinaryDenseConstructor::DoDeserializeFromString(
     const TString& originalData, const TChunkConstructionData& externalInfo) const {
-    auto array = DeserializeBinaryArray(originalData, externalInfo.GetRecordsCount(), GetCompressionCodec(externalInfo));
+    auto array = DeserializeBinaryArray(
+        originalData, externalInfo.GetRecordsCount(), externalInfo.GetColumnType(), GetCompressionCodec(externalInfo));
     return std::make_shared<TTrivialArray>(array);
 }
 
@@ -39,7 +41,7 @@ TBlobWithAdditionalAccessorData TDictionaryDenseConstructor::DoSerializeToBlobAn
     AFL_VERIFY(columnData->GetType() == IChunkedArray::EType::Dictionary)("type", columnData->GetType());
     const auto* dict = static_cast<const TDictionaryArray*>(columnData.get());
     const auto& dictionary = dict->GetDictionary();
-    AFL_VERIFY(dictionary->type_id() == arrow::Type::BINARY)("element_type", dictionary->type()->ToString());
+    AFL_VERIFY(arrow::is_binary_like(dictionary->type_id()))("element_type", dictionary->type()->ToString());
     const auto& dictBinary = static_cast<const arrow::BinaryArray&>(*dictionary);
     const auto codec = GetCompressionCodec(externalInfo);
     const TString dictBlob = SerializeBinaryArray(dictBinary, codec);
@@ -79,7 +81,7 @@ TConclusion<std::shared_ptr<IChunkedArray>> TDictionaryDenseConstructor::DoDeser
     const TStringBuf positionsBlob(originalData.data() + dictionaryBlobSize, originalData.size() - dictionaryBlobSize);
     const auto codec = GetCompressionCodec(externalInfo);
 
-    auto dictionary = DeserializeBinaryArray(dictBlob, dictLength, codec);
+    auto dictionary = DeserializeBinaryArray(dictBlob, dictLength, externalInfo.GetColumnType(), codec);
     std::shared_ptr<arrow::Array> positions = DeserializeIndices(
         positionsBlob, externalInfo.GetRecordsCount(), NDictionary::TConstructor::GetTypeByVariantsCount(dictLength), codec);
     return std::make_shared<TDictionaryArray>(dictionary, positions);

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/constructors.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/constructors.cpp
@@ -25,13 +25,13 @@ TBlobWithAdditionalAccessorData TBinaryDenseConstructor::DoSerializeToBlobAndMet
     const auto* trivial = static_cast<const TTrivialArray*>(columnData.get());
     AFL_VERIFY(arrow::is_binary_like(trivial->GetArray()->type_id()))("element_type", trivial->GetArray()->type()->ToString());
     const auto& binary = static_cast<const arrow::BinaryArray&>(*trivial->GetArray());
-    return { SerializeBinaryArray(binary, GetCompressionCodec(externalInfo)),
+    return { SerializeBinaryLikeArray(binary, GetCompressionCodec(externalInfo)),
         std::make_shared<TEmptyAdditionalData>() };
 }
 
 TConclusion<std::shared_ptr<IChunkedArray>> TBinaryDenseConstructor::DoDeserializeFromString(
     const TString& originalData, const TChunkConstructionData& externalInfo) const {
-    auto array = DeserializeBinaryArray(
+    auto array = DeserializeBinaryLikeArray(
         originalData, externalInfo.GetRecordsCount(), externalInfo.GetColumnType(), GetCompressionCodec(externalInfo));
     return std::make_shared<TTrivialArray>(array);
 }
@@ -44,7 +44,7 @@ TBlobWithAdditionalAccessorData TDictionaryDenseConstructor::DoSerializeToBlobAn
     AFL_VERIFY(arrow::is_binary_like(dictionary->type_id()))("element_type", dictionary->type()->ToString());
     const auto& dictBinary = static_cast<const arrow::BinaryArray&>(*dictionary);
     const auto codec = GetCompressionCodec(externalInfo);
-    const TString dictBlob = SerializeBinaryArray(dictBinary, codec);
+    const TString dictBlob = SerializeBinaryLikeArray(dictBinary, codec);
 
     AFL_VERIFY(dictBinary.length() <= Max<ui32>())("length", dictBinary.length());
     const ui32 dictLength = static_cast<ui32>(dictBinary.length());
@@ -81,7 +81,7 @@ TConclusion<std::shared_ptr<IChunkedArray>> TDictionaryDenseConstructor::DoDeser
     const TStringBuf positionsBlob(originalData.data() + dictionaryBlobSize, originalData.size() - dictionaryBlobSize);
     const auto codec = GetCompressionCodec(externalInfo);
 
-    auto dictionary = DeserializeBinaryArray(dictBlob, dictLength, externalInfo.GetColumnType(), codec);
+    auto dictionary = DeserializeBinaryLikeArray(dictBlob, dictLength, externalInfo.GetColumnType(), codec);
     std::shared_ptr<arrow::Array> positions = DeserializeIndices(
         positionsBlob, externalInfo.GetRecordsCount(), NDictionary::TConstructor::GetTypeByVariantsCount(dictLength), codec);
     return std::make_shared<TDictionaryArray>(dictionary, positions);

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
@@ -268,7 +268,7 @@ TVector<ui32> DecodeLengths(TStringBuf data, ui32 count) {
     return {};
 }
 
-TString SerializeBinaryArray(const arrow::BinaryArray& array, const std::shared_ptr<arrow::util::Codec>& codec) {
+TString SerializeBinaryLikeArray(const arrow::BinaryArray& array, const std::shared_ptr<arrow::util::Codec>& codec) {
     VerifyLittleEndian();
     TVector<ui32> lengths;
     lengths.reserve(array.length() - array.null_count());
@@ -301,8 +301,10 @@ TString SerializeBinaryArray(const arrow::BinaryArray& array, const std::shared_
     return out;
 }
 
-std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(
-    TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::util::Codec>& codec) {
+namespace {
+
+std::shared_ptr<arrow::ArrayData> DeserializeBinaryLikeArrayData(TStringBuf blob, ui32 recordsCount,
+    const std::shared_ptr<arrow::DataType>& valueType, const std::shared_ptr<arrow::util::Codec>& codec) {
     VerifyLittleEndian();
     size_t pos = 0;
     AFL_VERIFY(blob.size() >= 1);
@@ -346,20 +348,17 @@ std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(
 
     auto offsetsBuf = CopyToBuffer(offsets.data(), sizeof(int32_t) * offsets.size());
     auto valuesBuf = CopyToBuffer(values.data(), values.size());
-    auto data = arrow::ArrayData::Make(
-        arrow::binary(), recordsCount, { nullBitmap, offsetsBuf, valuesBuf }, nullBitmap ? arrow::kUnknownNullCount : 0);
-    return std::static_pointer_cast<arrow::BinaryArray>(arrow::MakeArray(data));
+    return arrow::ArrayData::Make(valueType, recordsCount, { nullBitmap, offsetsBuf, valuesBuf }, nullBitmap ? arrow::kUnknownNullCount : 0);
 }
 
-std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::DataType>& valueType,
+}   // namespace
+
+std::shared_ptr<arrow::BinaryArray> DeserializeBinaryLikeArray(TStringBuf blob, ui32 recordsCount,
+    const std::shared_ptr<arrow::DataType>& valueType,
     const std::shared_ptr<arrow::util::Codec>& codec) {
     AFL_VERIFY(arrow::is_binary_like(valueType->id()))("type", valueType->ToString());
-    auto array = DeserializeBinaryArray(blob, recordsCount, codec);
-    if (valueType->id() == arrow::Type::BINARY) {
-        return array;
-    }
-    return std::make_shared<arrow::StringArray>(arrow::ArrayData::Make(
-        valueType, array->length(), array->data()->buffers, array->null_count(), array->offset()));
+    return std::static_pointer_cast<arrow::BinaryArray>(
+        arrow::MakeArray(DeserializeBinaryLikeArrayData(blob, recordsCount, valueType, codec)));
 }
 
 TString SerializeIndices(const std::shared_ptr<arrow::Array>& positions, const std::shared_ptr<arrow::FixedWidthType>& indexType,

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
@@ -6,6 +6,7 @@
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/data.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/buffer.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/type_traits.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/util/bit_run_reader.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/util/bit_util.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/util/bitmap_ops.h>
@@ -348,6 +349,17 @@ std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(
     auto data = arrow::ArrayData::Make(
         arrow::binary(), recordsCount, { nullBitmap, offsetsBuf, valuesBuf }, nullBitmap ? arrow::kUnknownNullCount : 0);
     return std::static_pointer_cast<arrow::BinaryArray>(arrow::MakeArray(data));
+}
+
+std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::DataType>& valueType,
+    const std::shared_ptr<arrow::util::Codec>& codec) {
+    AFL_VERIFY(arrow::is_binary_like(valueType->id()))("type", valueType->ToString());
+    auto array = DeserializeBinaryArray(blob, recordsCount, codec);
+    if (valueType->id() == arrow::Type::BINARY) {
+        return array;
+    }
+    return std::make_shared<arrow::StringArray>(arrow::ArrayData::Make(
+        valueType, array->length(), array->data()->buffers, array->null_count(), array->offset()));
 }
 
 TString SerializeIndices(const std::shared_ptr<arrow::Array>& positions, const std::shared_ptr<arrow::FixedWidthType>& indexType,

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.h
@@ -17,13 +17,11 @@ namespace NKikimr::NArrow::NAccessor::NSubColumns {
 TString EncodeLengths(TConstArrayRef<ui32> values);
 TVector<ui32> DecodeLengths(TStringBuf data, ui32 count);
 
-// Serialize a binary sub-column (the values of a plain column or a dictionary) as
+// Serialize an arrow::is_binary_like sub-column (the values of a plain column or a dictionary) as
 //   [has-nulls][validity section][lengths section][value bytes section].
 // Each section is individually compressed with codec.
-TString SerializeBinaryArray(const arrow::BinaryArray& array, const std::shared_ptr<arrow::util::Codec>& codec);
-std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(
-    TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::util::Codec>& codec);
-std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::DataType>& valueType,
+TString SerializeBinaryLikeArray(const arrow::BinaryArray& array, const std::shared_ptr<arrow::util::Codec>& codec);
+std::shared_ptr<arrow::BinaryArray> DeserializeBinaryLikeArray(TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::DataType>& valueType,
     const std::shared_ptr<arrow::util::Codec>& codec);
 
 // Serialize a dictionary index stream (one index per record, nulls for absent records) as

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.h
@@ -23,6 +23,8 @@ TVector<ui32> DecodeLengths(TStringBuf data, ui32 count);
 TString SerializeBinaryArray(const arrow::BinaryArray& array, const std::shared_ptr<arrow::util::Codec>& codec);
 std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(
     TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::util::Codec>& codec);
+std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(TStringBuf blob, ui32 recordsCount, const std::shared_ptr<arrow::DataType>& valueType,
+    const std::shared_ptr<arrow::util::Codec>& codec);
 
 // Serialize a dictionary index stream (one index per record, nulls for absent records) as
 //   [has-nulls][validity bitmap][indices, packed at indexType's width]

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/ut/ut_dense_encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/ut/ut_dense_encoding.cpp
@@ -87,8 +87,8 @@ Y_UNIT_TEST_SUITE(DenseEncoding) {
     }
 
     void CheckBinaryArrayRoundTrip(const arrow::BinaryArray& array, const std::shared_ptr<arrow::util::Codec>& codec) {
-        const TString blob = SerializeBinaryArray(array, codec);
-        auto restored = DeserializeBinaryArray(blob, array.length(), codec);
+        const TString blob = SerializeBinaryLikeArray(array, codec);
+        auto restored = DeserializeBinaryLikeArray(blob, array.length(), arrow::binary(), codec);
         UNIT_ASSERT_VALUES_EQUAL(restored->length(), array.length());
         for (i64 i = 0; i < array.length(); ++i) {
             UNIT_ASSERT_VALUES_EQUAL(restored->IsNull(i), array.IsNull(i));
@@ -121,6 +121,18 @@ Y_UNIT_TEST_SUITE(DenseEncoding) {
             CheckStringArrayRoundTrip(withNulls, codec);
             CheckStringArrayRoundTrip(dense, codec);
             CheckStringArrayRoundTrip({}, codec);
+        }
+    }
+
+    Y_UNIT_TEST(Utf8RoundTrip) {
+        const auto array = MakeBinary({ "alpha", std::nullopt, "omega" });
+        for (const auto& codec : { ZstdCodec(), RawCodec() }) {
+            const auto restored = DeserializeBinaryLikeArray(SerializeBinaryLikeArray(*array, codec), array->length(), arrow::utf8(), codec);
+            UNIT_ASSERT(restored->type_id() == arrow::Type::STRING);
+            const auto& strings = static_cast<const arrow::StringArray&>(*restored);
+            UNIT_ASSERT_VALUES_EQUAL(strings.GetString(0), "alpha");
+            UNIT_ASSERT(strings.IsNull(1));
+            UNIT_ASSERT_VALUES_EQUAL(strings.GetString(2), "omega");
         }
     }
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -3,7 +3,6 @@
 
 #include <arrow/array/array_binary.h>
 #include <ydb/core/formats/arrow/accessor/common/json_value_view.h>
-#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/library/actors/core/log.h>
 #include <yql/essentials/minikql/jsonpath/jsonpath.h>
 #include <yql/essentials/types/binary_json/read.h>
@@ -137,15 +136,10 @@ TJsonPathAccessor::TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TS
 
 std::shared_ptr<IChunkedArray> TJsonPathAccessor::GetNativeStringArray() const {
     if (!RemainingPath.empty() || ValueType != EValueType::String || !ChunkedArrayAccessor ||
-        ChunkedArrayAccessor->GetType() != IChunkedArray::EType::Array || ChunkedArrayAccessor->GetDataType()->id() != arrow::Type::BINARY) {
+        ChunkedArrayAccessor->GetType() != IChunkedArray::EType::Array || ChunkedArrayAccessor->GetDataType()->id() != arrow::Type::STRING) {
         return nullptr;
     }
-
-    const auto& array = std::static_pointer_cast<TTrivialArray>(ChunkedArrayAccessor)->GetArray();
-    // Native string arrays are currently labeled arrow::binary, although they are guaranteed to be valid utf8
-    // by BinaryJson construction. So rewrapping is needed.
-    return std::make_shared<TTrivialArray>(arrow::MakeArray(
-        arrow::ArrayData::Make(arrow::utf8(), array->length(), array->data()->buffers, array->null_count(), array->offset())));
+    return ChunkedArrayAccessor;
 }
 
 void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -3,6 +3,7 @@
 
 #include <arrow/array/array_binary.h>
 #include <ydb/core/formats/arrow/accessor/common/json_value_view.h>
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/library/actors/core/log.h>
 #include <yql/essentials/minikql/jsonpath/jsonpath.h>
 #include <yql/essentials/types/binary_json/read.h>
@@ -132,6 +133,19 @@ TJsonPathAccessor::TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TS
         RemainingPathPtr = NYql::NJsonPath::ParseJsonPath(RemainingPath, issues, 5);
         AFL_VERIFY(issues.Empty())("RemainingPath", RemainingPath)("issues", issues.ToString());
     }
+}
+
+std::shared_ptr<IChunkedArray> TJsonPathAccessor::GetNativeStringArray() const {
+    if (!RemainingPath.empty() || ValueType != EValueType::String || !ChunkedArrayAccessor ||
+        ChunkedArrayAccessor->GetType() != IChunkedArray::EType::Array || ChunkedArrayAccessor->GetDataType()->id() != arrow::Type::BINARY) {
+        return nullptr;
+    }
+
+    const auto& array = std::static_pointer_cast<TTrivialArray>(ChunkedArrayAccessor)->GetArray();
+    // Native string arrays are currently labeled arrow::binary, although they are guaranteed to be valid utf8
+    // by BinaryJson construction. So rewrapping is needed.
+    return std::make_shared<TTrivialArray>(arrow::MakeArray(
+        arrow::ArrayData::Make(arrow::utf8(), array->length(), array->data()->buffers, array->null_count(), array->offset())));
 }
 
 void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h
@@ -59,6 +59,7 @@ public:
     TJsonPathAccessor(std::shared_ptr<IChunkedArray> accessor, TString remainingPath, const EValueType valueType,
         const std::optional<ui64>& cookie = std::nullopt);
 
+    std::shared_ptr<IChunkedArray> GetNativeStringArray() const;
     void VisitValues(const TValuesVisitor& visitor) const;
 
     bool IsValid() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.cpp
@@ -11,6 +11,8 @@
 #include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/library/formats/arrow/simple_arrays_cache.h>
 
+#include <contrib/libs/apache/arrow/cpp/src/arrow/type_traits.h>
+
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 TDictStats TDictStats::SelectSeparatedColumns(const TSettings& settings, const ui32 recordsCount) const {
@@ -97,7 +99,7 @@ TDictStats::TDictStats(const std::shared_ptr<arrow::RecordBatch>& original)
 
 TConstructorContainer TDictStats::GetAccessorConstructor(const ui32 columnIndex, const TEncodingParams& encodingParams) const {
     const auto type = GetAccessorType(columnIndex);
-    const bool useDenseEncoder = encodingParams.IsEnabled() && GetField(columnIndex)->type()->id() == arrow::Type::BINARY;
+    const bool useDenseEncoder = encodingParams.IsEnabled() && arrow::is_binary_like(GetField(columnIndex)->type()->id());
     switch (type) {
         case IChunkedArray::EType::Array:
             if (useDenseEncoder) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -53,8 +53,9 @@ EValueType ValueTypeForItem(const NBinaryJson::TBinaryJson& blob) {
 std::shared_ptr<arrow::DataType> GetArrowTypeForValueType(const EValueType valueType) {
     switch (valueType) {
         case EValueType::BinaryJson:
-        case EValueType::String:
             return arrow::binary();
+        case EValueType::String:
+            return arrow::utf8();
         case EValueType::Double:
             return arrow::float64();
         case EValueType::Bool:
@@ -69,8 +70,8 @@ bool CanBeDictionaryEncoded(EValueType valueType) {
 TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType) {
     switch (valueType) {
         case EValueType::String: {
-            AFL_VERIFY(array.type_id() == arrow::Type::BINARY)("actual", (ui32)array.type_id());
-            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
+            AFL_VERIFY(array.type_id() == arrow::Type::STRING)("actual", (ui32)array.type_id());
+            const auto view = static_cast<const arrow::StringArray&>(array).GetView(index);
             return TJsonValueView::OfString(TStringBuf(view.data(), view.size()));
         }
         case EValueType::Double:
@@ -94,8 +95,9 @@ NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, con
 ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType) {
     switch (valueType) {
         case EValueType::BinaryJson:
-        case EValueType::String:
             return static_cast<const arrow::BinaryArray&>(array).GetView(index).size();
+        case EValueType::String:
+            return static_cast<const arrow::StringArray&>(array).GetView(index).size();
         case EValueType::Double:
             return sizeof(double);
         case EValueType::Bool:
@@ -117,7 +119,7 @@ void AppendValueFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::
             return;
         case EValueType::String: {
             const auto scalar = ExtractStringScalar(blob);
-            AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(scalar.data(), scalar.size())));
+            AFL_VERIFY(NArrow::Append<arrow::StringType>(builder, arrow::util::string_view(scalar.data(), scalar.size())));
             return;
         }
         case EValueType::Double:

--- a/ydb/core/formats/arrow/program/kernel_logic.cpp
+++ b/ydb/core/formats/arrow/program/kernel_logic.cpp
@@ -55,10 +55,13 @@ std::shared_ptr<IChunkedArray> TGetJsonPath::ExtractArray(const std::shared_ptr<
         accessor = accessorResult.DetachResult();
     }
 
-    if (!accessor) {
-        return NAccessor::TTrivialArray::BuildEmpty(std::make_shared<arrow::StringType>());
+    if (!accessor || !accessor->IsValid()) {
+        return NAccessor::TTrivialArray::MakeBuilderUtf8().Finish(jsonAcc->GetRecordsCount());
     }
 
+    if (auto result = accessor->GetNativeStringArray()) {
+        return result;
+    }
 
     ui32 recordIndex = 0;
     auto builder = NAccessor::TTrivialArray::MakeBuilderUtf8(accessor->GetRecordsCount());

--- a/ydb/core/formats/arrow/program/ut/ut_kernel_logic.cpp
+++ b/ydb/core/formats/arrow/program/ut/ut_kernel_logic.cpp
@@ -71,13 +71,8 @@ Y_UNIT_TEST_SUITE(JsonValue) {
         UNIT_ASSERT(source->GetType() == NAccessor::IChunkedArray::EType::Array);
 
         auto result = TTestGetJsonPath().ExtractArray(input, "$.s");
-        auto resultArray = result->GetChunkedArray()->chunk(0);
-        const auto& sourceArray = std::static_pointer_cast<NAccessor::TTrivialArray>(source)->GetArray();
-        UNIT_ASSERT(resultArray->type_id() == arrow::Type::STRING);
-        // Check that no contents were copied.
-        // A new array may have been created to relabel arrow::binary() as arrow::utf8().
-        UNIT_ASSERT_VALUES_EQUAL(resultArray->data()->buffers[1].get(), sourceArray->data()->buffers[1].get());
-        UNIT_ASSERT_VALUES_EQUAL(resultArray->data()->buffers[2].get(), sourceArray->data()->buffers[2].get());
+        UNIT_ASSERT(source->GetDataType()->id() == arrow::Type::STRING);
+        UNIT_ASSERT_VALUES_EQUAL(result.get(), source.get());
     }
 
     Y_UNIT_TEST(HandlesNestedAndAbsentPaths) {

--- a/ydb/core/formats/arrow/program/ut/ut_kernel_logic.cpp
+++ b/ydb/core/formats/arrow/program/ut/ut_kernel_logic.cpp
@@ -1,0 +1,113 @@
+#include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/accessor.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/constructor.h>
+#include <ydb/core/formats/arrow/program/kernel_logic.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <yql/essentials/types/binary_json/write.h>
+
+#include <string_view>
+
+namespace NKikimr::NArrow::NSSA {
+namespace {
+
+class TTestGetJsonPath: public TGetJsonPath {
+public:
+    using TGetJsonPath::ExtractArray;
+};
+
+NAccessor::NSubColumns::TSettings BuildSettings(const double dictionaryFraction, const ui32 columnsLimit) {
+    NAccessor::NSubColumns::TSettings settings(
+        4, columnsLimit, 0, 0, NAccessor::NSubColumns::TDataAdapterContainer::GetDefault(), dictionaryFraction);
+    settings.SetEnableNativeColumns(true);
+    return settings;
+}
+
+std::shared_ptr<NAccessor::TSubColumnsArray> BuildSubColumns(
+    const std::vector<TString>& jsons, const NAccessor::NSubColumns::TSettings& settings) {
+    NAccessor::TTrivialArray::TPlainBuilder<arrow::BinaryType> builder;
+    ui32 index = 0;
+    for (const TString& json : jsons) {
+        if (json != "null") {
+            const auto value = NBinaryJson::SerializeToBinaryJson(json);
+            const auto* binaryJson = std::get_if<NBinaryJson::TBinaryJson>(&value);
+            UNIT_ASSERT(binaryJson);
+            builder.AddRecord(index, std::string_view(binaryJson->data(), binaryJson->size()));
+        }
+        ++index;
+    }
+    auto sourceJson = builder.Finish(index);
+    return NAccessor::TSubColumnsArray::Make(sourceJson, settings, sourceJson->GetDataType()).DetachResult();
+}
+
+TString ExtractJsonValue(const std::shared_ptr<NAccessor::TSubColumnsArray>& input, const std::string_view path) {
+    auto result = TTestGetJsonPath().ExtractArray(input, path);
+    UNIT_ASSERT_VALUES_EQUAL(result->GetRecordsCount(), input->GetRecordsCount());
+    TString values;
+    result->VisitValues([&](const std::shared_ptr<arrow::Array>& chunk) {
+        UNIT_ASSERT(chunk->type_id() == arrow::Type::STRING);
+        const auto* strings = static_cast<const arrow::StringArray*>(chunk.get());
+        for (i64 index = 0; index < strings->length(); ++index) {
+            if (strings->IsNull(index)) {
+                values.append("<null>");
+            } else {
+                const auto value = strings->GetView(index);
+                values.append(value.data(), value.size());
+            }
+            values.append(";");
+        }
+    });
+    return values;
+}
+
+}
+
+Y_UNIT_TEST_SUITE(JsonValue) {
+    Y_UNIT_TEST(UsesNativeStringBuffers) {
+        auto input = BuildSubColumns({ R"({"s":"x"})", R"({"s":"yy"})", R"({"s":"zzz"})" }, BuildSettings(0, 1024));
+        auto accessor = input->GetPathAccessor("$.s", input->GetRecordsCount()).DetachResult();
+        const auto& source = accessor->GetChunkedArrayAccessor();
+        UNIT_ASSERT(source->GetType() == NAccessor::IChunkedArray::EType::Array);
+
+        auto result = TTestGetJsonPath().ExtractArray(input, "$.s");
+        auto resultArray = result->GetChunkedArray()->chunk(0);
+        const auto& sourceArray = std::static_pointer_cast<NAccessor::TTrivialArray>(source)->GetArray();
+        UNIT_ASSERT(resultArray->type_id() == arrow::Type::STRING);
+        // Check that no contents were copied.
+        // A new array may have been created to relabel arrow::binary() as arrow::utf8().
+        UNIT_ASSERT_VALUES_EQUAL(resultArray->data()->buffers[1].get(), sourceArray->data()->buffers[1].get());
+        UNIT_ASSERT_VALUES_EQUAL(resultArray->data()->buffers[2].get(), sourceArray->data()->buffers[2].get());
+    }
+
+    Y_UNIT_TEST(HandlesNestedAndAbsentPaths) {
+        auto input = BuildSubColumns({ R"({"object":{"s":"x"}})", "null", R"({"object":{"s":"yy"}})" }, BuildSettings(0, 1024));
+        UNIT_ASSERT_VALUES_EQUAL(ExtractJsonValue(input, "$.object.s"), "x;<null>;yy;");
+        UNIT_ASSERT_VALUES_EQUAL(ExtractJsonValue(input, "$.absent"), "<null>;<null>;<null>;");
+    }
+
+    Y_UNIT_TEST(HandlesBinaryJsonAndDictionaryStrings) {
+        std::vector<TString> dictionaryDocs;
+        for (ui32 index = 0; index < 40; ++index) {
+            dictionaryDocs.emplace_back(TStringBuilder() << R"({"s":")" << (index % 2 ? "x" : "yy") << R"("})");
+        }
+        auto dictionaryInput = BuildSubColumns(dictionaryDocs, BuildSettings(1, 1024));
+        TString dictionaryExpected;
+        for (ui32 index = 0; index < dictionaryDocs.size(); ++index) {
+            dictionaryExpected.append(index % 2 ? "x;" : "yy;");
+        }
+        UNIT_ASSERT_VALUES_EQUAL(ExtractJsonValue(dictionaryInput, "$.s"), dictionaryExpected);
+
+        auto binaryJsonInput = BuildSubColumns({ R"({"value":"x"})", R"({"value":1})" }, BuildSettings(0, 1024));
+        UNIT_ASSERT_VALUES_EQUAL(ExtractJsonValue(binaryJsonInput, "$.value"), "x;1;");
+    }
+
+    Y_UNIT_TEST(ReadsFromOthers) {
+        auto input = BuildSubColumns({ R"({"s":"x"})", R"({"s":"yy"})" }, BuildSettings(0, 0));
+        UNIT_ASSERT_VALUES_EQUAL(input->GetColumnsData().GetStats().GetColumnsCount(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(input->GetOthersData().GetStats().GetColumnsCount(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ExtractJsonValue(input, "$.s"), "x;yy;");
+    }
+};
+
+} // namespace NKikimr::NArrow::NSSA

--- a/ydb/core/formats/arrow/program/ut/ya.make
+++ b/ydb/core/formats/arrow/program/ut/ya.make
@@ -1,0 +1,20 @@
+UNITTEST_FOR(ydb/core/formats/arrow/program)
+
+SIZE(SMALL)
+
+PEERDIR(
+    ydb/core/formats/arrow/accessor/plain
+    ydb/core/formats/arrow/accessor/sub_columns
+    ydb/core/formats/arrow/program
+    ydb/core/formats/arrow/serializer
+    yql/essentials/public/udf/service/stub
+    yql/essentials/sql/pg_dummy
+)
+
+SRCS(
+    ut_kernel_logic.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/formats/arrow/program/ya.make
+++ b/ydb/core/formats/arrow/program/ya.make
@@ -66,3 +66,7 @@ CFLAGS(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/kqp/ut/olap/types/json_ut.cpp
+++ b/ydb/core/kqp/ut/olap/types/json_ut.cpp
@@ -1873,6 +1873,30 @@ Y_UNIT_TEST_SUITE(KqpOlapJsonNativeScalars) {
         )" << NativeValueTypeCheck(EValueType::String);
         Variator::ToExecutor(Variator::SingleScript(script)).Execute();
     }
+
+    Y_UNIT_TEST(DictionaryCompaction) {
+        const TString script = TStringBuilder() << NativeTableSetup() << R"(
+        SCHEMA:
+        ALTER OBJECT `/Root/ColumnTable` (TYPE TABLE) SET (ACTION=ALTER_COLUMN, NAME=Col2, `DATA_ACCESSOR_CONSTRUCTOR.CLASS_NAME`=`SUB_COLUMNS`,
+                    `OTHERS_ALLOWED_FRACTION`=`0`, `ENABLE_NATIVE_COLUMNS`=`true`, `DICTIONARY_UNIQUE_FRACTION`=`1`)
+        ------
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES (1u, JsonDocument('{"a":"x"}')), (2u, JsonDocument('{"a":"y"}'))
+        ------
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES (3u, JsonDocument('{"a":"x"}')), (4u, JsonDocument('{"a":"y"}'))
+        ------
+        ONE_COMPACTION
+        ------
+        READ: SELECT JSON_VALUE(Col2, "$.a") FROM `/Root/ColumnTable` ORDER BY Col1;
+        EXPECTED: [[["x"]];[["y"]];[["x"]];[["y"]]]
+        ------
+        )" << NativeValueTypeCheck(EValueType::String) << R"(
+        ------
+        )"
+            << NSubColumnsScenarios::AccessorTypeCheck(NArrow::NAccessor::IChunkedArray::EType::Dictionary);
+        Variator::ToExecutor(Variator::SingleScript(script)).Execute();
+    }
 }
 
 }   // namespace NKikimr::NKqp

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
@@ -37,8 +37,9 @@ std::shared_ptr<NArrow::NAccessor::IChunkedArray> TMergedBuilder::MaybeDictionar
     if (!Settings.IsDictionary(filledRecordsCount, enumerateNotNull)) {
         return accessor;
     }
-    const NArrow::NAccessor::TChunkConstructionData cData(
-        accessor->GetRecordsCount(), nullptr, arrow::binary(), NArrow::NSerialization::TSerializerContainer::GetDefaultSerializer());
+    const NArrow::NAccessor::TChunkConstructionData cData(accessor->GetRecordsCount(), nullptr,
+        NArrow::NAccessor::NSubColumns::GetArrowTypeForValueType(valueType),
+        NArrow::NSerialization::TSerializerContainer::GetDefaultSerializer());
     return NArrow::NAccessor::NDictionary::TConstructor().Construct(accessor, cData).DetachResult();
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/ut/ut_merger.cpp
@@ -61,9 +61,6 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
 
         proto.AddKeyColumnNames("pk");
         proto.SetVersion(1);
-        proto.MutableOptions()->MutableCompactionPlannerConstructor()->SetClassName("l-buckets");
-        *proto.MutableOptions()->MutableCompactionPlannerConstructor()->MutableLBuckets() =
-            NKikimrSchemeOp::TCompactionPlannerConstructorContainer::TLOptimizer();
 
         auto info = TIndexInfo::BuildFromProto(1, proto, storages, cache);
         UNIT_ASSERT(info);
@@ -89,6 +86,45 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
         return out;
     }
 
+    std::shared_ptr<TSubColumnsArray> MergeChunks(const std::vector<std::shared_ptr<TSubColumnsArray>>& chunks, const TSettings& settings) {
+        NArrow::NAccessor::TCompositeChunkedArray::TBuilder cb(chunks.front()->GetDataType());
+        ui32 total = 0;
+        for (const auto& chunk : chunks) {
+            cb.AddChunk(chunk);
+            total += chunk->GetRecordsCount();
+        }
+        std::vector<std::shared_ptr<IChunkedArray>> inputs = { cb.Finish() };
+
+        const ui32 columnId = 2;
+        auto schema = MakeSchema(settings);
+        TColumnMergeContext mergeCtx(columnId, schema, 8u * 1024 * 1024, std::nullopt);
+        THolder<IColumnMerger> merger = IColumnMerger::TFactory::MakeHolder(TConstructor::GetClassNameStatic(), mergeCtx);
+        UNIT_ASSERT(merger);
+
+        TMergingContext mergingCtx({});
+        merger->Start(inputs, mergingCtx);
+
+        // Output row i is mapped to row i of the single (0-th) input.
+        arrow::UInt16Builder idxB;
+        arrow::UInt32Builder recB;
+        for (ui32 i = 0; i < total; ++i) {
+            UNIT_ASSERT(idxB.Append(0).ok());
+            UNIT_ASSERT(recB.Append(i).ok());
+        }
+        auto pkSchema = arrow::schema({ arrow::field(IColumnMerger::PortionIdFieldName, arrow::uint16()),
+            arrow::field(IColumnMerger::PortionRecordIndexFieldName, arrow::uint32()) });
+        auto pkBatch = arrow::RecordBatch::Make(pkSchema, total, { idxB.Finish().ValueOrDie(), recB.Finish().ValueOrDie() });
+
+        TMergingChunkContext chunkCtxOwner(pkBatch);
+        NColumnShard::TIndexationCounters counters("Compaction");
+        TChunkMergeContext chunkCtx(counters, chunkCtxOwner.Slice(0, total));
+        auto result = merger->Execute(chunkCtx, mergingCtx);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetChunks().size(), 1);
+
+        auto loader = schema->GetIndexInfo().GetColumnLoaderVerified(columnId);
+        return std::static_pointer_cast<TSubColumnsArray>(loader->ApplyVerified(result.GetChunks()[0]->GetData(), total));
+    }
+
     Y_UNIT_TEST(MultiChunkDivergentScalarType) {
         const auto settings = MakeSettings();
 
@@ -103,45 +139,40 @@ Y_UNIT_TEST_SUITE(SubColumnsCompaction) {
         UNIT_ASSERT_VALUES_EQUAL_C((ui32)chunk1->GetColumnsData().GetStats().GetValueType(0), (ui32)EValueType::Double,
             "chunk1 key 'a' must be a native Double column");
 
-        NArrow::NAccessor::TCompositeChunkedArray::TBuilder cb(chunk0->GetDataType());
-        cb.AddChunk(chunk0);
-        cb.AddChunk(chunk1);
-        std::vector<std::shared_ptr<IChunkedArray>> inputs = { cb.Finish() };
-
-        const ui32 columnId = 2;
-        auto schema = MakeSchema(settings);
-        TColumnMergeContext mergeCtx(columnId, schema, 8u * 1024 * 1024, std::nullopt);
-
-        THolder<IColumnMerger> merger = IColumnMerger::TFactory::MakeHolder(TConstructor::GetClassNameStatic(), mergeCtx);
-        UNIT_ASSERT(merger);
-
-        TMergingContext mergingCtx({});
-        merger->Start(inputs, mergingCtx);
-
-        const ui32 total = docs0.size() + docs1.size();
-        arrow::UInt16Builder idxB;
-        arrow::UInt32Builder recB;
-        for (ui32 i = 0; i < total; ++i) {
-            UNIT_ASSERT(idxB.Append(0).ok());
-            UNIT_ASSERT(recB.Append(i).ok());
-        }
-        auto pkSchema = arrow::schema({ arrow::field(IColumnMerger::PortionIdFieldName, arrow::uint16()),
-            arrow::field(IColumnMerger::PortionRecordIndexFieldName, arrow::uint32()) });
-        auto pkBatch = arrow::RecordBatch::Make(pkSchema, total, { idxB.Finish().ValueOrDie(), recB.Finish().ValueOrDie() });
-
-        TMergingChunkContext chunkCtxOwner(pkBatch);
-        NColumnShard::TIndexationCounters counters("Compaction");
-        TChunkMergeContext chunkCtx(counters, chunkCtxOwner.Slice(0, total));
-
-        auto result = merger->Execute(chunkCtx, mergingCtx);
-        UNIT_ASSERT_VALUES_EQUAL(result.GetChunks().size(), 1);
-
-        auto loader = schema->GetIndexInfo().GetColumnLoaderVerified(columnId);
-        auto merged = std::static_pointer_cast<TSubColumnsArray>(loader->ApplyVerified(result.GetChunks()[0]->GetData(), total));
+        auto merged = MergeChunks({ chunk0, chunk1 }, settings);
 
         // The merged portion must round-trip to the input documents.
         const TString expected =
             RenderDocs(BuildChunk({ docs0[0], docs0[1], docs0[2], docs0[3], docs1[0], docs1[1], docs1[2], docs1[3] }, settings));
         UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), expected);
+    }
+
+    Y_UNIT_TEST(DictionaryNativeString) {
+        auto settings = MakeSettings();
+        settings.SetDictionaryUniqueFraction(1.0);
+        const std::vector<TString> docs = { R"({"a":"xxxx"})", R"({"a":"xxxx"})", R"({"a":"yyyy"})", R"({"a":"yyyy"})" };
+        auto chunk = BuildChunk(docs, settings);
+
+        auto merged = MergeChunks({ chunk }, settings);
+        const auto& stats = merged->GetColumnsData().GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(stats.GetAccessorType(0), IChunkedArray::EType::Dictionary);
+        UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), RenderDocs(BuildChunk(docs, settings)));
+    }
+
+    Y_UNIT_TEST(DictionaryNativeStringWithNulls) {
+        auto settings = MakeSettings();
+        settings.SetDictionaryUniqueFraction(1.0);
+        const std::vector<TString> docs = { R"({"a":"xxxx"})", "{}", R"({"a":"yyyy"})", "{}" };
+        auto merged = MergeChunks({ BuildChunk(docs, settings) }, settings);
+        const auto& stats = merged->GetColumnsData().GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(stats.GetAccessorType(0), IChunkedArray::EType::Dictionary);
+
+        auto path = merged->GetPathAccessor("$.a", docs.size()).DetachResult();
+        TStringBuilder values;
+        path->VisitValues([&](const std::optional<TStringBuf>& value) {
+            values << (value ? *value : TStringBuf("<null>")) << ';';
+        });
+        UNIT_ASSERT_VALUES_EQUAL(values, "xxxx;<null>;yyyy;<null>;");
+        UNIT_ASSERT_VALUES_EQUAL(RenderDocs(merged), RenderDocs(BuildChunk(docs, settings)));
     }
 }


### PR DESCRIPTION
Native string arrays are used without copying for JSON_VALUE.
They are also now marked as arrow::utf8() instead of arrow::binary() - this is enforced by checks in BinaryJson code. That required replacing hardcoded arrow::binary() in some places to correctly preserve type info, but avoids an otherwise confusing binary() -> utf8() cast in GetNativeStringArray.
Added some tests on native + dictionary compaction.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
