### PR TITLE
Fix SelfHeal with PhantomsOnly

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -3,6 +3,8 @@
 #include <util/generic/hash_set.h>
 #include <util/system/compiler.h>
 
+#include <numeric>
+
 Y_UNIT_TEST_SUITE(SelfHeal) {
     void ChangeDiskStatus(TEnvironmentSetup& env, TPDiskId pdiskId, NKikimrBlobStorage::EDriveStatus status,
             NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus) {
@@ -490,5 +492,295 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
 
         UNIT_ASSERT_C(newPDiskId1 == originalPDiskId1, "Expected VDisk (0, 1, 0) not to be moved");
         UNIT_ASSERT_C(newPDiskId2 == originalPDiskId2, "Expected VDisk (0, 2, 0) not to be moved");
+    }
+
+    struct TVDiskState {
+        NKikimrBlobStorage::EVDiskStatus Status = NKikimrBlobStorage::EVDiskStatus::READY;
+        bool OnlyPhantomsRemain = false;
+
+        bool IsReady() const {
+            return Status == NKikimrBlobStorage::EVDiskStatus::READY;
+        }
+
+        bool IsOperational() const {
+            return Status >= NKikimrBlobStorage::EVDiskStatus::REPLICATING;
+        }
+
+        bool IsReplicatingWithPhantomsOnly() const {
+            return Status == NKikimrBlobStorage::EVDiskStatus::REPLICATING && OnlyPhantomsRemain;
+        }
+    };
+
+    using TVDiskKey = std::tuple<ui32, ui32, ui32, ui32>;
+    using TVDiskStates = std::map<TVDiskKey, TVDiskState>;
+
+    TVDiskKey MakeVDiskKey(ui32 groupId, ui32 ring, ui32 domain, ui32 vdisk) {
+        return {groupId, ring, domain, vdisk};
+    }
+
+    TVDiskKey MakeVDiskKey(const NKikimrBlobStorage::TBaseConfig::TVSlot& slot) {
+        return MakeVDiskKey(slot.GetGroupId(), slot.GetFailRealmIdx(), slot.GetFailDomainIdx(), slot.GetVDiskIdx());
+    }
+
+    NKikimrBlobStorage::TConfigResponse InvokeConfigRequest(TEnvironmentSetup& env,
+            const NKikimrBlobStorage::TConfigRequest& request, bool selfHeal) {
+        const TActorId sender = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId, __FILE__, __LINE__);
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerConfigRequest>();
+        ev->Record.MutableRequest()->CopyFrom(request);
+        ev->SelfHeal = selfHeal;
+        env.Runtime->SendToPipe(env.TabletId, sender, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+        auto response = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerConfigResponse>(sender);
+        return response->Get()->Record.GetResponse();
+    }
+
+    void ReportVDiskStates(TEnvironmentSetup& env, const NKikimrBlobStorage::TBaseConfig& base,
+            const TVDiskStates& states) {
+        std::map<std::pair<ui32, ui32>, ui64> pdiskGuids;
+        for (const auto& pdisk : base.GetPDisk()) {
+            pdiskGuids.emplace(std::make_pair(pdisk.GetNodeId(), pdisk.GetPDiskId()), pdisk.GetGuid());
+        }
+
+        const TActorId sender = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId, __FILE__, __LINE__);
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerRegisterNode>();
+        ev->Record.SetNodeID(env.Settings.ControllerNodeId);
+        for (const auto& slot : base.GetVSlot()) {
+            const TVDiskState& state = states.at(MakeVDiskKey(slot));
+            const auto& vslotId = slot.GetVSlotId();
+            auto *item = ev->Record.AddVDiskStatus();
+            item->SetNodeId(vslotId.GetNodeId());
+            item->SetPDiskId(vslotId.GetPDiskId());
+            item->SetVSlotId(vslotId.GetVSlotId());
+            item->SetPDiskGuid(pdiskGuids.at(std::make_pair(vslotId.GetNodeId(), vslotId.GetPDiskId())));
+            item->SetStatus(state.Status);
+            item->SetOnlyPhantomsRemain(state.OnlyPhantomsRemain);
+            auto *vdiskId = item->MutableVDiskId();
+            vdiskId->SetGroupID(slot.GetGroupId());
+            vdiskId->SetGroupGeneration(slot.GetGroupGeneration());
+            vdiskId->SetRing(slot.GetFailRealmIdx());
+            vdiskId->SetDomain(slot.GetFailDomainIdx());
+            vdiskId->SetVDisk(slot.GetVDiskIdx());
+        }
+        env.Runtime->SendToPipe(env.TabletId, sender, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+        env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerNodeServiceSetUpdate>(sender);
+    }
+
+    enum class EExpectedResult {
+        Success,
+        Degraded,
+        Disintegrated,
+        FitDegraded,
+        FitDisintegrated,
+    };
+
+    EExpectedResult EvaluateReassign(const TBlobStorageGroupInfo::TTopology& topology,
+            const TVector<TVDiskState>& states, ui32 targetOrderNumber, bool selfHeal) {
+        const TBlobStorageGroupInfo::IQuorumChecker& checker = topology.GetQuorumChecker();
+        TBlobStorageGroupInfo::TGroupVDisks nonOperational(&topology);
+        for (ui32 orderNumber = 0; orderNumber < states.size(); ++orderNumber) {
+            if (!states[orderNumber].IsOperational()) {
+                nonOperational |= {&topology, topology.GetVDiskId(orderNumber)};
+            }
+        }
+        if (!checker.CheckFailModelForGroup(nonOperational)) {
+            return EExpectedResult::FitDisintegrated;
+        } else if (checker.IsDegraded(nonOperational)) {
+            return EExpectedResult::FitDegraded;
+        }
+
+        TBlobStorageGroupInfo::TGroupVDisks failed(&topology);
+        for (ui32 orderNumber = 0; orderNumber < states.size(); ++orderNumber) {
+            if (!states[orderNumber].IsReady()) {
+                failed |= {&topology, topology.GetVDiskId(orderNumber)};
+            }
+        }
+        failed |= {&topology, topology.GetVDiskId(targetOrderNumber)};
+
+        if (!checker.CheckFailModelForGroup(failed)) {
+            return EExpectedResult::Disintegrated;
+        }
+
+        if (selfHeal) {
+            for (ui32 orderNumber = 0; orderNumber < states.size(); ++orderNumber) {
+                if (orderNumber != targetOrderNumber && states[orderNumber].IsReplicatingWithPhantomsOnly()) {
+                    failed = failed - TBlobStorageGroupInfo::TGroupVDisks(&topology, topology.GetVDiskId(orderNumber));
+                    break;
+                }
+            }
+        }
+        return checker.IsDegraded(failed) ? EExpectedResult::Degraded : EExpectedResult::Success;
+    }
+
+    void AssertReassignResult(const NKikimrBlobStorage::TConfigResponse& response, EExpectedResult expected,
+            ui32 groupId, const TString& context) {
+        UNIT_ASSERT_VALUES_EQUAL_C(response.GetSuccess(), expected == EExpectedResult::Success,
+            context << " Response# " << response.DebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDegradedSize(), expected == EExpectedResult::Degraded ? 1 : 0,
+            context << " Response# " << response.DebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDisintegratedSize(),
+            expected == EExpectedResult::Disintegrated ? 1 : 0, context << " Response# " << response.DebugString());
+        if (expected == EExpectedResult::Degraded) {
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GetGroupsGetDegraded(0), groupId, context);
+        } else if (expected == EExpectedResult::Disintegrated) {
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GetGroupsGetDisintegrated(0), groupId, context);
+        } else if (expected == EExpectedResult::FitDegraded || expected == EExpectedResult::FitDisintegrated) {
+            UNIT_ASSERT_VALUES_EQUAL_C(response.StatusSize(), 1, context << " Response# " << response.DebugString());
+            const auto failReason = expected == EExpectedResult::FitDegraded
+                ? NKikimrBlobStorage::TConfigResponse::TStatus::kMayGetDegraded
+                : NKikimrBlobStorage::TConfigResponse::TStatus::kMayLoseData;
+            UNIT_ASSERT_VALUES_EQUAL_C(static_cast<ui32>(response.GetStatus(0).GetFailReason()),
+                static_cast<ui32>(failReason),
+                context << " Response# " << response.DebugString());
+        }
+    }
+
+    Y_UNIT_TEST(RandomizedVDiskStates) {
+        constexpr ui32 numGroups = 64;
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TBlobStorageGroupInfo::TTopology topology(erasure, 1, erasure.BlobSubgroupSize(), 1, true);
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize() + 4,
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(4, numGroups);
+        env.Sim(TDuration::Minutes(1));
+        env.UpdateSettings(true, true, false);
+
+        const NKikimrBlobStorage::TBaseConfig base = env.FetchBaseConfig();
+        UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), numGroups);
+
+        struct TTestCase {
+            const NKikimrBlobStorage::TBaseConfig::TGroup *Group = nullptr;
+            TVector<const NKikimrBlobStorage::TBaseConfig::TVSlot*> SlotsByOrderNumber;
+            TVector<TVDiskState> States;
+            ui32 TargetOrderNumber = 0;
+        };
+
+        TVDiskStates states;
+        TVector<TTestCase> testCases;
+        testCases.reserve(numGroups);
+        for (const auto& group : base.GetGroup()) {
+            TTestCase& testCase = testCases.emplace_back();
+            testCase.Group = &group;
+            testCase.SlotsByOrderNumber.resize(topology.GetTotalVDisksNum());
+            testCase.States.resize(topology.GetTotalVDisksNum());
+
+            for (const auto& slot : base.GetVSlot()) {
+                if (slot.GetGroupId() == group.GetGroupId()) {
+                    const TVDiskIdShort vdiskId(slot.GetFailRealmIdx(), slot.GetFailDomainIdx(), slot.GetVDiskIdx());
+                    testCase.SlotsByOrderNumber[topology.GetOrderNumber(vdiskId)] = &slot;
+                }
+            }
+
+            TVector<ui32> orderNumbers(topology.GetTotalVDisksNum());
+            std::iota(orderNumbers.begin(), orderNumbers.end(), 0);
+            for (ui32 i = 0; i + 1 < orderNumbers.size(); ++i) {
+                std::swap(orderNumbers[i], orderNumbers[i + RandomNumber<ui32>(orderNumbers.size() - i)]);
+            }
+            testCase.TargetOrderNumber = orderNumbers[0];
+
+            // Keep every important validation outcome covered for every seed while randomizing VDisk positions.
+            // Every fifth case adds a fully randomized mix of the same readiness/operational state classes.
+            switch (testCases.size() % 5) {
+                case 0: // SelfHeal succeeds only because it may ignore the phantoms-only VDisk
+                    testCase.States[orderNumbers[0]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    testCase.States[orderNumbers[1]] = {NKikimrBlobStorage::EVDiskStatus::REPLICATING, true};
+                    break;
+
+                case 1: // evicting a third VDisk disintegrates the group, even for SelfHeal
+                    testCase.States[orderNumbers[1]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    testCase.States[orderNumbers[2]] = {NKikimrBlobStorage::EVDiskStatus::REPLICATING, true};
+                    break;
+
+                case 2: // non-operational VDisks trigger the earlier group fitter check
+                    testCase.States[orderNumbers[0]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    testCase.States[orderNumbers[1]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    break;
+
+                case 3: // a healthy group accepts an ordinary reassign
+                    break;
+
+                case 4: {
+                    const ui32 numNonReady = 1 + RandomNumber<ui32>(4);
+                    for (ui32 i = 0; i < numNonReady; ++i) {
+                        switch (RandomNumber<ui32>(3)) {
+                            case 0:
+                                testCase.States[orderNumbers[i]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                                break;
+                            case 1:
+                                testCase.States[orderNumbers[i]].Status = NKikimrBlobStorage::EVDiskStatus::REPLICATING;
+                                break;
+                            case 2:
+                                testCase.States[orderNumbers[i]] = {
+                                    NKikimrBlobStorage::EVDiskStatus::REPLICATING, true};
+                                break;
+                        }
+                    }
+                    testCase.TargetOrderNumber = RandomNumber<ui32>(orderNumbers.size());
+                    break;
+                }
+            }
+
+            for (ui32 orderNumber = 0; orderNumber < testCase.States.size(); ++orderNumber) {
+                UNIT_ASSERT(testCase.SlotsByOrderNumber[orderNumber]);
+                states.emplace(MakeVDiskKey(*testCase.SlotsByOrderNumber[orderNumber]), testCase.States[orderNumber]);
+            }
+        }
+
+        env.Runtime->FilterFunction = [&states](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerUpdateDiskStatus::EventType) {
+                auto *statuses = ev->Get<TEvBlobStorage::TEvControllerUpdateDiskStatus>()->Record.MutableVDiskStatus();
+                for (auto& status : *statuses) {
+                    const auto& vdiskId = status.GetVDiskId();
+                    const auto it = states.find(MakeVDiskKey(vdiskId.GetGroupID(), vdiskId.GetRing(),
+                        vdiskId.GetDomain(), vdiskId.GetVDisk()));
+                    if (it != states.end()) {
+                        status.SetStatus(it->second.Status);
+                        status.SetOnlyPhantomsRemain(it->second.OnlyPhantomsRemain);
+                    }
+                }
+            }
+            return true;
+        };
+        ReportVDiskStates(env, base, states);
+
+        ui32 selfHealSuccesses = 0;
+        ui32 disintegratedRejections = 0;
+        for (ui32 index = 0; index < testCases.size(); ++index) {
+            const TTestCase& testCase = testCases[index];
+            const auto *target = testCase.SlotsByOrderNumber[testCase.TargetOrderNumber];
+
+            NKikimrBlobStorage::TConfigRequest request;
+            request.SetIgnoreGroupReserve(true);
+            request.SetAllowUnusableDisks(true);
+            request.SetIgnoreDisintegratedGroupsChecks(true);
+            auto *reassign = request.AddCommand()->MutableReassignGroupDisk();
+            reassign->SetGroupId(testCase.Group->GetGroupId());
+            reassign->SetGroupGeneration(testCase.Group->GetGroupGeneration());
+            reassign->SetFailRealmIdx(target->GetFailRealmIdx());
+            reassign->SetFailDomainIdx(target->GetFailDomainIdx());
+            reassign->SetVDiskIdx(target->GetVDiskIdx());
+
+            const TString context = TStringBuilder() << "Case# " << index << " GroupId# "
+                << testCase.Group->GetGroupId() << " TargetOrderNumber# " << testCase.TargetOrderNumber;
+            const EExpectedResult regularExpected = EvaluateReassign(topology, testCase.States,
+                testCase.TargetOrderNumber, false);
+            NKikimrBlobStorage::TConfigResponse response = InvokeConfigRequest(env, request, false);
+            AssertReassignResult(response, regularExpected, testCase.Group->GetGroupId(), context + " SelfHeal# false");
+
+            if (regularExpected != EExpectedResult::Success) {
+                const EExpectedResult selfHealExpected = EvaluateReassign(topology, testCase.States,
+                    testCase.TargetOrderNumber, true);
+                response = InvokeConfigRequest(env, request, true);
+                AssertReassignResult(response, selfHealExpected, testCase.Group->GetGroupId(),
+                    context + " SelfHeal# true");
+                selfHealSuccesses += selfHealExpected == EExpectedResult::Success;
+                disintegratedRejections += selfHealExpected == EExpectedResult::Disintegrated;
+            }
+        }
+
+        UNIT_ASSERT_C(selfHealSuccesses, "Randomized test did not cover a SelfHeal-only successful reassign");
+        UNIT_ASSERT_C(disintegratedRejections,
+            "Randomized test did not cover fail-model rejection with IgnoreDisintegratedGroupsChecks=true");
     }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -402,7 +402,8 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
     }
 
     auto MakeCatchDiskStatuses = [](ui32 groupId, const THashSet<ui32>& phantomOnlyDomains,
-                                    const THashSet<ui32>& faultyDomains) {
+                                    const THashSet<ui32>& faultyDomains,
+                                    const THashSet<ui32>& readyFaultyDomains = {}) {
         return [=](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
             if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerUpdateDiskStatus::EventType) {
                 auto* vdiskStatuses = ev->Get<TEvBlobStorage::TEvControllerUpdateDiskStatus>()->Record.MutableVDiskStatus();
@@ -426,6 +427,10 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
                         // this VDisk is REPLICATING with only phantom blobs remaining
                         status.SetOnlyPhantomsRemain(true);
                         status.SetStatus(NKikimrBlobStorage::EVDiskStatus::REPLICATING);
+                    } else if (readyFaultyDomains.contains(domain)) {
+                        // this VDisk remains available even though its PDisk is marked FAULTY
+                        status.SetOnlyPhantomsRemain(false);
+                        status.SetStatus(NKikimrBlobStorage::EVDiskStatus::READY);
                     } else if (faultyDomains.contains(domain)) {
                         // this VDisk's PDisk is FAULTY, so it doesn't report its status
                         return false;
@@ -461,6 +466,32 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
         TPDiskId newPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
 
         UNIT_ASSERT_C(newPDiskId != originalPDiskId, "Expected VDisk (0, 1, 0) to be moved");
+    }
+
+    Y_UNIT_TEST(SelfHealDoesNotMoveReadyFaultyDiskWithPhantomsOnly) {
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize() + 1,
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(1, 1);
+        env.UpdateSettings(false, true, false); // disable self-heal
+
+        const ui32 groupId = env.GetGroups().at(0);
+        const TPDiskId originalPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
+
+        ChangeDiskStatus(env, originalPDiskId, NKikimrBlobStorage::EDriveStatus::FAULTY,
+            NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
+
+        env.Runtime->FilterFunction = MakeCatchDiskStatuses(groupId, /*phantomOnlyDomains=*/{0},
+            /*faultyDomains=*/{}, /*readyFaultyDomains=*/{1});
+
+        env.UpdateSettings(true, true, false); // enable self-heal
+        env.Sim(TDuration::Seconds(30));
+
+        const TPDiskId newPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
+        UNIT_ASSERT_C(newPDiskId == originalPDiskId, "Expected ready VDisk (0, 1, 0) not to be moved");
     }
 
     Y_UNIT_TEST(SelfHealWithTwoFailedDisksAndOnePhantomOnly) {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -334,8 +334,7 @@ namespace NKikimr::NBsController {
             }
         };
 
-        bool TBlobStorageController::ValidateConfigUpdates(TConfigState& state, bool suppressFailModelChecking,
-                bool suppressDegradedGroupsChecking, bool suppressDisintegratedGroupsChecking,
+        bool TBlobStorageController::ValidateConfigUpdates(TConfigState& state, TValidateConfigUpdatesParameters parameters,
                 TString *errorDescription, NKikimrBlobStorage::TConfigResponse *response) {
 
             // when bridged non-proxy groups get updated, we update parent group too
@@ -403,7 +402,8 @@ namespace NKikimr::NBsController {
             std::vector<TGroupId> disintegrated;
             std::vector<TGroupId> degraded;
 
-            if (!suppressDisintegratedGroupsChecking) {
+            // Check Disintegrated by ExpectedStatus
+            if (!parameters.SuppressDisintegratedGroupsChecking) {
                 for (auto&& [base, overlay] : state.Groups.Diff()) {
                     if (base && overlay->second) {
                         const TGroupInfo::TGroupStatus& prev = base->second->Status;
@@ -418,7 +418,7 @@ namespace NKikimr::NBsController {
             }
 
             // check that group modification would not degrade failure model
-            if (!suppressFailModelChecking) {
+            if (!parameters.SuppressFailModelChecking) {
                 THashSet<TGroupId> groupsToCheck;
                 for (auto&& [base, overlay] : state.VSlots.Diff()) {
                     if (base && base->second->Group) {
@@ -442,19 +442,22 @@ namespace NKikimr::NBsController {
                     }
                     if (const TGroupInfo *group = state.Groups.Find(groupId); group && group->VDisksInGroup) {
                         // process only groups with changed content; create topology for group
-                        auto& topology = *group->Topology;
+                        TBlobStorageGroupInfo::TTopology& topology = *group->Topology;
                         // fill in vector of failed disks (that are not fully operational)
                         TBlobStorageGroupInfo::TGroupVDisks failed(&topology);
-                        bool alreadySeenReplicatingWithPhantomsOnly = false;
+
+                        // A single non-Ready VDisk that is REPLICATING with only phantoms remaining may be ignored by
+                        // the degraded check when AllowDegradedWithSinglePhantomsOnly is set. The full failure set must
+                        // still pass the disintegrated check.
+                        TBlobStorageGroupInfo::TGroupVDisks allowedNonReady(&topology);
                         for (const TVSlotInfo *slot : group->VDisksInGroup) {
-                            bool replicatingWithPhantomsOnly = slot->IsReplicatingWithPhantomsOnly();
-                            // Allow exactly one VDisk that is REPLICATING with only phantoms remaining to be treated as nearly ready
-                            bool allowedOneReplicatingWithPhantomsOnly = replicatingWithPhantomsOnly && !alreadySeenReplicatingWithPhantomsOnly;
-                            if (!slot->IsReady && !allowedOneReplicatingWithPhantomsOnly) {
+                            if (!slot->IsReady) {
                                 failed |= {&topology, slot->GetShortVDiskId()};
-                            }
-                            if (replicatingWithPhantomsOnly) {
-                                alreadySeenReplicatingWithPhantomsOnly = true;
+
+                                if (parameters.AllowDegradedWithSinglePhantomsOnly &&
+                                        slot->IsReplicatingWithPhantomsOnly() && !allowedNonReady) {
+                                    allowedNonReady |= {&topology, slot->GetShortVDiskId()};
+                                }
                             }
                         }
                         // check the failure model
@@ -462,9 +465,12 @@ namespace NKikimr::NBsController {
                         if (!checker.CheckFailModelForGroup(failed)) {
                             disintegrated.push_back(groupId);
                             errors = true;
-                        } else if (!suppressDegradedGroupsChecking && checker.IsDegraded(failed)) {
-                            degraded.push_back(groupId);
-                            errors = true;
+                        } else {
+                            TBlobStorageGroupInfo::TGroupVDisks failedWithSkip = failed - allowedNonReady;
+                            if (!parameters.SuppressDegradedGroupsChecking && checker.IsDegraded(failedWithSkip)) {
+                                degraded.push_back(groupId);
+                                errors = true;
+                            }
                         }
                     } else {
                         Y_ABORT_UNLESS(group); // group must exist
@@ -529,12 +535,13 @@ namespace NKikimr::NBsController {
             }
 
             TString error;
-            const bool suppressFailModelChecking = flags.SuppressFailModelChecking;
-            const bool suppressDegradedGroupsChecking = flags.SuppressDegradedGroupsChecking;
-            const bool suppressDisintegratedGroupsChecking = flags.SuppressDisintegratedGroupsChecking;
+            const TValidateConfigUpdatesParameters parameters{
+                .SuppressFailModelChecking = flags.SuppressFailModelChecking,
+                .SuppressDegradedGroupsChecking = flags.SuppressDegradedGroupsChecking,
+                .SuppressDisintegratedGroupsChecking = flags.SuppressDisintegratedGroupsChecking,
+            };
 
-            if (!ValidateConfigUpdates(*state, suppressFailModelChecking, suppressDegradedGroupsChecking,
-                    suppressDisintegratedGroupsChecking, &error, response)) {
+            if (!ValidateConfigUpdates(*state, parameters, &error, response)) {
                 RollbackConfigUpdate(state);
                 return error;
             }

--- a/ydb/core/mind/bscontroller/config_cmd.cpp
+++ b/ydb/core/mind/bscontroller/config_cmd.cpp
@@ -297,8 +297,13 @@ namespace NKikimr::NBsController {
                 }
 
                 const bool hasChanges = Success && State->Changed() && !Cmd.GetRollback();
-                Success = Success && Self->ValidateConfigUpdates(*State, Cmd.GetIgnoreGroupFailModelChecks(),
-                    Cmd.GetIgnoreDegradedGroupsChecks(), Cmd.GetIgnoreDisintegratedGroupsChecks(), &Error, Response);
+                const TValidateConfigUpdatesParameters validationParameters{
+                    .SuppressFailModelChecking = Cmd.GetIgnoreGroupFailModelChecks(),
+                    .SuppressDegradedGroupsChecking = Cmd.GetIgnoreDegradedGroupsChecks(),
+                    .SuppressDisintegratedGroupsChecking = Cmd.GetIgnoreDisintegratedGroupsChecks(),
+                    .AllowDegradedWithSinglePhantomsOnly = SelfHeal,
+                };
+                Success = Success && Self->ValidateConfigUpdates(*State, validationParameters, &Error, Response);
 
                 if (Success && Cmd.GetRollback()) {
                     Rollback();

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1608,9 +1608,15 @@ private:
     IActor* CreateSystemViewsCollector();
     void UpdateSystemViews();
 
-    bool ValidateConfigUpdates(TConfigState& state, bool suppressFailModelChecking, bool suppressDegradedGroupsChecking,
-        bool suppressDisintegratedGroupsChecking, TString *errorDescription,
-        NKikimrBlobStorage::TConfigResponse *response = nullptr);
+    struct TValidateConfigUpdatesParameters {
+        bool SuppressFailModelChecking = false;
+        bool SuppressDegradedGroupsChecking = false;
+        bool SuppressDisintegratedGroupsChecking = false;
+        bool AllowDegradedWithSinglePhantomsOnly = false;
+    };
+
+    bool ValidateConfigUpdates(TConfigState& state, TValidateConfigUpdatesParameters parameters,
+            TString* errorDescription, NKikimrBlobStorage::TConfigResponse* response = nullptr);
 
     std::optional<TString> ValidateAndCommitConfigUpdate(std::optional<TConfigState>& state,
         TConfigTxFlags flags, TTransactionContext& txc,

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -511,17 +511,18 @@ public:
                 Metrics.GetState() == NKikimrBlobStorage::TPDiskState::Normal);
         }
 
-        bool ShouldBeSettledBySelfHeal() const {
-            return Status == NKikimrBlobStorage::EDriveStatus::FAULTY
-                || Status == NKikimrBlobStorage::EDriveStatus::TO_BE_REMOVED
-                || DecommitStatus == NKikimrBlobStorage::EDecommitStatus::DECOMMIT_IMMINENT
-                || MaintenanceStatus == NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED;
-        }
-
-        bool IsSelfHealReasonDecommit() const {
-            return DecommitStatus == NKikimrBlobStorage::EDecommitStatus::DECOMMIT_IMMINENT &&
-                Status != NKikimrBlobStorage::EDriveStatus::FAULTY &&
-                Status != NKikimrBlobStorage::EDriveStatus::TO_BE_REMOVED;
+        ESelfHealReassignmentPriority GetSelfHealReassignmentPriority() const {
+            if (Status == NKikimrBlobStorage::EDriveStatus::FAULTY ||
+                    Status == NKikimrBlobStorage::EDriveStatus::TO_BE_REMOVED) {
+                return ESelfHealReassignmentPriority::DriveStatus;
+            } else if (DecommitStatus == NKikimrBlobStorage::EDecommitStatus::DECOMMIT_IMMINENT) {
+                return ESelfHealReassignmentPriority::DecommitStatus;
+            } else if (MaintenanceStatus ==
+                    NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED) {
+                return ESelfHealReassignmentPriority::MaintenanceStatus;
+            } else {
+                return ESelfHealReassignmentPriority::None;
+            }
         }
 
         bool UsableInTermsOfDecommission(bool isSelfHealReasonDecommit) const {
@@ -535,7 +536,7 @@ public:
         }
 
         auto GetSelfHealStatusTuple() const {
-            return std::make_tuple(ShouldBeSettledBySelfHeal(), BadInTermsOfSelfHeal(), Decommitted(), IsSelfHealReasonDecommit());
+            return std::make_tuple(GetSelfHealReassignmentPriority(), BadInTermsOfSelfHeal(), Decommitted());
         }
 
         bool AcceptsNewSlots() const {
@@ -1849,6 +1850,7 @@ public:
     // For test purposes, required for self heal actor
     void CreateEmptyHostRecordsMap() {
         HostRecords = std::make_shared<THostRecordMapImpl>();
+        EnableSelfHealWithDegraded = std::make_shared<TControlWrapper>(0, 0, 1);
     }
 
     ui64 NextConfigTxSeqNo = 1;

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -405,7 +405,7 @@ namespace NKikimr::NBsController {
                     ui32 numVDisksPerFailDomain = 0;
 
                     for (const auto& [vdiskId, vdisk] : g.Content.VDisks) {
-                        hasVDisksToReassign |= vdisk.RequiresReassignment;
+                        hasVDisksToReassign |= vdisk.RequiresReassignment();
                         numFailRealms = Max<ui32>(numFailRealms, 1 + vdiskId.FailRealm);
                         numFailDomainsPerFailRealm = Max<ui32>(numFailDomainsPerFailRealm, 1 + vdiskId.FailDomain);
                         numVDisksPerFailDomain = Max<ui32>(numVDisksPerFailDomain, 1 + vdiskId.VDisk);
@@ -500,7 +500,7 @@ namespace NKikimr::NBsController {
 
                     bool allDisksAreFullyOperational = true;
                     for (const auto& [vdiskId, vdisk] : group.Content.VDisks) {
-                        if (vdisk.UnavailabilityRisk || vdisk.RequiresReassignment || !IsReady(vdisk, now)) {
+                        if (vdisk.UnavailabilityRisk || vdisk.RequiresReassignment() || !IsReady(vdisk, now)) {
                             // don't sanitize groups with non-operational or replicating disks
                             allDisksAreFullyOperational = false;
                             break;
@@ -572,55 +572,89 @@ namespace NKikimr::NBsController {
         std::optional<TVDiskID> FindVDiskToReplace(const TEvControllerUpdateSelfHealInfo::TGroupContent& content,
                 TMonotonic now, TBlobStorageGroupInfo::TTopology *topology, bool *isSelfHealReasonDecommit,
                 bool *ignoreDegradedGroupsChecks) {
-            // main idea of selfhealing is step-by-step healing of bad group; we can allow healing of group with more
-            // than one disk missing, but we should not move next faulty disk until previous one is replicated, at least
-            // partially (meaning only phantoms left)
+            using TGroupVDisks = TBlobStorageGroupInfo::TGroupVDisks;
+            // SelfHeal actor requests step-by-step reassignment of unhealthy VDisks
+            // of the storage group until all are fully operational
+            //
+            // SelfHeal evicts VDisks marked as required for reassignment due to either:
+            // 1. DriveStatus
+            // 2. DecommitStatus
+            // 3. MaintenanceStatus
+            // In this exact order of priority
+            //
+            // SelfHeal requests reassignment of an unhealthy VDisk except for the following cases:
+            // 1. Non-degraded group will become degraded in terms of non-Ready VDisks
+            //    after the reassignment
+            // 2. Immediate failure of all VDisks with UnavailabilityRisk after the reassignment
+            //    leads to the group disintegration
+            // 3. Reassignment is not urgent and there is other non-Ready VDisk in the same group
+            // 4. There is *actively* replicating VDisk in the same group
+            //    VDisks with PhantomsOnly status are not considered actively replicating,
+            //    exactly one such VDisk is allowed
 
-            // so, first we check that we have no replicating or starting disk in the group; but we allow one
-            // semi-replicated disk to prevent selfheal blocking
-            TBlobStorageGroupInfo::TGroupVDisks failedByReadiness(topology);
-            TBlobStorageGroupInfo::TGroupVDisks failedByUnavailabilityRisk(topology);
-            bool alreadySeenReplicatingWithPhantomsOnly = false;
+            TGroupVDisks nonReady(topology);
+            TGroupVDisks withUnavailabilityRisk(topology);
+            TGroupVDisks replicatingWithPhantomsOnly(topology);
+
             for (const auto& [vdiskId, vdisk] : content.VDisks) {
-                bool replicatingWithPhantomsOnly = false;
                 switch (vdisk.VDiskStatus) {
                     case NKikimrBlobStorage::EVDiskStatus::REPLICATING:
-                        if (vdisk.OnlyPhantomsRemain && !alreadySeenReplicatingWithPhantomsOnly) {
-                            alreadySeenReplicatingWithPhantomsOnly = true;
-                            replicatingWithPhantomsOnly = true;
+                        if (vdisk.OnlyPhantomsRemain && !replicatingWithPhantomsOnly) {
+                            replicatingWithPhantomsOnly = TGroupVDisks(topology, vdiskId);
                             break;
                         }
                         [[fallthrough]];
                     case NKikimrBlobStorage::EVDiskStatus::INIT_PENDING:
-                        return std::nullopt; // don't touch group with replicating or starting disks
+                        // reject the reassignment due to replicating VDisks
+                        return std::nullopt;
 
                     default:
                         break;
                 }
 
-                if (!IsReady(vdisk, now) && !replicatingWithPhantomsOnly) {
-                    failedByReadiness |= {topology, vdiskId};
+                if (!IsReady(vdisk, now)) {
+                    nonReady |= {topology, vdiskId};
                 }
+
                 if (vdisk.UnavailabilityRisk) {
-                    failedByUnavailabilityRisk |= {topology, vdiskId};
+                    withUnavailabilityRisk |= {topology, vdiskId};
                 }
             }
 
-            const auto& checker = topology->GetQuorumChecker();
-            const auto failed = failedByReadiness | failedByUnavailabilityRisk;
+            const TBlobStorageGroupInfo::IQuorumChecker& checker = topology->GetQuorumChecker();
+            std::multimap<ESelfHealReassignmentPriority, TVDiskID,
+                std::greater<ESelfHealReassignmentPriority>> candidates;
 
             for (const auto& [vdiskId, vdisk] : content.VDisks) {
-                if (vdisk.RequiresReassignment) {
-                    const auto newFailed = failed | TBlobStorageGroupInfo::TGroupVDisks(topology, vdiskId);
-                    if (!checker.CheckFailModelForGroup(newFailed)) {
-                        continue; // healing this disk would break the group
-                    } else if (checker.IsDegraded(failed) < checker.IsDegraded(newFailed)) {
-                        continue; // this group will become degraded when applying self-heal logic, skip disk
-                    }
-                    *isSelfHealReasonDecommit = vdisk.IsSelfHealReasonDecommit;
-                    *ignoreDegradedGroupsChecks = checker.IsDegraded(failedByReadiness) && *EnableSelfHealWithDegraded;
-                    return vdiskId;
+                if (vdisk.RequiresReassignment()) {
+                    candidates.emplace(vdisk.ReassignmentPriority, vdiskId);
                 }
+            }
+
+            for (const auto& [priority, vdiskId] : candidates) {
+                const auto& vdisk = content.VDisks.at(vdiskId);
+
+                const TGroupVDisks candidateMask = TGroupVDisks(topology, vdiskId);
+                const TGroupVDisks newNonReady = nonReady | candidateMask;
+
+                if (checker.IsDegraded(nonReady) < checker.IsDegraded(newNonReady)) {
+                    // failure model degradation
+                    continue;
+                }
+
+                if (!checker.CheckFailModelForGroup(newNonReady | withUnavailabilityRisk)) {
+                    // risk of disintegration
+                    continue;
+                }
+
+                if (!vdisk.IsReassignmentUrgent() && newNonReady != candidateMask) {
+                    // non-urgent reassignment in a group with another non-Ready VDisk
+                    continue;
+                }
+
+                *isSelfHealReasonDecommit = priority == ESelfHealReassignmentPriority::DecommitStatus;
+                *ignoreDegradedGroupsChecks = checker.IsDegraded(nonReady) && *EnableSelfHealWithDegraded;
+                return vdiskId;
             }
 
             // no options for this group
@@ -740,7 +774,9 @@ namespace NKikimr::NBsController {
                         ss << "{";
                         ss << vdiskId;
                         ss << (IsReady(vdisk, now) ? " Ready" : " NotReady");
-                        ss << (vdisk.RequiresReassignment ? " RequiresReassignment" : "");
+                        if (vdisk.RequiresReassignment()) {
+                            ss << " ReassignmentPriority# " << static_cast<ui32>(vdisk.ReassignmentPriority);
+                        }
                         ss << (vdisk.UnavailabilityRisk ? " UnavailabilityRisk" : "");
                         ss << (vdisk.Decommitted ? " Decommitted" : "");
                         ss << "}";
@@ -894,7 +930,7 @@ namespace NKikimr::NBsController {
                                         for (const auto& [vdiskId, vdisk] : group.Content.VDisks) {
                                             TABLED() {
                                                 const auto& l = vdisk.Location;
-                                                if (vdisk.RequiresReassignment) {
+                                                if (vdisk.RequiresReassignment()) {
                                                     out << "<strong>";
                                                 }
                                                 if (vdisk.UnavailabilityRisk) {
@@ -904,7 +940,7 @@ namespace NKikimr::NBsController {
                                                 if (vdisk.UnavailabilityRisk) {
                                                     out << "</font>";
                                                 }
-                                                if (vdisk.RequiresReassignment) {
+                                                if (vdisk.RequiresReassignment()) {
                                                     out << "</strong>";
                                                 }
                                             }
@@ -1002,7 +1038,7 @@ namespace NKikimr::NBsController {
                                         for (const auto& [vdiskId, vdisk] : group.Content.VDisks) {
                                             TABLED() {
                                                 const auto& l = vdisk.Location;
-                                                if (vdisk.RequiresReassignment) {
+                                                if (vdisk.RequiresReassignment()) {
                                                     out << "<strong>";
                                                 }
                                                 if (vdisk.UnavailabilityRisk) {
@@ -1012,7 +1048,7 @@ namespace NKikimr::NBsController {
                                                 if (vdisk.UnavailabilityRisk) {
                                                     out << "</font>";
                                                 }
-                                                if (vdisk.RequiresReassignment) {
+                                                if (vdisk.RequiresReassignment()) {
                                                     out << "</strong>";
                                                 }
                                             }
@@ -1087,10 +1123,9 @@ namespace NKikimr::NBsController {
             for (const TVSlotInfo *slot : groupInfo->VDisksInGroup) {
                 group->VDisks[slot->GetVDiskId()] = {
                     .Location = slot->VSlotId,
-                    .RequiresReassignment = slot->PDisk->ShouldBeSettledBySelfHeal(),
+                    .ReassignmentPriority = slot->PDisk->GetSelfHealReassignmentPriority(),
                     .UnavailabilityRisk = slot->PDisk->BadInTermsOfSelfHeal(),
                     .Decommitted =  slot->PDisk->Decommitted(),
-                    .IsSelfHealReasonDecommit = slot->PDisk->IsSelfHealReasonDecommit(),
                     .OnlyPhantomsRemain = slot->IsReplicatingWithPhantomsOnly(),
                     .IsReady = slot->IsReady,
                     .ReadySince = TMonotonic::Zero(),
@@ -1137,16 +1172,17 @@ namespace NKikimr::NBsController {
                     }
 
                     vdiskInfo = {
-                        vslotId,
-                        pdiskInfo ? pdiskInfo->ShouldBeSettledBySelfHeal() : false,
-                        pdiskInfo ? pdiskInfo->BadInTermsOfSelfHeal() : false,
-                        pdiskInfo ? pdiskInfo->Decommitted() : false,
-                        pdiskInfo ? pdiskInfo->IsSelfHealReasonDecommit() : false,
-                        info.IsReplicatingWithPhantomsOnly(), /* OnlyPhantomsRemain */
-                        true, /* IsReady; decision is based on ReadySince */
-                        info.ReadySince,
-                        info.VDiskStatus.value_or(NKikimrBlobStorage::EVDiskStatus::ERROR),
-                        pdiskInfo ? pdiskInfo->DiskScope : std::nullopt,
+                        .Location = vslotId,
+                        .ReassignmentPriority = pdiskInfo
+                            ? pdiskInfo->GetSelfHealReassignmentPriority()
+                            : ESelfHealReassignmentPriority::None,
+                        .UnavailabilityRisk = pdiskInfo ? pdiskInfo->BadInTermsOfSelfHeal() : false,
+                        .Decommitted = pdiskInfo ? pdiskInfo->Decommitted() : false,
+                        .OnlyPhantomsRemain = info.IsReplicatingWithPhantomsOnly(),
+                        .IsReady = true, // decision is based on ReadySince
+                        .ReadySince = info.ReadySince,
+                        .VDiskStatus = info.VDiskStatus.value_or(NKikimrBlobStorage::EVDiskStatus::ERROR),
+                        .DiskScope = pdiskInfo ? pdiskInfo->DiskScope : std::nullopt,
                     };
                 }
             }

--- a/ydb/core/mind/bscontroller/self_heal.h
+++ b/ydb/core/mind/bscontroller/self_heal.h
@@ -13,25 +13,43 @@ namespace NKikimr::NBsController {
         bool WithAttentionToReplication = false;
     };
 
+    enum class ESelfHealReassignmentPriority : ui8 {
+        None = 0,           // Reassignment is not required
+        MaintenanceStatus,  // Reassignment is only performed if *all* other
+                            // VDisks are fully operational
+        DecommitStatus,
+        DriveStatus,
+    };
+
     struct TEvControllerUpdateSelfHealInfo : TEventLocal<TEvControllerUpdateSelfHealInfo, TEvBlobStorage::EvControllerUpdateSelfHealInfo> {
         struct TGroupContent {
+
             struct TVDiskInfo {
                 TVSlotId Location;
-                bool RequiresReassignment;
+                ESelfHealReassignmentPriority ReassignmentPriority = ESelfHealReassignmentPriority::None;
                 bool UnavailabilityRisk;
                 bool Decommitted;
-                bool IsSelfHealReasonDecommit;
                 bool OnlyPhantomsRemain;
                 bool IsReady;
                 TMonotonic ReadySince;
                 NKikimrBlobStorage::EVDiskStatus VDiskStatus;
                 std::optional<TString> DiskScope;
+
+                bool RequiresReassignment() const {
+                    return ReassignmentPriority != ESelfHealReassignmentPriority::None;
+                }
+
+                bool IsReassignmentUrgent() const {
+                    return static_cast<ui8>(ReassignmentPriority) >
+                           static_cast<ui8>(ESelfHealReassignmentPriority::MaintenanceStatus);
+                }
             };
             ui32 Generation;
             TBlobStorageGroupType Type;
             TMap<TVDiskID, TVDiskInfo> VDisks;
             std::shared_ptr<TGroupGeometryInfo> Geometry;
         };
+
         struct TVDiskStatusUpdate {
             TVDiskID VDiskId;
             std::optional<bool> OnlyPhantomsRemain;

--- a/ydb/core/mind/bscontroller/ut_selfheal/self_heal_actor_ut.cpp
+++ b/ydb/core/mind/bscontroller/ut_selfheal/self_heal_actor_ut.cpp
@@ -47,42 +47,52 @@ void RegisterDiskResponders(TTestActorSystem& runtime, const TIntrusivePtr<TBlob
     }
 }
 
-TIntrusivePtr<TBlobStorageGroupInfo> CreateGroup() {
+TIntrusivePtr<TBlobStorageGroupInfo> CreateGroup(TBlobStorageGroupType::EErasureSpecies erasure =
+        TBlobStorageGroupType::Erasure4Plus2Block) {
+    const TBlobStorageGroupType groupType(erasure);
+    const ui32 numFailRealms = erasure == TBlobStorageGroupType::ErasureMirror3dc ? 3 : 1;
+    const ui32 numFailDomains = erasure == TBlobStorageGroupType::ErasureMirror3dc ? 3 : 0;
+    const ui32 numVDisks = numFailRealms * (numFailDomains ? numFailDomains : groupType.BlobSubgroupSize());
     TVector<TActorId> actorIds;
-    for (ui32 i = 0; i < 8; ++i) {
+    for (ui32 i = 0; i < numVDisks; ++i) {
         actorIds.push_back(MakeBlobStorageVDiskID(1, 1000 + i, 1000));
     }
-    return MakeIntrusive<TBlobStorageGroupInfo>(TBlobStorageGroupType::Erasure4Plus2Block, 1u, 0u, 1u, &actorIds,
-        TBlobStorageGroupInfo::EEM_NONE, TBlobStorageGroupInfo::ELCP_INITIAL, TCypherKey(), TGroupId::FromValue(0x82000000));
+    return MakeIntrusive<TBlobStorageGroupInfo>(groupType, 1u, numFailDomains, numFailRealms, &actorIds,
+        TBlobStorageGroupInfo::EEM_NONE, TBlobStorageGroupInfo::ELCP_INITIAL, TCypherKey(),
+        TGroupId::FromValue(0x82000000));
 }
 
 TEvControllerUpdateSelfHealInfo::TGroupContent Convert(const TIntrusivePtr<TBlobStorageGroupInfo>& info,
-        std::set<ui32> faultyIndexes, std::vector<E> status) {
+        std::set<ui32> faultyIndexes, std::vector<E> status, std::set<ui32> phantomsOnlyIndexes = {}) {
     TEvControllerUpdateSelfHealInfo::TGroupContent res;
     res.Generation = info->GroupGeneration;
     res.Type = info->Type;
-    res.Geometry = std::make_shared<TGroupGeometryInfo>(CreateGroupGeometry(TBlobStorageGroupType::Erasure4Plus2Block));
+    res.Geometry = std::make_shared<TGroupGeometryInfo>(CreateGroupGeometry(info->Type));
     for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
         auto& x = res.VDisks[info->GetVDiskId(i)];
         x.Location = {1, 1000 + i, 1000};
-        x.RequiresReassignment = x.UnavailabilityRisk = faultyIndexes.count(i);
+        x.ReassignmentPriority = faultyIndexes.count(i)
+            ? ESelfHealReassignmentPriority::DriveStatus
+            : ESelfHealReassignmentPriority::None;
+        x.UnavailabilityRisk = faultyIndexes.count(i);
         x.Decommitted = false;
-        x.IsSelfHealReasonDecommit = false;
-        x.OnlyPhantomsRemain = false;
-        x.IsReady = !x.UnavailabilityRisk;
-        x.ReadySince = TMonotonic::Zero();
         x.VDiskStatus = i < status.size() ? status[i] : E::READY;
+        x.OnlyPhantomsRemain = x.VDiskStatus == E::REPLICATING && phantomsOnlyIndexes.count(i);
+        x.IsReady = x.VDiskStatus == E::READY;
+        x.ReadySince = TMonotonic::Zero();
     }
     return res;
 }
 
 void ValidateCmd(const TActorId& parentId, TTestActorSystem& runtime, ui32 groupId, ui32 groupGeneration,
-        ui32 failRealmIdx, ui32 failDomainIdx, ui32 vdiskIdx) {
+        ui32 failRealmIdx, ui32 failDomainIdx, ui32 vdiskIdx, bool isSelfHealReasonDecommit = false) {
     auto res = runtime.WaitForEdgeActorEvent({parentId});
+    UNIT_ASSERT_EQUAL(res->GetTypeRewrite(), TEvBlobStorage::TEvControllerConfigRequest::EventType);
     auto *m = res->Get<TEvBlobStorage::TEvControllerConfigRequest>();
     UNIT_ASSERT(m->SelfHeal);
     auto& record = m->Record;
     auto& request = record.GetRequest();
+    UNIT_ASSERT_VALUES_EQUAL(request.GetIsSelfHealReasonDecommit(), isSelfHealReasonDecommit);
     UNIT_ASSERT_VALUES_EQUAL(request.CommandSize(), 1);
     auto& cmd = request.GetCommand(0);
     UNIT_ASSERT(cmd.HasReassignGroupDisk());
@@ -92,6 +102,13 @@ void ValidateCmd(const TActorId& parentId, TTestActorSystem& runtime, ui32 group
     UNIT_ASSERT_VALUES_EQUAL(reassign.GetFailRealmIdx(), failRealmIdx);
     UNIT_ASSERT_VALUES_EQUAL(reassign.GetFailDomainIdx(), failDomainIdx);
     UNIT_ASSERT_VALUES_EQUAL(reassign.GetVDiskIdx(), vdiskIdx);
+}
+
+void ValidateNoCmd(const TActorId& parentId, TTestActorSystem& runtime) {
+    runtime.Schedule(TDuration::Minutes(30),
+        new IEventHandle(TEvents::TSystem::Wakeup, 0, parentId, {}, nullptr, 0), nullptr, 1);
+    auto res = runtime.WaitForEdgeActorEvent({parentId});
+    UNIT_ASSERT_EQUAL(res->GetTypeRewrite(), TEvents::TSystem::Wakeup);
 }
 
 Y_UNIT_TEST_SUITE(SelfHealActorTest) {
@@ -107,6 +124,113 @@ Y_UNIT_TEST_SUITE(SelfHealActorTest) {
         });
     }
 
+    Y_UNIT_TEST(ReadyFaultyDiskWithPhantomsOnlyIsNotReassigned) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup();
+            RegisterDiskResponders(runtime, info);
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            ev->GroupsToUpdate[info->GroupID] = Convert(info, {0}, {E::READY, E::REPLICATING}, {1});
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            ValidateNoCmd(parentId, runtime);
+        });
+    }
+
+    Y_UNIT_TEST(ReadyFaultyDiskWaitsForPhantomsOnlyReplicationToFinish) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup();
+            RegisterDiskResponders(runtime, info);
+
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            ev->GroupsToUpdate[info->GroupID] = Convert(info, {0}, {E::READY, E::REPLICATING}, {1});
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            ValidateNoCmd(parentId, runtime);
+
+            auto update = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            update->VDiskStatusUpdate.push_back({
+                .VDiskId = info->GetVDiskId(1),
+                .OnlyPhantomsRemain = false,
+                .IsReady = true,
+                .VDiskStatus = E::READY,
+            });
+            runtime.Send(new IEventHandle(selfHealId, parentId, update.release()), 1);
+            ValidateCmd(parentId, runtime, 0x82000000, 1, 0, 0, 0);
+        });
+    }
+
+    Y_UNIT_TEST(UnavailableFaultyDiskWithPhantomsOnlyIsReassigned) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup();
+            RegisterDiskResponders(runtime, info);
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            ev->GroupsToUpdate[info->GroupID] = Convert(info, {0}, {E::ERROR, E::REPLICATING}, {1});
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            ValidateCmd(parentId, runtime, 0x82000000, 1, 0, 0, 0);
+        });
+    }
+
+    Y_UNIT_TEST(DriveStatusHasHighestPriority) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup();
+            RegisterDiskResponders(runtime, info);
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            auto& content = ev->GroupsToUpdate[info->GroupID].emplace(Convert(info, {2}, {}));
+            content.VDisks.at(info->GetVDiskId(0)).ReassignmentPriority =
+                ESelfHealReassignmentPriority::MaintenanceStatus;
+            content.VDisks.at(info->GetVDiskId(1)).ReassignmentPriority =
+                ESelfHealReassignmentPriority::DecommitStatus;
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            const TVDiskID expected = info->GetVDiskId(2);
+            ValidateCmd(parentId, runtime, expected.GroupID.GetRawId(), expected.GroupGeneration,
+                expected.FailRealm, expected.FailDomain, expected.VDisk);
+        });
+    }
+
+    Y_UNIT_TEST(DecommitIsUrgentAndPropagatesReason) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup(TBlobStorageGroupType::ErasureMirror3dc);
+            RegisterDiskResponders(runtime, info);
+            std::vector<E> status(4, E::READY);
+            status[3] = E::ERROR;
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            auto& content = ev->GroupsToUpdate[info->GroupID].emplace(Convert(info, {}, std::move(status)));
+            const TVDiskID expected = info->GetVDiskId(4);
+            content.VDisks.at(expected).ReassignmentPriority = ESelfHealReassignmentPriority::DecommitStatus;
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            ValidateCmd(parentId, runtime, expected.GroupID.GetRawId(), expected.GroupGeneration,
+                expected.FailRealm, expected.FailDomain, expected.VDisk, true);
+        });
+    }
+
+    Y_UNIT_TEST(MaintenanceWaitsForOtherNonReadyVDisk) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup(TBlobStorageGroupType::ErasureMirror3dc);
+            RegisterDiskResponders(runtime, info);
+            std::vector<E> status(4, E::READY);
+            status[3] = E::ERROR;
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            auto& content = ev->GroupsToUpdate[info->GroupID].emplace(Convert(info, {}, std::move(status)));
+            content.VDisks.at(info->GetVDiskId(4)).ReassignmentPriority =
+                ESelfHealReassignmentPriority::MaintenanceStatus;
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            ValidateNoCmd(parentId, runtime);
+        });
+    }
+
+    Y_UNIT_TEST(TriesEveryCandidateWithSamePriority) {
+        RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
+            auto info = CreateGroup(TBlobStorageGroupType::ErasureMirror3dc);
+            RegisterDiskResponders(runtime, info);
+            std::vector<E> status(4, E::READY);
+            status[3] = E::ERROR;
+            auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
+            ev->GroupsToUpdate[info->GroupID] = Convert(info, {0, 4}, std::move(status));
+            runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
+            const TVDiskID expected = info->GetVDiskId(4);
+            ValidateCmd(parentId, runtime, expected.GroupID.GetRawId(), expected.GroupGeneration,
+                expected.FailRealm, expected.FailDomain, expected.VDisk);
+        });
+    }
+
     Y_UNIT_TEST(NoMoreThanOneReplicating) {
         RunTestCase([&](const TActorId& selfHealId, const TActorId& parentId, TTestActorSystem& runtime) {
             auto info = CreateGroup();
@@ -114,9 +238,7 @@ Y_UNIT_TEST_SUITE(SelfHealActorTest) {
             auto ev = std::make_unique<TEvControllerUpdateSelfHealInfo>();
             ev->GroupsToUpdate[info->GroupID] = Convert(info, {0}, {E::ERROR, E::REPLICATING});
             runtime.Send(new IEventHandle(selfHealId, parentId, ev.release()), 1);
-            runtime.Schedule(TDuration::Minutes(30), new IEventHandle(TEvents::TSystem::Wakeup, 0, parentId, {}, nullptr, 0), nullptr, 1);
-            auto res = runtime.WaitForEdgeActorEvent({parentId});
-            UNIT_ASSERT_EQUAL(res->GetTypeRewrite(), TEvents::TSystem::Wakeup);
+            ValidateNoCmd(parentId, runtime);
         });
     }
 


### PR DESCRIPTION
- **Restrict failure model checks for groups with a single PhantomsOnly VDisk (#48902)**
- **Refactor reassign VDisk selection logic in SelfHeal actor (#49761)**

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
