### PR TITLE
Tablet memory allocations observability improvements

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -41,6 +41,7 @@
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/monotonic_provider.h>
+#include <ydb/library/actors/prof/tag.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 
@@ -134,6 +135,13 @@ private:
     bool Active = false;
 };
 
+static TActorActivityType DetectOwnerActivityType(NFlatExecutorSetup::ITablet* owner) {
+    if (auto* actor = dynamic_cast<IActor*>(owner)) {
+        return actor->GetActivityType();
+    }
+    return TActorActivityType();
+}
+
 TExecutor::TExecutor(
         NFlatExecutorSetup::ITablet* owner,
         const TActorId& ownerActorId)
@@ -141,6 +149,7 @@ TExecutor::TExecutor(
     , Time(TAppData::TimeProvider)
     , Owner(owner)
     , OwnerActorId(ownerActorId)
+    , OwnerActivityType(DetectOwnerActivityType(owner))
     , Emitter(new TIdEmitter)
     , CounterEventsInFlight(new TEvTabletCounters::TInFlightCookie)
     , Stats(new TExecutorStatsImpl())
@@ -2026,6 +2035,11 @@ bool TExecutor::CancelTransaction(ui64 id) {
 
 void TExecutor::ExecuteTransaction(TSeat* seat) {
     TActiveTransactionZone activeTransaction(this);
+    // Attribute allocations to the owner tablet's activity type when known.
+    std::optional<NProfiling::TMemoryTagScope> ownerScope;
+    if (OwnerActivityType != TActorActivityType()) {
+        ownerScope.emplace(OwnerActivityType.GetIndex());
+    }
     ++seat->Retries;
 
     THPTimer cpuTimer;

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -370,6 +370,7 @@ class TExecutor
     const TIntrusivePtr<ITimeProvider> Time = nullptr;
     NFlatExecutorSetup::ITablet * Owner;
     const TActorId OwnerActorId;
+    const NActors::TActorActivityType OwnerActivityType;
     TAutoPtr<NUtil::ILogger> Logger;
 
     ui32 FollowerId = 0;

--- a/ydb/core/tablet_flat/flat_scan_actor.h
+++ b/ydb/core/tablet_flat/flat_scan_actor.h
@@ -18,6 +18,7 @@
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/prof/tag.h>
 #include <util/generic/cast.h>
 
 namespace NKikimr {
@@ -55,6 +56,7 @@ namespace NOps {
             , Args(args)
             , Snapshot(std::move(snapshot))
             , MaxCyclesPerIteration(/* 10ms */ (NHPTimer::GetCyclesPerSecond() + 99) / 100)
+            , ScanMemoryTag(NProfiling::MakeTag(TypeName(*Scan).c_str()))
         {
         }
 
@@ -391,7 +393,9 @@ namespace NOps {
             {
                 TGuard<ui64, NUtil::TIncDecOps<ui64>> guard(Depth);
 
+                NProfiling::TMemoryTagScope scope(ScanMemoryTag);
                 auto hello = Scan->Prepare(this, Subset.Scheme);
+                scope.Release();
 
                 Conf = hello.Conf;
 
@@ -475,7 +479,9 @@ namespace NOps {
                     processed = 0;
                 }
 
+                NProfiling::TMemoryTagScope scope(ScanMemoryTag);
                 const auto ready = Process();
+                scope.Release();
 
                 processed += stat.UpdateRows(Seen, Skipped);
 
@@ -664,9 +670,11 @@ namespace NOps {
             /* After invocation of Finish(...) scan object is left on its
                 own and it has to handle self deletion if required. */
             IScan* scan = DetachScan();
+            NProfiling::TMemoryTagScope scope(ScanMemoryTag);
             auto prod = exc
                 ? scan->Finish(*exc)
                 : scan->Finish(status);
+            scope.Release();
 
             if (status != EStatus::Lost) {
                 auto ev = new TEvResult(Serial, status, std::move(Snapshot), prod);
@@ -752,6 +760,7 @@ namespace NOps {
         const NHPTimer::STime MaxCyclesPerIteration;
         static constexpr ui64 MinRowsPerCheck = 1000;
         ui64 TotalCpuTimeUs = 0;
+        ui32 ScanMemoryTag = 0;
     };
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

1. Attribute allocations made by localdb transactions to the tablet actor, not FLAT_EXECUTOR
2. Attribute allocations made by IScan implementations to tags associated with class names, not TABLET_OPS_HOST_A
