### PR TITLE
Wake adjacent pool owner for queued activations

### DIFF
--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -1,13 +1,162 @@
 #include "auto_config_initializer.h"
+#include "config_helpers.h"
 
 #include <ydb/core/protos/config.pb.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/scheduler_basic.h>
+#include <ydb/library/actors/core/subsystems/stats.h>
+#include <ydb/library/actors/core/thread_context.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/system/event.h>
 
+#include <atomic>
 
 Y_UNIT_TEST_SUITE(AutoConfig) {
 
 using namespace NKikimr;
 using namespace NAutoConfigInitializer;
+
+namespace {
+
+class TDelayedSignalActor : public NActors::TActorBootstrapped<TDelayedSignalActor> {
+public:
+    TDelayedSignalActor(
+            TManualEvent* ready,
+            TManualEvent* done,
+            NActors::TActorId* actorId,
+            std::atomic<ui32>* executionOwnerPoolId)
+        : Ready(ready)
+        , Done(done)
+        , ActorId(actorId)
+        , ExecutionOwnerPoolId(executionOwnerPoolId)
+    {}
+
+    void Bootstrap() {
+        Become(&TDelayedSignalActor::StateFunc);
+        *ActorId = SelfId();
+        Ready->Signal();
+    }
+
+    STFUNC(StateFunc) {
+        Y_VERIFY_S(
+            ev->GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType,
+            "unexpected event type# " << ev->GetTypeRewrite());
+        ExecutionOwnerPoolId->store(NActors::TlsThreadContext->OwnerPoolId(), std::memory_order_release);
+        Done->Signal();
+        PassAway();
+    }
+
+private:
+    TManualEvent* const Ready;
+    TManualEvent* const Done;
+    NActors::TActorId* const ActorId;
+    std::atomic<ui32>* const ExecutionOwnerPoolId;
+};
+
+class TStartAdjacentActor : public NActors::TActorBootstrapped<TStartAdjacentActor> {
+public:
+    TStartAdjacentActor(
+            ui32 adjacentPoolId,
+            TManualEvent* ready,
+            TManualEvent* done,
+            NActors::TActorId* actorId,
+            std::atomic<ui32>* executionOwnerPoolId)
+        : AdjacentPoolId(adjacentPoolId)
+        , Ready(ready)
+        , Done(done)
+        , ActorId(actorId)
+        , ExecutionOwnerPoolId(executionOwnerPoolId)
+    {}
+
+    void Bootstrap() {
+        Register(
+            new TDelayedSignalActor(Ready, Done, ActorId, ExecutionOwnerPoolId),
+            NActors::TMailboxType::HTSwap,
+            AdjacentPoolId);
+        PassAway();
+    }
+
+private:
+    const ui32 AdjacentPoolId;
+    TManualEvent* const Ready;
+    TManualEvent* const Done;
+    NActors::TActorId* const ActorId;
+    std::atomic<ui32>* const ExecutionOwnerPoolId;
+};
+
+THolder<NActors::TActorSystemSetup> CreateActorSystemSetup(
+        const NKikimrConfig::TActorSystemConfig& config)
+{
+    auto setup = MakeHolder<NActors::TActorSystemSetup>();
+    setup->NodeId = 1;
+    setup->CpuManager.Shared.United = config.GetUseUnitedPool();
+    setup->CpuManager.PingInfoByPool.resize(config.ExecutorSize());
+    ui32 poolId = 0;
+    for (const auto& poolConfig : config.GetExecutor()) {
+        NActorSystemConfigHelpers::AddExecutorPool(
+            setup->CpuManager,
+            poolConfig,
+            config,
+            poolId++,
+            nullptr);
+    }
+    setup->Scheduler.Reset(NActors::CreateSchedulerThread(
+        NActorSystemConfigHelpers::CreateSchedulerConfig(config.GetScheduler())));
+    return setup;
+}
+
+const NActors::TBasicExecutorPoolConfig& FindBasicPool(
+        const NActors::TCpuManagerConfig& config,
+        ui32 poolId)
+{
+    const NActors::TBasicExecutorPoolConfig* result = nullptr;
+    for (const auto& pool : config.Basic) {
+        if (pool.PoolId == poolId) {
+            result = &pool;
+            break;
+        }
+    }
+    UNIT_ASSERT_C(result, "BASIC executor pool " << poolId << " was not configured");
+    return *result;
+}
+
+ui64 GetSharedParkedTicks(const NActors::TActorSystem& actorSystem, ui32 poolId) {
+    NActors::TExecutorPoolStats poolStats;
+    TVector<NActors::TExecutorThreadStats> threadStats;
+    TVector<NActors::TExecutorThreadStats> sharedThreadStats;
+    NActors::GetActorSystemStats(actorSystem).GetPoolStats(
+        poolId,
+        poolStats,
+        threadStats,
+        sharedThreadStats);
+
+    ui64 parkedTicks = 0;
+    for (const auto& stats : sharedThreadStats) {
+        parkedTicks += stats.SafeParkedTicks;
+    }
+    return parkedTicks;
+}
+
+bool WaitForSharedThreadToPark(
+        const NActors::TActorSystem& actorSystem,
+        ui32 poolId,
+        TDuration timeout)
+{
+    const ui64 initialParkedTicks = GetSharedParkedTicks(actorSystem, poolId);
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        Sleep(TDuration::MilliSeconds(1));
+        if (GetSharedParkedTicks(actorSystem, poolId) > initialParkedTicks) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // anonymous namespace
 
 #define ASSERT_POOLS(pools, sys, user, batch, io, ic) \
     do { \
@@ -146,6 +295,83 @@ Y_UNIT_TEST(SharedAndUnitedAutoConfigMatrix) {
             }
         }
     }
+}
+
+Y_UNIT_TEST(AutoConfiguredAdjacentPoolWakesAfterIdle) {
+    NKikimrConfig::TActorSystemConfig config;
+    config.SetCpuCount(2);
+    config.SetUseSharedThreads(true);
+    config.SetUseUnitedPool(true);
+
+    ApplyAutoConfig(&config, false, false);
+
+    const ui32 ownerPoolId = config.GetSysExecutor();
+    const ui32 adjacentPoolId = config.GetBatchExecutor();
+    auto setup = CreateActorSystemSetup(config);
+
+    UNIT_ASSERT(setup->CpuManager.Shared.United);
+    UNIT_ASSERT_VALUES_EQUAL(setup->CpuManager.Basic.size(), 4);
+    UNIT_ASSERT_VALUES_EQUAL(setup->CpuManager.IO.size(), 1);
+
+    const auto& ownerPool = FindBasicPool(setup->CpuManager, ownerPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.PoolName, "User");
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.Threads, 1);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.DefaultThreadCount, 1);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.MaxThreadCount, 1);
+    UNIT_ASSERT(ownerPool.HasSharedThread);
+    UNIT_ASSERT(ownerPool.AllThreadsAreShared);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.ForcedForeignSlotCount, 1);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.AdjacentPools, (std::vector<i16>{static_cast<i16>(adjacentPoolId)}));
+
+    const auto& adjacentPool = FindBasicPool(setup->CpuManager, adjacentPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.PoolName, "Batch");
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.Threads, 0);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.DefaultThreadCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.MaxThreadCount, 0);
+    UNIT_ASSERT(!adjacentPool.HasSharedThread);
+    UNIT_ASSERT(adjacentPool.AllThreadsAreShared);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.ForcedForeignSlotCount, 0);
+    UNIT_ASSERT(adjacentPool.AdjacentPools.empty());
+
+    NActors::TActorSystem actorSystem(setup);
+    actorSystem.Start();
+
+    TManualEvent ready;
+    TManualEvent done;
+    NActors::TActorId adjacentActorId;
+    std::atomic<ui32> executionOwnerPoolId = Max<ui32>();
+    actorSystem.Register(
+        new TStartAdjacentActor(
+            adjacentPoolId,
+            &ready,
+            &done,
+            &adjacentActorId,
+            &executionOwnerPoolId),
+        NActors::TMailboxType::HTSwap,
+        ownerPoolId);
+
+    const bool actorIsReady = ready.WaitT(TDuration::Seconds(5));
+    const bool ownerIsParked = actorIsReady
+        && WaitForSharedThreadToPark(actorSystem, ownerPoolId, TDuration::Seconds(5));
+    if (ownerIsParked) {
+        actorSystem.Schedule(
+            TDuration::MilliSeconds(100),
+            new NActors::IEventHandle(
+                adjacentActorId,
+                NActors::TActorId(),
+                new NActors::TEvents::TEvWakeup()));
+    }
+    const bool completed = ownerIsParked && done.WaitT(TDuration::Seconds(5));
+
+    actorSystem.Stop();
+    UNIT_ASSERT_C(actorIsReady, "auto-configured Batch actor did not initialize");
+    UNIT_ASSERT_C(ownerIsParked, "auto-configured adjacent User thread did not become idle");
+    UNIT_ASSERT_C(completed,
+        "auto-configured Batch pool did not execute a delayed event after its adjacent User owner became idle");
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        executionOwnerPoolId.load(std::memory_order_acquire),
+        ownerPoolId,
+        "Batch activation was not executed by its adjacent User owner");
 }
 
 } // Y_UNIT_TEST_SUITE(AutoConfig)

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -876,8 +876,12 @@ namespace NActors {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "need to wake up");
             WakeUpLoop(semaphore.CurrentThreadCount);
         } else if (SharedPool) {
-            EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "shared pool wake up global threads");
-            SharedPool->WakeUpGlobalThreads(PoolId);
+            if (SharedPool->WakeUpAdjacentOwner(PoolId)) {
+                EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "shared pool wake up adjacent owner");
+            } else {
+                EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "shared pool wake up global threads");
+                SharedPool->WakeUpGlobalThreads(PoolId);
+            }
         }
     }
 

--- a/ydb/library/actors/core/executor_pool_shared.cpp
+++ b/ydb/library/actors/core/executor_pool_shared.cpp
@@ -35,6 +35,7 @@ namespace NActors {
         : PoolInfos(poolInfos)
     {
         PoolThreadRanges.resize(poolInfos.size());
+        AdjacentOwnerByPool.resize(poolInfos.size(), -1);
         ui64 totalThreads = 0;
         for (const auto& poolInfo : poolInfos) {
             PoolThreadRanges[poolInfo.PoolId].Begin = totalThreads;
@@ -42,6 +43,19 @@ namespace NActors {
             totalThreads += poolInfo.SharedThreadCount;
             if (poolInfo.InPriorityOrder) {
                 PriorityOrder.push_back(poolInfo.PoolId);
+            }
+            Y_ABORT_UNLESS(poolInfo.AdjacentPools.empty() || poolInfo.SharedThreadCount > 0,
+                "pool %d has adjacent pools but owns no shared threads", poolInfo.PoolId);
+            for (i16 adjacentPoolId : poolInfo.AdjacentPools) {
+                Y_ABORT_UNLESS(adjacentPoolId >= 0 && static_cast<size_t>(adjacentPoolId) < poolInfos.size(),
+                    "invalid adjacent pool %d for owner pool %d", adjacentPoolId, poolInfo.PoolId);
+                Y_ABORT_UNLESS(poolInfo.PoolId != adjacentPoolId,
+                    "pool %d cannot be adjacent to itself", poolInfo.PoolId);
+                i16& adjacentOwner = AdjacentOwnerByPool[adjacentPoolId];
+                Y_ABORT_UNLESS(adjacentOwner == -1,
+                    "adjacent pool %d has multiple owner pools: %d and %d",
+                    adjacentPoolId, adjacentOwner, poolInfo.PoolId);
+                adjacentOwner = poolInfo.PoolId;
             }
         }
         Sort(PoolInfos.begin(), PoolInfos.end(), [](const TPoolShortInfo& a, const TPoolShortInfo& b) {
@@ -494,6 +508,19 @@ namespace NActors {
             }
         }
         return true;
+    }
+
+    bool TSharedExecutorPool::WakeUpAdjacentOwner(i16 poolId) {
+        Y_ABORT_UNLESS(poolId >= 0 && static_cast<size_t>(poolId) < PoolManager.AdjacentOwnerByPool.size());
+        const i16 adjacentOwnerPoolId = PoolManager.AdjacentOwnerByPool[poolId];
+        if (adjacentOwnerPoolId == -1) {
+            return false;
+        }
+        if (WakeUpLocalThreads(adjacentOwnerPoolId)) {
+            EXECUTOR_POOL_SHARED_DEBUG(EDebugLevel::Executor, "wakeup from adjacent pool owner; poolId == ", poolId, " adjacentOwnerPoolId == ", adjacentOwnerPoolId);
+            return true;
+        }
+        return false;
     }
 
     bool TSharedExecutorPool::WakeUpGlobalThreads(i16 ownerPoolId) {

--- a/ydb/library/actors/core/executor_pool_shared.h
+++ b/ydb/library/actors/core/executor_pool_shared.h
@@ -44,6 +44,7 @@ namespace NActors {
         std::vector<TPoolShortInfo> PoolInfos;
         TStackVec<TPoolThreadRange, 8> PoolThreadRanges;
         TStackVec<i16, 8> PriorityOrder;
+        std::vector<i16> AdjacentOwnerByPool;
 
         TPoolManager(const std::vector<TPoolShortInfo> &poolInfos);
     };
@@ -163,6 +164,7 @@ namespace NActors {
         i16 GetSharedThreadCount() const override;
 
         bool WakeUpLocalThreads(i16 poolId);
+        bool WakeUpAdjacentOwner(i16 poolId);
         bool WakeUpGlobalThreads(i16 poolId);
 
         void FillForeignThreadsAllowed(std::vector<i16>& foreignThreadsAllowed) const override;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed delayed actor events getting stuck when an adjacent executor-pool owner is idle.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Each adjacent pool is mapped to its single shared-thread owner. Activation scheduling now notifies and wakes that owner after local workers and before the foreign-slot fallback, while startup validates that the owner is unique and owns a shared thread.

This PR is stacked on #51455, which contains the production-config regression test.