### PR TITLE
Move GTEST preference from agents into persqueue RULES.md

### DIFF
--- a/ydb/agents/GTEST_PREFER.md
+++ b/ydb/agents/GTEST_PREFER.md
@@ -1,9 +1,0 @@
-# C++ test framework preference
-
-Scope: the **test module** — the `ut/` directory (its `ya.make` and sources).
-
-- If that `ut/` **already has** C++ unit tests, use the **same** framework
-  (`UNITTEST` or `GTEST`) as the existing tests there.
-- If that `ut/` has **no** C++ unit tests yet, prefer **GTEST**.
-
-Test types and how to run them: [`TESTS.md`](TESTS.md).

--- a/ydb/core/persqueue/RULES.md
+++ b/ydb/core/persqueue/RULES.md
@@ -8,6 +8,8 @@
 
 ## Tests
 
+C++ `ut/` (its `ya.make` and sources): same framework as existing tests (`UNITTEST` or `GTEST`); if none yet, prefer **GTEST**. Types and how to run: [`agents/TESTS.md`](../../agents/TESTS.md).
+
 When changing topic read/write/offset/blob logic, cover:
 
 * **Small and large messages.** Large = >512 KiB (split into parts).
@@ -25,5 +27,4 @@ When changing topic read/write/offset/blob logic, cover:
 ## Monorepo
 
 [`agents/CODESTYLE.md`](../../agents/CODESTYLE.md) ·
-[`agents/GUIDE.md`](../../agents/GUIDE.md) ·
-[`agents/GTEST_PREFER.md`](../../agents/GTEST_PREFER.md)
+[`agents/GUIDE.md`](../../agents/GUIDE.md)


### PR DESCRIPTION
The C++ test framework rule is topics-specific, not a monorepo-wide agent guideline.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
