### PR TITLE
docs: align maintenance navigation on stable-25-4

### DIFF
--- a/ydb/docs/en/core/maintenance/toc_i.yaml
+++ b/ydb/docs/en/core/maintenance/toc_i.yaml
@@ -1,6 +1,4 @@
 items:
-- name: Backups
-  href: backup_and_recovery.md
 - name: Diagnostics
   include: { mode: link, path: ../troubleshooting/toc_p.yaml }
 - name: Cluster maintenance
@@ -12,6 +10,6 @@ items:
   - name: Changing an actor system's configuration
     href: ../devops/configuration-management/configuration-v1/change_actorsystem_configs.md
   - name: Maintenance without downtime
-    href: manual/maintenance-without-downtime.md
+    href: ../devops/concepts/maintenance-without-downtime.md
   - name: Updating configurations via CMS
     href: ../devops/configuration-management/configuration-v1/cms.md

--- a/ydb/docs/ru/core/maintenance/toc_i.yaml
+++ b/ydb/docs/ru/core/maintenance/toc_i.yaml
@@ -5,3 +5,11 @@ items:
   items:
   - name: Встроенный UI
     include: { mode: link, path: ../reference/embedded-ui/toc_p.yaml }
+  - name: Управление дисковой подсистемой кластера
+    include: { mode: link, path: manual/toc_p.yaml }
+  - name: Изменение конфигурации акторной системы
+    href: ../devops/configuration-management/configuration-v1/change_actorsystem_configs.md
+  - name: Обслуживание без простоев
+    href: ../devops/concepts/maintenance-without-downtime.md
+  - name: Обновление конфигурации через CMS
+    href: ../devops/configuration-management/configuration-v1/cms.md


### PR DESCRIPTION
Backport of the applicable maintenance-navigation part of #50860 to `stable-25-4`.

## Changes

- Remove the EN Maintenance `Backups` entry whose target file does not exist in this branch. Backup and recovery remains reachable from the canonical DevOps entry at `devops/backup-and-recovery.md`.
- Retarget EN Maintenance without downtime to the existing canonical DevOps concepts page.
- Add the matching existing disk-subsystem, actor-system configuration, maintenance-without-downtime, and CMS entries to the RU parent Maintenance TOC.
- Preserve the branch-local Embedded UI navigation.

## Why the overview is not backported

The `stable-25-4` EN tree does not contain `selfheal_statestorage.md` or `virtual_storage_groups_decommit.md`. Copying the current-main overview would introduce broken links, so this backport intentionally keeps the release-specific overview unchanged.

## Safety proof

- Every changed `href` and `include.path` target exists in `stable-25-4`.
- Normalized RU and EN parent Maintenance TOC paths match in the same order.
- Exact orphan-set comparison: 0 newly created EN paths and 0 newly created RU paths.
- `git diff --check` passes.

This PR targets only `stable-25-4`. Other `stable-X-Y` branches require their own branch-specific backport PRs.