### PR TITLE
EXT-1098 Report latency metrics for VDisk API

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/ut/ya.make
+++ b/ydb/core/blobstorage/vdisk/common/ut/ya.make
@@ -21,6 +21,7 @@ SRCS(
     memusage_ut.cpp
     vdisk_config_ut.cpp
     vdisk_events_ut.cpp
+    vdisk_histogram_latency_ut.cpp
     vdisk_lsnmngr_ut.cpp
     vdisk_outofspace_ut.cpp
     vdisk_pdisk_error_ut.cpp

--- a/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.cpp
@@ -20,15 +20,86 @@ namespace NKikimr {
 
             auto h = NMonitoring::ExplicitHistogram(GetCommonLatencyHistBounds(type));
             Histo = histoGroup->GetHistogram("LatencyMs", std::move(h));
+            LatencyUsMax.Init(histoGroup->GetCounter("LatencyUsMax", false));
+            LatencyUsCompletedSum = histoGroup->GetCounter("LatencyUsCompletedSum", true);
+            LatencyCompletedCount = histoGroup->GetCounter("LatencyCompletedCount", true);
+            InFlightLatencyUsSum = histoGroup->GetCounter("InFlightLatencyUsSum", false);
+            InFlightCount = histoGroup->GetCounter("InFlightCount", false);
         }
 
         void TLtcHisto::Collect(TDuration d, ui64 size) {
+            const ui64 durationUs = d.MicroSeconds();
             if (Histo) {
                 Histo->Collect(d.MillisecondsFloat());
             }
+            LatencyUsMax.Collect(durationUs);
+            LatencyUsCompletedSum->Add(durationUs);
+            LatencyCompletedCount->Inc();
             if (size) {
                 ThroughputBytes->Add(size);
             }
+        }
+
+        void TLtcHisto::AddInFlightRequest(ui64 requestId, TInstant receivedTime) {
+            InFlightRequests.emplace(requestId, receivedTime);
+        }
+
+        void TLtcHisto::RemoveInFlightRequest(ui64 requestId) {
+            InFlightRequests.erase(requestId);
+        }
+
+        void TLtcHisto::UpdateCounters(TInstant now) {
+            ui64 latencyUsSum = 0;
+            ui64 latencyUsMax = 0;
+            for (const auto& [requestId, receivedTime] : InFlightRequests) {
+                Y_UNUSED(requestId);
+                const ui64 latencyUs = now > receivedTime ? (now - receivedTime).MicroSeconds() : 0;
+                latencyUsSum += latencyUs;
+                latencyUsMax = Max(latencyUsMax, latencyUs);
+            }
+
+            InFlightLatencyUsSum->Set(latencyUsSum);
+            InFlightCount->Set(InFlightRequests.size());
+            LatencyUsMax.Collect(latencyUsMax);
+            LatencyUsMax.Update();
+        }
+
+        TInFlightLatencyGuard::TInFlightLatencyGuard(TLtcHistoPtr histogram, ui64 requestId, TInstant receivedTime)
+            : Histogram(std::move(histogram))
+            , RequestId(requestId)
+        {
+            if (Histogram) {
+                Histogram->AddInFlightRequest(RequestId, receivedTime);
+            }
+        }
+
+        TInFlightLatencyGuard::~TInFlightLatencyGuard() {
+            Reset();
+        }
+
+        TInFlightLatencyGuard::TInFlightLatencyGuard(TInFlightLatencyGuard&& other) noexcept
+            : Histogram(std::move(other.Histogram))
+            , RequestId(other.RequestId)
+        {
+            other.RequestId = 0;
+        }
+
+        TInFlightLatencyGuard& TInFlightLatencyGuard::operator=(TInFlightLatencyGuard&& other) noexcept {
+            if (this != &other) {
+                Reset();
+                Histogram = std::move(other.Histogram);
+                RequestId = other.RequestId;
+                other.RequestId = 0;
+            }
+            return *this;
+        }
+
+        void TInFlightLatencyGuard::Reset() {
+            if (Histogram) {
+                Histogram->RemoveInFlightRequest(RequestId);
+                Histogram.reset();
+            }
+            RequestId = 0;
         }
 
     } // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.h
@@ -3,9 +3,12 @@
 #include "defs.h"
 
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/util/max_tracker.h>
 
 #include <library/cpp/monlib/dynamic_counters/percentile/percentile.h>
 #include <library/cpp/monlib/metrics/histogram_collector.h>
+
+#include <util/generic/hash.h>
 
 namespace NKikimr {
     namespace NVDiskMon {
@@ -27,14 +30,44 @@ namespace NKikimr {
 
             // update histogram with with an operation with duration 'd'
             void Collect(TDuration d, ui64 size = 0);
+            void AddInFlightRequest(ui64 requestId, TInstant receivedTime);
+            void RemoveInFlightRequest(ui64 requestId);
+            void UpdateCounters(TInstant now);
 
         private:
             NMonitoring::THistogramPtr Histo;
             ::NMonitoring::TDynamicCounters::TCounterPtr ThroughputBytes;
+            TMaxTracker LatencyUsMax;
+            ::NMonitoring::TDynamicCounters::TCounterPtr LatencyUsCompletedSum;
+            ::NMonitoring::TDynamicCounters::TCounterPtr LatencyCompletedCount;
+            ::NMonitoring::TDynamicCounters::TCounterPtr InFlightLatencyUsSum;
+            ::NMonitoring::TDynamicCounters::TCounterPtr InFlightCount;
+            THashMap<ui64, TInstant> InFlightRequests;
         };
 
         using TLtcHistoPtr = std::shared_ptr<TLtcHisto>;
 
+        // Owns one in-flight latency record. Construction/destruction updates the tracked
+        // request set immediately; visible monitoring counters are snapshot-published by
+        // TLtcHisto::UpdateCounters().
+        class TInFlightLatencyGuard {
+        public:
+            TInFlightLatencyGuard() = default;
+            TInFlightLatencyGuard(TLtcHistoPtr histogram, ui64 requestId, TInstant receivedTime);
+            ~TInFlightLatencyGuard();
+
+            TInFlightLatencyGuard(const TInFlightLatencyGuard&) = delete;
+            TInFlightLatencyGuard& operator=(const TInFlightLatencyGuard&) = delete;
+
+            TInFlightLatencyGuard(TInFlightLatencyGuard&& other) noexcept;
+            TInFlightLatencyGuard& operator=(TInFlightLatencyGuard&& other) noexcept;
+
+            void Reset();
+
+        private:
+            TLtcHistoPtr Histogram;
+            ui64 RequestId = 0;
+        };
+
     } // NVDiskMon
 } // NKikimr
-

--- a/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency_ut.cpp
@@ -1,0 +1,115 @@
+#include "vdisk_histogram_latency.h"
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NVDiskMon {
+
+    Y_UNIT_TEST_SUITE(TVDiskLatencyCounters) {
+
+        Y_UNIT_TEST(CompletedAndInFlightLatencyCountersAreReportedSeparately) {
+            auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+            TLtcHisto histo(counters, "handleclass", "GetFast", NPDisk::DEVICE_TYPE_ROT);
+
+            histo.Collect(TDuration::MicroSeconds(123'456), 42);
+            histo.AddInFlightRequest(1, TInstant::MilliSeconds(1'000));
+            histo.AddInFlightRequest(2, TInstant::MilliSeconds(1'500));
+            histo.UpdateCounters(TInstant::MilliSeconds(2'500));
+
+            auto handleClassGroup = counters->FindSubgroup("handleclass", "GetFast");
+            UNIT_ASSERT(handleClassGroup);
+            auto latencyGroup = handleClassGroup->FindSubgroup("subsystem", "latency_histo");
+            UNIT_ASSERT(latencyGroup);
+
+            auto completedSum = latencyGroup->FindCounter("LatencyUsCompletedSum");
+            auto completedCount = latencyGroup->FindCounter("LatencyCompletedCount");
+            auto inFlightSum = latencyGroup->FindCounter("InFlightLatencyUsSum");
+            auto inFlightCount = latencyGroup->FindCounter("InFlightCount");
+            auto maxLatency = latencyGroup->FindCounter("LatencyUsMax");
+
+            UNIT_ASSERT(completedSum->ForDerivative());
+            UNIT_ASSERT(completedCount->ForDerivative());
+            UNIT_ASSERT(!inFlightSum->ForDerivative());
+            UNIT_ASSERT(!inFlightCount->ForDerivative());
+            UNIT_ASSERT(!maxLatency->ForDerivative());
+
+            UNIT_ASSERT_VALUES_EQUAL(completedSum->Val(), 123'456);
+            UNIT_ASSERT_VALUES_EQUAL(completedCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightSum->Val(), 2'500'000);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatency->Val(), 1'500'000);
+
+            histo.RemoveInFlightRequest(1);
+            histo.UpdateCounters(TInstant::MilliSeconds(3'000));
+
+            UNIT_ASSERT_VALUES_EQUAL(completedSum->Val(), 123'456);
+            UNIT_ASSERT_VALUES_EQUAL(completedCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightSum->Val(), 1'500'000);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+        }
+
+        Y_UNIT_TEST(InFlightLatencyGuardRemovesRequestOnDestruction) {
+            auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+            auto histo = std::make_shared<TLtcHisto>(counters, "handleclass", "GetFast", NPDisk::DEVICE_TYPE_ROT);
+
+            auto handleClassGroup = counters->FindSubgroup("handleclass", "GetFast");
+            UNIT_ASSERT(handleClassGroup);
+            auto latencyGroup = handleClassGroup->FindSubgroup("subsystem", "latency_histo");
+            UNIT_ASSERT(latencyGroup);
+
+            auto inFlightSum = latencyGroup->FindCounter("InFlightLatencyUsSum");
+            auto inFlightCount = latencyGroup->FindCounter("InFlightCount");
+            UNIT_ASSERT(inFlightSum);
+            UNIT_ASSERT(inFlightCount);
+
+            {
+                const ui64 requestId = 42;
+                TInFlightLatencyGuard guard(histo, requestId, TInstant::MilliSeconds(1'000));
+
+                histo->UpdateCounters(TInstant::MilliSeconds(2'500));
+
+                UNIT_ASSERT_VALUES_EQUAL(inFlightSum->Val(), 1'500'000);
+                UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+            }
+
+            histo->UpdateCounters(TInstant::MilliSeconds(3'000));
+            UNIT_ASSERT_VALUES_EQUAL(inFlightSum->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 0);
+        }
+
+        Y_UNIT_TEST(InFlightLatencyGuardMoveTransfersOwnership) {
+            auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+            auto histo = std::make_shared<TLtcHisto>(counters, "handleclass", "GetFast", NPDisk::DEVICE_TYPE_ROT);
+
+            auto handleClassGroup = counters->FindSubgroup("handleclass", "GetFast");
+            UNIT_ASSERT(handleClassGroup);
+            auto latencyGroup = handleClassGroup->FindSubgroup("subsystem", "latency_histo");
+            UNIT_ASSERT(latencyGroup);
+
+            auto inFlightSum = latencyGroup->FindCounter("InFlightLatencyUsSum");
+            auto inFlightCount = latencyGroup->FindCounter("InFlightCount");
+            UNIT_ASSERT(inFlightSum);
+            UNIT_ASSERT(inFlightCount);
+
+            {
+                TInFlightLatencyGuard movedGuard;
+                {
+                    const ui64 requestId = 42;
+                    TInFlightLatencyGuard guard(histo, requestId, TInstant::MilliSeconds(1'000));
+                    movedGuard = std::move(guard);
+                }
+
+                histo->UpdateCounters(TInstant::MilliSeconds(2'500));
+
+                UNIT_ASSERT_VALUES_EQUAL(inFlightSum->Val(), 1'500'000);
+                UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+            }
+
+            histo->UpdateCounters(TInstant::MilliSeconds(3'000));
+            UNIT_ASSERT_VALUES_EQUAL(inFlightSum->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 0);
+        }
+
+    } // Y_UNIT_TEST_SUITE(TVDiskLatencyCounters)
+
+} // namespace NKikimr::NVDiskMon

--- a/ydb/core/blobstorage/vdisk/common/vdisk_histograms.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histograms.cpp
@@ -44,5 +44,18 @@ namespace NKikimr {
             }
         }
 
+        void THistograms::UpdateCounters(TInstant now) {
+            for (const auto& histogram : {
+                     VGetAsyncLatencyHistogram,
+                     VGetFastLatencyHistogram,
+                     VGetDiscoverLatencyHistogram,
+                     VGetLowLatencyHistogram,
+                     VPutTabletLogLatencyHistogram,
+                     VPutUserDataLatencyHistogram,
+                     VPutAsyncBlobLatencyHistogram}) {
+                histogram->UpdateCounters(now);
+            }
+        }
+
     } // NVDiskMon
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_histograms.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histograms.h
@@ -17,6 +17,7 @@ namespace NKikimr {
                 NPDisk::EDeviceType type);
             const NVDiskMon::TLtcHistoPtr &GetHistogram(NKikimrBlobStorage::EGetHandleClass handleClass) const;
             const NVDiskMon::TLtcHistoPtr &GetHistogram(NKikimrBlobStorage::EPutHandleClass handleClass) const;
+            void UpdateCounters(TInstant now);
 
             NVDiskMon::TLtcHistoPtr VGetDiscoverLatencyHistogram;
             NVDiskMon::TLtcHistoPtr VGetFastLatencyHistogram;
@@ -29,4 +30,3 @@ namespace NKikimr {
 
     } // NVDiskMon
 } // NKikimr
-

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -110,11 +110,12 @@ namespace NKikimr {
             TLazyRetroSpan Span;
             std::shared_ptr<TVDiskSkeletonTrace> Trace;
             ui64 InternalMessageId;
+            NVDiskMon::TInFlightLatencyGuard InFlightLatency;
 
             TRecord(std::unique_ptr<IEventHandle> ev, TInstant now, ui32 recByteSize, const NBackpressure::TMessageId &msgId,
                     ui64 cost, TInstant deadline, NKikimrBlobStorage::EVDiskQueueId extQueueId,
                     const NBackpressure::TQueueClientId& clientId, TString name, std::shared_ptr<TVDiskSkeletonTrace> &&trace,
-                    ui64 internalMessageId)
+                    ui64 internalMessageId, NVDiskMon::TInFlightLatencyGuard inFlightLatency)
                 : Ev(std::move(ev))
                 , ReceivedTime(now)
                 , Deadline(deadline)
@@ -127,6 +128,7 @@ namespace NKikimr {
                 , Span(TWilson::VDiskTopLevel, std::move(Ev->TraceId), "VDisk.SkeletonFront.Queue")
                 , Trace(std::move(trace))
                 , InternalMessageId(internalMessageId)
+                , InFlightLatency(std::move(inFlightLatency))
             {
                 if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
                     wilsonSpan->Attribute("QueueName", std::move(name));
@@ -153,11 +155,14 @@ namespace NKikimr {
             struct TMsgInfo {
                 ui64 MsgId;
                 TInstant ReceivedTime;
+                NVDiskMon::TInFlightLatencyGuard InFlightLatency;
                 std::shared_ptr<TVDiskSkeletonTrace> VDiskSkeletonTrace;
 
-                TMsgInfo(ui64 msgId, TInstant receivedTime, std::shared_ptr<TVDiskSkeletonTrace> &&trace)
+                TMsgInfo(ui64 msgId, TInstant receivedTime,
+                        NVDiskMon::TInFlightLatencyGuard inFlightLatency, std::shared_ptr<TVDiskSkeletonTrace> &&trace)
                     : MsgId(msgId)
                     , ReceivedTime(receivedTime)
+                    , InFlightLatency(std::move(inFlightLatency))
                     , VDiskSkeletonTrace(std::move(trace))
                 {}
             };
@@ -247,7 +252,8 @@ namespace NKikimr {
                          const NBackpressure::TMessageId &msgId, ui64 cost, const TInstant &deadline,
                          NKikimrBlobStorage::EVDiskQueueId extQueueId, TFront& /*front*/,
                          const NBackpressure::TQueueClientId& clientId, std::shared_ptr<TVDiskSkeletonTrace> &&trace,
-                         ui64 internalMessageId) {
+                         ui64 internalMessageId, TInstant receivedTime, NVDiskMon::TLtcHistoPtr latencyHistogram) {
+                NVDiskMon::TInFlightLatencyGuard inFlightLatency(std::move(latencyHistogram), internalMessageId, receivedTime);
                 if (!Queue.Head() && CanSendToSkeleton(cost)) {
                     // send to Skeleton for further processing
                     ctx.Send(converted.release());
@@ -261,7 +267,8 @@ namespace NKikimr {
                     *SkeletonFrontInFlightCost += cost;
                     *SkeletonFrontInFlightBytes += recByteSize;
 
-                    Msgs.emplace(internalMessageId, TMsgInfo(msgId.MsgId, ctx.Now(), std::move(trace)));
+                    Msgs.emplace(internalMessageId, TMsgInfo(msgId.MsgId, ctx.Now(), std::move(inFlightLatency),
+                        std::move(trace)));
                     UpdateState();
                 } else {
                     // enqueue
@@ -273,16 +280,30 @@ namespace NKikimr {
 
                     TInstant now = TAppData::TimeProvider->Now();
                     Queue.Emplace(std::move(converted), now, recByteSize, msgId, cost, deadline, extQueueId,
-                        clientId, Name, std::move(trace), internalMessageId);
+                        clientId, Name, std::move(trace), internalMessageId, std::move(inFlightLatency));
                 }
             }
 
             template<typename TFront>
             void DropWithError(const TActorContext& ctx, TFront& front) {
+                DropInFlightOnError();
                 ProcessNext(ctx, front, true);
             }
 
         private:
+            void DropInFlightOnError() {
+                Msgs.clear();
+
+                InFlightCount = 0;
+                InFlightCost = 0;
+                InFlightBytes = 0;
+                IdleLight.Set(true, ++IdleLightSeqNo);
+                *SkeletonFrontInFlightCount = 0;
+                *SkeletonFrontInFlightCost = 0;
+                *SkeletonFrontInFlightBytes = 0;
+                UpdateState();
+            }
+
             template <class TFront>
             void ProcessNext(const TActorContext &ctx, TFront &front, bool forceError) {
                 // we can send next element to Skeleton if any
@@ -307,9 +328,11 @@ namespace NKikimr {
 
                         if (forceError) {
                             front.GetExtQueue(rec->ExtQueueId).DroppedWithError(ctx, rec, now, front);
+                            rec->InFlightLatency.Reset();
                         } else if (now >= rec->Deadline) {
                             ++Deadlines;
                             front.GetExtQueue(rec->ExtQueueId).DeadlineHappened(ctx, rec, now, front);
+                            rec->InFlightLatency.Reset();
                         } else {
                             ctx.Send(rec->Ev.release());
 
@@ -323,7 +346,8 @@ namespace NKikimr {
                             *SkeletonFrontInFlightCost += cost;
                             *SkeletonFrontInFlightBytes += recByteSize;
 
-                            Msgs.emplace(rec->InternalMessageId, TMsgInfo(rec->MsgId.MsgId, ctx.Now(), std::move(rec->Trace)));
+                            Msgs.emplace(rec->InternalMessageId, TMsgInfo(rec->MsgId.MsgId, ctx.Now(),
+                                std::move(rec->InFlightLatency), std::move(rec->Trace)));
                             UpdateState();
                         }
                         Queue.Pop();
@@ -1143,6 +1167,8 @@ namespace NKikimr {
         void UpdateStats(const TActorContext &ctx) {
             UpdateWhiteboard(ctx);
 
+            VCtx->Histograms.UpdateCounters(TAppData::TimeProvider->Now());
+
             // Update internal queue counters that are dependant on external ticker
             for (auto queue : {IntQueueAsyncGets.get(), IntQueueFastGets.get(), IntQueueDiscover.get(),
                                IntQueueLowGets.get(), IntQueueLogPuts.get(), IntQueueHugePutsForeground.get(),
@@ -1366,8 +1392,9 @@ namespace NKikimr {
                 }
 #endif
                 // good, enqueue it in intQueue
+                auto latencyHistogram = GetLatencyHistogram(*event->Get<TEvent>());
                 intQueue.Enqueue(ctx, recByteSize, std::move(event), msgId, cost, deadline, extQueueId, *this, clientId,
-                    std::move(trace), internalMessageId);
+                    std::move(trace), internalMessageId, now, std::move(latencyHistogram));
 
                 if constexpr (std::is_same_v<TEvent, TEvBlobStorage::TEvVPatchXorDiff>) {
                     // TEvVPatchXorDiff's cost is included in cost of other Patch operations
@@ -1387,6 +1414,35 @@ namespace NKikimr {
             }
 
             Sanitize(ctx);
+        }
+
+        template <typename TEvent>
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvent&) const {
+            return nullptr;
+        }
+
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPut& ev) const {
+            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+        }
+
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVMultiPut& ev) const {
+            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+        }
+
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVGet& ev) const {
+            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+        }
+
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPatchStart& ev) const {
+            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+        }
+
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPatchDiff& ev) const {
+            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+        }
+
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPatchXorDiff& ev) const {
+            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
         }
 
         bool Compatible(NKikimrBlobStorage::EVDiskQueueId extId, NKikimrBlobStorage::EVDiskInternalQueueId intId) {

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -1421,28 +1421,60 @@ namespace NKikimr {
             return nullptr;
         }
 
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogramByQueueId(NKikimrBlobStorage::EVDiskQueueId queueId) const {
+            switch (queueId) {
+                case NKikimrBlobStorage::EVDiskQueueId::GetAsyncRead:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EGetHandleClass::AsyncRead);
+                case NKikimrBlobStorage::EVDiskQueueId::GetFastRead:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EGetHandleClass::FastRead);
+                case NKikimrBlobStorage::EVDiskQueueId::GetDiscover:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EGetHandleClass::Discover);
+                case NKikimrBlobStorage::EVDiskQueueId::GetLowRead:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EGetHandleClass::LowRead);
+                case NKikimrBlobStorage::EVDiskQueueId::PutTabletLog:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EPutHandleClass::TabletLog);
+                case NKikimrBlobStorage::EVDiskQueueId::PutAsyncBlob:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EPutHandleClass::AsyncBlob);
+                case NKikimrBlobStorage::EVDiskQueueId::PutUserData:
+                    return VCtx->Histograms.GetHistogram(NKikimrBlobStorage::EPutHandleClass::UserData);
+                default:
+                    return nullptr;
+            }
+        }
+
+        template <typename TEvent>
+        NVDiskMon::TLtcHistoPtr GetLatencyHistogramByRequestClass(const TEvent& ev) const {
+            if (ev.Record.HasHandleClass()) {
+                return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            }
+            if (ev.Record.HasMsgQoS() && ev.Record.GetMsgQoS().HasExtQueueId()) {
+                return GetLatencyHistogramByQueueId(ev.Record.GetMsgQoS().GetExtQueueId());
+            }
+            return nullptr;
+        }
+
         NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPut& ev) const {
-            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            return GetLatencyHistogramByRequestClass(ev);
         }
 
         NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVMultiPut& ev) const {
-            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            return GetLatencyHistogramByRequestClass(ev);
         }
 
         NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVGet& ev) const {
-            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            return GetLatencyHistogramByRequestClass(ev);
         }
 
         NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPatchStart& ev) const {
-            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            return GetLatencyHistogramByRequestClass(ev);
         }
 
         NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPatchDiff& ev) const {
-            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            return GetLatencyHistogramByRequestClass(ev);
         }
 
         NVDiskMon::TLtcHistoPtr GetLatencyHistogram(const TEvBlobStorage::TEvVPatchXorDiff& ev) const {
-            return VCtx->Histograms.GetHistogram(ev.Record.GetHandleClass());
+            return GetLatencyHistogramByRequestClass(ev);
         }
 
         bool Compatible(NKikimrBlobStorage::EVDiskQueueId extId, NKikimrBlobStorage::EVDiskInternalQueueId intId) {

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_front_latency_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_front_latency_ut.cpp
@@ -1,0 +1,487 @@
+#include "blobstorage_skeletonfront.h"
+#include "skeleton_events.h"
+
+#include <ydb/core/base/counters.h>
+#include <ydb/core/base/services/blobstorage_service_id.h>
+#include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_config.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_pdisk_error.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+    namespace {
+
+        constexpr ui32 NodeId = 1;
+        constexpr ui32 PDiskId = 1;
+        constexpr ui32 VDiskSlotId = 0;
+        constexpr ui64 PDiskGuid = 1;
+        constexpr ui64 OwnerRound = 1;
+        constexpr ui32 MinHugeBlobInBytes = 64 << 10;
+        constexpr size_t MaxTrackerSlots = 15;
+        const TString StoragePoolName = "test_storage_pool";
+
+        TIntrusivePtr<TPDiskParams> MakePDiskParams() {
+            return MakeIntrusive<TPDiskParams>(
+                NPDisk::TOwner(0),
+                OwnerRound,
+                ui32(0),
+                ui32(128 << 20),
+                ui32(4 << 10),
+                ui64(1'000),
+                ui64(100 << 20),
+                ui64(100 << 20),
+                ui64(4 << 10),
+                ui64(4 << 10),
+                ui64(4 << 10),
+                NPDisk::DEVICE_TYPE_ROT,
+                false,
+                ui32(4 << 10));
+        }
+
+        TIntrusivePtr<TVDiskConfig> MakeConfig(ui64 maxHugePutsInFlight = 0) {
+            TVDiskIdShort vdiskId(0, 0, 0);
+            TVDiskConfig::TBaseInfo baseInfo(
+                vdiskId,
+                MakeBlobStoragePDiskID(NodeId, PDiskId),
+                PDiskGuid,
+                PDiskId,
+                NPDisk::DEVICE_TYPE_ROT,
+                VDiskSlotId,
+                NKikimrBlobStorage::TVDiskKind::Default,
+                OwnerRound,
+                StoragePoolName);
+
+            auto config = MakeIntrusive<TVDiskConfig>(baseInfo);
+            config->SkeletonFrontHugePuts_MaxInFlightCount = maxHugePutsInFlight;
+            config->SkeletonFrontExtPutUserData_TotalCost = 1'000'000'000'000ull;
+            config->SkeletonFrontQueueBackpressureCheckMsgId = false;
+            config->StatsUpdateInterval = TDuration::Days(1);
+            config->RunRepl = false;
+            return config;
+        }
+
+        TIntrusivePtr<NMonitoring::TDynamicCounters> FindSubgroup(
+            const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
+            const TString& name,
+            const TString& value) {
+            auto subgroup = counters->FindSubgroup(name, value);
+            UNIT_ASSERT_C(subgroup, "missing subgroup " << name << "=" << value);
+            return subgroup;
+        }
+
+        NMonitoring::TDynamicCounters::TCounterPtr FindCounter(
+            const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
+            const TString& name) {
+            auto counter = counters->FindCounter(name);
+            UNIT_ASSERT_C(counter, "missing counter " << name);
+            return counter;
+        }
+
+        void DispatchUntil(TTestBasicRuntime& runtime, const TActorId& actorId, ui32 eventType) {
+            TDispatchOptions options;
+            options.OnlyMailboxes.emplace_back(actorId.NodeId(), actorId.Hint());
+            options.FinalEvents.emplace_back(eventType);
+            runtime.DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        void DispatchBootstrap(TTestBasicRuntime& runtime, const TActorId& skeletonFrontId) {
+            DispatchUntil(runtime, skeletonFrontId, TEvents::TSystem::Bootstrap);
+        }
+
+        void SendToSkeletonFront(
+            TTestBasicRuntime& runtime,
+            const TActorId& skeletonFrontId,
+            const TActorId& edgeActor,
+            IEventBase* event,
+            ui32 eventType) {
+            const ui64 before = runtime.GetCounter(eventType);
+            runtime.Send(new IEventHandle(skeletonFrontId, edgeActor, event));
+            if (runtime.GetCounter(eventType) == before) {
+                DispatchUntil(runtime, skeletonFrontId, eventType);
+            }
+        }
+
+        TIntrusivePtr<NMonitoring::TDynamicCounters> GetPutUserDataLatencyGroup(
+            const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
+            const TIntrusivePtr<TVDiskConfig>& config,
+            const TIntrusivePtr<TBlobStorageGroupInfo>& info) {
+            auto group = GetServiceCounters(counters, "vdisks");
+            group = FindSubgroup(group, "storagePool", config->BaseInfo.StoragePoolName);
+            group = FindSubgroup(group, "group", Sprintf("%09" PRIu32, info->GroupID.GetRawId()));
+            group = FindSubgroup(group, "orderNumber", Sprintf("%02" PRIu32, info->GetOrderNumber(config->BaseInfo.VDiskIdShort)));
+            group = FindSubgroup(group, "pdisk", Sprintf("%09" PRIu32, config->BaseInfo.PDiskId));
+            group = FindSubgroup(group, "media", "rot");
+            group = FindSubgroup(group, "handleclass", "PutUserData");
+            return FindSubgroup(group, "subsystem", "latency_histo");
+        }
+
+        TIntrusivePtr<NMonitoring::TDynamicCounters> GetSkeletonFrontGroup(
+            const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
+            const TIntrusivePtr<TVDiskConfig>& config,
+            const TIntrusivePtr<TBlobStorageGroupInfo>& info) {
+            auto group = GetServiceCounters(counters, "vdisks");
+            group = FindSubgroup(group, "storagePool", config->BaseInfo.StoragePoolName);
+            group = FindSubgroup(group, "group", Sprintf("%09" PRIu32, info->GroupID.GetRawId()));
+            group = FindSubgroup(group, "orderNumber", Sprintf("%02" PRIu32, info->GetOrderNumber(config->BaseInfo.VDiskIdShort)));
+            group = FindSubgroup(group, "pdisk", Sprintf("%09" PRIu32, config->BaseInfo.PDiskId));
+            group = FindSubgroup(group, "media", "rot");
+            return FindSubgroup(group, "subsystem", "skeletonfront");
+        }
+
+        void SendRecoveryStatus(
+            TTestBasicRuntime& runtime,
+            const TActorId& skeletonFrontId,
+            const TActorId& edgeActor,
+            TEvFrontRecoveryStatus::EPhase phase) {
+            SendToSkeletonFront(
+                runtime,
+                skeletonFrontId,
+                edgeActor,
+                new TEvFrontRecoveryStatus(
+                    phase,
+                    NKikimrProto::OK,
+                    MakePDiskParams(),
+                    MinHugeBlobInBytes,
+                    TVDiskIncarnationGuid(1)),
+                TEvBlobStorage::EvFrontRecoveryStatus);
+        }
+
+        void UpdateStats(TTestBasicRuntime& runtime, const TActorId& skeletonFrontId, const TActorId& edgeActor) {
+            SendToSkeletonFront(
+                runtime,
+                skeletonFrontId,
+                edgeActor,
+                new TEvTimeToUpdateStats,
+                TEvBlobStorage::EvTimeToUpdateStats);
+        }
+
+        std::unique_ptr<TEvBlobStorage::TEvVPut> MakeUserDataPut(
+            const TLogoBlobID& blobId,
+            const TString& data,
+            const TVDiskID& vdiskId) {
+            auto put = std::make_unique<TEvBlobStorage::TEvVPut>(
+                blobId,
+                TRope(data),
+                vdiskId,
+                false,
+                nullptr,
+                TInstant::Max(),
+                NKikimrBlobStorage::UserData,
+                false);
+            UNIT_ASSERT_VALUES_EQUAL(put->Record.GetHandleClass(), NKikimrBlobStorage::UserData);
+            return put;
+        }
+
+        struct TTestEnv {
+            TIntrusivePtr<NMonitoring::TDynamicCounters> Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+            TIntrusivePtr<TBlobStorageGroupInfo> GroupInfo = MakeIntrusive<TBlobStorageGroupInfo>(
+                TBlobStorageGroupType(TErasureType::ErasureNone));
+            TIntrusivePtr<TVDiskConfig> Config;
+            TTestBasicRuntime Runtime;
+            TActorId EdgeActor;
+            TActorId SkeletonFrontId;
+            TActorId SkeletonId;
+
+            explicit TTestEnv(ui64 maxHugePutsInFlight)
+                : Config(MakeConfig(maxHugePutsInFlight))
+                , Runtime(NodeId, false)
+            {
+                Runtime.SetScheduledEventsSelectorFunc(&TTestActorRuntimeBase::DroppingScheduledEventsSelector);
+
+                TAppPrepare app;
+                app.ClearDomainsAndHive();
+                Runtime.Initialize(app.Unwrap());
+
+                EdgeActor = Runtime.AllocateEdgeActor(NodeId - 1);
+                SkeletonFrontId = Runtime.Register(
+                    CreateVDiskSkeletonFront(Config, GroupInfo, Counters),
+                    NodeId - 1);
+                Runtime.SetRegistrationObserverFunc([this](
+                                                        TTestActorRuntimeBase&,
+                                                        const TActorId& parentId,
+                                                        const TActorId& actorId) {
+                    if (parentId == SkeletonFrontId) {
+                        SkeletonId = actorId;
+                    }
+                });
+                DispatchBootstrap(Runtime, SkeletonFrontId);
+                UNIT_ASSERT_C(Runtime.FindActor(SkeletonFrontId, NodeId - 1), "SkeletonFront died during bootstrap");
+                UNIT_ASSERT_C(SkeletonId, "Skeleton actor was not registered during bootstrap");
+
+                SendRecoveryStatus(Runtime, SkeletonFrontId, EdgeActor, TEvFrontRecoveryStatus::LocalRecoveryDone);
+                SendRecoveryStatus(Runtime, SkeletonFrontId, EdgeActor, TEvFrontRecoveryStatus::SyncGuidRecoveryDone);
+
+                SendToSkeletonFront(
+                    Runtime,
+                    SkeletonFrontId,
+                    EdgeActor,
+                    new TEvBlobStorage::TEvVCheckReadiness(false),
+                    TEvBlobStorage::EvVCheckReadiness);
+                auto readiness = Runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVCheckReadinessResult>(
+                    EdgeActor,
+                    TDuration::Seconds(1));
+                UNIT_ASSERT_VALUES_EQUAL(readiness->Get()->Record.GetStatus(), NKikimrProto::OK);
+            }
+
+            TVDiskID GetVDiskId() const {
+                return GroupInfo->GetVDiskId(Config->BaseInfo.VDiskIdShort);
+            }
+        };
+
+        TAutoPtr<IEventHandle> GrabForwardedVPut(TTestEnv& env) {
+            NActors::TEventsList events = env.Runtime.CaptureMailboxEvents(env.SkeletonId.Hint(), env.SkeletonId.NodeId());
+            TAutoPtr<IEventHandle> handle;
+            auto* put = NActors::GrabEvent<TEvBlobStorage::TEvVPut>(events, handle);
+            UNIT_ASSERT_C(put, "missing forwarded TEvVPut");
+            env.Runtime.PushMailboxEventsFront(env.SkeletonId.Hint(), env.SkeletonId.NodeId(), events);
+            return handle;
+        }
+
+        TEvBlobStorage::TEvVPutResult::TPtr CompleteForwardedVPut(
+            TTestEnv& env,
+            TAutoPtr<IEventHandle> putHandle,
+            NKikimrProto::EReplyStatus status = NKikimrProto::OK) {
+            auto* put = putHandle->Get<TEvBlobStorage::TEvVPut>();
+            auto& record = put->Record;
+            const TLogoBlobID blobId = LogoBlobIDFromLogoBlobID(record.GetBlobID());
+            const TVDiskID vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
+            const ui32 recByteSize = put->GetCachedByteSize();
+            const TVMsgContext msgCtx(recByteSize, record.GetMsgQoS());
+            auto result = std::make_unique<TEvBlobStorage::TEvVPutResult>(
+                status,
+                blobId,
+                vdiskId,
+                nullptr,
+                TOutOfSpaceStatus(0u, 0.0),
+                TAppData::TimeProvider->Now(),
+                recByteSize,
+                &record,
+                nullptr,
+                nullptr,
+                nullptr,
+                put->GetBufferBytes(),
+                1,
+                status == NKikimrProto::OK ? TString() : TString("test error"));
+            std::unique_ptr<IEventHandle> resultHandle = std::make_unique<IEventHandle>(
+                putHandle->Sender,
+                env.SkeletonId,
+                result.release());
+
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.SkeletonId,
+                new TEvVDiskRequestCompleted(msgCtx, std::move(resultHandle)),
+                TEvBlobStorage::EvVDiskRequestCompleted);
+
+            auto completed = env.Runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVPutResult>(
+                env.EdgeActor,
+                TDuration::Seconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(completed->Get()->Record.GetStatus(), status);
+            return completed;
+        }
+
+    } // namespace
+
+    Y_UNIT_TEST_SUITE(TSkeletonFrontLatency) {
+
+        Y_UNIT_TEST(DroppedDelayedPutUserDataRemovesInFlightLatency) {
+            TTestEnv env(0);
+
+            const TString data(MinHugeBlobInBytes, 'x');
+            const TLogoBlobID blobId(1, 1, 1, 0, data.size(), 0);
+            auto put = MakeUserDataPut(blobId, data, env.GetVDiskId());
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                put.release(),
+                TEvBlobStorage::EvVPut);
+
+            auto latencyGroup = GetPutUserDataLatencyGroup(env.Counters, env.Config, env.GroupInfo);
+            auto inFlightCount = FindCounter(latencyGroup, "InFlightCount");
+            auto inFlightLatencyUsSum = FindCounter(latencyGroup, "InFlightLatencyUsSum");
+            auto maxLatencyUs = FindCounter(latencyGroup, "LatencyUsMax");
+            auto skeletonFrontGroup = GetSkeletonFrontGroup(env.Counters, env.Config, env.GroupInfo);
+            auto hugePutsForegroundDelayedCount = FindCounter(skeletonFrontGroup, "SkeletonFront/HugePutsForeground/DelayedCount");
+            auto hugePutsForegroundInFlightCount = FindCounter(skeletonFrontGroup, "SkeletonFront/HugePutsForeground/InFlightCount");
+
+            env.Runtime.AdvanceCurrentTime(TDuration::MilliSeconds(10));
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundDelayedCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundInFlightCount->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL_C(inFlightCount->Val(), 1,
+                                       "delayed# " << hugePutsForegroundDelayedCount->Val()
+                                                   << " queueInFlight# " << hugePutsForegroundInFlightCount->Val());
+            UNIT_ASSERT_GT(inFlightLatencyUsSum->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), inFlightLatencyUsSum->Val());
+            const ui64 maxLatencyUsBeforeError = maxLatencyUs->Val();
+
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                new TEvPDiskErrorStateChange(NKikimrProto::CORRUPTED, 0, "test error"),
+                TEvBlobStorage::EvPDiskErrorStateChange);
+
+            auto result = env.Runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVPutResult>(env.EdgeActor, TDuration::Seconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(result->Get()->Record.GetStatus(), NKikimrProto::ERROR);
+
+            // TQueueInplace::Pop() keeps the popped slot alive, so the forceError path has
+            // to reset the guard explicitly before the next counter snapshot is published.
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), maxLatencyUsBeforeError);
+        }
+
+        Y_UNIT_TEST(CompletedDelayedPutUserDataRemovesInFlightLatency) {
+            TTestEnv env(1);
+
+            const TString data(MinHugeBlobInBytes, 'x');
+            const TLogoBlobID firstBlobId(1, 1, 1, 0, data.size(), 0);
+            auto firstPut = MakeUserDataPut(firstBlobId, data, env.GetVDiskId());
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                firstPut.release(),
+                TEvBlobStorage::EvVPut);
+            auto firstForwarded = GrabForwardedVPut(env);
+
+            const TLogoBlobID secondBlobId(1, 1, 2, 0, data.size(), 0);
+            auto secondPut = MakeUserDataPut(secondBlobId, data, env.GetVDiskId());
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                secondPut.release(),
+                TEvBlobStorage::EvVPut);
+
+            auto latencyGroup = GetPutUserDataLatencyGroup(env.Counters, env.Config, env.GroupInfo);
+            auto inFlightCount = FindCounter(latencyGroup, "InFlightCount");
+            auto inFlightLatencyUsSum = FindCounter(latencyGroup, "InFlightLatencyUsSum");
+            auto maxLatencyUs = FindCounter(latencyGroup, "LatencyUsMax");
+            auto skeletonFrontGroup = GetSkeletonFrontGroup(env.Counters, env.Config, env.GroupInfo);
+            auto hugePutsForegroundDelayedCount = FindCounter(skeletonFrontGroup, "SkeletonFront/HugePutsForeground/DelayedCount");
+            auto hugePutsForegroundInFlightCount = FindCounter(skeletonFrontGroup, "SkeletonFront/HugePutsForeground/InFlightCount");
+
+            env.Runtime.AdvanceCurrentTime(TDuration::MilliSeconds(10));
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundDelayedCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundInFlightCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL_C(inFlightCount->Val(), 2,
+                                       "delayed# " << hugePutsForegroundDelayedCount->Val()
+                                                   << " queueInFlight# " << hugePutsForegroundInFlightCount->Val());
+            UNIT_ASSERT_GT(inFlightLatencyUsSum->Val(), 0);
+            UNIT_ASSERT_GT(maxLatencyUs->Val(), 0);
+            UNIT_ASSERT_LE(maxLatencyUs->Val(), inFlightLatencyUsSum->Val());
+
+            CompleteForwardedVPut(env, std::move(firstForwarded));
+            auto secondForwarded = GrabForwardedVPut(env);
+            UNIT_ASSERT_VALUES_EQUAL(
+                LogoBlobIDFromLogoBlobID(secondForwarded->Get<TEvBlobStorage::TEvVPut>()->Record.GetBlobID()),
+                secondBlobId);
+
+            env.Runtime.AdvanceCurrentTime(TDuration::MilliSeconds(10));
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundDelayedCount->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundInFlightCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+            UNIT_ASSERT_GT(inFlightLatencyUsSum->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), inFlightLatencyUsSum->Val());
+            const ui64 maxLatencyUsBeforeComplete = maxLatencyUs->Val();
+
+            CompleteForwardedVPut(env, std::move(secondForwarded));
+
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundDelayedCount->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(hugePutsForegroundInFlightCount->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), maxLatencyUsBeforeComplete);
+        }
+
+        Y_UNIT_TEST(MaxLatencyUsesMaxInFlightRequestLatency) {
+            TTestEnv env(2);
+
+            const TDuration firstAgeBeforeSecond = TDuration::MilliSeconds(10);
+            const TDuration ageAfterSecond = TDuration::MilliSeconds(20);
+
+            const TString data(MinHugeBlobInBytes, 'x');
+            const TLogoBlobID firstBlobId(1, 1, 1, 0, data.size(), 0);
+            auto firstPut = MakeUserDataPut(firstBlobId, data, env.GetVDiskId());
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                firstPut.release(),
+                TEvBlobStorage::EvVPut);
+            auto firstForwarded = GrabForwardedVPut(env);
+
+            auto latencyGroup = GetPutUserDataLatencyGroup(env.Counters, env.Config, env.GroupInfo);
+            auto inFlightCount = FindCounter(latencyGroup, "InFlightCount");
+            auto inFlightLatencyUsSum = FindCounter(latencyGroup, "InFlightLatencyUsSum");
+            auto maxLatencyUs = FindCounter(latencyGroup, "LatencyUsMax");
+
+            env.Runtime.AdvanceCurrentTime(firstAgeBeforeSecond);
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), firstAgeBeforeSecond.MicroSeconds());
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), firstAgeBeforeSecond.MicroSeconds());
+
+            const TLogoBlobID secondBlobId(1, 1, 2, 0, data.size(), 0);
+            auto secondPut = MakeUserDataPut(secondBlobId, data, env.GetVDiskId());
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                secondPut.release(),
+                TEvBlobStorage::EvVPut);
+            auto secondForwarded = GrabForwardedVPut(env);
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), firstAgeBeforeSecond.MicroSeconds());
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), firstAgeBeforeSecond.MicroSeconds());
+
+            env.Runtime.AdvanceCurrentTime(ageAfterSecond);
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+
+            const auto expectedMaxLatencyUs = (firstAgeBeforeSecond + ageAfterSecond).MicroSeconds();
+            const auto expectedInFlightLatencyUsSum = expectedMaxLatencyUs + ageAfterSecond.MicroSeconds();
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), expectedInFlightLatencyUsSum);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), expectedMaxLatencyUs);
+
+            CompleteForwardedVPut(env, std::move(firstForwarded));
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+
+            const auto remainingRequestLatencyUs = ageAfterSecond.MicroSeconds();
+            const auto maxLatencyUsBeforeRoll = maxLatencyUs->Val();
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), remainingRequestLatencyUs);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUsBeforeRoll, expectedMaxLatencyUs);
+
+            for (size_t i = 0; i < MaxTrackerSlots; ++i) {
+                UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(inFlightCount->Val(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(inFlightLatencyUsSum->Val(), remainingRequestLatencyUs);
+            UNIT_ASSERT_LT(maxLatencyUs->Val(), maxLatencyUsBeforeRoll);
+            UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), remainingRequestLatencyUs);
+
+            CompleteForwardedVPut(env, std::move(secondForwarded));
+        }
+
+    } // Y_UNIT_TEST_SUITE(TSkeletonFrontLatency)
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_front_latency_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_front_latency_ut.cpp
@@ -107,18 +107,26 @@ namespace NKikimr {
             }
         }
 
-        TIntrusivePtr<NMonitoring::TDynamicCounters> GetPutUserDataLatencyGroup(
+        TIntrusivePtr<NMonitoring::TDynamicCounters> GetLatencyGroup(
             const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
             const TIntrusivePtr<TVDiskConfig>& config,
-            const TIntrusivePtr<TBlobStorageGroupInfo>& info) {
+            const TIntrusivePtr<TBlobStorageGroupInfo>& info,
+            const TString& handleClass) {
             auto group = GetServiceCounters(counters, "vdisks");
             group = FindSubgroup(group, "storagePool", config->BaseInfo.StoragePoolName);
             group = FindSubgroup(group, "group", Sprintf("%09" PRIu32, info->GroupID.GetRawId()));
             group = FindSubgroup(group, "orderNumber", Sprintf("%02" PRIu32, info->GetOrderNumber(config->BaseInfo.VDiskIdShort)));
             group = FindSubgroup(group, "pdisk", Sprintf("%09" PRIu32, config->BaseInfo.PDiskId));
             group = FindSubgroup(group, "media", "rot");
-            group = FindSubgroup(group, "handleclass", "PutUserData");
+            group = FindSubgroup(group, "handleclass", handleClass);
             return FindSubgroup(group, "subsystem", "latency_histo");
+        }
+
+        TIntrusivePtr<NMonitoring::TDynamicCounters> GetPutUserDataLatencyGroup(
+            const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
+            const TIntrusivePtr<TVDiskConfig>& config,
+            const TIntrusivePtr<TBlobStorageGroupInfo>& info) {
+            return GetLatencyGroup(counters, config, info, "PutUserData");
         }
 
         TIntrusivePtr<NMonitoring::TDynamicCounters> GetSkeletonFrontGroup(
@@ -285,6 +293,52 @@ namespace NKikimr {
                 TDuration::Seconds(1));
             UNIT_ASSERT_VALUES_EQUAL(completed->Get()->Record.GetStatus(), status);
             return completed;
+        }
+
+        void AssertSingleInFlightLatency(TTestEnv& env, const TString& handleClass) {
+            auto latencyGroup = GetLatencyGroup(env.Counters, env.Config, env.GroupInfo, handleClass);
+            auto inFlightCount = FindCounter(latencyGroup, "InFlightCount");
+            auto inFlightLatencyUsSum = FindCounter(latencyGroup, "InFlightLatencyUsSum");
+            auto maxLatencyUs = FindCounter(latencyGroup, "LatencyUsMax");
+
+            UNIT_ASSERT_VALUES_EQUAL_C(inFlightCount->Val(), 1, "handleClass# " << handleClass);
+            UNIT_ASSERT_GT_C(inFlightLatencyUsSum->Val(), 0, "handleClass# " << handleClass);
+            UNIT_ASSERT_VALUES_EQUAL_C(maxLatencyUs->Val(), inFlightLatencyUsSum->Val(), "handleClass# " << handleClass);
+        }
+
+        void AssertNoInFlightLatency(TTestEnv& env, const TString& handleClass) {
+            auto latencyGroup = GetLatencyGroup(env.Counters, env.Config, env.GroupInfo, handleClass);
+            auto inFlightCount = FindCounter(latencyGroup, "InFlightCount");
+            auto inFlightLatencyUsSum = FindCounter(latencyGroup, "InFlightLatencyUsSum");
+
+            UNIT_ASSERT_VALUES_EQUAL_C(inFlightCount->Val(), 0, "handleClass# " << handleClass);
+            UNIT_ASSERT_VALUES_EQUAL_C(inFlightLatencyUsSum->Val(), 0, "handleClass# " << handleClass);
+        }
+
+        template <typename TMakePatchEvent>
+        void CheckPatchInFlightLatencyUsesExtQueueId(
+            TMakePatchEvent makePatchEvent,
+            ui32 eventType,
+            NKikimrBlobStorage::EVDiskQueueId expectedQueueId,
+            const TString& expectedHandleClass,
+            const TString& defaultHandleClass) {
+            TTestEnv env(0);
+            auto patch = makePatchEvent(env.GetVDiskId());
+            UNIT_ASSERT(!patch->Record.HasHandleClass());
+            UNIT_ASSERT_VALUES_EQUAL(patch->Record.GetMsgQoS().GetExtQueueId(), expectedQueueId);
+
+            SendToSkeletonFront(
+                env.Runtime,
+                env.SkeletonFrontId,
+                env.EdgeActor,
+                patch.release(),
+                eventType);
+
+            env.Runtime.AdvanceCurrentTime(TDuration::MilliSeconds(10));
+            UpdateStats(env.Runtime, env.SkeletonFrontId, env.EdgeActor);
+
+            AssertSingleInFlightLatency(env, expectedHandleClass);
+            AssertNoInFlightLatency(env, defaultHandleClass);
         }
 
     } // namespace
@@ -480,6 +534,56 @@ namespace NKikimr {
             UNIT_ASSERT_VALUES_EQUAL(maxLatencyUs->Val(), remainingRequestLatencyUs);
 
             CompleteForwardedVPut(env, std::move(secondForwarded));
+        }
+
+        Y_UNIT_TEST(PatchInFlightLatencyUsesExtQueueId) {
+            const TLogoBlobID originalBlobId(1, 1, 1, 0, 1, 0);
+            const TLogoBlobID patchedBlobId(1, 1, 2, 0, 1, 0);
+
+            CheckPatchInFlightLatencyUsesExtQueueId(
+                [&](const TVDiskID& vdiskId) {
+                    return std::make_unique<TEvBlobStorage::TEvVPatchStart>(
+                        originalBlobId,
+                        patchedBlobId,
+                        vdiskId,
+                        TInstant::Max(),
+                        TMaybe<ui64>(),
+                        false);
+                },
+                TEvBlobStorage::EvVPatchStart,
+                NKikimrBlobStorage::EVDiskQueueId::GetFastRead,
+                "GetFast",
+                "GetAsync");
+
+            CheckPatchInFlightLatencyUsesExtQueueId(
+                [&](const TVDiskID& vdiskId) {
+                    return std::make_unique<TEvBlobStorage::TEvVPatchDiff>(
+                        TLogoBlobID(originalBlobId, 1),
+                        TLogoBlobID(patchedBlobId, 1),
+                        vdiskId,
+                        0,
+                        TInstant::Max(),
+                        TMaybe<ui64>());
+                },
+                TEvBlobStorage::EvVPatchDiff,
+                NKikimrBlobStorage::EVDiskQueueId::PutAsyncBlob,
+                "PutAsyncBlob",
+                "PutTabletLog");
+
+            CheckPatchInFlightLatencyUsesExtQueueId(
+                [&](const TVDiskID& vdiskId) {
+                    return std::make_unique<TEvBlobStorage::TEvVPatchXorDiff>(
+                        TLogoBlobID(originalBlobId, 1),
+                        TLogoBlobID(patchedBlobId, 1),
+                        vdiskId,
+                        1,
+                        TInstant::Max(),
+                        TMaybe<ui64>());
+                },
+                TEvBlobStorage::EvVPatchXorDiff,
+                NKikimrBlobStorage::EVDiskQueueId::PutAsyncBlob,
+                "PutAsyncBlob",
+                "PutTabletLog");
         }
 
     } // Y_UNIT_TEST_SUITE(TSkeletonFrontLatency)

--- a/ydb/core/blobstorage/vdisk/skeleton/ut/ya.make
+++ b/ydb/core/blobstorage/vdisk/skeleton/ut/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
 
 SRCS(
     skeleton_oos_logic_ut.cpp
+    skeleton_front_latency_ut.cpp
     skeleton_vpatch_actor_ut.cpp
 )
 


### PR DESCRIPTION
### Changelog entry

Added VDisk latency counters for completed and currently in-flight requests.

### Description for reviewers

The new counters are reported per VDisk handle class:

- `LatencyUsCompletedSum`
- `LatencyCompletedCount`
- `InFlightLatencyUsSum`
- `InFlightCount`
- `LatencyUsMax`

Latency sums and max values are stored in microseconds because `TDynamicCounters` counters are integer-based. Dashboards should divide these values by `1000` to
display milliseconds.

Tested with:

- `./ya make --build relwithdebinfo ydb/core/blobstorage/vdisk/skeleton`
- `./ya make -tA ydb/core/blobstorage/vdisk/common/ut -F '*TVDiskLatencyCounters*'`