### PR TITLE
Do not background-ANALYZE statistics_v2 in the aggregator

### DIFF
--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -10,6 +10,7 @@
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/base/path.h>
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
@@ -470,6 +471,7 @@ void TStatisticsAggregator::Handle(TEvStatistics::TEvStatTableCreationResponse::
         {"tabletId", TabletID()});
 
     IsStatisticsTableCreated = true;
+    ResolveStatisticsTablePathId();
     if (PendingSaveStatistics) {
         PendingSaveStatistics = false;
         SaveStatisticsToTable();
@@ -478,6 +480,51 @@ void TStatisticsAggregator::Handle(TEvStatistics::TEvStatTableCreationResponse::
         PendingDeleteStatistics = false;
         DeleteStatisticsFromTable();
     }
+}
+
+void TStatisticsAggregator::ResolveStatisticsTablePathId() {
+    if (StatisticsTablePathId || Database.empty() || !IsStatisticsTableCreated) {
+        return;
+    }
+
+    using TNavigate = NSchemeCache::TSchemeCacheNavigate;
+    TNavigate::TEntry entry;
+    entry.RequestType = TNavigate::TEntry::ERequestType::ByPath;
+    entry.Path = SplitPath(Database + "/" + StatisticsTablePath);
+    entry.Operation = TNavigate::OpPath;
+    entry.ShowPrivatePath = true;
+
+    auto request = std::make_unique<TNavigate>();
+    request->DatabaseName = Database;
+    request->ResultSet.emplace_back(std::move(entry));
+
+    Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.release()));
+}
+
+void TStatisticsAggregator::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+    if (StatisticsTablePathId) {
+        return;
+    }
+
+    auto* request = ev->Get()->Request.Get();
+    if (!request || request->ResultSet.empty()) {
+        YDB_LOG_WARN("Failed to resolve statistics table path id: empty navigate result",
+            {"tabletId", TabletID()});
+        return;
+    }
+
+    const auto& entry = request->ResultSet[0];
+    if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok || !entry.TableId.PathId) {
+        YDB_LOG_WARN("Failed to resolve statistics table path id",
+            {"tabletId", TabletID()},
+            {"status", entry.Status});
+        return;
+    }
+
+    StatisticsTablePathId = entry.TableId.PathId;
+    YDB_LOG_DEBUG("Resolved statistics table path id",
+        {"tabletId", TabletID()},
+        {"pathId", StatisticsTablePathId});
 }
 
 void TStatisticsAggregator::Handle(TEvStatistics::TEvAnalyzeStatus::TPtr& ev) {
@@ -773,6 +820,9 @@ void TStatisticsAggregator::ScheduleNextBackgroundTraversal(NIceDb::TNiceDb& db,
     } else {
         chosenTable = FindStaleTable();
     }
+    if (chosenTable && IsStatisticsTable(chosenTable->PathId)) {
+        chosenTable = FindStaleTable();
+    }
 
     if (!chosenTable) {
         YDB_LOG_TRACE("Background traversal is skipped. No table is stale and no traversal interval elapsed",
@@ -949,6 +999,10 @@ std::optional<bool> TStatisticsAggregator::IsKnownTable(const TPathId& pathId) c
         return std::nullopt;
     }
     return false;
+}
+
+bool TStatisticsAggregator::IsStatisticsTable(const TPathId& pathId) const {
+    return StatisticsTablePathId && pathId == StatisticsTablePathId;
 }
 
 void TStatisticsAggregator::DeleteForceTraversalOperation(const TString& operationId, NIceDb::TNiceDb& db) {
@@ -1420,6 +1474,9 @@ TStatisticsAggregator::TScheduleTraversal* TStatisticsAggregator::FindStaleTable
 
     TScheduleTraversal* stalest = nullptr;
     for (auto& [pathId, traversal] : ScheduleTraversals) {
+        if (IsStatisticsTable(pathId)) {
+            continue;
+        }
         auto it = currentCounters.find(pathId);
         TChangeCounters current = it != currentCounters.end() ? it->second : TChangeCounters{};
         TChangeCounters lastAnalyze{traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes, 0};

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -123,6 +123,9 @@ private:
 
     void Handle(TEvStatistics::TEvAnalyze::TPtr& ev);
     void Handle(TEvStatistics::TEvStatTableCreationResponse::TPtr& ev);
+    void ResolveStatisticsTablePathId();
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
+    bool IsStatisticsTable(const TPathId& pathId) const;
     void Handle(TEvStatistics::TEvSaveStatisticsQueryResponse::TPtr& ev);
     void Handle(TEvStatistics::TEvDeleteStatisticsQueryResponse::TPtr& ev);
     void Handle(TEvStatistics::TEvAnalyzeActorResult::TPtr& ev);
@@ -211,6 +214,7 @@ private:
 
             hFunc(TEvStatistics::TEvAnalyze, Handle);
             hFunc(TEvStatistics::TEvStatTableCreationResponse, Handle);
+            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
             hFunc(TEvStatistics::TEvSaveStatisticsQueryResponse, Handle);
             hFunc(TEvStatistics::TEvDeleteStatisticsQueryResponse, Handle);
             hFunc(TEvStatistics::TEvAnalyzeActorResult, Handle);
@@ -293,6 +297,7 @@ private:
     bool ProcessUrgentInFlight = false;
 
     bool IsStatisticsTableCreated = false;
+    TPathId StatisticsTablePathId;
     bool PendingSaveStatistics = false;
     std::deque<TStatisticsItem> StatisticsToSave;
     bool PendingDeleteStatistics = false;

--- a/ydb/core/statistics/aggregator/tx_schedule_traversal.cpp
+++ b/ydb/core/statistics/aggregator/tx_schedule_traversal.cpp
@@ -35,10 +35,10 @@ struct TStatisticsAggregator::TTxScheduleTraversal : public TTxBase {
 
         NIceDb::TNiceDb db(txc.DB);
 
-        // Force ANALYZE must run even when no user tables are scheduled
-        // (database has only .metadata tables, or all user tables were dropped).
+        // First try to dispatch a table analyze operation.
         Self->ScheduleNextAnalyze(db, ctx);
 
+        // Next, if there is no analyze operation, try to schedule background traversal.
         if (!Self->TraversalPathId
                 && !Self->ScheduleTraversals.empty()
                 && Self->StatisticsConfig.GetEnableBackgroundColumnStatsCollection()) {
@@ -51,6 +51,7 @@ struct TStatisticsAggregator::TTxScheduleTraversal : public TTxBase {
         YDB_LOG_TRACE("TTxScheduleTraversal::Complete",
             {"tabletId", Self->TabletID()});
 
+        Self->ResolveStatisticsTablePathId();
         Self->Schedule(Self->TraversalPeriod, new TEvPrivate::TEvScheduleTraversal());
     }
 };

--- a/ydb/core/statistics/aggregator/tx_schedule_traversal.cpp
+++ b/ydb/core/statistics/aggregator/tx_schedule_traversal.cpp
@@ -30,22 +30,17 @@ struct TStatisticsAggregator::TTxScheduleTraversal : public TTxBase {
             return true;
         }
 
-        if (Self->ScheduleTraversals.empty()) {
-            YDB_LOG_TRACE("TTxScheduleTraversal. No info from schemeshard",
-                {"tabletId", Self->TabletID()});
-            return true;
-        }
-
         YDB_LOG_TRACE("TTxScheduleTraversal::Execute",
             {"tabletId", Self->TabletID()});
 
         NIceDb::TNiceDb db(txc.DB);
 
-        // First try to dispatch a table analyze operation.
+        // Force ANALYZE must run even when no user tables are scheduled
+        // (database has only .metadata tables, or all user tables were dropped).
         Self->ScheduleNextAnalyze(db, ctx);
 
-        // Next, if there is no analyze operation, try to schedule background traversal.
         if (!Self->TraversalPathId
+                && !Self->ScheduleTraversals.empty()
                 && Self->StatisticsConfig.GetEnableBackgroundColumnStatsCollection()) {
             Self->ScheduleNextBackgroundTraversal(db, ctx);
         }

--- a/ydb/core/statistics/aggregator/tx_schedule_traversal.cpp
+++ b/ydb/core/statistics/aggregator/tx_schedule_traversal.cpp
@@ -40,6 +40,7 @@ struct TStatisticsAggregator::TTxScheduleTraversal : public TTxBase {
 
         // Next, if there is no analyze operation, try to schedule background traversal.
         if (!Self->TraversalPathId
+                && Self->StatisticsTablePathId
                 && !Self->ScheduleTraversals.empty()
                 && Self->StatisticsConfig.GetEnableBackgroundColumnStatsCollection()) {
             Self->ScheduleNextBackgroundTraversal(db, ctx);

--- a/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
+++ b/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
@@ -111,6 +111,9 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
 
         for (auto& entry : statRecord.GetEntries()) {
             auto pathId = TPathId::FromProto(entry.GetPathId());
+            if (Self->IsStatisticsTable(pathId)) {
+                continue;
+            }
             newPathIds.insert(pathId);
             if (oldPathIds.find(pathId) == oldPathIds.end()) {
                 TStatisticsAggregator::TScheduleTraversal traversalTable;

--- a/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
@@ -306,10 +306,8 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
         UNIT_ASSERT_VALUES_EQUAL(observer.GetSaveCount(), 0);
     }
 
-    // SchemeShard must omit .metadata tables from TEvSchemeShardStats.
-    // ANALYZE writes into .metadata/statistics_v2; sending that path to SA
-    // schedules background ANALYZE of it, which writes more rows and
-    // retriggers itself — especially with a low change-ratio threshold.
+    // The aggregator must not schedule background ANALYZE for .metadata/statistics_v2
+    // to avoid a self-retriggering loop. SchemeShard still sends basic stats for it.
     Y_UNIT_TEST_TWIN(SkipMetadataFromBackgroundAnalyze, ColumnShard) {
         TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
             auto* stats = settings.AppConfig->MutableStatisticsConfig();
@@ -319,61 +317,28 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        const auto tableInfo = PrepareTableWithIndexes(env, "Database", "Table", ColumnShard);
-        const ui64 ssTabletId = tableInfo.PathId.OwnerId;
 
-        TVector<THashSet<TPathId>> snapshots;
-        auto statsObserver = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>(
-            [&](auto& ev) {
-                if (ev->Get()->Record.GetSchemeShardId() != ssTabletId) {
-                    return;
-                }
-                NKikimrStat::TSchemeShardStats record;
-                if (!record.ParseFromString(ev->Get()->Record.GetStats())) {
-                    return;
-                }
-                THashSet<TPathId> pathIds;
-                for (const auto& entry : record.GetEntries()) {
-                    pathIds.insert(TPathId::FromProto(entry.GetPathId()));
-                }
-                snapshots.push_back(std::move(pathIds));
-            });
-
-        WaitForPrimaryCollection(runtime, tableInfo.PathId, ColumnTableRowsNumber, 1, ColumnShard);
-
-        const auto metadataPathId = ResolvePathId(runtime, "/Root/Database/.metadata/statistics_v2");
+        TPathId metadataPathId;
+        for (ui32 attempt = 0; attempt < 300 && !metadataPathId; ++attempt) {
+            metadataPathId = ResolvePathId(runtime, "/Root/Database/.metadata/statistics_v2");
+            if (!metadataPathId) {
+                runtime.SimulateSleep(TDuration::MilliSeconds(100));
+            }
+        }
         UNIT_ASSERT(metadataPathId);
+
+        TSaveStatisticsObserver metadataObserver(runtime, metadataPathId);
+        const auto tableInfo = PrepareTableWithIndexes(env, "Database", "Table", ColumnShard);
         UNIT_ASSERT_VALUES_UNEQUAL(metadataPathId, tableInfo.PathId);
 
-        auto assertNoMetadataInSnapshots = [&] {
-            bool userTableSeen = false;
-            for (const auto& pathIds : snapshots) {
-                UNIT_ASSERT_C(
-                    !pathIds.contains(metadataPathId),
-                    "SchemeShard stats blob included .metadata/statistics_v2");
-                userTableSeen |= pathIds.contains(tableInfo.PathId);
-            }
-            UNIT_ASSERT_C(userTableSeen, "SchemeShard never sent the user table");
-        };
-        assertNoMetadataInSnapshots();
+        WaitForPrimaryCollection(runtime, tableInfo.PathId, ColumnTableRowsNumber, 1, ColumnShard);
+        UNIT_ASSERT_VALUES_EQUAL(metadataObserver.GetSaveCount(), 0);
 
-        // statistics_v2 is created during the first ANALYZE. Wait for SS blobs
-        // sent after that so a leak cannot hide in a snapshot taken before the
-        // table existed.
-        const size_t snapshotsAfterCollection = snapshots.size();
-        runtime.WaitFor("SchemeShard stats after .metadata/statistics_v2 exists", [&] {
-            return snapshots.size() >= snapshotsAfterCollection + 2;
-        });
-        assertNoMetadataInSnapshots();
+        RebootTablet(runtime, tableInfo.SaTabletId, runtime.AllocateEdgeActor());
+        WaitForBackgroundAnalyzeToStabilize(runtime);
+        UNIT_ASSERT_VALUES_EQUAL(metadataObserver.GetSaveCount(), 0);
 
-        // After the last user table is dropped, SchemeShard sends an empty
-        // snapshot. Metadata tables stay omitted.
         DropTable(env, "Database", "Table");
-        runtime.WaitFor("empty SchemeShard stats after drop", [&] {
-            return !snapshots.empty() && snapshots.back().empty();
-        });
-
-        // ANALYZE of a dropped table must fail rather than remain pending.
         auto result = Analyze(
             runtime, tableInfo.SaTabletId, {tableInfo.PathId},
             "operationId", {}, NKikimrStat::TEvAnalyzeResponse::STATUS_ERROR);

--- a/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
@@ -306,6 +306,77 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
         UNIT_ASSERT_VALUES_EQUAL(observer.GetSaveCount(), 0);
     }
 
+    // SchemeShard must omit .metadata tables from TEvSchemeShardStats.
+    // ANALYZE writes into .metadata/statistics_v2; sending that path to SA
+    // schedules background ANALYZE of it, which writes more rows and
+    // retriggers itself — especially with a low change-ratio threshold.
+    Y_UNIT_TEST_TWIN(SkipMetadataFromBackgroundAnalyze, ColumnShard) {
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            auto* stats = settings.AppConfig->MutableStatisticsConfig();
+            stats->SetEnableBackgroundColumnStatsCollection(true);
+            stats->SetBaseStatsSendIntervalSecondsDedicated(1);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareTableWithIndexes(env, "Database", "Table", ColumnShard);
+        const ui64 ssTabletId = tableInfo.PathId.OwnerId;
+
+        TVector<THashSet<TPathId>> snapshots;
+        auto statsObserver = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>(
+            [&](auto& ev) {
+                if (ev->Get()->Record.GetSchemeShardId() != ssTabletId) {
+                    return;
+                }
+                NKikimrStat::TSchemeShardStats record;
+                if (!record.ParseFromString(ev->Get()->Record.GetStats())) {
+                    return;
+                }
+                THashSet<TPathId> pathIds;
+                for (const auto& entry : record.GetEntries()) {
+                    pathIds.insert(TPathId::FromProto(entry.GetPathId()));
+                }
+                snapshots.push_back(std::move(pathIds));
+            });
+
+        WaitForPrimaryCollection(runtime, tableInfo.PathId, ColumnTableRowsNumber, 1, ColumnShard);
+
+        const auto metadataPathId = ResolvePathId(runtime, "/Root/Database/.metadata/statistics_v2");
+        UNIT_ASSERT(metadataPathId);
+        UNIT_ASSERT_VALUES_UNEQUAL(metadataPathId, tableInfo.PathId);
+
+        auto assertNoMetadataInSnapshots = [&] {
+            bool userTableSeen = false;
+            for (const auto& pathIds : snapshots) {
+                UNIT_ASSERT_C(
+                    !pathIds.contains(metadataPathId),
+                    "SchemeShard stats blob included .metadata/statistics_v2");
+                userTableSeen |= pathIds.contains(tableInfo.PathId);
+            }
+            UNIT_ASSERT_C(userTableSeen, "SchemeShard never sent the user table");
+        };
+        assertNoMetadataInSnapshots();
+
+        // statistics_v2 is created during the first ANALYZE. Wait for SS blobs
+        // sent after that so a leak cannot hide in a snapshot taken before the
+        // table existed.
+        const size_t snapshotsAfterCollection = snapshots.size();
+        runtime.WaitFor("SchemeShard stats after .metadata/statistics_v2 exists", [&] {
+            return snapshots.size() >= snapshotsAfterCollection + 2;
+        });
+        assertNoMetadataInSnapshots();
+
+        // Empty snapshot after the last user table is dropped so SA can
+        // remove the stale path from ScheduleTraversals.
+        DropTable(env, "Database", "Table");
+        runtime.WaitFor("user table dropped from SchemeShard stats", [&] {
+            return !snapshots.empty() && !snapshots.back().contains(tableInfo.PathId);
+        });
+        UNIT_ASSERT_C(
+            !snapshots.back().contains(metadataPathId),
+            "empty snapshot after drop still included .metadata/statistics_v2");
+    }
+
     Y_UNIT_TEST_TWIN(Counters, ColumnShard) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();

--- a/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
@@ -366,15 +366,20 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
         });
         assertNoMetadataInSnapshots();
 
-        // Empty snapshot after the last user table is dropped so SA can
-        // remove the stale path from ScheduleTraversals.
+        // After the last user table is dropped, SchemeShard sends an empty
+        // snapshot. Metadata tables stay omitted.
         DropTable(env, "Database", "Table");
-        runtime.WaitFor("user table dropped from SchemeShard stats", [&] {
-            return !snapshots.empty() && !snapshots.back().contains(tableInfo.PathId);
+        runtime.WaitFor("empty SchemeShard stats after drop", [&] {
+            return !snapshots.empty() && snapshots.back().empty();
         });
-        UNIT_ASSERT_C(
-            !snapshots.back().contains(metadataPathId),
-            "empty snapshot after drop still included .metadata/statistics_v2");
+
+        // ANALYZE of a dropped table must fail rather than remain pending.
+        auto result = Analyze(
+            runtime, tableInfo.SaTabletId, {tableInfo.PathId},
+            "operationId", {}, NKikimrStat::TEvAnalyzeResponse::STATUS_ERROR);
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(result.GetIssues(), issues);
+        UNIT_ASSERT_C(issues.ToString().Contains("Could not find table"), issues.ToString());
     }
 
     Y_UNIT_TEST_TWIN(Counters, ColumnShard) {

--- a/ydb/core/statistics/database/database.cpp
+++ b/ydb/core/statistics/database/database.cpp
@@ -12,8 +12,6 @@
 
 namespace NKikimr::NStat {
 
-static constexpr TStringBuf STATISTICS_TABLE = ".metadata/statistics_v2";
-
 // Canonical `column_tags` key for a statistic: the comma-joined ordered tag tuple for multi-column
 // stats, the single decimal tag for single-column stats, or the empty string for stats with no
 // column (SIMPLE/TABLE_SUMMARY). Producer (save) and consumer (load) must agree on this encoding.
@@ -129,7 +127,7 @@ public:
                 |>;
             };
 
-            UPSERT INTO `)" << STATISTICS_TABLE << R"(`
+            UPSERT INTO `)" << StatisticsTablePath << R"(`
                 (owner_id, local_path_id, stat_type, column_tags, data)
             SELECT owner_id, local_path_id, stat_type, column_tags, data FROM
             AS_TABLE(ListMap(ListZip($stat_types, $column_tags, $data), $to_struct));
@@ -238,7 +236,7 @@ void DispatchLoadStatisticsQuery(
         {"columnTags", serializedColumnTags});
 
     const auto statisticsTablePath = CanonizePath(
-        TStringBuilder() << database << '/' << STATISTICS_TABLE);
+        TStringBuilder() << database << '/' << StatisticsTablePath);
 
     auto readRowsRequest = Ydb::Table::ReadRowsRequest();
     readRowsRequest.set_path(statisticsTablePath);
@@ -316,7 +314,7 @@ public:
             DECLARE $owner_id AS Uint64;
             DECLARE $local_path_id AS Uint64;
 
-            DELETE FROM `)" << STATISTICS_TABLE << R"(`
+            DELETE FROM `)" << StatisticsTablePath << R"(`
             WHERE
                 owner_id = $owner_id AND
                 local_path_id = $local_path_id;

--- a/ydb/core/statistics/database/database.h
+++ b/ydb/core/statistics/database/database.h
@@ -7,6 +7,8 @@
 
 namespace NKikimr::NStat {
 
+inline constexpr TStringBuf StatisticsTablePath = ".metadata/statistics_v2";
+
 NActors::IActor* CreateStatisticsTableCreator(std::unique_ptr<NActors::IEventBase> event, const TString& database);
 
 NActors::IActor* CreateSaveStatisticsQuery(const NActors::TActorId& replyActorId, const TString& database,

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -9475,11 +9475,22 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         }
     }
 
+    // ANALYZE writes into .metadata/statistics_v2. Including that table in the
+    // blob schedules it for background ANALYZE, which writes more rows and
+    // retriggers itself.
+    auto isMetadataTable = [this](const TPathId& pathId) {
+        auto path = TPath::Init(pathId, this);
+        return path.IsResolved() && path.PathString().Contains("/.metadata/");
+    };
+
     int count = 0;
     int incompleteCount = 0;
 
     NKikimrStat::TSchemeShardStats record;
     for (const auto& [pathId, tableInfo] : Tables) {
+        if (isMetadataTable(pathId)) {
+            continue;
+        }
         const auto& stats = tableInfo->GetStats();
         const auto& aggregated = stats.Aggregated;
         bool areStatsFull = stats.AreStatsFull();
@@ -9503,6 +9514,9 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     auto columnTablesPathIds = ColumnTables.GetAllPathIds();
     for (const auto& pathId : columnTablesPathIds) {
+        if (isMetadataTable(pathId)) {
+            continue;
+        }
         const auto& tableInfo = ColumnTables.GetVerified(pathId);
         const auto& stats = tableInfo->GetStats();
         const TTableAggregatedStats* aggregatedStats = nullptr;
@@ -9539,9 +9553,8 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     if (!count) {
         LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
-            "SendBaseStatsToSA() No tables to send"
+            "SendBaseStatsToSA() No user tables to send"
             << ", at schemeshard: " << TabletID());
-        return TDuration::Seconds(30);
     }
 
     record.SetAreAllStatsFull(incompleteCount == 0);
@@ -9560,6 +9573,13 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         << ", path count: " << count
         << ", paths with incomplete stats: " << incompleteCount
         << ", at schemeshard: " << TabletID());
+
+    if (!count) {
+        // Still send the empty snapshot so SA can drop stale paths (e.g. after
+        // skipping .metadata tables), but keep the previous 30s backoff instead
+        // of the regular send interval to avoid churn on empty databases.
+        return TDuration::Seconds(30);
+    }
 
     if (IsServerlessDomain(SubDomains.at(RootPathId()))) {
         // In serverless subdomains several schemeshards send stats to a single SA

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -9477,14 +9477,9 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     int count = 0;
     int incompleteCount = 0;
-    bool hasUserTables = false;
 
     NKikimrStat::TSchemeShardStats record;
     for (const auto& [pathId, tableInfo] : Tables) {
-        if (TPath::IsInsideMetadataDirectory(pathId, this)) {
-            continue;
-        }
-        hasUserTables = true;
         const auto& stats = tableInfo->GetStats();
         const auto& aggregated = stats.Aggregated;
         bool areStatsFull = stats.AreStatsFull();
@@ -9508,10 +9503,6 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     auto columnTablesPathIds = ColumnTables.GetAllPathIds();
     for (const auto& pathId : columnTablesPathIds) {
-        if (TPath::IsInsideMetadataDirectory(pathId, this)) {
-            continue;
-        }
-        hasUserTables = true;
         const auto& tableInfo = ColumnTables.GetVerified(pathId);
         const auto& stats = tableInfo->GetStats();
         const TTableAggregatedStats* aggregatedStats = nullptr;
@@ -9547,15 +9538,10 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
     }
 
     if (!count) {
-        if (hasUserTables) {
-            LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
-                "SendBaseStatsToSA() No tables to send"
-                << ", at schemeshard: " << TabletID());
-            return TDuration::Seconds(30);
-        }
         LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
-            "SendBaseStatsToSA() No user tables to send"
+            "SendBaseStatsToSA() No tables to send"
             << ", at schemeshard: " << TabletID());
+        return TDuration::Seconds(30);
     }
 
     record.SetAreAllStatsFull(incompleteCount == 0);
@@ -9574,13 +9560,6 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         << ", path count: " << count
         << ", paths with incomplete stats: " << incompleteCount
         << ", at schemeshard: " << TabletID());
-
-    if (!hasUserTables) {
-        // Empty snapshot so SA can drop stale paths after metadata-only or
-        // fully dropped databases. 30s backoff avoids churn; the regular
-        // interval is for databases that still have user tables.
-        return TDuration::Seconds(30);
-    }
 
     if (IsServerlessDomain(SubDomains.at(RootPathId()))) {
         // In serverless subdomains several schemeshards send stats to a single SA

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -9478,19 +9478,17 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
     // ANALYZE writes into .metadata/statistics_v2. Including that table in the
     // blob schedules it for background ANALYZE, which writes more rows and
     // retriggers itself.
-    auto isMetadataTable = [this](const TPathId& pathId) {
-        auto path = TPath::Init(pathId, this);
-        return path.IsResolved() && path.PathString().Contains("/.metadata/");
-    };
 
     int count = 0;
     int incompleteCount = 0;
+    bool hasUserTables = false;
 
     NKikimrStat::TSchemeShardStats record;
     for (const auto& [pathId, tableInfo] : Tables) {
-        if (isMetadataTable(pathId)) {
+        if (TPath::Init(pathId, this).IsInsideMetadataDirectory()) {
             continue;
         }
+        hasUserTables = true;
         const auto& stats = tableInfo->GetStats();
         const auto& aggregated = stats.Aggregated;
         bool areStatsFull = stats.AreStatsFull();
@@ -9514,9 +9512,10 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     auto columnTablesPathIds = ColumnTables.GetAllPathIds();
     for (const auto& pathId : columnTablesPathIds) {
-        if (isMetadataTable(pathId)) {
+        if (TPath::Init(pathId, this).IsInsideMetadataDirectory()) {
             continue;
         }
+        hasUserTables = true;
         const auto& tableInfo = ColumnTables.GetVerified(pathId);
         const auto& stats = tableInfo->GetStats();
         const TTableAggregatedStats* aggregatedStats = nullptr;
@@ -9552,6 +9551,15 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
     }
 
     if (!count) {
+        if (hasUserTables) {
+            // User tables exist but none have reportable stats yet (e.g. a
+            // non-standalone column table before TableStats arrives). Sending
+            // an empty AreAllStatsFull snapshot would drop those paths from SA.
+            LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
+                "SendBaseStatsToSA() No tables to send"
+                << ", at schemeshard: " << TabletID());
+            return TDuration::Seconds(30);
+        }
         LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
             "SendBaseStatsToSA() No user tables to send"
             << ", at schemeshard: " << TabletID());
@@ -9574,10 +9582,10 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         << ", paths with incomplete stats: " << incompleteCount
         << ", at schemeshard: " << TabletID());
 
-    if (!count) {
-        // Still send the empty snapshot so SA can drop stale paths (e.g. after
-        // skipping .metadata tables), but keep the previous 30s backoff instead
-        // of the regular send interval to avoid churn on empty databases.
+    if (!hasUserTables) {
+        // Empty snapshot so SA can drop stale paths after metadata-only or
+        // fully dropped databases. 30s backoff avoids churn; the regular
+        // interval is for databases that still have user tables.
         return TDuration::Seconds(30);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -9475,17 +9475,13 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         }
     }
 
-    // ANALYZE writes into .metadata/statistics_v2. Including that table in the
-    // blob schedules it for background ANALYZE, which writes more rows and
-    // retriggers itself.
-
     int count = 0;
     int incompleteCount = 0;
     bool hasUserTables = false;
 
     NKikimrStat::TSchemeShardStats record;
     for (const auto& [pathId, tableInfo] : Tables) {
-        if (TPath::Init(pathId, this).IsInsideMetadataDirectory()) {
+        if (TPath::IsInsideMetadataDirectory(pathId, this)) {
             continue;
         }
         hasUserTables = true;
@@ -9512,7 +9508,7 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     auto columnTablesPathIds = ColumnTables.GetAllPathIds();
     for (const auto& pathId : columnTablesPathIds) {
-        if (TPath::Init(pathId, this).IsInsideMetadataDirectory()) {
+        if (TPath::IsInsideMetadataDirectory(pathId, this)) {
             continue;
         }
         hasUserTables = true;
@@ -9552,9 +9548,6 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
 
     if (!count) {
         if (hasUserTables) {
-            // User tables exist but none have reportable stats yet (e.g. a
-            // non-standalone column table before TableStats arrives). Sending
-            // an empty AreAllStatsFull snapshot would drop those paths from SA.
             LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,
                 "SendBaseStatsToSA() No tables to send"
                 << ", at schemeshard: " << TabletID());

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -611,19 +611,6 @@ const TPath::TChecker& TPath::TChecker::IsSystemDirectory(EStatus status) const 
         << " (" << BasicPathInfo(Path.Base()) << ")");
 }
 
-const TPath::TChecker& TPath::TChecker::IsMetadataDirectory(EStatus status) const {
-    if (Failed) {
-        return *this;
-    }
-
-    if (Path.Base()->IsMetadataDirectory()) {
-        return *this;
-    }
-
-    return Fail(status, TStringBuilder() << "path is not a .metadata directory"
-        << " (" << BasicPathInfo(Path.Base()) << ")");
-}
-
 const TPath::TChecker& TPath::TChecker::IsRtmrVolume(EStatus status) const {
     if (Failed) {
         return *this;
@@ -1802,18 +1789,6 @@ bool TPath::IsInsideTableIndexPath(bool failOnUnresolved) const {
     return true;
 }
 
-bool TPath::IsInsideMetadataDirectory() const {
-    if (!IsResolved()) {
-        return false;
-    }
-    for (const auto& element : Elements) {
-        if (element->IsMetadataDirectory()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool TPath::IsInsideCdcStreamPath() const {
     Y_ABORT_UNLESS(IsResolved());
 
@@ -1839,6 +1814,28 @@ bool TPath::IsInsideCdcStreamPath() const {
     }
 
     return true;
+}
+
+bool TPath::IsInsideMetadataDirectory() const {
+    Y_ABORT_UNLESS(IsResolved());
+    return IsInsideMetadataDirectory(Base()->PathId, SS);
+}
+
+bool TPath::IsInsideMetadataDirectory(const TPathId& pathId, TSchemeShard* ss) {
+    TPathId cur = pathId;
+    while (true) {
+        auto* elem = ss->PathsById.FindPtr(cur);
+        if (!elem) {
+            return false;
+        }
+        if ((*elem)->IsMetadataDirectory()) {
+            return true;
+        }
+        if ((*elem)->IsRoot()) {
+            return false;
+        }
+        cur = (*elem)->ParentPathId;
+    }
 }
 
 bool TPath::IsTableIndex(

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -1816,28 +1816,6 @@ bool TPath::IsInsideCdcStreamPath() const {
     return true;
 }
 
-bool TPath::IsInsideMetadataDirectory() const {
-    Y_ABORT_UNLESS(IsResolved());
-    return IsInsideMetadataDirectory(Base()->PathId, SS);
-}
-
-bool TPath::IsInsideMetadataDirectory(const TPathId& pathId, TSchemeShard* ss) {
-    TPathId cur = pathId;
-    while (true) {
-        auto* elem = ss->PathsById.FindPtr(cur);
-        if (!elem) {
-            return false;
-        }
-        if ((*elem)->IsMetadataDirectory()) {
-            return true;
-        }
-        if ((*elem)->IsRoot()) {
-            return false;
-        }
-        cur = (*elem)->ParentPathId;
-    }
-}
-
 bool TPath::IsTableIndex(
     const TMaybe<NKikimrSchemeOp::EIndexType>& type,
     bool failOnUnresolved) const

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -611,6 +611,19 @@ const TPath::TChecker& TPath::TChecker::IsSystemDirectory(EStatus status) const 
         << " (" << BasicPathInfo(Path.Base()) << ")");
 }
 
+const TPath::TChecker& TPath::TChecker::IsMetadataDirectory(EStatus status) const {
+    if (Failed) {
+        return *this;
+    }
+
+    if (Path.Base()->IsMetadataDirectory()) {
+        return *this;
+    }
+
+    return Fail(status, TStringBuilder() << "path is not a .metadata directory"
+        << " (" << BasicPathInfo(Path.Base()) << ")");
+}
+
 const TPath::TChecker& TPath::TChecker::IsRtmrVolume(EStatus status) const {
     if (Failed) {
         return *this;
@@ -1787,6 +1800,18 @@ bool TPath::IsInsideTableIndexPath(bool failOnUnresolved) const {
     }
 
     return true;
+}
+
+bool TPath::IsInsideMetadataDirectory() const {
+    if (!IsResolved()) {
+        return false;
+    }
+    for (const auto& element : Elements) {
+        if (element->IsMetadataDirectory()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool TPath::IsInsideCdcStreamPath() const {

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -87,6 +87,7 @@ public:
         const TChecker& IsLikeDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsSystemDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
+        const TChecker& IsMetadataDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsRtmrVolume(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsTheSameDomain(const TPath& another, EStatus status = EStatus::StatusInvalidParameter) const;
         const TChecker& FailOnWrongType(const TSet<TPathElement::EPathType>& expectedTypes) const;
@@ -184,6 +185,7 @@ public:
     bool AtLocalSchemeShardPath() const;
     bool IsInsideTableIndexPath(bool failOnUnresolved = true) const;
     bool IsInsideCdcStreamPath() const;
+    bool IsInsideMetadataDirectory() const;
     bool IsTableIndex(
         const TMaybe<NKikimrSchemeOp::EIndexType>& type = {},
         bool failOnUnresolved = true) const;

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -184,8 +184,6 @@ public:
     bool AtLocalSchemeShardPath() const;
     bool IsInsideTableIndexPath(bool failOnUnresolved = true) const;
     bool IsInsideCdcStreamPath() const;
-    bool IsInsideMetadataDirectory() const;
-    static bool IsInsideMetadataDirectory(const TPathId& pathId, TSchemeShard* ss);
     bool IsTableIndex(
         const TMaybe<NKikimrSchemeOp::EIndexType>& type = {},
         bool failOnUnresolved = true) const;

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -87,7 +87,6 @@ public:
         const TChecker& IsLikeDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsSystemDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
-        const TChecker& IsMetadataDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsRtmrVolume(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsTheSameDomain(const TPath& another, EStatus status = EStatus::StatusInvalidParameter) const;
         const TChecker& FailOnWrongType(const TSet<TPathElement::EPathType>& expectedTypes) const;
@@ -186,6 +185,7 @@ public:
     bool IsInsideTableIndexPath(bool failOnUnresolved = true) const;
     bool IsInsideCdcStreamPath() const;
     bool IsInsideMetadataDirectory() const;
+    static bool IsInsideMetadataDirectory(const TPathId& pathId, TSchemeShard* ss);
     bool IsTableIndex(
         const TMaybe<NKikimrSchemeOp::EIndexType>& type = {},
         bool failOnUnresolved = true) const;

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -168,10 +168,6 @@ bool TPathElement::IsSystemDirectory() const {
     return IsDirectory() && Name == NSysView::SysPathName;
 }
 
-bool TPathElement::IsMetadataDirectory() const {
-    return IsDirectory() && Name == ".metadata";
-}
-
 bool TPathElement::IsTableIndex() const {
     return PathType == EPathType::EPathTypeTableIndex;
 }

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -168,6 +168,10 @@ bool TPathElement::IsSystemDirectory() const {
     return IsDirectory() && Name == NSysView::SysPathName;
 }
 
+bool TPathElement::IsMetadataDirectory() const {
+    return IsDirectory() && Name == ".metadata";
+}
+
 bool TPathElement::IsTableIndex() const {
     return PathType == EPathType::EPathTypeTableIndex;
 }

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -114,7 +114,6 @@ public:
     bool IsRoot() const;
     bool IsDirectory() const;
     bool IsSystemDirectory() const;
-    bool IsMetadataDirectory() const;
     bool IsTableIndex() const;
     bool IsCdcStream() const;
     bool IsTable() const;

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -114,6 +114,7 @@ public:
     bool IsRoot() const;
     bool IsDirectory() const;
     bool IsSystemDirectory() const;
+    bool IsMetadataDirectory() const;
     bool IsTableIndex() const;
     bool IsCdcStream() const;
     bool IsTable() const;


### PR DESCRIPTION
- Do not schedule background ANALYZE for `.metadata/statistics_v2`. ANALYZE writes into that table, so collecting it would retrigger itself.
- SchemeShard still reports base stats for the table; the aggregator simply does not put it on the background schedule.
- Force ANALYZE still runs when `ScheduleTraversals` is empty (metadata-only database, or all user tables dropped).