### PR TITLE
[ICRDMA] Prevent possibility of multiple PassAway calls. NBYDB-2501

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -331,7 +331,9 @@ namespace NActors {
         while (!EarlyRdmaRecvs.empty()) {
             auto pending = std::move(EarlyRdmaRecvs.front());
             EarlyRdmaRecvs.pop_front();
-            TInputSessionTCP::WorkingState(pending);
+            if (!ProcessWorkingEvent(pending)) {
+                return;
+            }
         }
         Become(&TInterconnectSessionRdma::WorkingState);
     }
@@ -341,12 +343,18 @@ namespace NActors {
     }
 
     STATEFN(TInputSessionTCP::WorkingState) {
+        ProcessWorkingEvent(ev);
+    }
+
+    bool TInputSessionTCP::ProcessWorkingEvent(TAutoPtr<IEventHandle>& ev) {
         std::unique_ptr<IEventBase> termEv;
 
         if (Context->Terminated) {
-            return PassAway();
+            PassAway();
+            return false;
         }
 
+        const bool poisonPill = ev->GetTypeRewrite() == TEvents::TSystem::PoisonPill;
         try {
             WorkingStateImpl(ev);
         } catch (const TExReestablishConnection& ex) {
@@ -366,7 +374,10 @@ namespace NActors {
             Send(SessionId, termEv.release());
             PassAway();
             Socket.Reset();
+            return false;
         }
+
+        return !poisonPill;
     }
 
     void TInputSessionTCP::CloseInputSession() {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -255,6 +255,7 @@ namespace NActors {
                           TSessionParams params);
     protected:
         STATEFN(WorkingState);
+        bool ProcessWorkingEvent(TAutoPtr<IEventHandle>& ev);
         bool ReadyToReceive() const noexcept {
             return bool(Context);
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The old code didn't stop processing of early RDMA recv events in case of PassAway call 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
