### PR TITLE
docs: align maintenance navigation on stable-26-2

### DIFF
--- a/ydb/docs/en/core/maintenance/manual/index.md
+++ b/ydb/docs/en/core/maintenance/manual/index.md
@@ -1,24 +1,25 @@
-# Overview
+# Cluster Disk Subsystem Management Overview
 
-This section contains information about {{ ydb-short-name }} cluster maintenance operations.
+Managing a cluster's disk subsystem includes the following actions:
 
-Main topics:
+* Configuration changes:
 
-* [{#T}](../../devops/configuration-management/configuration-v2/state-storage-move.md)
-* [{#T}](../../devops/configuration-management/configuration-v2/static-group-move.md)
-* [{#T}](adding_storage_groups.md)
-* [{#T}](moving_vdisks.md)
-* [{#T}](balancing_load.md)
-* [{#T}](selfheal.md)
-* [{#T}](scrubbing.md)
-* [{#T}](disk_end_space.md)
-* [{#T}](../../devops/deployment-options/manual/decommissioning.md)
-* [{#T}](virtual_storage_groups_decommit.md)
-* [{#T}](failure_model.md)
-* [{#T}](node_restarting.md)
-* [{#T}](cluster_expansion.md)
-* [{#T}](config-overview.md)
-* [{#T}](dynamic-config-volatile-config.md)
-* [{#T}](replacing_nodes.md)
-* [{#T}](blobdepot.md)
-* [{#T}](blobdepot_decommit.md)
+ * [{#T}](../../devops/configuration-management/configuration-v2/cluster-expansion.md).
+ * [{#T}](adding_storage_groups.md).
+
+* Maintenance:
+
+ * [{#T}](../../devops/configuration-management/configuration-v2/replacing-nodes.md).
+ * [{#T}](scrubbing.md).
+ * [{#T}](selfheal.md).
+ * [{#T}](../../devops/deployment-options/manual/decommissioning.md).
+ * [{#T}](virtual_storage_groups_decommit.md).
+ * [{#T}](moving_vdisks.md).
+ * [{#T}](blobdepot.md).
+ * [{#T}](blobdepot_decommit.md).
+
+* Troubleshooting:
+
+ * [{#T}](failure_model.md).
+ * [{#T}](balancing_load.md).
+ * [{#T}](disk_end_space.md).

--- a/ydb/docs/en/core/maintenance/toc_i.yaml
+++ b/ydb/docs/en/core/maintenance/toc_i.yaml
@@ -1,6 +1,4 @@
 items:
-- name: Backups
-  href: backup_and_recovery.md
 - name: Diagnostics
   include: { mode: link, path: ../troubleshooting/toc_p.yaml }
 - name: Cluster maintenance
@@ -12,6 +10,6 @@ items:
   - name: Changing an actor system's configuration
     href: ../devops/configuration-management/configuration-v1/change_actorsystem_configs.md
   - name: Maintenance without downtime
-    href: manual/maintenance-without-downtime.md
+    href: ../devops/concepts/maintenance-without-downtime.md
   - name: Updating configurations via CMS
     href: ../devops/configuration-management/configuration-v1/cms.md

--- a/ydb/docs/ru/core/maintenance/toc_i.yaml
+++ b/ydb/docs/ru/core/maintenance/toc_i.yaml
@@ -5,3 +5,11 @@ items:
   items:
   - name: Встроенный UI
     include: { mode: link, path: ../reference/embedded-ui/toc_p.yaml }
+  - name: Управление дисковой подсистемой кластера
+    include: { mode: link, path: manual/toc_p.yaml }
+  - name: Изменение конфигурации акторной системы
+    href: ../devops/configuration-management/configuration-v1/change_actorsystem_configs.md
+  - name: Обслуживание без простоев
+    href: ../devops/concepts/maintenance-without-downtime.md
+  - name: Обновление конфигурации через CMS
+    href: ../devops/configuration-management/configuration-v1/cms.md


### PR DESCRIPTION
Backport of the applicable maintenance-navigation part of #50860 to `stable-26-2`.

## Changes

- Make the EN disk-subsystem overview match the RU overview that exists in this branch: the same groups, 13 link targets, and order.
- Remove the EN Maintenance `Backups` entry whose target file does not exist in this branch. Backup and recovery remains reachable from the canonical DevOps entry at `devops/backup-and-recovery.md`.
- Retarget EN Maintenance without downtime to the existing canonical DevOps concepts page.
- Add the matching existing disk-subsystem, actor-system configuration, maintenance-without-downtime, and CMS entries to the RU parent Maintenance TOC.
- Preserve the branch-local Embedded UI navigation.

## Why the rest of #50860 is not backported

- The `stable-26-2` EN tree does not contain `selfheal_statestorage.md`. Copying the current-main overview would introduce a broken link, so this backport matches the branch-local RU overview instead.
- The EN Backup layout is still the single `devops/backup-and-recovery.md` page. There is no `devops/backup-and-recovery/index.md` duplicate to delete, so inbound Backup links are left unchanged.

## Safety proof

- Every changed `href` and `include.path` target exists in `stable-26-2`.
- RU and EN overview link targets match exactly in the same order.
- Normalized RU and EN parent Maintenance TOC paths match in the same order.
- Exact orphan-set comparison: 0 newly created EN paths and 0 newly created RU paths.
- `git diff --check` passes.

This PR targets only `stable-26-2`. Other `stable-X-Y` branches require their own branch-specific backport PRs.