### PR TITLE
Fix hang in TTopicOffsetsActor.RetriesOnDeliveryProblem

### DIFF
--- a/ydb/core/kafka_proxy/ut/topic_location_actor_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/topic_location_actor_ut.cpp
@@ -1,406 +1,512 @@
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/kafka_proxy/actors/actors.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/schema/schema_ut_helpers.h>
 #include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/aclib/aclib.h>
-#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/services/persqueue_v1/actors/events.h>
 
 #include <library/cpp/testing/unittest/registar.h>
-#include <library/cpp/threading/future/async.h>
 
 #include <util/generic/algorithm.h>
-#include <util/thread/pool.h>
+
+#include <functional>
 
 namespace NKafka::NTests {
 
-using namespace NKikimr;
-using namespace NKikimr::NPQ::NSchema::NTests;
-using TEvLocationResponse = NKikimr::NGRpcProxy::V1::TEvPQProxy::TEvPartitionLocationResponse;
+    using namespace NKikimr;
+    using namespace NKikimr::NPQ::NSchema::NTests;
+    using TEvLocationResponse = NKikimr::NGRpcProxy::V1::TEvPQProxy::TEvPartitionLocationResponse;
+    using TNavigate = NSchemeCache::TSchemeCacheNavigate;
 
-namespace {
+    namespace {
 
-struct TSimulatedServer {
-    THolder<TThreadPool> Pool;
-    THolder<::NPersQueue::TTestServer> Server;
+        constexpr ui64 BALANCER_TABLET = 1001;
+        constexpr ui64 PARTITION_TABLET = 2001;
+        constexpr ui32 LOCATION_NODE_ID = 7;
+        constexpr ui32 LOCATION_GENERATION = 3;
 
-    ~TSimulatedServer() {
-        Server.Reset();
-        if (Pool) {
-            Pool->Stop();
-        }
-    }
-
-    NActors::TTestActorRuntime& GetRuntime() {
-        return *Server->CleverServer->GetRuntime();
-    }
-};
-
-std::unique_ptr<TSimulatedServer> CreateSimulatedServer() {
-    auto settings = TTopicSdkTestSetup::MakeServerSettings();
-    settings.SetUseRealThreads(false);
-
-    auto out = std::make_unique<TSimulatedServer>();
-    out->Server = MakeHolder<::NPersQueue::TTestServer>(settings, /*start=*/false);
-    out->Server->StartServer(/*doClientInit=*/false, TString("/Root"));
-
-    auto& runtime = out->GetRuntime();
-    runtime.UpdateCurrentTime(TInstant::Now());
-    out->Server->EnableLogs(
-        {NKikimrServices::KAFKA_PROXY, NKikimrServices::PQ_MLP_DESCRIBER},
-        NActors::NLog::PRI_DEBUG);
-
-    out->Server->AnnoyingClient->SetNoConfigMode();
-    out->Pool = MakeHolder<TThreadPool>();
-    out->Pool->Start(2);
-    auto* server = out->Server.Get();
-    auto future = NThreading::Async([server] {
-        server->AnnoyingClient->FullInit();
-        return true;
-    }, *out->Pool);
-    static_cast<NKikimr::TTestActorRuntime&>(runtime).WaitFuture(std::move(future));
-    return out;
-}
-
-class TEnableScheduleForRootGuard {
-public:
-    explicit TEnableScheduleForRootGuard(NActors::TTestActorRuntime& runtime)
-        : Runtime(runtime)
-        , RootActorId(std::make_shared<TActorId>())
-    {
-        PrevObserver = Runtime.SetRegistrationObserverFunc(
-            [rootActorId = RootActorId](
-                TTestActorRuntimeBase& rt,
-                const TActorId& parentId,
-                const TActorId& actorId)
+        class TFakeSchemeCacheActor: public NActors::TActorBootstrapped<TFakeSchemeCacheActor> {
+        public:
+            explicit TFakeSchemeCacheActor(ui32 partitions)
+                : Partitions(partitions)
             {
-                if (actorId == *rootActorId || parentId == *rootActorId) {
-                    rt.EnableScheduleForActor(actorId);
+            }
+
+            void Bootstrap() {
+                Become(&TFakeSchemeCacheActor::StateWork);
+            }
+
+            STRICT_STFUNC(StateWork,
+                          hFunc(TEvTxProxySchemeCache::TEvNavigateKeySet, Handle);)
+
+        private:
+            void Handle(TEvTxProxySchemeCache::TEvNavigateKeySet::TPtr& ev) {
+                auto request = std::move(ev->Get()->Request);
+                for (auto& entry : request->ResultSet) {
+                    entry.Status = TNavigate::EStatus::Ok;
+                    entry.Kind = TNavigate::EKind::KindTopic;
+                    auto pqInfo = MakeIntrusive<TNavigate::TPQGroupInfo>();
+                    pqInfo->Description.SetBalancerTabletID(BALANCER_TABLET);
+                    for (ui32 i = 0; i < Partitions; ++i) {
+                        auto* partition = pqInfo->Description.AddPartitions();
+                        partition->SetPartitionId(i);
+                        partition->SetTabletId(PARTITION_TABLET);
+                    }
+                    entry.PQGroupInfo = pqInfo;
+
+                    auto self = MakeIntrusive<TNavigate::TDirEntryInfo>();
+                    self->Info.SetName("topic");
+                    self->Info.SetPathType(NKikimrSchemeOp::EPathTypePersQueueGroup);
+                    self->Info.SetPathId(42);
+                    self->Info.SetSchemeshardId(7);
+                    entry.Self = self;
                 }
-            });
-    }
+                Send(ev->Sender, new TEvTxProxySchemeCache::TEvNavigateKeySetResult(std::move(request)));
+            }
 
-    ~TEnableScheduleForRootGuard() {
-        Runtime.SetRegistrationObserverFunc(std::move(PrevObserver));
-    }
+            ui32 Partitions;
+        };
 
-    TEnableScheduleForRootGuard(const TEnableScheduleForRootGuard&) = delete;
-    TEnableScheduleForRootGuard& operator=(const TEnableScheduleForRootGuard&) = delete;
+        class TFakePipeCacheActor: public NActors::TActorBootstrapped<TFakePipeCacheActor> {
+        public:
+            explicit TFakePipeCacheActor(ui32 partitions)
+                : Partitions(partitions)
+            {
+            }
 
-    void SetRoot(const TActorId& actorId) {
-        *RootActorId = actorId;
-        Runtime.EnableScheduleForActor(actorId, true);
-    }
+            void Bootstrap() {
+                Become(&TFakePipeCacheActor::StateWork);
+            }
 
-    const TActorId& GetRoot() const {
-        return *RootActorId;
-    }
+            STRICT_STFUNC(StateWork,
+                          hFunc(TEvPipeCache::TEvForward, Handle);
+                          IgnoreFunc(TEvPipeCache::TEvUnlink);)
 
-private:
-    NActors::TTestActorRuntime& Runtime;
-    std::shared_ptr<TActorId> RootActorId;
-    TTestActorRuntimeBase::TRegistrationObserver PrevObserver;
-};
+        private:
+            void Handle(TEvPipeCache::TEvForward::TPtr& ev) {
+                if (!ev->Get()->Ev ||
+                    ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
+                {
+                    return;
+                }
+                auto* response = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+                response->Record.SetStatus(true);
+                for (ui32 i = 0; i < Partitions; ++i) {
+                    auto* location = response->Record.AddLocations();
+                    location->SetPartitionId(i);
+                    location->SetNodeId(LOCATION_NODE_ID);
+                    location->SetGeneration(LOCATION_GENERATION);
+                }
+                Send(ev->Sender, response, 0, ev->Cookie);
+            }
 
-void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path, ui32 partitions = 1) {
-    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path, partitions)), Ydb::StatusIds::SUCCESS);
-}
+            ui32 Partitions;
+        };
 
-THolder<TEvLocationResponse> RunTopicLocation(
-    NActors::TTestActorRuntime& runtime,
-    const TString& path,
-    const TString& token = {},
-    TDuration waitTimeout = TDuration::Seconds(30))
-{
-    const auto edge = runtime.AllocateEdgeActor();
-    TEnableScheduleForRootGuard schedule(runtime);
-    schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", token)));
-    runtime.DispatchEvents();
-    auto handle = runtime.GrabEdgeEvent<TEvLocationResponse>(edge, waitTimeout);
-    UNIT_ASSERT(handle);
-    return THolder(handle->Release());
-}
+        struct TIsolatedEnv {
+            NActors::TTestBasicRuntime Runtime;
 
-auto BreakFirstLocationForward(NActors::TTestActorRuntime& runtime, size_t& broken) {
-    auto* rt = &runtime;
-    return runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [&broken, rt](TEvPipeCache::TEvForward::TPtr& ev) {
+            explicit TIsolatedEnv(ui32 partitions = 1)
+                : Runtime(1, false)
+            {
+                Runtime.Initialize(TAppPrepare().Unwrap());
+                Runtime.UpdateCurrentTime(TInstant::Now());
+                Runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+                Runtime.SetLogPriority(NKikimrServices::KAFKA_PROXY, NActors::NLog::PRI_DEBUG);
+                Runtime.SetLogPriority(NKikimrServices::PQ_DESCRIBER, NActors::NLog::PRI_DEBUG);
+
+                auto schemeCacheId = Runtime.Register(new TFakeSchemeCacheActor(partitions));
+                Runtime.RegisterService(MakeSchemeCacheID(), schemeCacheId);
+
+                auto pipeCacheId = Runtime.Register(new TFakePipeCacheActor(partitions));
+                Runtime.RegisterService(MakePipePerNodeCacheID(false), pipeCacheId);
+                Runtime.DispatchEvents();
+            }
+        };
+
+        class TEnableScheduleForRootGuard {
+        public:
+            explicit TEnableScheduleForRootGuard(NActors::TTestActorRuntime& runtime)
+                : Runtime(runtime)
+                , RootActorId(std::make_shared<TActorId>())
+            {
+                PrevObserver = Runtime.SetRegistrationObserverFunc(
+                    [rootActorId = RootActorId](
+                        TTestActorRuntimeBase& rt,
+                        const TActorId& parentId,
+                        const TActorId& actorId)
+                    {
+                        if (actorId == *rootActorId || parentId == *rootActorId) {
+                            rt.EnableScheduleForActor(actorId);
+                        }
+                    });
+            }
+
+            ~TEnableScheduleForRootGuard() {
+                Runtime.SetRegistrationObserverFunc(std::move(PrevObserver));
+            }
+
+            TEnableScheduleForRootGuard(const TEnableScheduleForRootGuard&) = delete;
+            TEnableScheduleForRootGuard& operator=(const TEnableScheduleForRootGuard&) = delete;
+
+            void SetRoot(const TActorId& actorId) {
+                *RootActorId = actorId;
+                Runtime.EnableScheduleForActor(actorId, true);
+            }
+
+            const TActorId& GetRoot() const {
+                return *RootActorId;
+            }
+
+        private:
+            NActors::TTestActorRuntime& Runtime;
+            std::shared_ptr<TActorId> RootActorId;
+            TTestActorRuntimeBase::TRegistrationObserver PrevObserver;
+        };
+
+        void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path, ui32 partitions = 1) {
+            AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path, partitions)), Ydb::StatusIds::SUCCESS);
+        }
+
+        THolder<TEvLocationResponse> GrabLocationResponse(
+            NActors::TTestActorRuntime& runtime,
+            const TActorId& edge,
+            TDuration waitTimeout)
+        {
+            auto handle = runtime.GrabEdgeEvent<TEvLocationResponse>(edge, waitTimeout);
+            UNIT_ASSERT(handle);
+            return THolder(handle->Release());
+        }
+
+        THolder<TEvLocationResponse> RunTopicLocation(
+            NActors::TTestActorRuntime& runtime,
+            const TString& path,
+            const TString& token = {},
+            TDuration waitTimeout = TDuration::Seconds(30))
+        {
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", token)));
+            return GrabLocationResponse(runtime, edge, waitTimeout);
+        }
+
+        // Isolated runtime has no cluster timers. Wait until the test observer has
+        // fired, jump past the actor retry delay, then grab the reply.
+        THolder<TEvLocationResponse> RunTopicLocationAfterInjection(
+            NActors::TTestActorRuntime& runtime,
+            const TString& path,
+            std::function<bool()> injected)
+        {
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", TString{})));
+
+            TDispatchOptions options;
+            options.CustomFinalCondition = std::move(injected);
+            runtime.DispatchEvents(options, TDuration::Seconds(5));
+            runtime.AdvanceCurrentTime(TDuration::MilliSeconds(250));
+            return GrabLocationResponse(runtime, edge, TDuration::Seconds(5));
+        }
+
+        auto BreakFirstLocationForward(NActors::TTestActorRuntime& runtime, size_t& broken) {
+            auto* rt = &runtime;
+            return runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [&broken, rt](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (!ev || !ev->Get()->Ev) {
+                        return;
+                    }
+                    if (ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType) {
+                        return;
+                    }
+                    if (broken >= 1) {
+                        return;
+                    }
+                    ++broken;
+                    const ui64 tabletId = ev->Get()->TabletId;
+                    const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
+                    rt->Send(new IEventHandle(
+                        ev->Sender,
+                        ev->Recipient,
+                        new TEvPipeCache::TEvDeliveryProblem(tabletId, true /*notDelivered*/),
+                        0,
+                        subscribeCookie));
+                    ev.Reset();
+                });
+        }
+
+        auto DropLocationForwards(NActors::TTestActorRuntime& runtime, size_t* dropped = nullptr) {
+            return runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [dropped](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (ev && ev->Get()->Ev &&
+                        ev->Get()->Ev->Type() == TEvPersQueue::TEvGetPartitionsLocation::EventType)
+                    {
+                        if (dropped) {
+                            ++*dropped;
+                        }
+                        ev.Reset();
+                    }
+                });
+        }
+
+        auto CaptureLocationRequestPartitions(TEvPipeCache::TEvForward::TPtr& ev) {
+            TVector<ui64> ids;
             if (!ev || !ev->Get()->Ev) {
-                return;
+                return ids;
             }
             if (ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType) {
-                return;
+                return ids;
             }
-            if (broken >= 1) {
-                return;
+            auto* req = static_cast<TEvPersQueue::TEvGetPartitionsLocation*>(ev->Get()->Ev.Get());
+            ids.assign(req->Record.GetPartitions().begin(), req->Record.GetPartitions().end());
+            return ids;
+        }
+
+    } // namespace
+
+    Y_UNIT_TEST_SUITE(TTopicLocationActor) {
+
+        Y_UNIT_TEST(SuccessReturnsLivePartitions) {
+            auto setup = CreateSetup("TopicLocationSmoke");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_location_smoke";
+            CreateTopic(runtime, path, /*partitions=*/3);
+
+            auto ev = RunTopicLocation(runtime, path);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 3u);
+            UNIT_ASSERT_GT(ev->PathId, 0);
+            UNIT_ASSERT_GT(ev->SchemeShardId, 0);
+            for (const auto& p : ev->Partitions) {
+                UNIT_ASSERT_GT(p.NodeId, 0);
+                UNIT_ASSERT_GT(p.Generation, 0);
+                UNIT_ASSERT_LT(p.PartitionId, 3);
             }
-            ++broken;
-            const ui64 tabletId = ev->Get()->TabletId;
-            const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
-            rt->Send(new IEventHandle(
-                ev->Sender,
-                ev->Recipient,
-                new TEvPipeCache::TEvDeliveryProblem(tabletId, true /*notDelivered*/),
-                0,
-                subscribeCookie));
-            ev.Reset();
-        });
-}
+        }
 
-auto DropLocationForwards(NActors::TTestActorRuntime& runtime) {
-    return runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (ev && ev->Get()->Ev &&
-                ev->Get()->Ev->Type() == TEvPersQueue::TEvGetPartitionsLocation::EventType)
-            {
-                ev.Reset();
-            }
-        });
-}
+        Y_UNIT_TEST(MissingTopicIsSchemeError) {
+            auto setup = CreateSetup("TopicLocationMissing");
+            auto& runtime = setup->GetRuntime();
 
-auto CaptureLocationRequestPartitions(TEvPipeCache::TEvForward::TPtr& ev) {
-    TVector<ui64> ids;
-    if (!ev || !ev->Get()->Ev) {
-        return ids;
-    }
-    if (ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType) {
-        return ids;
-    }
-    auto* req = static_cast<TEvPersQueue::TEvGetPartitionsLocation*>(ev->Get()->Ev.Get());
-    ids.assign(req->Record.GetPartitions().begin(), req->Record.GetPartitions().end());
-    return ids;
-}
+            auto ev = RunTopicLocation(runtime, "/Root/missing_topic_location");
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
+            UNIT_ASSERT(!ev->Issues.Empty());
+        }
 
-} // namespace
+        Y_UNIT_TEST(UnauthorizedStaysUnauthorized) {
+            auto setup = CreateSetup("TopicLocationAuth");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_location_auth";
+            CreateTopic(runtime, path);
 
-Y_UNIT_TEST_SUITE(TTopicLocationActor) {
+            auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
+            token->SaveSerializationInfo();
+            auto ev = RunTopicLocation(runtime, path, token->GetSerializedToken());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
+            UNIT_ASSERT(!ev->Issues.Empty());
+        }
 
-Y_UNIT_TEST(SuccessReturnsLivePartitions) {
-    auto setup = CreateSetup("TopicLocationSmoke");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_location_smoke";
-    CreateTopic(runtime, path, /*partitions=*/3);
+        Y_UNIT_TEST(RetriesOnDeliveryProblem) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_location_retry";
 
-    auto ev = RunTopicLocation(runtime, path);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 3u);
-    UNIT_ASSERT_GT(ev->PathId, 0);
-    UNIT_ASSERT_GT(ev->SchemeShardId, 0);
-    for (const auto& p : ev->Partitions) {
-        UNIT_ASSERT_GT(p.NodeId, 0);
-        UNIT_ASSERT_GT(p.Generation, 0);
-        UNIT_ASSERT_LT(p.PartitionId, 3);
-    }
-}
+            size_t broken = 0;
+            auto breakObserver = BreakFirstLocationForward(runtime, broken);
+            auto ev = RunTopicLocationAfterInjection(runtime, path, [&] {
+                return broken >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(broken, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT_GT(ev->Partitions[0].NodeId, 0);
+        }
 
-Y_UNIT_TEST(MissingTopicIsSchemeError) {
-    auto setup = CreateSetup("TopicLocationMissing");
-    auto& runtime = setup->GetRuntime();
+        Y_UNIT_TEST(RetriesOnFalseLocationStatus) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_location_false_status";
 
-    auto ev = RunTopicLocation(runtime, "/Root/missing_topic_location");
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
-    UNIT_ASSERT(!ev->Issues.Empty());
-}
+            size_t injected = 0;
+            ui64 firstCookie = 0;
+            auto injectObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [&injected, &firstCookie, rt = &runtime](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (!ev || !ev->Get()->Ev ||
+                        ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
+                    {
+                        return;
+                    }
+                    if (injected == 0) {
+                        firstCookie = ev->Cookie;
+                        ++injected;
+                        auto* rejected = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+                        rejected->Record.SetStatus(false);
+                        rt->Send(new IEventHandle(ev->Sender, ev->Recipient, rejected, 0, ev->Cookie));
 
-Y_UNIT_TEST(UnauthorizedStaysUnauthorized) {
-    auto setup = CreateSetup("TopicLocationAuth");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_location_auth";
-    CreateTopic(runtime, path);
+                        // Stale complete success must not win while the actor is waiting to retry.
+                        auto* stale = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+                        stale->Record.SetStatus(true);
+                        auto* location = stale->Record.AddLocations();
+                        location->SetPartitionId(0);
+                        location->SetNodeId(999);
+                        location->SetGeneration(1);
+                        rt->Send(new IEventHandle(ev->Sender, ev->Recipient, stale, 0, ev->Cookie));
+                        ev.Reset();
+                        return;
+                    }
+                    if (injected == 1 && firstCookie != 0) {
+                        ++injected;
+                        auto* staleGen = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+                        staleGen->Record.SetStatus(true);
+                        auto* location = staleGen->Record.AddLocations();
+                        location->SetPartitionId(0);
+                        location->SetNodeId(888);
+                        location->SetGeneration(1);
+                        rt->Send(new IEventHandle(ev->Sender, ev->Recipient, staleGen, 0, firstCookie));
+                    }
+                });
+            auto ev = RunTopicLocationAfterInjection(runtime, path, [&] {
+                return injected >= 1;
+            });
+            UNIT_ASSERT(injected >= 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT_VALUES_UNEQUAL(ev->Partitions[0].NodeId, 999u);
+            UNIT_ASSERT_VALUES_UNEQUAL(ev->Partitions[0].NodeId, 888u);
+        }
 
-    auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
-    token->SaveSerializationInfo();
-    auto ev = RunTopicLocation(runtime, path, token->GetSerializedToken());
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
-    UNIT_ASSERT(!ev->Issues.Empty());
-}
+        Y_UNIT_TEST(OldBalancerZeroCookieIsAccepted) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_location_old_cookie";
 
-Y_UNIT_TEST(RetriesOnDeliveryProblem) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_location_retry";
-    CreateTopic(runtime, path);
+            size_t injected = 0;
+            auto injectObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [&injected, rt = &runtime](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (!ev || !ev->Get()->Ev ||
+                        ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
+                    {
+                        return;
+                    }
+                    if (injected >= 1) {
+                        return;
+                    }
+                    ++injected;
+                    auto* response = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+                    response->Record.SetStatus(true);
+                    auto* location = response->Record.AddLocations();
+                    location->SetPartitionId(0);
+                    location->SetNodeId(42);
+                    location->SetGeneration(7);
+                    // Cookie 0: old PQRB does not echo the request cookie.
+                    rt->Send(new IEventHandle(ev->Sender, ev->Recipient, response, 0, 0));
+                    ev.Reset();
+                });
+            auto ev = RunTopicLocationAfterInjection(runtime, path, [&] {
+                return injected >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].NodeId, 42u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].Generation, 7u);
+        }
 
-    size_t broken = 0;
-    auto breakObserver = BreakFirstLocationForward(runtime, broken);
-    auto ev = RunTopicLocation(runtime, path);
-    UNIT_ASSERT_VALUES_EQUAL(broken, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT_GT(ev->Partitions[0].NodeId, 0);
-}
+        Y_UNIT_TEST(RetriesOnIncompleteLocationSet) {
+            TIsolatedEnv env(/*partitions=*/3);
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_location_incomplete";
 
-Y_UNIT_TEST(RetriesOnFalseLocationStatus) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_location_false_status";
-    CreateTopic(runtime, path);
+            size_t injected = 0;
+            TVector<ui64> requested;
+            auto injectObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [&injected, &requested, rt = &runtime](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (!ev || !ev->Get()->Ev ||
+                        ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
+                    {
+                        return;
+                    }
+                    requested = CaptureLocationRequestPartitions(ev);
+                    if (injected >= 1) {
+                        return;
+                    }
+                    ++injected;
+                    auto* response = new TEvPersQueue::TEvGetPartitionsLocationResponse();
+                    response->Record.SetStatus(true);
+                    auto* location = response->Record.AddLocations();
+                    location->SetPartitionId(0);
+                    location->SetNodeId(1);
+                    location->SetGeneration(1);
+                    rt->Send(new IEventHandle(ev->Sender, ev->Recipient, response));
+                    ev.Reset();
+                });
 
-    size_t injected = 0;
-    ui64 firstCookie = 0;
-    auto injectObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [&injected, &firstCookie, rt = &runtime](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (!ev || !ev->Get()->Ev ||
-                ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
-            {
-                return;
-            }
-            if (injected == 0) {
-                firstCookie = ev->Cookie;
-                ++injected;
-                auto* rejected = new TEvPersQueue::TEvGetPartitionsLocationResponse();
-                rejected->Record.SetStatus(false);
-                rt->Send(new IEventHandle(ev->Sender, ev->Recipient, rejected, 0, ev->Cookie));
+            auto ev = RunTopicLocationAfterInjection(runtime, path, [&] {
+                return injected >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(requested.size(), 3u);
+            Sort(requested);
+            UNIT_ASSERT_VALUES_EQUAL(requested[0], 0u);
+            UNIT_ASSERT_VALUES_EQUAL(requested[1], 1u);
+            UNIT_ASSERT_VALUES_EQUAL(requested[2], 2u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 3u);
+        }
 
-                // Stale complete success must not win while the actor is waiting to retry.
-                auto* stale = new TEvPersQueue::TEvGetPartitionsLocationResponse();
-                stale->Record.SetStatus(true);
-                auto* location = stale->Record.AddLocations();
-                location->SetPartitionId(0);
-                location->SetNodeId(999);
-                location->SetGeneration(1);
-                rt->Send(new IEventHandle(ev->Sender, ev->Recipient, stale, 0, ev->Cookie));
-                ev.Reset();
-                return;
-            }
-            if (injected == 1 && firstCookie != 0) {
-                ++injected;
-                auto* staleGen = new TEvPersQueue::TEvGetPartitionsLocationResponse();
-                staleGen->Record.SetStatus(true);
-                auto* location = staleGen->Record.AddLocations();
-                location->SetPartitionId(0);
-                location->SetNodeId(888);
-                location->SetGeneration(1);
-                rt->Send(new IEventHandle(ev->Sender, ev->Recipient, staleGen, 0, firstCookie));
-            }
-        });
-    auto ev = RunTopicLocation(runtime, path);
-    UNIT_ASSERT(injected >= 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT_VALUES_UNEQUAL(ev->Partitions[0].NodeId, 999u);
-    UNIT_ASSERT_VALUES_UNEQUAL(ev->Partitions[0].NodeId, 888u);
-}
+        Y_UNIT_TEST(TimesOutWhenLocationStuck) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_location_timeout";
 
-Y_UNIT_TEST(OldBalancerZeroCookieIsAccepted) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_location_old_cookie";
-    CreateTopic(runtime, path);
+            size_t dropped = 0;
+            auto dropObserver = DropLocationForwards(runtime, &dropped);
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", TString{})));
 
-    size_t injected = 0;
-    auto injectObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [&injected, rt = &runtime](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (!ev || !ev->Get()->Ev ||
-                ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
-            {
-                return;
-            }
-            if (injected >= 1) {
-                return;
-            }
-            ++injected;
-            auto* response = new TEvPersQueue::TEvGetPartitionsLocationResponse();
-            response->Record.SetStatus(true);
-            auto* location = response->Record.AddLocations();
-            location->SetPartitionId(0);
-            location->SetNodeId(42);
-            location->SetGeneration(7);
-            // Cookie 0: old PQRB does not echo the request cookie.
-            rt->Send(new IEventHandle(ev->Sender, ev->Recipient, response, 0, 0));
-            ev.Reset();
-        });
-    auto ev = RunTopicLocation(runtime, path);
-    UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].NodeId, 42u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].Generation, 7u);
-}
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&] {
+                return dropped >= 1;
+            };
+            runtime.DispatchEvents(options, TDuration::Seconds(5));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(31));
 
-Y_UNIT_TEST(RetriesOnIncompleteLocationSet) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_location_incomplete";
-    CreateTopic(runtime, path, /*partitions=*/3);
+            auto handle = runtime.GrabEdgeEvent<TEvLocationResponse>(edge, TDuration::Seconds(5));
+            UNIT_ASSERT(handle);
+            const auto* ev = handle->Get();
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::TIMEOUT);
+            UNIT_ASSERT(ev->Issues.ToString().Contains("timed out"));
+        }
 
-    size_t injected = 0;
-    TVector<ui64> requested;
-    auto injectObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [&injected, &requested, rt = &runtime](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (!ev || !ev->Get()->Ev ||
-                ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType)
-            {
-                return;
-            }
-            requested = CaptureLocationRequestPartitions(ev);
-            if (injected >= 1) {
-                return;
-            }
-            ++injected;
-            auto* response = new TEvPersQueue::TEvGetPartitionsLocationResponse();
-            response->Record.SetStatus(true);
-            auto* location = response->Record.AddLocations();
-            location->SetPartitionId(0);
-            location->SetNodeId(1);
-            location->SetGeneration(1);
-            rt->Send(new IEventHandle(ev->Sender, ev->Recipient, response));
-            ev.Reset();
-        });
+        Y_UNIT_TEST(PoisonRepliesCancelled) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_location_poison";
 
-    auto ev = RunTopicLocation(runtime, path);
-    UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(requested.size(), 3u);
-    Sort(requested);
-    UNIT_ASSERT_VALUES_EQUAL(requested[0], 0u);
-    UNIT_ASSERT_VALUES_EQUAL(requested[1], 1u);
-    UNIT_ASSERT_VALUES_EQUAL(requested[2], 2u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 3u);
-}
+            size_t dropped = 0;
+            auto dropObserver = DropLocationForwards(runtime, &dropped);
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", TString{})));
 
-Y_UNIT_TEST(TimesOutWhenLocationStuck) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_location_timeout";
-    CreateTopic(runtime, path);
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&] {
+                return dropped >= 1;
+            };
+            runtime.DispatchEvents(options, TDuration::Seconds(5));
+            runtime.Send(new IEventHandle(schedule.GetRoot(), edge, new NActors::TEvents::TEvPoison()));
 
-    auto dropObserver = DropLocationForwards(runtime);
-    const auto edge = runtime.AllocateEdgeActor();
-    TEnableScheduleForRootGuard schedule(runtime);
-    schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", TString{})));
+            auto handle = runtime.GrabEdgeEvent<TEvLocationResponse>(edge, TDuration::Seconds(5));
+            UNIT_ASSERT(handle);
+            const auto* ev = handle->Get();
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::CANCELLED);
+        }
 
-    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
-    runtime.AdvanceCurrentTime(TDuration::Seconds(31));
-
-    auto handle = runtime.GrabEdgeEvent<TEvLocationResponse>(edge, TDuration::Seconds(5));
-    UNIT_ASSERT(handle);
-    const auto* ev = handle->Get();
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::TIMEOUT);
-    UNIT_ASSERT(ev->Issues.ToString().Contains("timed out"));
-}
-
-Y_UNIT_TEST(PoisonRepliesCancelled) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_location_poison";
-    CreateTopic(runtime, path);
-
-    auto dropObserver = DropLocationForwards(runtime);
-    const auto edge = runtime.AllocateEdgeActor();
-    TEnableScheduleForRootGuard schedule(runtime);
-    schedule.SetRoot(runtime.Register(CreateTopicLocationActor(edge, path, "/Root", TString{})));
-
-    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
-    runtime.Send(new IEventHandle(schedule.GetRoot(), edge, new NActors::TEvents::TEvPoison()));
-
-    auto handle = runtime.GrabEdgeEvent<TEvLocationResponse>(edge, TDuration::Seconds(5));
-    UNIT_ASSERT(handle);
-    const auto* ev = handle->Get();
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::CANCELLED);
-}
-
-} // Y_UNIT_TEST_SUITE(TTopicLocationActor)
+    } // Y_UNIT_TEST_SUITE(TTopicLocationActor)
 
 } // namespace NKafka::NTests

--- a/ydb/core/kafka_proxy/ut/topic_offsets_actor_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/topic_offsets_actor_ut.cpp
@@ -1,529 +1,640 @@
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/kafka_proxy/actors/actors.h>
 #include <ydb/core/kafka_proxy/kafka_events.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/schema/schema_ut_helpers.h>
 #include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/public/api/protos/draft/persqueue_error_codes.pb.h>
-#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 
 #include <library/cpp/testing/unittest/registar.h>
-#include <library/cpp/threading/future/async.h>
 
 #include <util/generic/hash.h>
-#include <util/thread/pool.h>
 
 #include <functional>
 
 namespace NKafka::NTests {
 
-using namespace NKikimr;
-using namespace NKikimr::NPQ::NSchema::NTests;
+    using namespace NKikimr;
+    using namespace NKikimr::NPQ::NSchema::NTests;
+    using TNavigate = NSchemeCache::TSchemeCacheNavigate;
 
-namespace {
+    namespace {
 
-struct TSimulatedServer {
-    THolder<TThreadPool> Pool;
-    THolder<::NPersQueue::TTestServer> Server;
+        constexpr ui64 BALANCER_TABLET = 1001;
+        constexpr ui64 PARTITION_TABLET = 2001;
 
-    ~TSimulatedServer() {
-        Server.Reset();
-        if (Pool) {
-            Pool->Stop();
-        }
-    }
-
-    NActors::TTestActorRuntime& GetRuntime() {
-        return *Server->CleverServer->GetRuntime();
-    }
-};
-
-std::unique_ptr<TSimulatedServer> CreateSimulatedServer() {
-    auto settings = TTopicSdkTestSetup::MakeServerSettings();
-    settings.SetUseRealThreads(false);
-
-    auto out = std::make_unique<TSimulatedServer>();
-    out->Server = MakeHolder<::NPersQueue::TTestServer>(settings, /*start=*/false);
-    out->Server->StartServer(/*doClientInit=*/false, TString("/Root"));
-
-    auto& runtime = out->GetRuntime();
-    runtime.UpdateCurrentTime(TInstant::Now());
-    out->Server->EnableLogs(
-        {NKikimrServices::KAFKA_PROXY, NKikimrServices::PQ_MLP_DESCRIBER},
-        NActors::NLog::PRI_DEBUG);
-
-    out->Server->AnnoyingClient->SetNoConfigMode();
-    out->Pool = MakeHolder<TThreadPool>();
-    out->Pool->Start(2);
-    auto* server = out->Server.Get();
-    auto future = NThreading::Async([server] {
-        server->AnnoyingClient->FullInit();
-        return true;
-    }, *out->Pool);
-    static_cast<NKikimr::TTestActorRuntime&>(runtime).WaitFuture(std::move(future));
-    return out;
-}
-
-class TEnableScheduleForRootGuard {
-public:
-    explicit TEnableScheduleForRootGuard(NActors::TTestActorRuntime& runtime)
-        : Runtime(runtime)
-        , RootActorId(std::make_shared<TActorId>())
-    {
-        PrevObserver = Runtime.SetRegistrationObserverFunc(
-            [rootActorId = RootActorId](
-                TTestActorRuntimeBase& rt,
-                const TActorId& parentId,
-                const TActorId& actorId)
+        class TFakeSchemeCacheActor: public NActors::TActorBootstrapped<TFakeSchemeCacheActor> {
+        public:
+            explicit TFakeSchemeCacheActor(ui32 partitions)
+                : Partitions(partitions)
             {
-                if (actorId == *rootActorId || parentId == *rootActorId) {
-                    rt.EnableScheduleForActor(actorId);
+            }
+
+            void Bootstrap() {
+                Become(&TFakeSchemeCacheActor::StateWork);
+            }
+
+            STRICT_STFUNC(StateWork,
+                          hFunc(TEvTxProxySchemeCache::TEvNavigateKeySet, Handle);)
+
+        private:
+            void Handle(TEvTxProxySchemeCache::TEvNavigateKeySet::TPtr& ev) {
+                auto request = std::move(ev->Get()->Request);
+                for (auto& entry : request->ResultSet) {
+                    entry.Status = TNavigate::EStatus::Ok;
+                    entry.Kind = TNavigate::EKind::KindTopic;
+                    auto pqInfo = MakeIntrusive<TNavigate::TPQGroupInfo>();
+                    pqInfo->Description.SetBalancerTabletID(BALANCER_TABLET);
+                    for (ui32 i = 0; i < Partitions; ++i) {
+                        auto* partition = pqInfo->Description.AddPartitions();
+                        partition->SetPartitionId(i);
+                        partition->SetTabletId(PARTITION_TABLET);
+                    }
+                    entry.PQGroupInfo = pqInfo;
+
+                    auto self = MakeIntrusive<TNavigate::TDirEntryInfo>();
+                    self->Info.SetName("topic");
+                    self->Info.SetPathType(NKikimrSchemeOp::EPathTypePersQueueGroup);
+                    self->Info.SetPathId(42);
+                    self->Info.SetSchemeshardId(7);
+                    entry.Self = self;
                 }
-            });
-    }
-
-    ~TEnableScheduleForRootGuard() {
-        Runtime.SetRegistrationObserverFunc(std::move(PrevObserver));
-    }
-
-    TEnableScheduleForRootGuard(const TEnableScheduleForRootGuard&) = delete;
-    TEnableScheduleForRootGuard& operator=(const TEnableScheduleForRootGuard&) = delete;
-
-    void SetRoot(const TActorId& actorId) {
-        *RootActorId = actorId;
-        Runtime.EnableScheduleForActor(actorId, true);
-    }
-
-    const TActorId& GetRoot() const {
-        return *RootActorId;
-    }
-
-private:
-    NActors::TTestActorRuntime& Runtime;
-    std::shared_ptr<TActorId> RootActorId;
-    TTestActorRuntimeBase::TRegistrationObserver PrevObserver;
-};
-
-void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path, ui32 partitions = 1) {
-    AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path, partitions)), Ydb::StatusIds::SUCCESS);
-}
-
-TTopicOffsetsSettings MakeSettings(
-    const TString& path,
-    TVector<ui32> partitionIds = {},
-    TVector<TString> consumers = {})
-{
-    return {
-        .Path = path,
-        .Database = "/Root",
-        .PartitionIds = std::move(partitionIds),
-        .Consumers = std::move(consumers),
-    };
-}
-
-THolder<TEvKafka::TEvTopicOffsetsResponse> RunTopicOffsets(
-    NActors::TTestActorRuntime& runtime,
-    TTopicOffsetsSettings settings,
-    TDuration waitTimeout = TDuration::Seconds(30))
-{
-    const auto edge = runtime.AllocateEdgeActor();
-    TEnableScheduleForRootGuard schedule(runtime);
-    schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, std::move(settings))));
-    runtime.DispatchEvents();
-    auto handle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(edge, waitTimeout);
-    UNIT_ASSERT(handle);
-    return THolder(handle->Release());
-}
-
-THashMap<ui32, TEvKafka::TPartitionOffsetsInfo> IndexByPartition(
-    const TVector<TEvKafka::TPartitionOffsetsInfo>& partitions)
-{
-    THashMap<ui32, TEvKafka::TPartitionOffsetsInfo> out;
-    for (const auto& part : partitions) {
-        out[part.PartitionId] = part;
-    }
-    return out;
-}
-
-auto BreakFirstStatusForward(NActors::TTestActorRuntime& runtime, size_t& broken) {
-    auto* rt = &runtime;
-    return runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [&broken, rt](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (!ev || !ev->Get()->Ev) {
-                return;
+                Send(ev->Sender, new TEvTxProxySchemeCache::TEvNavigateKeySetResult(std::move(request)));
             }
-            if (ev->Get()->Ev->Type() != TEvPersQueue::TEvStatus::EventType) {
-                return;
-            }
-            if (broken >= 1) {
-                return;
-            }
-            ++broken;
-            const ui64 tabletId = ev->Get()->TabletId;
-            const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
-            rt->Send(new IEventHandle(
-                ev->Sender,
-                ev->Recipient,
-                new TEvPipeCache::TEvDeliveryProblem(tabletId, true /*notDelivered*/),
-                0,
-                subscribeCookie));
-            ev.Reset();
-        });
-}
 
-auto DropStatusForwards(NActors::TTestActorRuntime& runtime) {
-    return runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (ev && ev->Get()->Ev &&
-                ev->Get()->Ev->Type() == TEvPersQueue::TEvStatus::EventType)
+            ui32 Partitions;
+        };
+
+        class TFakePipeCacheActor: public NActors::TActorBootstrapped<TFakePipeCacheActor> {
+        public:
+            explicit TFakePipeCacheActor(ui32 partitions)
+                : Partitions(partitions)
             {
-                ev.Reset();
             }
-        });
-}
 
-auto InjectStatusOnce(
-    NActors::TTestActorRuntime& runtime,
-    size_t& injected,
-    std::function<void(TEvPersQueue::TEvStatusResponse&)> fill)
-{
-    auto* rt = &runtime;
-    return runtime.AddObserver<TEvPipeCache::TEvForward>(
-        [&injected, rt, fill = std::move(fill)](TEvPipeCache::TEvForward::TPtr& ev) {
-            if (!ev || !ev->Get()->Ev) {
-                return;
+            void Bootstrap() {
+                Become(&TFakePipeCacheActor::StateWork);
             }
-            if (ev->Get()->Ev->Type() != TEvPersQueue::TEvStatus::EventType) {
-                return;
+
+            STRICT_STFUNC(StateWork,
+                          hFunc(TEvPipeCache::TEvForward, Handle);
+                          IgnoreFunc(TEvPipeCache::TEvUnlink);)
+
+        private:
+            void Handle(TEvPipeCache::TEvForward::TPtr& ev) {
+                if (!ev->Get()->Ev || ev->Get()->Ev->Type() != TEvPersQueue::TEvStatus::EventType) {
+                    return;
+                }
+                auto* response = new TEvPersQueue::TEvStatusResponse();
+                for (ui32 i = 0; i < Partitions; ++i) {
+                    auto* part = response->Record.AddPartResult();
+                    part->SetPartition(i);
+                    part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_OK);
+                    part->SetStartOffset(0);
+                    part->SetEndOffset(0);
+                    part->SetGeneration(1);
+                    auto* consumer = part->AddConsumerResult();
+                    consumer->SetConsumer("user");
+                    consumer->SetErrorCode(NPersQueue::NErrorCode::OK);
+                    consumer->SetCommitedOffset(0);
+                }
+                Send(ev->Sender, response, 0, ev->Cookie);
             }
-            if (injected >= 1) {
-                return;
+
+            ui32 Partitions;
+        };
+
+        struct TIsolatedEnv {
+            NActors::TTestBasicRuntime Runtime;
+
+            explicit TIsolatedEnv(ui32 partitions = 1)
+                : Runtime(1, false)
+            {
+                Runtime.Initialize(TAppPrepare().Unwrap());
+                Runtime.UpdateCurrentTime(TInstant::Now());
+                Runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+                Runtime.SetLogPriority(NKikimrServices::KAFKA_PROXY, NActors::NLog::PRI_DEBUG);
+                Runtime.SetLogPriority(NKikimrServices::PQ_DESCRIBER, NActors::NLog::PRI_DEBUG);
+
+                auto schemeCacheId = Runtime.Register(new TFakeSchemeCacheActor(partitions));
+                Runtime.RegisterService(MakeSchemeCacheID(), schemeCacheId);
+
+                auto pipeCacheId = Runtime.Register(new TFakePipeCacheActor(partitions));
+                Runtime.RegisterService(MakePipePerNodeCacheID(false), pipeCacheId);
+                Runtime.DispatchEvents();
             }
-            ++injected;
-            auto* response = new TEvPersQueue::TEvStatusResponse();
-            fill(*response);
-            rt->Send(new IEventHandle(ev->Sender, ev->Recipient, response, 0, ev->Cookie));
-            ev.Reset();
-        });
-}
+        };
 
-} // namespace
+        class TEnableScheduleForRootGuard {
+        public:
+            explicit TEnableScheduleForRootGuard(NActors::TTestActorRuntime& runtime)
+                : Runtime(runtime)
+                , RootActorId(std::make_shared<TActorId>())
+            {
+                PrevObserver = Runtime.SetRegistrationObserverFunc(
+                    [rootActorId = RootActorId](
+                        TTestActorRuntimeBase& rt,
+                        const TActorId& parentId,
+                        const TActorId& actorId)
+                    {
+                        if (actorId == *rootActorId || parentId == *rootActorId) {
+                            rt.EnableScheduleForActor(actorId);
+                        }
+                    });
+            }
 
-Y_UNIT_TEST_SUITE(TTopicOffsetsActor) {
+            ~TEnableScheduleForRootGuard() {
+                Runtime.SetRegistrationObserverFunc(std::move(PrevObserver));
+            }
 
-Y_UNIT_TEST(SuccessReturnsAllPartitions) {
-    auto setup = CreateSetup("TopicOffsetsSmoke");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_smoke";
-    CreateTopic(runtime, path, /*partitions=*/3);
+            TEnableScheduleForRootGuard(const TEnableScheduleForRootGuard&) = delete;
+            TEnableScheduleForRootGuard& operator=(const TEnableScheduleForRootGuard&) = delete;
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 3u);
+            void SetRoot(const TActorId& actorId) {
+                *RootActorId = actorId;
+                Runtime.EnableScheduleForActor(actorId, true);
+            }
 
-    const auto byId = IndexByPartition(ev->Partitions);
-    for (ui32 i = 0; i < 3; ++i) {
-        UNIT_ASSERT(byId.contains(i));
-        const auto& part = byId.find(i)->second;
-        UNIT_ASSERT_VALUES_EQUAL(part.StartOffset, 0u);
-        UNIT_ASSERT_VALUES_EQUAL(part.EndOffset, 0u);
-        UNIT_ASSERT(part.Consumers.empty());
-    }
-}
+            const TActorId& GetRoot() const {
+                return *RootActorId;
+            }
 
-Y_UNIT_TEST(FiltersRequestedPartitions) {
-    auto setup = CreateSetup("TopicOffsetsFilter");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_filter";
-    CreateTopic(runtime, path, /*partitions=*/3);
+        private:
+            NActors::TTestActorRuntime& Runtime;
+            std::shared_ptr<TActorId> RootActorId;
+            TTestActorRuntimeBase::TRegistrationObserver PrevObserver;
+        };
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path, {1}));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].PartitionId, 1u);
-}
+        void CreateTopic(NActors::TTestActorRuntime& runtime, const TString& path, ui32 partitions = 1) {
+            AssertStatus(DoCreate(runtime, MakeCreateTopicRequest(path, partitions)), Ydb::StatusIds::SUCCESS);
+        }
 
-Y_UNIT_TEST(MissingTopicIsSchemeError) {
-    auto setup = CreateSetup("TopicOffsetsMissing");
-    auto& runtime = setup->GetRuntime();
+        TTopicOffsetsSettings MakeSettings(
+            const TString& path,
+            TVector<ui32> partitionIds = {},
+            TVector<TString> consumers = {})
+        {
+            return {
+                .Path = path,
+                .Database = "/Root",
+                .PartitionIds = std::move(partitionIds),
+                .Consumers = std::move(consumers),
+            };
+        }
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings("/Root/missing_topic_offsets"));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
-    UNIT_ASSERT(!ev->Issues.Empty());
-}
+        THolder<TEvKafka::TEvTopicOffsetsResponse> GrabTopicOffsetsResponse(
+            NActors::TTestActorRuntime& runtime,
+            const TActorId& edge,
+            TDuration waitTimeout)
+        {
+            auto handle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(edge, waitTimeout);
+            UNIT_ASSERT(handle);
+            return THolder(handle->Release());
+        }
 
-Y_UNIT_TEST(MissingPartitionIsSchemeError) {
-    auto setup = CreateSetup("TopicOffsetsMissingPart");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_missing_part";
-    CreateTopic(runtime, path);
+        THolder<TEvKafka::TEvTopicOffsetsResponse> RunTopicOffsets(
+            NActors::TTestActorRuntime& runtime,
+            TTopicOffsetsSettings settings,
+            TDuration waitTimeout = TDuration::Seconds(30))
+        {
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, std::move(settings))));
+            return GrabTopicOffsetsResponse(runtime, edge, waitTimeout);
+        }
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path, {99}));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
-    UNIT_ASSERT(ev->Issues.ToString().Contains("No partition 99"));
-}
+        // Isolated runtime has no cluster timers. Wait until the test observer has
+        // fired, jump past the actor retry delay, then grab the reply.
+        THolder<TEvKafka::TEvTopicOffsetsResponse> RunTopicOffsetsAfterInjection(
+            NActors::TTestActorRuntime& runtime,
+            TTopicOffsetsSettings settings,
+            std::function<bool()> injected)
+        {
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, std::move(settings))));
 
-Y_UNIT_TEST(MissingPartitionSkippedWhenFetchingConsumers) {
-    auto setup = CreateSetup("TopicOffsetsSkipPart");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_skip_part";
-    CreateTopic(runtime, path);
+            TDispatchOptions options;
+            options.CustomFinalCondition = std::move(injected);
+            runtime.DispatchEvents(options, TDuration::Seconds(5));
+            runtime.AdvanceCurrentTime(TDuration::MilliSeconds(250));
+            return GrabTopicOffsetsResponse(runtime, edge, TDuration::Seconds(5));
+        }
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path, {0, 99}, {"user"}));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].PartitionId, 0u);
-}
+        THashMap<ui32, TEvKafka::TPartitionOffsetsInfo> IndexByPartition(
+            const TVector<TEvKafka::TPartitionOffsetsInfo>& partitions)
+        {
+            THashMap<ui32, TEvKafka::TPartitionOffsetsInfo> out;
+            for (const auto& part : partitions) {
+                out[part.PartitionId] = part;
+            }
+            return out;
+        }
 
-Y_UNIT_TEST(ConsumersIncludeCommittedOffset) {
-    auto setup = CreateSetup("TopicOffsetsConsumer");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_consumer";
-    CreateTopic(runtime, path);
+        auto BreakFirstStatusForward(NActors::TTestActorRuntime& runtime, size_t& broken) {
+            auto* rt = &runtime;
+            return runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [&broken, rt](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (!ev || !ev->Get()->Ev) {
+                        return;
+                    }
+                    if (ev->Get()->Ev->Type() != TEvPersQueue::TEvStatus::EventType) {
+                        return;
+                    }
+                    if (broken >= 1) {
+                        return;
+                    }
+                    ++broken;
+                    const ui64 tabletId = ev->Get()->TabletId;
+                    const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
+                    rt->Send(new IEventHandle(
+                        ev->Sender,
+                        ev->Recipient,
+                        new TEvPipeCache::TEvDeliveryProblem(tabletId, true /*notDelivered*/),
+                        0,
+                        subscribeCookie));
+                    ev.Reset();
+                });
+        }
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path, {}, {"user"}));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    const auto it = ev->Partitions[0].Consumers.find("user");
-    UNIT_ASSERT(it != ev->Partitions[0].Consumers.end());
-    UNIT_ASSERT_VALUES_EQUAL(it->second.Offset, 0u);
-    UNIT_ASSERT_VALUES_EQUAL(it->second.PartitionIndex, 0u);
-}
+        auto DropStatusForwards(NActors::TTestActorRuntime& runtime, size_t* dropped = nullptr) {
+            return runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [dropped](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (ev && ev->Get()->Ev &&
+                        ev->Get()->Ev->Type() == TEvPersQueue::TEvStatus::EventType)
+                    {
+                        if (dropped) {
+                            ++*dropped;
+                        }
+                        ev.Reset();
+                    }
+                });
+        }
 
-Y_UNIT_TEST(UnknownConsumerIsOmitted) {
-    auto setup = CreateSetup("TopicOffsetsUnknownConsumer");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_unknown_consumer";
-    CreateTopic(runtime, path);
+        auto InjectStatusOnce(
+            NActors::TTestActorRuntime& runtime,
+            size_t& injected,
+            std::function<void(TEvPersQueue::TEvStatusResponse&)> fill)
+        {
+            auto* rt = &runtime;
+            return runtime.AddObserver<TEvPipeCache::TEvForward>(
+                [&injected, rt, fill = std::move(fill)](TEvPipeCache::TEvForward::TPtr& ev) {
+                    if (!ev || !ev->Get()->Ev) {
+                        return;
+                    }
+                    if (ev->Get()->Ev->Type() != TEvPersQueue::TEvStatus::EventType) {
+                        return;
+                    }
+                    if (injected >= 1) {
+                        return;
+                    }
+                    ++injected;
+                    auto* response = new TEvPersQueue::TEvStatusResponse();
+                    fill(*response);
+                    rt->Send(new IEventHandle(ev->Sender, ev->Recipient, response, 0, ev->Cookie));
+                    ev.Reset();
+                });
+        }
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path, {0}, {"nosuch"}));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT(!ev->Partitions[0].Consumers.contains("nosuch"));
-}
+    } // namespace
 
-Y_UNIT_TEST(RequireAuthenticationWithoutTokenIsUnauthorized) {
-    auto setup = CreateSetup("TopicOffsetsRequireAuth");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_require_auth";
-    CreateTopic(runtime, path);
+    Y_UNIT_TEST_SUITE(TTopicOffsetsActor) {
 
-    auto settings = MakeSettings(path);
-    settings.RequireAuthentication = true;
-    auto ev = RunTopicOffsets(runtime, std::move(settings));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
-    UNIT_ASSERT(ev->Issues.ToString().Contains("unauthenticated"));
-}
+        Y_UNIT_TEST(SuccessReturnsAllPartitions) {
+            auto setup = CreateSetup("TopicOffsetsSmoke");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_smoke";
+            CreateTopic(runtime, path, /*partitions=*/3);
 
-Y_UNIT_TEST(RequireSelectRowWithoutTokenSucceeds) {
-    auto setup = CreateSetup("TopicOffsetsSelectRowAnon");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_select_row_anon";
-    CreateTopic(runtime, path);
+            auto ev = RunTopicOffsets(runtime, MakeSettings(path));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 3u);
 
-    auto settings = MakeSettings(path);
-    settings.RequireSelectRow = true;
-    auto ev = RunTopicOffsets(runtime, std::move(settings));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-}
+            const auto byId = IndexByPartition(ev->Partitions);
+            for (ui32 i = 0; i < 3; ++i) {
+                UNIT_ASSERT(byId.contains(i));
+                const auto& part = byId.find(i)->second;
+                UNIT_ASSERT_VALUES_EQUAL(part.StartOffset, 0u);
+                UNIT_ASSERT_VALUES_EQUAL(part.EndOffset, 0u);
+                UNIT_ASSERT(part.Consumers.empty());
+            }
+        }
 
-Y_UNIT_TEST(RequireSelectRowWithBadTokenIsUnauthorized) {
-    auto setup = CreateSetup("TopicOffsetsSelectRowAuth");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_select_row_auth";
-    CreateTopic(runtime, path);
+        Y_UNIT_TEST(FiltersRequestedPartitions) {
+            auto setup = CreateSetup("TopicOffsetsFilter");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_filter";
+            CreateTopic(runtime, path, /*partitions=*/3);
 
-    auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
-    token->SaveSerializationInfo();
-    auto settings = MakeSettings(path);
-    settings.Token = token->GetSerializedToken();
-    settings.RequireSelectRow = true;
-    auto ev = RunTopicOffsets(runtime, std::move(settings));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
-}
+            auto ev = RunTopicOffsets(runtime, MakeSettings(path, {1}));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].PartitionId, 1u);
+        }
 
-Y_UNIT_TEST(UnauthenticatedExistenceCheckMissingIsSchemeError) {
-    auto setup = CreateSetup("TopicOffsetsExistCheckMissing");
-    auto& runtime = setup->GetRuntime();
+        Y_UNIT_TEST(MissingTopicIsSchemeError) {
+            auto setup = CreateSetup("TopicOffsetsMissing");
+            auto& runtime = setup->GetRuntime();
 
-    auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
-    token->SaveSerializationInfo();
-    auto settings = MakeSettings("/Root/topic_offsets_exist_check_missing");
-    settings.Token = token->GetSerializedToken();
-    settings.UnauthenticatedExistenceCheck = true;
-    auto ev = RunTopicOffsets(runtime, std::move(settings));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
-}
+            auto ev = RunTopicOffsets(runtime, MakeSettings("/Root/missing_topic_offsets"));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
+            UNIT_ASSERT(!ev->Issues.Empty());
+        }
 
-Y_UNIT_TEST(UnauthenticatedExistenceCheckHiddenIsUnauthorized) {
-    auto setup = CreateSetup("TopicOffsetsExistCheckHidden");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_exist_check_hidden";
-    CreateTopic(runtime, path);
+        Y_UNIT_TEST(MissingPartitionIsSchemeError) {
+            auto setup = CreateSetup("TopicOffsetsMissingPart");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_missing_part";
+            CreateTopic(runtime, path);
 
-    auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
-    token->SaveSerializationInfo();
-    auto settings = MakeSettings(path);
-    settings.Token = token->GetSerializedToken();
-    settings.UnauthenticatedExistenceCheck = true;
-    auto ev = RunTopicOffsets(runtime, std::move(settings));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
-}
+            auto ev = RunTopicOffsets(runtime, MakeSettings(path, {99}));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
+            UNIT_ASSERT(ev->Issues.ToString().Contains("No partition 99"));
+        }
 
-Y_UNIT_TEST(SelectRowUsesDedicatedTokenWhenDescriberIsAnonymous) {
-    auto setup = CreateSetup("TopicOffsetsSelectRowOptionalAuth");
-    auto& runtime = setup->GetRuntime();
-    const TString path = "/Root/topic_offsets_select_row_optional";
-    CreateTopic(runtime, path);
+        Y_UNIT_TEST(MissingPartitionSkippedWhenFetchingConsumers) {
+            auto setup = CreateSetup("TopicOffsetsSkipPart");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_skip_part";
+            CreateTopic(runtime, path);
 
-    auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
-    token->SaveSerializationInfo();
-    auto settings = MakeSettings(path);
-    settings.RequireSelectRow = true;
-    settings.SelectRowToken = token->GetSerializedToken();
-    auto ev = RunTopicOffsets(runtime, std::move(settings));
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
-    UNIT_ASSERT(ev->Issues.ToString().Contains("access denied"));
-}
+            auto ev = RunTopicOffsets(runtime, MakeSettings(path, {0, 99}, {"user"}));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].PartitionId, 0u);
+        }
 
-Y_UNIT_TEST(ParsesConsumerOffsetsAndSkipsErrors) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_offsets_parse_consumers";
-    CreateTopic(runtime, path);
+        Y_UNIT_TEST(ConsumersIncludeCommittedOffset) {
+            auto setup = CreateSetup("TopicOffsetsConsumer");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_consumer";
+            CreateTopic(runtime, path);
 
-    size_t injected = 0;
-    auto injectObserver = InjectStatusOnce(runtime, injected, [](TEvPersQueue::TEvStatusResponse& response) {
-        auto* part = response.Record.AddPartResult();
-        part->SetPartition(0);
-        part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_OK);
-        part->SetStartOffset(10);
-        part->SetEndOffset(20);
-        part->SetGeneration(3);
-        auto* ok = part->AddConsumerResult();
-        ok->SetConsumer("user");
-        ok->SetErrorCode(NPersQueue::NErrorCode::OK);
-        ok->SetCommitedOffset(15);
-        ok->SetCommittedMetadata("meta");
-        auto* bad = part->AddConsumerResult();
-        bad->SetConsumer("gone");
-        bad->SetErrorCode(NPersQueue::NErrorCode::SCHEMA_ERROR);
-        bad->SetCommitedOffset(99);
-    });
+            auto ev = RunTopicOffsets(runtime, MakeSettings(path, {}, {"user"}));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            const auto it = ev->Partitions[0].Consumers.find("user");
+            UNIT_ASSERT(it != ev->Partitions[0].Consumers.end());
+            UNIT_ASSERT_VALUES_EQUAL(it->second.Offset, 0u);
+            UNIT_ASSERT_VALUES_EQUAL(it->second.PartitionIndex, 0u);
+        }
 
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path, {0}, {"user"}));
-    UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].StartOffset, 10u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].EndOffset, 20u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].Generation, 3u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].Consumers.size(), 1u);
-    const auto it = ev->Partitions[0].Consumers.find("user");
-    UNIT_ASSERT(it != ev->Partitions[0].Consumers.end());
-    UNIT_ASSERT_VALUES_EQUAL(it->second.Offset, 15u);
-    UNIT_ASSERT_VALUES_EQUAL(it->second.Metadata, "meta");
-    UNIT_ASSERT(!ev->Partitions[0].Consumers.contains("gone"));
-}
+        Y_UNIT_TEST(UnknownConsumerIsOmitted) {
+            auto setup = CreateSetup("TopicOffsetsUnknownConsumer");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_unknown_consumer";
+            CreateTopic(runtime, path);
 
-Y_UNIT_TEST(RetriesOnDeliveryProblem) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_offsets_retry";
-    CreateTopic(runtime, path);
+            auto ev = RunTopicOffsets(runtime, MakeSettings(path, {0}, {"nosuch"}));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT(!ev->Partitions[0].Consumers.contains("nosuch"));
+        }
 
-    size_t broken = 0;
-    auto breakObserver = BreakFirstStatusForward(runtime, broken);
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path));
-    UNIT_ASSERT_VALUES_EQUAL(broken, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-}
+        Y_UNIT_TEST(RequireAuthenticationWithoutTokenIsUnauthorized) {
+            auto setup = CreateSetup("TopicOffsetsRequireAuth");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_require_auth";
+            CreateTopic(runtime, path);
 
-Y_UNIT_TEST(RetriesOnEmptyStatusResponse) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_offsets_empty_status";
-    CreateTopic(runtime, path);
+            auto settings = MakeSettings(path);
+            settings.RequireAuthentication = true;
+            auto ev = RunTopicOffsets(runtime, std::move(settings));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
+            UNIT_ASSERT(ev->Issues.ToString().Contains("unauthenticated"));
+        }
 
-    size_t injected = 0;
-    auto injectObserver = InjectStatusOnce(runtime, injected, [](TEvPersQueue::TEvStatusResponse&) {});
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path));
-    UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-}
+        Y_UNIT_TEST(RequireSelectRowWithoutTokenSucceeds) {
+            auto setup = CreateSetup("TopicOffsetsSelectRowAnon");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_select_row_anon";
+            CreateTopic(runtime, path);
 
-Y_UNIT_TEST(RetriesOnInitializingStatus) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_offsets_initializing";
-    CreateTopic(runtime, path);
+            auto settings = MakeSettings(path);
+            settings.RequireSelectRow = true;
+            auto ev = RunTopicOffsets(runtime, std::move(settings));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+        }
 
-    size_t injected = 0;
-    auto injectObserver = InjectStatusOnce(runtime, injected, [](TEvPersQueue::TEvStatusResponse& response) {
-        auto* part = response.Record.AddPartResult();
-        part->SetPartition(0);
-        part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_INITIALIZING);
-    });
-    auto ev = RunTopicOffsets(runtime, MakeSettings(path));
-    UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
-}
+        Y_UNIT_TEST(RequireSelectRowWithBadTokenIsUnauthorized) {
+            auto setup = CreateSetup("TopicOffsetsSelectRowAuth");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_select_row_auth";
+            CreateTopic(runtime, path);
 
-Y_UNIT_TEST(TimesOutWhenStatusStuck) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_offsets_timeout";
-    CreateTopic(runtime, path);
+            auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
+            token->SaveSerializationInfo();
+            auto settings = MakeSettings(path);
+            settings.Token = token->GetSerializedToken();
+            settings.RequireSelectRow = true;
+            auto ev = RunTopicOffsets(runtime, std::move(settings));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
+        }
 
-    auto dropObserver = DropStatusForwards(runtime);
-    const auto edge = runtime.AllocateEdgeActor();
-    TEnableScheduleForRootGuard schedule(runtime);
-    schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, MakeSettings(path))));
+        Y_UNIT_TEST(UnauthenticatedExistenceCheckMissingIsSchemeError) {
+            auto setup = CreateSetup("TopicOffsetsExistCheckMissing");
+            auto& runtime = setup->GetRuntime();
 
-    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
-    runtime.AdvanceCurrentTime(TDuration::Seconds(31));
+            auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
+            token->SaveSerializationInfo();
+            auto settings = MakeSettings("/Root/topic_offsets_exist_check_missing");
+            settings.Token = token->GetSerializedToken();
+            settings.UnauthenticatedExistenceCheck = true;
+            auto ev = RunTopicOffsets(runtime, std::move(settings));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SCHEME_ERROR);
+        }
 
-    auto handle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(edge, TDuration::Seconds(5));
-    UNIT_ASSERT(handle);
-    const auto* ev = handle->Get();
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::TIMEOUT);
-    UNIT_ASSERT(ev->Issues.ToString().Contains("timed out"));
+        Y_UNIT_TEST(UnauthenticatedExistenceCheckHiddenIsUnauthorized) {
+            auto setup = CreateSetup("TopicOffsetsExistCheckHidden");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_exist_check_hidden";
+            CreateTopic(runtime, path);
 
-    auto* late = new TEvPersQueue::TEvStatusResponse();
-    auto* part = late->Record.AddPartResult();
-    part->SetPartition(0);
-    part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_OK);
-    runtime.Send(new IEventHandle(schedule.GetRoot(), edge, late, 0, /*cookie=*/1));
-    auto lateHandle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(
-        edge, TDuration::MilliSeconds(200));
-    UNIT_ASSERT(!lateHandle);
-}
+            auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
+            token->SaveSerializationInfo();
+            auto settings = MakeSettings(path);
+            settings.Token = token->GetSerializedToken();
+            settings.UnauthenticatedExistenceCheck = true;
+            auto ev = RunTopicOffsets(runtime, std::move(settings));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
+        }
 
-Y_UNIT_TEST(PoisonRepliesCancelled) {
-    auto server = CreateSimulatedServer();
-    auto& runtime = server->GetRuntime();
-    const TString path = "/Root/topic_offsets_poison";
-    CreateTopic(runtime, path);
+        Y_UNIT_TEST(SelectRowUsesDedicatedTokenWhenDescriberIsAnonymous) {
+            auto setup = CreateSetup("TopicOffsetsSelectRowOptionalAuth");
+            auto& runtime = setup->GetRuntime();
+            const TString path = "/Root/topic_offsets_select_row_optional";
+            CreateTopic(runtime, path);
 
-    auto dropObserver = DropStatusForwards(runtime);
-    const auto edge = runtime.AllocateEdgeActor();
-    TEnableScheduleForRootGuard schedule(runtime);
-    schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, MakeSettings(path))));
+            auto token = MakeIntrusive<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
+            token->SaveSerializationInfo();
+            auto settings = MakeSettings(path);
+            settings.RequireSelectRow = true;
+            settings.SelectRowToken = token->GetSerializedToken();
+            auto ev = RunTopicOffsets(runtime, std::move(settings));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::UNAUTHORIZED);
+            UNIT_ASSERT(ev->Issues.ToString().Contains("access denied"));
+        }
 
-    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
-    runtime.Send(new IEventHandle(schedule.GetRoot(), edge, new NActors::TEvents::TEvPoison()));
+        Y_UNIT_TEST(ParsesConsumerOffsetsAndSkipsErrors) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_offsets_parse_consumers";
 
-    auto handle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(edge, TDuration::Seconds(5));
-    UNIT_ASSERT(handle);
-    const auto* ev = handle->Get();
-    UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::CANCELLED);
-}
+            size_t injected = 0;
+            auto injectObserver = InjectStatusOnce(runtime, injected, [](TEvPersQueue::TEvStatusResponse& response) {
+                auto* part = response.Record.AddPartResult();
+                part->SetPartition(0);
+                part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_OK);
+                part->SetStartOffset(10);
+                part->SetEndOffset(20);
+                part->SetGeneration(3);
+                auto* ok = part->AddConsumerResult();
+                ok->SetConsumer("user");
+                ok->SetErrorCode(NPersQueue::NErrorCode::OK);
+                ok->SetCommitedOffset(15);
+                ok->SetCommittedMetadata("meta");
+                auto* bad = part->AddConsumerResult();
+                bad->SetConsumer("gone");
+                bad->SetErrorCode(NPersQueue::NErrorCode::SCHEMA_ERROR);
+                bad->SetCommitedOffset(99);
+            });
 
-} // Y_UNIT_TEST_SUITE(TTopicOffsetsActor)
+            auto ev = RunTopicOffsetsAfterInjection(runtime, MakeSettings(path, {0}, {"user"}), [&] {
+                return injected >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].StartOffset, 10u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].EndOffset, 20u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].Generation, 3u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions[0].Consumers.size(), 1u);
+            const auto it = ev->Partitions[0].Consumers.find("user");
+            UNIT_ASSERT(it != ev->Partitions[0].Consumers.end());
+            UNIT_ASSERT_VALUES_EQUAL(it->second.Offset, 15u);
+            UNIT_ASSERT_VALUES_EQUAL(it->second.Metadata, "meta");
+            UNIT_ASSERT(!ev->Partitions[0].Consumers.contains("gone"));
+        }
+
+        Y_UNIT_TEST(RetriesOnDeliveryProblem) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_offsets_retry";
+
+            size_t broken = 0;
+            auto breakObserver = BreakFirstStatusForward(runtime, broken);
+            auto ev = RunTopicOffsetsAfterInjection(runtime, MakeSettings(path), [&] {
+                return broken >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(broken, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+        }
+
+        Y_UNIT_TEST(RetriesOnEmptyStatusResponse) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_offsets_empty_status";
+
+            size_t injected = 0;
+            auto injectObserver = InjectStatusOnce(runtime, injected, [](TEvPersQueue::TEvStatusResponse&) {});
+            auto ev = RunTopicOffsetsAfterInjection(runtime, MakeSettings(path), [&] {
+                return injected >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+        }
+
+        Y_UNIT_TEST(RetriesOnInitializingStatus) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_offsets_initializing";
+
+            size_t injected = 0;
+            auto injectObserver = InjectStatusOnce(runtime, injected, [](TEvPersQueue::TEvStatusResponse& response) {
+                auto* part = response.Record.AddPartResult();
+                part->SetPartition(0);
+                part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_INITIALIZING);
+            });
+            auto ev = RunTopicOffsetsAfterInjection(runtime, MakeSettings(path), [&] {
+                return injected >= 1;
+            });
+            UNIT_ASSERT_VALUES_EQUAL(injected, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Partitions.size(), 1u);
+        }
+
+        Y_UNIT_TEST(TimesOutWhenStatusStuck) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_offsets_timeout";
+
+            size_t dropped = 0;
+            auto dropObserver = DropStatusForwards(runtime, &dropped);
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, MakeSettings(path))));
+
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&] {
+                return dropped >= 1;
+            };
+            runtime.DispatchEvents(options, TDuration::Seconds(5));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(31));
+
+            auto handle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(edge, TDuration::Seconds(5));
+            UNIT_ASSERT(handle);
+            const auto* ev = handle->Get();
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::TIMEOUT);
+            UNIT_ASSERT(ev->Issues.ToString().Contains("timed out"));
+
+            auto* late = new TEvPersQueue::TEvStatusResponse();
+            auto* part = late->Record.AddPartResult();
+            part->SetPartition(0);
+            part->SetStatus(NKikimrPQ::TStatusResponse::STATUS_OK);
+            runtime.Send(new IEventHandle(schedule.GetRoot(), edge, late, 0, /*cookie=*/1));
+            const auto prevTimeout = runtime.SetDispatchTimeout(TDuration::MilliSeconds(200));
+            bool gotLate = false;
+            try {
+                gotLate = static_cast<bool>(runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(
+                    edge, TDuration::MilliSeconds(50)));
+            } catch (const NActors::TEmptyEventQueueException&) {
+            }
+            runtime.SetDispatchTimeout(prevTimeout);
+            UNIT_ASSERT(!gotLate);
+        }
+
+        Y_UNIT_TEST(PoisonRepliesCancelled) {
+            TIsolatedEnv env;
+            auto& runtime = env.Runtime;
+            const TString path = "/Root/topic_offsets_poison";
+
+            size_t dropped = 0;
+            auto dropObserver = DropStatusForwards(runtime, &dropped);
+            const auto edge = runtime.AllocateEdgeActor();
+            TEnableScheduleForRootGuard schedule(runtime);
+            schedule.SetRoot(runtime.Register(CreateTopicOffsetsActor(edge, MakeSettings(path))));
+
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&] {
+                return dropped >= 1;
+            };
+            runtime.DispatchEvents(options, TDuration::Seconds(5));
+            runtime.Send(new IEventHandle(schedule.GetRoot(), edge, new NActors::TEvents::TEvPoison()));
+
+            auto handle = runtime.GrabEdgeEvent<TEvKafka::TEvTopicOffsetsResponse>(edge, TDuration::Seconds(5));
+            UNIT_ASSERT(handle);
+            const auto* ev = handle->Get();
+            UNIT_ASSERT_VALUES_EQUAL(ev->Status, Ydb::StatusIds::CANCELLED);
+        }
+
+    } // Y_UNIT_TEST_SUITE(TTopicOffsetsActor)
 
 } // namespace NKafka::NTests


### PR DESCRIPTION
Fixes #51708: `TTopicOffsetsActor.RetriesOnDeliveryProblem` hung under simulated time. `TTestServer` with `UseRealThreads(false)` enables Schedule for every actor, so unbounded `DispatchEvents()` never drains and the suite is killed with TIMEOUT.

The same pattern also hung `TTopicLocationActor.RetriesOnDeliveryProblem` and the other retry/timeout tests in those files.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Retry/timeout/poison tests no longer start a full `TTestServer`. They use an isolated `TTestBasicRuntime` with fake scheme cache and fake pipe cache (same approach as `describe_operation_ut`).
* Retry tests wait until the observer has fired, then `AdvanceCurrentTime` past the actor retry delay.
* Timeout/poison tests stop dispatch with `CustomFinalCondition` so collapsed-time does not fire the 30s actor timeout early.