### PR TITLE
[ICRDMA] Mempool improvement: do not increment/decrement atomic counter for each allocation/deallocation for monitoring purpose NBYDB-2495

### DIFF
--- a/ydb/library/actors/interconnect/rdma/mem_pool.cpp
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.cpp
@@ -116,6 +116,8 @@ namespace NInterconnect::NRdma {
     TChunk(std::vector<ibv_mr*>&& mrs, IMemPool* pool) noexcept
         : MRs(std::move(mrs))
         , MemPool(pool)
+        , SlotSize(0)
+        , MaxUseCount(0)
     {
     }
 
@@ -151,7 +153,9 @@ namespace NInterconnect::NRdma {
     }
 
     bool TryAcquire(ui64 expGeneration) noexcept {
-        return ReclaimSemaphore.TryAcquire(expGeneration);
+        ui32 useCount = ReclaimSemaphore.TryAcquire(expGeneration);
+        TrackMaxUseCount(useCount);
+        return useCount;
     }
 
     ui64 GetGeneration() const noexcept {
@@ -163,9 +167,22 @@ namespace NInterconnect::NRdma {
         return MRs[0]->length;
     }
 
+    void SetSlotSize(ui32 sz) noexcept {
+        SlotSize.store(sz, std::memory_order_relaxed);
+    }
+
+    //Only for monitoring purpose
+    ui64 ExtractMaxAllocatedSz() noexcept {
+        ui32 curUseCount = ReclaimSemaphore.GetUseCount();
+        ui32 useCnt = MaxUseCount.exchange(curUseCount, std::memory_order_acq_rel);
+        return useCnt * SlotSize.load(std::memory_order_relaxed);
+    }
+
     private:
         std::vector<ibv_mr*> MRs;
         IMemPool* MemPool;
+        std::atomic<ui32> SlotSize;
+        std::atomic<ui32> MaxUseCount; //For monitoring and stats
         class TChunkUseLock {
             // Prevent reclaming just after new chunk allocation
             std::atomic<ui64> Lock = ReclaimingBitMask;
@@ -181,7 +198,8 @@ namespace NInterconnect::NRdma {
                 Lock.fetch_sub(1, std::memory_order_relaxed);
             }
 
-            bool TryAcquire(ui64 expectedGeneration) noexcept {
+            //Return 0 in case of failure or last UseCount
+            ui32 TryAcquire(ui64 expectedGeneration) noexcept {
                 ui64 x = Lock.fetch_add(1, std::memory_order_acq_rel);
                 Y_ABORT_UNLESS((x & UseCountMask) < UseCountMask);
                 if (Y_LIKELY(((x & (~ReclaimingBitMask)) >> UseCountBits) == expectedGeneration)) {
@@ -205,10 +223,10 @@ namespace NInterconnect::NRdma {
                                 x = (x & (~UseCountMask)) | 1ul; // It is what we expect in the memory
                             }
                     }
-                    return true;
+                    return (x & UseCountMask) + 1;
                 } else {
                     Lock.fetch_sub(1, std::memory_order_release);
-                    return false;
+                    return 0;
                 }
             }
 
@@ -240,7 +258,18 @@ namespace NInterconnect::NRdma {
             ui64 GetGeneration() const noexcept {
                 return (Lock.load(std::memory_order_relaxed) & ~ReclaimingBitMask) >> UseCountBits;
             }
-        } ReclaimSemaphore;
+
+            ui32 GetUseCount() const noexcept {
+                return Lock.load(std::memory_order_relaxed) & UseCountMask;
+            }
+        } __attribute__((aligned(64))) ReclaimSemaphore;
+    private:
+        void TrackMaxUseCount(ui32 newUseCount) noexcept {
+            ui32 maxUseCount = MaxUseCount.load(std::memory_order_relaxed);
+            while (maxUseCount < newUseCount && !MaxUseCount.compare_exchange_weak(maxUseCount, newUseCount,
+                std::memory_order_relaxed, std::memory_order_relaxed))
+            {}
+        }
     };
 
     TMemRegion::TMemRegion(TChunkPtr chunk, uint32_t offset, uint32_t size) noexcept
@@ -485,7 +514,6 @@ namespace NInterconnect::NRdma {
             , MaxChunk(maxChunk)
             , Alignment(NSystemInfo::GetPageSize())
         {
-            AllocatedCounter = counter->GetCounter("RdmaPoolAllocatedUserBytes", false);
             AllocatedChunksCounter = counter->GetCounter("RdmaPoolAllocatedChunks", false);
             MaxAllocated.Counter = counter->GetCounter("RdmaPoolAllocatedUserMaxBytes", false);
             ReclaimationRunCounter = counter->GetCounter("RdmaPoolReclaimationRunCounter", true);
@@ -563,19 +591,17 @@ namespace NInterconnect::NRdma {
             freeMemory(addr);
             mrs.clear();
         }
-
-        void TrackPeakAlloc(i64 newVal) noexcept {
-            i64 curVal = MaxAllocated.Val.load(std::memory_order_relaxed);
-            while (newVal > curVal) {
-                if (MaxAllocated.Val.compare_exchange_weak(curVal, newVal,
-                    std::memory_order_release, std::memory_order_relaxed)) {
-                    break;
-                }
-            }
-        }
     private:
+        // must be called with lock
         TChunkPtr TryReclaim(size_t size) noexcept {
             ReclaimationRunCounter->Inc();
+
+            {
+                // Updated monitoring before chunk reclaim. Oterwice we can lost last max
+                ui64 prevMax = MaxAllocated.Counter->Val();
+                ui64 maxAllocated = ExtractMaxAllocatedForAllChunks();
+                MaxAllocated.Counter->Set(std::max(maxAllocated, prevMax));
+            }
 
             auto it = ReclaimIt;
 
@@ -600,18 +626,43 @@ namespace NInterconnect::NRdma {
             return nullptr;
         }
 
+        // must be called with lock
+        ui64 ExtractMaxAllocatedForAllChunks() {
+            ui64 maxAllocated = 0;
+            for (TChunk& chunk : Chunks) {
+                maxAllocated += chunk.ExtractMaxAllocatedSz();
+            }
+            return maxAllocated;
+        }
+
+        void Tick(NMonotonic::TMonotonic time) noexcept override {
+            constexpr TDuration holdTime = TDuration::Seconds(15);
+
+            ui64 prevMax = MaxAllocated.Counter->Val();
+            ui64 maxAllocated = 0;
+
+            {
+                const std::lock_guard<std::mutex> lock(Mutex);
+                maxAllocated = ExtractMaxAllocatedForAllChunks();
+            }
+
+            if (time - MaxAllocated.Time > holdTime) {
+                MaxAllocated.Counter->Set(maxAllocated);
+                MaxAllocated.Time = time;
+            } else {
+                MaxAllocated.Counter->Set(std::max(maxAllocated, prevMax));
+            }
+        }
     protected:
 
         const NInterconnect::NRdma::NLinkMgr::TCtxsMap Ctxs;
         const size_t MaxChunk;
         const size_t Alignment;
-        ::NMonitoring::TDynamicCounters::TCounterPtr AllocatedCounter;
         ::NMonitoring::TDynamicCounters::TCounterPtr AllocatedChunksCounter;
         ::NMonitoring::TDynamicCounters::TCounterPtr ReclaimationRunCounter;
         ::NMonitoring::TDynamicCounters::TCounterPtr ReclaimationFailCounter;
         struct {
            NMonotonic::TMonotonic Time;
-           std::atomic<i64> Val = 0;
            ::NMonitoring::TDynamicCounters::TCounterPtr Counter;
         } MaxAllocated;
         std::atomic<size_t> AllocatedChunks = 0;
@@ -619,16 +670,6 @@ namespace NInterconnect::NRdma {
         std::mutex Mutex;
         TIntrusiveList<TChunk> Chunks;
         TIntrusiveList<TChunk>::TIterator ReclaimIt;
-
-        void Tick(NMonotonic::TMonotonic time) noexcept override {
-            constexpr TDuration holdTime = TDuration::Seconds(15);
-
-            if (time - MaxAllocated.Time > holdTime) {
-                MaxAllocated.Counter->Set(MaxAllocated.Val.load());
-                MaxAllocated.Val.store(AllocatedCounter->Val());
-                MaxAllocated.Time = time;
-            }
-        }
     };
 
     class TDummyMemPool: public TMemPoolBase {
@@ -818,6 +859,7 @@ namespace NInterconnect::NRdma {
                     return false;
                 }
                 TChain::TMemRegcontainer::iterator it = chain.FindHint(chunk);
+                chunk->SetSlotSize(chain.SlotSize);
                 const ui64 generation = chunk->GetGeneration();
                 for (ui32 i = 0; i < chain.SlotsInBatch; ++i) {
                     auto x = MakeIntrusive<TMemRegion>(chunk, i * chain.SlotSize, chain.SlotSize);
@@ -841,8 +883,8 @@ namespace NInterconnect::NRdma {
                 Y_ABORT_UNLESS(chainIndex < ChainsNum, "Invalid chain index: %u", chainIndex);
                 // Try to get slot from local cache
                 auto& localChain = Chains[chainIndex];
-                TMemRegionPtr slot = localChain.TryGetSlot();
-                if (slot) {
+
+                if (auto slot= localChain.TryGetSlot()) {
                     return slot;
                 }
 
@@ -853,8 +895,9 @@ namespace NInterconnect::NRdma {
                     auto batch = pool.Chains[chainIndex].GetSlotsBatch(allChunksAllocated);
                     if (batch) {
                         localChain.PutSlotsBatch(std::move(*batch));
-                        if (auto memRegion = localChain.TryGetSlot()) {
-                            return memRegion;
+                        auto slot = localChain.TryGetSlot();
+                        if (slot) {
+                            return slot;
                         }
                     } else {
                         break;
@@ -865,7 +908,11 @@ namespace NInterconnect::NRdma {
                     return nullptr;
                 }
 
-                return localChain.TryGetSlot();
+                auto slot = localChain.TryGetSlot();
+                if (slot) {
+                    return slot;
+                }
+                return nullptr;
             }
 
             void Free(TMemRegion&& mr, TSlotMemPool& pool) noexcept {
@@ -943,16 +990,11 @@ namespace NInterconnect::NRdma {
         TMemRegionPtr AllocImpl(int size, ui32 flags) noexcept override {
             if (auto memReg = LocalCache.AllocImpl(size, flags, *this)) {
                 memReg->Resize(size);
-                i64 newVal = AllocatedCounter->Add(size);
-
-                TrackPeakAlloc(newVal);
-
                 return memReg;
             }
             return nullptr;
         }
         void Free(TMemRegion&& mr, TChunk&) noexcept override {
-            AllocatedCounter->Sub(mr.GetSize());
             LocalCache.Free(std::move(mr), *this);
         }
 


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

before: before; after: after
metric                                                 before, us    after, us   after/before  improvement
reclaim_128m_6_threads/block0/t0                         0.921125     0.721395         0.7832x      +21.68%
reclaim_128m_6_threads/block0/t1                         0.985645     0.726350         0.7369x      +26.31%
reclaim_128m_6_threads/block0/t2                         1.029590     0.721570         0.7008x      +29.92%
reclaim_128m_6_threads/block0/t3                         1.063290     0.734645         0.6909x      +30.91%
reclaim_128m_6_threads/block0/t4                         1.044520     0.729205         0.6981x      +30.19%
reclaim_128m_6_threads/block0/t5                         0.882495     0.658180         0.7458x      +25.42%
reclaim_128m_6_threads/block1/t0                         0.855365     0.604755         0.7070x      +29.30%
reclaim_128m_6_threads/block1/t1                         0.752025     0.461145         0.6132x      +38.68%
reclaim_128m_6_threads/block1/t2                         0.559905     0.296260         0.5291x      +47.09%
reclaim_128m_6_threads/block1/t3                         0.498000     0.258250         0.5186x      +48.14%
reclaim_128m_6_threads/block1/t4                         0.437045     0.230820         0.5281x      +47.19%
reclaim_128m_6_threads/block1/t5                         0.416975     0.215090         0.5158x      +48.42%
reclaim_128m_6_threads/block2/t0                         1.549610     1.380705         0.8910x      +10.90%
reclaim_128m_6_threads/block2/t1                         1.539830     1.425465         0.9257x       +7.43%
reclaim_128m_6_threads/block2/t2                         1.649265     1.378155         0.8356x      +16.44%
reclaim_128m_6_threads/block2/t3                         1.618035     1.358295         0.8395x      +16.05%
reclaim_128m_6_threads/block2/t4                         0.963550     0.770279         0.7994x      +20.06%
reclaim_128m_6_threads/block2/t5                         0.789403     0.676104         0.8565x      +14.35%
reclaim_128m_6_threads/block3/t0                         0.871261     0.871978         1.0008x       -0.08%
reclaim_128m_6_threads/block3/t1                         0.893188     0.907501         1.0160x       -1.60%
reclaim_128m_6_threads/block3/t2                         0.726806     0.729797         1.0041x       -0.41%
reclaim_128m_6_threads/block3/t3                         0.687134     0.683594         0.9948x       +0.52%
reclaim_128m_6_threads/block3/t4                         0.704102     0.690918         0.9813x       +1.87%
reclaim_128m_6_threads/block3/t5                         0.699219     0.693359         0.9916x       +0.84%
reclaim_32m_2_threads/block0/t0                         41.001000    40.501000         0.9878x       +1.22%
reclaim_32m_2_threads/block0/t1                          8.432500     8.453000         1.0024x       -0.24%
reclaim_32m_2_threads/block1/t0                          0.571435     0.543160         0.9505x       +4.95%
reclaim_32m_2_threads/block1/t1                          0.233565     0.216690         0.9278x       +7.22%
reclaim_32m_2_threads/block2/t0                          4.051400     3.989550         0.9847x       +1.53%
reclaim_32m_2_threads/block2/t1                          1.114500     1.093500         0.9812x       +1.88%
reclaim_32m_2_threads/block3/t0                          3.002500     2.846600         0.9481x       +5.19%
reclaim_32m_2_threads/block3/t1                          1.947650     1.899300         0.9752x       +2.48%
reclaim_32m_2_threads/block4/t0                          4.295150     4.332300         1.0086x       -0.86%
reclaim_32m_2_threads/block4/t1                          1.104600     1.073400         0.9718x       +2.82%
reclaim_32m_2_threads/block5/t0                          3.013400     2.827350         0.9383x       +6.17%
reclaim_32m_2_threads/block5/t1                          1.913950     1.794850         0.9378x       +6.22%
reclaim_32m_3_threads/block0/t0                       7138.745000   480.795000         0.0674x      +93.26%
reclaim_32m_3_threads/block0/t1                       7103.665000   354.395000         0.0499x      +95.01%
reclaim_32m_3_threads/block0/t2                       7067.190000   261.180000         0.0370x      +96.30%
reclaim_32m_3_threads/block1/t0                          3.285900     3.211100         0.9772x       +2.28%
reclaim_32m_3_threads/block1/t1                          0.812300     0.599450         0.7380x      +26.20%
reclaim_32m_3_threads/block1/t2                          0.403450     0.260250         0.6451x      +35.49%
reclaim_32m_3_threads/block2/t0                          6.146000     3.319450         0.5401x      +45.99%
reclaim_32m_3_threads/block2/t1                          3.142200     3.093850         0.9846x       +1.54%
reclaim_32m_3_threads/block2/t2                          3.033800     3.075800         1.0138x       -1.38%
reclaim_32m_3_threads/block3/t0                          3.777750     3.709000         0.9818x       +1.82%
reclaim_32m_3_threads/block3/t1                          2.189700     2.132500         0.9739x       +2.61%
reclaim_32m_3_threads/block3/t2                          0.701172     0.704041         1.0041x       -0.41%
reclaim_32m_random_1_thread                             19.402400    18.847700         0.9714x       +2.86%
small_alloc_4k_8_threads                                 0.810523     0.215224         0.2655x      +73.45%

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
