### PR TITLE
YDB Bench: add local log workload

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -14,7 +14,8 @@ The tool provides four benchmarks:
 - `ping-bench`: pairwise actor ping throughput;
 - `star-ping-bench`: star-topology actor ping throughput.
 - `memory-bandwidth-bench`: mixed sequential-copy and random copy/write memory workload.
-- `local-ydb`: a local static/dynamic YDB cluster driven by `ydb workload kv`.
+- `local-ydb`: a local static/dynamic YDB cluster driven by the `kv`, `stock`,
+  or `log` YDB CLI workload.
 
 Inspect them and print the standard JSON Schema for the YAML configuration:
 
@@ -123,15 +124,20 @@ specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
 
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
-benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. A
-`values` list measures exact points. For adaptive runs, `search` defines the
-range and resolution. `maximize-throughput` uses a discrete ternary search and,
-after confirming a plateau, selects the lowest CPU-saturated load within the
-configured throughput tolerance of the best saturated measurement. A plateau
-is confirmed only when the selected role's CPU is saturated. `latency-slo` uses
-the configured `multiplier` to find the first failing point, then a binary
-search to find the highest load whose millisecond percentile, error count, and
-achieved-rate ratio satisfy the SLO. For example:
+benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. The
+`kv` and `stock` workloads accept either parameter; `log` searches `threads`
+because its CLI does not expose `--rate`. Log throughput is the number of
+successful batches per second; `rows-per-operation` controls how many rows are
+written by each batch. Its default `ttl-minutes: 0` is a zero-minute table TTL,
+not disabled TTL. A `values` list measures exact points. For adaptive runs,
+`search` defines the range and resolution. `maximize-throughput` uses a
+discrete ternary search and, after confirming a plateau, selects the lowest
+CPU-saturated load within the configured throughput tolerance of the best
+saturated measurement. A plateau is confirmed only when the selected role's
+CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
+first failing point, then a binary search to find the highest load whose
+millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
+For example:
 
 ```yaml
     load:

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -20,8 +20,8 @@ DIMENSIONS = (
 METRICS = tuple(
     MetricDefinition(name, unit)
     for name, unit in (
-        ("transactions", "transactions"),
-        ("throughput", "transactions/s"),
+        ("transactions", "operations"),
+        ("throughput", "operations/s"),
         ("retries", "retries"),
         ("errors", "errors"),
         ("p50_ms", "ms"),

--- a/ydb/tools/ydb_bench/examples/local-ydb-log.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-log.yaml
@@ -1,0 +1,30 @@
+local-ydb:
+  log-smoke:
+    workload:
+      type: log
+      operation: bulk-upsert
+      options:
+        min-partitions: 1
+        max-partitions: 1
+        partition-size-mb: 128
+        auto-partition: 0
+        rows-per-operation: 16
+    geometry:
+      preset: single
+    client:
+      threads: 8
+    load:
+      parameter: threads
+      values: [1, 2, 4]
+    measurement:
+      warmup: 1
+      duration: 3
+      repetitions: 1
+      verification-repetitions: 0
+    affinity:
+      ydb-cli:
+        mode: none
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -226,6 +226,61 @@ def _stock_run_builder(cli, definition, path, workload, load_parameter, load, se
     return command
 
 
+def _log_init_builder(cli, definition, path, workload):
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--min-partitions",
+        options["min-partitions"],
+        "--max-partitions",
+        options["max-partitions"],
+        "--partition-size",
+        options["partition-size-mb"],
+        "--auto-partition",
+        options["auto-partition"],
+        "--len",
+        options["string-length"],
+        "--int-cols",
+        options["integer-columns"],
+        "--str-cols",
+        options["string-columns"],
+        "--key-cols",
+        options["key-columns"],
+        "--ttl",
+        options["ttl-minutes"],
+        "--store",
+        options["store"],
+        "--null-percent",
+        options["null-percent"],
+    ]
+
+
+def _log_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del load_parameter, client_threads
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        load,
+        "--quiet",
+        "--rows",
+        options["rows-per-operation"],
+        "--len",
+        options["string-length"],
+        "--int-cols",
+        options["integer-columns"],
+        "--str-cols",
+        options["string-columns"],
+        "--key-cols",
+        options["key-columns"],
+        "--null-percent",
+        options["null-percent"],
+    ]
+
+
 def _validate_kv_options(options, location):
     if options["max-partitions"] < options["min-partitions"]:
         _config_error(location + ".max-partitions", "must not be below min-partitions")
@@ -235,6 +290,14 @@ def _validate_kv_options(options, location):
 
 def _validate_stock_options(options, location):
     del options, location
+
+
+def _validate_log_options(options, location):
+    if options["max-partitions"] < options["min-partitions"]:
+        _config_error(location + ".max-partitions", "must not be below min-partitions")
+    columns = options["integer-columns"] + options["string-columns"]
+    if options["key-columns"] > columns:
+        _config_error(location + ".key-columns", "must not exceed integer-columns plus string-columns")
 
 
 def _validate_option_value(option, value, location):
@@ -378,6 +441,33 @@ _DEFINITIONS = (
         run_builder=_stock_run_builder,
         options_validator=_validate_stock_options,
     ),
+    WorkloadDefinition(
+        name="log",
+        default_operation="bulk-upsert",
+        operations=("insert", "upsert", "bulk-upsert"),
+        load_parameters=("threads",),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("max-partitions", 1000),
+            WorkloadOption("partition-size-mb", 2000),
+            WorkloadOption("auto-partition", 1, allow_zero=True, choices=(0, 1)),
+            WorkloadOption("store", "row", kind="string", choices=("row", "column")),
+            WorkloadOption("ttl-minutes", 0, allow_zero=True),
+            WorkloadOption("string-length", 8),
+            WorkloadOption("integer-columns", 0, allow_zero=True),
+            WorkloadOption("string-columns", 0, allow_zero=True),
+            WorkloadOption("key-columns", 0, allow_zero=True),
+            WorkloadOption("rows-per-operation", 1),
+            WorkloadOption("null-percent", 10, allow_zero=True, maximum=100),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_log_init_builder,
+        run_builder=_log_run_builder,
+        options_validator=_validate_log_options,
+        dataset_scope="sample",
+        warmup_mode="separate",
+    ),
 )
 _validate_catalog(_DEFINITIONS)
 _WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
@@ -426,13 +516,14 @@ def workload_config_schema():
     for definition in _DEFINITIONS:
         for option in definition.options:
             option_schemas[option.name] = option.config_schema()
+    operations = tuple(dict.fromkeys(operation for definition in _DEFINITIONS for operation in definition.operations))
     return {
         "type": "object",
         "additionalProperties": False,
         "required": ["type", "operation"],
         "properties": {
             "type": {"enum": [definition.name for definition in _DEFINITIONS]},
-            "operation": {"enum": [operation for definition in _DEFINITIONS for operation in definition.operations]},
+            "operation": {"enum": list(operations)},
             "options": {
                 "type": "object",
                 "additionalProperties": False,

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -238,6 +238,10 @@ _JS = (
     "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
     "function localYdbWorkloadDefinition(type){const definition=(editor.model?.local_ydb_workloads||[]).find(item=>item.type"
     "===type);if(!definition)throw Error('Unknown local YDB workload: '+type);return definition}\n"
+    "const localYdbLoadDefaults={rate:{values:[1000],start:1000,maximum:100000},threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}};\n"
+    "function localYdbResetLoadParameter(load,parameter){const defaults=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;"
+    "if(load.values)return {...load,parameter,values:[...defaults.values]};return {...load,parameter,search:{...(load.search||{}),start:defaults.start,maximum:defaults.maximum}}}\n"
+    "function localYdbLoadForWorkload(load,parameters){return parameters.includes(load.parameter)?load:localYdbResetLoadParameter(load,parameters[0])}\n"
     "function defaultLocalYdbWorkload(type){const definition=localYdbWorkloadDefinition(type),operation=definition.default_"
     "operation,options=Object.fromEntries(definition.options.map(option=>[option.name,Object.prototype.hasOwnProperty.call("
     "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
@@ -498,7 +502,12 @@ function bindLocalYdbEditor(profile){
     if(event.target.id==='local-workload-type'){
       config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
       const parameters=localYdbWorkloadDefinition(event.target.value).load_parameters;
-      if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0];
+      config.load=localYdbLoadForWorkload(config.load,parameters);
+      editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
+    }
+    if(event.target.id==='local-load-parameter'){
+      const parameter=event.target.value;
+      if(parameter!==config.load.parameter)config.load=localYdbResetLoadParameter(config.load,parameter);
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     if(event.target.id==='local-geometry-preset'){
@@ -514,10 +523,11 @@ function bindLocalYdbEditor(profile){
     }
     if(event.target.id==='local-load-mode'){
       const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);
+      const defaults=localYdbLoadDefaults[config.load.parameter]||localYdbLoadDefaults.threads;
       if(mode==='points'){
-        config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[1000]}
+        config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[...defaults.values]}
       }else{
-        const search=config.load.search||{start:1000,maximum:100000,multiplier:2,resolution_percent:2};
+        const search=config.load.search||{start:defaults.start,maximum:defaults.maximum,multiplier:2,resolution_percent:2};
         const old=config.load.objective||{};
         const objective={
           type:mode,target_role:old.target_role||'dynamic',plateau_gain_percent:old.plateau_gain_percent??2,
@@ -1153,8 +1163,9 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '    .sort((left,right)=>left-right);\n'
     "  if(!xValues.length){container.innerHTML='<div class=empty>No compatible local YDB search summaries are available.</div>';return}\n"
     "  const percentile=baseline.parameters?.load?.objective?.percentile||'p99';\n"
+    "  const throughputUnit=localYdbThroughputUnit(baseline.parameters?.workload?.type);\n"
     '  const specifications=[\n'
-    "    ['throughput','median_throughput','Achieved throughput'],\n"
+    "    ['throughput','median_throughput','Achieved throughput ('+throughputUnit+')'],\n"
     "    ['latency_ms','median_'+percentile+'_ms',percentile+' latency (ms)'],\n"
     "    ['static_cpu','median_static_cpu_mean','Static node CPU (%)'],\n"
     "    ['dynamic_cpu','median_dynamic_cpu_mean','Dynamic node CPU (%)'],\n"
@@ -1192,6 +1203,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '  const baselineSemantic=JSON.stringify(localComparisonSemantic(baseline));\n'
     '  const rows=entries.map(item=>{\n'
     '    const metricView=localResultMetrics(item.result),metrics=metricView.metrics,config=localComparisonConfig(item);\n'
+    '    const throughputUnit=localYdbThroughputUnit(item.parameters?.workload?.type);\n'
     '    const context=localComparisonContext(item),build=localComparisonBuild(item);\n'
     '    const semanticCompatible=JSON.stringify(localComparisonSemantic(item))===baselineSemantic;\n'
     '    const sameMetricSource=metricView.source===baselineView.source,compatible=semanticCompatible&&sameMetricSource;\n'
@@ -1219,7 +1231,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "      '</td><td><code>'+\n"
     "      esc(String(item.binaries?.ydbd?.sha256??'—').slice(0,12))+'</code></td><td>'+\n"
     "      esc(metricLabel(item.result?.selected_load??'—'))+'</td>'+\n"
-    "      '<td>'+esc(metricLabel(metrics.throughput??'—'))+' '+localComparisonDelta(metrics.throughput,baselineMetrics.throughput,false,compatible)+'</td>'+\n"
+    "      '<td>'+esc(metricLabel(metrics.throughput??'—'))+' '+esc(throughputUnit)+' '+localComparisonDelta(metrics.throughput,baselineMetrics.throughput,false,compatible)+'</td>'+\n"
     "      '<td>'+esc(metricLabel(metrics[latencyMetric]??'—'))+' ms '+localComparisonDelta(metrics[latencyMetric],baselineMetrics[latencyMetric],true,compatible)+'</td>'+\n"
     "      '<td>'+esc(metrics.errors??'—')+' '+localComparisonDelta(metrics.errors,baselineMetrics.errors,true,compatible)+'</td>'+\n"
     "      '<td>'+esc(metricLabel(metrics.static_cpu_mean??'—'))+'%</td><td>'+esc(metricLabel(metrics.dynamic_cpu_mean??'—'))+'%</td>'+\n"
@@ -1391,6 +1403,9 @@ function localSearchAxisLabel(parameter,workload){
   if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';
   return parameter||'Search value'
 }
+function localYdbThroughputUnit(workload){
+  return {kv:'requests/s',stock:'transactions/s',log:'batches/s'}[workload]||'operations/s'
+}
 function localAttemptRows(attempts,xField='attempt'){return new Map(attempts.map(item=>[String(item[xField]),item]))}
 function localChart(title,metric,xName,xValues,series){
   return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+
@@ -1442,6 +1457,7 @@ function renderLocalYdbProfile(container,data){
   const progress=data.progress||{},attempts=data.attempts||[],searches=data.searches||[];
   const result=data.result||null,parameters=data.parameters||{},loadConfig=parameters.load||{};
   const objective=loadConfig.objective||{type:'points'};
+  const throughputUnit=localYdbThroughputUnit(parameters.workload?.type);
   const phaseElapsed=localElapsed(progress.phase_started_at);
   const phaseDuration=Number(progress.phase_duration_seconds);
   const profileElapsed=localElapsed(data.started_at,data.finished_at);
@@ -1483,7 +1499,7 @@ function renderLocalYdbProfile(container,data){
     html+=localVerificationSummary(data);
     html+='<div class=local-kpis>'+localKpi(
       localOutcomeLabel(result.outcome),selectedLabel,result.parameter||loadConfig.parameter,true
-    )+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),'transactions/s')+
+    )+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),throughputUnit)+
       localKpi(
         loadConfig.objective?.percentile||'p99',metricLabel(selected[latencyMetric]??'—'),'ms'
       )+localKpi('Dynamic nodes',result.dynamic_nodes,result.stop_reason||'')+'</div>'
@@ -1491,7 +1507,7 @@ function renderLocalYdbProfile(container,data){
     html+='<div class=local-kpis>'+localKpi(
       'Completed attempts',attempts.length,'search stage '+(progress.search_stage||1),true
     )+localKpi(
-      'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—','transactions/s'
+      'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—',throughputUnit
     )+localKpi(
       'Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms'
     )+'</div>'
@@ -1596,13 +1612,16 @@ function renderLocalYdbProfile(container,data){
         objective.type==='maximize-throughput'?'Ternary search progress':'Load search progress',
         'load',xName,xValues,candidateSeries
       ):'')+
-      localChart('Offered and achieved throughput','throughput',xName,xValues,throughputSeries)+
+      localChart(
+        (loadConfig.parameter==='rate'?'Offered and achieved':'Achieved')+' throughput ('+throughputUnit+')',
+        'throughput',xName,xValues,throughputSeries
+      )+
       localChart('Latency','latency_ms',xName,xValues,latencySeries)+
       localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+
       localChart('Errors and retries','errors',xName,xValues,errorSeries)+'</div>';
     html+='<h3>Attempts</h3><div class=local-attempts-scroll tabindex=0 role=region aria-label="Search attempts">'+
       '<table class=local-attempts><thead><tr><th>#</th><th>Stage</th><th>Dynamic</th><th>Candidate</th>'+
-      '<th>Throughput</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th>'+
+      '<th>Throughput ('+esc(throughputUnit)+')</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th>'+
       '<th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+
       attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+
         esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import socket
 import stat
+import subprocess
 import tempfile
 import textwrap
 import threading
@@ -404,10 +405,14 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
 
         catalog = local_ydb_workloads.web_workload_catalog()
-        self.assertEqual([item["type"] for item in catalog], ["kv", "stock"])
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log"])
         self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
         self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
         self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
+        self.assertEqual(catalog[2]["default_operation"], "bulk-upsert")
+        self.assertEqual(catalog[2]["operations"], ["insert", "upsert", "bulk-upsert"])
+        self.assertEqual(catalog[2]["load_parameters"], ["threads"])
+        self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         catalog_parameters = tuple(
             dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
         )
@@ -418,6 +423,12 @@ class YdbBenchTest(unittest.TestCase):
             next(option for option in catalog[0]["options"] if option["name"] == "init-upserts")["operation_defaults"],
             {"upsert": 0},
         )
+        operation_enum = workload_schema["properties"]["operation"]["enum"]
+        expected_operations = list(
+            dict.fromkeys(operation for definition in catalog for operation in definition["operations"])
+        )
+        self.assertEqual(operation_enum, expected_operations)
+        self.assertEqual(len(operation_enum), len(set(operation_enum)))
         json.dumps(catalog, allow_nan=False)
 
     def test_local_ydb_workload_registry_preserves_defaults_and_validation(self):
@@ -438,7 +449,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(stock["options"]["orders"], 100)
 
         invalid = (
-            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log"),
             ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
             (
                 {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
@@ -1488,6 +1499,140 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload["operation"], "put-rand-order")
         self.assertEqual(workload["options"]["products"], 10)
 
+    def test_local_ydb_log_profile_defaults_validation_and_web_contract(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              log-smoke:
+                workload: {type: log, operation: bulk-upsert}
+                load: {parameter: threads, values: [1, 2, 4]}
+        """))
+        profile = loaded.runs[0].parameters["local_ydb"]
+        self.assertEqual(
+            profile["workload"]["options"],
+            {
+                "min-partitions": 40,
+                "max-partitions": 1000,
+                "partition-size-mb": 2000,
+                "auto-partition": 1,
+                "store": "row",
+                "ttl-minutes": 0,
+                "string-length": 8,
+                "integer-columns": 0,
+                "string-columns": 0,
+                "key-columns": 0,
+                "rows-per-operation": 1,
+                "null-percent": 10,
+            },
+        )
+        definition = local_ydb_workloads.workload_definition("log")
+        self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "separate"))
+        self.assertEqual(profile["load"]["values"], [1, 2, 4])
+
+        model = web.editor_model(loaded, self.root / "results")
+        editor_profile = model["profiles"][0]["local_ydb"]
+        self.assertEqual(editor_profile["workload"]["type"], "log")
+        self.assertEqual(editor_profile["load"]["parameter"], "threads")
+        self.assertIn(
+            "threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}",
+            web._JS,
+        )
+        self.assertIn("localYdbLoadForWorkload(config.load,parameters)", web._JS)
+        self.assertIn("log:'batches/s'", web._JS)
+        transactions = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "transactions")
+        throughput = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "throughput")
+        self.assertEqual(transactions.unit, "operations")
+        self.assertEqual(throughput.unit, "operations/s")
+
+        invalid = (
+            ({"max-partitions": 3, "min-partitions": 4}, "max-partitions.*must not be below"),
+            (
+                {"integer-columns": 1, "string-columns": 1, "key-columns": 3},
+                "key-columns.*must not exceed",
+            ),
+            ({"null-percent": 101}, "null-percent.*must not exceed 100"),
+            ({"rows-per-operation": 0}, "rows-per-operation.*positive integer"),
+            ({"string-length": 0}, "string-length.*positive integer"),
+            ({"store": "external"}, "store.*must be one of row, column"),
+        )
+        for options, message in invalid:
+            with self.subTest(options=options), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.normalize_workload(
+                    {"type": "log", "operation": "bulk-upsert", "options": options},
+                    "workload",
+                )
+
+        invalid_load = self._config("""
+            local-ydb:
+              invalid:
+                workload: {type: log, operation: insert}
+                load: {parameter: rate, values: [1000]}
+        """)
+        with self.assertRaisesRegex(BenchmarkError, "load.parameter.*must be one of threads"):
+            load_config(invalid_load)
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for the web Builder behavior test")
+    def test_local_ydb_web_builder_resets_only_incompatible_load_parameters(self):
+        start = web._JS.index("const localYdbLoadDefaults=")
+        finish = web._JS.index("function defaultLocalYdbWorkload", start)
+        unit_start = web._JS.index("function localYdbThroughputUnit")
+        unit_finish = web._JS.index("function localAttemptRows", unit_start)
+        script = web._JS[start:finish] + web._JS[unit_start:unit_finish] + """
+            const points=localYdbResetLoadParameter(
+              {parameter:'rate',allow_errors:false,values:[1000]},'threads'
+            );
+            const automatic=localYdbResetLoadParameter({
+              parameter:'rate',allow_errors:true,
+              search:{start:777,maximum:9999,multiplier:3,resolution_percent:7},
+              objective:{type:'latency-slo',percentile:'p99',max_ms:10}
+            },'threads');
+            const custom={
+              parameter:'threads',allow_errors:false,
+              search:{start:7,maximum:91,multiplier:4,resolution_percent:9},
+              objective:{type:'maximize-throughput',target_role:'dynamic'}
+            };
+            const compatible=localYdbLoadForWorkload(custom,['rate','threads']);
+            process.stdout.write(JSON.stringify({
+              points,automatic,compatible,same_reference:compatible===custom,
+              units:['kv','stock','log','future'].map(localYdbThroughputUnit)
+            }));
+        """
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertEqual(
+            result["points"],
+            {
+                "parameter": "threads",
+                "allow_errors": False,
+                "values": [1, 2, 4, 8, 16, 32, 64],
+            },
+        )
+        self.assertEqual(
+            result["automatic"],
+            {
+                "parameter": "threads",
+                "allow_errors": True,
+                "search": {"start": 1, "maximum": 256, "multiplier": 3, "resolution_percent": 7},
+                "objective": {"type": "latency-slo", "percentile": "p99", "max_ms": 10},
+            },
+        )
+        self.assertTrue(result["same_reference"])
+        self.assertEqual(
+            result["compatible"],
+            {
+                "parameter": "threads",
+                "allow_errors": False,
+                "search": {"start": 7, "maximum": 91, "multiplier": 4, "resolution_percent": 9},
+                "objective": {"type": "maximize-throughput", "target_role": "dynamic"},
+            },
+        )
+        self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
+
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
         cli_context = local_ydb_workloads.WorkloadCli(
             Path("ydb"),
@@ -1543,6 +1688,214 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(add_command[add_command.index("run") + 1], "add-rand-order")
         self.assertEqual(put_command[put_command.index("run") + 1], "put-rand-order")
         self.assertEqual(add_command[add_command.index("--threads") + 1], 8)
+
+    def test_local_ydb_log_commands_are_golden_and_use_threads_as_load(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "log",
+                "operation": "bulk-upsert",
+                "options": {
+                    "min-partitions": 1,
+                    "max-partitions": 4,
+                    "partition-size-mb": 512,
+                    "auto-partition": 0,
+                    "store": "column",
+                    "ttl-minutes": 0,
+                    "string-length": 16,
+                    "integer-columns": 1,
+                    "string-columns": 2,
+                    "key-columns": 3,
+                    "rows-per-operation": 50,
+                    "null-percent": 0,
+                },
+            },
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "log",
+            "--path",
+            "log-table",
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_init_argv(cli_context, "log-table", workload),
+            base
+            + [
+                "init",
+                "--min-partitions",
+                1,
+                "--max-partitions",
+                4,
+                "--partition-size",
+                512,
+                "--auto-partition",
+                0,
+                "--len",
+                16,
+                "--int-cols",
+                1,
+                "--str-cols",
+                2,
+                "--key-cols",
+                3,
+                "--ttl",
+                0,
+                "--store",
+                "column",
+                "--null-percent",
+                0,
+            ],
+        )
+        expected_run = base + [
+            "run",
+            "bulk-upsert",
+            "--seconds",
+            30,
+            "--threads",
+            32,
+            "--quiet",
+            "--rows",
+            50,
+            "--len",
+            16,
+            "--int-cols",
+            1,
+            "--str-cols",
+            2,
+            "--key-cols",
+            3,
+            "--null-percent",
+            0,
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_run_argv(cli_context, "log-table", workload, "threads", 32, 30, 64),
+            expected_run,
+        )
+        self.assertNotIn("--rate", expected_run)
+        self.assertEqual(expected_run[expected_run.index("--rows") + 1], 50)
+        self.assertEqual(expected_run[expected_run.index("--threads") + 1], 32)
+        for operation in ("insert", "upsert", "bulk-upsert"):
+            with self.subTest(operation=operation):
+                command = local_ydb_workloads.build_run_argv(
+                    cli_context,
+                    "log-table",
+                    {**workload, "operation": operation},
+                    "threads",
+                    2,
+                    1,
+                    64,
+                )
+                self.assertEqual(command[command.index("run") + 1], operation)
+                self.assertNotIn("bulk_upsert", command)
+        self.assertEqual(
+            local_ydb_workloads.build_clean_argv(cli_context, "log-table", "log"),
+            base + ["clean"],
+        )
+        with self.assertRaisesRegex(BenchmarkError, "log does not support load parameter rate"):
+            local_ydb_workloads.build_run_argv(cli_context, "log-table", workload, "rate", 1000, 30, 64)
+
+    def test_local_ydb_log_uses_sample_lifecycle_and_preserves_rows_per_operation(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "log",
+                "operation": "bulk-upsert",
+                "options": {"rows-per-operation": 25},
+            },
+            "workload",
+        )
+        metrics_output = """
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            10 10 0 0 1 2 3 4
+        """
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        progress = []
+        with mock.patch.object(local_ydb, "LinuxCpuMonitor", return_value=monitor), mock.patch.object(
+            local_ydb, "atomic_write_text"
+        ), mock.patch.object(local_ydb, "atomic_write_json"), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command, metrics_output),
+        ):
+            lifecycle = local_ydb.WorkloadLifecycle(
+                cluster,
+                local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+                workload,
+                {"parameter": "threads"},
+                {"warmup": 1, "duration": 1},
+                64,
+                LOCAL_YDB_BENCHMARK,
+                topology,
+                {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+                None,
+                lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            )
+            lifecycle.open_profile(self.root / "log-profile", "ignored-profile-table")
+            _metrics, commands = lifecycle.run_sample(
+                2,
+                1,
+                1,
+                1,
+                self.root / "log-lifecycle",
+                "log-table",
+                {"attempt": 1},
+            )
+            lifecycle.close_profile()
+
+        self.assertEqual(
+            [command["phase"] for command in commands],
+            ["initializing-workload", "warming-up", "measuring", "cleaning-workload"],
+        )
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            ["initializing-workload", "warming-up", "measuring", "cleaning-workload"],
+        )
+        init, warmup, measure, clean = (command["argv"] for command in commands)
+        self.assertIn("init", init)
+        self.assertIn("clean", clean)
+        self.assertEqual(init[init.index("--path") + 1], clean[clean.index("--path") + 1])
+        for command in (warmup, measure):
+            self.assertEqual(command[command.index("run") + 1], "bulk-upsert")
+            self.assertEqual(command[command.index("--threads") + 1], "2")
+            self.assertEqual(command[command.index("--rows") + 1], "25")
+            self.assertNotIn("--rate", command)
 
     def test_local_ydb_command_record_preserves_argv_and_affinity(self):
         result = runner.CommandResult(
@@ -5275,9 +5628,10 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"Failed workload requests are allowed", script)
                 self.assertIn(b"editor.model?.local_ydb_workloads", script)
                 self.assertIn(b"definition.load_parameters", script)
-                self.assertIn(
-                    b"if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0]", script
-                )
+                self.assertIn(b"config.load=localYdbLoadForWorkload(config.load,parameters)", script)
+                self.assertIn(b"log:'batches/s'", script)
+                self.assertIn(b"<th>Throughput</th>", script)
+                self.assertIn(b"esc(throughputUnit)+' '+localComparisonDelta", script)
                 self.assertIn(b"if(option.choices.length)return localSelect", script)
                 self.assertIn(b"if(option.kind==='boolean')return localCheck", script)
                 self.assertIn(b"if(option.kind==='integer')", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added the YDB CLI log workload to local YDB benchmarks.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51544.

Adds typed log workload configuration for insert, upsert, and bulk-upsert operations, safe thread-search defaults in the web builder, workload-aware throughput units, and a runnable YAML example.