### PR TITLE
Executor GC: never build a collect request into the sentinel group

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4029,6 +4029,12 @@ void TExecutor::UpdateUsedTabletMemory() {
 }
 
 void TExecutor::UpdateCounters(const TActorContext &ctx) {
+    if (GcLogic && Counters) {
+        if (const ui64 dropped = GcLogic->TakeSentinelDroppedMarks()) {
+            Counters->Cumulative()[TExecutorCounters::GC_SENTINEL_DROPPED_MARKS].Increment(dropped);
+        }
+    }
+
     TAutoPtr<TTabletCountersBase> executorCounters;
     TAutoPtr<TTabletCountersBase> externalTabletCounters;
 

--- a/ydb/core/tablet_flat/flat_executor_counters.h
+++ b/ydb/core/tablet_flat/flat_executor_counters.h
@@ -121,7 +121,6 @@ namespace NTabletFlatExecutor {
     XX(GC_FORGOTTEN, "GcBlobsForgotten") \
     XX(GC_KEEPSET, "GcKeepFlagsSet") \
     XX(GC_NOTKEEPSET, "GcNotKeepFlagsSet") \
-    XX(GC_SENTINEL_DROPPED_MARKS, "GcSentinelDroppedMarks") \
     XX(CONSUMED_CPU, "ConsumedCPU") \
     XX(COMPACTION_READ_POSTPONED, "CompactionReadPostponed") \
     XX(COMPACTION_READ_CACHE_HITS, "CompactionReadCacheHits") \
@@ -134,6 +133,7 @@ namespace NTabletFlatExecutor {
     XX(BACKUP_CHANGELOG_ERRORS, "BackupChangelogErrors") \
     XX(BACKUP_SNAPSHOT_BYTES_WRITTEN, "BackupSnapshotBytesWritten") \
     XX(BACKUP_CHANGELOG_BYTES_WRITTEN, "BackupChangelogBytesWritten") \
+    XX(GC_SENTINEL_DROPPED_MARKS, "GcSentinelDroppedMarks") \
 
 // don't change order!
 #define FLAT_EXECUTOR_PERCENTILE_COUNTERS_MAP(XX) \

--- a/ydb/core/tablet_flat/flat_executor_counters.h
+++ b/ydb/core/tablet_flat/flat_executor_counters.h
@@ -121,6 +121,7 @@ namespace NTabletFlatExecutor {
     XX(GC_FORGOTTEN, "GcBlobsForgotten") \
     XX(GC_KEEPSET, "GcKeepFlagsSet") \
     XX(GC_NOTKEEPSET, "GcNotKeepFlagsSet") \
+    XX(GC_SENTINEL_DROPPED_MARKS, "GcSentinelDroppedMarks") \
     XX(CONSUMED_CPU, "ConsumedCPU") \
     XX(COMPACTION_READ_POSTPONED, "CompactionReadPostponed") \
     XX(COMPACTION_READ_CACHE_HITS, "CompactionReadCacheHits") \

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -501,9 +501,12 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                     affectedGroups[xit->GroupID];
             }
 
-            // Below the first surviving entry the generation resolves to the sentinel group:
-            // the blob was collected together with the cut entry, so a flag for it would be
-            // addressed to Max<ui32>() and fail forever.
+            // Below the first surviving entry GroupForGeneration returns Max<ui32>(): the entry
+            // was cut only after the barrier into its group had been advanced, so a flag sent
+            // there now would be addressed to a nonexistent group and fail forever (BS error ->
+            // TEvPoison -> boot loop). Dropping the mark is safe: live blobs in the old group
+            // are already covered by the Keep marks recorded there before the cut. A Delete for a
+            // blob deleted after the cut is lost, so the blob lingers until the group is released.
             ui32 activeGen = Max<ui32>();
             ui32 activeGroup = Max<ui32>();
             TVector<TLogoBlobID> *vec = nullptr;

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -504,12 +504,8 @@ ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                     affectedGroups[xit->GroupID];
             }
 
-            // Below the first surviving entry GroupForGeneration returns Max<ui32>(): the entry
-            // was cut only after the barrier into its group had been advanced, so a flag sent
-            // there now would be addressed to a nonexistent group and fail forever (BS error ->
-            // TEvPoison -> boot loop). Dropping the mark is safe: live blobs in the old group
-            // are already covered by the Keep marks recorded there before the cut. A Delete for a
-            // blob deleted after the cut is lost, so the blob lingers until the group is released.
+            // GroupForGeneration returns Max<ui32>() below the first surviving history entry.
+            // Dropping such a mark is safe: those blobs have already been deleted with the cut entry.
             ui32 activeGen = Max<ui32>();
             ui32 activeGroup = Max<ui32>();
             TVector<TLogoBlobID> *vec = nullptr;

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -1,5 +1,7 @@
 #include "flat_executor_gclogic.h"
 #include "flat_bio_eggs.h"
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/services/services.pb.h>
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet.h>
 #include <unordered_set>
@@ -269,7 +271,7 @@ void TExecutorGCLogic::SendCollectGarbage(const TActorContext& ctx) {
     const TGCTime minTime = std::min(uncommittedTime, std::min(uncommitedSnap, minBarrier));
 
     for (auto it = ChannelInfo.begin(); it != ChannelInfo.end(); ++it) {
-        it->second.SendCollectGarbage(minTime, TabletStorageInfo.Get(), it->first, Generation, ctx);
+        SentinelDroppedMarks += it->second.SendCollectGarbage(minTime, TabletStorageInfo.Get(), it->first, Generation, ctx);
     }
 }
 
@@ -440,9 +442,10 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbageEntry(
     ++GcWaitFor;
 }
 
-void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime, const TTabletStorageInfo *tabletStorageInfo, ui32 channel, ui32 generation, const TActorContext& ctx) {
+ui64 TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime, const TTabletStorageInfo *tabletStorageInfo, ui32 channel, ui32 generation, const TActorContext& ctx) {
     if (GcWaitFor > 0)
-        return;
+        return 0;
+    ui64 droppedMarks = 0;
 
     MinUncollectedTime = uncommittedTime;
     PendingRetry = false;
@@ -520,6 +523,8 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
 
                 if (vec) {
                     vec->push_back(blobId);
+                } else {
+                    ++droppedMarks;
                 }
             }
 
@@ -536,6 +541,8 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
 
                 if (vec) {
                     vec->push_back(blobId);
+                } else {
+                    ++droppedMarks;
                 }
             }
 
@@ -544,6 +551,14 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
             }
         }
     }
+    if (droppedMarks) {
+        LOG_WARN_S(ctx, NKikimrServices::TABLET_EXECUTOR,
+            "GC marks dropped by sentinel guard (blob generation below first surviving history entry)"
+            << " tablet " << tabletStorageInfo->TabletID
+            << " channel " << channel
+            << " dropped " << droppedMarks);
+    }
+    return droppedMarks;
 }
 
 bool TExecutorGCLogic::TChannelInfo::OnCollectGarbageSuccess() {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -501,6 +501,9 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                     affectedGroups[xit->GroupID];
             }
 
+            // Below the first surviving entry the generation resolves to the sentinel group:
+            // the blob was collected together with the cut entry, so a flag for it would be
+            // addressed to Max<ui32>() and fail forever.
             ui32 activeGen = Max<ui32>();
             ui32 activeGroup = Max<ui32>();
             TVector<TLogoBlobID> *vec = nullptr;
@@ -509,10 +512,12 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();
                     activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
-                    vec = &affectedGroups[activeGroup].first;
+                    vec = activeGroup == Max<ui32>() ? nullptr : &affectedGroups[activeGroup].first;
                 }
 
-                vec->push_back(blobId);
+                if (vec) {
+                    vec->push_back(blobId);
+                }
             }
 
             activeGen = Max<ui32>();
@@ -523,10 +528,12 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
                 if (activeGen != blobId.Generation()) {
                     activeGen = blobId.Generation();
                     activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
-                    vec = &affectedGroups[activeGroup].second;
+                    vec = activeGroup == Max<ui32>() ? nullptr : &affectedGroups[activeGroup].second;
                 }
 
-                vec->push_back(blobId);
+                if (vec) {
+                    vec->push_back(blobId);
+                }
             }
 
             for (auto &xpair : affectedGroups) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -60,6 +60,12 @@ public:
 
     THistoryCutter HistoryCutter;
 
+    // Marks dropped by the sentinel guard since the last drain; the executor moves
+    // this into the GcSentinelDroppedMarks cumulative counter on its periodic
+    // counters update (open item 7).
+    ui64 TakeSentinelDroppedMarks() { return std::exchange(SentinelDroppedMarks, 0); }
+    ui64 SentinelDroppedMarks = 0;
+
 
     struct TIntrospection {
         ui64 UncommitedEntries;
@@ -113,7 +119,9 @@ protected:
         ui32 FailCount;
 
         inline TChannelInfo();
-        void SendCollectGarbage(TGCTime uncommittedTime, const TTabletStorageInfo *tabletStorageInfo, ui32 channel, ui32 generation, const TActorContext& executor);
+        // Returns the number of GC marks dropped by the sentinel guard (group resolves
+        // to Max<ui32>() below the first surviving history entry).
+        ui64 SendCollectGarbage(TGCTime uncommittedTime, const TTabletStorageInfo *tabletStorageInfo, ui32 channel, ui32 generation, const TActorContext& executor);
         void SendCollectGarbageEntry(const TActorContext &ctx, TVector<TLogoBlobID> &&keep, TVector<TLogoBlobID> &&notKeep, ui64 tabletid, ui32 channel, ui32 bsgroup, ui32 generation, bool hard, std::optional<TGCTime> barrier = std::nullopt);
         bool OnCollectGarbageSuccess();
         void OnCollectGarbageFailure();

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -337,27 +337,8 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
             "history entry [10, 100) must not be cuttable while gen-50 blob has a pending DoNotKeep mark");
     }
 
-    // Precondition for the SendCollectGarbage sentinel guard: TChannelInfo::SendCollectGarbage guards against
-    // the Max<ui32>() sentinel returned by GroupForGeneration when a blob's
-    // generation falls below the first surviving history entry.  The old code
-    // unconditionally dereferenced &affectedGroups[activeGroup], inserting a
-    // garbage key into the map and later issuing a collect against a nonexistent
-    // group, which triggered a BS error -> TEvPoison boot loop.
-    //
-    // This fix cannot be exercised in the current unit-test suite without a
-    // running actor system and a BS-proxy intercept, because
-    // TChannelInfo::SendCollectGarbage takes a const TActorContext& and
-    // immediately dispatches TEvBlobStorage::TEvCollectGarbage messages through
-    // it.  A full integration test would need to:
-    //   1. Stand up a TActorSystem with a mock BS group.
-    //   2. Drive TExecutorGCLogic to the "bloated" SendCollectGarbage branch
-    //      (barrier < latestEntry->FromGeneration with a cut entry already in place).
-    //   3. Put a blob whose generation resolves to Max<ui32>() into the keep/
-    //      notKeep vectors and verify no message is sent to group Max<ui32>().
-    //
-    // A structural check below confirms that GroupForGeneration returns the
-    // sentinel for generations below the first history entry, which is the
-    // precondition that makes the fix necessary.
+    // The precondition the sentinel guard relies on: generations below the first
+    // surviving history entry resolve to Max<ui32>().
     Y_UNIT_TEST(GroupForGenerationReturnsSentinelBelowFirstEntry) {
         TIntrusivePtr<TTabletStorageInfo> info = new TTabletStorageInfo(31, TTabletTypes::Dummy);
         info->Channels.emplace_back();
@@ -369,19 +350,11 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
             "GroupForGeneration must return Max<ui32>() for generations below the first history entry");
     }
 
-    // The regression this guards: SendCollectGarbage resolved every blob's generation
-    // with GroupForGeneration and dereferenced &affectedGroups[activeGroup] without
-    // checking it. For a generation below the first surviving history entry that call
-    // returns the Max<ui32>() sentinel, so a collect went out to a group that does not
-    // exist -- BS error, TEvPoison, boot loop.
-    //
-    // Setup mirrors the state after a cut: the channel keeps a single history entry
-    // starting at generation 10, while GC still holds marks for generations 5 and 6
-    // that belonged to the entry which was cut away.
-    //
-    // Ablation: restore `vec = &affectedGroups[activeGroup].first/.second` and drop the
-    // `if (vec)` guards; the sentinel proxy then receives a collect and the second
-    // assertion below fails.
+    // SendCollectGarbage used to dereference &affectedGroups[GroupForGeneration(gen)]
+    // unchecked; below the first surviving entry that is Max<ui32>(), and the collect
+    // sent there ended in a BS error -> TEvPoison -> boot loop. Setup mirrors the state
+    // after a cut: one history entry from generation 10, GC marks left for 5 and 6.
+    // Ablation: drop the `if (vec)` guards and the sentinel proxy receives a collect.
     Y_UNIT_TEST(SendCollectGarbageSkipsSentinelGroup) {
         const ui64 tabletId = 32;
         const ui32 channel = 2;
@@ -437,8 +410,10 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
         // The collect is dispatched before the driver's wakeup, so by now it has been observed.
         UNIT_ASSERT_C(collectsByProxy[MakeBlobStorageProxyID(survivingGroup)] > 0,
             "the surviving history entry must still receive its collect request");
-        UNIT_ASSERT_VALUES_EQUAL_C(collectsByProxy[MakeBlobStorageProxyID(Max<ui32>())], 0u,
+        UNIT_ASSERT_VALUES_EQUAL_C(collectsByProxy.Value(MakeBlobStorageProxyID(Max<ui32>()), 0u), 0u,
             "a collect request must never be addressed to the Max<ui32>() sentinel group");
+        UNIT_ASSERT_VALUES_EQUAL_C(collectsByProxy.size(), 1u,
+            "collects must go to the surviving group only");
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -414,6 +414,9 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
             "a collect request must never be addressed to the Max<ui32>() sentinel group");
         UNIT_ASSERT_VALUES_EQUAL_C(collectsByProxy.size(), 1u,
             "collects must go to the surviving group only");
+        // The guard's second observable: monitoring reports both below-sentinel marks
+        // (the gen-5 keep and the gen-6 delete) as dropped.
+        UNIT_ASSERT_VALUES_EQUAL(gcLogic.TakeSentinelDroppedMarks(), 2u);
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic_ut.cpp
@@ -1,5 +1,9 @@
 #include "flat_executor_gclogic.h"
 #include "flat_sausage_grind.h"
+#include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr {
@@ -31,6 +35,24 @@ TAutoPtr<NPageCollection::TSteppedCookieAllocator> MakeGCCookies(
         TArrayRef<const NPageCollection::TSlot>(slots)
     );
 }
+
+// Drives one SendCollectGarbage pass from inside the actor system, since the call
+// needs a real TActorContext to dispatch TEvCollectGarbage.
+class TCollectGarbageDriver : public NActors::TActorBootstrapped<TCollectGarbageDriver> {
+public:
+    TCollectGarbageDriver(TExecutorGCLogic* logic, NActors::TActorId done)
+        : Logic(logic), Done(done) {}
+
+    void Bootstrap(const NActors::TActorContext& ctx) {
+        Logic->SendCollectGarbage(ctx);
+        ctx.Send(Done, new NActors::TEvents::TEvWakeup());
+        Die(ctx);
+    }
+
+private:
+    TExecutorGCLogic* const Logic;
+    const NActors::TActorId Done;
+};
 
 } // namespace
 
@@ -313,6 +335,110 @@ Y_UNIT_TEST_SUITE(THistoryCutter) {
         auto toCut = gcLogic.HistoryCutter.GetHistoryToCut(0);
         UNIT_ASSERT_C(toCut.empty(),
             "history entry [10, 100) must not be cuttable while gen-50 blob has a pending DoNotKeep mark");
+    }
+
+    // Precondition for the SendCollectGarbage sentinel guard: TChannelInfo::SendCollectGarbage guards against
+    // the Max<ui32>() sentinel returned by GroupForGeneration when a blob's
+    // generation falls below the first surviving history entry.  The old code
+    // unconditionally dereferenced &affectedGroups[activeGroup], inserting a
+    // garbage key into the map and later issuing a collect against a nonexistent
+    // group, which triggered a BS error -> TEvPoison boot loop.
+    //
+    // This fix cannot be exercised in the current unit-test suite without a
+    // running actor system and a BS-proxy intercept, because
+    // TChannelInfo::SendCollectGarbage takes a const TActorContext& and
+    // immediately dispatches TEvBlobStorage::TEvCollectGarbage messages through
+    // it.  A full integration test would need to:
+    //   1. Stand up a TActorSystem with a mock BS group.
+    //   2. Drive TExecutorGCLogic to the "bloated" SendCollectGarbage branch
+    //      (barrier < latestEntry->FromGeneration with a cut entry already in place).
+    //   3. Put a blob whose generation resolves to Max<ui32>() into the keep/
+    //      notKeep vectors and verify no message is sent to group Max<ui32>().
+    //
+    // A structural check below confirms that GroupForGeneration returns the
+    // sentinel for generations below the first history entry, which is the
+    // precondition that makes the fix necessary.
+    Y_UNIT_TEST(GroupForGenerationReturnsSentinelBelowFirstEntry) {
+        TIntrusivePtr<TTabletStorageInfo> info = new TTabletStorageInfo(31, TTabletTypes::Dummy);
+        info->Channels.emplace_back();
+        info->Channels[0].History.emplace_back(10u, 77u); // first entry starts at gen 10
+
+        // A generation strictly below the first entry must resolve to Max<ui32>().
+        ui32 group = info->Channels[0].GroupForGeneration(5);
+        UNIT_ASSERT_VALUES_EQUAL_C(group, Max<ui32>(),
+            "GroupForGeneration must return Max<ui32>() for generations below the first history entry");
+    }
+
+    // The regression this guards: SendCollectGarbage resolved every blob's generation
+    // with GroupForGeneration and dereferenced &affectedGroups[activeGroup] without
+    // checking it. For a generation below the first surviving history entry that call
+    // returns the Max<ui32>() sentinel, so a collect went out to a group that does not
+    // exist -- BS error, TEvPoison, boot loop.
+    //
+    // Setup mirrors the state after a cut: the channel keeps a single history entry
+    // starting at generation 10, while GC still holds marks for generations 5 and 6
+    // that belonged to the entry which was cut away.
+    //
+    // Ablation: restore `vec = &affectedGroups[activeGroup].first/.second` and drop the
+    // `if (vec)` guards; the sentinel proxy then receives a collect and the second
+    // assertion below fails.
+    Y_UNIT_TEST(SendCollectGarbageSkipsSentinelGroup) {
+        const ui64 tabletId = 32;
+        const ui32 channel = 2;
+        const ui32 survivingGroup = 77;
+        const ui32 survivingFromGen = 10;
+
+        TTestBasicRuntime runtime(1);
+        TAutoPtr<TAppPrepare> app = new TAppPrepare();
+        runtime.Initialize(app->Unwrap());
+
+        // Stand in for the BS proxies. Without these the collect requests resolve to no
+        // mailbox and are dropped before anything can observe them.
+        const auto survivingEdge = runtime.AllocateEdgeActor();
+        const auto sentinelEdge = runtime.AllocateEdgeActor();
+        runtime.RegisterService(MakeBlobStorageProxyID(survivingGroup), survivingEdge);
+        runtime.RegisterService(MakeBlobStorageProxyID(Max<ui32>()), sentinelEdge);
+
+        TIntrusivePtr<TTabletStorageInfo> info = new TTabletStorageInfo(tabletId, TTabletTypes::Dummy);
+        info->Channels.resize(channel + 1);
+        for (ui32 ch = 0; ch <= channel; ++ch) {
+            info->Channels[ch].Channel = ch;
+            // Single entry: everything below survivingFromGen resolves to the sentinel.
+            info->Channels[ch].History.emplace_back(survivingFromGen, survivingGroup);
+        }
+
+        // Tablet generation must exceed the blob generations below so they are collectable.
+        TExecutorGCLogic gcLogic(info, MakeGCCookies(*info, 20));
+        gcLogic.FollowersSyncComplete(true);
+
+        TGCBlobDelta delta;
+        // Generations 5 and 6 sit below the surviving entry -> sentinel group.
+        delta.Created.push_back(HistoryCutterUtBlob(tabletId, 5, channel));
+        delta.Deleted.push_back(HistoryCutterUtBlob(tabletId, 6, channel));
+        // Generation 12 resolves normally and must still be collected.
+        delta.Created.push_back(HistoryCutterUtBlob(tabletId, 12, channel));
+        TGCLogEntry entry(TGCTime(1, 1), delta);
+        gcLogic.ApplyLogEntry(entry);
+
+        // Count collect requests per proxy. GrabEdgeEvent cannot express "nothing
+        // arrived" -- it throws once the queue drains -- so observe and count instead.
+        THashMap<TActorId, ui32> collectsByProxy;
+        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::EvCollectGarbage) {
+                ++collectsByProxy[ev->Recipient];
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        const auto done = runtime.AllocateEdgeActor();
+        runtime.Register(new TCollectGarbageDriver(&gcLogic, done));
+        runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(done);
+
+        // The collect is dispatched before the driver's wakeup, so by now it has been observed.
+        UNIT_ASSERT_C(collectsByProxy[MakeBlobStorageProxyID(survivingGroup)] > 0,
+            "the surviving history entry must still receive its collect request");
+        UNIT_ASSERT_VALUES_EQUAL_C(collectsByProxy[MakeBlobStorageProxyID(Max<ui32>())], 0u,
+            "a collect request must never be addressed to the Max<ui32>() sentinel group");
     }
 }
 


### PR DESCRIPTION
`TExecutorGCLogic::TChannelInfo::SendCollectGarbage` resolves each blob's generation to a group with `GroupForGeneration` and then dereferences `&affectedGroups[activeGroup]` without checking the result:

```cpp
activeGroup = channelInfo->GroupForGeneration(blobId.Generation());
vec = &affectedGroups[activeGroup].first;
...
vec->push_back(blobId);
```

For a generation below the first surviving history entry, `GroupForGeneration` returns the `Max<ui32>()` sentinel. The sentinel then becomes a key in `affectedGroups`, and the loop at the end of the bloated branch issues a `TEvCollectGarbage` against a group that does not exist.

Observed on a test cluster as a boot loop: collect to the sentinel group → BS error → `TEvPoison` → the tablet reboots into the same state, roughly 87k generations burned before it was diagnosed.

This is reachable today without any feature flag: KeyValue (`keyvalue_state.cpp:853`) and BlobDepot (`data_trash.cpp:379`) already send `TEvCutTabletHistory`, and the executor cuts its own history in `flat_executor_gclogic.cpp:150`.

### Fix

Skip blobs whose generation resolves to the sentinel, in both the Keep and DoNotKeep loops. Dropping them is correct rather than merely safe: a generation below the first surviving entry was collected together with the entry that was cut away, so there is nothing left to flag.

### Testing

**`THistoryCutter::SendCollectGarbageSkipsSentinelGroup`** reproduces the state that triggers it — one surviving history entry starting at generation 10, with GC still holding marks for generations 5 and 6 — registers edge actors as the BS proxies for the surviving and the sentinel group, and asserts both directions:

- the surviving group still receives its collect request;
- the sentinel group receives none.

The second assertion alone would be satisfied by a guard that dropped everything, which is why the first is there too.

Ablation: restore `vec = &affectedGroups[activeGroup].first/.second` and drop the `if (vec)` checks — the test fails with **2** requests to the sentinel group, one per loop.

`ya make -tt ydb/core/tablet_flat/ut -F 'THistoryCutter::*'` → 12 tests, all pass.

### Merge order

#50180 (ColumnShard CutHistory) depends on this and on #51588, and must not merge before both.
