### PR TITLE
Fix scheduler cookie lifetime race

### DIFF
--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -944,8 +944,12 @@ private:
 
 class TFakeSchedulerCookie : public ISchedulerCookie {
 public:
-    bool Detach() noexcept override { delete this; return false; }
-    bool DetachEvent() noexcept override { Y_ABORT(); }
+    TFakeSchedulerCookie()
+        : ISchedulerCookie(1)
+    {}
+
+    bool DetachImpl() noexcept override { return false; }
+    bool DetachEventImpl() noexcept override { Y_ABORT(); }
     bool IsArmed() noexcept override { Y_ABORT(); }
 };
 

--- a/ydb/library/actors/core/scheduler_cookie.cpp
+++ b/ydb/library/actors/core/scheduler_cookie.cpp
@@ -6,7 +6,8 @@ namespace NActors {
 
     public:
         TSchedulerCookie2Way()
-            : Value(2)
+            : ISchedulerCookie(2)
+            , Value(2)
         {
         }
 
@@ -14,20 +15,18 @@ namespace NActors {
             return (AtomicGet(Value) == 2);
         }
 
-        bool Detach() noexcept override {
+        bool DetachImpl() noexcept override {
             const ui64 x = AtomicDecrement(Value);
             if (x == 1)
                 return true;
 
-            if (x == 0) {
-                delete this;
+            if (x == 0)
                 return false;
-            }
 
             Y_ABORT();
         }
 
-        bool DetachEvent() noexcept override {
+        bool DetachEventImpl() noexcept override {
             Y_ABORT();
         }
     };
@@ -41,7 +40,8 @@ namespace NActors {
 
     public:
         TSchedulerCookie3Way()
-            : Value(3)
+            : ISchedulerCookie(3)
+            , Value(3)
         {
         }
 
@@ -49,30 +49,24 @@ namespace NActors {
             return (AtomicGet(Value) == 3);
         }
 
-        bool Detach() noexcept override {
+        bool DetachImpl() noexcept override {
             const ui64 x = AtomicDecrement(Value);
             if (x == 2)
                 return true;
-            if (x == 1)
+            if (x == 1 || x == 0)
                 return false;
-            if (x == 0) {
-                delete this;
-                return false;
-            }
 
             Y_ABORT();
         }
 
-        bool DetachEvent() noexcept override {
+        bool DetachEventImpl() noexcept override {
             const ui64 x = AtomicDecrement(Value);
             if (x == 2)
                 return false;
             if (x == 1)
                 return true;
-            if (x == 0) {
-                delete this;
+            if (x == 0)
                 return false;
-            }
 
             Y_ABORT();
         }

--- a/ydb/library/actors/core/scheduler_cookie.h
+++ b/ydb/library/actors/core/scheduler_cookie.h
@@ -5,13 +5,42 @@
 
 namespace NActors {
     class ISchedulerCookie : TNonCopyable {
+        // Each logical participant owns one lifetime slot. Keep lifetime
+        // accounting outside the virtual implementation so a concurrent
+        // participant cannot destroy the cookie before DetachImpl() returns.
+        TAtomic Lifetime;
+
+        void Release() noexcept {
+            if (AtomicDecrement(Lifetime) == 0) {
+                delete this;
+            }
+        }
+
     protected:
+        explicit ISchedulerCookie(ui64 lifetime)
+            : Lifetime(lifetime)
+        {
+        }
+
         virtual ~ISchedulerCookie() {
         }
 
+        virtual bool DetachImpl() noexcept = 0;
+        virtual bool DetachEventImpl() noexcept = 0;
+
     public:
-        virtual bool Detach() noexcept = 0;
-        virtual bool DetachEvent() noexcept = 0;
+        bool Detach() noexcept {
+            const bool result = DetachImpl();
+            Release();
+            return result;
+        }
+
+        bool DetachEvent() noexcept {
+            const bool result = DetachEventImpl();
+            Release();
+            return result;
+        }
+
         virtual bool IsArmed() noexcept = 0;
 
         static ISchedulerCookie* Make2Way();

--- a/ydb/library/actors/core/ut/scheduler_cookie_ut.cpp
+++ b/ydb/library/actors/core/ut/scheduler_cookie_ut.cpp
@@ -1,0 +1,150 @@
+#include "../scheduler_cookie.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/vector.h>
+
+#include <atomic>
+#include <thread>
+
+using namespace NActors;
+
+namespace {
+
+    constexpr size_t CookieCount = 10000;
+
+    struct TDetachState {
+        std::atomic<size_t> Entered = 0;
+        std::atomic<size_t> Returned = 0;
+        std::atomic<bool> Destroyed = false;
+    };
+
+    class TObservedSchedulerCookie final : public ISchedulerCookie {
+        TDetachState& State;
+
+    public:
+        explicit TObservedSchedulerCookie(TDetachState& state)
+            : ISchedulerCookie(2)
+            , State(state)
+        {}
+
+        ~TObservedSchedulerCookie() override {
+            State.Destroyed.store(true, std::memory_order_release);
+        }
+
+        bool DetachImpl() noexcept override {
+            if (State.Entered.fetch_add(1, std::memory_order_acq_rel) == 0) {
+                while (State.Returned.load(std::memory_order_acquire) == 0) {
+                    std::this_thread::yield();
+                }
+                UNIT_ASSERT(!State.Destroyed.load(std::memory_order_acquire));
+            }
+            return false;
+        }
+
+        bool DetachEventImpl() noexcept override {
+            Y_ABORT();
+        }
+
+        bool IsArmed() noexcept override {
+            return true;
+        }
+    };
+
+    void WaitForParticipants(std::atomic<size_t>& ready, size_t expected) {
+        ready.fetch_add(1, std::memory_order_acq_rel);
+        while (ready.load(std::memory_order_acquire) < expected) {
+            std::this_thread::yield();
+        }
+    }
+
+}
+
+Y_UNIT_TEST_SUITE(SchedulerCookie) {
+    Y_UNIT_TEST(WaitsForConcurrentDetachImpl) {
+        TDetachState state;
+        auto* cookie = new TObservedSchedulerCookie(state);
+
+        auto detach = [&] {
+            cookie->Detach();
+            state.Returned.fetch_add(1, std::memory_order_release);
+        };
+
+        std::thread first(detach);
+        std::thread second(detach);
+        first.join();
+        second.join();
+
+        UNIT_ASSERT(state.Destroyed.load(std::memory_order_acquire));
+    }
+
+    Y_UNIT_TEST(ConcurrentDetach2Way) {
+        TVector<ISchedulerCookie*> cookies(CookieCount);
+        for (auto& cookie : cookies) {
+            cookie = ISchedulerCookie::Make2Way();
+        }
+
+        std::atomic<size_t> ready = 0;
+        TVector<ui8> firstResults(CookieCount);
+        TVector<ui8> secondResults(CookieCount);
+
+        std::thread first([&] {
+            for (size_t i = 0; i < CookieCount; ++i) {
+                WaitForParticipants(ready, 2 * (i + 1));
+                firstResults[i] = cookies[i]->Detach();
+            }
+        });
+        std::thread second([&] {
+            for (size_t i = 0; i < CookieCount; ++i) {
+                WaitForParticipants(ready, 2 * (i + 1));
+                secondResults[i] = cookies[i]->Detach();
+            }
+        });
+
+        first.join();
+        second.join();
+
+        for (size_t i = 0; i < CookieCount; ++i) {
+            UNIT_ASSERT_VALUES_UNEQUAL(firstResults[i], secondResults[i]);
+        }
+    }
+
+    Y_UNIT_TEST(ConcurrentDetach3Way) {
+        TVector<ISchedulerCookie*> cookies(CookieCount);
+        for (auto& cookie : cookies) {
+            cookie = ISchedulerCookie::Make3Way();
+        }
+
+        std::atomic<size_t> ready = 0;
+        TVector<ui8> firstResults(CookieCount);
+        TVector<ui8> secondResults(CookieCount);
+        TVector<ui8> eventResults(CookieCount);
+
+        std::thread first([&] {
+            for (size_t i = 0; i < CookieCount; ++i) {
+                WaitForParticipants(ready, 3 * (i + 1));
+                firstResults[i] = cookies[i]->Detach();
+            }
+        });
+        std::thread second([&] {
+            for (size_t i = 0; i < CookieCount; ++i) {
+                WaitForParticipants(ready, 3 * (i + 1));
+                secondResults[i] = cookies[i]->Detach();
+            }
+        });
+        std::thread event([&] {
+            for (size_t i = 0; i < CookieCount; ++i) {
+                WaitForParticipants(ready, 3 * (i + 1));
+                eventResults[i] = cookies[i]->DetachEvent();
+            }
+        });
+
+        first.join();
+        second.join();
+        event.join();
+
+        for (size_t i = 0; i < CookieCount; ++i) {
+            UNIT_ASSERT(firstResults[i] + secondResults[i] + eventResults[i] <= 2);
+        }
+    }
+}

--- a/ydb/library/actors/core/ut/ya.make
+++ b/ydb/library/actors/core/ut/ya.make
@@ -28,6 +28,7 @@ SRCS(
     performance_ut.cpp
     process_stats_ut.cpp
     ask_ut.cpp
+    scheduler_cookie_ut.cpp
     event_flat_ut.cpp
     event_pb_payload_ut.cpp
     event_pb_ut.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a race that could crash a node while cancelling scheduled actor events.

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Failure scenario:** the scheduler fires a cookie while another participant concurrently cancels or releases the same cookie. Both may enter virtual detach calls, and the call that decrements the shared counter to zero can run `delete this` while the other virtual call has not returned yet, invalidating the object and its vtable in the scheduler path.

**Root cause:** the single atomic `Value` combined two different responsibilities: deciding the 2-way/3-way fire-versus-cancel result and managing object lifetime. Reaching zero proved that all participants had started detaching, but did not prove that their virtual calls had completed.

**Fix:** `ISchedulerCookie` now keeps separate lifetime slots. Public `Detach()` and `DetachEvent()` first complete the virtual logical-state operation and only then release the participant lifetime slot. The cookie is reclaimed after every participant has left the virtual detach implementation, while the existing fire/cancel semantics remain unchanged.

The original Query01 crash was not reproduced locally; this root cause is inferred from the reported `cookie->Detach()` crash site and the lifetime interleaving in the implementation.