### PR TITLE
Fix static group self-heal drive status enum

### DIFF
--- a/ydb/tests/functional/config/test_distconf_static_group.py
+++ b/ydb/tests/functional/config/test_distconf_static_group.py
@@ -359,7 +359,7 @@ class TestStaticGroupSelfHealPlacementPolicy:
                 if (
                     pdisk.NodeId == source[0]
                     and pdisk.PDiskId != source[1]
-                    and pdisk.DriveStatus == bsconfig.EDriveStatus.ACTIVE
+                    and pdisk.DriveStatus == bsbase.EDriveStatus.ACTIVE
                 )
             ]
             assert_that(local_spares, "No local spare PDisk is available")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed the static-group self-heal placement-policy test to use the correct drive status enum.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes `ydb/tests/functional/config/test_distconf_static_group.py.TestStaticGroupSelfHealPlacementPolicy.test_local_policy_relocates_to_spare_pdisk_on_same_node` ([public test history](https://datalens.yandex/34xnbsom67hcq?&build_type=relwithdebinfo&branch=main&full_name=ydb/tests/functional/config/test_distconf_static_group.py.TestStaticGroupSelfHealPlacementPolicy.test_local_policy_relocates_to_spare_pdisk_on_same_node), [issue #49856](https://github.com/ydb-platform/ydb/issues/49856)).

The PDisk `DriveStatus` field uses `NKikimrBlobStorage.EDriveStatus` from `blobstorage_base3_pb2`; the test referenced a nonexistent enum export from `blobstorage_config_pb2`.