### PR TITLE
YDB Bench: Add workload result adapters

### DIFF
--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -2,7 +2,6 @@
 
 import csv
 import io
-import math
 import statistics
 
 from ydb.tools.ydb_bench.benchmarks.registry import (
@@ -12,6 +11,7 @@ from ydb.tools.ydb_bench.benchmarks.registry import (
     MetricDefinition,
 )
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import parse_generic_total_metrics
 
 DIMENSIONS = (
     DimensionDefinition("load"),
@@ -41,43 +41,7 @@ METRICS = tuple(
 
 
 def parse_cli_metrics(stdout):
-    """Parse the stable Total table printed by generic ``ydb workload``."""
-    lines = [line.strip() for line in stdout.splitlines()]
-    for index, line in enumerate(lines):
-        columns = line.split()
-        if not columns or columns[0] != "Total":
-            continue
-        for values_line in lines[index + 1 :]:
-            values = values_line.split()
-            if not values:
-                continue
-            # Current CLI prints the total duration in the first column below
-            # the "Total" heading.  Older builds omitted that value.
-            if len(values) == 9:
-                values = values[1:]
-            if len(values) != 8:
-                break
-            try:
-                result = {
-                    "transactions": int(values[0]),
-                    "throughput": float(values[1]),
-                    "retries": int(values[2]),
-                    "errors": int(values[3]),
-                    "p50_ms": float(values[4]),
-                    "p95_ms": float(values[5]),
-                    "p99_ms": float(values[6]),
-                    "pmax_ms": float(values[7]),
-                }
-                if not all(
-                    math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
-                ):
-                    raise ValueError("non-finite workload metric")
-                if any(value < 0 for value in result.values()):
-                    raise ValueError("negative workload metric")
-                return result
-            except ValueError:
-                break
-    raise BenchmarkError("YDB CLI workload output does not contain a valid Total row")
+    return parse_generic_total_metrics(stdout)
 
 
 def parse_metrics(stdout, _benchmark):
@@ -96,11 +60,15 @@ def validate_metrics(rows, configuration, _case):
     if len(rows) != 1:
         raise BenchmarkError("local YDB workload must produce exactly one aggregate row")
     allow_errors = configuration.parameters["local_ydb"]["load"].get("allow_errors", False)
-    if rows[0]["errors"] and not allow_errors:
-        raise BenchmarkError("YDB CLI workload reported {} errors".format(rows[0]["errors"]))
+    errors = rows[0].get("errors", 0)
+    if errors and not allow_errors:
+        raise BenchmarkError("YDB CLI workload reported {} errors".format(errors))
 
 
-def summarize_metrics(repetition_rows, benchmark):
+def summarize_metrics(repetition_rows, benchmark, metric_names=None):
+    metric_names = (
+        tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
+    )
     grouped = {}
     for row in repetition_rows:
         key = tuple(row[item.name] for item in benchmark.dimensions)
@@ -108,24 +76,32 @@ def summarize_metrics(repetition_rows, benchmark):
     result = []
     for key in sorted(grouped):
         rows = grouped[key]
-        if any(row["transactions"] == 0 for row in rows):
+        expected_keys = set(rows[0])
+        if any(set(row) != expected_keys for row in rows[1:]):
+            raise BenchmarkError("workload repetitions returned inconsistent metric keys")
+        if "transactions" in expected_keys and any(row["transactions"] == 0 for row in rows):
             continue
         record = {"affinity_mode": "roles"}
         record.update({item.name: value for item, value in zip(benchmark.dimensions, key)})
         record["samples"] = len(rows)
-        for metric in benchmark.metrics:
-            values = [row[metric.name] for row in rows]
-            record["median_" + metric.name] = statistics.median(values)
-            record["min_" + metric.name] = min(values)
-            record["max_" + metric.name] = max(values)
+        for name in metric_names:
+            if name not in expected_keys:
+                continue
+            values = [row[name] for row in rows]
+            record["median_" + name] = statistics.median(values)
+            record["min_" + name] = min(values)
+            record["max_" + name] = max(values)
         result.append(record)
     return result
 
 
-def render_summary(rows, benchmark):
+def render_summary(rows, benchmark, metric_names=None):
+    metric_names = (
+        tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
+    )
     columns = ["affinity_mode"] + [item.name for item in benchmark.dimensions] + ["samples"]
-    for metric in benchmark.metrics:
-        columns += ["median_" + metric.name, "min_" + metric.name, "max_" + metric.name]
+    for name in metric_names:
+        columns += ["median_" + name, "min_" + name, "max_" + name]
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
     writer.writeheader()

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -13,7 +13,9 @@ from ydb.tools.ydb_bench.lib.actors_core import RunConfiguration
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
 from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     allowed_load_parameters,
+    allowed_slo_metrics,
     all_load_parameters,
+    all_slo_percentiles,
     normalize_workload,
     workload_config_schema,
 )
@@ -160,7 +162,7 @@ def _profile_schema(benchmark):
                             "type": "object",
                             "additionalProperties": False,
                             "properties": {
-                                "percentile": {"enum": ["p50", "p95", "p99", "pmax"]},
+                                "percentile": {"enum": list(all_slo_percentiles())},
                                 "max-ms": {"type": "number", "minimum": 0},
                                 "max-errors": {"type": "integer", "minimum": 0},
                                 "min-achieved-rate-ratio": {
@@ -199,7 +201,7 @@ def _profile_schema(benchmark):
                                     "exclusiveMinimum": 0,
                                     "maximum": 100,
                                 },
-                                "percentile": {"enum": ["p50", "p95", "p99", "pmax"]},
+                                "percentile": {"enum": list(all_slo_percentiles())},
                                 "max-ms": {"type": "number", "minimum": 0},
                                 "max-errors": {"type": "integer", "minimum": 0},
                                 "min-achieved-rate-ratio": {
@@ -721,13 +723,16 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         else:
             if "max-ms" not in objective:
                 _config_error(location + ".load.objective", "latency-slo requires max-ms")
+            slo_metrics = allowed_slo_metrics(workload["type"])
+            percentile = _choice(
+                objective.get("percentile", "p99"),
+                tuple(slo_metrics),
+                location + ".load.objective.percentile",
+            )
             parsed_objective.update(
                 {
-                    "percentile": _choice(
-                        objective.get("percentile", "p99"),
-                        ("p50", "p95", "p99", "pmax"),
-                        location + ".load.objective.percentile",
-                    ),
+                    "percentile": percentile,
+                    "latency_metric": slo_metrics[percentile],
                     "max_ms": _finite_number(objective["max-ms"], location + ".load.objective.max-ms", 0),
                     "max_errors": _nonnegative_integer(
                         objective.get("max-errors", 0), location + ".load.objective.max-errors"

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -48,8 +48,8 @@ def evaluate_load(config, load, metrics):
     if invalid_reason is not None:
         return False, invalid_reason
 
+    errors = metrics.get("errors", 0)
     if "values" in config:
-        errors = metrics["errors"]
         passed = config.get("allow_errors", False) or not errors
         if errors:
             reason = "{} workload errors {}".format(
@@ -63,7 +63,8 @@ def evaluate_load(config, load, metrics):
     objective = config["objective"]
     objective_type = objective["type"]
     if objective_type == "maximize-throughput":
-        errors = metrics["errors"]
+        if "errors" not in metrics:
+            return True, "workload does not report request errors"
         if errors and not config.get("allow_errors", False):
             return False, "workload reported errors"
         if errors:
@@ -71,13 +72,13 @@ def evaluate_load(config, load, metrics):
         return True, "workload completed without errors"
 
     if objective_type == "latency-slo":
-        latency = metrics[objective["percentile"] + "_ms"]
+        latency = metrics[objective.get("latency_metric", objective["percentile"] + "_ms")]
         if latency > objective["max_ms"]:
             return False, "{} latency {:.3f} ms exceeds {:.3f} ms".format(
                 objective["percentile"], latency, objective["max_ms"]
             )
-        if not config.get("allow_errors", False) and metrics["errors"] > objective["max_errors"]:
-            return False, "errors {} exceed {}".format(metrics["errors"], objective["max_errors"])
+        if not config.get("allow_errors", False) and errors > objective["max_errors"]:
+            return False, "errors {} exceed {}".format(errors, objective["max_errors"])
         if config["parameter"] == "rate":
             ratio = metrics["throughput"] / load
             if ratio < objective["min_achieved_rate_ratio"]:
@@ -85,8 +86,10 @@ def evaluate_load(config, load, metrics):
                     ratio, objective["min_achieved_rate_ratio"]
                 )
         reason = "latency SLO satisfied"
-        if metrics["errors"]:
-            reason += "; {} workload errors allowed".format(metrics["errors"])
+        if "errors" not in metrics:
+            reason += "; workload does not report request errors"
+        elif errors:
+            reason += "; {} workload errors allowed".format(errors)
         return True, reason
 
     raise BenchmarkError("unsupported load objective: {}".format(objective_type))
@@ -169,7 +172,7 @@ def _run_throughput(config, measure, on_attempt):
                 decision += "; throughput increased from zero baseline"
             elif gain is not None:
                 decision += "; throughput gain {:.3f}%".format(gain)
-            if metrics["errors"]:
+            if "errors" not in metrics or metrics.get("errors", 0):
                 decision += "; " + evaluation_reason
         search_interval = {}
         if search_low is not None:

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -29,11 +29,15 @@ from ydb.tools.ydb_bench.lib.common import (
 from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
 from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
 from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
+    GENERIC_TOTAL_RESULT,
     WorkloadCli,
+    WorkloadRunRequest,
     build_cleanup_plan,
     build_prepare_plan,
     build_run_plan,
+    parse_workload_result,
     workload_definition,
+    workload_result_schema,
 )
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
 from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
@@ -712,16 +716,43 @@ def _command_record(phase, repetition, command, cpu_affinity, result=None):
     return record
 
 
-def _aggregate_measurements(rows):
-    keys = rows[0]
-    result = {key: statistics.median(row[key] for row in rows) for key in keys}
-    # One clean repetition must not hide request failures in another one. Error
-    # counts describe the whole attempted point; performance metrics remain
-    # medians so that an outlier repetition does not select the load.
-    result["errors"] = sum(row["errors"] for row in rows)
-    if all("transactions" in row for row in rows):
+def _aggregate_measurements(rows, workload_metrics=None):
+    if not rows:
+        raise BenchmarkError("cannot aggregate an empty workload measurement")
+    keys = tuple(rows[0])
+    expected_keys = set(keys)
+    for row in rows[1:]:
+        if set(row) != expected_keys:
+            raise BenchmarkError("workload repetitions returned inconsistent metric keys")
+    if workload_metrics is None:
+        workload_metrics = GENERIC_TOTAL_RESULT.metrics
+    aggregations = {metric.name: metric.repetition_aggregation for metric in workload_metrics}
+    result = {}
+    for key in keys:
+        values = [row[key] for row in rows]
+        result[key] = sum(values) if aggregations.get(key) == "sum" else statistics.median(values)
+    if "transactions" in expected_keys:
         result["empty_repetitions"] = sum(row["transactions"] == 0 for row in rows)
     return result
+
+
+_EXECUTOR_METRIC_NAMES = (
+    "static_cpu_mean",
+    "static_cpu_max",
+    "dynamic_cpu_mean",
+    "dynamic_cpu_max",
+    "cli_cpu_mean",
+    "cli_cpu_max",
+    "host_cpu_mean",
+    "host_cpu_max",
+)
+
+
+def _workload_metric_columns(benchmark, workload_metrics):
+    del benchmark
+    names = [metric.name for metric in workload_metrics]
+    names.extend(name for name in _EXECUTOR_METRIC_NAMES if name not in names)
+    return names
 
 
 def _search_scaling_evidence(result, saturation_percent):
@@ -770,6 +801,16 @@ def _is_finite_number(value):
         return math.isfinite(value)
     except (TypeError, ValueError, OverflowError):
         return False
+
+
+def _validate_measurement_window(window):
+    if (
+        not isinstance(window, tuple)
+        or len(window) != 2
+        or not all(_is_finite_number(value) for value in window)
+        or window[0] >= window[1]
+    ):
+        raise BenchmarkError("workload command returned an invalid CPU measurement window")
 
 
 def _write_csv(path, rows, columns):
@@ -892,9 +933,12 @@ class WorkloadLifecycle:
             plans = build_prepare_plan(self.workload_cli, state.table_path, self.workload)
             for plan in plans:
                 phase = self._prepare_phase(state, plan.name)
+                progress_fields = dict(state.fields)
+                if plan.progress_duration_seconds is not None:
+                    progress_fields["phase_duration_seconds"] = plan.progress_duration_seconds
                 self.progress(
                     phase,
-                    **state.fields,
+                    **progress_fields,
                     current_command=_command_record(
                         phase,
                         state.repetition,
@@ -951,9 +995,12 @@ class WorkloadLifecycle:
         for plan in plans:
             phase = self._cleanup_phase(state, plan.name)
             try:
+                progress_fields = dict(state.fields)
+                if plan.progress_duration_seconds is not None:
+                    progress_fields["phase_duration_seconds"] = plan.progress_duration_seconds
                 self.progress(
                     phase,
-                    **state.fields,
+                    **progress_fields,
                     current_command=_command_record(
                         phase,
                         state.repetition,
@@ -1087,7 +1134,7 @@ class WorkloadLifecycle:
             self.progress(
                 phases["warmup"],
                 **state.fields,
-                phase_duration_seconds=warmup,
+                phase_duration_seconds=warmup_plan.progress_duration_seconds or warmup,
                 current_command=_command_record(
                     phases["warmup"],
                     repetition,
@@ -1140,8 +1187,8 @@ class WorkloadLifecycle:
             self.cluster.ensure_running("cannot start workload measurement")
             progress_fields = {
                 **state.fields,
-                "phase_duration_seconds": self.measurement["duration"]
-                + (warmup if self.definition.warmup_mode == "inline" else 0),
+                "phase_duration_seconds": plan.progress_duration_seconds
+                or self.measurement["duration"] + (warmup if self.definition.warmup_mode == "inline" else 0),
                 "current_command": _command_record(
                     phases["measure"],
                     repetition,
@@ -1183,17 +1230,39 @@ class WorkloadLifecycle:
                     "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
                 )
             )
-        if plan.measurement_window_builder is not None:
-            window = plan.measurement_window_builder(result.stdout)
-            if (
-                not isinstance(window, tuple)
-                or len(window) != 2
-                or not all(_is_finite_number(value) for value in window)
-                or window[0] >= window[1]
-            ):
-                raise BenchmarkError("workload command returned an invalid CPU measurement window")
+        legacy_window = (
+            plan.measurement_window_builder(result.stdout) if plan.measurement_window_builder is not None else None
+        )
+        if legacy_window is not None:
+            _validate_measurement_window(legacy_window)
+        request = WorkloadRunRequest(
+            load_parameter=self.load_config["parameter"],
+            load=load,
+            duration_seconds=self.measurement["duration"],
+            warmup_seconds=warmup if self.definition.warmup_mode == "inline" else 0,
+            client_threads=self.client_threads,
+            objective=self.load_config.get("objective"),
+        )
+        workload_result = parse_workload_result(self.workload["type"], result, self.workload, request)
+        if legacy_window is not None and workload_result.measurement_window is not None:
+            raise BenchmarkError("workload result and command plan both returned a CPU measurement window")
+        window = workload_result.measurement_window if workload_result.measurement_window is not None else legacy_window
+        if window is not None:
+            _validate_measurement_window(window)
             cpu = monitor.summary(started_at_unix=window[0], finished_at_unix=window[1])
-        metrics = {**self.benchmark.parse_metrics(result.stdout, self.benchmark)[0], **cpu}
+        elif self.definition.warmup_mode == "inline":
+            raise BenchmarkError("{} inline warmup requires a CPU measurement window".format(self.definition.name))
+        result_artifact = {
+            "schema_id": self.definition.result_adapter.schema_id,
+            "metrics": workload_result.metrics,
+        }
+        if workload_result.details is not None:
+            result_artifact["details"] = workload_result.details
+        atomic_write_json(state.directory / "workload-result.json", result_artifact)
+        collisions = sorted(set(workload_result.metrics).intersection(cpu))
+        if collisions:
+            raise BenchmarkError("workload result metrics collide with CPU metrics: {}".format(", ".join(collisions)))
+        metrics = {**workload_result.metrics, **cpu}
         metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
         return metrics
 
@@ -1268,6 +1337,9 @@ def run_local_ydb(
     output_directory.mkdir(parents=True, exist_ok=True)
     benchmark = configuration.benchmark
     profile = configuration.parameters["local_ydb"]
+    definition = workload_definition(profile["workload"]["type"])
+    workload_metrics = definition.result_adapter.metrics
+    metric_columns = _workload_metric_columns(benchmark, workload_metrics)
     topology = discover_topology()
     affinities = plan_role_affinity(profile["affinity"], topology)
     _validate_role_affinity(profile["geometry"], affinities)
@@ -1293,6 +1365,7 @@ def run_local_ydb(
         "platform": collect_system_info(),
         "cpu_topology": topology_record(topology),
         "parameters": profile,
+        "workload_result_schema": workload_result_schema(profile["workload"]["type"]),
         "timeout_seconds": configuration.timeout_seconds,
         "role_affinity": {role: None if mask is None else list(mask) for role, mask in affinities.items()},
         "attempts": [],
@@ -1426,7 +1499,7 @@ def run_local_ydb(
                     samples.append(metrics)
                     repetition_rows.append(metrics)
                     commands.extend(repetition_commands)
-                aggregated = _aggregate_measurements(samples)
+                aggregated = _aggregate_measurements(samples, workload_metrics)
                 aggregated.update(
                     {
                         "load": load,
@@ -1521,13 +1594,16 @@ def run_local_ydb(
             )
             cluster.add_dynamic_nodes(new_count - dynamic_nodes)
 
-        summary_rows = benchmark.summarize_metrics(repetition_rows, benchmark)
+        summary_rows = benchmark.summarize_metrics(repetition_rows, benchmark, metric_columns)
         _write_csv(
             output_directory / "repetitions.csv",
             repetition_rows,
-            [item.name for item in benchmark.dimensions] + ["repetition"] + [item.name for item in benchmark.metrics],
+            [item.name for item in benchmark.dimensions] + ["repetition"] + metric_columns,
         )
-        atomic_write_text(output_directory / "summary.csv", benchmark.render_summary(summary_rows, benchmark))
+        atomic_write_text(
+            output_directory / "summary.csv",
+            benchmark.render_summary(summary_rows, benchmark, metric_columns),
+        )
 
         verification_repetitions = profile["measurement"].get("verification_repetitions", 0)
         selected_load = manifest["result"]["selected_load"]
@@ -1587,14 +1663,12 @@ def run_local_ydb(
                     _write_csv(
                         output_directory / "verification-repetitions.csv",
                         verification_rows,
-                        [item.name for item in benchmark.dimensions]
-                        + ["repetition"]
-                        + [item.name for item in benchmark.metrics],
+                        [item.name for item in benchmark.dimensions] + ["repetition"] + metric_columns,
                     )
-                    partial_summary = benchmark.summarize_metrics(verification_rows, benchmark)
+                    partial_summary = benchmark.summarize_metrics(verification_rows, benchmark, metric_columns)
                     atomic_write_text(
                         output_directory / "verification-summary.csv",
-                        benchmark.render_summary(partial_summary, benchmark),
+                        benchmark.render_summary(partial_summary, benchmark, metric_columns),
                     )
                     verification.update(
                         {
@@ -1628,7 +1702,8 @@ def run_local_ydb(
                 [
                     {name: value for name, value in row.items() if name not in ("passed", "decision")}
                     for row in verification_rows
-                ]
+                ],
+                workload_metrics,
             )
             verified_metrics.pop("repetition", None)
             accepted, decision = evaluate_load(profile["load"], selected_load, verified_metrics)

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -21,6 +21,141 @@ class WorkloadCommandPlan:
     argv: tuple
     timeout_seconds: float | None = None
     measurement_window_builder: object = None
+    progress_duration_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class WorkloadMetric:
+    name: str
+    unit: str
+    repetition_aggregation: str = "median"
+    required: bool = False
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class WorkloadRunRequest:
+    load_parameter: str
+    load: int
+    duration_seconds: int
+    warmup_seconds: int
+    client_threads: int
+    objective: object
+
+
+@dataclass(frozen=True)
+class WorkloadResult:
+    metrics: dict
+    details: object = None
+    measurement_window: tuple | None = None
+
+
+@dataclass(frozen=True)
+class WorkloadResultAdapter:
+    schema_id: str
+    parse: object
+    metrics: tuple
+    slo_metrics: tuple = ()
+
+
+def parse_generic_total_metrics(stdout):
+    """Parse the stable Total table printed by generic ``ydb workload``."""
+
+    lines = [line.strip() for line in stdout.splitlines()]
+    for index, line in enumerate(lines):
+        columns = line.split()
+        if not columns or columns[0] != "Total":
+            continue
+        for values_line in lines[index + 1 :]:
+            values = values_line.split()
+            if not values:
+                continue
+            # Current CLI prints the total duration in the first column below
+            # the "Total" heading. Older builds omitted that value.
+            if len(values) == 9:
+                values = values[1:]
+            if len(values) != 8:
+                break
+            try:
+                result = {
+                    "transactions": int(values[0]),
+                    "throughput": float(values[1]),
+                    "retries": int(values[2]),
+                    "errors": int(values[3]),
+                    "p50_ms": float(values[4]),
+                    "p95_ms": float(values[5]),
+                    "p99_ms": float(values[6]),
+                    "pmax_ms": float(values[7]),
+                }
+                if not all(
+                    math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
+                ):
+                    raise ValueError("non-finite workload metric")
+                if any(value < 0 for value in result.values()):
+                    raise ValueError("negative workload metric")
+                return result
+            except ValueError:
+                break
+    raise BenchmarkError("YDB CLI workload output does not contain a valid Total row")
+
+
+def _parse_generic_total_result(command_result, normalized_workload, request):
+    del normalized_workload, request
+    return WorkloadResult(parse_generic_total_metrics(command_result.stdout))
+
+
+GENERIC_TOTAL_RESULT = WorkloadResultAdapter(
+    schema_id="generic-total-v1",
+    parse=_parse_generic_total_result,
+    metrics=tuple(
+        WorkloadMetric(name, unit, repetition_aggregation=aggregation, required=True)
+        for name, unit, aggregation in (
+            ("transactions", "operations", "median"),
+            ("throughput", "operations/s", "median"),
+            ("retries", "retries", "median"),
+            ("errors", "errors", "sum"),
+            ("p50_ms", "ms", "median"),
+            ("p95_ms", "ms", "median"),
+            ("p99_ms", "ms", "median"),
+            ("pmax_ms", "ms", "median"),
+        )
+    ),
+    slo_metrics=(
+        ("p50", "p50_ms"),
+        ("p95", "p95_ms"),
+        ("p99", "p99_ms"),
+        ("pmax", "pmax_ms"),
+    ),
+)
+
+_RESERVED_RESULT_METRIC_NAMES = frozenset(
+    (
+        "load",
+        "dynamic_nodes",
+        "repetition",
+        "empty_repetitions",
+        "attempt",
+        "search_stage",
+        "started_at",
+        "finished_at",
+        "duration_seconds",
+        "commands",
+        "passed",
+        "decision",
+        "search_low",
+        "search_high",
+        "throughput_gain_percent",
+        "target_cpu_saturated",
+        "static_cpu_mean",
+        "static_cpu_max",
+        "dynamic_cpu_mean",
+        "dynamic_cpu_max",
+        "cli_cpu_mean",
+        "cli_cpu_max",
+        "host_cpu_mean",
+        "host_cpu_max",
+    )
+)
 
 
 @dataclass(frozen=True)
@@ -89,6 +224,8 @@ class WorkloadDefinition:
     prepare_plan_builder: object = None
     run_plan_builder: object = None
     cleanup_plan_builder: object = None
+    result_adapter: WorkloadResultAdapter = GENERIC_TOTAL_RESULT
+    throughput_unit: str = "operations/s"
 
 
 def _config_error(location, message):
@@ -331,7 +468,78 @@ def _validate_catalog(definitions):
     if len(names) != len(set(names)):
         raise ValueError("local YDB workload names must be unique")
     option_schemas = {}
+    result_schemas = {}
     for definition in definitions:
+        adapter = definition.result_adapter
+        if not isinstance(adapter, WorkloadResultAdapter):
+            raise ValueError("invalid result adapter for {}".format(definition.name))
+        if not isinstance(adapter.schema_id, str) or re.fullmatch("[a-z0-9][a-z0-9._-]*", adapter.schema_id) is None:
+            raise ValueError("invalid result schema id for {}".format(definition.name))
+        if not callable(adapter.parse):
+            raise ValueError("result adapter parse must be callable for {}".format(definition.name))
+        if not isinstance(adapter.metrics, tuple) or not adapter.metrics:
+            raise ValueError("result adapter metrics must be a non-empty tuple for {}".format(definition.name))
+        result_schema = (adapter.metrics, adapter.slo_metrics)
+        if adapter.schema_id in result_schemas and result_schemas[adapter.schema_id] != result_schema:
+            raise ValueError("result schema id {} has incompatible definitions".format(adapter.schema_id))
+        result_schemas[adapter.schema_id] = result_schema
+        metric_names = []
+        for metric in adapter.metrics:
+            if not isinstance(metric, WorkloadMetric):
+                raise ValueError("invalid result metric for {}".format(definition.name))
+            if not isinstance(metric.name, str) or re.fullmatch("[a-z][a-z0-9_]*", metric.name) is None:
+                raise ValueError("invalid result metric name for {}".format(definition.name))
+            if metric.name in _RESERVED_RESULT_METRIC_NAMES:
+                raise ValueError("result metric name is reserved for {}.{}".format(definition.name, metric.name))
+            if not isinstance(metric.unit, str) or not metric.unit:
+                raise ValueError("result metric {} requires a unit".format(metric.name))
+            if metric.repetition_aggregation not in ("median", "sum"):
+                raise ValueError("invalid repetition aggregation for {}.{}".format(definition.name, metric.name))
+            if not isinstance(metric.required, bool):
+                raise ValueError(
+                    "result metric required flag must be boolean for {}.{}".format(definition.name, metric.name)
+                )
+            if not isinstance(metric.description, str):
+                raise ValueError(
+                    "result metric description must be a string for {}.{}".format(definition.name, metric.name)
+                )
+            metric_names.append(metric.name)
+        if len(metric_names) != len(set(metric_names)):
+            raise ValueError("result metric names must be unique for {}".format(definition.name))
+        throughput = next((metric for metric in adapter.metrics if metric.name == "throughput"), None)
+        if throughput is None or not throughput.required or throughput.repetition_aggregation != "median":
+            raise ValueError(
+                "result adapter throughput must be required and median-aggregated for {}".format(definition.name)
+            )
+        transactions = next((metric for metric in adapter.metrics if metric.name == "transactions"), None)
+        if transactions is not None and (not transactions.required or transactions.repetition_aggregation != "median"):
+            raise ValueError(
+                "result adapter transactions must be required and median-aggregated for {}".format(definition.name)
+            )
+        errors = next((metric for metric in adapter.metrics if metric.name == "errors"), None)
+        if errors is not None and (not errors.required or errors.repetition_aggregation != "sum"):
+            raise ValueError("result adapter errors must be required and sum-aggregated for {}".format(definition.name))
+        if not isinstance(definition.throughput_unit, str) or not definition.throughput_unit:
+            raise ValueError("throughput unit must be a non-empty string for {}".format(definition.name))
+        if not isinstance(adapter.slo_metrics, tuple):
+            raise ValueError("SLO metrics must be a tuple for {}".format(definition.name))
+        slo_percentiles = []
+        for item in adapter.slo_metrics:
+            if not isinstance(item, tuple) or len(item) != 2 or not all(isinstance(value, str) for value in item):
+                raise ValueError("invalid SLO metric mapping for {}".format(definition.name))
+            percentile, metric_name = item
+            if not percentile or metric_name not in metric_names:
+                raise ValueError("invalid SLO metric mapping for {}".format(definition.name))
+            metric = next(metric for metric in adapter.metrics if metric.name == metric_name)
+            if not metric.required or metric.unit != "ms" or metric.repetition_aggregation != "median":
+                raise ValueError(
+                    "SLO metric {}.{} must be required, measured in ms, and median-aggregated".format(
+                        definition.name, metric_name
+                    )
+                )
+            slo_percentiles.append(percentile)
+        if len(slo_percentiles) != len(set(slo_percentiles)):
+            raise ValueError("SLO percentiles must be unique for {}".format(definition.name))
         if definition.dataset_scope not in ("sample", "geometry", "profile"):
             raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
         if definition.warmup_mode not in ("separate", "inline"):
@@ -421,6 +629,7 @@ _DEFINITIONS = (
         init_builder=_kv_init_builder,
         run_builder=_kv_run_builder,
         options_validator=_validate_kv_options,
+        throughput_unit="requests/s",
     ),
     WorkloadDefinition(
         name="stock",
@@ -440,6 +649,7 @@ _DEFINITIONS = (
         init_builder=_stock_init_builder,
         run_builder=_stock_run_builder,
         options_validator=_validate_stock_options,
+        throughput_unit="transactions/s",
     ),
     WorkloadDefinition(
         name="log",
@@ -467,6 +677,7 @@ _DEFINITIONS = (
         options_validator=_validate_log_options,
         dataset_scope="sample",
         warmup_mode="separate",
+        throughput_unit="batches/s",
     ),
 )
 _validate_catalog(_DEFINITIONS)
@@ -533,6 +744,28 @@ def workload_config_schema():
     }
 
 
+def _workload_result_schema(definition):
+    adapter = definition.result_adapter
+    metrics = []
+    for metric in adapter.metrics:
+        descriptor = {
+            "name": metric.name,
+            "unit": definition.throughput_unit if metric.name == "throughput" else metric.unit,
+            "repetition_aggregation": metric.repetition_aggregation,
+            "required": metric.required,
+        }
+        if metric.description:
+            descriptor["description"] = metric.description
+        metrics.append(descriptor)
+    return {
+        "schema_id": adapter.schema_id,
+        "metrics": metrics,
+        "slo_metrics": dict(adapter.slo_metrics),
+        "throughput_unit": definition.throughput_unit,
+        "reports_errors": any(metric.name == "errors" for metric in adapter.metrics),
+    }
+
+
 def web_workload_catalog():
     """Return a stable JSON-compatible workload description for the web builder."""
 
@@ -542,6 +775,10 @@ def web_workload_catalog():
             "default_operation": definition.default_operation,
             "operations": list(definition.operations),
             "load_parameters": list(definition.load_parameters),
+            "throughput_unit": definition.throughput_unit,
+            "slo_metrics": dict(definition.result_adapter.slo_metrics),
+            "reports_errors": any(metric.name == "errors" for metric in definition.result_adapter.metrics),
+            "result_schema_id": definition.result_adapter.schema_id,
             "options": [
                 {
                     "name": option.name,
@@ -569,6 +806,20 @@ def allowed_load_parameters(workload_type):
 
 def all_load_parameters():
     return tuple(dict.fromkeys(parameter for definition in _DEFINITIONS for parameter in definition.load_parameters))
+
+
+def all_slo_percentiles():
+    return tuple(
+        dict.fromkeys(
+            percentile
+            for definition in _DEFINITIONS
+            for percentile, _metric_name in definition.result_adapter.slo_metrics
+        )
+    )
+
+
+def allowed_slo_metrics(workload_type):
+    return dict(_definition(workload_type).result_adapter.slo_metrics)
 
 
 def build_init_argv(cli, path, workload):
@@ -608,6 +859,10 @@ def _validate_command_plans(plans, description, allow_default_timeout=False):
             raise BenchmarkError(
                 "{} command {} has an invalid measurement window builder".format(description, plan.name)
             )
+        if plan.progress_duration_seconds is not None and (
+            not _is_finite_number(plan.progress_duration_seconds) or plan.progress_duration_seconds <= 0
+        ):
+            raise BenchmarkError("{} command {} must have a positive progress duration".format(description, plan.name))
     return plans
 
 
@@ -677,7 +932,11 @@ def build_run_plan(
             warmup_seconds,
         )
     plan = _validate_command_plans((plan,), "{} run plan".format(definition.name))[0]
-    if definition.warmup_mode == "inline" and plan.measurement_window_builder is None:
+    if (
+        definition.warmup_mode == "inline"
+        and plan.measurement_window_builder is None
+        and definition.result_adapter is GENERIC_TOTAL_RESULT
+    ):
         raise BenchmarkError("{} inline warmup requires a CPU measurement window".format(definition.name))
     return plan
 
@@ -707,6 +966,47 @@ def workload_definition(workload_type):
     """Return immutable lifecycle metadata for one registered workload."""
 
     return _definition(workload_type)
+
+
+def workload_result_schema(workload_type):
+    """Return the JSON-compatible metric schema produced by one workload."""
+
+    return _workload_result_schema(_definition(workload_type))
+
+
+def parse_workload_result(workload_type, command_result, normalized_workload, request):
+    """Parse and validate one workload command result through its adapter."""
+
+    definition = _definition(workload_type)
+    adapter = definition.result_adapter
+    if not isinstance(request, WorkloadRunRequest):
+        raise BenchmarkError("workload result adapter requires a valid run request")
+    parsed = adapter.parse(command_result, normalized_workload, request)
+    if not isinstance(parsed, WorkloadResult):
+        raise BenchmarkError("workload result adapter {} returned an invalid result".format(adapter.schema_id))
+    if not isinstance(parsed.metrics, dict):
+        raise BenchmarkError("workload result adapter {} metrics must be a mapping".format(adapter.schema_id))
+    declared = {metric.name: metric for metric in adapter.metrics}
+    unknown = sorted((name for name in parsed.metrics if name not in declared), key=str)
+    if unknown:
+        raise BenchmarkError(
+            "workload result adapter {} returned unknown metrics: {}".format(
+                adapter.schema_id, ", ".join(map(str, unknown))
+            )
+        )
+    missing = [metric.name for metric in adapter.metrics if metric.required and metric.name not in parsed.metrics]
+    if missing:
+        raise BenchmarkError(
+            "workload result adapter {} omitted required metrics: {}".format(adapter.schema_id, ", ".join(missing))
+        )
+    for name, value in parsed.metrics.items():
+        if not _is_finite_number(value) or value < 0:
+            raise BenchmarkError(
+                "workload result adapter {} metric {} must be a finite non-negative number".format(
+                    adapter.schema_id, name
+                )
+            )
+    return WorkloadResult(dict(parsed.metrics), parsed.details, parsed.measurement_window)
 
 
 def workload_table_path(workload_type, path):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -235,6 +235,7 @@ class YdbBenchTest(unittest.TestCase):
         }
         events = []
         self.last_local_ydb_cluster = cluster
+        self.last_local_ydb_monitor = monitor
         with mock.patch.object(local_ydb, "LocalYdbCluster", return_value=cluster), mock.patch.object(
             local_ydb, "LinuxCpuMonitor", return_value=monitor
         ), mock.patch.object(
@@ -441,6 +442,13 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["operations"], ["insert", "upsert", "bulk-upsert"])
         self.assertEqual(catalog[2]["load_parameters"], ["threads"])
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
+        self.assertEqual([item["result_schema_id"] for item in catalog], ["generic-total-v1"] * 3)
+        self.assertEqual(
+            [item["throughput_unit"] for item in catalog],
+            ["requests/s", "transactions/s", "batches/s"],
+        )
+        self.assertTrue(all(item["reports_errors"] for item in catalog))
+        self.assertEqual(catalog[0]["slo_metrics"]["p99"], "p99_ms")
         catalog_parameters = tuple(
             dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
         )
@@ -1507,6 +1515,238 @@ class YdbBenchTest(unittest.TestCase):
                 Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
                 20 nan 0 0 1 2 3 4
             """)
+
+    def test_local_ydb_result_adapter_rejects_invalid_metric_mappings(self):
+        metric_schema = (
+            local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
+            local_ydb_workloads.WorkloadMetric("latency_ms", "ms"),
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("threads", 4, 10, 0, 8, None)
+        command_result = self._local_ydb_command_result(("ydb", "workload", "fake"))
+        invalid_results = (
+            ({"throughput": 1, "unknown": 2}, "unknown metrics"),
+            ({"latency_ms": 2}, "omitted required metrics: throughput"),
+            ({"throughput": float("nan")}, "finite non-negative number"),
+            ({"throughput": True}, "finite non-negative number"),
+            ({"throughput": -1}, "finite non-negative number"),
+        )
+        for index, (metrics, message) in enumerate(invalid_results):
+            with self.subTest(metrics=metrics):
+                adapter = local_ydb_workloads.WorkloadResultAdapter(
+                    "fake-invalid-{}".format(index),
+                    lambda _result, _workload, _request, metrics=metrics: local_ydb_workloads.WorkloadResult(metrics),
+                    metric_schema,
+                )
+                definition = replace(
+                    local_ydb_workloads.workload_definition("kv"),
+                    result_adapter=adapter,
+                    throughput_unit="widgets/s",
+                )
+                with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+                    with self.assertRaisesRegex(BenchmarkError, message):
+                        local_ydb_workloads.parse_workload_result(
+                            "kv",
+                            command_result,
+                            {"type": "kv", "operation": "upsert", "options": {}},
+                            request,
+                        )
+
+    def test_local_ydb_catalog_rejects_unsafe_result_metric_contracts(self):
+        definition = local_ydb_workloads.workload_definition("kv")
+        generic = local_ydb_workloads.GENERIC_TOTAL_RESULT
+
+        def changed_metric(name, **changes):
+            return tuple(replace(metric, **changes) if metric.name == name else metric for metric in generic.metrics)
+
+        invalid_adapters = (
+            (replace(generic, metrics=changed_metric("throughput", repetition_aggregation="sum")), "throughput"),
+            (replace(generic, metrics=changed_metric("transactions", required=False)), "transactions"),
+            (replace(generic, metrics=changed_metric("errors", required=False)), "errors"),
+            (replace(generic, metrics=changed_metric("p99_ms", repetition_aggregation="sum")), "SLO metric"),
+            (
+                local_ydb_workloads.WorkloadResultAdapter(
+                    "reserved-v1",
+                    generic.parse,
+                    (
+                        local_ydb_workloads.WorkloadMetric("throughput", "operations/s", required=True),
+                        local_ydb_workloads.WorkloadMetric("load", "items"),
+                    ),
+                ),
+                "reserved",
+            ),
+        )
+        for adapter, message in invalid_adapters:
+            with self.subTest(message=message), self.assertRaisesRegex(ValueError, message):
+                local_ydb_workloads._validate_catalog((replace(definition, result_adapter=adapter),))
+
+    def test_local_ydb_result_adapter_repetition_schema_is_consistent_without_fake_errors(self):
+        metrics = (
+            local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
+            local_ydb_workloads.WorkloadMetric("latency_ms", "ms"),
+        )
+        aggregated = local_ydb._aggregate_measurements(
+            [{"throughput": 10}, {"throughput": 20}],
+            metrics,
+        )
+        self.assertEqual(aggregated, {"throughput": 15.0})
+        self.assertNotIn("errors", aggregated)
+        passed, reason = load_control.evaluate_load(
+            {"parameter": "threads", "allow_errors": False, "values": [1]},
+            1,
+            aggregated,
+        )
+        self.assertTrue(passed)
+        self.assertEqual(reason, "configured point")
+        with self.assertRaisesRegex(BenchmarkError, "inconsistent metric keys"):
+            local_ydb._aggregate_measurements(
+                [
+                    {"throughput": 10, "latency_ms": 1},
+                    {"throughput": 20},
+                ],
+                metrics,
+            )
+
+    def test_local_ydb_custom_result_adapter_writes_details_and_controls_progress_and_cpu_window(self):
+        requests = []
+
+        def parse_result(_command_result, normalized_workload, request):
+            requests.append((normalized_workload, request))
+            return local_ydb_workloads.WorkloadResult(
+                {"throughput": 12.5, "latency_ms": 7},
+                details={"transactions": {"new-order": 42}},
+                measurement_window=(101.0, 109.0),
+            )
+
+        adapter = local_ydb_workloads.WorkloadResultAdapter(
+            "fake-json-v1",
+            parse_result,
+            (
+                local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
+                local_ydb_workloads.WorkloadMetric(
+                    "latency_ms",
+                    "ms",
+                    required=True,
+                    description="fake SLO latency",
+                ),
+            ),
+            (("p99", "latency_ms"),),
+        )
+
+        def build_run_plan(*_args):
+            return local_ydb_workloads.WorkloadCommandPlan(
+                "run",
+                ("ydb", "workload", "fake", "run"),
+                30,
+                progress_duration_seconds=17,
+            )
+
+        definition = replace(
+            local_ydb_workloads.workload_definition("kv"),
+            warmup_mode="inline",
+            run_plan_builder=build_run_plan,
+            result_adapter=adapter,
+            throughput_unit="widgets/s",
+        )
+        configuration = load_config(self._config("""
+            local-ydb:
+              fake-adapter:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 2, duration: 3, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            manifest, output, events = self._run_mock_local_ydb(
+                configuration,
+                "fake-adapter",
+                [{"throughput": 999}],
+            )
+
+        self.assertEqual(len(requests), 1)
+        request = requests[0][1]
+        self.assertEqual(
+            (request.load_parameter, request.load, request.duration_seconds, request.warmup_seconds),
+            ("threads", 1, 3, 2),
+        )
+        self.assertEqual(request.client_threads, 64)
+        self.assertIsNone(request.objective)
+        measuring = [
+            event["fields"]["progress"]
+            for event in events
+            if event["type"] == "step-progress" and event["fields"]["progress"]["phase"] == "measuring"
+        ]
+        self.assertEqual(measuring[0]["phase_duration_seconds"], 17)
+        artifact = json.loads(
+            (output / "dynamic-nodes-01" / "load-00000001" / "repeat-001" / "workload-result.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(
+            artifact,
+            {
+                "schema_id": "fake-json-v1",
+                "metrics": {"latency_ms": 7, "throughput": 12.5},
+                "details": {"transactions": {"new-order": 42}},
+            },
+        )
+        self.assertEqual(manifest["attempts"][0]["throughput"], 12.5)
+        self.assertNotIn("errors", manifest["attempts"][0])
+        self.assertEqual(manifest["workload_result_schema"]["schema_id"], "fake-json-v1")
+        self.assertEqual(manifest["workload_result_schema"]["slo_metrics"], {"p99": "latency_ms"})
+        self.assertEqual(manifest["workload_result_schema"]["throughput_unit"], "widgets/s")
+        self.assertEqual(manifest["workload_result_schema"]["metrics"][1]["description"], "fake SLO latency")
+        repetitions_header = (output / "repetitions.csv").read_text(encoding="utf-8").splitlines()[0]
+        summary_header = (output / "summary.csv").read_text(encoding="utf-8").splitlines()[0]
+        self.assertIn("latency_ms", repetitions_header)
+        self.assertIn("median_latency_ms", summary_header)
+        self.assertNotIn("errors", repetitions_header)
+        self.assertNotIn("errors", summary_header)
+        self.last_local_ydb_monitor.summary.assert_called_once_with(
+            started_at_unix=101.0,
+            finished_at_unix=109.0,
+        )
+        self.last_local_ydb_cluster.ensure_running.assert_called()
+
+    def test_local_ydb_result_adapter_maps_configured_slo_to_declared_metric(self):
+        adapter = local_ydb_workloads.WorkloadResultAdapter(
+            "fake-slo-v1",
+            lambda _result, _workload, _request: local_ydb_workloads.WorkloadResult(
+                {"throughput": 1, "new_order_p90_ms": 4}
+            ),
+            (
+                local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
+                local_ydb_workloads.WorkloadMetric("new_order_p90_ms", "ms", required=True),
+            ),
+            (("p90", "new_order_p90_ms"),),
+        )
+        definition = replace(
+            local_ydb_workloads.workload_definition("kv"),
+            result_adapter=adapter,
+            throughput_unit="widgets/s",
+        )
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            configuration = load_config(self._config("""
+                local-ydb:
+                  fake-slo:
+                    workload: {type: kv, operation: upsert}
+                    load:
+                      parameter: threads
+                      search: {start: 1, maximum: 2}
+                      objective: {type: latency-slo, percentile: p90, max-ms: 5}
+            """)).runs[0]
+
+        objective = configuration.parameters["local_ydb"]["load"]["objective"]
+        self.assertEqual(objective["latency_metric"], "new_order_p90_ms")
+        passed, reason = load_control.evaluate_load(
+            configuration.parameters["local_ydb"]["load"],
+            1,
+            {"throughput": 1, "new_order_p90_ms": 4},
+        )
+        self.assertTrue(passed)
+        self.assertIn("does not report request errors", reason)
 
     def test_local_ydb_cli_total_row_rejects_negative_counters(self):
         for values in ("-1 10 0 0 1 2 3 4", "1 10 -1 0 1 2 3 4", "1 10 0 -1 1 2 3 4"):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add extensible result adapters for local YDB CLI workloads.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on #51547. Move generic Total parsing behind a typed result-adapter contract, publish self-describing workload result schemas, preserve optional metric sets without fabricated values, and support adapter-provided CPU windows, details artifacts, progress durations, and latency metric mappings. KV, stock, and log retain their existing result shape.