### PR TITLE
Return a query error instead of an internal assert for non-physical effect input

### DIFF
--- a/ydb/core/kqp/opt/kqp_opt_effects.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_effects.cpp
@@ -661,7 +661,19 @@ bool BuildEffects(const TVector<TExprBase>& effects, TExprNode::TPtr& returning,
                 .Done();
         }
 
-        YQL_ENSURE(newEffect);
+        if (!newEffect) {
+            // The SELECT feeding this data-modification effect could not be lowered to a
+            // physical input. A known trigger is OFFSET without a bounding LIMIT
+            // (e.g. `INSERT INTO ... SELECT ... LIMIT NULL OFFSET N`), which leaves a bare
+            // Skip node that is not a physical stage. Surface a query error instead of
+            // crashing with an internal YQL_ENSURE assert.
+            ctx.AddError(TIssue(ctx.GetPosition(effect.Pos()),
+                "Unsupported SELECT in a data modification query: it could not be lowered to a "
+                "physical input. A common cause is OFFSET without a bounding LIMIT "
+                "(e.g. LIMIT NULL OFFSET N). Add an explicit LIMIT or use a key-range "
+                "predicate instead of OFFSET."));
+            return false;
+        }
         builtEffects.push_back(newEffect.Cast());
     }
 

--- a/ydb/core/kqp/ut/effects/kqp_effects_ut.cpp
+++ b/ydb/core/kqp/ut/effects/kqp_effects_ut.cpp
@@ -234,6 +234,40 @@ Y_UNIT_TEST_SUITE(KqpEffects) {
         ])", FormatResultSetYson(result.GetResultSet(0)));
     }
 
+    // Regression test: INSERT ... SELECT ... LIMIT NULL OFFSET N leaves a bare Skip node that is
+    // not lowered to a physical stage. It used to crash BuildEffects with an internal
+    // YQL_ENSURE(newEffect) assert; now it must fail with a normal query error.
+    Y_UNIT_TEST(InsertSelect_OffsetWithoutLimit_GracefulError) {
+        auto kikimr = DefaultKikimrRunner();
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto ret = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `Foo` (
+                Key Uint32,
+                Value1 String,
+                Value2 Int32,
+                PRIMARY KEY (Key)
+            )
+        )").ExtractValueSync();
+        UNIT_ASSERT_C(ret.IsSuccess(), ret.GetIssues().ToString());
+
+        auto result = session.ExecuteDataQuery(R"(
+            REPLACE INTO `/Root/Foo` (Key, Value1, Value2) VALUES
+                (10u, "foo", 5), (11u, "bar", 7)
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+        // The query must fail gracefully with a user-facing error, not leak the internal
+        // YQL_ENSURE(newEffect) assert ("requirement newEffect failed").
+        result = session.ExecuteDataQuery(R"(
+            INSERT INTO `/Root/TwoShard` SELECT * FROM `/Root/Foo` ORDER BY Key LIMIT NULL OFFSET 100
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT_C(!result.IsSuccess(), "Expected a query error, got success");
+        const TString issues = result.GetIssues().ToString();
+        UNIT_ASSERT_C(!issues.Contains("newEffect"), issues);
+    }
+
     Y_UNIT_TEST(InsertAbort_Select_Duplicates) {
         auto kikimr = DefaultKikimrRunner();
         auto db = kikimr.GetTableClient();


### PR DESCRIPTION
## Problem

`INSERT`/`UPSERT ... SELECT ... LIMIT NULL OFFSET N` (an unbounded `OFFSET` with no bounding `LIMIT`) leaves a bare `Skip` node that is never lowered to a physical DQ stage. `BuildEffects` then leaves `newEffect` empty and hits `YQL_ENSURE(newEffect)`, so the user gets an opaque internal error:

```
contrib/ydb/core/kqp/opt/kqp_opt_effects.cpp:664  BuildEffects(): requirement newEffect failed
```

instead of a normal query error.

## Fix

Replace the bare `YQL_ENSURE(newEffect)` with a graceful `ctx.AddError(...) + return false`, producing a user-facing message that also hints at the common cause (`OFFSET` without a bounding `LIMIT`).

## Test

Adds `KqpEffects::InsertSelect_OffsetWithoutLimit_GracefulError` in `kqp_effects_ut`: runs `INSERT INTO ... SELECT ... LIMIT NULL OFFSET N` and asserts the query fails with a normal error and does not leak the internal `newEffect` assert.

## Workaround for users

Avoid `OFFSET` for bulk copy: use an explicit `LIMIT`, or paginate by key range (`WHERE key > <cursor>`) instead of `OFFSET`.