### PR TITLE
Fix ANALYZE slowdown on small column tables with many shards

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3381,6 +3381,10 @@ message TStatisticsConfig {
     // When (RowUpdates + RowDeletes since last ANALYZE) / RowCount * 100 >= this value,
     // column statistics are considered stale and will be recalculated.
     optional uint32 BackgroundAnalyzeChangeRatioThresholdPercent = 8 [default = 20];
+
+    // Column tables smaller than or equal to this size are scanned as a whole table
+    // rather than per shard. 0 disables the optimization (always per-shard).
+    optional uint64 AnalyzeWholeTableScanMaxBytes = 9 [default = 10737418240]; // 10 GiB
 };
 
 message TSystemTabletBackupConfig {

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -1139,6 +1139,8 @@ void TStatisticsAggregator::StartAnalyzeActor(const TActorContext& ctx, const TS
     auto analyzeActorConfig = TAnalyzeActor::TConfig{
         .MaxTotalScanActorsInFlight = StatisticsConfig.GetAnalyzeMaxTotalScanActorsInFlight(),
         .MaxPerNodeScanActorsInFlight = StatisticsConfig.GetAnalyzeMaxPerNodeScanActorsInFlight(),
+        .WholeTableScanMaxBytes = StatisticsConfig.GetAnalyzeWholeTableScanMaxBytes(),
+        .TableBytesSize = GetTableBytesSize(pathId),
     };
     AnalyzeActorId = ctx.Register(new TAnalyzeActor(
         SelfId(), operationId, database, pathId, columnTags, analyzeActorConfig),
@@ -1331,22 +1333,41 @@ bool TStatisticsAggregator::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev
  }
 
 TStatisticsAggregator::TChangeCounters TStatisticsAggregator::GetCurrentChangeCounters(const TPathId& pathId) const {
+    NKikimrStat::TSchemeShardStats stats;
+    const auto* entry = FindBaseStatisticsEntry(pathId, stats);
+    if (!entry) {
+        return {};
+    }
+    return {entry->GetRowUpdates(), entry->GetRowDeletes(), entry->GetRowCount()};
+}
+
+std::optional<ui64> TStatisticsAggregator::GetTableBytesSize(const TPathId& pathId) const {
+    NKikimrStat::TSchemeShardStats stats;
+    const auto* entry = FindBaseStatisticsEntry(pathId, stats);
+    if (!entry || !entry->HasBytesSize()) {
+        return std::nullopt;
+    }
+    return entry->GetBytesSize();
+}
+
+const NKikimrStat::TPathEntry* TStatisticsAggregator::FindBaseStatisticsEntry(
+    const TPathId& pathId, NKikimrStat::TSchemeShardStats& stats) const
+{
     // A path is owned by the schemeshard identified by pathId.OwnerId, so its
     // base stats live in that schemeshard's blob (see IsKnownTable).
     auto it = BaseStatistics.find(pathId.OwnerId);
     if (it == BaseStatistics.end() || !it->second.Latest) {
-        return {};
+        return nullptr;
     }
-    NKikimrStat::TSchemeShardStats stats;
     if (!stats.ParseFromString(*it->second.Latest)) {
-        return {};
+        return nullptr;
     }
     for (const auto& entry : stats.GetEntries()) {
         if (TPathId::FromProto(entry.GetPathId()) == pathId) {
-            return {entry.GetRowUpdates(), entry.GetRowDeletes(), entry.GetRowCount()};
+            return &entry;
         }
     }
-    return {};
+    return nullptr;
 }
 
 bool TStatisticsAggregator::IsChangeRatioAboveThreshold(

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -27,6 +27,7 @@
 
 #include <util/generic/intrlist.h>
 
+#include <optional>
 #include <random>
 
 namespace NKikimr::NStat {
@@ -175,6 +176,9 @@ private:
     bool IsChangeRatioAboveThreshold(
         const TChangeCounters& lastAnalyze, const TChangeCounters& current) const;
     TChangeCounters GetCurrentChangeCounters(const TPathId& pathId) const;
+    std::optional<ui64> GetTableBytesSize(const TPathId& pathId) const;
+    const NKikimrStat::TPathEntry* FindBaseStatisticsEntry(
+        const TPathId& pathId, NKikimrStat::TSchemeShardStats& stats) const;
 
     // Returns cached change counters, rebuilding the cache from BaseStatistics
     // if it is invalid. The cache is invalidated when BaseStatistics is updated

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -349,7 +349,24 @@ void TAnalyzeActor::HandleNavigateResult() {
         return;
     }
 
-    if (IsColumnTable) {
+    // Per-shard scans for column tables unless size is known and at or below
+    // the whole-table threshold. Unknown size (missing/unparsed base stats)
+    // stays per-shard to avoid a full-table scan of a potentially large table.
+    UsePerShardScans = IsColumnTable
+        && (Config.WholeTableScanMaxBytes == 0
+            || !Config.TableBytesSize
+            || *Config.TableBytesSize > Config.WholeTableScanMaxBytes);
+    YDB_LOG_DEBUG("Scan strategy",
+        {"selfId", SelfId()},
+        {"operationId", OperationId.Quote()},
+        {"pathId", PathId},
+        {"isColumnTable", IsColumnTable},
+        {"tableBytesSizeKnown", Config.TableBytesSize.has_value()},
+        {"tableBytesSize", Config.TableBytesSize.value_or(0)},
+        {"wholeTableScanMaxBytes", Config.WholeTableScanMaxBytes},
+        {"usePerShardScans", UsePerShardScans});
+
+    if (UsePerShardScans) {
         // Resolve table shard ids.
         TVector<TCell> minusInf(KeyColumnTypes.size());
         TVector<TCell> plusInf;
@@ -427,7 +444,7 @@ void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
     }
 
     // Report initial progress: shards known, none done yet
-    ui32 shardsTotal = IsColumnTable ? static_cast<ui32>(TabletId2NodeId.size()) : 1;
+    ui32 shardsTotal = UsePerShardScans ? static_cast<ui32>(TabletId2NodeId.size()) : 1;
     SendProgressEvent(shardsTotal, 0);
 
     Send(MakePipePerNodeCacheID(EPipePerNodeCache::Leader), new TEvPipeCache::TEvUnlink(0));
@@ -460,13 +477,13 @@ void TAnalyzeActor::StartColumnStatEvalTasks() {
     Y_ENSURE(!PendingTasks.empty());
 
 
-    if (IsColumnTable) {
+    if (UsePerShardScans) {
         for (const auto& [tabletId, nodeId] : TabletId2NodeId) {
             NodeId2State.try_emplace(nodeId, nodeId).first->second.PendingTablets.push_back(tabletId);
         }
     }
 
-    SelectBuilder.emplace(/*isIntermediateAggregation=*/IsColumnTable);
+    SelectBuilder.emplace(/*isIntermediateAggregation=*/UsePerShardScans);
     size_t totalSize = 0;
 
     if (!CountSeq && !RowCount) {
@@ -511,7 +528,7 @@ void TAnalyzeActor::DispatchSomeScanActors() {
         };
     };
 
-    if (!IsColumnTable) {
+    if (!UsePerShardScans) {
         Y_ENSURE(ScanActorsInFlight.empty());
         YDB_LOG_DEBUG("Dispatching scan actor for the whole table",
             {"selfId", SelfId()});
@@ -568,7 +585,7 @@ void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     ScanActorsInFlight.erase(actorIt);
 
     ++ScansCompletedTotal;
-    const ui32 shardsTotal = IsColumnTable ? static_cast<ui32>(TabletId2NodeId.size()) : 1;
+    const ui32 shardsTotal = UsePerShardScans ? static_cast<ui32>(TabletId2NodeId.size()) : 1;
     // Cap intermediate progress below 100%: simple-stats and stage-2 rounds share
     // ScansCompletedTotal, so 100% is only emitted from the final-result branch.
     const ui32 shardsDoneCap = shardsTotal > 0 ? shardsTotal - 1 : 0;

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -10,6 +10,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorid.h>
 
+#include <optional>
 #include <queue>
 
 namespace NKikimr::NStat {
@@ -19,6 +20,8 @@ public:
     struct TConfig {
         ui64 MaxTotalScanActorsInFlight = 100;
         i64 MaxPerNodeScanActorsInFlight = 1;
+        ui64 WholeTableScanMaxBytes = 10ULL << 30; // 10 GiB
+        std::optional<ui64> TableBytesSize;
     };
 
 private:
@@ -94,6 +97,7 @@ private:
 
     TString TableName;
     bool IsColumnTable = false;
+    bool UsePerShardScans = false;
     TVector<TColumnDesc> Columns;
     TVector<TMultiColumnStatDesc> MultiColumnStatDescs;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;

--- a/ydb/core/statistics/aggregator/ut/ut_analyze_op.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze_op.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/library/testlib/helpers.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
+#include <ydb/core/base/hive.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/statistics/events.h>
@@ -231,7 +232,13 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
         // The AnalyzeActor reports progress to the Statistics Aggregator as each
         // shard's scan completes. Verify that intermediate progress is reflected
         // by GetAnalyzeOperation while the analyze is still in flight.
-        TTestEnv env(1, 1);
+        // Threshold 0 disables whole-table scans so the column-table branch
+        // still dispatches one scan per shard.
+        TTestEnv env(1, 1, /*useRealThreads=*/false,
+            [](Tests::TServerSettings& settings) {
+                settings.AppConfig->MutableStatisticsConfig()
+                    ->SetAnalyzeWholeTableScanMaxBytes(0);
+            });
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
 
@@ -292,6 +299,83 @@ Y_UNIT_TEST_SUITE(AnalyzeOpList) {
         UNIT_ASSERT_VALUES_EQUAL(op.InProgressPathsSize(), 1);
         UNIT_ASSERT_VALUES_EQUAL(op.GetInProgressPaths(0), tableInfo.Path);
         UNIT_ASSERT_VALUES_EQUAL(op.DonePathsSize(), 0);
+    }
+
+    Y_UNIT_TEST(SmallColumnTableWholeTableScan) {
+        // Small column tables (default 10 GiB threshold) skip Hive locate
+        // and scan the whole table in one query. Wait for base statistics so
+        // table size is known; unknown size would fall back to per-shard scans.
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+        WaitForSchemeShardStatsUpdate(runtime, tableInfo.PathId.OwnerId, /*requireFull=*/true);
+
+        ui32 hiveDistributionRequests = 0;
+        auto observer = runtime.AddObserver<TEvHive::TEvRequestTabletDistribution>(
+            [&](auto&) { ++hiveDistributionRequests; });
+
+        Analyze(runtime, tableInfo.SaTabletId, {{tableInfo.PathId}}, "opWhole", "/Root/Database");
+
+        UNIT_ASSERT_VALUES_EQUAL(hiveDistributionRequests, 0);
+        ValidateStatistics(runtime, tableInfo.PathId);
+    }
+
+    Y_UNIT_TEST(ColumnTablePerShardScanWhenSizeUnknown) {
+        // When the table is known but BytesSize is absent, TableBytesSize is
+        // unset and a column table must use per-shard scans rather than
+        // treating a missing size as 0 (small).
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+
+        bool statsSeen = false;
+        auto stripBytesSize = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>(
+            [&](auto& ev) {
+                NKikimrStat::TSchemeShardStats statRecord;
+                if (!statRecord.ParseFromString(ev->Get()->Record.GetStats())) {
+                    return;
+                }
+                for (auto& entry : *statRecord.MutableEntries()) {
+                    entry.ClearBytesSize();
+                }
+                TString stats;
+                UNIT_ASSERT(statRecord.SerializeToString(&stats));
+                ev->Get()->Record.SetStats(stats);
+                statsSeen = true;
+            });
+
+        const auto tableInfo = PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+        runtime.WaitFor("SchemeShard stats without BytesSize", [&]{ return statsSeen; });
+
+        ui32 hiveDistributionRequests = 0;
+        auto observer = runtime.AddObserver<TEvHive::TEvRequestTabletDistribution>(
+            [&](auto&) { ++hiveDistributionRequests; });
+
+        Analyze(runtime, tableInfo.SaTabletId, {{tableInfo.PathId}}, "opUnknownSize", "/Root/Database");
+
+        UNIT_ASSERT_GT(hiveDistributionRequests, 0);
+        ValidateStatistics(runtime, tableInfo.PathId);
+    }
+
+    Y_UNIT_TEST(ColumnTablePerShardScanWhenThresholdDisabled) {
+        TTestEnv env(1, 1, /*useRealThreads=*/false,
+            [](Tests::TServerSettings& settings) {
+                settings.AppConfig->MutableStatisticsConfig()
+                    ->SetAnalyzeWholeTableScanMaxBytes(0);
+            });
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTable(env, "Database", "Table", /*shardCount=*/4);
+
+        ui32 hiveDistributionRequests = 0;
+        auto observer = runtime.AddObserver<TEvHive::TEvRequestTabletDistribution>(
+            [&](auto&) { ++hiveDistributionRequests; });
+
+        Analyze(runtime, tableInfo.SaTabletId, {{tableInfo.PathId}}, "opPerShard", "/Root/Database");
+
+        UNIT_ASSERT_GT(hiveDistributionRequests, 0);
+        ValidateStatistics(runtime, tableInfo.PathId);
     }
 
     Y_UNIT_TEST_TWIN(ForgetTerminal, ColumnShard) {


### PR DESCRIPTION
This is a fix for the regression after https://github.com/ydb-platform/ydb/pull/35600 got merged. For small tables the constant overhead of per-shard scans appears to be too big (10s of seconds for a 256-shard table that is almost empty).

Fixes an ANALYZE regression from per-shard column-table scans: small or nearly empty tables with many shards paid a large fixed cost (Hive tablet locate plus one scan per shard).

Column tables use a whole-table scan only when data size is known and at or below AnalyzeWholeTableScanMaxBytes (default 10 GiB). Larger tables still scan per shard with intermediate aggregation. If size is unknown (missing or unparsed base stats, or BytesSize unset), ANALYZE keeps per-shard scans instead of treating the size as 0. Set the threshold to 0 to always scan per shard.

Changes
* Add AnalyzeWholeTableScanMaxBytes to TStatisticsConfig (default 10 GiB).
* Pass optional table BytesSize from aggregator base statistics into TAnalyzeActor.
* Choose the scan path with UsePerShardScans (whole-table vs per-shard).
* Tests: keep per-shard progress in ProgressIntermediate; cover whole-table, threshold disabled, and unknown size