### PR TITLE
Fix fork checkout in rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -179,6 +179,9 @@ jobs:
           token: ${{ secrets.YDBOT_TOKEN }}
           fetch-depth: 0
           filter: blob:none
+          # SECURITY: This opts into fork checkout under pull_request_target.
+          # Keep subsequent operations limited to git; never execute PR files.
+          allow-unsafe-pr-checkout: true
 
       - name: Configure git
         run: |


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Allow `actions/checkout` to check out fork PR heads from the trusted `pull_request_target` rebase workflow.

The workflow already verifies that the trigger actor is a repository collaborator and that fork PRs allow maintainer edits. It only performs Git operations after checkout. The added security comment explicitly prohibits executing files from the PR branch.

Fixes the checkout failure seen in #42314: `Refusing to check out fork pull request code from a pull_request_target workflow`.