### PR TITLE
Fix united mode in tiny actor system auto config

### DIFF
--- a/ydb/core/driver_lib/run/auto_config_initializer.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer.cpp
@@ -281,6 +281,7 @@ namespace NKikimr::NAutoConfigInitializer {
                 executor->SetPriority(priority);
                 executor->SetSpinThreshold(0);
                 executor->SetHasSharedThread(hasSharedThread);
+                executor->SetAllThreadsAreShared(useUnitedPool);
             };
 
             assignPool(systemExecutor, "System", 30, cpuCount >= 3);

--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -120,4 +120,32 @@ Y_UNIT_TEST(GetServicePoolsWith4AndMoreCPUs) {
     }
 }
 
+Y_UNIT_TEST(SharedAndUnitedAutoConfigMatrix) {
+    for (ui32 cpuCount = 1; cpuCount <= 4; ++cpuCount) {
+        for (const bool useSharedThreads : {false, true}) {
+            for (const bool useUnitedPool : {false, true}) {
+                NKikimrConfig::TActorSystemConfig config;
+                config.SetCpuCount(cpuCount);
+                config.SetUseSharedThreads(useSharedThreads);
+                config.SetUseUnitedPool(useUnitedPool);
+
+                ApplyAutoConfig(&config, false, false);
+
+                bool hasBasicPool = false;
+                for (const auto& executor : config.GetExecutor()) {
+                    if (executor.GetType() != NKikimrConfig::TActorSystemConfig::TExecutor::BASIC) {
+                        continue;
+                    }
+                    hasBasicPool = true;
+                    UNIT_ASSERT_VALUES_EQUAL_C(
+                        executor.GetAllThreadsAreShared(), useUnitedPool,
+                        "cpu# " << cpuCount << " shared# " << useSharedThreads
+                        << " united# " << useUnitedPool << " pool# " << executor.GetName());
+                }
+                UNIT_ASSERT_C(hasBasicPool, "cpu# " << cpuCount << " produced no BASIC pools");
+            }
+        }
+    }
+}
+
 } // Y_UNIT_TEST_SUITE(AutoConfig)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed United pool mode being ignored by actor-system auto configuration for one to three CPUs with shared threads enabled.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51357. Propagate `UseUnitedPool` through the tiny auto-config path without changing thread topology, and cover CPU 1–4 × Shared × United.