### PR TITLE
YQ-5657 fixed checkpoints propagation on finished graph

### DIFF
--- a/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
@@ -105,6 +105,7 @@ public:
         NYql::NDq::TComputeActorState state;
         state.Sources = Sources;
         state.Sinks = Sinks;
+
         TString result;
         for (const auto& [nodeNum, nodeState] : NodeStates) {
             if (!nodeState) {
@@ -118,6 +119,7 @@ public:
                 result.AppendNoAlias(savedBuf.data(), savedBuf.size());
             }
         }
+
         auto& stateData = state.MiniKqlProgram.ConstructInPlace().Data;
         stateData.Blob = result;
         Y_ENSURE(LastVersion, "LastVersion is empty");
@@ -1140,12 +1142,11 @@ std::vector<NYql::NDq::TComputeActorState> TStateStorage::ApplyIncrements(
         {"taskCount", context->Tasks.size()});
 
     std::vector<NYql::NDq::TComputeActorState> states;
+
     try {
-        for (auto& task : context->Tasks)
-        {
+        for (auto& task : context->Tasks) {
             TIncrementLogic logic;
-            for (auto& state : task.States)
-            {
+            for (auto& state : task.States) {
                 logic.Apply(state);
             }
             states.push_back(std::move(logic.Build()));
@@ -1153,6 +1154,7 @@ std::vector<NYql::NDq::TComputeActorState> TStateStorage::ApplyIncrements(
     } catch (...) {
         issues.AddIssue(CurrentExceptionMessage());
     }
+
     return states;
 }
 

--- a/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
@@ -57,38 +57,45 @@ public:
             TStringBuf buf(blob);
 
             while (!buf.empty()) {
-                auto nodeStateSize = NKikimr::NMiniKQL::ReadUi64(buf);
+                auto& nodeState = NodeStates[nodeNum++];
+                const ui64 nodeStateSize = NKikimr::NMiniKQL::ReadUi64(buf);
+                if (nodeStateSize == std::numeric_limits<ui64>::max()) {
+                    // Stateful operator was not initialized
+                    continue;
+                }
+
+                if (!nodeState) {
+                    nodeState.emplace();
+                }
+
                 Y_ENSURE(buf.size() >= nodeStateSize, "State/buf is corrupted");
                 TStringBuf nodeStateBuf(buf.data(), nodeStateSize);
                 buf.Skip(nodeStateSize);
 
                 NKikimr::NMiniKQL::TInputSerializer reader(nodeStateBuf);
                 auto type = reader.GetType();
-                auto& nodeState = NodeStates[nodeNum];
-                nodeState.Type = type;
+                nodeState->Type = type;
 
                 switch (type) {
-                    case NKikimr::NMiniKQL::EMkqlStateType::SIMPLE_BLOB:
-                    {
-                        nodeState.SimpleBlobNodeState = TString(nodeStateBuf.data(), nodeStateBuf.size());
+                    case NKikimr::NMiniKQL::EMkqlStateType::SIMPLE_BLOB: {
+                        nodeState->SimpleBlobNodeState = TString(nodeStateBuf.data(), nodeStateBuf.size());
+                        break;
                     }
-                    break;
                     case NKikimr::NMiniKQL::EMkqlStateType::SNAPSHOT:
-                    case NKikimr::NMiniKQL::EMkqlStateType::INCREMENT:
-                    {
+                    case NKikimr::NMiniKQL::EMkqlStateType::INCREMENT: {
                         reader.ReadItems(
                             [&](std::string_view key, std::string_view value) {
-                                nodeState.Items[TString(key)] = TString(value);
+                                nodeState->Items[TString(key)] = TString(value);
                             },
                             [&](std::string_view key) {
                                 // Not used for SNAPSHOT.
-                                nodeState.Items.erase(TString(key));
+                                nodeState->Items.erase(TString(key));
                             });
+                        break;
                     }
-                    break;
                 }
-                ++nodeNum;
             }
+
             Y_ENSURE(buf.empty(), "State/buf is corrupted");
         }
     }
@@ -100,12 +107,12 @@ public:
         state.Sinks = Sinks;
         TString result;
         for (const auto& [nodeNum, nodeState] : NodeStates) {
-
-            if (nodeState.Type == NKikimr::NMiniKQL::EMkqlStateType::SIMPLE_BLOB) {
-                NKikimr::NMiniKQL::TNodeStateHelper::AddNodeState(result, nodeState.SimpleBlobNodeState);
+            if (!nodeState) {
+                NKikimr::NMiniKQL::WriteUi64(result, std::numeric_limits<ui64>::max());
+            } else if (nodeState->Type == NKikimr::NMiniKQL::EMkqlStateType::SIMPLE_BLOB) {
+                NKikimr::NMiniKQL::TNodeStateHelper::AddNodeState(result, nodeState->SimpleBlobNodeState);
             } else {
-                NYql::NUdf::TUnboxedValue saved =
-                     NKikimr::NMiniKQL::TOutputSerializer::MakeSnapshotState(nodeState.Items, 0);
+                const auto saved = NKikimr::NMiniKQL::TOutputSerializer::MakeSnapshotState(nodeState->Items, 0);
                 const TStringBuf savedBuf = saved.AsStringRef();
                 NKikimr::NMiniKQL::WriteUi64(result, savedBuf.size());
                 result.AppendNoAlias(savedBuf.data(), savedBuf.size());
@@ -118,7 +125,7 @@ public:
         return state;
     }
 
-    static EStateType GetStateType(const ui64 taskId, const NYql::NDq::TComputeActorState& state) {
+    static EStateType GetStateType(const NYql::NDq::TComputeActorState& state) {
         if (!state.MiniKqlProgram) {
             return EStateType::Snapshot;
         }
@@ -128,7 +135,8 @@ public:
         while (!buf.empty()) {
             const ui64 nodeStateSize = NKikimr::NMiniKQL::ReadUi64(buf);
             if (nodeStateSize == std::numeric_limits<ui64>::max()) {
-                throw yexception() << "Task " << taskId << " has incomplete program state: some stateful operators are still not initialized.";
+                // Stateful operator was not initialized
+                continue;
             }
 
             Y_ENSURE(buf.size() >= nodeStateSize, "State/buf is corrupted");
@@ -145,12 +153,13 @@ public:
     }
 
 private:
-    struct NodeState {
+    struct TNodeState {
         NKikimr::NMiniKQL::EMkqlStateType Type;
         std::map<TString, TString> Items;
         TString SimpleBlobNodeState;
     };
-    std::map<ui64, NodeState> NodeStates;
+
+    std::map<ui64, std::optional<TNodeState>> NodeStates;
     std::list<NYql::NDq::TSourceState> Sources;
     std::list<NYql::NDq::TSinkState> Sinks;
     TMaybe<ui64> LastVersion;
@@ -432,7 +441,7 @@ EStateType TStateStorage::DeserializeState(const TContextPtr& context, TContext:
 
     auto res = state.ParseFromString(blob);
     Y_ENSURE(res, "Parsing error");
-    return TIncrementLogic::GetStateType(taskInfo.TaskId, state);
+    return TIncrementLogic::GetStateType(state);
 }
 
 size_t TStateStorage::SerializeState(
@@ -469,7 +478,7 @@ TFuture<IStateStorage::TSaveStateResult> TStateStorage::SaveState(
     size_t size = 0;
 
     try {
-        type = TIncrementLogic::GetStateType(taskId, state);
+        type = TIncrementLogic::GetStateType(state);
         size = SerializeState(state, serializedState);
         if (!size || serializedState.empty()) {
             return MakeFuture(TSaveStateResult(0, NYql::TIssues{NYql::TIssue{"Failed to serialize compute actor state"}}));

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -1081,16 +1081,6 @@ private:
             Send(MakePipePerNodeCacheID(true), new TEvPipeCache::TEvUnlink(0));
         }
 
-        if (CheckpointCoordinatorId) {
-            Send(CheckpointCoordinatorId, new NActors::TEvents::TEvPoisonPill());
-            CheckpointCoordinatorId = TActorId{};
-            const auto context = TasksGraph.GetMeta().UserRequestContext;
-            if (AppData()->FeatureFlags.GetEnableStreamingQueriesCounters() && context && !context->StreamingQueryPath.empty()) {
-                auto counters = Counters->Counters->GetKqpCounters();
-                counters = counters->GetSubgroup("host", "");
-                counters->RemoveSubgroup("path", context->StreamingQueryPath);
-            }
-        }
         TBase::PassAway();
     }
 

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -2005,6 +2005,25 @@ protected:
 
         if (Planner) {
             Planner->Unsubscribe();
+
+            if (CheckpointCoordinatorId) {
+                // For streaming queries compute actors persist after finish, so we should abort them
+                for (const auto& computeActorId : Planner->GetAllComputeActors()) {
+                    this->Send(computeActorId, NYql::NDq::TEvDq::TEvAbortExecution::Aborted("Query execution finished."));
+                }
+            }
+        }
+
+        if (CheckpointCoordinatorId) {
+            this->Send(CheckpointCoordinatorId, new NActors::TEvents::TEvPoisonPill());
+            CheckpointCoordinatorId = TActorId{};
+
+            const auto context = TasksGraph.GetMeta().UserRequestContext;
+            if (AppData()->FeatureFlags.GetEnableStreamingQueriesCounters() && context && !context->StreamingQueryPath.empty()) {
+                auto counters = Counters->Counters->GetKqpCounters();
+                counters = counters->GetSubgroup("host", "");
+                counters->RemoveSubgroup("path", context->StreamingQueryPath);
+            }
         }
 
         if (KqpTableResolverId) {

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -751,6 +751,7 @@ bool TKqpPlanner::AcknowledgeCA(ui64 taskId, TActorId computeActor, const NYql::
     auto& task = TasksGraph.GetTask(taskId);
     if (!task.ComputeActorId) {
         task.ComputeActorId = computeActor;
+        AllComputeActors.emplace(computeActor);
         PendingComputeTasks.erase(taskId);
         auto [it, success] = PendingComputeActors.try_emplace(computeActor);
         YQL_ENSURE(success);
@@ -846,11 +847,15 @@ void TKqpPlanner::ShiftConsumption() {
     }
 }
 
-const THashMap<TActorId, TProgressStat>& TKqpPlanner::GetPendingComputeActors() {
+const THashSet<TActorId>& TKqpPlanner::GetAllComputeActors() const {
+    return AllComputeActors;
+}
+
+const THashMap<TActorId, TProgressStat>& TKqpPlanner::GetPendingComputeActors() const {
     return PendingComputeActors;
 }
 
-const THashSet<ui64>& TKqpPlanner::GetPendingComputeTasks() {
+const THashSet<ui64>& TKqpPlanner::GetPendingComputeTasks() const {
     return PendingComputeTasks;
 }
 

--- a/ydb/core/kqp/executer_actor/kqp_planner.h
+++ b/ydb/core/kqp/executer_actor/kqp_planner.h
@@ -83,8 +83,9 @@ public:
     ui32 GetCurrentRetryDelay(ui32 requestId);
     void Unsubscribe();
 
-    const THashMap<TActorId, TProgressStat>& GetPendingComputeActors();
-    const THashSet<ui64>& GetPendingComputeTasks();
+    const THashSet<TActorId>& GetAllComputeActors() const;
+    const THashMap<TActorId, TProgressStat>& GetPendingComputeActors() const;
+    const THashSet<ui64>& GetPendingComputeTasks() const;
     TMaybe<ui64> GetActualNodeIdForTask(ui64 taskId) const;
 
     void PropagateChannelsUpdates(const THashMap<TActorId, THashSet<ui64>>& updates);
@@ -130,6 +131,7 @@ private:
     ui64 MkqlMemoryLimit;
     NYql::NDq::IDqAsyncIoFactory::TPtr AsyncIoFactory;
 
+    THashSet<TActorId> AllComputeActors; // All compute actors which was acknowledged
     THashMap<TActorId, TProgressStat> PendingComputeActors; // Running compute actors (pure and DS)
     THashSet<ui64> PendingComputeTasks; // Not started yet, waiting resources
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/common.cpp
@@ -859,9 +859,15 @@ void TStreamingTestFixture::CheckScriptExecutionsCount(ui64 expectedExecutionsCo
     });
 }
 
-void TStreamingTestFixture::WaitCheckpointUpdate(const TString& checkpointId) {
+void TStreamingTestFixture::WaitCheckpointUpdate(const TString& checkpointId, std::optional<std::pair<ui64, ui64>> initialBound) {
     std::optional<ui64> minGeneration;
     std::optional<ui64> minSeqNo;
+
+    if (initialBound) {
+        minGeneration = initialBound->first;
+        minSeqNo = initialBound->second;
+    }
+
     WaitFor(TEST_OPERATION_TIMEOUT, "checkpoint update", [&](TString& error) {
         const auto& result = ExecQuery(fmt::format(
             R"sql(

--- a/ydb/core/kqp/ut/federated_query/datastreams/common.h
+++ b/ydb/core/kqp/ut/federated_query/datastreams/common.h
@@ -210,7 +210,7 @@ public:
 
     // Streaming queries
 
-    void WaitCheckpointUpdate(const TString& checkpointId);
+    void WaitCheckpointUpdate(const TString& checkpointId, std::optional<std::pair<ui64, ui64>> initialBound = std::nullopt);
 
     ui64 GetLastCheckpointSeqNo(const TString& checkpointId);
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -336,11 +336,12 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         });
     }
 
-    Y_UNIT_TEST_F(RestoreScriptPhysicalGraphBasic, TStreamingTestFixture) {
-        constexpr char writeBucket[] = "test_bucket_restore_script_physical_graph";
+    Y_UNIT_TEST_TWIN_F(RestoreScriptPhysicalGraphBasic, ModernChannels, TStreamingTestFixture) {
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+        const auto writeBucket = TStringBuilder() << Name_ << "test_bucket";
         CreateBucket(writeBucket);
 
-        constexpr char topicName[] = "restoreScriptTopic";
+        const auto topicName = TStringBuilder() << Name_ << "Topic";
         CreateTopic(topicName);
 
         constexpr char pqSourceName[] = "sourceName";
@@ -387,9 +388,10 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(writeBucket), TStringBuilder() << sampleResult << sampleResult);
     }
 
-    Y_UNIT_TEST_F(RestoreScriptPhysicalGraphGroupByHop, TStreamingTestFixture) {
-        constexpr char sourceTopicName[] = "restoreScriptGroupByHopTopicSource";
-        constexpr char sinkTopicName[] = "restoreScriptGroupByHopTopicSink";
+    Y_UNIT_TEST_TWIN_F(RestoreScriptPhysicalGraphGroupByHop, ModernChannels, TStreamingTestFixture) {
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+        const auto sourceTopicName = TStringBuilder() << Name_ << "TopicSource";
+        const auto sinkTopicName = TStringBuilder() << Name_ << "TopicSink";
         CreateTopic(sourceTopicName);
         CreateTopic(sinkTopicName);
 
@@ -445,13 +447,14 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         executeQuery({.SaveState = true, .PhysicalGraph = LoadPhysicalGraph(executionId)});
     }
 
-    Y_UNIT_TEST_F(RestoreScriptPhysicalGraphOnRetry, TStreamingTestFixture) {
+    Y_UNIT_TEST_TWIN_F(RestoreScriptPhysicalGraphOnRetry, ModernChannels, TStreamingTestFixture) {
+        DqChannelsVersion = ModernChannels ? 2 : 1;
         const auto pqGateway = SetupMockPqGateway();
 
-        constexpr char writeBucket[] = "test_bucket_restore_script_physical_graph_on_retry";
+        const auto writeBucket = TStringBuilder() << Name_ << "test_bucket";
         CreateBucket(writeBucket);
 
-        constexpr char topicName[] = "restoreScriptTopicOnRetry";
+        const auto topicName = TStringBuilder() << Name_ << "Topic";
         CreateTopic(topicName);
 
         constexpr char pqSourceName[] = "sourceName";
@@ -2457,6 +2460,20 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
 
             ExecQuery(query, EStatus::GENERIC_ERROR);
         }
+    }
+
+    Y_UNIT_TEST_F(WriteLargeMessageIntoTopic, TStreamingTestFixture) {
+        const auto outputTopic = TStringBuilder() << Name_ << "OutputTopicName";
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreateTopic(outputTopic);
+        CreatePqSource(pqSourceName);
+
+        ExecQuery(fmt::format(R"(
+            INSERT INTO `{pq_source}`.`{output_topic}`
+            SELECT String::JoinFromList(ListReplicate("X", 10000000), "-");)",
+            "pq_source"_a = pqSourceName,
+            "output_topic"_a = outputTopic
+        ), EStatus::EXTERNAL_ERROR, "Max message size for YDS is 1048576 bytes but received message with size of");
     }
 }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#include <ydb/core/base/counters.h>
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/ut/federated_query/common/common.h>
@@ -430,6 +431,566 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             messages.emplace_back(TStringBuilder() << "value" << id << "key" << id);
             ReadTopicMessages(outputTopicName, messages);
         }
+    }
+
+    Y_UNIT_TEST_QUAD_F(CheckpointPropagationAfterSubgraphFinalization, LocalTopics, ModernChannels, TStreamingWithSchemaSecretsTestFixture) {
+        NodeCount = 2;
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+        InternalInitFederatedQuerySetupFactory = true;
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto firstInputTopicName = TStringBuilder() << Name_ << "InputTopicName1";
+        const auto secondInputTopicName = TStringBuilder() << Name_ << "InputTopicName2";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(firstInputTopicName, NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(2, 2), LocalTopics);
+        CreateTopic(secondInputTopicName, std::nullopt, LocalTopics);
+        CreateTopic(outputTopicName, std::nullopt, LocalTopics);
+
+        constexpr char tableName[] = "outputTable";
+        ExecQuery(fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Data String NOT NULL,
+                    PRIMARY KEY (Data)
+                );
+            )",
+            "table_name"_a = tableName
+        ));
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        if constexpr (!LocalTopics) {
+            CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+        }
+
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                PRAGMA ydb.OptValidateStreamingCheckpoints = "FALSE"; -- Enable `LIMIT` operator in at-least-once semantic
+                PRAGMA ydb.MaxTasksPerStage = "2"; -- Ensure configuration where one of chanels will be remote, and one local
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 0, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 1, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 2, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 3, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 4, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 5, "tasks": 2 }}
+                ] @@;
+
+                $data = SELECT * FROM {pq_source}`{first_input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        time String NOT NULL,
+                        event String
+                    )
+                ) LIMIT 2;
+
+                $grouped = SELECT
+                    event,
+                    CAST(SOME(time) AS String) AS time,
+                    CAST(COUNT(*) AS String) AS count
+                FROM $data
+                GROUP BY
+                    HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"),
+                    event;
+
+                $processed = SELECT Unwrap(event || "-" || time || "-" || count) AS Data FROM $grouped
+                UNION ALL SELECT * FROM {pq_source}`{second_input_topic}`;
+
+                INSERT INTO {pq_source}`{output_topic}` SELECT * FROM $processed;
+
+                UPSERT INTO `{table}` SELECT * FROM $processed;
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = LocalTopics ? TStringBuilder() : TStringBuilder() << "`" << pqSourceName << "`.",
+            "first_input_topic"_a = firstInputTopicName,
+            "second_input_topic"_a = secondInputTopicName,
+            "output_topic"_a = outputTopicName,
+            "table"_a = tableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        WaitCheckpointUpdate(checkpointId);
+
+        auto disposition = TInstant::Now();
+        WriteTopicMessage(firstInputTopicName, R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})", /* partition */ 0, LocalTopics);
+        WriteTopicMessage(firstInputTopicName, R"({"time": "2025-08-25T00:00:00.000000Z", "event": "A"})", /* partition */ 1, LocalTopics);
+        ReadTopicMessages(outputTopicName, {"A-2025-08-24T00:00:00.000000Z-1", "A-2025-08-25T00:00:00.000000Z-1"}, disposition, /* sort */ true, LocalTopics);
+        WaitCheckpointUpdate(checkpointId);
+
+        // Check table data (should be flushed on checkpoint)
+        {
+            const auto& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{table_name}` ORDER BY Data;)",
+                "table_name"_a = tableName
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+            ui64 index = 0;
+            const std::vector expected = {"A-2025-08-24T00:00:00.000000Z-1", "A-2025-08-25T00:00:00.000000Z-1"};
+            CheckScriptResult(results[0], 1, 2, [&](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), expected[index++]);
+            });
+
+            ExecQuery(fmt::format(R"(
+                DELETE FROM `{table_name}`;)",
+                "table_name"_a = tableName
+            ));
+        }
+
+        // Checkpoints still works
+        WaitCheckpointUpdate(checkpointId);
+        WaitCheckpointUpdate(checkpointId);
+
+        disposition = TInstant::Now();
+        WriteTopicMessage(secondInputTopicName, "test_message", /* partition */ 0, LocalTopics);
+        ReadTopicMessage(outputTopicName, "test_message", disposition, LocalTopics);
+        WaitCheckpointUpdate(checkpointId);
+
+        // Check table data (should be flushed on checkpoint)
+        {
+            const auto& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{table_name}` ORDER BY Data;)",
+                "table_name"_a = tableName
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+            CheckScriptResult(results[0], 1, 1, [](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), "test_message");
+            });
+        }
+
+        Sleep(TDuration::Seconds(1));
+        CheckScriptExecutionsCount(1, 1);
+
+        ValidateStreamingQueryAst(queryName, AstChecker(/* txCount */ 1, /* stagesCount */ 6));
+
+        DropTopic(firstInputTopicName, LocalTopics);
+        DropTopic(secondInputTopicName, LocalTopics);
+        DropTopic(outputTopicName, LocalTopics);
+    }
+
+    Y_UNIT_TEST_TWIN_F(CheckpointPropagationWithUninitializedStatefulOperator, ModernChannels, TStreamingWithSchemaSecretsTestFixture) {
+        NodeCount = 2;
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+
+        const std::shared_ptr<TConnectorClientMock> connectorClient = SetupMockConnectorClient();
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto limitedInputTopicName = TStringBuilder() << Name_ << "InputTopicNameLimited";
+        const auto mainInputTopicName = TStringBuilder() << Name_ << "InputTopicNameMain";
+        const auto auxInputTopicName = TStringBuilder() << Name_ << "InputTopicNameAux";
+        const auto outputTopicName = TStringBuilder() << Name_ << "OutputTopicName";
+        CreateTopic(limitedInputTopicName, NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(2, 2));
+        CreateTopic(mainInputTopicName);
+        CreateTopic(auxInputTopicName, NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(2, 2));
+        CreateTopic(outputTopicName);
+
+        constexpr char outputTableName[] = "outputTable";
+        ExecQuery(fmt::format(R"(
+            CREATE TABLE `{output_table}` (
+                Data String NOT NULL,
+                PRIMARY KEY (Data)
+            );)",
+            "output_table"_a = outputTableName
+        ));
+
+        constexpr char lookupTableName[] = "lookup";
+        ExecExternalQuery(fmt::format(R"(
+            CREATE TABLE `{lookup_table}` (
+                fqdn String,
+                payload String,
+                PRIMARY KEY (fqdn)
+            );)",
+            "lookup_table"_a = lookupTableName
+        ));
+
+        constexpr char ydbSourceName[] = "ydbSourceName";
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreateYdbSource(ydbSourceName);
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        {   // Prepare connector mock
+            const std::vector<TColumn> columns = {
+                {"fqdn", Ydb::Type::STRING},
+                {"payload", Ydb::Type::STRING}
+            };
+            SetupMockConnectorTableDescription(connectorClient, {
+                .TableName = lookupTableName,
+                .Columns = columns,
+                .DescribeCount = 2,
+                .ListSplitsCount = 1
+            });
+
+            const std::vector<std::string> fqdnColumn = {"host1.example.com"};
+            const std::vector<std::string> payloadColumn = {"P1"};
+            SetupMockConnectorTableData(connectorClient, {
+                .TableName = lookupTableName,
+                .Columns = columns,
+                .NumberReadSplits = 2,
+                .ResultFactory = [&]() {
+                    return MakeRecordBatch(
+                        MakeArray<arrow::BinaryBuilder>("fqdn", fqdnColumn, arrow::binary()),
+                        MakeArray<arrow::BinaryBuilder>("payload", payloadColumn, arrow::binary())
+                    );
+                }
+            });
+        }
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                -- Emulate situation when right input of map join is hanging,
+                -- so left input stay uninitialized with underlying group by hop.
+                --
+                -- Note: during checkpoint such hanging of right join input will lead to checkpoint hanging,
+                -- so in test query will be restarted after zero checkpoint completion.
+
+                PRAGMA ydb.OptValidateStreamingCheckpoints = "FALSE"; -- Enable `LIMIT` operator in at-least-once semantic
+                PRAGMA ydb.MaxTasksPerStage = "2"; -- Ensure configuration where one of chanels will be remote, and one local
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 0, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 1, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 2, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 3, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 4, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 5, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 6, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 7, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 8, "tasks": 2 }}
+                ] @@;
+
+                $left_join_stream = SELECT * FROM `{pq_source}`.`{limited_input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        time String NOT NULL,
+                        event String
+                    )
+                );
+
+                $left_join_stream_grouped = SELECT
+                    event,
+                    CAST(SOME(time) AS String) AS time,
+                    CAST(COUNT(*) AS String) AS count
+                FROM $left_join_stream
+                GROUP BY
+                    HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"),
+                    event;
+
+                -- Both sides of this join is empty, so group by hop wont be initialized at least on one side
+                $joined_data = SELECT
+                    Unwrap(l.event || "-" || l.time || "-" || l.count || "-" || r.payload) AS Data
+                FROM $left_join_stream_grouped AS l
+                LEFT JOIN `{ydb_source}`.`{lookup_table}` AS r ON l.event = r.fqdn;
+
+                $united_data = SELECT * FROM $joined_data
+                UNION ALL SELECT * FROM `{pq_source}`.`{aux_input_topic}`; -- Actually `aux_input_topic` will hit LIMIT
+
+                $limited_data = SELECT * FROM $united_data LIMIT 2;
+
+                $processed = SELECT * FROM $limited_data
+                UNION ALL SELECT * FROM `{pq_source}`.`{main_input_topic}`;
+
+                INSERT INTO `{pq_source}`.`{output_topic}` SELECT * FROM $processed;
+
+                UPSERT INTO `{output_table}` SELECT * FROM $processed;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "ydb_source"_a = ydbSourceName,
+            "limited_input_topic"_a = limitedInputTopicName,
+            "aux_input_topic"_a = auxInputTopicName,
+            "main_input_topic"_a = mainInputTopicName,
+            "output_topic"_a = outputTopicName,
+            "output_table"_a = outputTableName,
+            "lookup_table"_a = lookupTableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        ValidateStreamingQueryAst(queryName, [](const TString& ast) {
+            UNIT_ASSERT_STRING_CONTAINS(ast, "MapJoinCore");
+            AstChecker(/* txCount */ 1, /* stagesCount */ 9)(ast);
+            Cerr << TString(TStringBuilder() << "Ast:\n" << ast << "\n") << Flush;
+        });
+
+        Sleep(TDuration::Seconds(1)); // Wait for zero checkpoint
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        const auto seqNo = GetLastCheckpointSeqNo(checkpointId);
+        UNIT_ASSERT_VALUES_EQUAL(seqNo, 1);
+
+        // Check that query works
+        auto disposition = TInstant::Now();
+        WriteTopicMessage(limitedInputTopicName, R"({"time": "2025-08-24T00:00:00.000000Z", "event": "host1.example.com"})", /* partition */ 0);
+        WriteTopicMessage(limitedInputTopicName, R"({"time": "2025-08-25T00:00:00.000000Z", "event": "host1.example.com"})", /* partition */ 1);
+        ReadTopicMessage(outputTopicName, "host1.example.com-2025-08-24T00:00:00.000000Z-1-P1", disposition);
+
+        // Check table empty
+        {
+            const std::vector<TResultSet>& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{table_name}` ORDER BY Data;)",
+                "table_name"_a = outputTableName
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(results[0].RowsCount(), 0);
+        }
+
+        ExecQuery(fmt::format(R"(
+            ALTER STREAMING QUERY `{query_name}` SET (
+                RUN = FALSE
+            );)",
+            "query_name"_a = queryName
+        ));
+
+        // After restart right side of map join is hanging
+        connectorClient->LockReading();
+        UNIT_ASSERT_VALUES_EQUAL(GetLastCheckpointSeqNo(checkpointId), seqNo); // No checkpoints expected
+
+        ExecQuery(fmt::format(R"(
+            ALTER STREAMING QUERY `{query_name}` SET (
+                RUN = TRUE
+            );)",
+            "query_name"_a = queryName
+        ));
+
+        // Hit limit value and mark whole join as finished
+        disposition = TInstant::Now();
+        WriteTopicMessage(auxInputTopicName, "test_message1", /* partition */ 0);
+        WriteTopicMessage(auxInputTopicName, "test_message2", /* partition */ 1);
+        ReadTopicMessages(outputTopicName, {"test_message1", "test_message2"}, disposition, /* sort */ true);
+        UNIT_ASSERT_VALUES_EQUAL(GetLastCheckpointSeqNo(checkpointId), seqNo); // No checkpoints expected
+        Sleep(TDuration::Seconds(1));
+
+        // Test that limit is reached
+        disposition = TInstant::Now();
+        WriteTopicMessage(auxInputTopicName, "test_lost_message", /* partition */ 0);
+        WriteTopicMessages(mainInputTopicName, {"test_message3", "test_message4"});
+        ReadTopicMessages(outputTopicName, {"test_message3", "test_message4"}, disposition, /* sort */ true);
+        UNIT_ASSERT_VALUES_EQUAL(GetLastCheckpointSeqNo(checkpointId), seqNo); // No checkpoints expected
+
+        // Unlock right joins side and wait checkpoint
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        connectorClient->UnlockReading();
+        WaitCheckpointUpdate(checkpointId);
+
+        // Check table data (should be flushed on checkpoint)
+        {
+            const auto& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{table_name}` ORDER BY Data;)",
+                "table_name"_a = outputTableName
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+            ui64 index = 0;
+            const std::vector expected = {"test_message1", "test_message2", "test_message3", "test_message4"};
+            CheckScriptResult(results[0], 1, 4, [&](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), expected[index++]);
+            });
+        }
+
+        // Test that query continue working
+        disposition = TInstant::Now();
+        WriteTopicMessage(mainInputTopicName, "test_message5");
+        ReadTopicMessage(outputTopicName, "test_message5", disposition);
+        CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        WaitCheckpointUpdate(checkpointId);
+
+        Sleep(TDuration::Seconds(1));
+        CheckScriptExecutionsCount(2, 1);
+
+        DropTopic(limitedInputTopicName);
+        DropTopic(auxInputTopicName);
+        DropTopic(mainInputTopicName);
+        DropTopic(outputTopicName);
+        ExecExternalQuery(fmt::format(R"(
+            DROP TABLE `{table_name}`;)",
+            "table_name"_a = lookupTableName
+        ));
+    }
+
+    Y_UNIT_TEST_TWIN_F(CheckpointPropagationWithFiniteResultAndCheckpoints, ModernChannels, TStreamingWithSchemaSecretsTestFixture) {
+        NodeCount = 2;
+        DqChannelsVersion = ModernChannels ? 2 : 1;
+        SetupAppConfig().MutableFeatureFlags()->SetEnableStreamingQueriesCounters(false);
+
+        const auto inputTopicName = TStringBuilder() << Name_ << "InputTopicName";
+        const IMockPqGateway::TPtr pqGateway = SetupMockPqGateway({
+            .LockWritingByDefault = true,
+            .Topics = {{inputTopicName, {.PartitionCount = 2}}},
+        });
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto firstOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName1";
+        const auto secondOutputTopicName = TStringBuilder() << Name_ << "OutputTopicName2";
+        CreateTopic(inputTopicName, NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(2, 2));
+        CreateTopic(firstOutputTopicName);
+        CreateTopic(secondOutputTopicName);
+
+        constexpr char tableName[] = "outputTable";
+        ExecQuery(fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Data String NOT NULL,
+                    PRIMARY KEY (Data)
+                );
+            )",
+            "table_name"_a = tableName
+        ));
+
+        constexpr char pqSourceName[] = "pqSourceName";
+        CreatePqSourceBasicAuth(pqSourceName, /* useSchemaSecrets  */ true);
+
+        constexpr TDuration CHECKPOINT_INTERVAL = TDuration::Seconds(10);
+        const auto queryName = TStringBuilder() << Name_ << "StreamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` WITH (
+                CHECKPOINT_INTERVAL = "PT{checkpoint_interval}S"
+            ) AS
+            DO BEGIN
+                PRAGMA ydb.OptValidateStreamingCheckpoints = "FALSE"; -- Enable `LIMIT` operator in at-least-once semantic
+                PRAGMA ydb.MaxTasksPerStage = "2"; -- Ensure configuration where one of chanels will be remote, and one local
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 0, "tasks": 2 }},
+                    {{ "tx": 0, "stage": 1, "tasks": 1 }},
+                    {{ "tx": 0, "stage": 2, "tasks": 1 }}
+                ] @@;
+
+                $data = SELECT * FROM `{pq_source}`.`{input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        time String NOT NULL,
+                        event String
+                    )
+                ) LIMIT 3;
+
+                $grouped = SELECT
+                    event,
+                    CAST(SOME(time) AS String) AS time,
+                    CAST(COUNT(*) AS String) AS count
+                FROM $data
+                GROUP BY
+                    HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"),
+                    event;
+
+                $processed = SELECT Unwrap(event || "-" || time || "-" || count) AS Data FROM $grouped;
+
+                INSERT INTO `{pq_source}`.`{first_output_topic}` SELECT * FROM $processed;
+
+                INSERT INTO `{pq_source}`.`{second_output_topic}` SELECT * FROM $processed;
+
+                UPSERT INTO `{table}` SELECT * FROM $processed;
+            END DO;)",
+            "query_name"_a = queryName,
+            "checkpoint_interval"_a = CHECKPOINT_INTERVAL.Seconds(),
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "first_output_topic"_a = firstOutputTopicName,
+            "second_output_topic"_a = secondOutputTopicName,
+            "table"_a = tableName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        const auto& checkpointId = GetStreamingQueryCheckpointId(queryName);
+        const auto seqNo = GetLastCheckpointSeqNo(checkpointId);
+
+        const auto readSession0 = pqGateway->WaitReadSession(inputTopicName);
+        const auto readSession1 = pqGateway->WaitReadSession(inputTopicName);
+        readSession0->AddDataReceivedEvent(0, R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})");
+        readSession0->AddDataReceivedEvent(1, R"({"time": "2025-08-25T00:00:00.000000Z", "event": "A"})");
+
+        const auto firstWriteSession = pqGateway->WaitWriteSession(firstOutputTopicName);
+        firstWriteSession->Unlock();
+        firstWriteSession->ExpectMessage("A-2025-08-24T00:00:00.000000Z-1");
+
+        const auto secondWriteSession = pqGateway->WaitWriteSession(secondOutputTopicName);
+        secondWriteSession->LockAcks(); // One of sinks is hanging
+        secondWriteSession->Unlock();
+        secondWriteSession->ExpectMessage("A-2025-08-24T00:00:00.000000Z-1");
+
+        // Hit limit and finish most part of the graph
+        readSession1->AddDataReceivedEvent(2, R"({"time": "2025-08-26T00:00:00.000000Z", "event": "A"})");
+        firstWriteSession->ExpectMessages({"A-2025-08-25T00:00:00.000000Z-1", "A-2025-08-26T00:00:00.000000Z-1"});
+        secondWriteSession->ExpectMessages({"A-2025-08-25T00:00:00.000000Z-1", "A-2025-08-26T00:00:00.000000Z-1"});
+
+        // Check table data (should be flushed on finish)
+        {
+            Sleep(TDuration::Seconds(1));
+            const auto& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{table_name}` ORDER BY Data;)",
+                "table_name"_a = tableName
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 1);
+
+            ui64 index = 0;
+            const std::vector expected = {"A-2025-08-24T00:00:00.000000Z-1", "A-2025-08-25T00:00:00.000000Z-1", "A-2025-08-26T00:00:00.000000Z-1"};
+            CheckScriptResult(results[0], 1, 3, [&](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Data").GetString(), expected[index++]);
+            });
+        }
+
+        // Expected graph state now:
+        // [source stage, finished] -> [limit stage, finished] -> [group by stage + 2x PQ sinks, waiting sink{1}] -> [table sink stage, finished]
+        // Checkpoint will be injected into source stage and must pass all stages
+
+        auto newSeqNo = CheckNoCheckpointUpdate(checkpointId, CHECKPOINT_INTERVAL / 2);
+        UNIT_ASSERT_VALUES_EQUAL(newSeqNo, seqNo); // No checkpoints due to checkpointing interval
+
+        const auto pqCountersExtractor = [&](const ui64 nodeIndex) -> ::NMonitoring::TDynamicCounters::TCounterPtr {
+            const NMonitoring::TDynamicCounterPtr kqpCounters = GetCounters("kqp", nodeIndex);
+            const auto sourceTracker = kqpCounters->GetSubgroup("subsystem", "DqSinkTracker");
+            const auto sourceCounters = sourceTracker->GetSubgroup("sink", "PqSink");
+            const auto inflyData = sourceCounters->GetCounter("InFlyData");
+            const auto inFlyCheckpoints = sourceCounters->GetCounter("InFlyCheckpoints");
+
+            if (inflyData->Val() != 0) {
+                return inFlyCheckpoints;
+            }
+
+            return nullptr;
+        };
+
+        auto counters = pqCountersExtractor(/* nodeIndex */ 0);
+        if (!counters) {
+            counters = pqCountersExtractor(/* nodeIndex */ 1);
+        }
+        UNIT_ASSERT_C(counters, "Counters not found for PQ sink");
+        UNIT_ASSERT_VALUES_EQUAL(counters->Val(), 0);
+
+        WaitFor(CHECKPOINT_INTERVAL, "checkpoint propagation", [&](TString& error) {
+            if (GetLastCheckpointSeqNo(checkpointId) == seqNo) {
+                error = "new checkpoint still is not created";
+                return false;
+            }
+
+            return counters->Val() == 1;
+        });
+
+        newSeqNo = GetLastCheckpointSeqNo(checkpointId);
+        secondWriteSession->UnlockAcks();
+        WaitCheckpointUpdate(checkpointId, std::pair(1, newSeqNo)); // Checkpoint should successfully finish
+
+        readSession0->ExpectSessionClosed(TDuration::Seconds(1));
+        readSession1->ExpectSessionClosed(TDuration::Seconds(1));
+        Sleep(TDuration::Seconds(1));
+        CheckScriptExecutionsCount(1, 0);
+
+        ValidateStreamingQueryAst(queryName, AstChecker(/* txCount */ 1, /* stagesCount */ 4));
+
+        DropTopic(inputTopicName);
+        DropTopic(firstOutputTopicName);
+        DropTopic(secondOutputTopicName);
     }
 
     Y_UNIT_TEST_F(CreateStreamingQueryWithDefineAction, TStreamingTestFixture) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/ya.make
+++ b/ydb/core/kqp/ut/federated_query/datastreams/ya.make
@@ -27,6 +27,7 @@ SRCS(
 PEERDIR(
     library/cpp/protobuf/interop
     library/cpp/threading/local_executor
+    ydb/core/base
     ydb/core/cms/console
     ydb/core/kqp
     ydb/core/kqp/ut/common

--- a/ydb/library/testlib/pq_helpers/mock_pq_gateway.cpp
+++ b/ydb/library/testlib/pq_helpers/mock_pq_gateway.cpp
@@ -228,8 +228,8 @@ public:
         AddEvent(NYdb::NTopic::TSessionClosedEvent(status, std::move(issues)));
     }
 
-    void ExpectSessionClosed() final {
-        WaitFor(OperationTimeout, "close read session", [this]() {
+    void ExpectSessionClosed(std::optional<TDuration> timeout) final {
+        WaitFor(timeout.value_or(OperationTimeout), "close read session", [this]() {
             return Closed.load();
         });
     }
@@ -330,7 +330,7 @@ public:
         auto message = NYdb::NTopic::TWriteMessage::CompressedMessage(data, codec, originalSize);
         message.SeqNo(seqNo);
         message.CreateTimestamp(createTimestamp);
-        Write(std::move(continuationToken), data, seqNo, createTimestamp);
+        Write(std::move(continuationToken), std::move(message), /* tx */ nullptr);
     }
 
     bool Close(TDuration /*closeTimeout*/) final {
@@ -527,13 +527,23 @@ private:
 class TMockPqGateway final : public IMockPqGateway {
     class TMockTopicClient final : public NYql::ITopicClient {
     public:
-        explicit TMockTopicClient(TMockPqGateway* self)
+        explicit TMockTopicClient(TMockPqGateway* const self)
             : Self(self)
+            , Topics(self->Settings.Topics)
         {}
 
-        NYdb::NTopic::TAsyncDescribeTopicResult DescribeTopic(const TString& /*path*/, const NYdb::NTopic::TDescribeTopicSettings& /*settings*/) final {
+        NYdb::NTopic::TAsyncDescribeTopicResult DescribeTopic(const TString& path, const NYdb::NTopic::TDescribeTopicSettings& /*settings*/) final {
+            TMockPqGatewaySettings::TTopicInfo settings;
+            if (const auto it = Topics.find(path); it != Topics.end()) {
+                settings = it->second;
+            }
+
             Ydb::Topic::DescribeTopicResult describe;
-            describe.add_partitions();
+            for (ui64 i = 0; i < settings.PartitionCount; ++i) {
+                auto* partition = describe.add_partitions();
+                partition->set_partition_id(i);
+            }
+
             return NThreading::MakeFuture(NYdb::NTopic::TDescribeTopicResult(NYdb::TStatus(NYdb::EStatus::SUCCESS, {}), std::move(describe)));
         }
 
@@ -565,7 +575,8 @@ class TMockPqGateway final : public IMockPqGateway {
         }
 
     private:
-        TMockPqGateway* Self;
+        TMockPqGateway* const Self = nullptr;
+        const std::unordered_map<TString, TMockPqGatewaySettings::TTopicInfo> Topics;
     };
 
     class TMockFederatedTopicClient final : public NYql::IFederatedTopicClient {
@@ -616,8 +627,6 @@ class TMockPqGateway final : public IMockPqGateway {
         //// IDeferredPublishClient interface implementation
 
         NYdb::NTopic::TAsyncBeginPublicationResult BeginPublication(const TString& extPublicationId, const NYdb::NTopic::TBeginPublicationSettings& settings) final {
-            Y_UNUSED(settings);
-
             ui64 intId = 0;
             with_lock (Mutex) {
                 intId = ++PublicationIntId;
@@ -748,7 +757,7 @@ class TMockPqGateway final : public IMockPqGateway {
 
     struct TTopicInfo {
         std::unordered_map<ui64, IMockPqReadSession::TPtr> ReadSessionsByPartition;
-        ui64 LastCreatedPartitionId = 0;
+        std::queue<ui64> CreatedPartitionIds;
         TMockPqWriteSession::TPtr WriteSession;
     };
 
@@ -792,9 +801,14 @@ public:
         return NThreading::MakeFuture<TListStreams>(std::move(streams));
     }
 
-    IPqGateway::TAsyncDescribeFederatedTopicResult DescribeFederatedTopic(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& /*path*/, const TString& /*token*/) final {
+    IPqGateway::TAsyncDescribeFederatedTopicResult DescribeFederatedTopic(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& path, const TString& /*token*/) final {
+        TMockPqGatewaySettings::TTopicInfo topicSettings;
+        if (const auto it = Settings.Topics.find(path); it != Settings.Topics.end()) {
+            topicSettings = it->second;
+        }
+
         return NThreading::MakeFuture<TDescribeFederatedTopicResult>(IPqGateway::TDescribeFederatedTopicResult{{
-            .PartitionsCount = 1,
+            .PartitionsCount = topicSettings.PartitionCount,
         }});
     }
 
@@ -834,12 +848,16 @@ public:
         IMockPqReadSession::TPtr session;
         with_lock (Mutex) {
             auto& info = Topics[topic];
-            auto it = info.ReadSessionsByPartition.find(info.LastCreatedPartitionId);
-            if (it != info.ReadSessionsByPartition.end()) {
-                session = std::move(it->second);
-                info.ReadSessionsByPartition.erase(it);
+            if (info.CreatedPartitionIds.empty()) {
+                return session;
             }
+
+            const auto it = info.ReadSessionsByPartition.find(info.CreatedPartitionIds.front());
+            Y_ENSURE(it != info.ReadSessionsByPartition.end());
+            info.CreatedPartitionIds.pop();
+            session = it->second;
         }
+
         return session;
     }
 
@@ -894,7 +912,7 @@ private:
         with_lock (Mutex) {
             auto& info = Topics[path];
             info.ReadSessionsByPartition[partitionId] = session;
-            info.LastCreatedPartitionId = partitionId;
+            info.CreatedPartitionIds.emplace(partitionId);
         }
 
         if (Settings.Runtime && Settings.Notifier) {

--- a/ydb/library/testlib/pq_helpers/mock_pq_gateway.h
+++ b/ydb/library/testlib/pq_helpers/mock_pq_gateway.h
@@ -62,7 +62,7 @@ public:
 
     virtual void AddCloseSessionEvent(NYdb::EStatus status, NYdb::NIssue::TIssues issues = {}) = 0;
 
-    virtual void ExpectSessionClosed() = 0;
+    virtual void ExpectSessionClosed(std::optional<TDuration> timeout = std::nullopt) = 0;
 };
 
 class IMockPqWriteSession {
@@ -125,6 +125,7 @@ public:
     virtual IMockPqReadSession::TPtr ExtractReadSession(const TString& topic) = 0;
 
     // Get read session for a specific partition (multi-partition topics). Returns nullptr if not created.
+    // Topics with multiple partition must be registered in TMockPqGatewaySettings.
     virtual IMockPqReadSession::TPtr GetReadSession(const TString& topic, ui64 partitionId) = 0;
 
     // Wait for read session creation
@@ -140,10 +141,15 @@ public:
 };
 
 struct TMockPqGatewaySettings {
+    struct TTopicInfo {
+        ui32  PartitionCount = 1;
+    };
+
     bool LockWritingByDefault = false;
     TDuration OperationTimeout = TDuration::Seconds(10);
     NActors::TTestActorRuntimeBase* Runtime = nullptr;
     NActors::TActorId Notifier;
+    std::unordered_map<TString, TTopicInfo> Topics;
 };
 
 TIntrusivePtr<IMockPqGateway> CreateMockPqGateway(const TMockPqGatewaySettings& settings = {});

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -853,13 +853,15 @@ protected:
     }
 
     void OnSinkFinished(ui64 outputIndex) override final {
-        SinksMap.at(outputIndex).FinishIsAcknowledged = true;
-        ContinueExecute(EResumeSource::CASinkFinished);
+        if (!std::exchange(SinksMap.at(outputIndex).FinishIsAcknowledged, true)) {
+            ContinueExecute(EResumeSource::CASinkFinished);
+        }
     }
 
     void OnTransformFinished(ui64 outputIndex) override final {
-        OutputTransformsMap.at(outputIndex).FinishIsAcknowledged = true;
-        ContinueExecute(EResumeSource::CATransformFinished);
+        if (!std::exchange(OutputTransformsMap.at(outputIndex).FinishIsAcknowledged, true)) {
+            ContinueExecute(EResumeSource::CATransformFinished);
+        }
     }
 
 protected: //TDqComputeActorCheckpoints::ICallbacks

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1283,7 +1283,9 @@ protected:
                 break;
             }
             case EEvWakeupTag::PeriodicStatsTag: {
-                if (State == NDqProto::COMPUTE_STATE_EXECUTING || State == NDqProto::COMPUTE_STATE_UNKNOWN) {
+                if (State == NDqProto::COMPUTE_STATE_EXECUTING || State == NDqProto::COMPUTE_STATE_UNKNOWN ||
+                    Checkpoints // Tasks with checkpoints should stay after finishing
+                ) {
                     ReportStats();
                     this->Schedule(RuntimeSettings.ReportStatsSettings->MaxInterval, new NActors::TEvents::TEvWakeup(EEvWakeupTag::PeriodicStatsTag));
                 }
@@ -2760,7 +2762,6 @@ protected:
     void ReportStats() {
         auto now = TInstant::Now();
         if ((State != NDqProto::COMPUTE_STATE_EXECUTING && !Task.GetCreateSuspended())      // non streaming queries
-            || ((State != NDqProto::COMPUTE_STATE_UNKNOWN && State != NDqProto::COMPUTE_STATE_EXECUTING) && Task.GetCreateSuspended())
             || !RuntimeSettings.ReportStatsSettings
             || now - LastSendStatsTime < RuntimeSettings.ReportStatsSettings->MinInterval) {
             return;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -185,7 +185,7 @@ public:
 
             if (auto reportStatsSettings = RuntimeSettings.ReportStatsSettings) {
                 if (reportStatsSettings->MaxInterval) {
-                    CA_LOG_D("Set periodic stats " << reportStatsSettings->MaxInterval);
+                    CA_LOG_D("Set periodic stats " << reportStatsSettings->MaxInterval << ", has checkpoints: " << (Checkpoints ? "true" : "false"));
                     this->Schedule(reportStatsSettings->MaxInterval, new NActors::TEvents::TEvWakeup(EEvWakeupTag::PeriodicStatsTag));
                 }
             }
@@ -549,6 +549,8 @@ protected:
             // So, if there is space in the channel buffer (and on previous step is was full), we send ChannelDataAck
             // event with the last known seqNo, and the process on the other side of this channel updates its state
             // and sends us a new batch of data.
+            //
+            // Note: in case of handling `Finished` status with Checkpoints, there is always DataWasSent=true, because outputs are finished.
             if (Channels) {
                 bool pollSent = false;
                 for (auto& [channelId, inputChannel] : InputChannelsMap) {
@@ -600,6 +602,7 @@ protected:
                         return;
                     }
                 }
+
                 if ((!Channels || Channels->CheckInFlight("Tasks execution finished")) && AllAsyncOutputsFinished()) {
                     State = NDqProto::COMPUTE_STATE_FINISHED;
                     CA_LOG_D("Compute state finished. All channels and sinks finished");
@@ -902,6 +905,7 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
                 channelInfo.ResumeByCheckpoint();
             }
         }
+
         // sources or input channels was unpaused, trigger new poll
         ResumeExecution(EResumeSource::CAResumeByCheckpoint);
     }
@@ -1306,7 +1310,10 @@ protected:
                     Checkpoints // Tasks with checkpoints should stay after finishing
                 ) {
                     ReportStats();
-                    this->Schedule(RuntimeSettings.ReportStatsSettings->MaxInterval, new NActors::TEvents::TEvWakeup(EEvWakeupTag::PeriodicStatsTag));
+
+                    const auto statsInterval = RuntimeSettings.ReportStatsSettings->MaxInterval;
+                    CA_LOG_T("Schedule next periodic stats " << statsInterval);
+                    this->Schedule(statsInterval, new NActors::TEvents::TEvWakeup(EEvWakeupTag::PeriodicStatsTag));
                 }
                 break;
             }
@@ -2291,8 +2298,8 @@ protected:
         it->second.Failed = true;
     }
 
-    void HandleAsyncOutputError(const TEvPrivate::TEvAsyncOutputError::TPtr& ev) {
-        InternalError(ev->Get()->StatusCode, ev->Get()->Issues);
+    void HandleAsyncOutputError(TEvPrivate::TEvAsyncOutputError::TPtr& ev) {
+        InternalError(ev->Get()->StatusCode, std::move(ev->Get()->Issues));
     }
 
     void HandleCheckIdleness(const TEvPrivate::TEvCheckIdleness::TPtr& ev) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1158,6 +1158,7 @@ protected:
         IDqComputeActorAsyncOutput* AsyncOutput = nullptr;
         NActors::IActor* Actor = nullptr;
         bool Finished = false; // If sink/transform is in finished state, it receives only checkpoints.
+        bool Failed = false; // If sink/transform reported fatal error, in this case we should stop pushing data
         bool FinishIsAcknowledged = false; // Async output has acknowledged its finish.
         TIssuesBuffer IssuesBuffer;
         bool PopStarted = false;
@@ -2246,23 +2247,32 @@ protected:
     }
 
     void OnSinkError(ui64 outputIndex, const TIssues& issues, NYql::NDqProto::StatusIds::StatusCode fatalCode) override final {
+        const auto it = SinksMap.find(outputIndex);
+        YQL_ENSURE(it != SinksMap.end(), "Unexpected output index: " << outputIndex);
+
         if (fatalCode == NYql::NDqProto::StatusIds::UNSPECIFIED) {
-            SinksMap.at(outputIndex).IssuesBuffer.Push(issues);
+            it->second.IssuesBuffer.Push(issues);
             return;
         }
 
+        // Resources must be cleaned up from compute actor handler, so just schedule failure event
         CA_LOG_E("Sink[" << outputIndex << "] fatal error: " << issues.ToOneLineString());
         this->Send(this->SelfId(), new TEvPrivate::TEvAsyncOutputError(fatalCode, issues));
+        it->second.Failed = true;
     }
 
     void OnOutputTransformError(ui64 outputIndex, const TIssues& issues, NYql::NDqProto::StatusIds::StatusCode fatalCode) override final {
+        const auto it = OutputTransformsMap.find(outputIndex);
+        YQL_ENSURE(it != OutputTransformsMap.end(), "Unexpected output index: " << outputIndex);
+
         if (fatalCode == NYql::NDqProto::StatusIds::UNSPECIFIED) {
-            OutputTransformsMap.at(outputIndex).IssuesBuffer.Push(issues);
+            it->second.IssuesBuffer.Push(issues);
             return;
         }
 
         CA_LOG_E("OutputTransform[" << outputIndex << "] fatal error: " << issues.ToOneLineString());
         this->Send(this->SelfId(), new TEvPrivate::TEvAsyncOutputError(fatalCode, issues));
+        it->second.Failed = true;
     }
 
     void HandleAsyncOutputError(const TEvPrivate::TEvAsyncOutputError::TPtr& ev) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -541,7 +541,9 @@ protected:
             }
         }
 
-        if (status != ERunStatus::Finished) {
+        if (status != ERunStatus::Finished ||
+            Checkpoints // We should send acks after finish in order to receive checkpoints
+        ) {
             // If the incoming channel's buffer was full at the moment when last ChannelDataAck event had been sent,
             // there will be no attempts to send a new piece of data from the other side of this channel.
             // So, if there is space in the channel buffer (and on previous step is was full), we send ChannelDataAck
@@ -553,7 +555,7 @@ protected:
                     pollSent |= Channels->PollChannel(channelId, GetInputChannelFreeSpace(channelId));
                 }
 
-                if (!pollSent) {
+                if (status != ERunStatus::Finished && !pollSent) {
                     CA_LOG_T("Cannot poll input channels, continue execute, data was sent: " << ProcessOutputsState.DataWasSent);
                     if (ProcessOutputsState.DataWasSent) {
                         ContinueExecute(EResumeSource::CADataSent);
@@ -602,6 +604,11 @@ protected:
                     State = NDqProto::COMPUTE_STATE_FINISHED;
                     CA_LOG_D("Compute state finished. All channels and sinks finished");
                     ReportStateAndMaybeDie(NYql::NDqProto::StatusIds::SUCCESS, {TIssue("success")});
+
+                    if (Checkpoints) {
+                        // Continue checkpoints distribution after finish (now stale data in inputs may be skipped)
+                        ContinueExecute(EResumeSource::CAFinish);
+                    }
                 }
             }
         }
@@ -810,7 +817,9 @@ protected:
     }
 
     void ContinueExecute(EResumeSource source = EResumeSource::Default) {
-        if (!ResumeEventScheduled && Running) {
+        if (!ResumeEventScheduled && (Running ||
+            Checkpoints // After finish graph should continue checkpoints distribution
+        )) {
             ResumeEventScheduled = true;
             this->Send(this->SelfId(), new TEvDqCompute::TEvResumeExecution{source});
         }
@@ -886,6 +895,10 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
     void ResumeInputsByCheckpoint() override final {
         for (auto& [id, channelInfo] : InputChannelsMap) {
             if (channelInfo.PendingCheckpoint) {
+                if (const IDqInputChannel::TPtr channel = channelInfo.Channel) {
+                    Y_ENSURE(channel->Empty() || State == NDqProto::COMPUTE_STATE_FINISHED);
+                }
+
                 channelInfo.ResumeByCheckpoint();
             }
         }
@@ -1129,13 +1142,16 @@ protected:
 
         std::vector<TDrainedChannelMessage> DrainChannel(const ui32 countLimit) {
             std::vector<TDrainedChannelMessage> result;
-            if (Finished) {
+            const bool hasCheckpoint = CheckpointingMode != NDqProto::ECheckpointingMode::CHECKPOINTING_MODE_DISABLED;
+            if (Finished &&
+                !hasCheckpoint // Checkpoints can be sent after channel finish
+            ) {
                 Y_ABORT_UNLESS(Channel->IsFinished());
                 return result;
             }
 
             result.reserve(countLimit);
-            for (ui32 i = 0; i < countLimit && !Finished; ++i) {
+            for (ui32 i = 0; i < countLimit && (!Finished || hasCheckpoint); ++i) {
                 TDrainedChannelMessage message;
                 if (!message.ReadData(*this)) {
                     break;

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -41,8 +41,12 @@ protected:
              static_cast<TDerived*>(this)->PollSources(std::move(sourcesState));
         }
 
-        if ((status == ERunStatus::PendingInput || status == ERunStatus::Finished) && this->Checkpoints && this->Checkpoints->HasPendingCheckpoint() && !this->Checkpoints->ComputeActorStateSaved() && ReadyToCheckpoint()) {
-            this->Checkpoints->DoCheckpoint();
+        if ((status == ERunStatus::PendingInput || status == ERunStatus::Finished) && this->Checkpoints) {
+            DrainCheckpointsFromInputChannelsAfterFinish(); // Drain checkpoints from finished channels
+
+            if (this->Checkpoints->HasPendingCheckpoint() && !this->Checkpoints->ComputeActorStateSaved() && ReadyToCheckpoint()) {
+                this->Checkpoints->DoCheckpoint();
+            }
         }
 
         TBase::ProcessOutputsImpl(status);
@@ -80,6 +84,9 @@ protected:
 
     bool DoHandleChannelsAfterFinishImpl() override final {
         Y_ABORT_UNLESS(this->Checkpoints);
+
+        // Read checkpoint from input channels
+        DrainCheckpointsFromInputChannelsAfterFinish();
 
         if (this->Checkpoints->HasPendingCheckpoint() && !this->Checkpoints->ComputeActorStateSaved() && ReadyToCheckpoint()) {
             this->Checkpoints->DoCheckpoint();
@@ -431,6 +438,35 @@ protected:
             TaskRunner->GetReadRanges(),
             TaskRunner->GetRandomProvider()
         );
+    }
+
+    // Must be called under bound MKQL allocator
+    void DrainCheckpointsFromInputChannelsAfterFinish() {
+        Y_ABORT_UNLESS(this->Checkpoints);
+
+        if (this->Channels) {
+            // There is no need to drain v1 channels, because checkpoints will be registered automatically in TakeInputChannelData() method
+            return;
+        }
+
+        CA_LOG_D("Drain #" << this->InputChannelsMap.size() << " inputs after finish");
+
+        // In v2 channels case, checkpoint must be drained manually, because after finish input producer cannot be used.
+        // All stale data, that was in channel after early finish should be drained.
+        for (const auto& [_, info] : this->InputChannelsMap) {
+            const IDqInputChannel::TPtr& channel = info.Channel;
+            Y_ENSURE(channel);
+
+            if (info.CheckpointingMode == NDqProto::ECheckpointingMode::CHECKPOINTING_MODE_DISABLED || !channel->IsFinished()) {
+                continue;
+            }
+
+            TUnboxedValueBatch batch(channel->GetInputType());
+            TMaybe<TInstant> watermark;
+            while (channel->Pop(batch, watermark)) {
+                CA_LOG_T("Skipped data batch after early finish with rows #" << batch.RowCount() << ", watermark: " << (watermark ? ToString(*watermark) : "<null>"));
+            }
+        }
     }
 
     const NYql::NDq::TDqTaskRunnerStats* GetTaskRunnerStats() override {

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -180,8 +180,12 @@ protected: //TDqComputeActorChannels::ICalbacks
 
 protected: //TDqComputeActorCheckpoints::ICallbacks
     bool ReadyToCheckpoint() const override final {
+        // When task become finished, there will be no read attempts from inputs,
+        // so stale data may stay in channels/sources
+        const auto allowNonEmptyInputs = this->State == NDqProto::COMPUTE_STATE_FINISHED;
+
         for (const auto& [_, sourceInfo] : this->SourcesMap) {
-            if (!sourceInfo.Buffer->Empty()) {
+            if (!sourceInfo.Buffer->Empty() && !allowNonEmptyInputs) {
                 return false;
             }
         }
@@ -191,19 +195,19 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
                 continue;
             }
 
-            // A finished channel may no longer become paused, but its buffer still needs to be drained.
-            if (!channelInfo.IsPaused() && !channelInfo.Channel->IsFinished()) {
+            // Checkpoints should be distributed also over finished channels, so here we wait pause unconditionally
+            if (!channelInfo.IsPaused()) {
                 return false;
             }
 
-            if (!channelInfo.Channel->Empty()) {
+            if (!channelInfo.Channel->Empty() && !allowNonEmptyInputs) {
                 return false;
             }
         }
 
         for (const auto& [_, transformInfo] : this->InputTransformsMap) {
             const auto buffer = transformInfo.Buffer;
-            if (!buffer->Empty()) {
+            if (!buffer->Empty() && !allowNonEmptyInputs) {
                 return false;
             }
 

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -508,7 +508,7 @@ protected:
 
     void DrainAsyncOutput(ui64 outputIndex, typename TBase::TAsyncOutputInfoBase& outputInfo) override final {
         this->ProcessOutputsState.AllOutputsFinished &= outputInfo.Finished;
-        if (outputInfo.Finished && !this->Checkpoints) {
+        if ((outputInfo.Finished && !this->Checkpoints) || outputInfo.Failed) {
             return;
         }
 

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -278,7 +278,8 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
 
         ui64 checkpointedInputChannels = 0;
         ui64 emptyInputChannels = 0;
-        ui64 finishedOrPausedInputChannels = 0;
+        ui64 pausedInputChannels = 0;
+        ui64 finishedInputChannels = 0;
         ui64 bytesInInputChannels = 0;
         i64 inputChannelsFreeSpace = 0;
         for (const auto& [_, channelInfo] : this->InputChannelsMap) {
@@ -287,7 +288,8 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
 
                 if (channelInfo.Channel) {
                     emptyInputChannels += channelInfo.Channel->Empty();
-                    finishedOrPausedInputChannels += channelInfo.IsPaused() || channelInfo.Channel->IsFinished();
+                    pausedInputChannels += channelInfo.IsPaused();
+                    finishedInputChannels += channelInfo.Channel->IsFinished();
                     bytesInInputChannels += channelInfo.Channel->GetStoredBytes();
                     inputChannelsFreeSpace += channelInfo.Channel->GetFreeSpace();
                 }
@@ -308,7 +310,8 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
         }
 
         diagnostics << "Inputs state. ["
-            << "Channels paused or finished: " << finishedOrPausedInputChannels << " / " << checkpointedInputChannels
+            << "Channels paused: " << pausedInputChannels << " / " << checkpointedInputChannels
+            << ". Channels finished: " << finishedInputChannels << " / " << checkpointedInputChannels
             << ". Channels empty: " << emptyInputChannels << " / " << checkpointedInputChannels << " (stored bytes: " << bytesInInputChannels << ", fs: " << inputChannelsFreeSpace << ")"
             << ". Sources empty: " << emptySources << " / " << this->SourcesMap.size() << " (stored bytes: " << bytesInSources << ", fs: " << sourcesFreeSpace << ")"
             << ". Transforms empty: " << emptyInputTransforms << " / " << this->InputTransformsMap.size() << " (stored bytes: " << bytesInInputTransforms << ", fs: " << inputTransformsFreeSpace << ")"
@@ -335,7 +338,7 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
                 }
             }
 
-            return TStringBuilder() << " no + soft + hard limit: {" << noLimit << " + " << softLimit << " + " << hardLimit << "} / " << objects.size();
+            return TStringBuilder() << "no + soft + hard limit: {" << noLimit << " + " << softLimit << " + " << hardLimit << "} / " << objects.size();
         };
 
         diagnostics

--- a/ydb/library/yql/dq/actors/compute/events/events.h
+++ b/ydb/library/yql/dq/actors/compute/events/events.h
@@ -30,6 +30,7 @@ enum class EResumeSource : ui32 {
     CAWatermarkIdleness,
     CAWakeupCallback,
     CAResumeByCheckpoint,
+    CAFinish,
 
     Last,
 };

--- a/ydb/library/yql/dq/runtime/dq_channel_service.cpp
+++ b/ydb/library/yql/dq/runtime/dq_channel_service.cpp
@@ -846,14 +846,16 @@ bool TInputDescriptor::PushDataChunk(TDataChunk&& data) {
     (*InputBufferChunks)++;
     *InputBufferBytes += data.Bytes;
 
-    if (FinishPushed.load() &&
-        !data.Checkpoint // Checkpoints may be generated after channel finish
-    ) {
+    if (FinishPushed.load()) {
         if (data.ConfirmFinish) {
             Finished.store(true);
             ActorSystem->Send(Info.InputActorId, new TEvDqCompute::TEvResumeExecution{EResumeSource::CAWakeupCallback});
         }
-        return false;
+
+        // Checkpoints may be generated after channel finish
+        if (!data.Checkpoint) {
+            return false;
+        }
     }
 
     std::lock_guard lock(QueueMutex);

--- a/ydb/library/yql/dq/runtime/dq_channel_service.cpp
+++ b/ydb/library/yql/dq/runtime/dq_channel_service.cpp
@@ -144,7 +144,9 @@ void TLocalBuffer::SetFillAggregator(std::shared_ptr<TDqFillAggregator> aggregat
 }
 
 void TLocalBuffer::Push(TDataChunk&& data) {
-    if (!FinishPushed && !Finished.load()) {
+    if ((!FinishPushed && !Finished.load()) ||
+        data.Checkpoint // Checkpoints may be generated after channel finish
+    ) {
         if (data.Finished) {
             FinishPushed = true;
         }
@@ -211,7 +213,7 @@ void TLocalBuffer::PushDataChunk(TDataChunk&& data) {
         NeedToNotifyOutput.store(true);
     }
 
-    NotifyInput(false);
+    NotifyInput(Finished.load());
 }
 
 bool TLocalBuffer::IsFinished() {
@@ -458,7 +460,9 @@ void TOutputDescriptor::PushDataChunk(TDataChunk&& data, TNodeState* nodeState, 
         PushStats.Resume();
     }
 
-    if (FinishPushed.load() && !data.ConfirmFinish) {
+    if (FinishPushed.load() && !data.ConfirmFinish &&
+        !data.Checkpoint // Checkpoint traffic should be handled after finish
+    ) {
         return;
     }
 
@@ -780,7 +784,9 @@ void TOutputBuffer::SetFillAggregator(std::shared_ptr<TDqFillAggregator> aggrega
 }
 
 void TOutputBuffer::Push(TDataChunk&& data) {
-    if (!Descriptor->IsTerminatedOrAborted() && !Descriptor->IsFinished()) {
+    if (!Descriptor->IsTerminatedOrAborted() && (!Descriptor->IsFinished() ||
+        data.Checkpoint // Checkpoints may be generated after channel finish
+    )) {
         Descriptor->PushDataChunk(std::move(data), NodeState.get(), Descriptor);
     }
 }
@@ -840,7 +846,9 @@ bool TInputDescriptor::PushDataChunk(TDataChunk&& data) {
     (*InputBufferChunks)++;
     *InputBufferBytes += data.Bytes;
 
-    if (FinishPushed.load()) {
+    if (FinishPushed.load() &&
+        !data.Checkpoint // Checkpoints may be generated after channel finish
+    ) {
         if (data.ConfirmFinish) {
             Finished.store(true);
             ActorSystem->Send(Info.InputActorId, new TEvDqCompute::TEvResumeExecution{EResumeSource::CAWakeupCallback});

--- a/ydb/library/yql/dq/runtime/dq_channel_service.cpp
+++ b/ydb/library/yql/dq/runtime/dq_channel_service.cpp
@@ -2513,7 +2513,6 @@ TString TDqChannelService::GetDebugInfo() {
 // TFastDqOutputChannel::
 
 bool TFastDqInputChannel::Pop(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>& watermark) {
-
     if (PausedByCheckpoint) {
         return false;
     }

--- a/ydb/library/yql/dq/runtime/dq_channel_service_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_channel_service_impl.h
@@ -955,9 +955,10 @@ public:
     }
 
     void Push(NDqProto::TCheckpoint&& checkpoint) override {
-        if (!Serializer->Buffer->IsFinished()) {
-            Serializer->Push(std::move(checkpoint));
-        }
+        Serializer->Buffer->IsFinished(); // Finish check must be called to notify channel consumers
+
+        // Checkpoints may be sent after channel finish
+        Serializer->Push(std::move(checkpoint));
     }
 
     void Finish() override {

--- a/ydb/library/yql/dq/runtime/dq_input_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_input_impl.h
@@ -267,7 +267,7 @@ public:
 
     [[nodiscard]]
     bool Empty() const override {
-        return Batches.empty() || IsPaused() && BeforeBarrier.BatchesCount == 0;
+        return Batches.empty() || (IsPaused() && BeforeBarrier.BatchesCount == 0);
     }
 
 private:
@@ -293,6 +293,7 @@ public:
     }
 
     void ResumeByCheckpoint() override {
+        // Note: resume may be called on non empty channel after of task finishing
         Y_ENSURE(IsPausedByCheckpoint());
         BeforeBarrier = PendingBarriers.front();
         PendingBarriers.pop_front();

--- a/ydb/library/yql/dq/runtime/dq_input_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_input_impl.h
@@ -294,7 +294,6 @@ public:
 
     void ResumeByCheckpoint() override {
         Y_ENSURE(IsPausedByCheckpoint());
-        Y_ENSURE(Empty());
         BeforeBarrier = PendingBarriers.front();
         PendingBarriers.pop_front();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed checkpoints propagation on finished graph.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Also fixed list:

- [Fixed state save/recovery for not initialized stateful operators](https://github.com/ydb-platform/ydb/pull/51600/changes/2583164896160b0107ed934b46e145298a738771)
- [Fixed streaming query compute actors cleanup](https://github.com/ydb-platform/ydb/pull/51600/changes/29ea3220d8e2151339ec2d135ec49a3e6a18c28c)
- [Fixed busy wait for mixed finished/unfinished sinks](https://github.com/ydb-platform/ydb/pull/51600/changes/e52e43cb79ebfded7d09232cefcaa2dfcfbd0a42)
- [Fixed race on sink failure status report](https://github.com/ydb-platform/ydb/pull/51600/changes/35c225eb6c0e1a813cc6d91fcbe316b35e87d6e2)