### PR TITLE
[NEW RBO] Disable YQL peephole in new RBO

### DIFF
--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
@@ -2,15 +2,137 @@
 #include "kqp_rbo_physical_strict_cast.h"
 
 #include <yql/essentials/core/yql_expr_optimize.h>
+#include <yql/essentials/core/yql_expr_type_annotation.h>
+#include <yql/essentials/core/yql_opt_utils.h>
 
 namespace NKikimr::NKqp {
 namespace {
 
 using namespace NYql;
 
+bool IsSqlScalar(const TTypeAnnotationNode* type) {
+    return type && (IsDataOrOptionalOfData(type) || type->GetKind() == ETypeAnnotationKind::Null);
+}
+
+TExprNode::TPtr TupleItem(const TExprNode::TPtr& tuple, size_t index, TExprContext& ctx) {
+    return ctx.NewCallable(
+        tuple->Pos(), "Nth",
+        {tuple, ctx.NewAtom(tuple->Pos(), ToString(index), TNodeFlags::Default)});
+}
+
+bool CanExpandFiniteSqlIn(const TExprNode::TPtr& node) {
+    if (HasSetting(*node->Child(2), "tableSource")) {
+        return false;
+    }
+
+    const auto lookupType = node->Child(1)->GetTypeAnn();
+    const auto collectionType = node->Head().GetTypeAnn();
+    if (!IsSqlScalar(lookupType) || !collectionType) {
+        return false;
+    }
+    if (collectionType->GetKind() == ETypeAnnotationKind::Tuple) {
+        const auto tupleType = collectionType->Cast<TTupleExprType>();
+        return tupleType->GetSize() && AllOf(tupleType->GetItems(), IsSqlScalar);
+    }
+
+    const auto collection = node->HeadPtr();
+    return collectionType->GetKind() == ETypeAnnotationKind::List &&
+        (collection->IsList() || collection->IsCallable("AsList")) &&
+        collection->ChildrenSize() &&
+        IsSqlScalar(collectionType->Cast<TListExprType>()->GetItemType());
+}
+
+TExprNode::TPtr ExpandFiniteSqlIn(const TExprNode::TPtr& node, TExprContext& ctx) {
+    if (!CanExpandFiniteSqlIn(node)) {
+        return node;
+    }
+
+    const auto collection = node->HeadPtr();
+    const auto lookup = node->ChildPtr(1);
+    const bool ansi = HasSetting(*node->Child(2), "ansi");
+    const bool legacyNullable = !ansi && IsSqlInCollectionItemsNullable(NNodes::TCoSqlIn(node));
+    const bool explicitItems = collection->IsList() || collection->IsCallable("AsList");
+    const size_t size = explicitItems
+        ? collection->ChildrenSize()
+        : collection->GetTypeAnn()->Cast<TTupleExprType>()->GetSize();
+
+    TExprNode::TListType equals;
+    equals.reserve(size);
+    for (size_t index = 0; index < size; ++index) {
+        auto item = explicitItems ? collection->ChildPtr(index) : TupleItem(collection, index, ctx);
+        auto equal = ctx.NewCallable(node->Pos(), "==", {lookup, std::move(item)});
+        if (legacyNullable) {
+            equal = ctx.Builder(node->Pos())
+                .Callable("Coalesce")
+                    .Add(0, std::move(equal))
+                    .Add(1, MakeBool(node->Pos(), false, ctx))
+                .Seal().Build();
+        }
+        equals.push_back(std::move(equal));
+    }
+
+    auto result = ctx.NewCallable(node->Pos(), "Or", std::move(equals));
+    if (legacyNullable && lookup->GetTypeAnn()->HasOptionalOrNull()) {
+        result = ctx.Builder(node->Pos())
+            .Callable("If")
+                .Callable(0, "HasNull")
+                    .Add(0, lookup)
+                .Seal()
+                .Add(1, MakeNull(node->Pos(), ctx))
+                .Add(2, std::move(result))
+            .Seal().Build();
+    }
+    return result;
+}
+
+bool IsSupportedHasNullType(const TTypeAnnotationNode* type) {
+    type = RemoveAllOptionals(type);
+    return type && (type->GetKind() == ETypeAnnotationKind::Data ||
+                    type->GetKind() == ETypeAnnotationKind::Null);
+}
+
+TExprNode::TPtr ExpandScalarHasNull(
+    const TExprNode::TPtr& node,
+    TExprContext& ctx,
+    const TTypeAnnotationContext& types) {
+    const auto type = node->Head().GetTypeAnn();
+    if (!IsSupportedHasNullType(type)) {
+        return node;
+    }
+
+    TExprNode::TPtr result;
+    switch (type->GetKind()) {
+        case ETypeAnnotationKind::Data:
+            result = MakeBool(node->Pos(), false, ctx);
+            break;
+        case ETypeAnnotationKind::Null:
+            result = MakeBool(node->Pos(), true, ctx);
+            break;
+        case ETypeAnnotationKind::Optional:
+            result = ctx.Builder(node->Pos())
+                .Callable("IfPresent")
+                    .Add(0, node->HeadPtr())
+                    .Lambda(1)
+                        .Param("item")
+                        .Callable("HasNull")
+                            .Arg(0, "item")
+                        .Seal()
+                    .Seal()
+                    .Add(2, MakeBool(node->Pos(), true, ctx))
+                .Seal()
+                .Build();
+            break;
+        default:
+            return node;
+    }
+
+    result = KeepWorld(std::move(result), *node, ctx, types);
+    return KeepSideEffects(std::move(result), node->HeadPtr(), ctx);
+}
+
 TExprNode::TPtr FindCompatibilityNode(const TExprNode::TPtr& root) {
     return FindNode(root, [](const TExprNode::TPtr& node) {
-        return node->IsCallable("StrictCast");
+        return node->IsCallable({"StrictCast", "HasNull", "SqlIn"});
     });
 }
 
@@ -23,9 +145,15 @@ bool NeedsRboCompatibilityLowering(const NYql::TExprNode::TPtr& root) {
 NYql::TExprNode::TPtr RewriteRboCompatibilityNode(
     const NYql::TExprNode::TPtr& node,
     NYql::TExprContext& ctx,
-    const NYql::TTypeAnnotationContext&) {
+    const NYql::TTypeAnnotationContext& types) {
     if (node->IsCallable("StrictCast")) {
         return NPhysicalConvertionUtils::ExpandScalarStrictCast(node, ctx);
+    }
+    if (node->IsCallable("HasNull")) {
+        return ExpandScalarHasNull(node, ctx, types);
+    }
+    if (node->IsCallable("SqlIn")) {
+        return ExpandFiniteSqlIn(node, ctx);
     }
     return node;
 }

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
@@ -1,0 +1,19 @@
+#include "kqp_rbo_compatibility.h"
+
+namespace NKikimr::NKqp {
+
+bool NeedsRboCompatibilityLowering(const NYql::TExprNode::TPtr&) {
+    return false;
+}
+
+NYql::TExprNode::TPtr RewriteRboCompatibilityNode(
+    const NYql::TExprNode::TPtr& node,
+    NYql::TExprContext&,
+    const NYql::TTypeAnnotationContext&) {
+    return node;
+}
+
+void EnsureRboCompatibilityLowered(const NYql::TExprNode::TPtr&) {
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
@@ -20,6 +20,75 @@ TExprNode::TPtr TupleItem(const TExprNode::TPtr& tuple, size_t index, TExprConte
         {tuple, ctx.NewAtom(tuple->Pos(), ToString(index), TNodeFlags::Default)});
 }
 
+bool CanExpandTupleComparison(const TExprNode::TPtr& node) {
+    const auto leftType = node->Head().GetTypeAnn();
+    const auto rightType = node->Tail().GetTypeAnn();
+    if (!leftType || !rightType ||
+        leftType->GetKind() != ETypeAnnotationKind::Tuple ||
+        rightType->GetKind() != ETypeAnnotationKind::Tuple) {
+        return false;
+    }
+
+    const auto leftItems = leftType->Cast<TTupleExprType>()->GetItems();
+    const auto rightItems = rightType->Cast<TTupleExprType>()->GetItems();
+    if (leftItems.size() != rightItems.size()) {
+        return false;
+    }
+    for (size_t index = 0; index < leftItems.size(); ++index) {
+        if (!IsSqlScalar(leftItems[index]) || !IsSqlScalar(rightItems[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TExprNode::TPtr BuildTupleItemComparison(
+    const TExprNode::TPtr& node,
+    size_t index,
+    TStringBuf callable,
+    TExprContext& ctx) {
+    return ctx.NewCallable(
+        node->Pos(), callable,
+        {TupleItem(node->HeadPtr(), index, ctx), TupleItem(node->TailPtr(), index, ctx)});
+}
+
+TExprNode::TPtr ExpandTupleComparison(const TExprNode::TPtr& node, TExprContext& ctx) {
+    if (!CanExpandTupleComparison(node)) {
+        return node;
+    }
+
+    const size_t size = node->Head().GetTypeAnn()->Cast<TTupleExprType>()->GetSize();
+    const auto callable = node->Content();
+    if (!size) {
+        return MakeBool(node->Pos(), callable == "==" || callable == "<=" || callable == ">=", ctx);
+    }
+
+    if (callable == "==" || callable == "!=") {
+        TExprNode::TListType items;
+        items.reserve(size);
+        for (size_t index = 0; index < size; ++index) {
+            items.push_back(BuildTupleItemComparison(node, index, callable, ctx));
+        }
+        return ctx.NewCallable(node->Pos(), callable == "==" ? "And" : "Or", std::move(items));
+    }
+
+    const TStringBuf strictCallable = callable.StartsWith('<') ? "<" : ">";
+    auto result = BuildTupleItemComparison(node, size - 1, callable, ctx);
+    for (size_t index = size - 1; index-- > 0;) {
+        result = ctx.Builder(node->Pos())
+            .Callable("If")
+                .Callable(0, "Coalesce")
+                    .Add(0, BuildTupleItemComparison(node, index, "==", ctx))
+                    .Add(1, MakeBool(node->Pos(), false, ctx))
+                .Seal()
+                .Add(1, std::move(result))
+                .Add(2, BuildTupleItemComparison(node, index, strictCallable, ctx))
+            .Seal()
+            .Build();
+    }
+    return result;
+}
+
 bool CanExpandFiniteSqlIn(const TExprNode::TPtr& node) {
     if (HasSetting(*node->Child(2), "tableSource")) {
         return false;
@@ -91,6 +160,12 @@ bool IsSupportedHasNullType(const TTypeAnnotationNode* type) {
                     type->GetKind() == ETypeAnnotationKind::Null);
 }
 
+bool IsComplexComparison(const TExprNode::TPtr& node) {
+    return node->IsCallable({"==", ">", "<", ">=", "<=", "!="}) &&
+        (!IsDataOrOptionalOfData(node->Head().GetTypeAnn()) ||
+         !IsDataOrOptionalOfData(node->Tail().GetTypeAnn()));
+}
+
 TExprNode::TPtr ExpandScalarHasNull(
     const TExprNode::TPtr& node,
     TExprContext& ctx,
@@ -132,7 +207,7 @@ TExprNode::TPtr ExpandScalarHasNull(
 
 TExprNode::TPtr FindCompatibilityNode(const TExprNode::TPtr& root) {
     return FindNode(root, [](const TExprNode::TPtr& node) {
-        return node->IsCallable({"StrictCast", "HasNull", "SqlIn"});
+        return node->IsCallable({"StrictCast", "HasNull", "SqlIn"}) || IsComplexComparison(node);
     });
 }
 
@@ -154,6 +229,15 @@ NYql::TExprNode::TPtr RewriteRboCompatibilityNode(
     }
     if (node->IsCallable("SqlIn")) {
         return ExpandFiniteSqlIn(node, ctx);
+    }
+    if (IsComplexComparison(node)) {
+        if (node->Head().GetTypeAnn()->GetKind() == ETypeAnnotationKind::Null ||
+            node->Tail().GetTypeAnn()->GetKind() == ETypeAnnotationKind::Null) {
+            auto result = KeepWorld(MakeBoolNothing(node->Pos(), ctx), *node, ctx, types);
+            result = KeepSideEffects(std::move(result), node->TailPtr(), ctx);
+            return KeepSideEffects(std::move(result), node->HeadPtr(), ctx);
+        }
+        return ExpandTupleComparison(node, ctx);
     }
     return node;
 }

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
@@ -3,6 +3,7 @@
 
 #include <yql/essentials/core/yql_expr_optimize.h>
 #include <yql/essentials/core/yql_expr_type_annotation.h>
+#include <yql/essentials/core/yql_opt_range.h>
 #include <yql/essentials/core/yql_opt_utils.h>
 
 namespace NKikimr::NKqp {
@@ -207,7 +208,8 @@ TExprNode::TPtr ExpandScalarHasNull(
 
 TExprNode::TPtr FindCompatibilityNode(const TExprNode::TPtr& root) {
     return FindNode(root, [](const TExprNode::TPtr& node) {
-        return node->IsCallable({"StrictCast", "HasNull", "SqlIn"}) || IsComplexComparison(node);
+        return node->IsCallable({"StrictCast", "HasNull", "SqlIn", "RangeEmpty", "AsRange", "RangeFor"}) ||
+            IsComplexComparison(node);
     });
 }
 
@@ -238,6 +240,15 @@ NYql::TExprNode::TPtr RewriteRboCompatibilityNode(
             return KeepSideEffects(std::move(result), node->HeadPtr(), ctx);
         }
         return ExpandTupleComparison(node, ctx);
+    }
+    if (node->IsCallable("RangeEmpty")) {
+        return ExpandRangeEmpty(node, ctx);
+    }
+    if (node->IsCallable("AsRange")) {
+        return ExpandAsRange(node, ctx);
+    }
+    if (node->IsCallable("RangeFor")) {
+        return ExpandRangeFor(node, ctx);
     }
     return node;
 }

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.cpp
@@ -1,19 +1,40 @@
 #include "kqp_rbo_compatibility.h"
+#include "kqp_rbo_physical_strict_cast.h"
+
+#include <yql/essentials/core/yql_expr_optimize.h>
 
 namespace NKikimr::NKqp {
+namespace {
 
-bool NeedsRboCompatibilityLowering(const NYql::TExprNode::TPtr&) {
-    return false;
+using namespace NYql;
+
+TExprNode::TPtr FindCompatibilityNode(const TExprNode::TPtr& root) {
+    return FindNode(root, [](const TExprNode::TPtr& node) {
+        return node->IsCallable("StrictCast");
+    });
+}
+
+} // namespace
+
+bool NeedsRboCompatibilityLowering(const NYql::TExprNode::TPtr& root) {
+    return !!FindCompatibilityNode(root);
 }
 
 NYql::TExprNode::TPtr RewriteRboCompatibilityNode(
     const NYql::TExprNode::TPtr& node,
-    NYql::TExprContext&,
+    NYql::TExprContext& ctx,
     const NYql::TTypeAnnotationContext&) {
+    if (node->IsCallable("StrictCast")) {
+        return NPhysicalConvertionUtils::ExpandScalarStrictCast(node, ctx);
+    }
     return node;
 }
 
-void EnsureRboCompatibilityLowered(const NYql::TExprNode::TPtr&) {
+void EnsureRboCompatibilityLowered(const NYql::TExprNode::TPtr& root) {
+    if (const auto unsupported = FindCompatibilityNode(root)) {
+        YQL_ENSURE(false, "Focused RBO compatibility lowering failed on "
+                              << unsupported->Content());
+    }
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.h
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_compatibility.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <yql/essentials/core/yql_type_annotation.h>
+
+namespace NKikimr::NKqp {
+
+bool NeedsRboCompatibilityLowering(const NYql::TExprNode::TPtr& root);
+
+NYql::TExprNode::TPtr RewriteRboCompatibilityNode(
+    const NYql::TExprNode::TPtr& node,
+    NYql::TExprContext& ctx,
+    const NYql::TTypeAnnotationContext& types);
+
+void EnsureRboCompatibilityLowered(const NYql::TExprNode::TPtr& root);
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_convert_to_physical.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_convert_to_physical.cpp
@@ -265,7 +265,10 @@ TExprNode::TPtr ConvertToPhysical(TOpRoot& root, TRBOContext& rboCtx) {
                 memLimit = -i64(*memLimitSetting);
             }
 
-            currentStageBody = Build<TPhysicalAggregationBuilder>(aggregate, ctx, op->Pos, currentStageBody, memLimit);
+            // The full physical-stage peephole performs this pruning later.
+            const bool pruneUnusedOutputs = !rboCtx.KqpCtx.Config->GetEnableNewRBOPhysicalStagePeephole();
+            currentStageBody = TPhysicalAggregationBuilder(aggregate, ctx, op->Pos, pruneUnusedOutputs)
+                .BuildPhysicalOp(currentStageBody, memLimit);
             if (!aggregate->IsSingleConsumer()) {
                 currentStageBody = NPhysicalConvertionUtils::BuildMultiConsumerHandler(currentStageBody, aggregate->GetNumOfConsumers(), ctx, op->Pos);
             }

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_aggregation_builder.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_aggregation_builder.cpp
@@ -1007,10 +1007,24 @@ TExprNode::TPtr TPhysicalAggregationBuilder::BuildFinishHandlerLambda(const TVec
         lambdaArgsMap.insert({keyFields[i], lambdaArgsCounter++});
     }
 
+    const auto liveOutputs = PruneUnusedOutputs
+        ? NPhysicalConvertionUtils::BuildNameSet(NPhysicalConvertionUtils::GetLiveOutputIUs(*Aggregate))
+        : THashSet<TString>{};
+
     TVector<TExprNode::TPtr> lambdaResults;
+    const auto addResult = [&](TExprNode::TPtr result, const TString& logicalName) {
+        if (!PruneUnusedOutputs || liveOutputs.contains(logicalName)) {
+            lambdaResults.push_back(std::move(result));
+        }
+    };
+
+    Y_ENSURE(!isDistinct || keyFields.size() == aggTraitsList.size());
     for (ui32 i = 0; i < keyFields.size(); ++i) {
         const auto it = lambdaArgsMap.find(keyFields[i]);
-        lambdaResults.push_back(lambdaArgs[it->second]);
+        if (isDistinct) {
+            Y_ENSURE(keyFields[i] == aggTraitsList[i].OriginalColName);
+        }
+        addResult(lambdaArgs[it->second], isDistinct ? aggTraitsList[i].ResultColName : keyFields[i]);
     }
 
     if (!isDistinct) {
@@ -1073,10 +1087,11 @@ TExprNode::TPtr TPhysicalAggregationBuilder::BuildFinishHandlerLambda(const TVec
                 .Done().Ptr();
                 // clang-format on
             }
-            lambdaResults.push_back(finishState);
+            addResult(std::move(finishState), aggTraits.ResultColName);
         }
     }
 
+    Y_ENSURE(lambdaResults.size() == (PruneUnusedOutputs ? liveOutputs.size() : Aggregate->GetOutputIUs().size()));
     return Ctx.NewLambda(Pos, Ctx.NewArguments(Pos, std::move(lambdaArgs)), std::move(lambdaResults));
 }
 
@@ -1091,6 +1106,7 @@ TExprNode::TPtr TPhysicalAggregationBuilder::BuildNarrowMapForPhysicalAggregatio
     for (const auto& aggTraits : aggTraitsList) {
         outputFields.push_back(aggTraits.StateFieldName);
     }
+    Y_ENSURE(outputFields.size() == Aggregate->GetOutputIUs().size());
 
     if (keyFields.empty() && aggregationPhase != EOpPhase::Intermediate) {
         // clang-format off
@@ -1114,7 +1130,7 @@ TExprNode::TPtr TPhysicalAggregationBuilder::BuildNarrowMapForPhysicalAggregatio
         .Callable("NarrowMap")
             .Add(0, input)
             .Lambda(1)
-                .Params("wide_param", outputFields.size())
+                .Params("wide_param", PruneUnusedOutputs ? outputs.size() : outputFields.size())
                 .Callable(0, "AsStruct")
                 .Do([&](TExprNodeBuilder& parent) -> TExprNodeBuilder& {
                     ui32 outputIndex = 0;
@@ -1128,11 +1144,13 @@ TExprNode::TPtr TPhysicalAggregationBuilder::BuildNarrowMapForPhysicalAggregatio
                         if (!outputs.contains(fieldName)) {
                             continue;
                         }
-                        parent.List(outputIndex++)
+                        parent.List(outputIndex)
                             .Atom(0, fieldName)
-                            .Arg(1, "wide_param", i)
+                            .Arg(1, "wide_param", PruneUnusedOutputs ? outputIndex : i)
                         .Seal();
+                        ++outputIndex;
                     }
+                    Y_ENSURE(outputIndex == outputs.size());
                     return parent;
                 })
                 .Seal()

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_aggregation_builder.h
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_aggregation_builder.h
@@ -42,9 +42,10 @@ class TPhysicalAggregationBuilder: public TPhysicalUnaryOpBuilderWithMemLimit {
     };
 
 public:
-    TPhysicalAggregationBuilder(TIntrusivePtr<TOpAggregate> aggregate, TExprContext& ctx, TPositionHandle pos)
+    TPhysicalAggregationBuilder(TIntrusivePtr<TOpAggregate> aggregate, TExprContext& ctx, TPositionHandle pos, bool pruneUnusedOutputs = false)
         : TPhysicalUnaryOpBuilderWithMemLimit(ctx, pos)
-        , Aggregate(aggregate) {
+        , Aggregate(aggregate)
+        , PruneUnusedOutputs(pruneUnusedOutputs) {
     }
 
     TExprNode::TPtr BuildPhysicalOp(TExprNode::TPtr input, std::optional<i64> memLimit) override;
@@ -128,6 +129,7 @@ private:
 
     // Holds an aggregate operator.
     TIntrusivePtr<TOpAggregate> Aggregate;
+    const bool PruneUnusedOutputs;
     // This Map represents a simple physical aggregation functions.
     const THashMap<TString, TString> AggregationFunctionToAggregationCallable{{"sum", "AggrAdd"}, {"min", "AggrMin"}, {"max", "AggrMax"}};
     // The name of the physical aggregation.

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_convertion_utils.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_convertion_utils.cpp
@@ -133,22 +133,25 @@ TExprNode::TPtr ReplaceArg(TExprNode::TPtr input, TExprNode::TPtr arg, TExprCont
 }
 
 TExprNode::TPtr ExtractMembers(TExprNode::TPtr input, TExprContext &ctx, TVector<TInfoUnit> members) {
-    TVector<TCoAtom> memberAtoms;
-    memberAtoms.reserve(members.size());
+    auto arg = ctx.NewArgument(input->Pos(), "extract_members_arg");
+    TExprNode::TListType fields;
+    fields.reserve(members.size());
     for (const auto& iu : members) {
-        memberAtoms.push_back(Build<TCoAtom>(ctx, input->Pos())
-            .Value(iu.GetFullName())
-        .Done());
+        fields.emplace_back(ctx.Builder(input->Pos())
+            .List()
+                .Atom(0, iu.GetFullName())
+                .Callable(1, "Member")
+                    .Add(0, arg)
+                    .Atom(1, iu.GetFullName())
+                .Seal()
+            .Seal()
+            .Build());
     }
 
-    // clang-format off
-    return Build<TCoExtractMembers>(ctx, input->Pos())
-        .Input(input)
-        .Members<TCoAtomList>()
-            .Add(memberAtoms)
-        .Build()
-    .Done().Ptr();
-    // clang-format on
+    auto body = ctx.NewCallable(input->Pos(), "AsStruct", std::move(fields));
+    auto lambda = ctx.NewLambda(input->Pos(), ctx.NewArguments(input->Pos(), {std::move(arg)}), std::move(body));
+    // OrderedMap is conservative when constraints have not been computed for the newly built input yet.
+    return ctx.NewCallable(input->Pos(), "OrderedMap", {std::move(input), std::move(lambda)});
 }
 
 TExprNode::TPtr BuildRenameMap(TExprNode::TPtr input, const TVector<std::pair<TString, TString>>& renames, TExprContext& ctx) {

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_lookup_join_builder.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_lookup_join_builder.cpp
@@ -21,6 +21,23 @@ TCoNameValueTuple BuildMemberTuple(const TString& name, const TString& sourceNam
     // clang-format on
 }
 
+TExprBase BuildOptionalIf(const TExprBase& predicate, const TExprBase& value, TExprContext& ctx, TPositionHandle pos) {
+    const auto item = ctx.NewCallable(pos, "Just", {value.Ptr()});
+    return TExprBase(ctx.Builder(pos)
+        .Callable("If")
+            .Callable(0, "Coalesce")
+                .Add(0, predicate.Ptr())
+                .Callable(1, "Bool")
+                    .Atom(0, "false")
+                .Seal()
+            .Seal()
+            .Add(1, item)
+            .Callable(2, "EmptyFrom")
+                .Add(0, item)
+            .Seal()
+        .Seal().Build());
+}
+
 } // anonymous namespace
 
 namespace NKikimr::NKqp::NLookupJoinBuilder {
@@ -123,17 +140,7 @@ TLookupKeysResult BuildLookupKeys(TOpTableLookup& lookup, TExprNode::TPtr inputS
             const auto predicate = equalities.size() == 1
                 ? equalities.front()
                 : TExprBase(Build<TCoAnd>(ctx, pos).Add(equalities).Done());
-            // clang-format off
-            maybeKey = Build<TCoOptionalIf>(ctx, pos)
-                .Predicate<TCoCoalesce>()
-                    .Predicate(predicate)
-                    .Value<TCoBool>()
-                        .Literal().Build("false")
-                    .Build()
-                .Build()
-                .Value(keyStruct)
-            .Done();
-            // clang-format on
+            maybeKey = BuildOptionalIf(predicate, keyStruct, ctx, pos);
         }
 
         // We have to check that ranges are not null. For example `where a is null`, where a is a pk, is also valid point predicate for us.
@@ -272,15 +279,7 @@ TExprNode::TPtr TPhysicalIndexLookupJoinBuilder::ProcessFetchedRows(TExprNode::T
             .Input(processedRow)
             .Lambda()
                 .Args({row})
-                .Body<TCoOptionalIf>()
-                    .Predicate<TCoCoalesce>()
-                        .Predicate(lambda.Body())
-                        .Value<TCoBool>()
-                            .Literal().Build("false")
-                        .Build()
-                    .Build()
-                    .Value(row)
-                .Build()
+                .Body(BuildOptionalIf(lambda.Body(), row, Ctx, Pos))
             .Build()
         .Done();
         // clang-format on
@@ -325,15 +324,7 @@ TExprNode::TPtr TPhysicalIndexLookupJoinBuilder::ProcessFetchedRows(TExprNode::T
             .Input(processedRow)
             .Lambda()
                 .Args({rightArg})
-                .Body<TCoOptionalIf>()
-                    .Predicate<TCoCoalesce>()
-                        .Predicate(pred)
-                        .Value<TCoBool>()
-                            .Literal().Build("false")
-                        .Build()
-                    .Build()
-                    .Value(rightArg)
-                .Build()
+                .Body(BuildOptionalIf(pred, rightArg, Ctx, Pos))
             .Build()
         .Done();
         // clang-format on

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_query_builder.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_query_builder.cpp
@@ -1,4 +1,5 @@
 #include "kqp_rbo_physical_query_builder.h"
+#include "kqp_rbo_compatibility.h"
 
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/opt/peephole/kqp_opt_peephole.h>
@@ -124,13 +125,57 @@ TPhysicalQueryBuilder::TPhysicalQueryBuilder(TOpRoot& root, TStageGraph&& graph,
 TExprNode::TPtr TPhysicalQueryBuilder::BuildPhysicalQuery() {
     auto phyStages = BuildPhysicalStageGraph();
     SubmitPhysicalStagesTrace(RBOCtx, "After physical stage graph build", phyStages);
-    phyStages = EnableWideChannelsPhysicalStages(std::move(phyStages));
-    SubmitPhysicalStagesTrace(RBOCtx, "After wide channel rewrite", phyStages);
-    phyStages = PeepHoleOptimizePhysicalStages(std::move(phyStages));
-    SubmitPhysicalStagesTrace(RBOCtx, "After physical peephole", phyStages);
+    const bool fullPeephole = RBOCtx.KqpCtx.Config->GetEnableNewRBOPhysicalStagePeephole();
+    phyStages = PreparePhysicalStages(std::move(phyStages), fullPeephole);
+    SubmitPhysicalStagesTrace(RBOCtx, "After physical stage preparation", phyStages);
+    if (!fullPeephole) {
+        phyStages = LowerPhysicalStageCompatibility(std::move(phyStages));
+        SubmitPhysicalStagesTrace(RBOCtx, "After compatibility lowering", phyStages);
+    } else {
+        phyStages = PeepHoleOptimizePhysicalStages(std::move(phyStages));
+        SubmitPhysicalStagesTrace(RBOCtx, "After physical peephole", phyStages);
+    }
     auto physicalQuery = BuildPhysicalQuery(std::move(phyStages));
     SubmitPhysicalExprTrace(RBOCtx, "Final physical query", physicalQuery);
     return physicalQuery;
+}
+
+TVector<TExprNode::TPtr> TPhysicalQueryBuilder::LowerPhysicalStageCompatibility(TVector<TExprNode::TPtr>&& physicalStages) {
+    Y_ENSURE(!physicalStages.empty());
+    auto root = physicalStages.back();
+    if (!NeedsRboCompatibilityLowering(root)) {
+        return std::move(physicalStages);
+    }
+
+    TOptimizeExprSettings settings(&RBOCtx.TypeCtx);
+    settings.CustomInstantTypeTransformer = RBOCtx.TypeCtx.CustomInstantTypeTransformer.Get();
+    constexpr size_t MaxPasses = 64;
+    for (size_t pass = 0; pass < MaxPasses && NeedsRboCompatibilityLowering(root); ++pass) {
+        TExprNode::TPtr output;
+        const auto status = OptimizeExpr(
+            root,
+            output,
+            [&](const TExprNode::TPtr& node, TExprContext& ctx) {
+                return RewriteRboCompatibilityNode(node, ctx, RBOCtx.TypeCtx);
+            },
+            RBOCtx.ExprCtx,
+            settings);
+        YQL_ENSURE(status != IGraphTransformer::TStatus::Error,
+            "Failed to lower execution-incompatible callables in new RBO physical stages");
+        if (status == IGraphTransformer::TStatus::Ok) {
+            break;
+        }
+
+        YQL_ENSURE(status == IGraphTransformer::TStatus::Repeat);
+        YQL_ENSURE(output != root, "RBO compatibility lowering made no progress");
+        root = std::move(output);
+        TypeAnnotate(root);
+    }
+
+    EnsureRboCompatibilityLowered(root);
+    TVector<TExprNode::TPtr> stagesTopSorted;
+    TopologicalSort(TDqPhyStage(root), stagesTopSorted);
+    return stagesTopSorted;
 }
 
 TVector<TExprNode::TPtr> TPhysicalQueryBuilder::BuildPhysicalStageGraph() {
@@ -638,7 +683,7 @@ void TPhysicalQueryBuilder::KeepTypeAnnotationForStageAndFirstLevelChilds(TDqPhy
     }
 }
 
-TVector<TExprNode::TPtr> TPhysicalQueryBuilder::EnableWideChannelsPhysicalStages(TVector<TExprNode::TPtr>&& physicalStages) {
+TVector<TExprNode::TPtr> TPhysicalQueryBuilder::PreparePhysicalStages(TVector<TExprNode::TPtr>&& physicalStages, bool enableWideChannels) {
     Y_ENSURE(physicalStages.size());
     auto root = physicalStages.back();
     if (!root->GetTypeAnn()) {
@@ -660,12 +705,14 @@ TVector<TExprNode::TPtr> TPhysicalQueryBuilder::EnableWideChannelsPhysicalStages
         // clang-format on
 
         TypeAnnotate(newStage);
-        rootStage = NYql::NDq::RebuildStageInputsAsWide(TDqPhyStage(newStage), ctx).Ptr();
+        rootStage = enableWideChannels
+            ? NYql::NDq::RebuildStageInputsAsWide(TDqPhyStage(newStage), ctx).Ptr()
+            : newStage;
         replaces[dqPhyStage.Raw()] = rootStage;
     }
 
     TypeAnnotate(rootStage);
-    YQL_CLOG(TRACE, CoreDq) << "[NEW RBO Wide channels] " << KqpExprToPrettyString(TExprBase(rootStage), ctx);
+    YQL_CLOG(TRACE, CoreDq) << "[NEW RBO Physical stages] " << KqpExprToPrettyString(TExprBase(rootStage), ctx);
 
     TVector<TExprNode::TPtr> stagesTopSorted;
     TopologicalSort(TDqPhyStage(rootStage), stagesTopSorted);

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_query_builder.h
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_query_builder.h
@@ -21,8 +21,9 @@ public:
 
 private:
     TVector<NYql::TExprNode::TPtr> BuildPhysicalStageGraph();
+    TVector<NYql::TExprNode::TPtr> LowerPhysicalStageCompatibility(TVector<NYql::TExprNode::TPtr>&& physicalStages);
     TVector<NYql::TExprNode::TPtr> PeepHoleOptimizePhysicalStages(TVector<NYql::TExprNode::TPtr>&& physicalStages);
-    TVector<NYql::TExprNode::TPtr> EnableWideChannelsPhysicalStages(TVector<NYql::TExprNode::TPtr>&& physicalStages);
+    TVector<NYql::TExprNode::TPtr> PreparePhysicalStages(TVector<NYql::TExprNode::TPtr>&& physicalStages, bool enableWideChannels);
     NYql::TExprNode::TPtr BuildPhysicalQuery(TVector<NYql::TExprNode::TPtr>&& physicalStages);
     NYql::TExprNode::TPtr PeepHoleOptimize(NYql::TExprNode::TPtr input, const TVector<const NYql::TTypeAnnotationNode*>& argsType) const;
     bool CanApplyPeepHole(NYql::TExprNode::TPtr input, const std::initializer_list<std::string_view>& callableNames) const;

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_strict_cast.cpp
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_strict_cast.cpp
@@ -1,0 +1,240 @@
+#include "kqp_rbo_physical_strict_cast.h"
+
+#include <yql/essentials/core/yql_expr_type_annotation.h>
+
+#include <utility>
+
+namespace NKikimr::NKqp::NPhysicalConvertionUtils {
+
+using namespace NYql;
+
+namespace {
+
+bool IsScalarCastType(const TTypeAnnotationNode* type) {
+    while (type && type->GetKind() == ETypeAnnotationKind::Optional) {
+        type = type->Cast<TOptionalExprType>()->GetItemType();
+    }
+    return type && type->GetKind() == ETypeAnnotationKind::Data;
+}
+
+bool StrongCastMayFail(const TTypeAnnotationNode* source, const TTypeAnnotationNode* target) {
+    return CastResult<true>(source, target) & NUdf::ECastOptions::MayFail;
+}
+
+TExprNode::TPtr ExpandDataCast(const TExprNode::TPtr& input, TExprContext& ctx) {
+    const auto* from = input->Head().GetTypeAnn()->Cast<TDataExprType>();
+    const auto* to = input->GetTypeAnn()->Cast<TDataExprType>();
+    const auto fromFeatures = NUdf::GetDataTypeInfo(from->GetSlot()).Features;
+    const auto toFeatures = NUdf::GetDataTypeInfo(to->GetSlot()).Features;
+
+    if (((fromFeatures & NUdf::TzDateType) && (toFeatures & (NUdf::DateType | NUdf::TzDateType))) ||
+        ((toFeatures & NUdf::TzDateType) && (fromFeatures & (NUdf::DateType | NUdf::TzDateType)))) {
+        return ctx.Builder(input->Pos())
+            .Callable("Apply")
+                .Callable(0, "Udf")
+                    .Atom(0, TString("DateTime2.Make") + to->GetName())
+                .Seal()
+                .Add(1, input->HeadPtr())
+            .Seal().Build();
+    }
+
+    return ctx.RenameNode(*input, "SafeCast");
+}
+
+TExprNode::TPtr ExpandOptionalDataCast(const TExprNode::TPtr& input, TExprContext& ctx) {
+    const auto* targetType = input->GetTypeAnn()->Cast<TOptionalExprType>()->GetItemType();
+    const auto options = CastResult<false>(input->Head().GetTypeAnn(), targetType);
+
+    TExprNode::TPtr casted;
+    if (options & NUdf::ECastOptions::MayFail) {
+        casted = ctx.RenameNode(*input, "SafeCast");
+    } else {
+        casted = ctx.Builder(input->Pos())
+            .Callable("Just")
+                .Callable(0, "SafeCast")
+                    .Add(0, input->HeadPtr())
+                    .Add(1, ExpandType(input->Tail().Pos(), *targetType, ctx))
+                .Seal()
+            .Seal().Build();
+    }
+
+    if (options & NUdf::ECastOptions::MayLoseData) {
+        casted = ctx.Builder(input->Pos())
+            .Callable("Filter")
+                .Add(0, std::move(casted))
+                .Lambda(1)
+                    .Param("casted")
+                    .Callable("==")
+                        .Add(0, input->HeadPtr())
+                        .Arg(1, "casted")
+                    .Seal()
+                .Seal()
+            .Seal().Build();
+    }
+
+    return casted;
+}
+
+TExprNode::TPtr ExpandOptionalCast(const TExprNode::TPtr& input, TExprContext& ctx) {
+    const auto sourceType = input->Head().GetTypeAnn();
+    const auto targetType = input->GetTypeAnn();
+    const auto* sourceItemType = sourceType->Cast<TOptionalExprType>()->GetItemType();
+    const auto* targetItemType = targetType->Cast<TOptionalExprType>()->GetItemType();
+    const bool mayFail = StrongCastMayFail(sourceItemType, targetItemType);
+    const auto sourceLevel = GetOptionalLevel(sourceItemType);
+    const auto targetLevel = GetOptionalLevel(targetItemType);
+
+    if (mayFail && targetLevel > 0U) {
+        auto stub = ExpandType(input->Tail().Pos(), *targetType, ctx);
+        auto type = ExpandType(input->Tail().Pos(), *targetItemType, ctx);
+
+        if (sourceLevel == targetLevel) {
+            return ctx.Builder(input->Pos())
+                .Callable("FlatMap")
+                    .Add(0, input->HeadPtr())
+                    .Lambda(1)
+                        .Param("item")
+                        .Callable("If")
+                            .Callable(0, "Or")
+                                .Callable(0, "Exists")
+                                    .Callable(0, "StrictCast")
+                                        .Arg(0, "item")
+                                        .Add(1, type)
+                                    .Seal()
+                                .Seal()
+                                .Callable(1, "Not")
+                                    .Callable(0, "Exists")
+                                        .Arg(0, "item")
+                                    .Seal()
+                                .Seal()
+                            .Seal()
+                            .Callable(1, "Just")
+                                .Callable(0, "StrictCast")
+                                    .Arg(0, "item")
+                                    .Add(1, std::move(type))
+                                .Seal()
+                            .Seal()
+                            .Callable(2, "Nothing")
+                                .Add(0, std::move(stub))
+                            .Seal()
+                        .Seal()
+                    .Seal()
+                .Seal().Build();
+        }
+
+        if (sourceLevel < targetLevel) {
+            auto casted = ctx.ChangeChild(*input, 1U, std::move(type));
+            return ctx.Builder(input->Pos())
+                .Callable("If")
+                    .Callable(0, "Or")
+                        .Callable(0, "Exists")
+                            .Add(0, casted)
+                        .Seal()
+                        .Callable(1, "Not")
+                            .Callable(0, "Exists")
+                                .Add(0, input->HeadPtr())
+                            .Seal()
+                        .Seal()
+                    .Seal()
+                    .Callable(1, "Just")
+                        .Add(0, std::move(casted))
+                    .Seal()
+                    .Callable(2, "Nothing")
+                        .Add(0, std::move(stub))
+                    .Seal()
+                .Seal().Build();
+        }
+    }
+
+    const bool flat = mayFail || sourceLevel > targetLevel;
+    auto type = ExpandType(input->Tail().Pos(), flat ? *targetType : *targetItemType, ctx);
+    if (!mayFail && sourceLevel < targetLevel) {
+        return ctx.Builder(input->Pos())
+            .Callable("Just")
+                .Callable(0, "StrictCast")
+                    .Add(0, input->HeadPtr())
+                    .Add(1, std::move(type))
+                .Seal()
+            .Seal().Build();
+    }
+
+    return ctx.Builder(input->Pos())
+        .Callable(flat ? "FlatMap" : "Map")
+            .Add(0, input->HeadPtr())
+            .Lambda(1)
+                .Param("item")
+                .Callable("StrictCast")
+                    .Arg(0, "item")
+                    .Add(1, std::move(type))
+                .Seal()
+            .Seal()
+        .Seal().Build();
+}
+
+} // anonymous namespace
+
+TExprNode::TPtr ExpandScalarStrictCast(const TExprNode::TPtr& input, TExprContext& ctx) {
+    YQL_ENSURE(input->IsCallable("StrictCast"), "Expected StrictCast, got " << input->Content());
+    YQL_ENSURE(
+        input->Head().GetTypeAnn() && input->GetTypeAnn(),
+        "StrictCast must be type-annotated before expansion");
+    YQL_ENSURE(
+        IsScalarCastType(input->Head().GetTypeAnn()) && IsScalarCastType(input->GetTypeAnn()),
+        "KQP physical conversion supports StrictCast only over Data and its Optional wrappers; got "
+            << *input->Head().GetTypeAnn() << " to " << *input->GetTypeAnn());
+    YQL_ENSURE(
+        !(CastResult<true>(input->Head().GetTypeAnn(), input->GetTypeAnn()) & NUdf::ECastOptions::Impossible),
+        "KQP physical conversion cannot expand an impossible StrictCast from "
+            << *input->Head().GetTypeAnn() << " to " << *input->GetTypeAnn());
+
+    const auto sourceKind = input->Head().GetTypeAnn()->GetKind();
+    const auto targetKind = input->GetTypeAnn()->GetKind();
+    if (sourceKind == targetKind) {
+        switch (sourceKind) {
+            case ETypeAnnotationKind::Data:
+                return ExpandDataCast(input, ctx);
+            case ETypeAnnotationKind::Optional:
+                return ExpandOptionalCast(input, ctx);
+            default:
+                break;
+        }
+    } else if (targetKind == ETypeAnnotationKind::Optional) {
+        const auto* targetItemType = input->GetTypeAnn()->Cast<TOptionalExprType>()->GetItemType();
+        auto type = ExpandType(input->Tail().Pos(), *targetItemType, ctx);
+        if (StrongCastMayFail(input->Head().GetTypeAnn(), targetItemType)) {
+            if (sourceKind == ETypeAnnotationKind::Data && targetItemType->GetKind() == ETypeAnnotationKind::Data) {
+                return ExpandOptionalDataCast(input, ctx);
+            }
+
+            return ctx.Builder(input->Pos())
+                .Callable("Map")
+                    .Callable(0, "StrictCast")
+                        .Add(0, input->HeadPtr())
+                        .Add(1, std::move(type))
+                    .Seal()
+                    .Lambda(1)
+                        .Param("item")
+                        .Callable("Just")
+                            .Arg(0, "item")
+                        .Seal()
+                    .Seal()
+                .Seal().Build();
+        }
+
+        return ctx.Builder(input->Pos())
+            .Callable("Just")
+                .Callable(0, "StrictCast")
+                    .Add(0, input->HeadPtr())
+                    .Add(1, std::move(type))
+                .Seal()
+            .Seal().Build();
+    }
+
+    YQL_ENSURE(
+        false,
+        "KQP physical conversion cannot expand StrictCast from "
+            << *input->Head().GetTypeAnn() << " to " << *input->GetTypeAnn());
+    return input;
+}
+
+} // namespace NKikimr::NKqp::NPhysicalConvertionUtils

--- a/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_strict_cast.h
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/kqp_rbo_physical_strict_cast.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <yql/essentials/ast/yql_expr.h>
+
+namespace NKikimr::NKqp::NPhysicalConvertionUtils {
+
+// Expands one typed StrictCast over Data or Optional wrappers around it.
+// The result can contain smaller StrictCast nodes, so callers must
+// type-annotate and repeat until no StrictCast remains.
+NYql::TExprNode::TPtr ExpandScalarStrictCast(const NYql::TExprNode::TPtr &input,
+                                             NYql::TExprContext &ctx);
+
+} // namespace NKikimr::NKqp::NPhysicalConvertionUtils

--- a/ydb/core/kqp/opt/rbo/physical_conversion/ya.make
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/ya.make
@@ -11,6 +11,7 @@ SRCS(
     kqp_rbo_physical_union_all_builder.cpp
     kqp_rbo_physical_filter_builder.cpp
     kqp_rbo_physical_source_builder.cpp
+    kqp_rbo_physical_strict_cast.cpp
     kqp_rbo_physical_convertion_utils.cpp
     kqp_rbo_physical_query_builder.cpp
 )

--- a/ydb/core/kqp/opt/rbo/physical_conversion/ya.make
+++ b/ydb/core/kqp/opt/rbo/physical_conversion/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     kqp_rbo_convert_to_physical.cpp
+    kqp_rbo_compatibility.cpp
     kqp_rbo_physical_aggregation_builder.cpp
     kqp_rbo_physical_sort_builder.cpp
     kqp_rbo_physical_join_builder.cpp

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -107,6 +107,7 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, UseGraceJoinCoreForMap);
     REGISTER_SETTING(*this, UseBlockHashJoin);
     REGISTER_SETTING(*this, UseBlockHashJoinForCross);
+    REGISTER_SETTING(*this, EnableNewRBOPhysicalStagePeephole);
     REGISTER_SETTING(*this, BlockHashJoinSwapLeftJoinSides);
     REGISTER_SETTING(*this, EnableOrderPreservingLookupJoin);
     REGISTER_SETTING(*this, OptEnableParallelUnionAllConnectionsForExtend);
@@ -391,6 +392,11 @@ bool TKikimrConfiguration::GetUseBlockHashJoin() const {
 
 bool TKikimrConfiguration::GetUseBlockHashJoinForCross() const {
     return UseBlockHashJoinForCross.Get().GetOrElse(TTableServiceConfig::GetUseBlockHashJoinForCross());
+}
+
+bool TKikimrConfiguration::GetEnableNewRBOPhysicalStagePeephole() const {
+    return EnableNewRBOPhysicalStagePeephole.Get().GetOrElse(
+        TTableServiceConfig::GetEnableNewRBOPhysicalStagePeephole());
 }
 
 bool TKikimrConfiguration::GetUseKqpTasksGraphV2() const {

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -63,6 +63,7 @@ public:
     NCommon::TConfSetting<bool, Static> UseGraceJoinCoreForMap;
     NCommon::TConfSetting<bool, Static> UseBlockHashJoin;
     NCommon::TConfSetting<bool, Static> UseBlockHashJoinForCross;
+    NCommon::TConfSetting<bool, Static> EnableNewRBOPhysicalStagePeephole;
     NCommon::TConfSetting<bool, Static> BlockHashJoinSwapLeftJoinSides;
     NCommon::TConfSetting<bool, Static> EnableOrderPreservingLookupJoin;
     NCommon::TConfSetting<bool, Static> OptEnableParallelUnionAllConnectionsForExtend;
@@ -257,6 +258,7 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool GetDqHashCombineExportTypeInfo() const;
     bool GetUseBlockHashJoin() const;
     bool GetUseBlockHashJoinForCross() const;
+    bool GetEnableNewRBOPhysicalStagePeephole() const;
     bool GetUseKqpTasksGraphV2() const;
     bool IsAutoIndexSelectionDisabled() const;
     bool IsAutoIndexSelectionForIndexLookupJoinEnabled() const;

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_olap_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_olap_ut.cpp
@@ -1968,6 +1968,8 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
             NYdb::NQuery::TExecuteQuerySettings scanSettings;
             scanSettings.ExecMode(NYdb::NQuery::EExecMode::Explain);
             auto it = client.StreamExecuteQuery(R"(
+                PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = "true";
+
                 SELECT
                     b, COUNT(*), SUM(a)
                 FROM `/Root/ColumnShard`
@@ -2042,7 +2044,8 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
             NYdb::NQuery::TExecuteQuerySettings scanSettings;
             scanSettings.ExecMode(NYdb::NQuery::EExecMode::Explain);
             auto it = client.StreamExecuteQuery(R"(
-    	    	PRAGMA ydb.UseBlockHashJoin = "false";
+                PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = "true";
+                PRAGMA ydb.UseBlockHashJoin = "false";
                 PRAGMA ydb.OptimizerHints =
                 '
                     JoinType(T1 T2 Shuffle)
@@ -2120,7 +2123,9 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
         )";
 
         {
-            auto res = StreamExplainQuery(query, client);
+            auto res = StreamExplainQuery(
+                TStringBuilder() << "PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = \"true\";\n" << query,
+                client);
             UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
 
             auto plan = CollectStreamResult(res);
@@ -2482,6 +2487,7 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
     Y_UNIT_TEST(OlapFilterPeephole) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(true);
 
         auto settings = TKikimrSettings(appConfig).SetWithSampleTables(false);
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
@@ -2580,9 +2586,11 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
 
         for (ui32 i = 0; i < queries.size(); ++i) {
             const auto query = queries[i];
+            const TString explainQuery = TStringBuilder()
+                << "PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = \"true\";\n" << query;
             auto result =
                 session2
-                    .ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
+                    .ExecuteQuery(explainQuery, NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
                     .ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
 
@@ -2605,9 +2613,11 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
 
         for (ui32 i = 0; i < queries.size(); ++i) {
             const auto query = queries[i];
+            const TString explainQuery = TStringBuilder()
+                << "PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = \"true\";\n" << query;
             auto result =
                 session2
-                    .ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
+                    .ExecuteQuery(explainQuery, NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
                     .ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
 

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_olap_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_olap_ut.cpp
@@ -2209,6 +2209,7 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
     Y_UNIT_TEST(CountWhereColumnIsNull) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(false);
 
         auto settings = TKikimrSettings(appConfig)
             .SetWithSampleTables(false);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_olap_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_olap_ut.cpp
@@ -184,6 +184,7 @@ Y_UNIT_TEST_SUITE(KqpRboOlap) {
     Y_UNIT_TEST(PredicatePushdown) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(false);
         constexpr bool logQueries = false;
         auto settings = TKikimrSettings(appConfig)
             .SetWithSampleTables(false);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -4220,6 +4220,7 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         auto runQueries = [&](bool newRbo) {
             NKikimrConfig::TAppConfig appConfig;
             appConfig.MutableTableServiceConfig()->SetEnableNewRBO(newRbo);
+            appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(false);
             appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
             appConfig.MutableTableServiceConfig()->SetDefaultCostBasedOptimizationLevel(4);
             appConfig.MutableTableServiceConfig()->SetDefaultEnableShuffleElimination(false);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -8665,6 +8665,7 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
     Y_UNIT_TEST(JoinOptionalKeys) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(false);
         appConfig.MutableTableServiceConfig()->SetAllowOlapDataQuery(true);
         appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
         appConfig.MutableTableServiceConfig()->SetDefaultLangVer(NYql::GetMaxLangVersion());

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -9683,8 +9683,10 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         for (ui32 i = 0; i < queries.size(); ++i) {
             const auto& query = queries[i];
             auto session = queryClient.GetSession().GetValueSync().GetSession();
+            const TString explainQuery = TStringBuilder()
+                << "PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = \"true\";\n" << query;
             auto result =
-                session.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
+                session.ExecuteQuery(explainQuery, NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
                     .ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
             auto ast = *result.GetStats()->GetAst();

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -1773,6 +1773,7 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
     Y_UNIT_TEST(DistinctAllTypeMatchesLogicalOutputColumns) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(false);
         appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
         appConfig.MutableTableServiceConfig()->SetAllowOlapDataQuery(true);
         appConfig.MutableTableServiceConfig()->SetDefaultLangVer(NYql::GetMaxLangVersion());
@@ -2439,6 +2440,7 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
     void TestAggregation(bool columnStore) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBOPhysicalStagePeephole(false);
         appConfig.MutableTableServiceConfig()->SetAllowOlapDataQuery(true);
         appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
         appConfig.MutableTableServiceConfig()->SetDefaultLangVer(NYql::GetMaxLangVersion());

--- a/ydb/core/kqp/ut/yql/kqp_pragma_ut.cpp
+++ b/ydb/core/kqp/ut/yql/kqp_pragma_ut.cpp
@@ -43,6 +43,47 @@ Y_UNIT_TEST_SUITE(KqpPragma) {
         UNIT_ASSERT(HasIssue(result.GetIssues(), NYql::TIssuesIds::CORE_TYPE_ANN));
     }
 
+    Y_UNIT_TEST(NewRboPhysicalStagePeepholeOverride) {
+        for (const bool serviceDefault : {false, true}) {
+            NKikimrConfig::TAppConfig appConfig;
+            auto* tableServiceConfig = appConfig.MutableTableServiceConfig();
+            tableServiceConfig->SetEnableNewRBO(true);
+            tableServiceConfig->SetEnableFallbackToYqlOptimizer(false);
+            if (!serviceDefault) {
+                tableServiceConfig->SetEnableNewRBOPhysicalStagePeephole(false);
+            }
+
+            TKikimrSettings settings(appConfig);
+            settings.SetWithSampleTables(false);
+            TKikimrRunner kikimr(settings);
+            kikimr.GetTestClient().CreateTable("/Root", R"(
+                Name: "PragmaTable"
+                Columns { Name: "Key", Type: "Uint64" }
+                Columns { Name: "Value", Type: "Uint64" }
+                KeyColumnNames: ["Key"]
+                UniformPartitionsCount: 2
+            )");
+            auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+            const auto hasWideChannels = [&](TMaybe<bool> pragmaValue) {
+                TStringBuilder query;
+                if (pragmaValue) {
+                    query << "PRAGMA ydb.EnableNewRBOPhysicalStagePeephole = \""
+                          << (*pragmaValue ? "true" : "false") << "\";\n";
+                }
+                query << "SELECT COUNT(*) FROM `/Root/PragmaTable`;";
+
+                auto result = session.ExplainDataQuery(query).GetValueSync();
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+                return TString(result.GetAst()).Contains("_wide_channels");
+            };
+
+            UNIT_ASSERT_VALUES_EQUAL(hasWideChannels(Nothing()), serviceDefault);
+            UNIT_ASSERT_VALUES_EQUAL(hasWideChannels(!serviceDefault), !serviceDefault);
+            UNIT_ASSERT_VALUES_EQUAL(hasWideChannels(Nothing()), serviceDefault);
+        }
+    }
+
     Y_UNIT_TEST(OrderedColumns) {
         TKikimrRunner kikimr;
         NYdb::NScripting::TScriptingClient client(kikimr.GetDriver());

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -562,7 +562,6 @@ message TTableServiceConfig {
     optional bool EnableInlineJoinFiltersAfterCBO = 140 [default = true, (InvalidateCompileCache) = true];
     optional bool EnableVectorSearchActor = 141 [default = true, (InvalidateCompileCache) = true];
     optional bool EnableOlapPushdownRegexp = 142 [default = false, (InvalidateCompileCache) = true];
-
     optional bool EnableSmallComputeMemoryAllocations = 143 [default = true];
 
     // Prune key columns
@@ -574,4 +573,9 @@ message TTableServiceConfig {
     // (NRm::TTxState::IsReasonableToStartSpilling), shrink the sender inflight window down to
     // the cold inflight value instead of letting channels soak the full per channel limit.
     optional bool EnableSpillingChannelBackpressure = 146 [default = false];
+
+    // Selects physical-stage post-processing after new RBO conversion. True rebuilds wide inputs and runs
+    // the full YQL peephole; false uses focused KQP compatibility lowering and prunes unused aggregation
+    // outputs. Can be overridden per query with PRAGMA ydb.EnableNewRBOPhysicalStagePeephole.
+    optional bool EnableNewRBOPhysicalStagePeephole = 147 [default = true, (InvalidateCompileCache) = true];
 };


### PR DESCRIPTION
YQL peephole is really slow, on moderately sized queries it takes approximately as much time as all of new RBO rules & properties together. On simpler queries it dominates runtime even more.

This PR tries to implement a tiny peephole optimizer concerned with only one of the YQL peephole tasks: rewriting callables to something that can be executed enabling us to disable peephole.