### PR TITLE
YDB Bench: add local YDB workload lifecycle

### DIFF
--- a/ydb/tools/ydb_bench/lib/linux_telemetry.py
+++ b/ydb/tools/ydb_bench/lib/linux_telemetry.py
@@ -1,11 +1,21 @@
 """Linux CPU sampling for benchmark process roles."""
 
+import math
 import os
 import threading
 import time
 from pathlib import Path
 
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
 
 
 class LinuxCpuMonitor:
@@ -64,6 +74,7 @@ class LinuxCpuMonitor:
 
     def _sample(self):
         now = time.monotonic()
+        now_unix = time.time()
         host = self._read_host_ticks()
         process_ticks = {
             role: sum(ticks for pid in tuple(provider()) if (ticks := self._read_process_ticks(pid)) is not None)
@@ -94,18 +105,47 @@ class LinuxCpuMonitor:
                 record["host_cpu"] = 100.0 * (total_delta - idle_delta) / total_delta
         if len(record) > 1:
             record["timestamp_monotonic"] = now
+            record["timestamp_unix"] = now_unix
             self._records.append(record)
         self._previous_time = now
         self._previous_host = host
         self._previous_process = process_ticks
 
-    def summary(self):
+    def summary(self, started_at_unix=None, finished_at_unix=None):
+        windowed = started_at_unix is not None or finished_at_unix is not None
+        if windowed:
+            if started_at_unix is None or finished_at_unix is None:
+                raise BenchmarkError("CPU measurement window requires both start and finish")
+            if (
+                not _is_finite_number(started_at_unix)
+                or not _is_finite_number(finished_at_unix)
+                or started_at_unix >= finished_at_unix
+            ):
+                raise BenchmarkError("CPU measurement window must be finite and increasing")
+
+        def inside_measurement_window(record):
+            if started_at_unix is None and finished_at_unix is None:
+                return True
+            timestamp = record.get("timestamp_unix")
+            if timestamp is None:
+                return False
+            interval_started_at = timestamp - record["elapsed_seconds"]
+            if started_at_unix is not None and interval_started_at < started_at_unix:
+                return False
+            if finished_at_unix is not None and timestamp > finished_at_unix:
+                return False
+            return True
+
+        records = [
+            record
+            for record in self._records
+            if record.get("elapsed_seconds", 0) > 0 and inside_measurement_window(record)
+        ]
+        if windowed and not records:
+            raise BenchmarkError("CPU measurement window does not contain a complete sample interval")
+
         def aggregate(name):
-            samples = [
-                (record[name], record["elapsed_seconds"])
-                for record in self._records
-                if name in record and record["elapsed_seconds"] > 0
-            ]
+            samples = [(record[name], record["elapsed_seconds"]) for record in records if name in record]
             if not samples:
                 return 0.0, 0.0
             elapsed = sum(duration for _, duration in samples)

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -4,11 +4,13 @@ import csv
 import errno
 import io
 import itertools
+import math
 import os
 import socket
 import statistics
 import sys
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,9 +30,10 @@ from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
 from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
 from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     WorkloadCli,
-    build_clean_argv,
-    build_init_argv,
-    build_run_argv,
+    build_cleanup_plan,
+    build_prepare_plan,
+    build_run_plan,
+    workload_definition,
 )
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
 from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
@@ -334,8 +337,9 @@ class LocalYdbCluster:
         if self.cancel_event is not None and self.cancel_event.is_set():
             raise BenchmarkInterrupted("local YDB benchmark was cancelled")
 
-    def _run(self, command, timeout=None, cpu_affinity=None):
-        self._check_cancelled()
+    def _run(self, command, timeout=None, cpu_affinity=None, ignore_cancellation=False):
+        if not ignore_cancellation:
+            self._check_cancelled()
         self.ensure_running("cannot run YDB CLI command")
         result = run_command(
             command,
@@ -343,7 +347,7 @@ class LocalYdbCluster:
             timeout or self.timeout,
             work_dir_hint=self.directory,
             cpu_affinity=cpu_affinity,
-            cancel_event=self.cancel_event,
+            cancel_event=None if ignore_cancellation else self.cancel_event,
         )
         self.ensure_running("YDB process exited while running a CLI command")
         if result.interrupted:
@@ -757,12 +761,439 @@ def _role_capacity(mask, topology):
     return len(mask) if mask is not None else len(topology.allowed_cpus)
 
 
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
 def _write_csv(path, rows, columns):
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=columns, extrasaction="ignore", lineterminator="\n")
     writer.writeheader()
     writer.writerows(rows)
     atomic_write_text(path, output.getvalue())
+
+
+@dataclass
+class _DatasetState:
+    directory: Path
+    table_path: str
+    purpose: str
+    repetition: object
+    fields: dict
+    commands: list = field(default_factory=list)
+    cleanup_armed: bool = False
+    cleaned: bool = False
+
+
+class WorkloadLifecycle:
+    """Execute workload datasets according to declarative lifecycle metadata."""
+
+    def __init__(
+        self,
+        cluster,
+        workload_cli,
+        workload,
+        load_config,
+        measurement,
+        client_threads,
+        benchmark,
+        topology,
+        affinities,
+        cancel_event,
+        progress,
+    ):
+        self.cluster = cluster
+        self.workload_cli = workload_cli
+        self.workload = workload
+        self.load_config = load_config
+        self.measurement = measurement
+        self.client_threads = client_threads
+        self.benchmark = benchmark
+        self.topology = topology
+        self.affinities = affinities
+        self.cancel_event = cancel_event
+        self.progress = progress
+        self.definition = workload_definition(workload["type"])
+        self._profile_opened = False
+        self._profile_closed = False
+        self._profile_state = None
+
+    @property
+    def profile_commands(self):
+        if self._profile_state is None:
+            return ()
+        return tuple(self._profile_state.commands)
+
+    def _check_cancelled(self):
+        if self.cancel_event is not None and self.cancel_event.is_set():
+            raise BenchmarkInterrupted("local YDB benchmark was cancelled")
+
+    def _phases(self, purpose):
+        if purpose == "verification":
+            return {
+                "init": "verification-initializing",
+                "warmup": "verification-warmup",
+                "measure": "verification-measuring",
+                "clean": "verification-cleanup",
+            }
+        return {
+            "init": "initializing-workload",
+            "warmup": "warming-up",
+            "measure": "measuring",
+            "clean": "cleaning-workload",
+        }
+
+    def _prepare_phase(self, state, name):
+        if name == "init":
+            return self._phases(state.purpose)["init"]
+        prefix = "verification-" if state.purpose == "verification" else ""
+        return prefix + "preparing-" + name
+
+    def _cleanup_phase(self, state, name):
+        if name == "clean":
+            return self._phases(state.purpose)["clean"]
+        prefix = "verification-" if state.purpose == "verification" else ""
+        return prefix + "cleaning-" + name
+
+    def _write_profile_commands(self, state, cleanup_errors=None):
+        if self.definition.dataset_scope != "profile":
+            return
+        try:
+            atomic_write_json(state.directory / "commands.json", state.commands)
+        except BaseException as error:
+            if cleanup_errors is None:
+                raise
+            cleanup_errors.append(error)
+
+    @staticmethod
+    def _write_cleanup_error(path, error, cleanup_errors):
+        try:
+            atomic_write_text(path, str(error) + "\n")
+        except BaseException as artifact_error:
+            cleanup_errors.append(artifact_error)
+
+    def _prepare_dataset(self, state):
+        state.cleanup_armed = True
+        try:
+            plans = build_prepare_plan(self.workload_cli, state.table_path, self.workload)
+            for plan in plans:
+                phase = self._prepare_phase(state, plan.name)
+                self.progress(
+                    phase,
+                    **state.fields,
+                    current_command=_command_record(
+                        phase,
+                        state.repetition,
+                        plan.argv,
+                        self.affinities["ydb_cli"],
+                    ),
+                )
+                result, attempts = self.cluster.init_workload(plan.argv, timeout=plan.timeout_seconds)
+                state.commands.extend(
+                    _command_record(
+                        phase,
+                        state.repetition,
+                        attempt.command,
+                        self.affinities["ydb_cli"],
+                        attempt,
+                    )
+                    for attempt in attempts
+                )
+                atomic_write_text(state.directory / "{}.stdout.txt".format(plan.name), result.stdout)
+                atomic_write_text(state.directory / "{}.stderr.txt".format(plan.name), result.stderr)
+                atomic_write_json(
+                    state.directory / "{}-attempts.json".format(plan.name),
+                    [
+                        {
+                            "command": [str(part) for part in attempt.command],
+                            "exit_code": attempt.exit_code,
+                            "timed_out": attempt.timed_out,
+                            "duration_seconds": attempt.duration_seconds,
+                            "stdout": attempt.stdout,
+                            "stderr": attempt.stderr,
+                        }
+                        for attempt in attempts
+                    ],
+                )
+                self._write_profile_commands(state)
+        except BaseException as error:
+            try:
+                self._cleanup_dataset(state, primary_error=error)
+            except BaseException:
+                pass
+            raise
+
+    def _cleanup_dataset(self, state, primary_error=None):
+        if not state.cleanup_armed or state.cleaned:
+            return
+        state.cleaned = True
+        errors = []
+        try:
+            plans = build_cleanup_plan(self.workload_cli, state.table_path, self.workload)
+        except BaseException as error:
+            plans = ()
+            errors.append(error)
+            self._write_cleanup_error(state.directory / "clean.error.txt", error, errors)
+        for plan in plans:
+            phase = self._cleanup_phase(state, plan.name)
+            try:
+                self.progress(
+                    phase,
+                    **state.fields,
+                    current_command=_command_record(
+                        phase,
+                        state.repetition,
+                        plan.argv,
+                        self.affinities["ydb_cli"],
+                    ),
+                )
+            except BaseException as error:
+                errors.append(error)
+                self._write_cleanup_error(
+                    state.directory / "{}.progress.error.txt".format(plan.name),
+                    error,
+                    errors,
+                )
+            try:
+                result = self.cluster._run(
+                    plan.argv,
+                    timeout=plan.timeout_seconds,
+                    cpu_affinity=self.affinities["ydb_cli"],
+                    ignore_cancellation=True,
+                )
+            except BaseException as error:
+                errors.append(error)
+                self._write_cleanup_error(state.directory / "{}.error.txt".format(plan.name), error, errors)
+            else:
+                try:
+                    state.commands.append(
+                        _command_record(
+                            phase,
+                            state.repetition,
+                            result.command,
+                            self.affinities["ydb_cli"],
+                            result,
+                        )
+                    )
+                except BaseException as error:
+                    errors.append(error)
+                for suffix, value in (("stdout", result.stdout), ("stderr", result.stderr)):
+                    try:
+                        atomic_write_text(
+                            state.directory / "{}.{}.txt".format(plan.name, suffix),
+                            value,
+                        )
+                    except BaseException as error:
+                        errors.append(error)
+            finally:
+                self._write_profile_commands(state, errors)
+        if errors and primary_error is None:
+            control_flow_error = next(
+                (error for error in errors if isinstance(error, (BenchmarkInterrupted, KeyboardInterrupt))),
+                None,
+            )
+            if control_flow_error is not None:
+                raise control_flow_error
+            if len(errors) == 1 and isinstance(errors[0], BenchmarkError):
+                raise errors[0]
+            raise BenchmarkError("workload cleanup failed: {}".format("; ".join(map(str, errors))))
+
+    def open_profile(self, directory, table_path):
+        if self._profile_opened:
+            raise BenchmarkError("workload profile lifecycle is already open")
+        self._profile_opened = True
+        if self.definition.dataset_scope != "profile":
+            return
+        directory = Path(directory)
+        directory.mkdir(parents=True)
+        state = _DatasetState(
+            directory=directory,
+            table_path=table_path,
+            purpose="profile",
+            repetition=None,
+            fields={"profile_dataset": True},
+        )
+        self._profile_state = state
+        self._prepare_dataset(state)
+
+    def close_profile(self, primary_error=None):
+        if self._profile_closed:
+            return
+        self._profile_closed = True
+        if self._profile_state is not None:
+            self._cleanup_dataset(self._profile_state, primary_error=primary_error)
+        if primary_error is None:
+            self._check_cancelled()
+
+    def _run_workload(self, state, load, dynamic_nodes, repetition, commands):
+        phases = self._phases(state.purpose)
+        warmup = self.measurement["warmup"]
+        if warmup and self.definition.warmup_mode == "separate":
+            warmup_plan = build_run_plan(
+                self.workload_cli,
+                state.table_path,
+                self.workload,
+                self.load_config["parameter"],
+                load,
+                warmup,
+                self.client_threads,
+            )
+            self.progress(
+                phases["warmup"],
+                **state.fields,
+                phase_duration_seconds=warmup,
+                current_command=_command_record(
+                    phases["warmup"],
+                    repetition,
+                    warmup_plan.argv,
+                    self.affinities["ydb_cli"],
+                ),
+            )
+            result = self.cluster._run(
+                warmup_plan.argv,
+                timeout=warmup_plan.timeout_seconds,
+                cpu_affinity=self.affinities["ydb_cli"],
+            )
+            commands.append(
+                _command_record(
+                    phases["warmup"],
+                    repetition,
+                    result.command,
+                    self.affinities["ydb_cli"],
+                    result,
+                )
+            )
+            atomic_write_text(state.directory / "warmup.stdout.txt", result.stdout)
+            atomic_write_text(state.directory / "warmup.stderr.txt", result.stderr)
+
+        cli_pids = []
+        monitor = LinuxCpuMonitor(
+            {
+                "static": lambda: self.cluster.static_pids,
+                "dynamic": lambda: self.cluster.dynamic_pids,
+                "cli": lambda: tuple(cli_pids),
+            },
+            {
+                "static": _role_capacity(self.affinities["static_nodes"], self.topology),
+                "dynamic": _role_capacity(self.affinities["dynamic_nodes"], self.topology),
+                "cli": _role_capacity(self.affinities["ydb_cli"], self.topology),
+            },
+        )
+        monitor.start()
+        try:
+            plan = build_run_plan(
+                self.workload_cli,
+                state.table_path,
+                self.workload,
+                self.load_config["parameter"],
+                load,
+                self.measurement["duration"],
+                self.client_threads,
+                warmup_seconds=warmup if self.definition.warmup_mode == "inline" else 0,
+            )
+            self.cluster.ensure_running("cannot start workload measurement")
+            progress_fields = {
+                **state.fields,
+                "phase_duration_seconds": self.measurement["duration"]
+                + (warmup if self.definition.warmup_mode == "inline" else 0),
+                "current_command": _command_record(
+                    phases["measure"],
+                    repetition,
+                    plan.argv,
+                    self.affinities["ydb_cli"],
+                ),
+            }
+            if self.definition.warmup_mode == "inline":
+                progress_fields["inline_warmup_seconds"] = warmup
+            self.progress(phases["measure"], **progress_fields)
+            result = run_command(
+                plan.argv,
+                {},
+                plan.timeout_seconds,
+                cpu_affinity=self.affinities["ydb_cli"],
+                cancel_event=self.cancel_event,
+                on_process_started=lambda process: cli_pids.append(process.pid),
+            )
+        finally:
+            cpu = monitor.stop()
+        self.cluster.ensure_running("YDB process exited during workload measurement")
+        commands.append(
+            _command_record(
+                phases["measure"],
+                repetition,
+                result.command,
+                self.affinities["ydb_cli"],
+                result,
+            )
+        )
+        atomic_write_text(state.directory / "stdout.txt", result.stdout)
+        atomic_write_text(state.directory / "stderr.txt", result.stderr)
+        atomic_write_json(state.directory / "cpu-samples.json", list(monitor.records))
+        if result.interrupted:
+            raise BenchmarkInterrupted("YDB CLI workload was interrupted")
+        if result.timed_out or result.exit_code:
+            raise BenchmarkError(
+                "YDB CLI workload {}".format(
+                    "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
+                )
+            )
+        if plan.measurement_window_builder is not None:
+            window = plan.measurement_window_builder(result.stdout)
+            if (
+                not isinstance(window, tuple)
+                or len(window) != 2
+                or not all(_is_finite_number(value) for value in window)
+                or window[0] >= window[1]
+            ):
+                raise BenchmarkError("workload command returned an invalid CPU measurement window")
+            cpu = monitor.summary(started_at_unix=window[0], finished_at_unix=window[1])
+        metrics = {**self.benchmark.parse_metrics(result.stdout, self.benchmark)[0], **cpu}
+        metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
+        return metrics
+
+    def run_sample(
+        self,
+        load,
+        dynamic_nodes,
+        repetition,
+        repetitions,
+        directory,
+        table_path,
+        progress_fields,
+        purpose="search",
+    ):
+        if not self._profile_opened or self._profile_closed:
+            raise BenchmarkError("workload profile lifecycle is not open")
+        self._check_cancelled()
+        directory = Path(directory)
+        directory.mkdir(parents=True)
+        fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
+        commands = []
+        if self.definition.dataset_scope == "sample":
+            dataset = _DatasetState(directory, table_path, purpose, repetition, fields, commands)
+            self._prepare_dataset(dataset)
+        else:
+            dataset = self._profile_state
+            if dataset is None or dataset.cleaned:
+                raise BenchmarkError("profile-scoped workload dataset is unavailable")
+            dataset = _DatasetState(directory, dataset.table_path, purpose, repetition, fields)
+        run_error = None
+        try:
+            metrics = self._run_workload(dataset, load, dynamic_nodes, repetition, commands)
+            return metrics, commands
+        except BaseException as error:
+            run_error = error
+            raise
+        finally:
+            if self.definition.dataset_scope == "sample":
+                self._cleanup_dataset(dataset, primary_error=run_error)
+                if run_error is None:
+                    self._check_cancelled()
 
 
 def run_local_ydb(
@@ -870,229 +1301,36 @@ def run_local_ydb(
         cancel_event,
         publish_progress,
     )
-    workload_cli = None
-
-    def run_repetition(
-        load,
-        dynamic_nodes,
-        repetition,
-        repetitions,
-        directory,
-        table_path,
-        progress_fields,
-        purpose="search",
-    ):
-        if cancel_event is not None and cancel_event.is_set():
-            raise BenchmarkInterrupted("local YDB benchmark was cancelled")
-        phases = (
-            {
-                "init": "verification-initializing",
-                "warmup": "verification-warmup",
-                "measure": "verification-measuring",
-                "clean": "verification-cleanup",
-            }
-            if purpose == "verification"
-            else {
-                "init": "initializing-workload",
-                "warmup": "warming-up",
-                "measure": "measuring",
-                "clean": "cleaning-workload",
-            }
-        )
-        directory.mkdir(parents=True)
-        fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
-        commands = []
-        init_command = build_init_argv(workload_cli, table_path, profile["workload"])
-        publish_progress(
-            phases["init"],
-            **fields,
-            current_command=_command_record(
-                phases["init"],
-                repetition,
-                init_command,
-                affinities["ydb_cli"],
-            ),
-        )
-        init, init_attempts = cluster.init_workload(init_command)
-        commands.extend(
-            _command_record(
-                phases["init"],
-                repetition,
-                init_attempt.command,
-                affinities["ydb_cli"],
-                init_attempt,
-            )
-            for init_attempt in init_attempts
-        )
-        atomic_write_text(directory / "init.stdout.txt", init.stdout)
-        atomic_write_text(directory / "init.stderr.txt", init.stderr)
-        atomic_write_json(
-            directory / "init-attempts.json",
-            [
-                {
-                    "command": [str(part) for part in attempt.command],
-                    "exit_code": attempt.exit_code,
-                    "timed_out": attempt.timed_out,
-                    "duration_seconds": attempt.duration_seconds,
-                    "stdout": attempt.stdout,
-                    "stderr": attempt.stderr,
-                }
-                for attempt in init_attempts
-            ],
-        )
-        run_error = None
-        try:
-            warmup = profile["measurement"]["warmup"]
-            if warmup:
-                warmup_command = build_run_argv(
-                    workload_cli,
-                    table_path,
-                    profile["workload"],
-                    profile["load"]["parameter"],
-                    load,
-                    warmup,
-                    profile["client"]["threads"],
-                )
-                publish_progress(
-                    phases["warmup"],
-                    **fields,
-                    phase_duration_seconds=warmup,
-                    current_command=_command_record(
-                        phases["warmup"],
-                        repetition,
-                        warmup_command,
-                        affinities["ydb_cli"],
-                    ),
-                )
-                result = cluster._run(
-                    warmup_command,
-                    timeout=warmup + 30,
-                    cpu_affinity=affinities["ydb_cli"],
-                )
-                commands.append(
-                    _command_record(
-                        phases["warmup"],
-                        repetition,
-                        result.command,
-                        affinities["ydb_cli"],
-                        result,
-                    )
-                )
-                atomic_write_text(directory / "warmup.stdout.txt", result.stdout)
-                atomic_write_text(directory / "warmup.stderr.txt", result.stderr)
-
-            cli_pids = []
-            monitor = LinuxCpuMonitor(
-                {
-                    "static": lambda: cluster.static_pids,
-                    "dynamic": lambda: cluster.dynamic_pids,
-                    "cli": lambda: tuple(cli_pids),
-                },
-                {
-                    "static": _role_capacity(affinities["static_nodes"], topology),
-                    "dynamic": _role_capacity(affinities["dynamic_nodes"], topology),
-                    "cli": _role_capacity(affinities["ydb_cli"], topology),
-                },
-            )
-            monitor.start()
-            try:
-                command = build_run_argv(
-                    workload_cli,
-                    table_path,
-                    profile["workload"],
-                    profile["load"]["parameter"],
-                    load,
-                    profile["measurement"]["duration"],
-                    profile["client"]["threads"],
-                )
-                cluster.ensure_running("cannot start workload measurement")
-                publish_progress(
-                    phases["measure"],
-                    **fields,
-                    phase_duration_seconds=profile["measurement"]["duration"],
-                    current_command=_command_record(
-                        phases["measure"],
-                        repetition,
-                        command,
-                        affinities["ydb_cli"],
-                    ),
-                )
-                result = run_command(
-                    command,
-                    {},
-                    profile["measurement"]["duration"] + 30,
-                    cpu_affinity=affinities["ydb_cli"],
-                    cancel_event=cancel_event,
-                    on_process_started=lambda process: cli_pids.append(process.pid),
-                )
-            finally:
-                cpu = monitor.stop()
-            cluster.ensure_running("YDB process exited during workload measurement")
-            commands.append(
-                _command_record(
-                    phases["measure"],
-                    repetition,
-                    result.command,
-                    affinities["ydb_cli"],
-                    result,
-                )
-            )
-            atomic_write_text(directory / "stdout.txt", result.stdout)
-            atomic_write_text(directory / "stderr.txt", result.stderr)
-            atomic_write_json(directory / "cpu-samples.json", list(monitor.records))
-            if result.interrupted:
-                raise BenchmarkInterrupted("YDB CLI workload was interrupted")
-            if result.timed_out or result.exit_code:
-                raise BenchmarkError(
-                    "YDB CLI workload {}".format(
-                        "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
-                    )
-                )
-            metrics = {**benchmark.parse_metrics(result.stdout, benchmark)[0], **cpu}
-            metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
-            return metrics, commands
-        except BaseException as error:
-            run_error = error
-            raise
-        finally:
-            try:
-                clean_command = build_clean_argv(
-                    workload_cli,
-                    table_path,
-                    profile["workload"]["type"],
-                )
-                publish_progress(
-                    phases["clean"],
-                    **fields,
-                    current_command=_command_record(
-                        phases["clean"],
-                        repetition,
-                        clean_command,
-                        affinities["ydb_cli"],
-                    ),
-                )
-                clean = cluster._run(clean_command, cpu_affinity=affinities["ydb_cli"])
-                commands.append(
-                    _command_record(
-                        phases["clean"],
-                        repetition,
-                        clean.command,
-                        affinities["ydb_cli"],
-                        clean,
-                    )
-                )
-                atomic_write_text(directory / "clean.stdout.txt", clean.stdout)
-                atomic_write_text(directory / "clean.stderr.txt", clean.stderr)
-            except BenchmarkError as error:
-                atomic_write_text(directory / "clean.error.txt", str(error) + "\n")
-                if run_error is None:
-                    raise
-
     repetition_rows = []
     cluster_stopped = False
+    lifecycle = None
+
+    def close_lifecycle(primary_error=None):
+        if lifecycle is None:
+            return
+        try:
+            lifecycle.close_profile(primary_error=primary_error)
+        except BaseException:
+            if primary_error is None:
+                raise
+
     try:
         cluster.start()
         workload_cli = WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database)
+        lifecycle = WorkloadLifecycle(
+            cluster,
+            workload_cli,
+            profile["workload"],
+            profile["load"],
+            profile["measurement"],
+            profile["client"]["threads"],
+            benchmark,
+            topology,
+            affinities,
+            cancel_event,
+            publish_progress,
+        )
+        lifecycle.open_profile(output_directory / "workload", "ydb_bench_profile")
         while True:
             dynamic_nodes = len(cluster.dynamic_nodes)
             search_stage = len(manifest["searches"]) + 1
@@ -1111,7 +1349,7 @@ def run_local_ydb(
                 for repetition in range(1, repetitions + 1):
                     directory = geometry_directory / "load-{:08d}".format(load) / "repeat-{:03d}".format(repetition)
                     table_path = "ydb_bench_{}_{}_{}".format(dynamic_nodes, load, repetition)
-                    metrics, repetition_commands = run_repetition(
+                    metrics, repetition_commands = lifecycle.run_sample(
                         load,
                         dynamic_nodes,
                         repetition,
@@ -1267,7 +1505,7 @@ def run_local_ydb(
                 for repetition in range(1, verification_repetitions + 1):
                     directory = output_directory / "verification" / "repeat-{:03d}".format(repetition)
                     table_path = "ydb_bench_verify_{}_{}_{}".format(dynamic_nodes, selected_load, repetition)
-                    metrics, commands = run_repetition(
+                    metrics, commands = lifecycle.run_sample(
                         selected_load,
                         dynamic_nodes,
                         repetition,
@@ -1381,6 +1619,7 @@ def run_local_ydb(
                 verification=verification,
             )
 
+        close_lifecycle()
         publish_progress("stopping-cluster", result=compact_result_progress())
         cluster.stop()
         cluster_stopped = True
@@ -1423,6 +1662,7 @@ def run_local_ydb(
         write_manifest(manifest_path, manifest)
         return manifest
     except (BenchmarkInterrupted, KeyboardInterrupt) as error:
+        close_lifecycle(primary_error=error)
         interruption = (
             error
             if isinstance(error, BenchmarkInterrupted)
@@ -1450,7 +1690,8 @@ def run_local_ydb(
         if interruption is error:
             raise
         raise interruption from error
-    except BenchmarkError as error:
+    except Exception as error:
+        close_lifecycle(primary_error=error)
         manifest.update({"status": "failed", "state": "failed", "finished_at": _utc_now(), "error": str(error)})
         publish_progress("failed", error=str(error))
         write_manifest(manifest_path, manifest)
@@ -1465,5 +1706,8 @@ def run_local_ydb(
             )
         raise
     finally:
-        if not cluster_stopped:
-            cluster.stop()
+        try:
+            close_lifecycle(primary_error=sys.exc_info()[1])
+        finally:
+            if not cluster_stopped:
+                cluster.stop()

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,5 +1,6 @@
 """Declarative local-YDB workload catalog and YDB CLI command builders."""
 
+import math
 import re
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -12,6 +13,14 @@ class WorkloadCli:
     executable: object
     endpoint: str
     database: str
+
+
+@dataclass(frozen=True)
+class WorkloadCommandPlan:
+    name: str
+    argv: tuple
+    timeout_seconds: float | None = None
+    measurement_window_builder: object = None
 
 
 @dataclass(frozen=True)
@@ -75,10 +84,24 @@ class WorkloadDefinition:
     init_builder: object
     run_builder: object
     options_validator: object
+    dataset_scope: str = "sample"
+    warmup_mode: str = "separate"
+    prepare_plan_builder: object = None
+    run_plan_builder: object = None
+    cleanup_plan_builder: object = None
 
 
 def _config_error(location, message):
     raise BenchmarkError("invalid benchmark config at {}: {}".format(location, message))
+
+
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
 
 
 def _mapping(value, location, allowed=()):
@@ -246,6 +269,16 @@ def _validate_catalog(definitions):
         raise ValueError("local YDB workload names must be unique")
     option_schemas = {}
     for definition in definitions:
+        if definition.dataset_scope not in ("sample", "profile"):
+            raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
+        if definition.warmup_mode not in ("separate", "inline"):
+            raise ValueError("unknown warmup mode for {}: {}".format(definition.name, definition.warmup_mode))
+        for name in ("prepare_plan_builder", "run_plan_builder", "cleanup_plan_builder"):
+            builder = getattr(definition, name)
+            if builder is not None and not callable(builder):
+                raise ValueError("{} must be callable for {}".format(name, definition.name))
+        if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
+            raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
         if len(definition.operations) != len(set(definition.operations)):
             raise ValueError("operations must be unique for {}".format(definition.name))
         if len(definition.load_parameters) != len(set(definition.load_parameters)):
@@ -464,6 +497,125 @@ def build_run_argv(cli, path, workload, load_parameter, load, seconds, client_th
 def build_clean_argv(cli, path, workload_type):
     definition = _definition(workload_type)
     return _workload_base(cli, definition, path) + ["clean"]
+
+
+def _validate_command_plans(plans, description, allow_default_timeout=False):
+    if not isinstance(plans, tuple) or not plans:
+        raise BenchmarkError("{} must produce a non-empty tuple of command plans".format(description))
+    for plan in plans:
+        if not isinstance(plan, WorkloadCommandPlan):
+            raise BenchmarkError("{} produced an invalid command plan".format(description))
+        if not plan.name or not isinstance(plan.name, str) or re.fullmatch("[a-z0-9-]+", plan.name) is None:
+            raise BenchmarkError("{} produced an invalid command plan name".format(description))
+        if not isinstance(plan.argv, tuple) or not plan.argv:
+            raise BenchmarkError("{} command {} must have a non-empty argv tuple".format(description, plan.name))
+        if plan.timeout_seconds is None and allow_default_timeout:
+            pass
+        elif not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
+            raise BenchmarkError("{} command {} must have a positive timeout".format(description, plan.name))
+        if plan.measurement_window_builder is not None and not callable(plan.measurement_window_builder):
+            raise BenchmarkError(
+                "{} command {} has an invalid measurement window builder".format(description, plan.name)
+            )
+    return plans
+
+
+def build_prepare_plan(cli, path, workload):
+    """Build the pure command plan which creates one workload dataset."""
+
+    definition = _definition(workload["type"])
+    if definition.prepare_plan_builder is None:
+        plans = (
+            WorkloadCommandPlan(
+                "init",
+                tuple(definition.init_builder(cli, definition, path, workload)),
+                120,
+            ),
+        )
+    else:
+        plans = definition.prepare_plan_builder(cli, definition, path, workload)
+    return _validate_command_plans(plans, "{} prepare plan".format(definition.name))
+
+
+def build_run_plan(
+    cli,
+    path,
+    workload,
+    load_parameter,
+    load,
+    seconds,
+    client_threads,
+    warmup_seconds=0,
+):
+    """Build one pure workload command plan without executing a process."""
+
+    definition = _definition(workload["type"])
+    if load_parameter not in definition.load_parameters:
+        raise BenchmarkError(
+            "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)
+        )
+    if definition.run_plan_builder is None:
+        if warmup_seconds:
+            raise BenchmarkError("{} does not support inline warmup".format(definition.name))
+        plan = WorkloadCommandPlan(
+            "run",
+            tuple(
+                definition.run_builder(
+                    cli,
+                    definition,
+                    path,
+                    workload,
+                    load_parameter,
+                    load,
+                    seconds,
+                    client_threads,
+                )
+            ),
+            seconds + 30,
+        )
+    else:
+        plan = definition.run_plan_builder(
+            cli,
+            definition,
+            path,
+            workload,
+            load_parameter,
+            load,
+            seconds,
+            client_threads,
+            warmup_seconds,
+        )
+    plan = _validate_command_plans((plan,), "{} run plan".format(definition.name))[0]
+    if definition.warmup_mode == "inline" and plan.measurement_window_builder is None:
+        raise BenchmarkError("{} inline warmup requires a CPU measurement window".format(definition.name))
+    return plan
+
+
+def build_cleanup_plan(cli, path, workload):
+    """Build the pure command plan which removes one workload dataset."""
+
+    definition = _definition(workload["type"])
+    if definition.cleanup_plan_builder is None:
+        plans = (
+            WorkloadCommandPlan(
+                "clean",
+                tuple(_workload_base(cli, definition, path) + ["clean"]),
+                None,
+            ),
+        )
+    else:
+        plans = definition.cleanup_plan_builder(cli, definition, path, workload)
+    return _validate_command_plans(
+        plans,
+        "{} cleanup plan".format(definition.name),
+        allow_default_timeout=True,
+    )
+
+
+def workload_definition(workload_type):
+    """Return immutable lifecycle metadata for one registered workload."""
+
+    return _definition(workload_type)
 
 
 def workload_table_path(workload_type, path):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -115,7 +115,14 @@ class YdbBenchTest(unittest.TestCase):
             timeout_seconds=timeout,
         )
 
-    def _run_mock_local_ydb(self, configuration, output_name, measurements):
+    def _run_mock_local_ydb(
+        self,
+        configuration,
+        output_name,
+        measurements,
+        cancel_event=None,
+        cleanup_action=None,
+    ):
         def command_result(command, stdout="", exit_code=0, stderr="", interrupted=False, timed_out=False):
             return runner.CommandResult(
                 command=tuple(str(part) for part in command),
@@ -149,11 +156,17 @@ class YdbBenchTest(unittest.TestCase):
             static_pids=(10,),
             dynamic_pids=(20,),
         )
-        cluster.init_workload.side_effect = lambda command: (
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
             command_result(command),
             [command_result(command)],
         )
-        cluster._run.side_effect = lambda command, **_kwargs: command_result(command)
+
+        def run_cluster_command(command, **_kwargs):
+            if cleanup_action is not None and "clean" in command:
+                cleanup_action()
+            return command_result(command)
+
+        cluster._run.side_effect = run_cluster_command
         monitor = mock.Mock(records=[])
         monitor.start.return_value = monitor
         monitor.stop.return_value = {
@@ -165,6 +178,16 @@ class YdbBenchTest(unittest.TestCase):
             "cli_cpu_max": 6,
             "host_cpu_mean": 7,
             "host_cpu_max": 8,
+        }
+        monitor.summary.return_value = {
+            "static_cpu_mean": 11,
+            "static_cpu_max": 12,
+            "dynamic_cpu_mean": 13,
+            "dynamic_cpu_max": 14,
+            "cli_cpu_mean": 15,
+            "cli_cpu_max": 16,
+            "host_cpu_mean": 17,
+            "host_cpu_max": 18,
         }
         outputs = iter(measurements)
 
@@ -211,8 +234,110 @@ class YdbBenchTest(unittest.TestCase):
                 output,
                 tool_revision="test",
                 event_sink=events.append,
+                cancel_event=cancel_event,
             )
         return manifest, output, events
+
+    @staticmethod
+    def _local_ydb_command_result(command, stdout="", exit_code=0, interrupted=False):
+        return runner.CommandResult(
+            command=tuple(str(part) for part in command),
+            stdout=stdout,
+            stderr="",
+            exit_code=exit_code,
+            started_at="2026-08-25T10:00:00+00:00",
+            finished_at="2026-08-25T10:00:01+00:00",
+            duration_seconds=1.0,
+            interrupted=interrupted,
+        )
+
+    @staticmethod
+    def _synthetic_profile_workload(cleanup_names=("clean",), measurement_window=(101.0, 109.0)):
+        def prepare(cli_context, _definition, path, _workload):
+            return (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    (cli_context.executable, "synthetic", "init", path),
+                    10,
+                ),
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "import",
+                    (cli_context.executable, "synthetic", "import", path),
+                    20,
+                ),
+            )
+
+        def run(cli_context, _definition, path, _workload, _parameter, load, seconds, threads, warmup):
+            return local_ydb_workloads.WorkloadCommandPlan(
+                "run",
+                (
+                    cli_context.executable,
+                    "synthetic",
+                    "run",
+                    path,
+                    "--load",
+                    load,
+                    "--seconds",
+                    seconds,
+                    "--threads",
+                    threads,
+                    "--warmup",
+                    warmup,
+                ),
+                warmup + seconds + 30,
+                measurement_window_builder=lambda _stdout: measurement_window,
+            )
+
+        def cleanup(cli_context, _definition, path, _workload):
+            return tuple(
+                local_ydb_workloads.WorkloadCommandPlan(
+                    name,
+                    (cli_context.executable, "synthetic", name, path),
+                    5,
+                )
+                for name in cleanup_names
+            )
+
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="synthetic",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("sessions",),
+            options=(),
+            uses_path=True,
+            table_name=None,
+            init_builder=lambda *_args: (),
+            run_builder=lambda *_args: (),
+            options_validator=lambda *_args: None,
+            dataset_scope="profile",
+            warmup_mode="inline",
+            prepare_plan_builder=prepare,
+            run_plan_builder=run,
+            cleanup_plan_builder=cleanup,
+        )
+        return definition, {"type": "synthetic", "operation": "run", "options": {}}
+
+    @staticmethod
+    def _synthetic_workload_lifecycle(workload, cluster, progress, cancel_event=None):
+        topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        return local_ydb.WorkloadLifecycle(
+            cluster,
+            local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+            workload,
+            {"parameter": "sessions"},
+            {"warmup": 5, "duration": 10},
+            4,
+            LOCAL_YDB_BENCHMARK,
+            topology,
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            cancel_event,
+            lambda phase, **fields: progress.append({"phase": phase, **fields}),
+        )
 
     def _worker_metrics_benchmark(self):
         return replace(
@@ -502,6 +627,617 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads.build_clean_argv(cli_context, "table-prefix", "kv"),
             base + ["clean"],
         )
+        prepare = local_ydb_workloads.build_prepare_plan(cli_context, "table-prefix", workload)
+        run = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "table-prefix",
+            workload,
+            "rate",
+            250,
+            30,
+            64,
+        )
+        cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "table-prefix", workload)
+        self.assertEqual(
+            prepare,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    tuple(
+                        base
+                        + [
+                            "init",
+                            "--init-upserts",
+                            1000,
+                            "--min-partitions",
+                            40,
+                            "--max-partitions",
+                            1000,
+                            "--partition-size",
+                            2000,
+                            "--max-first-key",
+                            65536,
+                            "--len",
+                            64,
+                            "--cols",
+                            2,
+                            "--int-cols",
+                            1,
+                            "--key-cols",
+                            1,
+                            "--rows",
+                            1,
+                        ]
+                    ),
+                    120,
+                ),
+            ),
+        )
+        self.assertEqual(
+            run.argv,
+            tuple(
+                local_ydb_workloads.build_run_argv(
+                    cli_context,
+                    "table-prefix",
+                    workload,
+                    "rate",
+                    250,
+                    30,
+                    64,
+                )
+            ),
+        )
+        self.assertEqual(run.timeout_seconds, 60)
+        self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
+        self.assertIsNone(cleanup[0].timeout_seconds)
+
+    def test_local_ydb_workload_registry_validates_lifecycle_metadata_and_plans(self):
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="inline",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("sessions",),
+            options=(),
+            uses_path=True,
+            table_name=None,
+            init_builder=lambda *_args: (),
+            run_builder=lambda *_args: (),
+            options_validator=lambda *_args: None,
+            dataset_scope="profile",
+            warmup_mode="inline",
+            run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", ("ydb",), 1),
+        )
+        local_ydb_workloads._validate_catalog((definition,))
+        with self.assertRaisesRegex(ValueError, "dataset scope"):
+            local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="attempt"),))
+        with self.assertRaisesRegex(ValueError, "inline warmup requires"):
+            local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "CPU measurement window"):
+                local_ydb_workloads.build_run_plan(
+                    local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                    "path",
+                    {"type": "inline", "operation": "run", "options": {}},
+                    "sessions",
+                    1,
+                    1,
+                    1,
+                    warmup_seconds=0,
+                )
+            with self.assertRaisesRegex(BenchmarkError, "non-empty argv"):
+                invalid = replace(
+                    definition,
+                    run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", (), 1),
+                )
+                with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": invalid}):
+                    local_ydb_workloads.build_run_plan(
+                        local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                        "path",
+                        {"type": "inline", "operation": "run", "options": {}},
+                        "sessions",
+                        1,
+                        1,
+                        1,
+                        warmup_seconds=1,
+                    )
+            for timeout in (float("nan"), float("inf"), True, 10**1000):
+                nonfinite = replace(
+                    definition,
+                    run_plan_builder=lambda *_args, timeout=timeout: local_ydb_workloads.WorkloadCommandPlan(
+                        "run",
+                        ("ydb",),
+                        timeout,
+                    ),
+                )
+                with self.subTest(timeout=timeout), mock.patch.object(
+                    local_ydb_workloads,
+                    "_WORKLOADS",
+                    {"inline": nonfinite},
+                ), self.assertRaisesRegex(BenchmarkError, "positive timeout"):
+                    local_ydb_workloads.build_run_plan(
+                        local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                        "path",
+                        {"type": "inline", "operation": "run", "options": {}},
+                        "sessions",
+                        1,
+                        1,
+                        1,
+                        warmup_seconds=1,
+                    )
+
+    def test_local_ydb_profile_inline_lifecycle_prepares_once_and_cleans_once(self):
+        definition, workload = self._synthetic_profile_workload()
+        metrics_output = """
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            10 10 0 0 1 2 3 4
+        """
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        monitor.summary.return_value = {
+            "static_cpu_mean": 11,
+            "static_cpu_max": 12,
+            "dynamic_cpu_mean": 13,
+            "dynamic_cpu_max": 14,
+            "cli_cpu_mean": 15,
+            "cli_cpu_max": 16,
+            "host_cpu_mean": 17,
+            "host_cpu_max": 18,
+        }
+        progress = []
+        profile_directory = self.root / "synthetic-profile"
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command, metrics_output),
+        ) as execute:
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(profile_directory, "tpcc-dataset")
+            first_metrics, first_commands = lifecycle.run_sample(
+                8,
+                1,
+                1,
+                2,
+                self.root / "synthetic-repeat-1",
+                "ignored-1",
+                {"attempt": 1},
+            )
+            second_metrics, second_commands = lifecycle.run_sample(
+                16,
+                1,
+                2,
+                2,
+                self.root / "synthetic-repeat-2",
+                "ignored-2",
+                {"attempt": 2},
+            )
+            lifecycle.close_profile()
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual([call.args[0][2] for call in cluster.init_workload.call_args_list], ["init", "import"])
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.assertEqual(cluster._run.call_args.kwargs["timeout"], 5)
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            [
+                "initializing-workload",
+                "preparing-import",
+                "measuring",
+                "measuring",
+                "cleaning-workload",
+            ],
+        )
+        self.assertNotIn("warming-up", [item["phase"] for item in progress])
+        self.assertEqual([len(first_commands), len(second_commands)], [1, 1])
+        self.assertEqual(first_metrics["static_cpu_mean"], 11)
+        self.assertEqual(second_metrics["load"], 16)
+        self.assertEqual(
+            monitor.summary.call_args_list,
+            [
+                mock.call(started_at_unix=101.0, finished_at_unix=109.0),
+                mock.call(started_at_unix=101.0, finished_at_unix=109.0),
+            ],
+        )
+        for call in execute.call_args_list:
+            argv = call.args[0]
+            self.assertEqual(argv[argv.index("--warmup") + 1], 5)
+            self.assertEqual(call.args[2], 45)
+        profile_commands = lifecycle.profile_commands
+        self.assertEqual([item["argv"][2] for item in profile_commands], ["init", "import", "clean"])
+
+    def test_local_ydb_profile_lifecycle_cleans_partial_prepare_without_masking_error(self):
+        definition, workload = self._synthetic_profile_workload()
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        initialized = self._local_ydb_command_result(("ydb", "synthetic", "init"))
+        cluster.init_workload.side_effect = ((initialized, [initialized]), BenchmarkError("import failed"))
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(local_ydb, "atomic_write_json"):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            with self.assertRaisesRegex(BenchmarkError, "import failed"):
+                lifecycle.open_profile(self.root / "partial-profile", "tpcc-dataset")
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+
+    def test_local_ydb_inline_lifecycle_rejects_huge_cpu_measurement_window(self):
+        definition, workload = self._synthetic_profile_workload(measurement_window=(10**1000, 10**1000 + 1))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text"), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command),
+        ):
+            lifecycle = self._synthetic_workload_lifecycle(workload, cluster, progress)
+            lifecycle.open_profile(self.root / "huge-window-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "invalid CPU measurement window") as caught:
+                lifecycle.run_sample(
+                    8,
+                    1,
+                    1,
+                    1,
+                    self.root / "huge-window-repeat",
+                    "ignored",
+                    {},
+                )
+            lifecycle.close_profile(primary_error=caught.exception)
+
+        monitor.summary.assert_not_called()
+        self.assertEqual(cluster._run.call_count, 1)
+
+    def test_local_ydb_profile_lifecycle_preserves_run_error_when_cleanup_fails(self):
+        definition, workload = self._synthetic_profile_workload()
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = BenchmarkError("cleanup failed")
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        progress = []
+        failed_run = self._local_ydb_command_result(("ydb", "synthetic", "run"), exit_code=17)
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text") as write_text, mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb, "run_command", return_value=failed_run
+        ):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(self.root / "run-error-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "exited with code 17") as caught:
+                lifecycle.run_sample(
+                    8,
+                    1,
+                    1,
+                    1,
+                    self.root / "run-error-repeat",
+                    "ignored",
+                    {},
+                )
+            lifecycle.close_profile(primary_error=caught.exception)
+
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.assertIn("clean.error.txt", [Path(call.args[0]).name for call in write_text.call_args_list])
+
+    def test_local_ydb_profile_lifecycle_attempts_all_cleanup_steps_and_only_cleanup_error_fails(self):
+        definition, workload = self._synthetic_profile_workload(("clean", "vacuum"))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = (
+            OSError("clean failed"),
+            self._local_ydb_command_result(("ydb", "synthetic", "vacuum")),
+        )
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(local_ydb, "atomic_write_json"):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(self.root / "cleanup-error-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "clean failed"):
+                lifecycle.close_profile()
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+
+    def test_local_ydb_profile_lifecycle_runs_cleanup_when_progress_fails(self):
+        class FailingCleanupProgress(list):
+            def append(self, item):
+                if item["phase"].startswith("cleaning-"):
+                    raise OSError("cleanup progress failed")
+                super().append(item)
+
+        definition, workload = self._synthetic_profile_workload(("clean", "vacuum"))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        progress = FailingCleanupProgress()
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(local_ydb, "atomic_write_json"):
+            lifecycle = self._synthetic_workload_lifecycle(workload, cluster, progress)
+            lifecycle.open_profile(self.root / "cleanup-progress-error-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "cleanup progress failed"):
+                lifecycle.close_profile()
+
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+
+    def test_local_ydb_profile_lifecycle_cancellation_cleanup_ignores_cancel_event(self):
+        definition, workload = self._synthetic_profile_workload()
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        progress = []
+        interrupted = self._local_ydb_command_result(("ydb", "synthetic", "run"), interrupted=True)
+        cancel_event = threading.Event()
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text"), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb, "run_command", return_value=interrupted
+        ):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+                cancel_event,
+            )
+            lifecycle.open_profile(self.root / "cancel-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkInterrupted, "was interrupted") as caught:
+                lifecycle.run_sample(
+                    8,
+                    1,
+                    1,
+                    1,
+                    self.root / "cancel-repeat",
+                    "ignored",
+                    {},
+                )
+            cancel_event.set()
+            lifecycle.close_profile(primary_error=caught.exception)
+
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+
+    def test_local_ydb_profile_lifecycle_cleanup_artifact_failures_do_not_mask_primary(self):
+        definition, workload = self._synthetic_profile_workload(("clean", "vacuum"))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ) as write_text, mock.patch.object(local_ydb, "atomic_write_json") as write_json:
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(self.root / "artifact-error-profile", "tpcc-dataset")
+            primary = BenchmarkInterrupted("cancelled")
+            write_text.side_effect = OSError("text write failed")
+            write_json.side_effect = OSError("json write failed")
+            lifecycle.close_profile(primary_error=primary)
+
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+
+    def test_local_ydb_unexpected_profile_error_cleans_before_terminal_failure(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              unexpected-failure:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="profile")
+
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(OSError, "measurement failed"):
+                self._run_mock_local_ydb(
+                    configuration,
+                    "unexpected-profile-error",
+                    [OSError("measurement failed")],
+                )
+
+        manifest = json.loads((self.root / "unexpected-profile-error" / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["status"], "failed")
+        self.assertEqual(manifest["state"], "failed")
+        self.assertEqual(manifest["progress"]["phase"], "failed")
+        self.assertEqual(self.last_local_ydb_cluster._run.call_count, 1)
+        cleanup = self.last_local_ydb_cluster._run.call_args
+        self.assertIn("clean", cleanup.args[0])
+        self.assertTrue(cleanup.kwargs["ignore_cancellation"])
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
+
+    def test_local_ydb_cancelled_during_cleanup_never_publishes_success(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              cleanup-cancellation:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        cancel_event = threading.Event()
+
+        with self.assertRaisesRegex(BenchmarkInterrupted, "was cancelled"):
+            self._run_mock_local_ydb(
+                configuration,
+                "cleanup-cancellation",
+                [{"throughput": 10}],
+                cancel_event=cancel_event,
+                cleanup_action=cancel_event.set,
+            )
+
+        manifest = json.loads((self.root / "cleanup-cancellation" / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["status"], "interrupted")
+        self.assertEqual(manifest["state"], "cancelled")
+        self.assertEqual(manifest["progress"]["phase"], "cancelled")
+        self.assertEqual(self.last_local_ydb_cluster._run.call_count, 1)
+        self.assertTrue(self.last_local_ydb_cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
+
+    def test_local_ydb_cleanup_plan_uses_cluster_configuration_timeout(self):
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            self.root / "cluster-timeout",
+            {"static_nodes": 1, "dynamic_nodes": 1},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            73,
+        )
+        cli_context = local_ydb_workloads.WorkloadCli(cluster.ydb_cli, "grpc://host:2135", cluster.database)
+        plan = local_ydb_workloads.build_cleanup_plan(
+            cli_context,
+            "table-prefix",
+            {"type": "kv"},
+        )[0]
+        result = self._local_ydb_command_result(plan.argv)
+        with mock.patch.object(local_ydb, "run_command", return_value=result) as execute:
+            cluster._run(plan.argv, timeout=plan.timeout_seconds, ignore_cancellation=True)
+
+        self.assertIsNone(plan.timeout_seconds)
+        self.assertEqual(execute.call_args.args[2], 73)
 
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""
@@ -858,7 +1594,7 @@ class YdbBenchTest(unittest.TestCase):
             static_pids=(10,),
             dynamic_pids=(20,),
         )
-        cluster.init_workload.side_effect = lambda command: (
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
             command_result(command),
             [command_result(command)],
         )
@@ -1444,6 +2180,41 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(summary["dynamic_cpu_max"], 30.0)
         self.assertAlmostEqual(summary["host_cpu_mean"], (10 + 60 + 1) / 2.01)
         self.assertEqual(summary["host_cpu_max"], 40.0)
+
+    def test_linux_cpu_summary_filters_complete_intervals_inside_measurement_window(self):
+        monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1}, interval=0.5)
+        monitor._records = [
+            {"elapsed_seconds": 1.0, "timestamp_unix": 101.0, "dynamic_cpu": 10.0, "host_cpu": 15.0},
+            {"elapsed_seconds": 1.0, "timestamp_unix": 102.0, "dynamic_cpu": 20.0, "host_cpu": 25.0},
+            {"elapsed_seconds": 1.0, "timestamp_unix": 103.0, "dynamic_cpu": 30.0, "host_cpu": 35.0},
+            {"elapsed_seconds": 1.0, "timestamp_unix": 104.0, "dynamic_cpu": 40.0, "host_cpu": 45.0},
+        ]
+        summary = monitor.summary(started_at_unix=101.0, finished_at_unix=103.0)
+        self.assertEqual(summary["dynamic_cpu_mean"], 25.0)
+        self.assertEqual(summary["dynamic_cpu_max"], 30.0)
+        self.assertEqual(summary["host_cpu_mean"], 30.0)
+        self.assertEqual(summary["host_cpu_max"], 35.0)
+
+    def test_linux_cpu_summary_rejects_invalid_or_empty_measurement_window(self):
+        monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1})
+        monitor._records = [
+            {"elapsed_seconds": 1.0, "timestamp_unix": 101.0, "dynamic_cpu": 10.0, "host_cpu": 15.0},
+        ]
+        for start, finish in (
+            (100.0, None),
+            (101.0, 101.0),
+            (float("nan"), 102.0),
+            (True, 102.0),
+            (10**1000, 10**1000 + 1),
+        ):
+            with self.subTest(start=start, finish=finish), self.assertRaisesRegex(BenchmarkError, "CPU measurement"):
+                monitor.summary(started_at_unix=start, finished_at_unix=finish)
+        with self.assertRaisesRegex(BenchmarkError, "does not contain"):
+            monitor.summary(started_at_unix=102.0, finished_at_unix=103.0)
+
+        default_summary = monitor.summary()
+        self.assertEqual(default_summary["dynamic_cpu_mean"], 10.0)
+        self.assertEqual(default_summary["host_cpu_mean"], 15.0)
 
     def test_local_ydb_attempt_aggregates_errors_across_repetitions(self):
         metrics = local_ydb._aggregate_measurements(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added lifecycle-aware orchestration for local YDB workloads.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51543.

Introduces declarative sample/profile dataset scopes, separate/inline warmup modes, reliable cleanup, and measurement-window-aware Linux CPU telemetry while preserving existing KV and stock behavior.