### PR TITLE
ydb-bench: centralize local YDB workload catalog

### DIFF
--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -11,6 +11,12 @@ from yaml.constructor import ConstructorError
 from ydb.tools.ydb_bench.benchmarks import BENCHMARKS
 from ydb.tools.ydb_bench.lib.actors_core import RunConfiguration
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
+    allowed_load_parameters,
+    all_load_parameters,
+    normalize_workload,
+    workload_config_schema,
+)
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
 
 PROFILE_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$"
@@ -103,46 +109,7 @@ def _profile_schema(benchmark):
             "additionalProperties": False,
             "required": ["workload", "load"],
             "properties": {
-                "workload": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": ["type", "operation"],
-                    "properties": {
-                        "type": {"enum": ["kv", "stock"]},
-                        "operation": {
-                            "enum": [
-                                "upsert",
-                                "select",
-                                "read-rows",
-                                "mixed",
-                                "user-hist",
-                                "rand-user-hist",
-                                "add-rand-order",
-                                "put-rand-order",
-                                "put-same-order",
-                            ]
-                        },
-                        "options": {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "min-partitions": {"type": "integer", "minimum": 1},
-                                "max-partitions": {"type": "integer", "minimum": 1},
-                                "partition-size-mb": {"type": "integer", "minimum": 1},
-                                "init-upserts": {"type": "integer", "minimum": 0},
-                                "max-first-key": {"type": "integer", "minimum": 1},
-                                "value-size": {"type": "integer", "minimum": 1},
-                                "columns": {"type": "integer", "minimum": 2},
-                                "rows-per-query": {"type": "integer", "minimum": 1},
-                                "products": {"type": "integer", "minimum": 1, "maximum": 500000},
-                                "quantity": {"type": "integer", "minimum": 1},
-                                "orders": {"type": "integer", "minimum": 0},
-                                "auto-partition": {"enum": [0, 1]},
-                                "limit": {"type": "integer", "minimum": 1},
-                            },
-                        },
-                    },
-                },
+                "workload": workload_config_schema(),
                 "geometry": {
                     "type": "object",
                     "additionalProperties": False,
@@ -169,7 +136,7 @@ def _profile_schema(benchmark):
                         # compatibility with configs written before search and
                         # objective became separate concepts.
                         "mode": {"enum": ["points", "maximize-throughput", "latency-slo"]},
-                        "parameter": {"enum": ["rate", "threads"]},
+                        "parameter": {"enum": list(all_load_parameters())},
                         "allow-errors": {"type": "boolean"},
                         "values": {
                             "type": "array",
@@ -539,53 +506,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     if perf_enabled:
         _config_error(location, "does not support --perf; CPU utilization is collected per process role")
 
-    workload = _mapping(value.get("workload"), location + ".workload", ("type", "operation", "options"))
-    for required in ("type", "operation"):
-        if required not in workload:
-            _config_error(location + ".workload", "missing required field: {}".format(required))
-    workload_type = _choice(workload["type"], ("kv", "stock"), location + ".workload.type")
-    operations = {
-        "kv": ("upsert", "select", "read-rows", "mixed"),
-        "stock": ("user-hist", "rand-user-hist", "add-rand-order", "put-rand-order", "put-same-order"),
-    }
-    operation = _choice(workload["operation"], operations[workload_type], location + ".workload.operation")
-    if workload_type == "kv":
-        option_defaults = {
-            "min-partitions": 40,
-            "max-partitions": 1000,
-            "partition-size-mb": 2000,
-            "init-upserts": 0 if operation == "upsert" else 1000,
-            "max-first-key": 65536,
-            "value-size": 64,
-            "columns": 2,
-            "rows-per-query": 1,
-        }
-    else:
-        option_defaults = {
-            "min-partitions": 40,
-            "products": 100,
-            "quantity": 1000,
-            "orders": 100,
-            "auto-partition": 1,
-            "limit": 10,
-        }
-    raw_options = _mapping(workload.get("options"), location + ".workload.options", tuple(option_defaults))
-    options = {}
-    for name, default in option_defaults.items():
-        raw = raw_options.get(name, default)
-        options[name] = (
-            _nonnegative_integer(raw, location + ".workload.options." + name)
-            if name in ("init-upserts", "orders", "auto-partition")
-            else _positive_integer(raw, location + ".workload.options." + name)
-        )
-    if workload_type == "kv" and options["max-partitions"] < options["min-partitions"]:
-        _config_error(location + ".workload.options.max-partitions", "must not be below min-partitions")
-    if workload_type == "kv" and options["columns"] < 2:
-        _config_error(location + ".workload.options.columns", "must be at least 2")
-    if workload_type == "stock" and options["products"] > 500000:
-        _config_error(location + ".workload.options.products", "must not exceed 500000")
-    if workload_type == "stock" and options["auto-partition"] not in (0, 1):
-        _config_error(location + ".workload.options.auto-partition", "must be 0 or 1")
+    workload = normalize_workload(value.get("workload"), location + ".workload")
 
     geometry = _mapping(
         value.get("geometry"),
@@ -652,7 +573,11 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     )
     if "parameter" not in load:
         _config_error(location + ".load", "missing required field: parameter")
-    parameter = _choice(load["parameter"], ("rate", "threads"), location + ".load.parameter")
+    parameter = _choice(
+        load["parameter"],
+        allowed_load_parameters(workload["type"]),
+        location + ".load.parameter",
+    )
     legacy_fields = {
         "mode",
         "start",
@@ -865,7 +790,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         threads=(client_threads,),
         parameters={
             "local_ydb": {
-                "workload": {"type": workload_type, "operation": operation, "options": options},
+                "workload": workload,
                 "geometry": geometry_config,
                 "client": {"threads": client_threads},
                 "load": load_config,

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -26,6 +26,12 @@ from ydb.tools.ydb_bench.lib.common import (
 )
 from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
 from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
+    WorkloadCli,
+    build_clean_argv,
+    build_init_argv,
+    build_run_argv,
+)
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
 from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
 from ydb.tools.ydb_bench.lib.system_info import collect_system_info
@@ -681,139 +687,6 @@ class LocalYdbCluster:
         return records
 
 
-def _workload_base(cluster, workload_type, path=None):
-    command = [
-        cluster.ydb_cli,
-        "--endpoint",
-        cluster.client_endpoint,
-        "--database",
-        cluster.database,
-        "workload",
-        workload_type,
-    ]
-    if path is not None:
-        command += ["--path", path]
-    return command
-
-
-def _kv_init_command(cluster, path, options):
-    return _workload_base(cluster, "kv", path) + [
-        "init",
-        "--init-upserts",
-        options["init-upserts"],
-        "--min-partitions",
-        options["min-partitions"],
-        "--max-partitions",
-        options["max-partitions"],
-        "--partition-size",
-        options["partition-size-mb"],
-        "--max-first-key",
-        options["max-first-key"],
-        "--len",
-        options["value-size"],
-        "--cols",
-        options["columns"],
-        "--int-cols",
-        1,
-        "--key-cols",
-        1,
-        "--rows",
-        options["rows-per-query"],
-    ]
-
-
-def _kv_run_command(cluster, path, workload, load_config, load, seconds, client_threads):
-    options = workload["options"]
-    threads = load if load_config["parameter"] == "threads" else client_threads
-    command = _workload_base(cluster, "kv", path) + [
-        "run",
-        workload["operation"],
-        "--seconds",
-        seconds,
-        "--threads",
-        threads,
-        "--quiet",
-        "--max-first-key",
-        options["max-first-key"],
-        "--int-cols",
-        1,
-        "--key-cols",
-        1,
-        "--cols",
-        options["columns"],
-    ]
-    if workload["operation"] != "mixed":
-        command += ["--rows", options["rows-per-query"]]
-    if workload["operation"] in ("upsert", "mixed"):
-        command += ["--len", options["value-size"]]
-    if load_config["parameter"] == "rate":
-        command += ["--rate", load]
-    return command
-
-
-def _stock_init_command(cluster, path, options):
-    del path
-    return _workload_base(cluster, "stock") + [
-        "init",
-        "--products",
-        options["products"],
-        "--quantity",
-        options["quantity"],
-        "--orders",
-        options["orders"],
-        "--min-partitions",
-        options["min-partitions"],
-        "--auto-partition",
-        options["auto-partition"],
-    ]
-
-
-def _stock_run_command(cluster, path, workload, load_config, load, seconds, client_threads):
-    del path
-    options = workload["options"]
-    threads = load if load_config["parameter"] == "threads" else client_threads
-    command = _workload_base(cluster, "stock") + [
-        "run",
-        workload["operation"],
-        "--seconds",
-        seconds,
-        "--threads",
-        threads,
-        "--quiet",
-    ]
-    if workload["operation"] in ("user-hist", "rand-user-hist"):
-        command += ["--limit", options["limit"]]
-    else:
-        command += ["--products", options["products"]]
-    if load_config["parameter"] == "rate":
-        command += ["--rate", load]
-    return command
-
-
-def _init_command(cluster, path, workload):
-    if workload["type"] == "stock":
-        return _stock_init_command(cluster, path, workload["options"])
-    return _kv_init_command(cluster, path, workload["options"])
-
-
-def _run_workload_command(cluster, path, workload, load_config, load, seconds, client_threads):
-    if workload["type"] == "stock":
-        return _stock_run_command(cluster, path, workload, load_config, load, seconds, client_threads)
-    return _kv_run_command(cluster, path, workload, load_config, load, seconds, client_threads)
-
-
-def _workload_table_path(workload_type, path):
-    # Unlike KV, stock has no --path option and creates its tables directly in
-    # the selected database.  "stock" is the first table created by its init.
-    return "stock" if workload_type == "stock" else path
-
-
-def _clean_workload_command(cluster, workload_type, path):
-    if workload_type == "stock":
-        return _workload_base(cluster, workload_type) + ["clean"]
-    return _workload_base(cluster, workload_type, path) + ["clean"]
-
-
 def _command_record(phase, repetition, command, cpu_affinity, result=None):
     record = {
         "phase": phase,
@@ -997,6 +870,7 @@ def run_local_ydb(
         cancel_event,
         publish_progress,
     )
+    workload_cli = None
 
     def run_repetition(
         load,
@@ -1028,7 +902,7 @@ def run_local_ydb(
         directory.mkdir(parents=True)
         fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
         commands = []
-        init_command = _init_command(cluster, table_path, profile["workload"])
+        init_command = build_init_argv(workload_cli, table_path, profile["workload"])
         publish_progress(
             phases["init"],
             **fields,
@@ -1070,11 +944,11 @@ def run_local_ydb(
         try:
             warmup = profile["measurement"]["warmup"]
             if warmup:
-                warmup_command = _run_workload_command(
-                    cluster,
+                warmup_command = build_run_argv(
+                    workload_cli,
                     table_path,
                     profile["workload"],
-                    profile["load"],
+                    profile["load"]["parameter"],
                     load,
                     warmup,
                     profile["client"]["threads"],
@@ -1122,11 +996,11 @@ def run_local_ydb(
             )
             monitor.start()
             try:
-                command = _run_workload_command(
-                    cluster,
+                command = build_run_argv(
+                    workload_cli,
                     table_path,
                     profile["workload"],
-                    profile["load"],
+                    profile["load"]["parameter"],
                     load,
                     profile["measurement"]["duration"],
                     profile["client"]["threads"],
@@ -1182,10 +1056,10 @@ def run_local_ydb(
             raise
         finally:
             try:
-                clean_command = _clean_workload_command(
-                    cluster,
-                    profile["workload"]["type"],
+                clean_command = build_clean_argv(
+                    workload_cli,
                     table_path,
+                    profile["workload"]["type"],
                 )
                 publish_progress(
                     phases["clean"],
@@ -1218,6 +1092,7 @@ def run_local_ydb(
     cluster_stopped = False
     try:
         cluster.start()
+        workload_cli = WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database)
         while True:
             dynamic_nodes = len(cluster.dynamic_nodes)
             search_stage = len(manifest["searches"]) + 1

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,0 +1,471 @@
+"""Declarative local-YDB workload catalog and YDB CLI command builders."""
+
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+@dataclass(frozen=True)
+class WorkloadCli:
+    executable: object
+    endpoint: str
+    database: str
+
+
+@dataclass(frozen=True)
+class WorkloadOption:
+    name: str
+    default: object
+    kind: str = "integer"
+    operation_defaults: tuple = ()
+    allow_zero: bool = False
+    maximum: object = None
+    choices: tuple = ()
+    schema_minimum: object = None
+    pattern: str | None = None
+    allow_empty: bool = False
+
+    def default_for(self, operation):
+        return dict(self.operation_defaults).get(operation, self.default)
+
+    @property
+    def minimum(self):
+        if self.kind != "integer":
+            return None
+        if self.schema_minimum is not None:
+            return self.schema_minimum
+        return 0 if self.allow_zero else 1
+
+    def config_schema(self):
+        if self.kind == "integer":
+            if self.choices:
+                return {"enum": list(self.choices)}
+            schema = {"type": "integer", "minimum": self.minimum}
+            if self.maximum is not None:
+                schema["maximum"] = self.maximum
+            return schema
+        if self.kind in ("string", "duration"):
+            schema = {"type": "string"}
+            if not self.allow_empty:
+                schema["minLength"] = 1
+            if self.choices:
+                schema["enum"] = list(self.choices)
+            if self.pattern is not None:
+                schema["pattern"] = self.pattern
+            return schema
+        if self.kind == "boolean":
+            schema = {"type": "boolean"}
+            if self.choices:
+                schema["enum"] = list(self.choices)
+            return schema
+        raise ValueError("unknown workload option kind: {}".format(self.kind))
+
+
+@dataclass(frozen=True)
+class WorkloadDefinition:
+    name: str
+    default_operation: str
+    operations: tuple
+    load_parameters: tuple
+    options: tuple
+    uses_path: bool
+    table_name: str | None
+    init_builder: object
+    run_builder: object
+    options_validator: object
+
+
+def _config_error(location, message):
+    raise BenchmarkError("invalid benchmark config at {}: {}".format(location, message))
+
+
+def _mapping(value, location, allowed=()):
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        _config_error(location, "must be a mapping")
+    unknown = sorted((item for item in value if item not in allowed), key=str)
+    if unknown:
+        _config_error(location, "contains unknown fields: {}".format(", ".join(map(str, unknown))))
+    return value
+
+
+def _workload_base(cli, definition, path):
+    command = [
+        cli.executable,
+        "--endpoint",
+        cli.endpoint,
+        "--database",
+        cli.database,
+        "workload",
+        definition.name,
+    ]
+    if definition.uses_path:
+        command += ["--path", path]
+    return command
+
+
+def _kv_init_builder(cli, definition, path, workload):
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--init-upserts",
+        options["init-upserts"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--max-partitions",
+        options["max-partitions"],
+        "--partition-size",
+        options["partition-size-mb"],
+        "--max-first-key",
+        options["max-first-key"],
+        "--len",
+        options["value-size"],
+        "--cols",
+        options["columns"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--rows",
+        options["rows-per-query"],
+    ]
+
+
+def _kv_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    options = workload["options"]
+    threads = load if load_parameter == "threads" else client_threads
+    command = _workload_base(cli, definition, path) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+        "--max-first-key",
+        options["max-first-key"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--cols",
+        options["columns"],
+    ]
+    if workload["operation"] != "mixed":
+        command += ["--rows", options["rows-per-query"]]
+    if workload["operation"] in ("upsert", "mixed"):
+        command += ["--len", options["value-size"]]
+    if load_parameter == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _stock_init_builder(cli, definition, path, workload):
+    del path
+    options = workload["options"]
+    return _workload_base(cli, definition, None) + [
+        "init",
+        "--products",
+        options["products"],
+        "--quantity",
+        options["quantity"],
+        "--orders",
+        options["orders"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--auto-partition",
+        options["auto-partition"],
+    ]
+
+
+def _stock_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del path
+    options = workload["options"]
+    threads = load if load_parameter == "threads" else client_threads
+    command = _workload_base(cli, definition, None) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+    ]
+    if workload["operation"] in ("user-hist", "rand-user-hist"):
+        command += ["--limit", options["limit"]]
+    else:
+        command += ["--products", options["products"]]
+    if load_parameter == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _validate_kv_options(options, location):
+    if options["max-partitions"] < options["min-partitions"]:
+        _config_error(location + ".max-partitions", "must not be below min-partitions")
+    if options["columns"] < 2:
+        _config_error(location + ".columns", "must be at least 2")
+
+
+def _validate_stock_options(options, location):
+    del options, location
+
+
+def _validate_option_value(option, value, location):
+    if option.kind == "integer":
+        minimum = 0 if option.allow_zero else 1
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            requirement = "non-negative" if option.allow_zero else "positive"
+            _config_error(location, "must be a {} integer".format(requirement))
+        if option.maximum is not None and value > option.maximum:
+            _config_error(location, "must not exceed {}".format(option.maximum))
+    elif option.kind in ("string", "duration"):
+        if not isinstance(value, str):
+            _config_error(location, "must be a string")
+        if not option.allow_empty and not value:
+            _config_error(location, "must not be empty")
+        if option.pattern is not None and re.search(option.pattern, value) is None:
+            _config_error(location, "must match pattern {}".format(option.pattern))
+    elif option.kind == "boolean":
+        if not isinstance(value, bool):
+            _config_error(location, "must be a boolean")
+    else:
+        raise ValueError("unknown workload option kind: {}".format(option.kind))
+    if option.choices and value not in option.choices:
+        if option.kind == "integer":
+            _config_error(location, "must be {}".format(" or ".join(map(str, option.choices))))
+        _config_error(location, "must be one of {}".format(", ".join(map(str, option.choices))))
+
+
+def _validate_catalog(definitions):
+    names = [definition.name for definition in definitions]
+    if len(names) != len(set(names)):
+        raise ValueError("local YDB workload names must be unique")
+    option_schemas = {}
+    for definition in definitions:
+        if len(definition.operations) != len(set(definition.operations)):
+            raise ValueError("operations must be unique for {}".format(definition.name))
+        if len(definition.load_parameters) != len(set(definition.load_parameters)):
+            raise ValueError("load parameters must be unique for {}".format(definition.name))
+        if definition.default_operation not in definition.operations:
+            raise ValueError("default operation must belong to {}".format(definition.name))
+        option_names = [option.name for option in definition.options]
+        if len(option_names) != len(set(option_names)):
+            raise ValueError("option names must be unique for {}".format(definition.name))
+        for option in definition.options:
+            if option.kind not in ("integer", "string", "boolean", "duration"):
+                raise ValueError("unknown workload option kind: {}".format(option.kind))
+            if option.kind != "integer" and (
+                option.allow_zero or option.maximum is not None or option.schema_minimum is not None
+            ):
+                raise ValueError("integer-only metadata is set for {}.{}".format(definition.name, option.name))
+            if option.kind not in ("string", "duration") and (option.pattern is not None or option.allow_empty):
+                raise ValueError("string-only metadata is set for {}.{}".format(definition.name, option.name))
+            if option.kind == "duration" and option.pattern is None:
+                raise ValueError("duration option {} requires a pattern".format(option.name))
+            if option.pattern is not None:
+                if "(?" in option.pattern or "\\" in option.pattern:
+                    raise ValueError("pattern for {}.{} is not portable".format(definition.name, option.name))
+                try:
+                    re.compile(option.pattern)
+                except re.error as error:
+                    raise ValueError("invalid pattern for {}.{}".format(definition.name, option.name)) from error
+            try:
+                choices_are_unique = len(option.choices) == len(set(option.choices))
+            except TypeError as error:
+                raise ValueError("choices must be scalar for {}.{}".format(definition.name, option.name)) from error
+            if not choices_are_unique:
+                raise ValueError("choices must be unique for {}.{}".format(definition.name, option.name))
+            operation_defaults = [operation for operation, _ in option.operation_defaults]
+            if len(operation_defaults) != len(set(operation_defaults)):
+                raise ValueError("operation defaults must be unique for {}.{}".format(definition.name, option.name))
+            for operation, value in ((None, option.default),) + option.operation_defaults:
+                if operation is not None and operation not in definition.operations:
+                    raise ValueError("option default refers to unknown operation {}".format(operation))
+                try:
+                    _validate_option_value(option, value, "{}.{}".format(definition.name, option.name))
+                except BenchmarkError as error:
+                    raise ValueError(
+                        "invalid default for {}.{}: {}".format(definition.name, option.name, error)
+                    ) from error
+            for choice in option.choices:
+                try:
+                    _validate_option_value(option, choice, "{}.{}".format(definition.name, option.name))
+                except BenchmarkError as error:
+                    raise ValueError(
+                        "invalid choice for {}.{}: {}".format(definition.name, option.name, error)
+                    ) from error
+            schema = option.config_schema()
+            if option.name in option_schemas and option_schemas[option.name] != schema:
+                raise ValueError("option {} has incompatible schemas across workloads".format(option.name))
+            option_schemas[option.name] = schema
+
+
+_DEFINITIONS = (
+    WorkloadDefinition(
+        name="kv",
+        default_operation="upsert",
+        operations=("upsert", "select", "read-rows", "mixed"),
+        load_parameters=("rate", "threads"),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("max-partitions", 1000),
+            WorkloadOption("partition-size-mb", 2000),
+            WorkloadOption("init-upserts", 1000, operation_defaults=(("upsert", 0),), allow_zero=True),
+            WorkloadOption("max-first-key", 65536),
+            WorkloadOption("value-size", 64),
+            WorkloadOption("columns", 2, schema_minimum=2),
+            WorkloadOption("rows-per-query", 1),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_kv_init_builder,
+        run_builder=_kv_run_builder,
+        options_validator=_validate_kv_options,
+    ),
+    WorkloadDefinition(
+        name="stock",
+        default_operation="put-rand-order",
+        operations=("user-hist", "rand-user-hist", "add-rand-order", "put-rand-order", "put-same-order"),
+        load_parameters=("rate", "threads"),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("products", 100, maximum=500000),
+            WorkloadOption("quantity", 1000),
+            WorkloadOption("orders", 100, allow_zero=True),
+            WorkloadOption("auto-partition", 1, allow_zero=True, choices=(0, 1)),
+            WorkloadOption("limit", 10),
+        ),
+        uses_path=False,
+        table_name="stock",
+        init_builder=_stock_init_builder,
+        run_builder=_stock_run_builder,
+        options_validator=_validate_stock_options,
+    ),
+)
+_validate_catalog(_DEFINITIONS)
+_WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
+
+
+def _definition(workload_type):
+    try:
+        return _WORKLOADS[workload_type]
+    except (KeyError, TypeError) as error:
+        raise BenchmarkError("unknown local YDB workload: {}".format(workload_type)) from error
+
+
+def normalize_workload(raw, location):
+    """Validate and fill defaults for one workload configuration mapping."""
+
+    workload = _mapping(raw, location, ("type", "operation", "options"))
+    for required in ("type", "operation"):
+        if required not in workload:
+            _config_error(location, "missing required field: {}".format(required))
+
+    workload_type = workload["type"]
+    if not isinstance(workload_type, str) or workload_type not in _WORKLOADS:
+        _config_error(location + ".type", "must be one of {}".format(", ".join(_WORKLOADS)))
+    definition = _WORKLOADS[workload_type]
+    operation = workload["operation"]
+    if operation not in definition.operations:
+        _config_error(location + ".operation", "must be one of {}".format(", ".join(definition.operations)))
+
+    options_location = location + ".options"
+    raw_options = _mapping(
+        workload.get("options"), options_location, tuple(option.name for option in definition.options)
+    )
+    options = {}
+    for option in definition.options:
+        value = raw_options.get(option.name, option.default_for(operation))
+        _validate_option_value(option, value, options_location + "." + option.name)
+        options[option.name] = value
+    definition.options_validator(options, options_location)
+    return {"type": definition.name, "operation": operation, "options": options}
+
+
+def workload_config_schema():
+    """Return the structurally compatible config-schema fragment for workloads."""
+
+    option_schemas = {}
+    for definition in _DEFINITIONS:
+        for option in definition.options:
+            option_schemas[option.name] = option.config_schema()
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["type", "operation"],
+        "properties": {
+            "type": {"enum": [definition.name for definition in _DEFINITIONS]},
+            "operation": {"enum": [operation for definition in _DEFINITIONS for operation in definition.operations]},
+            "options": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": option_schemas,
+            },
+        },
+    }
+
+
+def web_workload_catalog():
+    """Return a stable JSON-compatible workload description for the web builder."""
+
+    return [
+        {
+            "type": definition.name,
+            "default_operation": definition.default_operation,
+            "operations": list(definition.operations),
+            "load_parameters": list(definition.load_parameters),
+            "options": [
+                {
+                    "name": option.name,
+                    "kind": option.kind,
+                    "default": option.default,
+                    "operation_defaults": dict(option.operation_defaults),
+                    "allow_zero": option.allow_zero,
+                    "minimum": option.minimum,
+                    "maximum": option.maximum,
+                    "choices": list(option.choices),
+                    "pattern": option.pattern,
+                    "allow_empty": option.allow_empty,
+                    "schema": option.config_schema(),
+                }
+                for option in definition.options
+            ],
+        }
+        for definition in _DEFINITIONS
+    ]
+
+
+def allowed_load_parameters(workload_type):
+    return _definition(workload_type).load_parameters
+
+
+def all_load_parameters():
+    return tuple(dict.fromkeys(parameter for definition in _DEFINITIONS for parameter in definition.load_parameters))
+
+
+def build_init_argv(cli, path, workload):
+    definition = _definition(workload["type"])
+    return definition.init_builder(cli, definition, path, workload)
+
+
+def build_run_argv(cli, path, workload, load_parameter, load, seconds, client_threads):
+    definition = _definition(workload["type"])
+    if load_parameter not in definition.load_parameters:
+        raise BenchmarkError(
+            "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)
+        )
+    return definition.run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads)
+
+
+def build_clean_argv(cli, path, workload_type):
+    definition = _definition(workload_type)
+    return _workload_base(cli, definition, path) + ["clean"]
+
+
+def workload_table_path(workload_type, path):
+    definition = _definition(workload_type)
+    return definition.table_name if definition.table_name is not None else path

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -30,6 +30,7 @@ from ydb.tools.ydb_bench.lib.actors_core import run_benchmark
 from ydb.tools.ydb_bench.lib.common import extract_executable
 from ydb.tools.ydb_bench.lib.import_results import MAX_TOTAL_SIZE, export_archive, import_archive
 from ydb.tools.ydb_bench.lib.local_ydb import run_local_ydb
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import web_workload_catalog
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, plan_affinity, topology_record
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
@@ -227,8 +228,7 @@ _JS = (
     'et index=0;index<numbers.length;){let end=index;while(end+1<numbers.length&&numbers[end+1]===numbers[end]+1)end++;parts.'
     "push(index===end?String(numbers[index]):numbers[index]+'-'+numbers[end]);index=end+1}return parts.join(', ')}\n"
     "function yamlArray(values){return '['+values.map(value=>String(value)).join(', ')+']'}\n"
-    "const localYdbOperations={kv:['upsert','select','read-rows','mixed'],stock:['user-hist','rand-user-hist','add-rand-"
-    "order','put-rand-order','put-same-order']};\n"
+    "function yamlScalar(value){return typeof value==='string'?JSON.stringify(value):String(value)}\n"
     "const localYdbGeometryKeys={static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes',max_dynamic_nodes:'max-dynamic-"
     "nodes',disk_size_gb:'disk-size-gb',storage_groups:'storage-groups'};\n"
     "const localYdbSearchKeys={resolution_percent:'resolution-percent'};\n"
@@ -236,10 +236,12 @@ _JS = (
     "lateau-points',cpu_saturation_percent:'cpu-saturation-percent'};\n"
     "const localYdbSloKeys={max_ms:'max-ms',max_errors:'max-errors',min_achieved_rate_ratio:'min-achieved-rate-ratio'};\n"
     "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
-    "function defaultLocalYdbWorkload(type){return type==='stock'?{type:'stock',operation:'put-rand-order',options:{'min-p"
-    "artitions':40,products:100,quantity:1000,orders:100,'auto-partition':1,limit:10}}:{type:'kv',operation:'upsert',options"
-    ":{'min-partitions':40,'max-partitions':1000,'partition-size-mb':2000,'init-upserts':0,'max-first-key':65536,'value-siz"
-    "e':64,columns:2,'rows-per-query':1}}}\n"
+    "function localYdbWorkloadDefinition(type){const definition=(editor.model?.local_ydb_workloads||[]).find(item=>item.type"
+    "===type);if(!definition)throw Error('Unknown local YDB workload: '+type);return definition}\n"
+    "function defaultLocalYdbWorkload(type){const definition=localYdbWorkloadDefinition(type),operation=definition.default_"
+    "operation,options=Object.fromEntries(definition.options.map(option=>[option.name,Object.prototype.hasOwnProperty.call("
+    "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
+    "ions}}\n"
     "function defaultLocalYdb(){return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
     ":{threads:64},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
@@ -247,7 +249,7 @@ _JS = (
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
     "load:','      type: '+workload.type,'      operation: '+workload.operation,'      options:');for(const [key,value] of "
-    "Object.entries(workload.options))lines.push('        '+key+': '+value);lines.push('    geometry:','      preset: '+conf"
+    "Object.entries(workload.options))lines.push('        '+key+': '+yamlScalar(value));lines.push('    geometry:','      preset: '+conf"
     "ig.geometry.preset);for(const [key,yamlKey] of Object.entries(localYdbGeometryKeys))lines.push('      '+yamlKey+': '+c"
     "onfig.geometry[key]);lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
     "+config.load.parameter,'      allow-errors: '+Boolean(config.load.allow_errors));if(config.load.values)lines.push('      values: '+yamlArray(config.load.values));else{lines."
@@ -340,15 +342,43 @@ function localSelect(id,label,value,choices,help=''){
 function localCheck(id,label,checked,help=''){
   return '<div class=field><label><input id="'+id+'" type=checkbox '+(checked?'checked':'')+'> '+esc(label)+'</label><small class=muted>'+esc(help)+'</small></div>'
 }
+function localYdbOptionField(option,value){
+  const id='local-option-'+option.name;
+  if(option.choices.length)return localSelect(id,option.name,value,option.choices);
+  if(option.kind==='boolean')return localCheck(id,option.name,Boolean(value));
+  if(option.kind==='integer'){
+    const maximum=option.maximum===null?'':' max='+option.maximum;
+    return localField(id,option.name,value,'','type=number min='+option.minimum+maximum)
+  }
+  return localField(id,option.name,value,'','type=text')
+}
+function localYdbOptionValue(option){
+  const id='local-option-'+option.name,input=document.querySelector('#'+id);
+  let value;
+  if(option.choices.length){
+    value=option.kind==='integer'?Number(input.value):option.kind==='boolean'?input.value==='true':input.value
+  }else if(option.kind==='boolean'){
+    value=input.checked
+  }else if(option.kind==='integer'){
+    value=localInteger(id,option.allow_zero?0:1)
+  }else{
+    value=input.value
+  }
+  if((option.kind==='string'||option.kind==='duration')&&!option.allow_empty&&!value.length){
+    throw Error(option.name+' must not be empty.')
+  }
+  return value
+}
 function localYdbProfileEditor(profile){
   const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
+  const definition=localYdbWorkloadDefinition(workload.type);
   const loadMode=load.values?'points':load.objective.type;
-  const options=Object.entries(workload.options).map(([key,value])=>localField('local-option-'+key,key,value)).join('');
+  const options=definition.options.map(option=>localYdbOptionField(option,workload.options[option.name])).join('');
   const geometryFields=Object.entries(localYdbGeometryKeys)
     .map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
   const loadCommon=
     localSelect('local-load-mode','Objective',loadMode,['points','maximize-throughput','latency-slo'])+
-    localSelect('local-load-parameter','Parameter',load.parameter,['rate','threads'])+
+    localSelect('local-load-parameter','Parameter',load.parameter,definition.load_parameters)+
     localCheck(
       'local-load-allow-errors','Allow failed workload requests',Boolean(load.allow_errors),
       'Failed requests remain visible in results but do not limit load search.'
@@ -404,9 +434,9 @@ function localYdbProfileEditor(profile){
       'benchmark','Benchmark',profile.benchmark,editor.model.benchmarks.map(item=>item.name)
     )+localField('profile-name','Profile name',profile.name,'letters, digits, . _ and -')+'</div>'+
     '<h3>Workload</h3><div class=form-grid>'+localSelect(
-      'local-workload-type','Type',workload.type,['kv','stock']
+      'local-workload-type','Type',workload.type,editor.model.local_ydb_workloads.map(item=>item.type)
     )+localSelect(
-      'local-workload-operation','Operation',workload.operation,localYdbOperations[workload.type]
+      'local-workload-operation','Operation',workload.operation,definition.operations
     )+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+
     localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+
     '</div><h3>Client and load</h3><div class=form-grid>'+
@@ -467,6 +497,8 @@ function bindLocalYdbEditor(profile){
     profile.name=name;profile.key=benchmarkName+'/'+name;const config=profile.local_ydb;
     if(event.target.id==='local-workload-type'){
       config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
+      const parameters=localYdbWorkloadDefinition(event.target.value).load_parameters;
+      if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0];
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     if(event.target.id==='local-geometry-preset'){
@@ -506,10 +538,12 @@ function bindLocalYdbEditor(profile){
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     config.workload.operation=document.querySelector('#local-workload-operation').value;
-    for(const input of document.querySelectorAll('[id^=local-option-]')){
-      const key=input.id.slice('local-option-'.length);
-      const minimum=['init-upserts','orders','auto-partition'].includes(key)?0:1;
-      config.workload.options[key]=localInteger(input.id,minimum)
+    const workloadDefinition=localYdbWorkloadDefinition(config.workload.type);
+    for(const option of workloadDefinition.options){
+      const key=option.name,value=localYdbOptionValue(option);
+      if(option.maximum!==null&&value>option.maximum)throw Error(key+' must be <= '+option.maximum+'.');
+      if(option.choices.length&&!option.choices.includes(value))throw Error(key+' must be one of '+option.choices.join(', ')+'.');
+      config.workload.options[key]=value
     }
     config.geometry.preset=document.querySelector('#local-geometry-preset').value;
     for(const key of Object.keys(localYdbGeometryKeys)){
@@ -1971,6 +2005,7 @@ def editor_model(loaded, output):
         "benchmarks": benchmark_catalog(),
         "affinity_modes": list(AFFINITY_MODES),
         "background_load_modes": list(BACKGROUND_LOAD_MODES),
+        "local_ydb_workloads": web_workload_catalog(),
         "profiles": profiles,
     }
 

--- a/ydb/tools/ydb_bench/lib/ya.make
+++ b/ydb/tools/ydb_bench/lib/ya.make
@@ -9,6 +9,7 @@ PY_SRCS(
     import_results.py
     load_control.py
     local_ydb.py
+    local_ydb_workloads.py
     linux_telemetry.py
     runner.py
     results.py

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -34,6 +34,7 @@ from ydb.tools.ydb_bench.lib import (
     linux_telemetry,
     load_control,
     local_ydb,
+    local_ydb_workloads,
     runner,
     topology,
     web,
@@ -273,6 +274,235 @@ class YdbBenchTest(unittest.TestCase):
         local_load_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["load"]
         self.assertEqual(local_load_schema["properties"]["allow-errors"], {"type": "boolean"})
 
+    def test_local_ydb_workload_registry_generates_schema_and_web_catalog(self):
+        workload_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["workload"]
+        self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
+
+        catalog = local_ydb_workloads.web_workload_catalog()
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock"])
+        self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
+        self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
+        self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
+        catalog_parameters = tuple(
+            dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
+        )
+        load_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["load"]
+        self.assertEqual(tuple(load_schema["properties"]["parameter"]["enum"]), catalog_parameters)
+        self.assertEqual(local_ydb_workloads.all_load_parameters(), catalog_parameters)
+        self.assertEqual(
+            next(option for option in catalog[0]["options"] if option["name"] == "init-upserts")["operation_defaults"],
+            {"upsert": 0},
+        )
+        json.dumps(catalog, allow_nan=False)
+
+    def test_local_ydb_workload_registry_preserves_defaults_and_validation(self):
+        upsert = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "upsert"},
+            "local-ydb.profile.workload",
+        )
+        select = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "select"},
+            "local-ydb.profile.workload",
+        )
+        stock = local_ydb_workloads.normalize_workload(
+            {"type": "stock", "operation": "put-rand-order"},
+            "local-ydb.profile.workload",
+        )
+        self.assertEqual(upsert["options"]["init-upserts"], 0)
+        self.assertEqual(select["options"]["init-upserts"], 1000)
+        self.assertEqual(stock["options"]["orders"], 100)
+
+        invalid = (
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
+                r"products.*must not exceed 500000",
+            ),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"auto-partition": 2}},
+                r"auto-partition.*must be 0 or 1",
+            ),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"max-partitions": 10}},
+                r"options.*unknown fields: max-partitions",
+            ),
+        )
+        for workload, message in invalid:
+            with self.subTest(workload=workload), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.normalize_workload(workload, "local-ydb.profile.workload")
+
+    def test_local_ydb_workload_registry_supports_typed_options(self):
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="synthetic",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("threads",),
+            options=(
+                local_ydb_workloads.WorkloadOption(
+                    "tx-mode",
+                    "serializable-rw",
+                    kind="string",
+                    choices=("serializable-rw", "snapshot-rw"),
+                ),
+                local_ydb_workloads.WorkloadOption("enabled", True, kind="boolean"),
+                local_ydb_workloads.WorkloadOption(
+                    "warmup",
+                    "10s",
+                    kind="duration",
+                    pattern=r"^[1-9][0-9]*s$",
+                ),
+                local_ydb_workloads.WorkloadOption("label", "mode: fast # tagged", kind="string"),
+            ),
+            uses_path=True,
+            table_name=None,
+            init_builder=None,
+            run_builder=None,
+            options_validator=lambda options, location: None,
+        )
+        local_ydb_workloads._validate_catalog((definition,))
+        divergent = replace(
+            definition,
+            name="other",
+            options=(local_ydb_workloads.WorkloadOption("tx-mode", 1),),
+        )
+        with self.assertRaisesRegex(ValueError, "tx-mode has incompatible schemas"):
+            local_ydb_workloads._validate_catalog((definition, divergent))
+        for pattern in (r"(?P<seconds>[0-9]+)s", r"^[0-9]+\s+s$"):
+            nonportable = replace(
+                definition,
+                options=(local_ydb_workloads.WorkloadOption("warmup", "10s", kind="duration", pattern=pattern),),
+            )
+            with self.subTest(pattern=pattern), self.assertRaisesRegex(ValueError, "pattern.*is not portable"):
+                local_ydb_workloads._validate_catalog((nonportable,))
+        with mock.patch.object(local_ydb_workloads, "_DEFINITIONS", (definition,)), mock.patch.object(
+            local_ydb_workloads,
+            "_WORKLOADS",
+            {definition.name: definition},
+        ):
+            workload = local_ydb_workloads.normalize_workload(
+                {"type": "synthetic", "operation": "run"},
+                "workload",
+            )
+            self.assertEqual(
+                workload["options"],
+                {
+                    "tx-mode": "serializable-rw",
+                    "enabled": True,
+                    "warmup": "10s",
+                    "label": "mode: fast # tagged",
+                },
+            )
+            schema = local_ydb_workloads.workload_config_schema()["properties"]["options"]["properties"]
+            self.assertEqual(
+                schema["tx-mode"],
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": ["serializable-rw", "snapshot-rw"],
+                },
+            )
+            self.assertEqual(schema["enabled"], {"type": "boolean"})
+            self.assertEqual(schema["warmup"]["pattern"], r"^[1-9][0-9]*s$")
+            catalog = local_ydb_workloads.web_workload_catalog()
+            self.assertEqual(
+                [option["kind"] for option in catalog[0]["options"]],
+                ["string", "boolean", "duration", "string"],
+            )
+            self.assertEqual(catalog[0]["options"][2]["schema"], schema["warmup"])
+            special = "mode: fast # tagged\nsecond line"
+            self.assertEqual(yaml.safe_load("option: " + json.dumps(special))["option"], special)
+
+            invalid = (
+                ({"tx-mode": "", "enabled": True, "warmup": "10s"}, "tx-mode.*must not be empty"),
+                ({"tx-mode": "snapshot-rw", "enabled": 1, "warmup": "10s"}, "enabled.*must be a boolean"),
+                ({"tx-mode": "snapshot-rw", "enabled": False, "warmup": "0s"}, "warmup.*must match pattern"),
+            )
+            for options, message in invalid:
+                with self.subTest(options=options), self.assertRaisesRegex(BenchmarkError, message):
+                    local_ydb_workloads.normalize_workload(
+                        {"type": "synthetic", "operation": "run", "options": options},
+                        "workload",
+                    )
+
+    def test_local_ydb_workload_registry_builds_golden_cli_commands(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "select"},
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "kv",
+            "--path",
+            "table-prefix",
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_init_argv(cli_context, "table-prefix", workload),
+            base
+            + [
+                "init",
+                "--init-upserts",
+                1000,
+                "--min-partitions",
+                40,
+                "--max-partitions",
+                1000,
+                "--partition-size",
+                2000,
+                "--max-first-key",
+                65536,
+                "--len",
+                64,
+                "--cols",
+                2,
+                "--int-cols",
+                1,
+                "--key-cols",
+                1,
+                "--rows",
+                1,
+            ],
+        )
+        self.assertEqual(
+            local_ydb_workloads.build_run_argv(cli_context, "table-prefix", workload, "rate", 250, 30, 64),
+            base
+            + [
+                "run",
+                "select",
+                "--seconds",
+                30,
+                "--threads",
+                64,
+                "--quiet",
+                "--max-first-key",
+                65536,
+                "--int-cols",
+                1,
+                "--key-cols",
+                1,
+                "--cols",
+                2,
+                "--rows",
+                1,
+                "--rate",
+                250,
+            ],
+        )
+        self.assertEqual(
+            local_ydb_workloads.build_clean_argv(cli_context, "table-prefix", "kv"),
+            base + ["clean"],
+        )
+
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""
             Window Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
@@ -485,6 +715,7 @@ class YdbBenchTest(unittest.TestCase):
         model = web.editor_model(loaded, self.root / "results")
         benchmark = next(item for item in model["benchmarks"] if item["name"] == "local-ydb")
         profile = model["profiles"][0]
+        self.assertEqual(model["local_ydb_workloads"], local_ydb_workloads.web_workload_catalog())
         self.assertTrue(benchmark["builder_supported"])
         self.assertEqual(benchmark["profile_kind"], "local-ydb")
         self.assertEqual(profile["local_ydb"]["workload"]["type"], "stock")
@@ -522,42 +753,53 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload["options"]["products"], 10)
 
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
-        cluster = mock.Mock(
-            ydb_cli=Path("ydb"),
-            client_endpoint="grpc://host.example:2135",
-            database="/Root/bench",
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("ydb"),
+            "grpc://host.example:2135",
+            "/Root/bench",
         )
-        command = local_ydb._stock_init_command(
-            cluster,
-            "ignored-table-prefix",
+        workload = local_ydb_workloads.normalize_workload(
             {
-                "products": 10,
-                "quantity": 100,
-                "orders": 0,
-                "min-partitions": 1,
-                "auto-partition": 0,
+                "type": "stock",
+                "operation": "add-rand-order",
+                "options": {
+                    "products": 10,
+                    "quantity": 100,
+                    "orders": 0,
+                    "min-partitions": 1,
+                    "auto-partition": 0,
+                },
             },
+            "workload",
+        )
+        command = local_ydb_workloads.build_init_argv(
+            cli_context,
+            "ignored-table-prefix",
+            workload,
         )
         self.assertNotIn("--path", command)
         self.assertNotIn("ignored-table-prefix", command)
-        self.assertEqual(local_ydb._workload_table_path("stock", "ignored-table-prefix"), "stock")
-        self.assertNotIn("--path", local_ydb._clean_workload_command(cluster, "stock", "ignored-table-prefix"))
+        self.assertEqual(local_ydb_workloads.workload_table_path("stock", "ignored-table-prefix"), "stock")
+        self.assertNotIn(
+            "--path",
+            local_ydb_workloads.build_clean_argv(cli_context, "ignored-table-prefix", "stock"),
+        )
 
-        run_options = {"products": 10, "limit": 5}
-        add_command = local_ydb._stock_run_command(
-            cluster,
+        workload["options"]["limit"] = 5
+        add_command = local_ydb_workloads.build_run_argv(
+            cli_context,
             "ignored-table-prefix",
-            {"operation": "add-rand-order", "options": run_options},
-            {"parameter": "threads"},
+            workload,
+            "threads",
             8,
             30,
             64,
         )
-        put_command = local_ydb._stock_run_command(
-            cluster,
+        put_command = local_ydb_workloads.build_run_argv(
+            cli_context,
             "ignored-table-prefix",
-            {"operation": "put-rand-order", "options": run_options},
-            {"parameter": "threads"},
+            {**workload, "operation": "put-rand-order"},
+            "threads",
             8,
             30,
             64,
@@ -884,14 +1126,18 @@ class YdbBenchTest(unittest.TestCase):
         self.last_local_ydb_cluster.stop.assert_called_once_with()
 
     def test_local_ydb_kv_commands_keep_table_path(self):
-        cluster = mock.Mock(
-            ydb_cli=Path("ydb"),
-            client_endpoint="grpc://host.example:2135",
-            database="/Root/bench",
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("ydb"),
+            "grpc://host.example:2135",
+            "/Root/bench",
         )
-        command = local_ydb._workload_base(cluster, "kv", "table-prefix")
-        self.assertEqual(command[-2:], ["--path", "table-prefix"])
-        self.assertEqual(local_ydb._workload_table_path("kv", "table-prefix"), "table-prefix")
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "upsert"},
+            "workload",
+        )
+        command = local_ydb_workloads.build_init_argv(cli_context, "table-prefix", workload)
+        self.assertEqual(command[command.index("--path") : command.index("--path") + 2], ["--path", "table-prefix"])
+        self.assertEqual(local_ydb_workloads.workload_table_path("kv", "table-prefix"), "table-prefix")
 
     def test_load_controllers_find_capacity_and_latency_boundary(self):
         throughput_attempts = []
@@ -4256,6 +4502,21 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"local-load-allow-errors", script)
                 self.assertIn(b"allow-errors: ", script)
                 self.assertIn(b"Failed workload requests are allowed", script)
+                self.assertIn(b"editor.model?.local_ydb_workloads", script)
+                self.assertIn(b"definition.load_parameters", script)
+                self.assertIn(
+                    b"if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0]", script
+                )
+                self.assertIn(b"if(option.choices.length)return localSelect", script)
+                self.assertIn(b"if(option.kind==='boolean')return localCheck", script)
+                self.assertIn(b"if(option.kind==='integer')", script)
+                self.assertIn(b"return localField(id,option.name,value,'','type=text')", script)
+                self.assertIn(b"function yamlScalar(value)", script)
+                self.assertIn(b"key+': '+yamlScalar(value)", script)
+                self.assertIn(b"!option.allow_empty&&!value.length", script)
+                self.assertNotIn(b"new RegExp(option.pattern)", script)
+                self.assertNotIn(b"const localYdbOperations=", script)
+                self.assertNotIn(b"type==='stock'?", script)
                 self.assertIn(b"verification-repetitions:", script)
                 self.assertIn(b"local-measurement-verification-repetitions", script)
                 self.assertIn(b"localInteger('local-measurement-verification-repetitions',0,20)", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Prepared local YDB benchmarks for additional workload types without changing existing KV and stock behavior.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51542. A typed workload catalog now owns config defaults, validation, schema, CLI commands, load parameters, and web-builder metadata for KV and stock.