### PR TITLE
ydb-bench: show recent local YDB activity

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -181,7 +181,9 @@ The web profile page shows the same live phase with elapsed time and a countdown
 for warmup and measurement. Completed attempts appear immediately on synchronized
 search-order charts for candidate load, current best load, throughput, latency,
 CPU by role, errors, and retries. Geometry stages and the chronological attempt
-table remain available after completion. Profile `run.json` stores attempt and
+table remain available after completion. A bounded recent-activity log replays
+profile phase transitions and commands after a page reload without exposing the
+full event payload. Profile `run.json` stores attempt and
 stage timestamps, durations, structured decisions, scaling actions, and the
 final outcome so consumers do not have to parse diagnostic text.
 

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -34,6 +34,10 @@ from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, 
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
 _STREAM_CHUNK_SIZE = 1024 * 1024
+_LOCAL_YDB_ACTIVITY_LIMIT = 200
+_EVENT_LOG_RECORD_BYTES = 4 * 1024 * 1024
+_LOCAL_YDB_ACTIVITY_RESPONSE_BYTES = 512 * 1024
+_MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
 _HTML = (
     "<!doctype html><html lang=en><meta charset=utf-8>"
     '<meta name=viewport content="width=device-width,initial-scale=1">'
@@ -157,6 +161,11 @@ _CSS = (
 .local-command-entry{margin:.55rem 0;padding:.55rem;border:1px solid #e4e7ec;border-radius:5px;background:var(--panel)}
 .local-profile-config{margin:.8rem 0;padding:.7rem .8rem;border:1px solid #d0d5dd;border-radius:7px;background:#fff}
 .local-profile-config pre{max-height:24rem;overflow:auto;white-space:pre;margin:.7rem 0 0}
+.local-activity{margin:.8rem 0;padding:.7rem .8rem;border:1px solid #d0d5dd;border-radius:7px;background:#fff}
+.local-activity>summary{cursor:pointer}.local-activity-log{max-height:20rem;overflow:auto;margin:.65rem 0 0;padding:0;list-style:none}
+.local-activity-item{display:grid;grid-template-columns:6.5rem minmax(10rem,1fr);gap:.35rem .75rem;padding:.45rem 0;border-top:1px solid #e4e7ec}
+.local-activity-item:first-child{border-top:0}.local-activity-time{color:var(--muted);font-variant-numeric:tabular-nums}
+.local-activity-command{grid-column:2;margin:.15rem 0}.local-activity-command summary{cursor:pointer;color:var(--muted)}
 .attempt-pass{color:var(--good);font-weight:650}.attempt-fail{color:var(--bad);font-weight:650}
 .comparison-delta{font-weight:650}.comparison-delta.good{color:var(--good)}.comparison-delta.bad{color:var(--bad)}
 .verification-badge{display:inline-flex;align-items:center;margin-left:.35rem;padding:.08rem .42rem;border:1px solid #d0d5dd}
@@ -837,6 +846,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "async function loadChartData(runIds,benchmark=null){const query=new URLSearchParams;for(const run of runIds)query.append"
     "('run',run);if(benchmark)query.set('benchmark',benchmark);return api('/api/chart-data?'+query)}\n"
     "async function loadLocalYdbComparison(runIds){const query=new URLSearchParams;for(const run of runIds)query.append('run',run);return api('/api/local-ydb-comparison?'+query)}\n"
+    "async function loadLocalYdbActivity(runId,profile,after){const query=new URLSearchParams({profile,after:String(after)});return api('/api/runs/'+enc(runId)+'/local-ydb-activity?'+query)}\n"
     "function globLabelMatch(value,pattern){value=String(value);pattern=String(pattern||'*');return pattern.split('|').map(it"
     "em=>item.trim()).filter(Boolean).some(mask=>{if(mask==='*')return true;const parts=mask.split('*');let offset=0;if(parts"
     '[0]&&!value.startsWith(parts[0]))return false;for(const part of parts){if(!part)continue;const found=value.indexOf(part,'
@@ -1226,6 +1236,52 @@ function localCommandDetails(item,open){
       '</code></pre></div>'
     ).join('')+'</details>'
 }
+function localActivityTime(value){
+  const date=new Date(value);
+  return Number.isFinite(date.valueOf())?date.toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'}):'—'
+}
+function localActivityLabel(item){
+  if(item.type==='step-started')return 'Profile started';
+  if(item.type==='step-finished')return 'Profile '+(item.state||'finished');
+  return localPhaseLabel(item.phase)
+}
+function localActivityContext(item){
+  const verification=item.verification&&typeof item.verification==='object'?item.verification:null;
+  return [
+    item.search_stage?'stage '+item.search_stage:null,
+    item.attempt?'attempt #'+item.attempt:null,
+    item.repetition?'repetition '+item.repetition+'/'+(item.repetitions||'?'):null,
+    item.load!==undefined?(item.parameter||'load')+' '+metricLabel(item.load):null,
+    item.dynamic_nodes!==undefined?item.dynamic_nodes+' dynamic':null,
+    item.target_dynamic_nodes!==undefined?'target '+item.target_dynamic_nodes+' dynamic':null,
+    item.passed===true?'passed':item.passed===false?'failed':null,
+    verification?.completed_repetitions!==undefined?
+      'verification '+verification.completed_repetitions+'/'+(verification.configured_repetitions||'?'):null,
+    verification?.accepted===true?'holdout accepted':verification?.accepted===false?'holdout rejected':null,
+    item.decision||verification?.decision||item.reason||item.error||null
+  ].filter(Boolean).join(' · ')
+}
+function localActivityLog(events,truncated,open,error=''){
+  const rows=events.map(item=>{
+    const command=item.current_command?.argv?.length?'<details class=local-activity-command><summary>Command</summary>'+
+      '<pre class=local-command-code><code>'+esc(localCommandText(item.current_command))+'</code></pre></details>':'';
+    const context=localActivityContext(item);
+    return '<li class=local-activity-item><time class=local-activity-time datetime="'+esc(item.at||'')+'">'+
+      esc(localActivityTime(item.at))+'</time><div><strong>'+esc(localActivityLabel(item))+'</strong>'+
+      (context?'<div class=muted>'+esc(context)+'</div>':'')+'</div>'+command+'</li>'
+  }).join('');
+  return '<details class=local-activity data-local-activity'+(open?' open':'')+'><summary><strong>Recent activity</strong> '+
+    '<span class=muted>'+events.length+' events</span></summary>'+
+    (truncated?'<p class=muted>Earlier activity was omitted; recent events are bounded for display.</p>':'')+
+    (error?'<p class="notice error">'+esc(error)+'</p>':'')+
+    (rows?'<ol class=local-activity-log data-local-activity-log>'+rows+'</ol>':
+      '<p class=muted>No profile activity has been recorded yet.</p>')+'</details>'
+}
+function localRestoreActivityScroll(container,scrollTop,pinned){
+  const log=container.querySelector('[data-local-activity-log]');
+  if(!log)return;
+  log.scrollTop=pinned?log.scrollHeight:Math.min(scrollTop,Math.max(0,log.scrollHeight-log.clientHeight))
+}
 function localProfileDetails(data,open){
   const configuration={
     parameters:data.parameters||{},timeout_seconds:data.timeout_seconds??null,role_affinity:data.role_affinity||{}
@@ -1333,8 +1389,17 @@ function localBestRows(attempts,objective,xField='attempt'){
   return rows
 }
 function renderLocalYdbProfile(container,data){
+  const previousActivity=container.querySelector('[data-local-activity]');
+  const previousActivityLog=container.querySelector('[data-local-activity-log]');
+  const activityOpen=previousActivity?previousActivity.open:['running','preparing'].includes(data.state);
+  const activityScrollTop=previousActivityLog?.scrollTop||0;
+  const activityPinned=!previousActivityLog||
+    previousActivityLog.scrollHeight-previousActivityLog.scrollTop-previousActivityLog.clientHeight<8;
   if(data.state==='preparing'){
-    container.innerHTML='<div class=notice>Preparing local YDB profile and extracting binaries…</div>';return
+    container.innerHTML='<div class=notice>Preparing local YDB profile and extracting binaries…</div>'+localActivityLog(
+      data.activity||[],Boolean(data.activity_truncated),activityOpen,data.activity_error||''
+    );
+    localRestoreActivityScroll(container,activityScrollTop,activityPinned);return
   }
   const openCommandAttempts=new Set(
     [...container.querySelectorAll('[data-command-attempt][open]')].map(details=>details.dataset.commandAttempt)
@@ -1373,6 +1438,9 @@ function renderLocalYdbProfile(container,data){
       '<pre class=local-command-code><code>'+esc(localCommandText(progress.current_command))+
       '</code></pre></section>'
   }
+  html+=localActivityLog(
+    data.activity||[],Boolean(data.activity_truncated),activityOpen,data.activity_error||''
+  );
   if(result){
     const selected=localResultMetrics(result).metrics;
     const latencyMetric=(loadConfig.objective?.percentile||'p99')+'_ms';
@@ -1513,6 +1581,7 @@ function renderLocalYdbProfile(container,data){
       ).join('')+'</tbody></table></div>';
   }else html+='<div class=empty>No completed search attempts yet. The timeline will appear after the first measurement.</div>';
   container.innerHTML=html;
+  localRestoreActivityScroll(container,activityScrollTop,activityPinned);
   for(const axisButton of container.querySelectorAll('[data-local-chart-x]'))axisButton.onclick=()=>{
     container.dataset.localYdbXAxis=axisButton.dataset.localChartX;renderLocalYdbProfile(container,data)
   };
@@ -1522,12 +1591,25 @@ function renderLocalYdbProfile(container,data){
   )
 }
 async function mountLocalYdbProfile(container,runId,profile,runState){
-  let loading=false,terminal=false;
+  let loading=false,terminal=false,activity=[],activityAfter=0,activityTruncated=false;
   const scheduleRunRefresh=()=>{if(['running','queued'].includes(runState)&&!refreshTimer)refreshTimer=setTimeout(()=>renderRun(runId,'local-ydb/'+profile),700)};
   const refresh=async()=>{
     if(loading)return;loading=true;
     try{
-      const data=await api('/api/runs/'+enc(runId)+'/local-ydb-profile?profile='+enc(profile));
+      const [data,activityUpdate]=await Promise.all([
+        api('/api/runs/'+enc(runId)+'/local-ydb-profile?profile='+enc(profile)),
+        loadLocalYdbActivity(runId,profile,activityAfter).catch(error=>({error:error.message}))
+      ]);
+      if(activityUpdate.error)data.activity_error='Recent activity could not be loaded: '+activityUpdate.error;
+      else{
+        const merged=new Map(activity.map(item=>[item.sequence,item]));
+        for(const item of activityUpdate.events||[])merged.set(item.sequence,item);
+        activity=[...merged.values()].sort((left,right)=>left.sequence-right.sequence);
+        if(activity.length>200){activity=activity.slice(-200);activityTruncated=true}
+        activityTruncated=activityTruncated||Boolean(activityUpdate.truncated);
+        if(Number.isSafeInteger(activityUpdate.after))activityAfter=Math.max(activityAfter,activityUpdate.after)
+      }
+      data.activity=activity;data.activity_truncated=activityTruncated;
       renderLocalYdbProfile(container,data);terminal=!['running','preparing'].includes(data.state);
       if(terminal&&refreshTimer){clearInterval(refreshTimer);refreshTimer=null}
       if(terminal)scheduleRunRefresh()
@@ -1595,12 +1677,12 @@ async function mountLocalYdbProfile(container,runId,profile,runState){
     "card run-tree\"><details'+open+'><summary><strong>Execution details</strong> — affinity, cases and artifacts</summary><"
     "table><tr><th>Affinity</th><th>Runs</th><th>State</th></tr>'+affinityRows(id,steps)+'</table></details></section>'}\n"
     "    const running=(run.steps||[]).find(step=>step.state==='running'),live=['running','queued','failed','recovery_requir"
-    "ed'].includes(run.state);\n"
+    "ed'].includes(run.state),showLiveOutput=activeBenchmark!=='local-ydb';\n"
     "    if(live)content+='<section class=card><h2>Current step</h2>'+ (running?'<p><strong>'+esc(running.benchmark)+' / '+e"
     "sc(running.profile)+'</strong>, '+esc(running.affinity)+', '+esc(running.threads??'—')+' threads, repeat '+running.repe"
-    "at+', elapsed '+esc(stepDuration(running))+'</p>':'<p class=muted>No step is currently running.</p>')+'<h3>Live stdout"
-    "</h3><pre class=log>'+esc(run.tail?.stdout||'No stdout captured yet.')+'</pre><h3>Live stderr</h3><pre class=log>'+esc"
-    "(run.tail?.stderr||'No stderr captured yet.')+'</pre></section>';content+='</div>';\n"
+    "at+', elapsed '+esc(stepDuration(running))+'</p>':'<p class=muted>No step is currently running.</p>')+(showLiveOutput"
+    "?'<h3>Live stdout</h3><pre class=log>'+esc(run.tail?.stdout||'No stdout captured yet.')+'</pre><h3>Live stderr</h3><p"
+    "re class=log>'+esc(run.tail?.stderr||'No stderr captured yet.')+'</pre>':'')+'</section>';content+='</div>';\n"
     "    app.innerHTML=shell('runs',content);\n"
     "    document.querySelector('#refresh-run').onclick=()=>renderRun(id,activeProfile);\n"
     "    document.querySelector('#repeat-run').onclick=()=>reuseRun(id);\n"
@@ -2347,12 +2429,46 @@ class RunService:
 
     def _emit_locked(self, run, event):
         event = dict(event)
-        event["sequence"] = run["store"].manifest.get("events", 0) + 1
+        sequence = run["store"].manifest.get("events", 0) + 1
+        if sequence > _MAX_SAFE_JSON_INTEGER:
+            raise BenchmarkError("event sequence exceeds the JSON safe-integer range")
+        event["sequence"] = sequence
         event["at"] = _utc_now()
+        if event.get("type") in ("stdout", "stderr"):
+            event["data"] = str(event.get("data", ""))[-self.tail_limit :]
+        persisted_event = event
         try:
-            serialized_event = json.dumps(event, sort_keys=True, allow_nan=False)
+            serialized_event = json.dumps(persisted_event, sort_keys=True, allow_nan=False)
         except ValueError as error:
             raise BenchmarkError("event contains a non-finite JSON number") from error
+        serialized_size = len(serialized_event.encode("utf-8")) + 1
+        if serialized_size > _EVENT_LOG_RECORD_BYTES:
+            persisted_event = {
+                "sequence": event["sequence"],
+                "at": event["at"],
+                "payload_truncated": True,
+                "original_size_bytes": serialized_size,
+            }
+            for name in ("type", "step_id", "state"):
+                value = event.get(name)
+                if isinstance(value, str):
+                    persisted_event[name] = value[:2048]
+            fields = event.get("fields")
+            if isinstance(fields, dict):
+                persisted_fields = {}
+                for name in ("reason", "error"):
+                    value = fields.get(name)
+                    if isinstance(value, str):
+                        persisted_fields[name] = value[:2048]
+                if persisted_fields:
+                    persisted_event["fields"] = persisted_fields
+            serialized_event = json.dumps(persisted_event, sort_keys=True, allow_nan=False)
+            if len(serialized_event.encode("utf-8")) + 1 > _EVENT_LOG_RECORD_BYTES:
+                persisted_event.pop("fields", None)
+                for name in ("type", "step_id", "state"):
+                    if name in persisted_event:
+                        persisted_event[name] = persisted_event[name][:128]
+                serialized_event = json.dumps(persisted_event, sort_keys=True, allow_nan=False)
         if event.get("type") in ("stdout", "stderr"):
             key = event["type"]
             run["tail"][key] = (run["tail"][key] + str(event.get("data", "")))[-self.tail_limit :]
@@ -2374,7 +2490,7 @@ class RunService:
                         pass
         if event.get("type") == "step-finished" and step_id:
             run["store"].transition_step(step_id, event.get("state", "passed"), **event.get("fields", {}))
-        run["events"].append(event)
+        run["events"].append(persisted_event)
         run["store"].manifest["events"] = event["sequence"]
         with (run["root"] / "events.jsonl").open("a", encoding="utf-8") as stream:
             stream.write(serialized_event + "\n")
@@ -2699,6 +2815,235 @@ class RunService:
             "error",
         )
         return {name: value[name] for name in fields if name in value}
+
+    def local_ydb_activity(self, run_id, profile, after=0):
+        if not isinstance(profile, str) or not profile:
+            raise BenchmarkError("local-ydb profile is required")
+        if isinstance(after, bool) or not isinstance(after, int) or after < 0 or after > _MAX_SAFE_JSON_INTEGER:
+            raise BenchmarkError("activity cursor must be a non-negative integer in the JSON safe range")
+
+        root = _run_directory(self.output, run_id)
+        manifest = load_manifest(root / "run.json")
+        matching_steps = [
+            item
+            for item in manifest.get("steps", [])
+            if item.get("benchmark") == "local-ydb" and item.get("profile") == profile
+        ]
+        profile_exists = bool(matching_steps) or any(
+            item.get("benchmark") == "local-ydb" and item.get("profile") == profile for item in manifest.get("runs", [])
+        )
+        if not profile_exists:
+            raise BenchmarkError("local-ydb profile not found: {}".format(profile))
+        step_ids = {item["id"] for item in matching_steps if isinstance(item.get("id"), str) and item["id"]}
+
+        def bounded_scalar(value, limit=2048):
+            if isinstance(value, str):
+                return value[:limit]
+            if value is None or isinstance(value, bool):
+                return value
+            if isinstance(value, int) and abs(value) <= _MAX_SAFE_JSON_INTEGER:
+                return value
+            if isinstance(value, float) and math.isfinite(value) and abs(value) <= _MAX_SAFE_JSON_INTEGER:
+                return value
+            return None
+
+        def project_command(value):
+            if not isinstance(value, dict) or not isinstance(value.get("argv"), (list, tuple)):
+                return None
+            command = {
+                "argv": [
+                    str(part)[:512]
+                    for part in value["argv"][:64]
+                    if part is None or isinstance(part, (str, bool, int, float))
+                ]
+            }
+            cpus = value.get("cpu_affinity")
+            if isinstance(cpus, (list, tuple)):
+                command["cpu_affinity"] = [
+                    cpu
+                    for cpu in cpus[:4096]
+                    if isinstance(cpu, int) and not isinstance(cpu, bool) and 0 <= cpu <= _MAX_SAFE_JSON_INTEGER
+                ]
+            for name in ("phase", "repetition"):
+                projected = bounded_scalar(value.get(name))
+                if projected is not None:
+                    command[name] = projected
+            return command
+
+        def project_progress(value):
+            if not isinstance(value, dict):
+                return {}
+            result = {}
+            fields = (
+                "phase",
+                "phase_started_at",
+                "phase_duration_seconds",
+                "search_stage",
+                "attempt",
+                "static_nodes",
+                "dynamic_nodes",
+                "parameter",
+                "load",
+                "repetition",
+                "repetitions",
+                "passed",
+                "decision",
+                "target_dynamic_nodes",
+                "reason",
+            )
+            for name in fields:
+                projected = bounded_scalar(value.get(name))
+                if projected is not None:
+                    result[name] = projected
+            command = project_command(value.get("current_command"))
+            if command is not None:
+                result["current_command"] = command
+            verification = value.get("verification")
+            if isinstance(verification, bool):
+                result["verification"] = verification
+            elif isinstance(verification, dict):
+                result["verification"] = {
+                    name: projected
+                    for name in (
+                        "status",
+                        "configured_repetitions",
+                        "completed_repetitions",
+                        "accepted",
+                        "evaluation_kind",
+                        "decision",
+                        "throughput_delta_percent",
+                        "saturated_repetitions",
+                    )
+                    if (projected := bounded_scalar(verification.get(name))) is not None
+                }
+            return result
+
+        def project_event(event):
+            event_type = event.get("type")
+            if event_type not in ("step-started", "step-progress", "step-finished"):
+                return None
+            item = {
+                "sequence": event["sequence"],
+                "type": event_type,
+            }
+            at = bounded_scalar(event.get("at"))
+            if at is not None:
+                item["at"] = at
+            if event_type == "step-progress":
+                fields = event.get("fields")
+                progress = fields.get("progress") if isinstance(fields, dict) else None
+                item.update(project_progress(progress))
+            elif event_type == "step-finished":
+                state = bounded_scalar(event.get("state"))
+                if state is not None:
+                    item["state"] = state
+                fields = event.get("fields")
+                if not isinstance(fields, dict):
+                    fields = {}
+                for name in ("reason", "error"):
+                    projected = bounded_scalar(fields.get(name))
+                    if projected is not None:
+                        item[name] = projected
+            return item
+
+        events_path = root / "events.jsonl"
+
+        def event_log_snapshot_size():
+            if events_path.is_symlink():
+                raise BenchmarkError("run event log must be a regular file")
+            try:
+                size = events_path.stat().st_size
+            except FileNotFoundError:
+                return 0
+            if not events_path.is_file():
+                raise BenchmarkError("run event log must be a regular file")
+            return size
+
+        cursor = after
+        matched = 0
+        activity = deque(maxlen=_LOCAL_YDB_ACTIVITY_LIMIT)
+
+        def consume(event):
+            nonlocal cursor, matched
+            sequence = event["sequence"]
+            if sequence <= after:
+                return
+            cursor = sequence
+            step_id = event.get("step_id")
+            if not isinstance(step_id, str) or step_id not in step_ids:
+                return
+            item = project_event(event)
+            if item is not None:
+                activity.append(item)
+                matched += 1
+
+        with self._lock:
+            run = self._runs.get(run_id)
+        live_events = None
+        if run:
+            with run["lock"]:
+                last_sequence = run["store"].manifest.get("events", 0)
+                if after >= last_sequence:
+                    live_events = ()
+                elif run["events"] and after >= run["events"][0]["sequence"] - 1:
+                    live_events = tuple(dict(event) for event in run["events"] if event["sequence"] > after)
+                else:
+                    snapshot_size = event_log_snapshot_size()
+        else:
+            snapshot_size = event_log_snapshot_size()
+
+        if live_events is not None:
+            for event in live_events:
+                consume(event)
+        elif snapshot_size:
+            try:
+                stream = events_path.open("rb")
+            except OSError as error:
+                raise BenchmarkError("cannot read run event log") from error
+            with stream:
+                remaining = snapshot_size
+                previous_sequence = 0
+                while remaining:
+                    line = stream.readline(min(remaining, _EVENT_LOG_RECORD_BYTES + 1))
+                    if not line:
+                        raise BenchmarkError("run event log ended before its snapshot boundary")
+                    remaining -= len(line)
+                    if len(line) > _EVENT_LOG_RECORD_BYTES or not line.endswith(b"\n"):
+                        raise BenchmarkError("run event log contains an oversized or incomplete event")
+                    try:
+                        event = json.loads(line.decode("utf-8"), parse_constant=_non_finite_json_as_null)
+                    except (UnicodeDecodeError, ValueError) as error:
+                        raise BenchmarkError("run event log contains malformed JSON") from error
+                    if not isinstance(event, dict):
+                        raise BenchmarkError("run event log event must be an object")
+                    sequence = event.get("sequence")
+                    if (
+                        not isinstance(sequence, int)
+                        or isinstance(sequence, bool)
+                        or sequence <= previous_sequence
+                        or sequence > _MAX_SAFE_JSON_INTEGER
+                    ):
+                        raise BenchmarkError("run event log sequences must be strictly increasing integers")
+                    previous_sequence = sequence
+                    if not isinstance(event.get("type"), str):
+                        raise BenchmarkError("run event log event type must be a string")
+                    consume(event)
+
+        bounded = deque()
+        response_bytes = 0
+        for item in reversed(activity):
+            encoded_size = len(json.dumps(item, allow_nan=False, separators=(",", ":")).encode("utf-8")) + 1
+            if encoded_size > _LOCAL_YDB_ACTIVITY_RESPONSE_BYTES:
+                continue
+            if response_bytes + encoded_size > _LOCAL_YDB_ACTIVITY_RESPONSE_BYTES:
+                break
+            bounded.appendleft(item)
+            response_bytes += encoded_size
+        return {
+            "events": list(bounded),
+            "after": cursor,
+            "truncated": matched > len(bounded),
+        }
 
     def local_ydb_comparison(self, run_ids):
         if not isinstance(run_ids, list) or not run_ids or len(run_ids) > 20:
@@ -3220,6 +3565,19 @@ def _handler(service):
             if path == "/api/local-ydb-comparison":
                 try:
                     value = service.local_ydb_comparison(parse_qs(parsed.query).get("run", []))
+                except BenchmarkError as error:
+                    return self._json(400, {"error": str(error)})
+                return self._json(200, value)
+            if path.startswith("/api/runs/") and path.endswith("/local-ydb-activity"):
+                run_id = unquote(path[len("/api/runs/") : -len("/local-ydb-activity")])
+                query = parse_qs(parsed.query)
+                profile = query.get("profile", [""])[-1]
+                try:
+                    after = int(query.get("after", [0])[-1])
+                except ValueError:
+                    return self._json(400, {"error": "activity cursor must be a non-negative integer"})
+                try:
+                    value = service.local_ydb_activity(run_id, profile, after)
                 except BenchmarkError as error:
                     return self._json(400, {"error": str(error)})
                 return self._json(200, value)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -16,6 +16,7 @@ import time
 import unittest
 import urllib.request
 import zipfile
+from collections import deque
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import FrozenInstanceError, fields, replace
 from pathlib import Path
@@ -3502,6 +3503,316 @@ class WebTest(unittest.TestCase):
         finally:
             service.shutdown()
 
+    def test_run_service_compacts_oversized_event_log_records_without_changing_lifecycle(self):
+        def oversized_executor(run, emit, _cancelled):
+            step_id = run["store"].manifest["steps"][0]["id"]
+            emit({"type": "step-started", "step_id": step_id})
+            emit(
+                {
+                    "type": "step-finished",
+                    "step_id": step_id,
+                    "state": "passed",
+                    "fields": {"reason": "x" * 4096},
+                }
+            )
+
+        with mock.patch.object(web, "_EVENT_LOG_RECORD_BYTES", 512):
+            service = RunService(self.root, executor=oversized_executor)
+            try:
+                run_id = service.start(
+                    "ping-bench:\n  oversized: {threads: [1], duration: 1, repetitions: 1, affinity: [none]}\n"
+                )["id"]
+                run = service._runs[run_id]
+                self.assertTrue(run["finished"].wait(2))
+                manifest = json.loads((run["root"] / "run.json").read_text(encoding="utf-8"))
+                self.assertEqual(manifest["state"], "passed")
+                self.assertEqual(manifest["steps"][0]["state"], "passed")
+                persisted = [
+                    json.loads(line) for line in (run["root"] / "events.jsonl").read_text(encoding="utf-8").splitlines()
+                ]
+                compacted = next(event for event in persisted if event.get("payload_truncated"))
+                self.assertEqual(compacted["type"], "step-finished")
+                self.assertEqual(compacted["state"], "passed")
+                self.assertGreater(compacted["original_size_bytes"], web._EVENT_LOG_RECORD_BYTES)
+                self.assertTrue(
+                    all(
+                        len((json.dumps(event, sort_keys=True) + "\n").encode("utf-8")) <= web._EVENT_LOG_RECORD_BYTES
+                        for event in persisted
+                    )
+                )
+            finally:
+                service.shutdown()
+
+    def test_run_service_keeps_original_failure_when_compacting_oversized_event(self):
+        def oversized_executor(run, emit, _cancelled):
+            step_id = run["store"].manifest["steps"][0]["id"]
+            emit({"type": "step-started", "step_id": step_id})
+            emit(
+                {
+                    "type": "step-finished",
+                    "step_id": step_id,
+                    "state": "failed",
+                    "fields": {"error": "x" * 4096},
+                }
+            )
+            raise BenchmarkError("original benchmark failure")
+
+        with mock.patch.object(web, "_EVENT_LOG_RECORD_BYTES", 512):
+            service = RunService(self.root, executor=oversized_executor)
+            try:
+                run_id = service.start(
+                    "ping-bench:\n  oversized: {threads: [1], duration: 1, repetitions: 1, affinity: [none]}\n"
+                )["id"]
+                run = service._runs[run_id]
+                self.assertTrue(run["finished"].wait(2))
+                manifest = json.loads((run["root"] / "run.json").read_text(encoding="utf-8"))
+                self.assertEqual(manifest["state"], "failed")
+                self.assertEqual(manifest["steps"][0]["state"], "failed")
+                self.assertEqual(manifest["error"], "original benchmark failure")
+                persisted = [
+                    json.loads(line) for line in (run["root"] / "events.jsonl").read_text(encoding="utf-8").splitlines()
+                ]
+                compacted = next(event for event in persisted if event.get("payload_truncated"))
+                self.assertEqual(compacted["type"], "step-finished")
+                self.assertEqual(compacted["state"], "failed")
+            finally:
+                service.shutdown()
+
+    def test_local_ydb_activity_is_profile_scoped_bounded_and_strictly_projected(self):
+        run_root = self.root / "local-ydb-activity"
+        self._manifest(run_root)
+        manifest_path = run_root / "run.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["runs"] = [
+            {"benchmark": "local-ydb", "profile": "capacity", "status": "running"},
+            {"benchmark": "local-ydb", "profile": "other", "status": "running"},
+        ]
+        manifest["steps"] = [
+            {
+                "id": "capacity-step",
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "state": "running",
+            },
+            {
+                "id": "other-step",
+                "benchmark": "local-ydb",
+                "profile": "other",
+                "state": "running",
+            },
+        ]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        events = [
+            {
+                "sequence": 1,
+                "at": "2025-01-01T00:00:00+00:00",
+                "type": "step-started",
+                "step_id": "capacity-step",
+                "fields": {"role_affinity": {"private": list(range(1000))}},
+            }
+        ]
+        for index in range(205):
+            progress = {
+                "phase": "measuring",
+                "search_stage": 1,
+                "attempt": index + 1,
+                "parameter": "rate",
+                "load": 1000 + index,
+                "latest_attempt": {"commands": [{"private": "not projected"}]},
+            }
+            if index == 204:
+                progress.update(
+                    {
+                        "current_command": {
+                            "phase": "measuring",
+                            "repetition": 2,
+                            "argv": ["/tmp/ydb", "workload", "run"],
+                            "cpu_affinity": [0, 128],
+                            "private": "not projected",
+                        },
+                        "verification": {
+                            "status": "completed",
+                            "configured_repetitions": 3,
+                            "completed_repetitions": 3,
+                            "accepted": True,
+                            "evaluation_kind": "objective",
+                            "decision": "latency-slo-passed",
+                            "samples": [{"commands": ["not projected"]}],
+                        },
+                    }
+                )
+            events.append(
+                {
+                    "sequence": index + 2,
+                    "at": "2025-01-01T00:00:{:02d}+00:00".format(index % 60),
+                    "type": "step-progress",
+                    "step_id": "capacity-step",
+                    "fields": {"progress": progress},
+                }
+            )
+        last_target_sequence = events[-1]["sequence"]
+        events.append(
+            {
+                "sequence": last_target_sequence + 1,
+                "at": "2025-01-01T00:04:00+00:00",
+                "type": "step-progress",
+                "step_id": "other-step",
+                "fields": {"progress": {"phase": "measuring", "attempt": 999}},
+            }
+        )
+        (run_root / "events.jsonl").write_text(
+            "".join(json.dumps(event) + "\n" for event in events),
+            encoding="utf-8",
+        )
+
+        service = RunService(self.root)
+        try:
+            with mock.patch.object(service, "events", side_effect=AssertionError("must stream event log")):
+                activity = service.local_ydb_activity("local-ydb-activity", "capacity")
+            self.assertTrue(activity["truncated"])
+            self.assertEqual(len(activity["events"]), web._LOCAL_YDB_ACTIVITY_LIMIT)
+            self.assertEqual(activity["after"], last_target_sequence + 1)
+            self.assertTrue(all(item["sequence"] <= last_target_sequence for item in activity["events"]))
+            projected = activity["events"][-1]
+            self.assertEqual(projected["current_command"]["argv"], ["/tmp/ydb", "workload", "run"])
+            self.assertEqual(projected["current_command"]["cpu_affinity"], [0, 128])
+            self.assertNotIn("private", projected["current_command"])
+            self.assertNotIn("latest_attempt", projected)
+            self.assertTrue(projected["verification"]["accepted"])
+            self.assertEqual(projected["verification"]["evaluation_kind"], "objective")
+            self.assertNotIn("samples", projected["verification"])
+            replay = service.local_ydb_activity("local-ydb-activity", "capacity", after=last_target_sequence)
+            self.assertEqual(replay, {"events": [], "after": last_target_sequence + 1, "truncated": False})
+            live_event = {
+                "sequence": last_target_sequence + 2,
+                "type": "step-progress",
+                "step_id": "capacity-step",
+                "fields": {"progress": {"phase": "finishing"}},
+            }
+            service._runs["local-ydb-activity"] = {
+                "lock": threading.RLock(),
+                "events": deque([live_event]),
+                "store": mock.Mock(manifest={"events": live_event["sequence"]}),
+            }
+            try:
+                with mock.patch.object(web, "load_manifest", return_value=manifest), mock.patch.object(
+                    Path, "open", side_effect=AssertionError("live poll must not replay the event log")
+                ):
+                    live = service.local_ydb_activity("local-ydb-activity", "capacity", after=last_target_sequence + 1)
+                self.assertEqual(live["after"], live_event["sequence"])
+                self.assertEqual(live["events"][0]["phase"], "finishing")
+            finally:
+                del service._runs["local-ydb-activity"]
+            with self.assertRaisesRegex(BenchmarkError, "non-negative integer"):
+                service.local_ydb_activity("local-ydb-activity", "capacity", after=-1)
+            with self.assertRaisesRegex(BenchmarkError, "JSON safe range"):
+                service.local_ydb_activity("local-ydb-activity", "capacity", after=web._MAX_SAFE_JSON_INTEGER + 1)
+            with self.assertRaisesRegex(BenchmarkError, "profile not found"):
+                service.local_ydb_activity("local-ydb-activity", "missing")
+            (run_root / "events.jsonl").write_text(
+                json.dumps({"sequence": "one", "type": "step-progress"}) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(BenchmarkError, "strictly increasing integers"):
+                service.local_ydb_activity("local-ydb-activity", "capacity")
+            (run_root / "events.jsonl").write_text(
+                json.dumps({"sequence": 1, "type": 7}) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(BenchmarkError, "type must be a string"):
+                service.local_ydb_activity("local-ydb-activity", "capacity")
+            (run_root / "events.jsonl").write_text(
+                json.dumps({"sequence": web._MAX_SAFE_JSON_INTEGER + 1, "type": "step-progress"}) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(BenchmarkError, "strictly increasing integers"):
+                service.local_ydb_activity("local-ydb-activity", "capacity")
+
+            large_events = []
+            for sequence in range(1, 41):
+                large_events.append(
+                    {
+                        "sequence": sequence,
+                        "type": "step-progress",
+                        "step_id": "capacity-step",
+                        "fields": {
+                            "progress": {
+                                "phase": "measuring",
+                                "current_command": {"argv": ["x" * 512] * 64},
+                            }
+                        },
+                    }
+                )
+            (run_root / "events.jsonl").write_text(
+                "".join(json.dumps(event) + "\n" for event in large_events),
+                encoding="utf-8",
+            )
+            bounded = service.local_ydb_activity("local-ydb-activity", "capacity")
+            self.assertTrue(bounded["truncated"])
+            self.assertLess(len(bounded["events"]), len(large_events))
+            self.assertLessEqual(
+                len(json.dumps(bounded["events"], separators=(",", ":")).encode("utf-8")),
+                web._LOCAL_YDB_ACTIVITY_RESPONSE_BYTES + 2,
+            )
+        finally:
+            service.shutdown()
+
+    def test_local_ydb_activity_http_endpoint_validates_profile_and_cursor(self):
+        run_root = self.root / "local-ydb-http-activity"
+        self._manifest(run_root)
+        manifest_path = run_root / "run.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["runs"] = [{"benchmark": "local-ydb", "profile": "capacity", "status": "running"}]
+        manifest["steps"] = [
+            {
+                "id": "capacity-step",
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "state": "running",
+            }
+        ]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        (run_root / "events.jsonl").write_text(
+            json.dumps(
+                {
+                    "sequence": 1,
+                    "at": "2025-01-01T00:00:00+00:00",
+                    "type": "step-progress",
+                    "step_id": "capacity-step",
+                    "fields": {"progress": {"phase": "warming-up", "load": 1000}},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        server = make_server("127.0.0.1", 0, self.root)
+        worker = threading.Thread(target=server.serve_forever, daemon=True)
+        worker.start()
+        base = "http://127.0.0.1:{}".format(server.server_port)
+        endpoint = base + "/api/runs/local-ydb-http-activity/local-ydb-activity"
+        try:
+            with urllib.request.urlopen(endpoint + "?profile=capacity&after=0") as response:
+                activity = json.loads(response.read())
+            self.assertEqual(activity["after"], 1)
+            self.assertEqual(activity["events"][0]["phase"], "warming-up")
+            for query, message in (
+                ("?after=0", "profile is required"),
+                ("?profile=capacity&after=abc", "non-negative integer"),
+                ("?profile=capacity&after=-1", "non-negative integer"),
+                (
+                    "?profile=capacity&after={}".format(web._MAX_SAFE_JSON_INTEGER + 1),
+                    "JSON safe range",
+                ),
+            ):
+                with self.assertRaises(HTTPError) as context:
+                    urllib.request.urlopen(endpoint + query)
+                self.assertEqual(context.exception.code, 400)
+                self.assertIn(message, json.loads(context.exception.read())["error"])
+        finally:
+            server.shutdown()
+            worker.join()
+            server.server_close()
+
     def test_local_ydb_profile_projection_supports_preparing_and_live_results(self):
         run_root = self.root / "local-ydb-run"
         self._manifest(run_root, "running")
@@ -3935,6 +4246,13 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"for(const points of segments)", script)
                 self.assertIn(b"function mountChartBuilder", script)
                 self.assertIn(b"function mountLocalYdbProfile", script)
+                self.assertIn(b"function loadLocalYdbActivity", script)
+                self.assertIn(b"/local-ydb-activity?", script)
+                self.assertIn(b"function localActivityLog", script)
+                self.assertIn(b"Recent activity", script)
+                self.assertIn(b"activityScrollTop", script)
+                self.assertIn(b"activityPinned", script)
+                self.assertIn(b"showLiveOutput=activeBenchmark!=='local-ydb'", script)
                 self.assertIn(b"local-load-allow-errors", script)
                 self.assertIn(b"allow-errors: ", script)
                 self.assertIn(b"Failed workload requests are allowed", script)
@@ -4044,6 +4362,7 @@ class WebTest(unittest.TestCase):
                 stylesheet = response.read()
                 self.assertIn(b".local-attempts-scroll{max-width:100%;overflow-x:auto}", stylesheet)
                 self.assertIn(b".local-attempts{width:max-content;min-width:100%}", stylesheet)
+                self.assertIn(b".local-activity-log{max-height:20rem;overflow:auto", stylesheet)
                 self.assertNotIn(b".local-attempts{display:block", stylesheet)
             with urllib.request.urlopen(base + "/api/runs") as response:
                 self.assertEqual(json.loads(response.read())[0]["id"], "complete")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added a bounded recent-activity view for local YDB benchmark profiles.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51541. The profile page incrementally replays projected lifecycle and command events while preserving activity across reloads; event-log reads and responses remain bounded.