### PR TITLE
ydb-bench: verify effective TPCC threads

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -163,6 +163,9 @@ that dataset for every search and verification sample at the geometry, then
 runs both `tpcc clean` and recursive `scheme rmdir` cleanup. `client.threads`
 maps to the TPC-C runner's `--threads`; it defaults to 2, while
 `import-threads: 0` asks the CLI to select import concurrency automatically.
+The result is rejected if the CLI reports a different number of execution
+threads than `client.threads`, which prevents CPU-based CLI clamping from
+silently changing the configuration being compared.
 
 TPC-C warmup is inline. The CLI receives the explicit value
 `max(measurement.warmup, floor(warehouses / 10) + 1)` so terminal startup is

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -232,7 +232,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
     tpcc_tpmc = _tpcc_number(summary["tpmc"], "summary.tpmc")
     efficiency = _tpcc_number(summary["efficiency"], "summary.efficiency", maximum=100)
     max_sessions = _tpcc_integer(summary["max_sessions"], "summary.max_sessions", 1)
-    _tpcc_integer(summary["threads"], "summary.threads", 1)
+    threads = _tpcc_integer(summary["threads"], "summary.threads", 1)
     warmup_seconds = _tpcc_integer(summary["warmup_seconds"], "summary.warmup_seconds", 1)
 
     options = normalized_workload["options"]
@@ -241,6 +241,8 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         _tpcc_result_error("field summary.warehouses does not match the configured warehouses")
     if max_sessions != request.load:
         _tpcc_result_error("field summary.max_sessions does not match the requested load")
+    if threads != request.client_threads:
+        _tpcc_result_error("field summary.threads does not match the requested client threads")
     if warmup_seconds != expected_warmup:
         _tpcc_result_error("field summary.warmup_seconds does not match the effective warmup")
     if measured_seconds < request.duration_seconds or measured_seconds > request.duration_seconds + 60:

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -2280,6 +2280,10 @@ class YdbBenchTest(unittest.TestCase):
                 "summary.max_sessions.*requested load",
             ),
             (
+                changed(lambda value: value["summary"].__setitem__("threads", 1)),
+                "summary.threads.*requested client threads",
+            ),
+            (
                 changed(lambda value: value["summary"].__setitem__("warmup_seconds", 3)),
                 "summary.warmup_seconds.*effective warmup",
             ),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

TPCC benchmarks now reject results when the CLI reduces the configured execution thread count.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Checks the CLI-reported effective worker count against client.threads so CPU-based clamping cannot silently label a run with the wrong configuration. Stacked on #51559.