### PR TITLE
ydb-bench: stabilize throughput plateau selection

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -124,9 +124,10 @@ block device.
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
 benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. A
 `values` list measures exact points. For adaptive runs, `search` defines the
-range and resolution. `maximize-throughput` uses a discrete ternary search and
-prefers the lowest load with the best observed throughput; a plateau is
-confirmed only when the selected role's CPU is saturated. `latency-slo` uses
+range and resolution. `maximize-throughput` uses a discrete ternary search and,
+after confirming a plateau, selects the lowest CPU-saturated load within the
+configured throughput tolerance of the best saturated measurement. A plateau
+is confirmed only when the selected role's CPU is saturated. `latency-slo` uses
 the configured `multiplier` to find the first failing point, then a binary
 search to find the highest load whose millisecond percentile, error count, and
 achieved-rate ratio satisfy the SLO. For example:

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -39,6 +39,15 @@ def _best_throughput(attempts):
     return max(candidates, key=lambda item: (item["throughput"], -item["load"]))["load"]
 
 
+def _lowest_saturated_plateau_load(attempts, tolerance_percent):
+    candidates = [item for item in attempts if item["passed"] and item.get("target_cpu_saturated")]
+    if not candidates:
+        return None
+    best_throughput = max(item["throughput"] for item in candidates)
+    minimum_throughput = best_throughput * (1.0 - tolerance_percent / 100.0)
+    return min(item["load"] for item in candidates if item["throughput"] >= minimum_throughput)
+
+
 def _throughput_gain(lower, upper):
     if lower > 0:
         return 100.0 * (upper - lower) / lower
@@ -90,7 +99,7 @@ def _run_throughput(config, measure, on_attempt):
     plateau = 0
     plateau_confirmed = False
 
-    def sample(load, reason, baseline=None):
+    def sample(load, reason, baseline=None, search_low=None, search_high=None):
         nonlocal failing_load
         if load in measured:
             return measured[load]
@@ -109,8 +118,18 @@ def _run_throughput(config, measure, on_attempt):
                 decision += "; throughput gain {:.3f}%".format(gain)
             if metrics["errors"]:
                 decision += "; {} workload errors allowed".format(metrics["errors"])
+        search_interval = {}
+        if search_low is not None:
+            search_interval["search_low"] = search_low
+        if search_high is not None:
+            search_interval["search_high"] = search_high
         record = _with_decision(
-            {**metrics, "throughput_gain_percent": gain, "target_cpu_saturated": saturated},
+            {
+                **metrics,
+                **search_interval,
+                "throughput_gain_percent": gain,
+                "target_cpu_saturated": saturated,
+            },
             load,
             passed,
             decision,
@@ -120,7 +139,7 @@ def _run_throughput(config, measure, on_attempt):
 
     start = search["start"]
     maximum = search["maximum"]
-    first = sample(start, "minimum ternary-search load")
+    first = sample(start, "minimum ternary-search load", search_low=start, search_high=maximum)
     if not first["passed"]:
         return LoadSearchResult(
             tuple(attempts),
@@ -139,19 +158,25 @@ def _run_throughput(config, measure, on_attempt):
         upper_load = high - third
         if lower_load >= upper_load:
             break
-        lower = sample(lower_load, "lower ternary probe")
+        lower = sample(lower_load, "lower ternary probe", search_low=low, search_high=high)
         if not lower["passed"]:
             plateau = 0
             high = lower_load - 1
             continue
-        upper = sample(upper_load, "upper ternary probe", baseline=lower)
+        upper = sample(
+            upper_load,
+            "upper ternary probe",
+            baseline=lower,
+            search_low=low,
+            search_high=high,
+        )
         if not upper["passed"]:
             plateau = 0
             high = upper_load - 1
             continue
         gain = _throughput_gain(lower["throughput"], upper["throughput"])
         saturated_plateau = (
-            gain is not None and gain < objective["plateau_gain_percent"] and upper["target_cpu_saturated"]
+            gain is not None and abs(gain) <= objective["plateau_gain_percent"] and upper["target_cpu_saturated"]
         )
         if saturated_plateau:
             plateau += 1
@@ -165,8 +190,12 @@ def _run_throughput(config, measure, on_attempt):
             low = lower_load + 1
 
     for load in sorted({low, (low + high) // 2, high}):
-        sample(load, "final ternary candidate")
-    selected = _best_throughput(attempts)
+        sample(load, "final ternary candidate", search_low=low, search_high=high)
+    selected = (
+        _lowest_saturated_plateau_load(attempts, objective["plateau_gain_percent"])
+        if plateau_confirmed
+        else _best_throughput(attempts)
+    )
     if selected is None:
         outcome = "no-feasible-point"
         stop_reason = "ternary search found no feasible load"

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1058,14 +1058,28 @@ function localChart(title,metric,xName,xValues,series){
     svgChart(metric,xName,xValues,series,chartColors)+'</section>'
 }
 function localBestRows(attempts,objective,xField='attempt'){
-  let bestLoad=null,bestThroughput=-Infinity,currentStage=null;const rows=new Map;
+  let bestLoad=null,currentStage=null,stageAttempts=[];const rows=new Map;
   for(const item of attempts){
-    if(currentStage!==item.search_stage){currentStage=item.search_stage;bestLoad=null;bestThroughput=-Infinity}
+    if(currentStage!==item.search_stage){currentStage=item.search_stage;bestLoad=null;stageAttempts=[]}
+    stageAttempts.push(item);
     if(item.passed){
-      if(objective==='latency-slo'){if(bestLoad===null||item.load>bestLoad)bestLoad=item.load}
-      else if(Number(item.throughput)>bestThroughput){bestThroughput=Number(item.throughput);bestLoad=item.load}
+      if(objective?.type==='latency-slo'){
+        if(bestLoad===null||item.load>bestLoad)bestLoad=item.load
+      }else if(objective?.type==='maximize-throughput'){
+        const saturated=stageAttempts.filter(value=>value.passed&&value.target_cpu_saturated);
+        if(saturated.length){
+          const bestThroughput=Math.max(...saturated.map(value=>Number(value.throughput)));
+          const minimumThroughput=bestThroughput*(1-Number(objective.plateau_gain_percent||0)/100);
+          bestLoad=Math.min(...saturated.filter(value=>Number(value.throughput)>=minimumThroughput).map(value=>value.load))
+        }
+      }else{
+        const best=stageAttempts.filter(value=>value.passed).sort(
+          (left,right)=>Number(right.throughput)-Number(left.throughput)||left.load-right.load
+        )[0];
+        bestLoad=best?.load??null
+      }
     }
-    rows.set(String(item[xField]),{...item,current_best:bestLoad,passed_load:item.passed?item.load:null,failed_load:item.passed?null:item.load})
+    rows.set(String(item[xField]),{...item,current_best:bestLoad,failed_load:item.passed?null:item.load})
   }
   return rows
 }
@@ -1079,7 +1093,7 @@ function renderLocalYdbProfile(container,data){
   const profileConfigOpen=container.querySelector('[data-local-profile-config][open]')!==null;
   const progress=data.progress||{},attempts=data.attempts||[],searches=data.searches||[];
   const result=data.result||null,parameters=data.parameters||{},loadConfig=parameters.load||{};
-  const objective=loadConfig.objective?.type||'points';
+  const objective=loadConfig.objective||{type:'points'};
   const phaseElapsed=localElapsed(progress.phase_started_at);
   const phaseDuration=Number(progress.phase_duration_seconds);
   const profileElapsed=localElapsed(data.started_at,data.finished_at);
@@ -1170,10 +1184,13 @@ function renderLocalYdbProfile(container,data){
       suffix:xAxis==='parameter'&&stages.length>1?
         ' · stage '+item.search_stage+' · '+item.dynamic_nodes+' dynamic':''
     }));
+    const bestLabel=objective.type==='latency-slo'?'Highest passing':
+      (objective.type==='maximize-throughput'?'Plateau candidate':'Best observed');
     const candidateSeries=groups.flatMap(group=>[
       {rows:group.bestRows,metric:'load',label:'Candidate'+group.suffix,colorIndex:7},
-      {rows:group.bestRows,metric:'current_best',label:'Current best'+group.suffix,colorIndex:0},
-      {rows:group.bestRows,metric:'passed_load',label:'Passed'+group.suffix,colorIndex:10},
+      {rows:group.bestRows,metric:'current_best',label:bestLabel+group.suffix,colorIndex:0},
+      {rows:group.bestRows,metric:'search_low',label:'Search low'+group.suffix,colorIndex:10},
+      {rows:group.bestRows,metric:'search_high',label:'Search high'+group.suffix,colorIndex:9},
       {rows:group.bestRows,metric:'failed_load',label:'Failed'+group.suffix,colorIndex:8}
     ]);
     const throughputSeries=groups.flatMap(group=>{
@@ -1205,12 +1222,14 @@ function renderLocalYdbProfile(container,data){
       {rows:group.rows,metric:'errors',label:'Errors'+group.suffix,colorIndex:8},
       {rows:group.rows,metric:'retries',label:'Retries'+group.suffix,colorIndex:1}
     ]);
+    const showSearchProgress=xAxis==='attempt';
+    const chartSeries={
+      throughput:throughputSeries,latency_ms:latencySeries,cpu_percent:cpuSeries,errors:errorSeries
+    };
+    if(showSearchProgress)chartSeries.load=candidateSeries;
     chartBinding={
       xName,xValues,
-      series:{
-        load:candidateSeries,throughput:throughputSeries,latency_ms:latencySeries,
-        cpu_percent:cpuSeries,errors:errorSeries
-      }
+      series:chartSeries
     };
     const axisHelp=xAxis==='parameter'?
       'Points are ordered by the searched parameter; geometry stages remain separate.':
@@ -1221,7 +1240,10 @@ function renderLocalYdbProfile(container,data){
       '<button type=button data-local-chart-x=parameter class="'+(xAxis==='parameter'?'primary':'')+
       '" aria-pressed="'+(xAxis==='parameter')+'">'+esc(searchAxisLabel)+'</button></div></div>'+
       '<p class=muted>'+esc(axisHelp)+'</p><div class=local-charts>'+
-      localChart('Candidate and current best','load',xName,xValues,candidateSeries)+
+      (showSearchProgress?localChart(
+        objective.type==='maximize-throughput'?'Ternary search progress':'Load search progress',
+        'load',xName,xValues,candidateSeries
+      ):'')+
       localChart('Offered and achieved throughput','throughput',xName,xValues,throughputSeries)+
       localChart('Latency','latency_ms',xName,xValues,latencySeries)+
       localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -576,7 +576,7 @@ class YdbBenchTest(unittest.TestCase):
             },
             on_attempt=lambda attempt: throughput_attempts.append(attempt["load"]),
         )
-        self.assertEqual(throughput.selected_load, 40)
+        self.assertEqual(throughput.selected_load, 38)
         self.assertEqual(throughput.outcome, "plateau-found")
         self.assertEqual(throughput_attempts[0], 10)
         self.assertEqual(len(throughput_attempts), len(set(throughput_attempts)))
@@ -631,6 +631,45 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(no_feasible_latency.outcome, "no-feasible-point")
         self.assertEqual(no_feasible_latency.failing_load, 10)
         self.assertEqual(below_start_attempts, [10])
+
+    def test_throughput_plateau_uses_absolute_gain_and_stable_lowest_load(self):
+        result = load_control.search_load(
+            {
+                "parameter": "rate",
+                "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 40},
+                "objective": {
+                    "type": "maximize-throughput",
+                    "target_role": "dynamic",
+                    "cpu_saturation_percent": 80,
+                    "plateau_gain_percent": 2,
+                    "plateau_points": 2,
+                },
+            },
+            lambda load: {
+                "throughput": 1000 - load,
+                "errors": 0,
+                "dynamic_cpu_mean": 90,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+        )
+        self.assertEqual(result.outcome, "best-observed")
+        self.assertEqual(result.selected_load, 10)
+        self.assertEqual((result.attempts[0]["search_low"], result.attempts[0]["search_high"]), (10, 100))
+        self.assertTrue(
+            any(item["search_high"] - item["search_low"] < 90 for item in result.attempts if "search_low" in item)
+        )
+
+        selected = load_control._lowest_saturated_plateau_load(
+            [
+                {"load": 30, "throughput": 5600, "passed": True, "target_cpu_saturated": False},
+                {"load": 54, "throughput": 5500, "passed": True, "target_cpu_saturated": True},
+                {"load": 61, "throughput": 5637.45, "passed": True, "target_cpu_saturated": True},
+                {"load": 340, "throughput": 5694.58, "passed": True, "target_cpu_saturated": True},
+            ],
+            2,
+        )
+        self.assertEqual(selected, 61)
 
     def test_throughput_controller_uses_ternary_search_and_error_bounds(self):
         config = {
@@ -3358,6 +3397,12 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"Failed workload requests are allowed", script)
                 self.assertIn(b"function localElapsed(started,finished=null)", script)
                 self.assertIn(b"Search process", script)
+                self.assertIn(b"Ternary search progress", script)
+                self.assertIn(b"Plateau candidate", script)
+                self.assertIn(b"Search low", script)
+                self.assertIn(b"Search high", script)
+                self.assertNotIn(b"Candidate and current best", script)
+                self.assertNotIn(b"label:'Passed'", script)
                 self.assertIn(b"function localSearchAxisLabel", script)
                 self.assertIn(b"data-local-chart-x", script)
                 self.assertIn(b"Attempts (search order)", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improved local YDB throughput searches to select the lowest stable saturated load and show ternary-search progress clearly.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Plateau comparisons now use an absolute tolerance, final selection uses the lowest saturated point within that tolerance, and the run UI displays the evolving plateau candidate and search interval.