### PR TITLE
Support HTTP proxy and Topic SQS API in the YDB test recipe

### DIFF
--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -44,6 +44,8 @@ class EmptyArguments(object):
         self.dont_use_log_files = False
         self.enabled_feature_flags = []
         self.enabled_grpc_services = []
+        self.enable_http_proxy = False
+        self.enable_sqs_topic_api = False
 
 
 def _get_build_path(path):
@@ -224,6 +226,9 @@ class Recipe(object):
     def write_kafka_api_port(self, kafka_api_port):
         self.setenv('YDB_KAFKA_PROXY_PORT', str(kafka_api_port))
 
+    def write_http_proxy_endpoint(self, http_proxy_port):
+        self.setenv('YDB_HTTP_PROXY_ENDPOINT', 'http://localhost:%d' % http_proxy_port)
+
     def read_metafile(self):
         return json.loads(self.read(self.metafile_path()))
 
@@ -362,6 +367,32 @@ def resolve_deploy_config_action(config_path, target_config):
     return 'generate'
 
 
+def resolve_http_proxy_config(arguments):
+    enable_sqs_topic_api = (
+        getattr(arguments, 'enable_sqs_topic_api', False)
+        or os.getenv('YDB_ENABLE_SQS_TOPIC_API') == 'true'
+    )
+    enable_http_proxy = (
+        enable_sqs_topic_api
+        or getattr(arguments, 'enable_http_proxy', False)
+        or os.getenv('YDB_ENABLE_HTTP_PROXY') == 'true'
+    )
+
+    if not enable_http_proxy:
+        return None
+
+    config = {
+        'enabled': True,
+        'yandex_cloud_service_region': ['ru-central1', 'ru-central-1'],
+    }
+    if enable_sqs_topic_api:
+        config.update({
+            'sqs_topic_enabled': True,
+            'ymq_enabled': False,
+        })
+    return config
+
+
 def deploy(arguments):
     initialize_working_dir(arguments)
     recipe = Recipe(arguments)
@@ -411,6 +442,10 @@ def deploy(arguments):
         kafka_api_port = int(kafka_api_port)
     if kafka_api_port != 0:
         optionals['kafka_api_port'] = kafka_api_port
+
+    http_proxy_config = resolve_http_proxy_config(arguments)
+    if http_proxy_config is not None:
+        optionals['http_proxy_config'] = http_proxy_config
 
     enabled_grpc_services = arguments.enabled_grpc_services.copy()  # type: typing.List[str]
     if 'YDB_GRPC_SERVICES' in os.environ:
@@ -477,6 +512,7 @@ def deploy(arguments):
     endpoints = []
     mon_port = None
     kafka_api_port = None
+    http_proxy_port = None
     for node_id, node in cluster.nodes.items():
         info['nodes'][node_id] = {
             'pid': node.pid,
@@ -485,6 +521,7 @@ def deploy(arguments):
             'grpc_port': node.port,
             'mon_port': node.mon_port,
             'kafka_api_port': node.kafka_api_port,
+            'http_proxy_port': node.http_proxy_port,
             'command': node.command,
             'cwd': node.cwd,
             'stderr_file': node.stderr_file_name,
@@ -501,6 +538,9 @@ def deploy(arguments):
         if kafka_api_port is None:
             kafka_api_port = node.kafka_api_port
 
+        if http_proxy_port is None:
+            http_proxy_port = node.http_proxy_port
+
         endpoints.append("localhost:%d" % node.grpc_port)
 
     endpoint = endpoints[0]
@@ -515,6 +555,8 @@ def deploy(arguments):
         recipe.write_certificates_path(configuration.grpc_tls_ca.decode("utf-8"))
     if kafka_api_port is not None:
         recipe.write_kafka_api_port(kafka_api_port)
+    if http_proxy_port is not None:
+        recipe.write_http_proxy_endpoint(http_proxy_port)
     return endpoint, database
 
 
@@ -623,6 +665,8 @@ def produce_arguments(args):
     parser.add_argument("--base-port-offset", action="store", type=int, default=0)
     parser.add_argument("--pq-client-service-type", action='append', default=[])
     parser.add_argument("--enable-pqcd", action='store_true', default=False)
+    parser.add_argument("--enable-http-proxy", action='store_true', default=False)
+    parser.add_argument("--enable-sqs-topic-api", action='store_true', default=False)
     parser.add_argument("--config-path", action="store")
     parsed, _ = parser.parse_known_args(args)
     arguments = EmptyArguments()
@@ -637,6 +681,8 @@ def produce_arguments(args):
     arguments.enable_pq = parsed.enable_pq
     arguments.pq_client_service_types = parsed.pq_client_service_type
     arguments.enable_pqcd = parsed.enable_pqcd
+    arguments.enable_http_proxy = parsed.enable_http_proxy
+    arguments.enable_sqs_topic_api = parsed.enable_sqs_topic_api
     arguments.config_path = parsed.config_path
     return arguments
 

--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -3,9 +3,12 @@ import tempfile
 import unittest
 
 from ydb.public.tools.lib.cmds import (
+    EmptyArguments,
     generic_connector_config,
     parse_grpc_tls_enable,
+    produce_arguments,
     resolve_deploy_config_action,
+    resolve_http_proxy_config,
     same_config_path,
     should_generate_grpc_tls_data,
     should_preserve_existing_config,
@@ -112,3 +115,53 @@ def test_should_generate_grpc_tls_data_uses_explicit_path():
                 pass
             assert should_generate_grpc_tls_data(tmpdir) is False
             os.unlink(path)
+
+
+def test_resolve_http_proxy_config_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv('YDB_ENABLE_HTTP_PROXY', raising=False)
+    monkeypatch.delenv('YDB_ENABLE_SQS_TOPIC_API', raising=False)
+
+    assert resolve_http_proxy_config(EmptyArguments()) is None
+
+
+def test_resolve_http_proxy_config_enables_datastreams_proxy(monkeypatch):
+    monkeypatch.setenv('YDB_ENABLE_HTTP_PROXY', 'true')
+    monkeypatch.delenv('YDB_ENABLE_SQS_TOPIC_API', raising=False)
+
+    assert resolve_http_proxy_config(EmptyArguments()) == {
+        'enabled': True,
+        'yandex_cloud_service_region': ['ru-central1', 'ru-central-1'],
+    }
+
+
+def test_resolve_http_proxy_config_enables_topic_sqs_and_proxy(monkeypatch):
+    monkeypatch.delenv('YDB_ENABLE_HTTP_PROXY', raising=False)
+    monkeypatch.setenv('YDB_ENABLE_SQS_TOPIC_API', 'true')
+
+    assert resolve_http_proxy_config(EmptyArguments()) == {
+        'enabled': True,
+        'sqs_topic_enabled': True,
+        'ymq_enabled': False,
+        'yandex_cloud_service_region': ['ru-central1', 'ru-central-1'],
+    }
+
+
+def test_resolve_http_proxy_config_accepts_command_line_options(monkeypatch):
+    monkeypatch.delenv('YDB_ENABLE_HTTP_PROXY', raising=False)
+    monkeypatch.delenv('YDB_ENABLE_SQS_TOPIC_API', raising=False)
+    arguments = EmptyArguments()
+    arguments.enable_sqs_topic_api = True
+
+    assert resolve_http_proxy_config(arguments) == {
+        'enabled': True,
+        'sqs_topic_enabled': True,
+        'ymq_enabled': False,
+        'yandex_cloud_service_region': ['ru-central1', 'ru-central-1'],
+    }
+
+
+def test_produce_arguments_accepts_http_proxy_options():
+    arguments = produce_arguments(['--enable-http-proxy', '--enable-sqs-topic-api'])
+
+    assert arguments.enable_http_proxy is True
+    assert arguments.enable_sqs_topic_api is True

--- a/ydb/public/tools/ydb_recipe/README.md
+++ b/ydb/public/tools/ydb_recipe/README.md
@@ -1,0 +1,44 @@
+# YDB test recipe
+
+The YDB test recipe starts a local YDB cluster for tests built with `ya make` and exports its connection settings. Add it to a test target with:
+
+```yamake
+INCLUDE(${ARCADIA_ROOT}/ydb/public/tools/ydb_recipe/recipe.inc)
+```
+
+The recipe always exports `YDB_ENDPOINT`, `YDB_DATABASE`, and `YDB_CONNECTION_STRING`.
+
+## HTTP APIs
+
+Set `YDB_ENABLE_HTTP_PROXY=true` to start the unified HTTP proxy. The recipe then exports its base URL as `YDB_HTTP_PROXY_ENDPOINT`. DataStreams-compatible Kinesis API is available whenever this proxy is enabled. AWS clients should use `ru-central1` as the signing region.
+
+Set `YDB_ENABLE_SQS_TOPIC_API=true` to enable SQS API backed by YDB Topics. This option implies `YDB_ENABLE_HTTP_PROXY=true`, so setting both variables is not required. The legacy YMQ-backed SQS API is not enabled by this option.
+
+Shared topic consumers additionally require the `enable_topic_message_level_parallelism` feature flag. A test using Topic SQS API can configure the recipe as follows:
+
+```yamake
+ENV(YDB_ENABLE_SQS_TOPIC_API=true)
+ENV(YDB_FEATURE_FLAGS="enable_topic_message_level_parallelism")
+
+INCLUDE(${ARCADIA_ROOT}/ydb/public/tools/ydb_recipe/recipe.inc)
+```
+
+Use the exported proxy endpoint together with the database path when creating an SQS client:
+
+```python
+import os
+
+import boto3
+
+database = '/' + os.environ['YDB_DATABASE'].strip('/')
+client = boto3.client(
+    'sqs',
+    aws_access_key_id='unused',
+    aws_secret_access_key='unused',
+    aws_session_token='root@builtin',
+    endpoint_url=os.environ['YDB_HTTP_PROXY_ENDPOINT'] + database,
+    region_name='ru-central1',
+)
+```
+
+When invoking `ydb_recipe` directly, `--enable-http-proxy` and `--enable-sqs-topic-api` are the command-line equivalents of the environment variables.

--- a/ydb/public/tools/ydb_recipe/ut/test_sqs_topic_api.py
+++ b/ydb/public/tools/ydb_recipe/ut/test_sqs_topic_api.py
@@ -1,0 +1,39 @@
+import os
+
+import boto3
+
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+
+SQS_REGION = 'ru-central1'
+SECURITY_TOKEN = 'root@builtin'
+TOPIC_NAME = 'sqs-topic-api-test'
+CONSUMER_NAME = 'ydb-sqs-consumer'
+
+
+def test_sqs_topic_api_is_available_through_recipe():
+    database = '/' + os.environ['YDB_DATABASE'].strip('/')
+    with ydb.Driver(endpoint=os.environ['YDB_ENDPOINT'], database=database) as driver:
+        driver.wait(timeout=10, fail_fast=True)
+        with ydb.QuerySessionPool(driver) as session_pool:
+            session_pool.execute_with_retries("""
+                CREATE TOPIC `{}`
+                  (CONSUMER `{}`
+                    WITH (
+                      type = 'shared',
+                      keep_messages_order = false
+                    )
+                  );
+            """.format(TOPIC_NAME, CONSUMER_NAME))
+
+    client = boto3.client(
+        service_name='sqs',
+        aws_access_key_id='unused',
+        aws_secret_access_key='unused',
+        aws_session_token=SECURITY_TOKEN,
+        endpoint_url=os.environ['YDB_HTTP_PROXY_ENDPOINT'] + database,
+        region_name=SQS_REGION,
+    )
+
+    response = client.get_queue_url(QueueName=TOPIC_NAME)
+    assert response['QueueUrl']

--- a/ydb/public/tools/ydb_recipe/ut/ya.make
+++ b/ydb/public/tools/ydb_recipe/ut/ya.make
@@ -1,0 +1,20 @@
+PY3TEST()
+
+ENV(YDB_ENABLE_SQS_TOPIC_API=true)
+ENV(YDB_FEATURE_FLAGS="enable_topic_message_level_parallelism")
+
+TEST_SRCS(
+    test_sqs_topic_api.py
+)
+
+PEERDIR(
+    contrib/python/boto3
+    ydb/tests/oss/ydb_sdk_import
+)
+
+INCLUDE(${ARCADIA_ROOT}/ydb/public/tools/ydb_recipe/recipe.inc)
+
+SIZE(MEDIUM)
+TIMEOUT(120)
+
+END()

--- a/ydb/public/tools/ydb_recipe/ya.make
+++ b/ydb/public/tools/ydb_recipe/ya.make
@@ -18,3 +18,5 @@ FILES(
 )
 
 END()
+
+RECURSE_FOR_TESTS(ut)


### PR DESCRIPTION
### Changelog entry

Added HTTP proxy and Topic SQS API support to the YDB test recipe.

### Description for reviewers

This change adds:

- `YDB_ENABLE_HTTP_PROXY=true` and `--enable-http-proxy`;
- `YDB_ENABLE_SQS_TOPIC_API=true` and `--enable-sqs-topic-api`;
- automatic HTTP proxy activation for Topic SQS API;
- the exported `YDB_HTTP_PROXY_ENDPOINT`;
- unit tests for environment variables and command-line options;
- an integration test using a shared Topic consumer and SQS `GetQueueUrl`;
- recipe documentation with Kinesis and Topic SQS examples.

Legacy YMQ-backed SQS API remains disabled. Shared consumers still require the explicit `enable_topic_message_level_parallelism` feature flag.

Closes #51515