### PR TITLE
YDB Bench: Reject empty local YDB samples

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -158,10 +158,15 @@ For example:
 Set `load.allow-errors: true` when request-level errors reported by
 `ydb workload` are an expected part of the experiment. Such points remain
 eligible for selection and the error counts stay in CSV, manifests, tables,
-and charts. The flag does not hide or tolerate a failed CLI process, timeout,
-malformed output, cluster failure, or workload setup/cleanup failure. For a
-latency SLO, it disables the `max-errors` rejection while keeping the latency
-and achieved-rate checks active.
+and charts, provided every repetition completed at least one successful
+operation. A repetition with zero successful operations makes the whole point
+ineligible, even when errors are allowed. It remains in the raw repetition and
+attempt diagnostics, but is omitted from summary comparison rows and its
+latency is not plotted as a zero. The flag does not hide or tolerate a failed
+CLI process, timeout, malformed output, cluster failure, or workload
+setup/cleanup failure. For a latency SLO, it disables the `max-errors`
+rejection while keeping the successful-operation, latency, and achieved-rate
+checks active.
 
 The previous flat `mode`, `start`, and `slo` fields remain accepted for config
 compatibility, but newly generated YAML uses `search` and `objective`.

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -72,6 +72,8 @@ def parse_cli_metrics(stdout):
                     math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
                 ):
                     raise ValueError("non-finite workload metric")
+                if any(value < 0 for value in result.values()):
+                    raise ValueError("negative workload metric")
                 return result
             except ValueError:
                 break
@@ -106,6 +108,8 @@ def summarize_metrics(repetition_rows, benchmark):
     result = []
     for key in sorted(grouped):
         rows = grouped[key]
+        if any(row["transactions"] == 0 for row in rows):
+            continue
         record = {"affinity_mode": "roles"}
         record.update({item.name: value for item, value in zip(benchmark.dimensions, key)})
         record["samples"] = len(rows)

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -32,8 +32,22 @@ def _with_decision(metrics, load, passed, reason):
     return {**metrics, "load": load, "passed": bool(passed), "decision": reason}
 
 
+def _invalid_measurement_reason(metrics):
+    empty_repetitions = metrics.get("empty_repetitions")
+    if empty_repetitions:
+        noun = "repetition" if empty_repetitions == 1 else "repetitions"
+        return "invalid measurement: {} {} completed with zero successful operations".format(empty_repetitions, noun)
+    if metrics.get("transactions") == 0:
+        return "invalid measurement: workload completed with zero successful operations"
+    return None
+
+
 def evaluate_load(config, load, metrics):
     """Return whether one measured load is feasible and explain the decision."""
+    invalid_reason = _invalid_measurement_reason(metrics)
+    if invalid_reason is not None:
+        return False, invalid_reason
+
     if "values" in config:
         errors = metrics["errors"]
         passed = config.get("allow_errors", False) or not errors
@@ -183,7 +197,7 @@ def _run_throughput(config, measure, on_attempt):
         return LoadSearchResult(
             tuple(attempts),
             None,
-            "workload errors at minimum load {}".format(start),
+            "minimum load {} is infeasible: {}".format(start, first["decision"]),
             "no-feasible-point",
             failing_load=start,
         )
@@ -244,8 +258,16 @@ def _run_throughput(config, measure, on_attempt):
             objective["target_role"]
         )
     elif failing_load is not None:
-        outcome = "bounded-by-errors"
-        stop_reason = "workload errors bounded the ternary search below {}".format(failing_load)
+        failing_attempt = measured[failing_load]
+        invalid_reason = _invalid_measurement_reason(failing_attempt)
+        if invalid_reason is not None:
+            outcome = "bounded-by-invalid-sample"
+            stop_reason = "invalid measurement bounded the ternary search below {}: {}".format(
+                failing_load, invalid_reason
+            )
+        else:
+            outcome = "bounded-by-errors"
+            stop_reason = "workload errors bounded the ternary search below {}".format(failing_load)
     elif selected == maximum and measured.get(maximum, {}).get("passed"):
         outcome = "lower-bound"
         stop_reason = "maximum configured load {} remains the best observed point".format(maximum)
@@ -301,7 +323,7 @@ def _run_latency(config, measure, on_attempt):
         return LoadSearchResult(
             tuple(attempts),
             None,
-            "minimum load {} does not satisfy latency SLO".format(first_fail),
+            "minimum load {} is infeasible: {}".format(first_fail, measured[first_fail]["decision"]),
             "no-feasible-point",
             failing_load=first_fail,
         )
@@ -320,12 +342,18 @@ def _run_latency(config, measure, on_attempt):
             high = candidate
 
     selected = low or None
-    reason = "latency SLO bracketed between {} and {}".format(low, high)
+    invalid_reason = _invalid_measurement_reason(measured[high])
+    if invalid_reason is not None:
+        outcome = "bounded-by-invalid-sample"
+        reason = "invalid measurement bounded the latency search above {}: {}".format(low, invalid_reason)
+    else:
+        outcome = "boundary-found"
+        reason = "latency SLO bracketed between {} and {}".format(low, high)
     return LoadSearchResult(
         tuple(attempts),
         selected,
         reason,
-        "boundary-found" if selected is not None else "no-feasible-point",
+        outcome if selected is not None else "no-feasible-point",
         passing_load=selected,
         failing_load=high,
     )

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -719,6 +719,8 @@ def _aggregate_measurements(rows):
     # counts describe the whole attempted point; performance metrics remain
     # medians so that an outlier repetition does not select the load.
     result["errors"] = sum(row["errors"] for row in rows)
+    if all("transactions" in row for row in rows):
+        result["empty_repetitions"] = sum(row["transactions"] == 0 for row in rows)
     return result
 
 

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1115,7 +1115,11 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     'function localResultMetrics(result){\n'
     "  const verified=Boolean(result?.metrics_source==='verification'&&result?.verified_metrics&&\n"
     "    typeof result.verified_metrics==='object');\n"
-    "  return {metrics:(verified?result.verified_metrics:result?.selected_metrics)||{},verified,source:verified?'Holdout':'Search'}\n"
+    "  const raw=(verified?result.verified_metrics:result?.selected_metrics)||{};\n"
+    '  const metrics=Number(raw.empty_repetitions)>0?{\n'
+    '    ...raw,p50_ms:null,p95_ms:null,p99_ms:null,pmax_ms:null\n'
+    '  }:raw;\n'
+    "  return {metrics,verified,source:verified?'Holdout':'Search'}\n"
     '}\n'
     'function localVerificationCount(result,parameters={},verification={}){\n'
     '  return result?.verification_repetitions??verification?.configured_repetitions??verification?.completed_repetitions??\n'
@@ -1395,6 +1399,7 @@ function localOutcomeLabel(outcome){
     'boundary-found':'SLO boundary found','plateau-found':'Throughput plateau found',
     'lower-bound':'Capacity lower bound','best-observed':'Best observed point',
     'no-feasible-point':'No feasible point','bounded-by-errors':'Bounded by workload errors',
+    'bounded-by-invalid-sample':'Bounded by invalid measurement',
     'search-limit-reached':'Search limit reached'
   })[outcome]||outcome||'Search in progress'
 }
@@ -1406,7 +1411,14 @@ function localSearchAxisLabel(parameter,workload){
 function localYdbThroughputUnit(workload){
   return {kv:'requests/s',stock:'transactions/s',log:'batches/s'}[workload]||'operations/s'
 }
-function localAttemptRows(attempts,xField='attempt'){return new Map(attempts.map(item=>[String(item[xField]),item]))}
+function localAttemptLatency(item,metric='p99_ms'){
+  return Number(item.empty_repetitions)>0?'—':item[metric]
+}
+function localAttemptRows(attempts,xField='attempt'){
+  return new Map(attempts.map(item=>[String(item[xField]),Number(item.empty_repetitions)>0?{
+    ...item,p50_ms:null,p95_ms:null,p99_ms:null,pmax_ms:null
+  }:item]))
+}
 function localChart(title,metric,xName,xValues,series){
   return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+
     svgChart(metric,xName,xValues,series,chartColors)+'</section>'
@@ -1509,7 +1521,7 @@ function renderLocalYdbProfile(container,data){
     )+localKpi(
       'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—',throughputUnit
     )+localKpi(
-      'Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms'
+      'Latest p99',attempts.length?metricLabel(localAttemptLatency(attempts.at(-1))):'—','ms'
     )+'</div>'
   }
   const currentStage=Number(progress.search_stage||0);
@@ -1625,7 +1637,7 @@ function renderLocalYdbProfile(container,data){
       '<th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+
       attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+
         esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+
-        '</td><td>'+esc(metricLabel(item.p99_ms))+' ms</td><td>'+esc(item.errors)+'</td><td>'+
+        '</td><td>'+esc(metricLabel(localAttemptLatency(item)))+' ms</td><td>'+esc(item.errors)+'</td><td>'+
         esc(metricLabel(item.static_cpu_mean))+'%</td><td>'+esc(metricLabel(item.dynamic_cpu_mean))+
         '%</td><td>'+esc(metricLabel(item.cli_cpu_mean))+'%</td><td class="'+
         (item.passed?'attempt-pass':'attempt-fail')+'">'+(item.passed?'PASS':'FAIL')+'</td><td>'+esc(item.decision)+
@@ -3260,14 +3272,14 @@ class RunService:
                     metrics = result.get("selected_metrics")
                     if isinstance(metrics, dict):
                         metric_names = {metric.name for metric in BENCHMARKS["local-ydb"].metrics}
-                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated"))
+                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated", "empty_repetitions"))
                         compact_result["selected_metrics"] = {
                             name: metrics[name] for name in metric_names if name in metrics
                         }
                     verified_metrics = result.get("verified_metrics")
                     if isinstance(verified_metrics, dict):
                         metric_names = {metric.name for metric in BENCHMARKS["local-ydb"].metrics}
-                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated"))
+                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated", "empty_repetitions"))
                         compact_result["verified_metrics"] = {
                             name: verified_metrics[name] for name in metric_names if name in verified_metrics
                         }

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -142,8 +142,9 @@ class YdbBenchTest(unittest.TestCase):
                 raise value
             return """
                 Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
-                1 {throughput} {throughput} 0 {errors} 1 2 {p99_ms} 4
+                {transactions} {throughput} 0 {errors} 1 2 {p99_ms} 4
             """.format(
+                transactions=value.get("transactions", 1),
                 throughput=value.get("throughput", 10),
                 errors=value.get("errors", 0),
                 p99_ms=value.get("p99_ms", 3),
@@ -1277,6 +1278,11 @@ class YdbBenchTest(unittest.TestCase):
                 20 nan 0 0 1 2 3 4
             """)
 
+    def test_local_ydb_cli_total_row_rejects_negative_counters(self):
+        for values in ("-1 10 0 0 1 2 3 4", "1 10 -1 0 1 2 3 4", "1 10 0 -1 1 2 3 4"):
+            with self.subTest(values=values), self.assertRaisesRegex(BenchmarkError, "valid Total row"):
+                parse_cli_metrics("Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)\n" + values)
+
     def test_local_ydb_profile_parses_geometry_load_and_role_affinity(self):
         loaded = load_config(self._config("""
                 local-ydb:
@@ -1632,6 +1638,42 @@ class YdbBenchTest(unittest.TestCase):
             },
         )
         self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
+    def test_local_ydb_web_hides_latency_for_empty_measurements(self):
+        result_start = web._JS.index("function localResultMetrics")
+        result_finish = web._JS.index("function localVerificationCount", result_start)
+        attempt_start = web._JS.index("function localAttemptLatency")
+        attempt_finish = web._JS.index("function localChart", attempt_start)
+        script = web._JS[result_start:result_finish] + web._JS[attempt_start:attempt_finish] + """
+            const empty={attempt:1,empty_repetitions:1,throughput:123,errors:7,p99_ms:0};
+            const valid={attempt:2,empty_repetitions:0,throughput:100,errors:1,p99_ms:9};
+            const rows=localAttemptRows([empty,valid]);
+            const holdout=localResultMetrics({
+              metrics_source:'verification',
+              verified_metrics:{empty_repetitions:1,throughput:123,errors:7,p99_ms:0}
+            });
+            process.stdout.write(JSON.stringify({
+              empty_label:localAttemptLatency(empty),valid_label:localAttemptLatency(valid),
+              empty_chart:rows.get('1'),valid_chart:rows.get('2'),holdout
+            }));
+        """
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertEqual(result["empty_label"], "—")
+        self.assertEqual(result["valid_label"], 9)
+        self.assertIsNone(result["empty_chart"]["p99_ms"])
+        self.assertEqual(result["empty_chart"]["throughput"], 123)
+        self.assertEqual(result["empty_chart"]["errors"], 7)
+        self.assertEqual(result["valid_chart"]["p99_ms"], 9)
+        self.assertIsNone(result["holdout"]["metrics"]["p99_ms"])
+        self.assertEqual(result["holdout"]["metrics"]["throughput"], 123)
 
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
         cli_context = local_ydb_workloads.WorkloadCli(
@@ -2150,6 +2192,34 @@ class YdbBenchTest(unittest.TestCase):
         self.assertIn("exceeds", manifest["verification"]["decision"])
         self.assertNotIn("saturated_repetitions", manifest["verification"])
 
+    def test_local_ydb_verification_rejects_an_empty_repetition_when_errors_are_allowed(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              empty-holdout:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, allow-errors: true, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        manifest, _output, _events = self._run_mock_local_ydb(
+            configuration,
+            "verification-empty-repetition",
+            [
+                {"transactions": 10, "throughput": 10, "errors": 1},
+                {"transactions": 10, "throughput": 9, "errors": 1},
+                {"transactions": 0, "throughput": 0, "errors": 10},
+            ],
+        )
+        self.assertEqual(manifest["state"], "passed")
+        self.assertEqual(manifest["result"]["selected_load"], 1)
+        self.assertEqual(manifest["result"]["verified_metrics"]["empty_repetitions"], 1)
+        self.assertFalse(manifest["result"]["holdout_accepted"])
+        self.assertFalse(manifest["verification"]["accepted"])
+        self.assertIn("zero successful operations", manifest["verification"]["decision"])
+
     def test_local_ydb_verification_failure_preserves_search_and_partial_holdout(self):
         configuration = load_config(self._config("""
             local-ydb:
@@ -2521,6 +2591,122 @@ class YdbBenchTest(unittest.TestCase):
         self.assertFalse(passed)
         self.assertIn("exceeds", reason)
 
+    def test_load_controllers_reject_zero_success_measurements_before_objectives(self):
+        point_configs = (
+            {"parameter": "threads", "values": [1]},
+            {"parameter": "threads", "allow_errors": True, "values": [1]},
+        )
+        for config in point_configs:
+            with self.subTest(controller="points", allow_errors=config.get("allow_errors", False)):
+                result = load_control.search_load(
+                    config,
+                    lambda _load: {"transactions": 0, "throughput": 0, "errors": 10},
+                )
+                self.assertIsNone(result.selected_load)
+                self.assertFalse(result.attempts[0]["passed"])
+                self.assertIn("zero successful operations", result.attempts[0]["decision"])
+
+        throughput = load_control.search_load(
+            {
+                "parameter": "threads",
+                "allow_errors": True,
+                "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 2},
+                "objective": {
+                    "type": "maximize-throughput",
+                    "target_role": "dynamic",
+                    "cpu_saturation_percent": 90,
+                    "plateau_gain_percent": 1,
+                    "plateau_points": 2,
+                },
+            },
+            lambda load: {
+                "transactions": 0 if load >= 70 else 1,
+                "throughput": 100 - abs(load - 55),
+                "errors": 0,
+                "dynamic_cpu_mean": 50,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+        )
+        self.assertEqual(throughput.outcome, "bounded-by-invalid-sample")
+        self.assertIn("invalid measurement", throughput.stop_reason)
+
+        latency = load_control.search_load(
+            {
+                "parameter": "threads",
+                "allow_errors": True,
+                "search": {"start": 10, "maximum": 40, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "max_ms": 10,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            lambda load: {
+                "transactions": 0 if load >= 20 else 1,
+                "throughput": load,
+                "errors": 0,
+                "p99_ms": 1,
+            },
+        )
+        self.assertEqual(latency.selected_load, 19)
+        self.assertEqual(latency.outcome, "bounded-by-invalid-sample")
+        self.assertIn("invalid measurement", latency.stop_reason)
+
+        for allow_errors in (False, True):
+            with self.subTest(controller="maximize-throughput", allow_errors=allow_errors):
+                result = load_control.search_load(
+                    {
+                        "parameter": "threads",
+                        "allow_errors": allow_errors,
+                        "search": {"start": 1, "maximum": 2, "multiplier": 2, "resolution_percent": 5},
+                        "objective": {
+                            "type": "maximize-throughput",
+                            "target_role": "dynamic",
+                            "cpu_saturation_percent": 90,
+                            "plateau_gain_percent": 1,
+                            "plateau_points": 2,
+                        },
+                    },
+                    lambda _load: {
+                        "transactions": 0,
+                        "throughput": 0,
+                        "errors": 10,
+                        "dynamic_cpu_mean": 100,
+                        "static_cpu_mean": 10,
+                        "host_cpu_mean": 50,
+                    },
+                )
+                self.assertIsNone(result.selected_load)
+                self.assertFalse(result.attempts[0]["passed"])
+                self.assertIn("zero successful operations", result.attempts[0]["decision"])
+
+            with self.subTest(controller="latency-slo", allow_errors=allow_errors):
+                result = load_control.search_load(
+                    {
+                        "parameter": "threads",
+                        "allow_errors": allow_errors,
+                        "search": {"start": 1, "maximum": 2, "multiplier": 2, "resolution_percent": 5},
+                        "objective": {
+                            "type": "latency-slo",
+                            "percentile": "p99",
+                            "max_ms": 10,
+                            "max_errors": 0,
+                            "min_achieved_rate_ratio": 0.98,
+                        },
+                    },
+                    lambda _load: {"transactions": 0, "throughput": 0, "errors": 10, "p99_ms": 1},
+                )
+                self.assertIsNone(result.selected_load)
+                self.assertFalse(result.attempts[0]["passed"])
+                self.assertIn("zero successful operations", result.attempts[0]["decision"])
+
+    def test_evaluate_load_remains_compatible_without_success_metadata(self):
+        config = {"parameter": "threads", "allow_errors": True, "values": [1]}
+        self.assertTrue(load_control.evaluate_load(config, 1, {"throughput": 0, "errors": 1})[0])
+
     def test_linux_cpu_summary_weights_intervals_and_ignores_short_spikes_for_max(self):
         monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1}, interval=0.5)
         monitor._records = [
@@ -2579,6 +2765,53 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(metrics["throughput"], 20)
         self.assertEqual(metrics["errors"], 100)
+
+    def test_local_ydb_attempt_rejects_one_empty_repetition(self):
+        metrics = local_ydb._aggregate_measurements(
+            [
+                {"transactions": 10, "throughput": 10, "errors": 1},
+                {"transactions": 0, "throughput": 0, "errors": 10},
+                {"transactions": 20, "throughput": 20, "errors": 2},
+            ]
+        )
+        passed, reason = load_control.evaluate_load(
+            {"parameter": "threads", "allow_errors": True, "values": [1]},
+            1,
+            metrics,
+        )
+        self.assertEqual(metrics["empty_repetitions"], 1)
+        self.assertEqual(metrics["errors"], 13)
+        self.assertFalse(passed)
+        self.assertIn("1 repetition", reason)
+        self.assertIn("zero successful operations", reason)
+
+    def test_local_ydb_attempt_allows_partial_errors_when_every_repetition_succeeds(self):
+        metrics = local_ydb._aggregate_measurements(
+            [
+                {"transactions": 10, "throughput": 10, "errors": 1},
+                {"transactions": 20, "throughput": 20, "errors": 2},
+            ]
+        )
+        passed, reason = load_control.evaluate_load(
+            {"parameter": "threads", "allow_errors": True, "values": [1]},
+            1,
+            metrics,
+        )
+        self.assertEqual(metrics["empty_repetitions"], 0)
+        self.assertEqual(metrics["errors"], 3)
+        self.assertTrue(passed)
+        self.assertIn("errors allowed", reason)
+
+    def test_local_ydb_summary_omits_points_with_an_empty_repetition(self):
+        rows = [
+            {"load": 1, "dynamic_nodes": 1, "transactions": 10},
+            {"load": 1, "dynamic_nodes": 1, "transactions": 0},
+            {"load": 2, "dynamic_nodes": 1, "transactions": 20},
+        ]
+        for row in rows:
+            row.update({metric.name: row.get(metric.name, 1) for metric in LOCAL_YDB_BENCHMARK.metrics})
+        summary = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
+        self.assertEqual([(row["load"], row["dynamic_nodes"]) for row in summary], [(2, 1)])
 
     def test_local_ydb_scaling_uses_failing_boundary_and_minimum_attempt(self):
         attempts = (
@@ -5315,6 +5548,30 @@ class WebTest(unittest.TestCase):
                     service.local_ydb_comparison(["baseline"])
         finally:
             service.shutdown()
+
+    def test_local_ydb_comparison_projects_empty_holdout_repetitions(self):
+        run_root = self.root / "empty-holdout"
+        self._local_ydb_result(run_root, 1000, verified=True)
+        profile_path = run_root / "local-ydb" / "capacity" / "run.json"
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        profile["result"]["holdout_accepted"] = False
+        profile["result"]["verified_metrics"].update(
+            {"empty_repetitions": 1, "p99_ms": 0, "throughput": 0, "errors": 10}
+        )
+        profile["verification"].update(
+            {"accepted": False, "decision": "invalid measurement: zero successful operations"}
+        )
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+
+        service = RunService(self.root)
+        try:
+            comparison = service.local_ydb_comparison(["empty-holdout"])
+        finally:
+            service.shutdown()
+        result = comparison["entries"][0]["result"]
+        self.assertEqual(result["verified_metrics"]["empty_repetitions"], 1)
+        self.assertEqual(result["verified_metrics"]["p99_ms"], 0)
+        self.assertFalse(result["holdout_accepted"])
 
     def test_local_ydb_profile_projection_preserves_terminal_state_without_nested_manifest(self):
         run_root = self.root / "terminal-local-ydb-run"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reject local YDB measurements where any repetition completes without successful operations.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51545. Treat zero-success repetitions as infeasible independently of the error policy, preserve their validity metadata for diagnostics and verification, and avoid publishing misleading zero-latency points in summaries and UI charts.