### PR TITLE
Fix tenant restart-loop when Kafka listening port is already in use

### DIFF
--- a/ydb/core/kafka_proxy/kafka_listener.h
+++ b/ydb/core/kafka_proxy/kafka_listener.h
@@ -16,7 +16,7 @@ inline NActors::IActor* CreateKafkaListener(
         [=](const TActorId& listenerActorId, TIntrusivePtr<TSocketDescriptor> socket, TNetworkConfig::TSocketAddressType address) {
             return CreateKafkaConnection(listenerActorId, socket, address, config, serverCreds);
         },
-        NKikimrServices::EServiceKikimr::KAFKA_PROXY, EErrorAction::Abort);
+        NKikimrServices::EServiceKikimr::KAFKA_PROXY);
 }
 
 } // namespace NKafka

--- a/ydb/core/raw_socket/sock_listener.cpp
+++ b/ydb/core/raw_socket/sock_listener.cpp
@@ -29,15 +29,19 @@ public:
     TPollerToken::TPtr PollerToken;
     THashSet<TActorId> Connections;
 
-    EErrorAction ErrorAction;
-
     TSocketListener(const TActorId& poller, const TListenerSettings& settings, const TConnectionCreator& connectionCreator,
-                    NKikimrServices::EServiceKikimr service, EErrorAction errorAction)
+                    NKikimrServices::EServiceKikimr service)
         : Poller(poller)
         , Settings(settings)
         , ConnectionCreator(connectionCreator)
-        , Service(service)
-        , ErrorAction(errorAction) {
+        , Service(service) {
+    }
+
+    STATEFN(StateInit) {
+        switch (ev->GetTypeRewrite()) {
+            sFunc(TEvents::TEvWakeup, Bootstrap);
+            sFunc(TEvents::TEvPoison, PassAway);
+        }
     }
 
     STATEFN(StateWorking) {
@@ -50,6 +54,9 @@ public:
     }
 
     void Bootstrap() {
+        Become(&TThis::StateInit);
+        Socket.Reset();
+
         TSocketType socket({.TcpNotDelay = Settings.TcpNotDelay});
         TSocketAddressType bindAddress(socket.MakeAddress(Settings.Address, Settings.Port));
         int err = socket.Bind(bindAddress.get());
@@ -82,17 +89,7 @@ public:
                 {"error", strerror(-err)});
         }
 
-        switch(ErrorAction) {
-            case EErrorAction::Abort:
-                Cerr << "Failed to set up listener on port " << Settings.Port
-                                << " errno# " << -err << " (" << strerror(-err) << ")" << Endl;
-                abort();
-                break;
-
-            case EErrorAction::Ignore:
-                PassAway();
-                break;
-        }
+        Schedule(TDuration::Seconds(1), new TEvents::TEvWakeup());
     }
 
     void PassAway() override {
@@ -131,9 +128,8 @@ public:
 };
 
 NActors::IActor* CreateSocketListener(const NActors::TActorId& poller, const TListenerSettings& settings,
-                                      TConnectionCreator connectionCreator, NKikimrServices::EServiceKikimr service,
-                                      EErrorAction errorAction) {
-    return new TSocketListener(poller, settings, connectionCreator, service, errorAction);
+                                      TConnectionCreator connectionCreator, NKikimrServices::EServiceKikimr service) {
+    return new TSocketListener(poller, settings, connectionCreator, service);
 }
 
 } // namespace NKikimr::NRawSocket

--- a/ydb/core/raw_socket/sock_listener.cpp
+++ b/ydb/core/raw_socket/sock_listener.cpp
@@ -79,12 +79,12 @@ public:
                 Become(&TThis::StateWorking);
                 return;
             } else {
-                YDB_LOG_ERROR("Failed to listen",
+                YDB_LOG_WARN("Failed to listen",
                     {"bindAddress", bindAddress->ToString()},
                     {"error", strerror(-err)});
             }
         } else {
-            YDB_LOG_ERROR("Failed to bind",
+            YDB_LOG_WARN("Failed to bind",
                 {"bindAddress", bindAddress->ToString()},
                 {"error", strerror(-err)});
         }
@@ -96,6 +96,7 @@ public:
         for (const NActors::TActorId& connection : Connections) {
             Send(connection, new NActors::TEvents::TEvPoison());
         }
+        TBase::PassAway();
     }
 
     void Handle(TEvents::TEvUnsubscribe::TPtr ev) {

--- a/ydb/core/raw_socket/sock_listener.h
+++ b/ydb/core/raw_socket/sock_listener.h
@@ -18,17 +18,11 @@ struct TListenerSettings {
     bool TcpNotDelay = false;
 };
 
-enum EErrorAction {
-    Ignore,
-    Abort
-};
-
 using TConnectionCreator = std::function<NActors::IActor* (const NActors::TActorId& listenerActorId,
                                                            TIntrusivePtr<TSocketDescriptor> socket,
                                                            TNetworkConfig::TSocketAddressType address)>;
 
 NActors::IActor* CreateSocketListener(const NActors::TActorId& poller, const TListenerSettings& settings,
-                                      TConnectionCreator connectionCreator, NKikimrServices::EServiceKikimr service,
-                                      EErrorAction errorAction = EErrorAction::Ignore);
+                                      TConnectionCreator connectionCreator, NKikimrServices::EServiceKikimr service);
 
 } // namespace NKikimr::NRawSocket

--- a/ydb/core/raw_socket/ut/sock_listener_ut.cpp
+++ b/ydb/core/raw_socket/ut/sock_listener_ut.cpp
@@ -1,0 +1,71 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/network/sock.h>
+#include <ydb/core/raw_socket/sock_listener.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/interconnect/poller/poller_actor.h>
+#include <ydb/library/services/services.pb.h>
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NRawSocket;
+
+namespace {
+
+class TDummyConnectionActor: public TActor<TDummyConnectionActor> {
+public:
+    TDummyConnectionActor()
+        : TActor(&TDummyConnectionActor::StateWork)
+    {
+    }
+
+    STRICT_STFUNC(StateWork,
+        cFunc(TEvents::TEvPoison::EventType, PassAway);
+    )
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TSocketListener) {
+    Y_UNIT_TEST(RetryBindUntilPortIsFree) {
+        TTestBasicRuntime runtime;
+        runtime.Initialize(TAppPrepare().Unwrap());
+
+        TInet6StreamSocket occupying;
+        occupying.CheckSock();
+        TSockAddrInet6 addr("::", 0);
+        UNIT_ASSERT_VALUES_EQUAL(occupying.Bind(&addr), 0);
+        UNIT_ASSERT_VALUES_EQUAL(occupying.Listen(10), 0);
+        const ui16 port = addr.GetPort();
+        UNIT_ASSERT(port != 0);
+
+        const TActorId pollerId = runtime.Register(CreatePollerActor());
+        TListenerSettings settings;
+        settings.Port = port;
+        settings.Address = "::";
+
+        const TActorId listenerId = runtime.Register(CreateSocketListener(
+            pollerId,
+            settings,
+            [](const TActorId&, TIntrusivePtr<TSocketDescriptor>, TNetworkConfig::TSocketAddressType) -> IActor* {
+                return new TDummyConnectionActor();
+            },
+            NKikimrServices::KAFKA_PROXY));
+        runtime.EnableScheduleForActor(listenerId, true);
+
+        // Bootstrap fails to bind and schedules a retry. Sleep delivers that retry while the port is still busy.
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        occupying.Close();
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        TInet6StreamSocket probe;
+        probe.CheckSock();
+        TSockAddrInet6 probeAddr("::", port);
+        UNIT_ASSERT_C(probe.Bind(&probeAddr) != 0,
+            "listener should own the port after the occupying socket is closed");
+    }
+}

--- a/ydb/core/raw_socket/ut/sock_listener_ut.cpp
+++ b/ydb/core/raw_socket/ut/sock_listener_ut.cpp
@@ -68,4 +68,42 @@ Y_UNIT_TEST_SUITE(TSocketListener) {
         UNIT_ASSERT_C(probe.Bind(&probeAddr) != 0,
             "listener should own the port after the occupying socket is closed");
     }
+
+    Y_UNIT_TEST(PoisonStopsRetryWhilePortIsBusy) {
+        TTestBasicRuntime runtime;
+        runtime.Initialize(TAppPrepare().Unwrap());
+
+        TInet6StreamSocket occupying;
+        occupying.CheckSock();
+        TSockAddrInet6 addr("::", 0);
+        UNIT_ASSERT_VALUES_EQUAL(occupying.Bind(&addr), 0);
+        UNIT_ASSERT_VALUES_EQUAL(occupying.Listen(10), 0);
+        const ui16 port = addr.GetPort();
+        UNIT_ASSERT(port != 0);
+
+        const TActorId pollerId = runtime.Register(CreatePollerActor());
+        TListenerSettings settings;
+        settings.Port = port;
+        settings.Address = "::";
+
+        const TActorId listenerId = runtime.Register(CreateSocketListener(
+            pollerId,
+            settings,
+            [](const TActorId&, TIntrusivePtr<TSocketDescriptor>, TNetworkConfig::TSocketAddressType) -> IActor* {
+                return new TDummyConnectionActor();
+            },
+            NKikimrServices::KAFKA_PROXY));
+        runtime.EnableScheduleForActor(listenerId, true);
+        runtime.SimulateSleep(TDuration::Zero());
+
+        runtime.Send(new IEventHandle(listenerId, TActorId(), new TEvents::TEvPoison()));
+        occupying.Close();
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        TInet6StreamSocket probe;
+        probe.CheckSock();
+        TSockAddrInet6 probeAddr("::", port);
+        UNIT_ASSERT_C(probe.Bind(&probeAddr) == 0,
+            "poisoned listener must not bind the port after a scheduled retry");
+    }
 }

--- a/ydb/core/raw_socket/ut/ya.make
+++ b/ydb/core/raw_socket/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(ydb/core/raw_socket)
 SIZE(small)
 SRCS(
     buffered_writer_ut.cpp
+    sock_listener_ut.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
Fixes [YDBBUGS-751](https://st.yandex-team.ru/YDBBUGS-751): a shared Kafka port in cluster config aborted `ydbd` with `Address already in use`, so tenant nodes restart-looped. HTTP-proxy already retries bind; Kafka now does the same.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Kafka: retry bind when the listening port is already in use instead of aborting the process.

### Description for reviewers <!-- (optional) description for those who read this PR -->

* `TSocketListener` no longer takes `EErrorAction`. On bind/listen failure it logs and retries every 1s (same as HTTP-proxy).
* `CreateKafkaListener` no longer requests `Abort`.
* UT `TSocketListener::RetryBindUntilPortIsFree` occupies the port, waits for a retry, then checks the listener owns it after the occupant closes.