### PR TITLE
Return retryable COORDINATOR_NOT_AVAILABLE on Kafka EndTxn KQP failures.

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
@@ -142,9 +142,15 @@ namespace NKafka {
     void TTransactionActor::Handle(NKqp::TEvKqp::TEvCreateSessionResponse::TPtr& ev, const TActorContext& ctx) {
         YDB_LOG_DEBUG("KQP session created",
             {LogPrefix()});
+        if (!Kqp || !CommitStarted || ev->Cookie != KqpCookie) {
+            YDB_LOG_DEBUG("Ignoring stale KQP create-session response",
+                {LogPrefix()},
+                {"expectedCookie", KqpCookie},
+                {"actualCookie", ev->Cookie});
+            return;
+        }
         if (!Kqp->HandleCreateSessionResponse(ev, ctx)) {
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::BROKER_NOT_AVAILABLE, "Failed to create KQP session");
-            Die(ctx);
+            FailEndTxnRetryable(ctx, "Failed to create KQP session");
             return;
         }
 
@@ -157,14 +163,19 @@ namespace NKafka {
         YDB_LOG_DEBUG("Received query response from KQP for request",
             {LogPrefix()},
             {"lastSentToKqpRequest", GetAsStr(LastSentToKqpRequest)});
+        if (!Kqp || !CommitStarted || ev->Cookie != KqpCookie) {
+            YDB_LOG_DEBUG("Ignoring stale KQP response",
+                {LogPrefix()},
+                {"expectedCookie", KqpCookie},
+                {"actualCookie", ev->Cookie});
+            return;
+        }
         const TString metadataDatabasePath = GetMetadataDatabasePath();
         const auto ydbStatus = ev->Get()->Record.GetYdbStatus();
         bool producerCreated = TryRequestProducerMetadataTablesCreation(ydbStatus, metadataDatabasePath, ResourceDatabasePath, ctx);
         bool consumerCreated = TryRequestConsumerMetadataTablesCreation(ydbStatus, metadataDatabasePath, ResourceDatabasePath, ctx);
         if (producerCreated || consumerCreated) {
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::INVALID_TXN_STATE,
-                "Kafka metadata tables are not initialized yet. Please retry.");
-            Die(ctx);
+            FailEndTxnRetryable(ctx, "Kafka metadata tables are not initialized yet. Please retry.");
             return;
         }
 
@@ -172,8 +183,7 @@ namespace NKafka {
             YDB_LOG_WARN(error,
                 {LogPrefix()},
                 {"error", error});
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::BROKER_NOT_AVAILABLE, error->data());
-            Die(ctx);
+            FailEndTxnRetryable(ctx, error->data());
             return;
         }
 
@@ -197,7 +207,7 @@ namespace NKafka {
         YDB_LOG_DEBUG("Sending create session request to KQP for database",
             {LogPrefix()},
             {"databasePath", DatabasePath});
-        Kqp->SendCreateSessionRequest(ctx);
+        Kqp->SendCreateSessionRequest(ctx, ++KqpCookie);
     }
 
     void TTransactionActor::SendToKqpValidationRequests(const TActorContext& ctx) {
@@ -262,6 +272,21 @@ namespace NKafka {
         }
         Send(MakeTransactionsServiceID(SelfId().NodeId()), new TEvKafka::TEvTransactionActorDied(TransactionalId, ProducerInstanceId));
         TBase::Die(ctx);
+    }
+
+    void TTransactionActor::FailEndTxnRetryable(const TActorContext& ctx, const TString& errorMessage) {
+        if (EndTxnRequestPtr) {
+            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::COORDINATOR_NOT_AVAILABLE, errorMessage);
+        }
+        ++KqpCookie;
+        if (Kqp) {
+            Kqp->CloseKqpSession(ctx);
+            Kqp.reset();
+        }
+        KqpSessionId = "";
+        LastSentToKqpRequest = EKafkaTxnKqpRequests::NO_REQUEST;
+        CommitStarted = false;
+        EndTxnRequestPtr.Destroy();
     }
 
     bool TTransactionActor::TxnExpired() {
@@ -369,8 +394,7 @@ namespace NKafka {
             TString error = TStringBuilder() << "KQP returned wrong number of result sets on SELECT query. Expected " << expectedResultsSize << ", got " << resultsSize << ".";
             YDB_LOG_WARN(error,
                 {LogPrefix()});
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::BROKER_NOT_AVAILABLE, error);
-            Die(ctx);
+            FailEndTxnRetryable(ctx, error);
             return;
         }
 
@@ -382,8 +406,7 @@ namespace NKafka {
             TString error = TStringBuilder() << "Error parsing producer state response from KQP. Reason: " << y.what();
             YDB_LOG_WARN(error,
                 {LogPrefix()});
-            SendFailResponse<TEndTxnResponseData>(EndTxnRequestPtr, EKafkaErrors::BROKER_NOT_AVAILABLE, error);
-            Die(ctx);
+            FailEndTxnRetryable(ctx, error);
             return;
         }
         if (auto error = GetErrorInProducerState(producerState)) {
@@ -409,6 +432,12 @@ namespace NKafka {
         YDB_LOG_DEBUG("Validated producer and consumers states. Everything is alright, adding kafka operations to transaction",
             {LogPrefix()});
         auto kqpTxnId = response.Record.GetResponse().GetTxMeta().id();
+        if (PartitionsInTxn.empty() && OffsetsToCommit.empty()) {
+            YDB_LOG_DEBUG("No kafka operations to add; committing empty transaction",
+                {LogPrefix()});
+            HandleAddKafkaOperationsResponse(kqpTxnId, ctx);
+            return;
+        }
         // finally everything is valid and we can add kafka operations to transaction and attempt to commit
         SendAddKafkaOperationsToTxRequest(kqpTxnId);
     }

--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
@@ -458,14 +458,12 @@ namespace NKafka {
     }
 
     TMaybe<TString> TTransactionActor::GetErrorFromYdbResponse(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev) {
-        TStringBuilder builder = TStringBuilder() << "Received error on request to KQP. Last sent request: " << GetAsStr(LastSentToKqpRequest) << ". Reason: ";
-        if (ev->Cookie != KqpCookie) {
-            return builder << "Unexpected cookie in TEvQueryResponse. Expected KQP Cookie: " << KqpCookie << ", Actual: " << ev->Cookie << ".";
-        } else if (ev->Get()->Record.GetYdbStatus() != Ydb::StatusIds::SUCCESS) {
-            return builder << "Unexpected YDB status in TEvQueryResponse. Expected YDB SUCCESS status, Actual: " << ev->Get()->Record.GetYdbStatus() << ".";
-        } else {
+        if (ev->Get()->Record.GetYdbStatus() == Ydb::StatusIds::SUCCESS) {
             return {};
         }
+        return TStringBuilder() << "Received error on request to KQP. Last sent request: " << GetAsStr(LastSentToKqpRequest)
+            << ". Reason: Unexpected YDB status in TEvQueryResponse. Expected YDB SUCCESS status, Actual: "
+            << ev->Get()->Record.GetYdbStatus() << ".";
     }
 
     TMaybe<TProducerState> TTransactionActor::ParseProducerState(const NKqp::TEvKqp::TEvQueryResponse& response) {

--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.h
@@ -120,6 +120,9 @@ namespace NKafka {
             void HandleSelectResponse(const NKqp::TEvKqp::TEvQueryResponse& response, const TActorContext& ctx);
             void HandleAddKafkaOperationsResponse(const TString& kqpTransactionId, const TActorContext& ctx);
             void HandleCommitResponse(const TActorContext& ctx);
+            // Kafka Java treats BROKER_NOT_AVAILABLE / INVALID_TXN_STATE as fatal on EndTxn.
+            // COORDINATOR_NOT_AVAILABLE is retryable; keep the actor so a retry still sees partitions/offsets.
+            void FailEndTxnRetryable(const TActorContext& ctx, const TString& errorMessage);
             TMaybe<TString> GetErrorFromYdbResponse(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev);
             TMaybe<TProducerState> ParseProducerState(const NKqp::TEvKqp::TEvQueryResponse& response);
             TMaybe<TString> GetErrorInProducerState(const TMaybe<TProducerState>& producerState);

--- a/ydb/core/kafka_proxy/kqp_helper.cpp
+++ b/ydb/core/kafka_proxy/kqp_helper.cpp
@@ -10,9 +10,9 @@ TKqpTxHelper::TKqpTxHelper(TString database)
     : DataBase(database)
 {}
 
-void TKqpTxHelper::SendCreateSessionRequest(const TActorContext& ctx) {
+void TKqpTxHelper::SendCreateSessionRequest(const TActorContext& ctx, ui64 cookie) {
     auto ev = MakeCreateSessionRequest();
-    ctx.Send(MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release(), 0, 0);
+    ctx.Send(MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release(), 0, cookie);
 }
 
 void TKqpTxHelper::BeginTransaction(ui64 cookie, const TActorContext& ctx) {

--- a/ydb/core/kafka_proxy/kqp_helper.h
+++ b/ydb/core/kafka_proxy/kqp_helper.h
@@ -15,7 +15,7 @@ class TKqpTxHelper {
 public:
     TKqpTxHelper(TString database);
     // kqp actor id can be changed for testing purposes
-    void SendCreateSessionRequest(const TActorContext& ctx);
+    void SendCreateSessionRequest(const TActorContext& ctx, ui64 cookie = 0);
     void BeginTransaction(ui64 cookie, const TActorContext& ctx);
     bool HandleCreateSessionResponse(TEvKqp::TEvCreateSessionResponse::TPtr& ev, const TActorContext& ctx);
     void CloseKqpSession(const TActorContext& ctx);

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -5126,6 +5126,20 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         UNIT_ASSERT_VALUES_EQUAL(offsetFetchResponse->Groups[0].Topics[0].Partitions[0].CommittedOffset, 2);
     }
 
+    Y_UNIT_TEST(TransactionShouldCommitIfNoPartitionsOrOffsetsWereAdded) {
+        TInsecureTestServer testServer("1", false, true);
+        TKafkaTestClient kafkaClient(testServer.Port);
+
+        TString transactionalId = TStringBuilder() << "my-tx-producer-" << RandomNumber<ui64>();
+        auto initProducerIdResp = kafkaClient.InitProducerId(transactionalId, 30000);
+        UNIT_ASSERT_VALUES_EQUAL(initProducerIdResp->ErrorCode, EKafkaErrors::NONE_ERROR);
+        TProducerInstanceId producerInstanceId = {initProducerIdResp->ProducerId, initProducerIdResp->ProducerEpoch};
+
+        // Kafka Streams EOS commits after changelog restore with no Produce and no offsets.
+        auto endTxnResponse = kafkaClient.EndTxn(transactionalId, producerInstanceId, true);
+        UNIT_ASSERT_VALUES_EQUAL(endTxnResponse->ErrorCode, EKafkaErrors::NONE_ERROR);
+    }
+
     Y_UNIT_TEST(TransactionsFailAfterEnablingServerlessTransactionsFlagAtRuntime) {
         TInsecureTestServer testServer("1", false, true);
         testServer.KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_ERROR);

--- a/ydb/core/kafka_proxy/ut/ut_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_transaction_actor.cpp
@@ -46,10 +46,10 @@ namespace {
                 THolder<NKqp::TEvKqp::TEvQueryResponse> response;
                 if (ev->Get()->Record.GetRequest().GetTxControl().commit_tx()) {
                     Cout << "Sending response on commit from dummy kqp" << Endl;
-                    response = MakeSimpleSuccessResponse();
+                    response = MakeStatusResponse(ReturnSuccessOnCommit ? Ydb::StatusIds::SUCCESS : Ydb::StatusIds::ABORTED);
                 } else if (ev->Get()->Record.GetRequest().HasKafkaApiOperations()) {
                     Cout << "Sending response on add kafka operations from dummy kqp" << Endl;
-                    response = MakeSimpleSuccessResponse();
+                    response = MakeStatusResponse(Ydb::StatusIds::SUCCESS);
                 } else {
                     Cout << "Sending response on select from dummy kqp" << Endl;
                     response = MakeResponseOnSelectFromKqp();
@@ -63,14 +63,9 @@ namespace {
                 ));
             }
 
-            THolder<NKqp::TEvKqp::TEvQueryResponse> MakeSimpleSuccessResponse() {
+            THolder<NKqp::TEvKqp::TEvQueryResponse> MakeStatusResponse(Ydb::StatusIds::StatusCode status) {
                 auto response = MakeHolder<NKqp::TEvKqp::TEvQueryResponse>();
-                NKikimrKqp::TEvQueryResponse record;
-                if (ReturnSuccessOnCommit) {
-                    record.SetYdbStatus(Ydb::StatusIds::SUCCESS);
-                } else {
-                    record.SetYdbStatus(Ydb::StatusIds::ABORTED);
-                }
+                response->Record.SetYdbStatus(status);
                 return response;
             }
 
@@ -204,7 +199,6 @@ namespace {
             const TString TransactionalId = "123"; // transactional id from kafka SDK
             const i64 ProducerId = 1;
             const i32 ProducerEpoch = 1;
-            ui32 QueryRequestsCounter = 0;
 
             void SetUp(NUnitTest::TTestContext&) override {
                 Ctx.ConstructInPlace();
@@ -228,7 +222,6 @@ namespace {
             }
 
             void TearDown(NUnitTest::TTestContext&) override  {
-                QueryRequestsCounter = 0;
                 Ctx->Finalize();
             }
 
@@ -300,14 +293,9 @@ namespace {
             void AddObserverForAddOperationsRequest(std::function<void(const TEvKqp::TEvQueryRequest*)> callback, TMaybe<std::unordered_map<TString, i32>> consumerGenerationsToReturnInValidationRequest = Nothing()) {
                 DummyKqpActor->SetValidationResponse(TransactionalId, ProducerId, ProducerEpoch, consumerGenerationsToReturnInValidationRequest);
 
-                auto observer = [callback = std::move(callback), this](TAutoPtr<IEventHandle>& input) {
-                    // handle query request
+                auto observer = [callback = std::move(callback)](TAutoPtr<IEventHandle>& input) {
                     if (auto* event = input->CastAsLocal<TEvKqp::TEvQueryRequest>()) {
-                        // first request is a validation request with select statements
-                        // second request should be a commit request
-                        if (QueryRequestsCounter == 0) {
-                            QueryRequestsCounter++;
-                        } else {
+                        if (event->Record.GetRequest().HasKafkaApiOperations()) {
                             callback(event);
                         }
                     }
@@ -618,18 +606,26 @@ namespace {
             UNIT_ASSERT_VALUES_EQUAL(txnActorDiedEvent->ProducerState.Epoch, ProducerEpoch);
         }
 
-        Y_UNIT_TEST(OnEndTxnWithCommitAndAbortFromTxn_shouldReturnBROKER_NOT_AVAILABLE) {
+        Y_UNIT_TEST(OnEndTxnWithCommitAndAbortFromTxn_shouldReturnCOORDINATOR_NOT_AVAILABLE) {
             ui64 correlationId = 987;
+            DummyKqpActor->SetValidationResponse(TransactionalId, ProducerId, ProducerEpoch);
             DummyKqpActor->SetCommitResponse(false);
 
             auto response = SendEndTxnRequest(true, correlationId);
 
             UNIT_ASSERT(response != nullptr);
-            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::BROKER_NOT_AVAILABLE);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::COORDINATOR_NOT_AVAILABLE);
             UNIT_ASSERT_EQUAL(response->Response->ApiKey(), NKafka::EApiKey::END_TXN);
             const auto& result = static_cast<const NKafka::TEndTxnResponseData&>(*response->Response);
             UNIT_ASSERT_VALUES_EQUAL(response->CorrelationId, correlationId);
-            UNIT_ASSERT_VALUES_EQUAL(result.ErrorCode, NKafka::EKafkaErrors::BROKER_NOT_AVAILABLE);
+            UNIT_ASSERT_VALUES_EQUAL(result.ErrorCode, NKafka::EKafkaErrors::COORDINATOR_NOT_AVAILABLE);
+
+            DummyKqpActor->SetCommitResponse(true);
+            auto retry = SendEndTxnRequest(true, correlationId + 1);
+            UNIT_ASSERT(retry != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(retry->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+            const auto& retryResult = static_cast<const NKafka::TEndTxnResponseData&>(*retry->Response);
+            UNIT_ASSERT_VALUES_EQUAL(retryResult.ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
         }
 
         Y_UNIT_TEST(OnEndTxnWithCommitAndNoConsumerStateFound_shouldReturnINVALID_TXN_STATE) {

--- a/ydb/core/kafka_proxy/ut/ut_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_transaction_actor.cpp
@@ -26,6 +26,10 @@ namespace {
                 ReturnSuccessOnCommit = success;
             }
 
+            void SetCreateSessionResponse(bool success) {
+                ReturnSuccessOnCreateSession = success;
+            }
+
         private:
             STFUNC(StateFunc) {
                 switch (ev->GetTypeRewrite()) {
@@ -36,8 +40,10 @@ namespace {
 
             void Handle(NKqp::TEvKqp::TEvCreateSessionRequest::TPtr& ev, const TActorContext& ctx) {
                 auto response = MakeHolder<TEvKqp::TEvCreateSessionResponse>();
-                response->Record.SetYdbStatus(Ydb::StatusIds::SUCCESS);
-                response->Record.MutableResponse()->SetSessionId("123");
+                response->Record.SetYdbStatus(ReturnSuccessOnCreateSession ? Ydb::StatusIds::SUCCESS : Ydb::StatusIds::UNAVAILABLE);
+                if (ReturnSuccessOnCreateSession) {
+                    response->Record.MutableResponse()->SetSessionId("123");
+                }
                 Send(new IEventHandle(ev->Sender, ctx.SelfID, response.Release(), 0, ev->Cookie));
             }
 
@@ -158,6 +164,7 @@ namespace {
             i32 ProducerEpochToReturn = 0;
             TMaybe<std::unordered_map<TString, i32>> ConsumerGenerationsToReturn = Nothing();
             bool ReturnSuccessOnCommit = true;
+            bool ReturnSuccessOnCreateSession = true;
         };
 
     class TTransactionActorFixture : public NUnitTest::TBaseFixture {
@@ -621,6 +628,27 @@ namespace {
             UNIT_ASSERT_VALUES_EQUAL(result.ErrorCode, NKafka::EKafkaErrors::COORDINATOR_NOT_AVAILABLE);
 
             DummyKqpActor->SetCommitResponse(true);
+            auto retry = SendEndTxnRequest(true, correlationId + 1);
+            UNIT_ASSERT(retry != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(retry->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+            const auto& retryResult = static_cast<const NKafka::TEndTxnResponseData&>(*retry->Response);
+            UNIT_ASSERT_VALUES_EQUAL(retryResult.ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+        }
+
+        Y_UNIT_TEST(OnEndTxnWithCommitAndCreateSessionFailure_shouldReturnCOORDINATOR_NOT_AVAILABLE) {
+            ui64 correlationId = 654;
+            DummyKqpActor->SetCreateSessionResponse(false);
+
+            auto response = SendEndTxnRequest(true, correlationId);
+
+            UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::COORDINATOR_NOT_AVAILABLE);
+            UNIT_ASSERT_EQUAL(response->Response->ApiKey(), NKafka::EApiKey::END_TXN);
+            const auto& result = static_cast<const NKafka::TEndTxnResponseData&>(*response->Response);
+            UNIT_ASSERT_VALUES_EQUAL(response->CorrelationId, correlationId);
+            UNIT_ASSERT_VALUES_EQUAL(result.ErrorCode, NKafka::EKafkaErrors::COORDINATOR_NOT_AVAILABLE);
+
+            DummyKqpActor->SetCreateSessionResponse(true);
             auto retry = SendEndTxnRequest(true, correlationId + 1);
             UNIT_ASSERT(retry != nullptr);
             UNIT_ASSERT_VALUES_EQUAL(retry->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);


### PR DESCRIPTION
Java treats BROKER_NOT_AVAILABLE as fatal, which aborted Kafka Streams EOS commits. Keep the transaction actor so a retry still sees partitions and offsets.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
