### PR TITLE
Add Y_WEAK macro support for GCC to avoid duplicate symbols on Windows

### DIFF
--- a/ydb/library/wasm/api/compartment.cpp
+++ b/ydb/library/wasm/api/compartment.cpp
@@ -6,6 +6,10 @@ namespace NYdb::NWasm {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Y_WEAK is a no-op on Windows (COFF); omitting stubs avoids duplicate
+// symbols with the strong overrides in library/wasm/engine.
+#if defined(__GNUC__)
+
 Y_WEAK void IWebAssemblyCompartment::AddPrecompiledModule(const TModuleBytecode& /*bytecode*/, TStringBuf /*name*/)
 {
     YT_UNIMPLEMENTED();
@@ -45,6 +49,8 @@ Y_WEAK void SetCurrentCompartment(IWebAssemblyCompartment*)
 {
     YT_UNIMPLEMENTED();
 }
+
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/library/wasm/api/data_transfer.cpp
+++ b/ydb/library/wasm/api/data_transfer.cpp
@@ -31,6 +31,9 @@ TCopyGuard::TCopyGuard(IWebAssemblyCompartment* compartment, uintptr_t offset)
     , CopiedOffset_(offset)
 { }
 
+// Y_WEAK is a no-op on Windows (COFF); omitting the stub avoids duplicate
+// symbols with the strong override in library/wasm/engine.
+#if defined(__GNUC__)
 Y_WEAK TCopyGuard::~TCopyGuard()
 {
     if (Compartment_ != nullptr && CopiedOffset_ != 0) {
@@ -41,6 +44,7 @@ Y_WEAK TCopyGuard::~TCopyGuard()
         }
     }
 }
+#endif
 
 TCopyGuard::TCopyGuard(TCopyGuard&& other) noexcept
 {

--- a/ydb/library/wasm/api/function.cpp
+++ b/ydb/library/wasm/api/function.cpp
@@ -8,6 +8,9 @@ namespace NYdb::NWasm {
 
 namespace NDetail {
 
+// Y_WEAK is a no-op on Windows (COFF); omitting the stub avoids duplicate
+// symbols with the strong override in library/wasm/engine.
+#if defined(__GNUC__)
 Y_WEAK void WavmInvoke(
     IWebAssemblyCompartment* /*compartment*/,
     TWebAssemblyRuntimeType /*runtimeType*/,
@@ -17,6 +20,7 @@ Y_WEAK void WavmInvoke(
 {
     YT_UNIMPLEMENTED();
 }
+#endif
 
 } // namespace NDetail
 

--- a/ydb/library/wasm/api/memory_pool.cpp
+++ b/ydb/library/wasm/api/memory_pool.cpp
@@ -19,6 +19,9 @@ TWebAssemblyMemoryPool::TWebAssemblyMemoryPool(IWebAssemblyCompartment* compartm
     : Compartment_(compartment)
 { }
 
+// Y_WEAK is a no-op on Windows (COFF); omitting the stub avoids duplicate
+// symbols with the strong override in library/wasm/engine.
+#if defined(__GNUC__)
 Y_WEAK TWebAssemblyMemoryPool::~TWebAssemblyMemoryPool()
 {
     try {
@@ -27,6 +30,7 @@ Y_WEAK TWebAssemblyMemoryPool::~TWebAssemblyMemoryPool()
         // FreeBytes may throw; never throw from dtor.
     }
 }
+#endif
 
 TWebAssemblyMemoryPool::TWebAssemblyMemoryPool(TWebAssemblyMemoryPool&& other) noexcept
     : Compartment_(std::exchange(other.Compartment_, nullptr))

--- a/ydb/library/wasm/api/type_builder.cpp
+++ b/ydb/library/wasm/api/type_builder.cpp
@@ -19,12 +19,19 @@ namespace NYdb::NWasm {
     XX(unsigned int, EWebAssemblyValueType::Int32)
     XX(unsigned char, EWebAssemblyValueType::Int32)
 
+    // LLP64 (Windows): long is 32-bit; LP64 (Linux/macOS): long is 64-bit.
+#if defined(_win_)
+    XX(long, EWebAssemblyValueType::Int32)
+    XX(unsigned long, EWebAssemblyValueType::Int32)
+    XX(long long, EWebAssemblyValueType::Int64)
+    XX(unsigned long long, EWebAssemblyValueType::Int64)
+#else
     XX(long, EWebAssemblyValueType::Int64)
     XX(unsigned long, EWebAssemblyValueType::Int64)
-
-#   if defined (__APPLE__)
+#   if defined(__APPLE__)
         XX(unsigned long long, EWebAssemblyValueType::Int64)
 #   endif
+#endif
 
     XX(float, EWebAssemblyValueType::Float32)
     XX(double, EWebAssemblyValueType::Float64)
@@ -37,6 +44,10 @@ namespace NYdb::NWasm {
     XX(const uint8_t**, EWebAssemblyValueType::UintPtr)
     XX(int*, EWebAssemblyValueType::UintPtr)
     XX(unsigned long*, EWebAssemblyValueType::UintPtr)
+#if defined(_win_)
+    XX(long long*, EWebAssemblyValueType::UintPtr)
+    XX(unsigned long long*, EWebAssemblyValueType::UintPtr)
+#endif
     XX(void*, EWebAssemblyValueType::UintPtr)
     XX(void**, EWebAssemblyValueType::UintPtr)
     XX(void* const*, EWebAssemblyValueType::UintPtr)
@@ -48,6 +59,9 @@ namespace NYdb::NWasm {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Y_WEAK is a no-op on Windows (COFF); omitting the stub avoids duplicate
+// symbols with the strong override in library/wasm/engine.
+#if defined(__GNUC__)
 Y_WEAK TWebAssemblyRuntimeType GetTypeId(
     bool /*intrinsic*/,
     EWebAssemblyValueType /*returnType*/,
@@ -55,6 +69,7 @@ Y_WEAK TWebAssemblyRuntimeType GetTypeId(
 {
     YT_UNIMPLEMENTED();
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Add Y_WEAK macro support for GCC to avoid duplicate symbols on Windows