### PR TITLE
Fix stale mirror credentials after config change and add pqrb tests

### DIFF
--- a/ydb/core/persqueue/pqrb/mirror_describer.cpp
+++ b/ydb/core/persqueue/pqrb/mirror_describer.cpp
@@ -35,7 +35,7 @@ void TMirrorDescriber::StartInit(const TActorContext& ctx) {
     ++DescribeGeneration;
     DescribeTopicRequestInFlight = false;
     CredentialsRequestInFlight = false;
-    ctx.Send(SelfId(), new TEvPQ::TEvInitCredentials);
+    ctx.Send(SelfId(), new TEvPQ::TEvInitCredentials, 0, DescribeGeneration);
 }
 
 void TMirrorDescriber::Handle(TEvents::TEvPoisonPill::TPtr&, const TActorContext& ctx) {
@@ -133,7 +133,14 @@ void TMirrorDescriber::DescribeTopic(const TActorContext& ctx) {
     DescribeTopicRequestInFlight = true;
 }
 
-void TMirrorDescriber::HandleInitCredentials(TEvPQ::TEvInitCredentials::TPtr& /*ev*/, const TActorContext& ctx) {
+void TMirrorDescriber::HandleInitCredentials(TEvPQ::TEvInitCredentials::TPtr& ev, const TActorContext& ctx) {
+    if (ev->Cookie != 0 && ev->Cookie != DescribeGeneration) {
+        YDB_LOG_DEBUG("Ignoring stale credentials init",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"cookie", ev->Cookie},
+            {"generation", DescribeGeneration});
+        return;
+    }
     if (CredentialsRequestInFlight) {
         YDB_LOG_WARN("Credentials request already inflight",
             {"logPrefix", NPQ_LOG_PREFIX});
@@ -147,7 +154,8 @@ void TMirrorDescriber::HandleInitCredentials(TEvPQ::TEvInitCredentials::TPtr& /*
     future.Subscribe(
         [
             actorSystem = ctx.ActorSystem(),
-            selfId = SelfId()
+            selfId = SelfId(),
+            generation = DescribeGeneration
         ](const NThreading::TFuture<NYdb::TCredentialsProviderFactoryPtr>& result) {
             THolder<TEvPQ::TEvCredentialsCreated> ev;
             if (result.HasException()) {
@@ -161,13 +169,20 @@ void TMirrorDescriber::HandleInitCredentials(TEvPQ::TEvInitCredentials::TPtr& /*
             } else {
                 ev = MakeHolder<TEvPQ::TEvCredentialsCreated>(result.GetValue());
             }
-            actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev.Release()));
+            actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev.Release(), 0, generation));
         }
     );
     CredentialsRequestInFlight = true;
 }
 
 void TMirrorDescriber::HandleCredentialsCreated(TEvPQ::TEvCredentialsCreated::TPtr& ev, const TActorContext& ctx) {
+    if (ev->Cookie != DescribeGeneration) {
+        YDB_LOG_DEBUG("Ignoring stale credentials",
+            {"logPrefix", NPQ_LOG_PREFIX},
+            {"cookie", ev->Cookie},
+            {"generation", DescribeGeneration});
+        return;
+    }
     CredentialsRequestInFlight = false;
     if (ev->Get()->Error) {
         YDB_LOG_WARN("Cannot initialize credentials",
@@ -195,15 +210,6 @@ void TMirrorDescriber::ScheduleDescription(const TActorContext& ctx) {
 
 TString TMirrorDescriber::BuildLogPrefix() const {
     return TStringBuilder() << "[MirrorDescriber][" << TopicName << "] ";
-}
-
-TString TMirrorDescriber::GetCurrentState() const {
-    if (CurrentStateFunc() == &TThis::StateInit) {
-        return "StateInitConsumer";
-    } else if (CurrentStateFunc() == &TThis::StateWork) {
-        return "StateWork";
-    }
-    return "UNKNOWN";
 }
 
 NActors::IActor* CreateMirrorDescriber(

--- a/ydb/core/persqueue/pqrb/mirror_describer.h
+++ b/ydb/core/persqueue/pqrb/mirror_describer.h
@@ -41,6 +41,7 @@ private:
     {
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPQ::TEvChangePartitionConfig, HandleChangeConfig);
+            HFunc(TEvPQ::TEvCredentialsCreated, HandleCredentialsCreated);
             CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             HFunc(TEvents::TEvPoisonPill, Handle);
             HFunc(TEvPQ::TEvMirrorTopicDescription, HandleDescriptionResult);
@@ -63,7 +64,6 @@ private:
     void DescribeTopic(const TActorContext& ctx);
 
     TString BuildLogPrefix() const override;
-    TString GetCurrentState() const;
 
 public:
     TMirrorDescriber(

--- a/ydb/core/persqueue/pqrb/partition_scale_request.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.cpp
@@ -168,7 +168,7 @@ void TPartitionScaleRequest::Handle(TEvTxUserProxy::TEvProposeTransactionStatus:
             for (auto& issue : msg->Record.GetIssues()) {
                 issues << issue.ShortDebugString() + ", ";
             }
-            YDB_LOG_ERROR("TPartitionScaleRequest SchemaShard error when trying to execute a split",
+            YDB_LOG_ERROR("TPartitionScaleRequest SchemaShard error when trying to execute a scale request",
                 {"logPrefix", LogPrefix()},
                 {"status", TEvTxUserProxy::TResultStatus::Str(status)},
                 {"request", issues});

--- a/ydb/core/persqueue/pqrb/partition_scale_request.cpp
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.cpp
@@ -1,6 +1,7 @@
 #include "partition_scale_request.h"
 #include "read_balancer_log.h"
 
+#include <ydb/core/base/path.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/library/actors/core/events.h>
 
@@ -141,26 +142,39 @@ void TPartitionScaleRequest::Handle(NSchemeShard::TEvSchemeShard::TEvNotifyTxCom
 
 void TPartitionScaleRequest::Handle(TEvTxUserProxy::TEvProposeTransactionStatus::TPtr& ev, const NActors::TActorContext& ctx) {
     auto msg = ev->Get();
+    const auto status = msg->Status();
 
-    auto status = static_cast<TEvTxUserProxy::TEvProposeTransactionStatus::EStatus>(msg->Record.GetStatus());
-    if (status != TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress) {
-        TStringBuilder issues;
-        for (auto& issue : ev->Get()->Record.GetIssues()) {
-            issues << issue.ShortDebugString() + ", ";
-        }
-        YDB_LOG_ERROR("TPartitionScaleRequest SchemaShard error when trying to execute a split",
-            {"logPrefix", LogPrefix()},
-            {"request", issues});
-        ReplyAndDie(status, ctx);
-    } else {
-        NTabletPipe::TClientConfig clientConfig;
-        clientConfig.RetryPolicy = {.RetryLimitCount = 3};
-        if (!SchemePipeActorId) {
-            SchemePipeActorId = ctx.Register(NTabletPipe::CreateClient(ctx.SelfID, msg->Record.GetSchemeShardTabletId(), clientConfig));
-        }
+    switch (status) {
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress: {
+            NTabletPipe::TClientConfig clientConfig;
+            clientConfig.RetryPolicy = {.RetryLimitCount = 3};
+            if (!SchemePipeActorId) {
+                SchemePipeActorId = ctx.Register(NTabletPipe::CreateClient(ctx.SelfID, msg->Record.GetSchemeShardTabletId(), clientConfig));
+            }
 
-        auto request = std::make_unique<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion>(msg->Record.GetTxId());
-        NTabletPipe::SendData(this->SelfId(), SchemePipeActorId, request.release());
+            auto request = std::make_unique<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion>(msg->Record.GetTxId());
+            NTabletPipe::SendData(this->SelfId(), SchemePipeActorId, request.release());
+            return;
+        }
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete:
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecAlready:
+            YDB_LOG_DEBUG("TPartitionScaleRequest completed",
+                {"logPrefix", LogPrefix()},
+                {"status", TEvTxUserProxy::TResultStatus::Str(status)});
+            ReplyAndDie(status, ctx);
+            return;
+        default: {
+            TStringBuilder issues;
+            for (auto& issue : msg->Record.GetIssues()) {
+                issues << issue.ShortDebugString() + ", ";
+            }
+            YDB_LOG_ERROR("TPartitionScaleRequest SchemaShard error when trying to execute a split",
+                {"logPrefix", LogPrefix()},
+                {"status", TEvTxUserProxy::TResultStatus::Str(status)},
+                {"request", issues});
+            ReplyAndDie(status, ctx);
+            return;
+        }
     }
 }
 

--- a/ydb/core/persqueue/pqrb/partition_scale_request.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/core/base/path.h>
 #include "ydb/core/base/tablet_pipe.h"
 #include "ydb/core/persqueue/events/internal.h"
 #include <ydb/core/tx/schemeshard/schemeshard.h>
@@ -52,7 +51,6 @@ private:
             HFunc(TEvents::TEvPoisonPill, Handle);
         }
     }
-    std::pair<TString, TString> SplitPath(const TString& path);
     void SendProposeRequest(const NActors::TActorContext &ctx);
     void FillProposeRequest(TEvTxUserProxy::TEvProposeTransaction& proposal, const NActors::TActorContext &ctx);
     bool IsOurPipe(const TActorId& clientId) const;

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing_app.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing_app.cpp
@@ -119,7 +119,7 @@ void TBalancer::RenderApp(NApp::TNavigationBar& __navigationBar) const {
                             }
                             TABLED() {
                                 if (partition.Commited) {
-                                    __stream << "commited";
+                                    __stream << "committed";
                                 } else if (partition.ReadingFinished) {
                                     if (partition.ScaleAwareSDK) {
                                         __stream << "reading child";

--- a/ydb/core/persqueue/pqrb/ut/balancing_app_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/balancing_app_ut.cpp
@@ -1,0 +1,144 @@
+#include "pqrb_ut_common.h"
+
+#include <ydb/library/actors/core/mon.h>
+
+namespace NKikimr::NPQ {
+
+namespace {
+
+TString FetchBalancerHtml(TTestContext& tc) {
+    ForwardToTablet(
+        *tc.Runtime,
+        tc.BalancerTabletId,
+        tc.Edge,
+        new NMon::TEvRemoteHttpInfo(TStringBuilder() << "/app?TabletID=" << tc.BalancerTabletId)
+    );
+    auto res = tc.Runtime->GrabEdgeEvent<NMon::TEvRemoteHttpInfoRes>(TDuration::Seconds(10));
+    UNIT_ASSERT(res);
+    return res->Html;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TPqrbBalancingApp) {
+
+Y_UNIT_TEST(RenderAppCoversFamilyPartitionAndSessionStates) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {
+            {0, {tc.TabletId, 1}},
+            {1, {tc.TabletId, 2}},
+            {2, {tc.TabletId, 3}},
+        },
+        .Strategy = NKikimrPQ::TPQTabletConfig::CAN_SPLIT,
+        .Consumers = {
+            {"user", NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING},
+            {"other", NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING},
+        },
+        .ParentPartitionIds = {{1, {0}}, {2, {0}}},
+        .ChildPartitionIds = {{0, {1, 2}}},
+        .NextPartitionId = 3,
+    });
+    WaitBalancerReady(tc);
+
+    auto pipe0 = RegisterReadSession("session-0", tc);
+    auto lock0 = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::Seconds(10));
+    UNIT_ASSERT(lock0);
+    UNIT_ASSERT_VALUES_EQUAL(lock0->Record.GetPartition(), 0u);
+
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe0, "user", 0, /*scaleAwareSDK=*/true, /*startedReadingFromEndOffset=*/false),
+        0,
+        GetPipeConfigWithRetries(),
+        pipe0
+    );
+
+    absl::flat_hash_set<ui32> lockedChildren;
+    for (ui32 i = 0; i < 2; ++i) {
+        auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::Seconds(10));
+        UNIT_ASSERT(lock);
+        lockedChildren.insert(lock->Record.GetPartition());
+    }
+    UNIT_ASSERT(lockedChildren.contains(1));
+    UNIT_ASSERT(lockedChildren.contains(2));
+
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPQ::TEvReadingPartitionStatusRequest("user", 0, 1, 1),
+        0,
+        GetPipeConfigWithRetries()
+    );
+    DispatchFor(tc);
+
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe0, "user", 1, /*scaleAwareSDK=*/false, /*startedReadingFromEndOffset=*/true),
+        0,
+        GetPipeConfigWithRetries(),
+        pipe0
+    );
+    DispatchFor(tc);
+
+    tc.Runtime->SendToPipe(
+        tc.BalancerTabletId,
+        tc.Edge,
+        new TEvPersQueue::TEvReadingPartitionFinishedRequest(pipe0, "user", 2, /*scaleAwareSDK=*/false, /*startedReadingFromEndOffset=*/false),
+        0,
+        GetPipeConfigWithRetries(),
+        pipe0
+    );
+    DispatchFor(tc);
+
+    auto pipe1 = RegisterReadSession("session-1", tc);
+    Y_UNUSED(pipe1);
+    DispatchFor(tc, TDuration::MilliSeconds(200));
+
+    const TString html = FetchBalancerHtml(tc);
+    UNIT_ASSERT_C(html.Contains("Families"), html.substr(0, 2000));
+    UNIT_ASSERT(html.Contains("Partitions"));
+    UNIT_ASSERT(html.Contains("Statistics"));
+    UNIT_ASSERT(html.Contains("Sessions"));
+    UNIT_ASSERT(html.Contains("session-0"));
+    UNIT_ASSERT(html.Contains("Total:"));
+    UNIT_ASSERT(html.Contains("committed") || html.Contains("reading child") || html.Contains("finished"));
+    UNIT_ASSERT(html.Contains("scheduled. iteration:") || html.Contains("iteration:"));
+    UNIT_ASSERT(html.Contains("Free") || html.Contains("Ready") || html.Contains("Read") || html.Contains("Finished"));
+    UNIT_ASSERT(html.Contains("Active"));
+    UNIT_ASSERT(html.Contains("Inactive"));
+    UNIT_ASSERT(html.Contains("?TabletID="));
+}
+
+Y_UNIT_TEST(RenderAppAfterSessionShowsConsumerTab) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    PQTabletPrepare({}, {}, tc);
+    SendBalancerUpdate(tc, TBalancerUpdate{
+        .Partitions = {{0, {tc.TabletId, 1}}},
+        .Consumers = {{"user", NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_STREAMING}},
+    });
+    WaitBalancerReady(tc);
+
+    auto pipe = RegisterReadSession("lonely-session", tc);
+    auto lock = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvLockPartition>(TDuration::Seconds(10));
+    UNIT_ASSERT(lock);
+    Y_UNUSED(pipe);
+
+    const TString html = FetchBalancerHtml(tc);
+    UNIT_ASSERT_C(html.Contains("Families"), html.substr(0, 2000));
+    UNIT_ASSERT(html.Contains("Ready") || html.Contains("Free") || html.Contains("Read"));
+    UNIT_ASSERT(html.Contains("lonely-session"));
+}
+
+} // Y_UNIT_TEST_SUITE(TPqrbBalancingApp)
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/graph_cmp_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/graph_cmp_ut.cpp
@@ -104,4 +104,50 @@ Y_UNIT_TEST(MissingSourcePartitionBeforeNewRootIsAnError) {
     UNIT_ASSERT(c.RootPartitionsMismatch->Error);
 }
 
+Y_UNIT_TEST(NonRootSourcePartitionsAreSkipped) {
+    std::vector<TPartitionInfo> source;
+    source.push_back(RootPartition(0));
+
+    Ydb::Topic::DescribeTopicResult::PartitionInfo child;
+    child.set_partition_id(1);
+    child.set_active(true);
+    child.add_parent_partition_ids(0);
+    source.push_back(child);
+
+    auto c = ComparePartitionGraphs(RootGraph(1), source);
+    UNIT_ASSERT(!c.RootPartitionsMismatch);
+}
+
+Y_UNIT_TEST(HoleInTargetBeforeNewRootIsAnError) {
+    auto c = ComparePartitionGraphs(RootGraph(1), std::vector<TPartitionInfo>{
+        RootPartition(0),
+        RootPartition(2),
+    });
+    UNIT_ASSERT(c.RootPartitionsMismatch);
+    UNIT_ASSERT(c.RootPartitionsMismatch->Error);
+}
+
+Y_UNIT_TEST(AlterPlanCopiesSourceBounds) {
+    Ydb::Topic::DescribeTopicResult::PartitionInfo p0;
+    p0.set_partition_id(0);
+    p0.set_active(true);
+    p0.mutable_key_range()->set_from_bound("aa");
+    p0.mutable_key_range()->set_to_bound("mm");
+
+    Ydb::Topic::DescribeTopicResult::PartitionInfo p1;
+    p1.set_partition_id(1);
+    p1.set_active(true);
+    p1.mutable_key_range()->set_from_bound("mm");
+    p1.mutable_key_range()->set_to_bound("zz");
+
+    auto c = ComparePartitionGraphs(RootGraph(1), std::vector<TPartitionInfo>{p0, p1});
+    UNIT_ASSERT(c.RootPartitionsMismatch);
+    UNIT_ASSERT(!c.RootPartitionsMismatch->Error);
+    UNIT_ASSERT_VALUES_EQUAL(c.RootPartitionsMismatch->AlterRootPartitions.size(), 2u);
+    UNIT_ASSERT_EQUAL(c.RootPartitionsMismatch->AlterRootPartitions[0].Action, EPartitionAction::Modify);
+    UNIT_ASSERT_EQUAL(c.RootPartitionsMismatch->AlterRootPartitions[1].Action, EPartitionAction::Create);
+    UNIT_ASSERT(c.RootPartitionsMismatch->AlterRootPartitions[0].FromBound.has_value());
+    UNIT_ASSERT(c.RootPartitionsMismatch->AlterRootPartitions[1].ToBound.has_value());
+}
+
 } // Y_UNIT_TEST_SUITE(TPqrbGraphCmp)

--- a/ydb/core/persqueue/pqrb/ut/partition_scale_manager_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/partition_scale_manager_ut.cpp
@@ -1,0 +1,712 @@
+#include "pqrb_ut_common.h"
+
+#include <ydb/core/persqueue/pqrb/partition_scale_manager.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
+
+#include <expected>
+
+namespace NKikimr::NPQ {
+
+namespace {
+
+enum EEv {
+    EvScaleStatus = EventSpaceBegin(TEvents::ES_PRIVATE),
+    EvUpdateDb,
+    EvUpdateConfig,
+    EvAbort,
+    EvDieMgr,
+    EvTrySend,
+    EvMirrorHandled,
+    EvReady,
+};
+
+struct TEvScaleStatus : TEventLocal<TEvScaleStatus, EvScaleStatus> {
+    ui32 PartitionId = 0;
+    NKikimrPQ::EScaleStatus Status = NKikimrPQ::EScaleStatus::NEED_SPLIT;
+    TMaybe<NKikimrPQ::TPartitionScaleParticipants> Participants;
+    TMaybe<TString> SplitBoundary;
+};
+
+struct TEvUpdateDb : TEventLocal<TEvUpdateDb, EvUpdateDb> {
+    TString Path;
+    explicit TEvUpdateDb(TString path)
+        : Path(std::move(path))
+    {}
+};
+
+struct TEvUpdateConfig : TEventLocal<TEvUpdateConfig, EvUpdateConfig> {
+    ui64 PathId = 1;
+    int Version = 1;
+    NKikimrPQ::TPQTabletConfig Config;
+};
+
+struct TEvAbort : TEventLocal<TEvAbort, EvAbort> {};
+struct TEvDieMgr : TEventLocal<TEvDieMgr, EvDieMgr> {};
+struct TEvTrySend : TEventLocal<TEvTrySend, EvTrySend> {};
+
+struct TEvMirrorHandled : TEventLocal<TEvMirrorHandled, EvMirrorHandled> {
+    std::expected<void, std::string> Result;
+    explicit TEvMirrorHandled(std::expected<void, std::string> result)
+        : Result(std::move(result))
+    {}
+};
+
+struct TEvReady : TEventLocal<TEvReady, EvReady> {};
+
+NKikimrPQ::TPQTabletConfig MakeScaleConfig(
+    ui32 maxPartitions,
+    ui32 curPartitions,
+    bool mirror = false,
+    const std::vector<std::pair<ui32, std::vector<ui32>>>& children = {}
+) {
+    NKikimrPQ::TPQTabletConfig config;
+    auto* strategy = config.MutablePartitionStrategy();
+    strategy->SetPartitionStrategyType(NKikimrPQ::TPQTabletConfig::CAN_SPLIT);
+    strategy->SetMinPartitionCount(1);
+    strategy->SetMaxPartitionCount(maxPartitions);
+    for (ui32 i = 0; i < curPartitions; ++i) {
+        auto* p = config.AddAllPartitions();
+        p->SetPartitionId(i);
+        p->SetStatus(NKikimrPQ::ETopicPartitionStatus::Active);
+        p->MutableKeyRange()->SetFromBound(TString(1, 'a' + i));
+        p->MutableKeyRange()->SetToBound(TString(1, 'b' + i));
+    }
+    for (const auto& [id, childIds] : children) {
+        while (config.AllPartitionsSize() <= id) {
+            auto* p = config.AddAllPartitions();
+            p->SetPartitionId(config.AllPartitionsSize() - 1);
+            p->SetStatus(NKikimrPQ::ETopicPartitionStatus::Active);
+        }
+        auto* p = config.MutableAllPartitions(id);
+        for (ui32 child : childIds) {
+            p->AddChildPartitionIds(child);
+            while (config.AllPartitionsSize() <= child) {
+                auto* c = config.AddAllPartitions();
+                c->SetPartitionId(config.AllPartitionsSize() - 1);
+                c->SetStatus(NKikimrPQ::ETopicPartitionStatus::Active);
+            }
+            config.MutableAllPartitions(child)->AddParentPartitionIds(id);
+        }
+    }
+    if (mirror) {
+        config.MutablePartitionConfig()->MutableMirrorFrom()->SetTopic("src");
+        config.MutablePartitionConfig()->MutableMirrorFrom()->SetEndpoint("src");
+        config.MutablePartitionConfig()->MutableMirrorFrom()->SetEndpointPort(2135);
+    }
+    return config;
+}
+
+NYdb::NTopic::TDescribeTopicResult MakeDescribeResult(ui32 rootCount, bool ok = true) {
+    Ydb::Topic::DescribeTopicResult proto;
+    for (ui32 i = 0; i < rootCount; ++i) {
+        auto* p = proto.add_partitions();
+        p->set_partition_id(i);
+        p->set_active(true);
+        p->mutable_key_range()->set_from_bound(TString(1, 'A' + i));
+        p->mutable_key_range()->set_to_bound(TString(1, 'B' + i));
+    }
+    return NYdb::NTopic::TDescribeTopicResult(
+        NYdb::TStatus(ok ? NYdb::EStatus::SUCCESS : NYdb::EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()),
+        std::move(proto)
+    );
+}
+
+class TScaleManagerHost : public TActorBootstrapped<TScaleManagerHost> {
+public:
+    TScaleManagerHost(
+        TActorId edge,
+        TPartitionGraph graph,
+        NKikimrPQ::TPQTabletConfig config,
+        TString dbPath
+    )
+        : Edge(edge)
+        , Graph(std::move(graph))
+        , Config(std::move(config))
+        , Manager("topic", "/Root/topic", dbPath, /*pathId=*/1, /*version=*/1, Config, Graph)
+    {
+    }
+
+    void Bootstrap() {
+        Become(&TThis::StateWork);
+        Send(Edge, new TEvReady());
+    }
+
+    STRICT_STFUNC(StateWork,
+        hFunc(TEvScaleStatus, Handle);
+        hFunc(TEvUpdateDb, Handle);
+        hFunc(TEvUpdateConfig, Handle);
+        hFunc(TEvAbort, Handle);
+        hFunc(TEvDieMgr, Handle);
+        hFunc(TEvTrySend, Handle);
+        hFunc(TEvPQ::TEvMirrorTopicDescription, Handle);
+        hFunc(TPartitionScaleRequest::TEvPartitionScaleRequestDone, Handle);
+        hFunc(TEvents::TEvWakeup, Handle);
+        cFunc(TEvents::TEvPoison::EventType, PassAway);
+    )
+
+private:
+    void Handle(TEvScaleStatus::TPtr& ev) {
+        Manager.HandleScaleStatusChange(
+            ev->Get()->PartitionId,
+            ev->Get()->Status,
+            ev->Get()->Participants,
+            ev->Get()->SplitBoundary,
+            ActorContext()
+        );
+    }
+
+    void Handle(TEvUpdateDb::TPtr& ev) {
+        Manager.UpdateDatabasePath(ev->Get()->Path, ActorContext());
+    }
+
+    void Handle(TEvUpdateConfig::TPtr& ev) {
+        Manager.UpdateBalancerConfig(ev->Get()->PathId, ev->Get()->Version, ev->Get()->Config);
+    }
+
+    void Handle(TEvAbort::TPtr&) {
+        Manager.AbortInflightScaleRequest(ActorContext());
+    }
+
+    void Handle(TEvDieMgr::TPtr&) {
+        Manager.Die(ActorContext());
+    }
+
+    void Handle(TEvTrySend::TPtr&) {
+        Manager.TrySendScaleRequest(ActorContext());
+    }
+
+    void Handle(TEvPQ::TEvMirrorTopicDescription::TPtr& ev) {
+        auto result = Manager.HandleMirrorTopicDescriptionResult(ev, ActorContext());
+        Send(Edge, new TEvMirrorHandled(std::move(result)));
+    }
+
+    void Handle(TPartitionScaleRequest::TEvPartitionScaleRequestDone::TPtr& ev) {
+        const auto status = ev->Get()->Status;
+        Manager.HandleScaleRequestResult(ev, ActorContext());
+        Send(Edge, new TPartitionScaleRequest::TEvPartitionScaleRequestDone(status));
+    }
+
+    void Handle(TEvents::TEvWakeup::TPtr& ev) {
+        if (ev->Get()->Tag == TPartitionScaleManager::TRY_SCALE_REQUEST_WAKE_UP_TAG) {
+            Manager.TrySendScaleRequest(ActorContext());
+        }
+    }
+
+    const TActorId Edge;
+    TPartitionGraph Graph;
+    NKikimrPQ::TPQTabletConfig Config;
+    TPartitionScaleManager Manager;
+};
+
+TActorId StartHost(
+    TTestContext& tc,
+    const NKikimrPQ::TPQTabletConfig& config,
+    const TString& dbPath = "/Root"
+) {
+    auto graph = MakePartitionGraph(config);
+    auto host = tc.Runtime->Register(new TScaleManagerHost(tc.Edge, std::move(graph), config, dbPath));
+    tc.Runtime->EnableScheduleForActor(host);
+    tc.Runtime->SetRegistrationObserverFunc(
+        [&](TTestActorRuntimeBase& runtime, const TActorId&, const TActorId& id) {
+            runtime.EnableScheduleForActor(id);
+        }
+    );
+    auto ready = tc.Runtime->GrabEdgeEvent<TEvReady>(TDuration::Seconds(10));
+    UNIT_ASSERT(ready);
+    return host;
+}
+
+const NKikimrSchemeOp::TPersQueueGroupDescription& GroupOf(TProposeCapture& captured) {
+    UNIT_ASSERT(!captured.Records.empty());
+    return captured.Records.front().GetTransaction().GetModifyScheme().GetAlterPersQueueGroup();
+}
+
+void SendScale(
+    TTestContext& tc,
+    const TActorId& host,
+    ui32 partitionId,
+    NKikimrPQ::EScaleStatus status = NKikimrPQ::EScaleStatus::NEED_SPLIT,
+    TMaybe<TString> boundary = TString("m"),
+    TMaybe<NKikimrPQ::TPartitionScaleParticipants> participants = Nothing()
+) {
+    auto ev = MakeHolder<TEvScaleStatus>();
+    ev->PartitionId = partitionId;
+    ev->Status = status;
+    ev->SplitBoundary = std::move(boundary);
+    ev->Participants = std::move(participants);
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, ev.Release()));
+    DispatchFor(tc);
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TPqrbPartitionScaleManager) {
+
+Y_UNIT_TEST(EmptyDatabasePathDoesNotSendUntilUpdated) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1), /*dbPath=*/"");
+
+    SendScale(tc, host, 0);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, new TEvUpdateDb("/Root")));
+    WaitProposes(tc, blocked);
+}
+
+Y_UNIT_TEST(NormalStatusRemovesPendingSplit) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1), /*dbPath=*/"");
+
+    SendScale(tc, host, 0);
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NORMAL);
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, new TEvUpdateDb("/Root")));
+    DispatchFor(tc, TDuration::MilliSeconds(200));
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(SplitWithoutBoundaryUsesMiddleOfRange) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, Nothing());
+    WaitProposes(tc, blocked);
+    UNIT_ASSERT_VALUES_EQUAL(GroupOf(blocked).SplitSize(), 1u);
+    UNIT_ASSERT(!GroupOf(blocked).GetSplit(0).GetSplitBoundary().empty());
+}
+
+Y_UNIT_TEST(EmptySplitBoundaryIsDropped) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString());
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(MissingPartitionWithoutParticipantsIsDropped) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    SendScale(tc, host, 99);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(MissingPartitionWithParticipantsStaysPending) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    NKikimrPQ::TPartitionScaleParticipants participants;
+    participants.AddChildPartitionIds(10);
+    participants.AddChildPartitionIds(11);
+    SendScale(tc, host, 5, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString("m"), participants);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(AdjacentParticipantsAreRejected) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    NKikimrPQ::TPartitionScaleParticipants participants;
+    participants.AddAdjacentPartitionIds(1);
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString("m"), participants);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(ExistingChildrenAreRemovedFromPending) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto config = MakeScaleConfig(10, 1, false, {{0, {1, 2}}});
+    auto host = StartHost(tc, config);
+    NKikimrPQ::TPartitionScaleParticipants participants;
+    participants.AddChildPartitionIds(1);
+    participants.AddChildPartitionIds(3);
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString("m"), participants);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(UnorderedSplitWhenChildAlreadyExists) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto config = MakeScaleConfig(10, 3);
+    auto host = StartHost(tc, config);
+    NKikimrPQ::TPartitionScaleParticipants participants;
+    participants.AddChildPartitionIds(1);
+    participants.AddChildPartitionIds(2);
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString("m"), participants);
+    WaitProposes(tc, blocked);
+
+    const auto& split = GroupOf(blocked).GetSplit(0);
+    UNIT_ASSERT(split.GetCreateRootLevelSibling());
+    UNIT_ASSERT_VALUES_EQUAL(split.ChildPartitionIdsSize(), 2u);
+}
+
+Y_UNIT_TEST(QuotaLimitsNumberOfSplits) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(2, 1));
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString("m"));
+    WaitProposes(tc, blocked);
+    UNIT_ASSERT_VALUES_EQUAL(GroupOf(blocked).SplitSize(), 1u);
+}
+
+Y_UNIT_TEST(QuotaExhaustedDoesNotSendSplit) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(1, 1));
+    SendScale(tc, host, 0, NKikimrPQ::EScaleStatus::NEED_SPLIT, TString("m"));
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(InflightRequestBlocksSecondSendUntilResult) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 2));
+    SendScale(tc, host, 0);
+    WaitProposes(tc, blocked);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 1u);
+    SendScale(tc, host, 1);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 1u);
+}
+
+Y_UNIT_TEST(SuccessfulResultRetriesRemainingSplits) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 2));
+    SendScale(tc, host, 0);
+    SendScale(tc, host, 1);
+    WaitProposes(tc, blocked);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 1u);
+
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TPartitionScaleRequest::TEvPartitionScaleRequestDone(
+            TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete
+        )
+    ));
+    WaitProposes(tc, blocked, 2);
+}
+
+Y_UNIT_TEST(FailedResultSchedulesRetry) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    SendScale(tc, host, 0);
+    WaitProposes(tc, blocked);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 1u);
+
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TPartitionScaleRequest::TEvPartitionScaleRequestDone(
+            TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecError
+        )
+    ));
+    DispatchFor(tc);
+
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, new TEvTrySend()));
+    DispatchFor(tc);
+    UNIT_ASSERT_VALUES_EQUAL_C(blocked.Records.size(), 1u, "Retry must wait for backoff");
+
+    tc.Runtime->ResetScheduledCount();
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+    WaitProposes(tc, blocked, 2);
+}
+
+Y_UNIT_TEST(AbortInflightAllowsNewRequest) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    SendScale(tc, host, 0);
+    WaitProposes(tc, blocked);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 1u);
+
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, new TEvAbort()));
+    DispatchFor(tc);
+    SendScale(tc, host, 0);
+    WaitProposes(tc, blocked, 2);
+}
+
+Y_UNIT_TEST(DiePoisonsInflightRequest) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto host = StartHost(tc, MakeScaleConfig(10, 1));
+    SendScale(tc, host, 0);
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, new TEvDieMgr()));
+    DispatchFor(tc);
+}
+
+Y_UNIT_TEST(MirroredSplitDisabledByFeatureFlag) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+    tc.Runtime->GetAppData(0).FeatureFlags.SetEnableMirroredTopicSplitMerge(false);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, true));
+    SendScale(tc, host, 0);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(MirroredSplitWithoutParticipantsIsDropped) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+    tc.Runtime->GetAppData(0).FeatureFlags.SetEnableMirroredTopicSplitMerge(true);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, true));
+    SendScale(tc, host, 0);
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(ReorderPrefersSmallerPrescribedChildren) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 2), /*dbPath=*/"");
+    NKikimrPQ::TPartitionScaleParticipants late;
+    late.AddChildPartitionIds(20);
+    late.AddChildPartitionIds(21);
+    NKikimrPQ::TPartitionScaleParticipants early;
+    early.AddChildPartitionIds(5);
+    early.AddChildPartitionIds(6);
+
+    auto first = MakeHolder<TEvScaleStatus>();
+    first->PartitionId = 0;
+    first->SplitBoundary = TString("m");
+    first->Participants = late;
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, first.Release()));
+
+    auto second = MakeHolder<TEvScaleStatus>();
+    second->PartitionId = 1;
+    second->SplitBoundary = TString("n");
+    second->Participants = early;
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, second.Release()));
+    DispatchFor(tc);
+
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, new TEvUpdateDb("/Root")));
+    WaitProposes(tc, blocked);
+
+    UNIT_ASSERT_VALUES_EQUAL(GroupOf(blocked).GetSplit(0).GetPartition(), 1u);
+}
+
+Y_UNIT_TEST(MirrorDescriptionCreatesRootBoundaries) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, true));
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(MakeDescribeResult(3))
+    ));
+    auto handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(handled->Result.has_value());
+    WaitProposes(tc, blocked);
+
+    const auto& group = GroupOf(blocked);
+    UNIT_ASSERT_VALUES_EQUAL(group.RootPartitionBoundariesSize(), 3u);
+    UNIT_ASSERT(!group.GetRootPartitionBoundaries(0).GetCreatePartition());
+    UNIT_ASSERT(group.GetRootPartitionBoundaries(1).GetCreatePartition());
+}
+
+Y_UNIT_TEST(MirrorDescriptionQuotaTooLowSendsNothing) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(1, 1, true));
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(MakeDescribeResult(3))
+    ));
+    auto handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(handled->Result.has_value());
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(MirrorDescriptionMismatchReturnsError) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, true));
+    Ydb::Topic::DescribeTopicResult proto;
+    auto* p = proto.add_partitions();
+    p->set_partition_id(2);
+    p->set_active(true);
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(NYdb::NTopic::TDescribeTopicResult(
+            NYdb::TStatus(NYdb::EStatus::SUCCESS, NYdb::NIssue::TIssues()),
+            std::move(proto)
+        ))
+    ));
+    auto handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(!handled->Result.has_value());
+}
+
+Y_UNIT_TEST(InvalidMirrorDescriptionIsIgnored) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, true));
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(TString("nope"))
+    ));
+    auto handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(handled->Result.has_value());
+
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(MakeDescribeResult(1, false))
+    ));
+    handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(handled->Result.has_value());
+}
+
+Y_UNIT_TEST(MatchingMirrorDescriptionDoesNotScale) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TProposeCapture blocked;
+    InstallProposeCapture(tc, blocked);
+    auto host = StartHost(tc, MakeScaleConfig(10, 2, true));
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(MakeDescribeResult(2))
+    ));
+    auto handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(handled->Result.has_value());
+    UNIT_ASSERT_VALUES_EQUAL(blocked.Records.size(), 0u);
+}
+
+Y_UNIT_TEST(NonMirroredTopicClearsMirrorInfo) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, false));
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(MakeDescribeResult(5))
+    ));
+    auto handled = tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10));
+    UNIT_ASSERT(handled);
+    UNIT_ASSERT(handled->Result.has_value());
+}
+
+Y_UNIT_TEST(UpdateConfigClearsMirrorInfoWhenMirroringDisabled) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    auto host = StartHost(tc, MakeScaleConfig(10, 1, true));
+    tc.Runtime->Send(new IEventHandle(
+        host,
+        tc.Edge,
+        new TEvPQ::TEvMirrorTopicDescription(MakeDescribeResult(1))
+    ));
+    Y_UNUSED(tc.Runtime->GrabEdgeEvent<TEvMirrorHandled>(TDuration::Seconds(10)));
+
+    auto ev = MakeHolder<TEvUpdateConfig>();
+    ev->Config = MakeScaleConfig(10, 1, false);
+    tc.Runtime->Send(new IEventHandle(host, tc.Edge, ev.Release()));
+    DispatchFor(tc);
+}
+
+} // Y_UNIT_TEST_SUITE(TPqrbPartitionScaleManager)
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/pqrb_ut_common.h
+++ b/ydb/core/persqueue/pqrb/ut/pqrb_ut_common.h
@@ -5,6 +5,9 @@
 #include <ydb/core/persqueue/ut/common/pq_ut_common.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/hfunc.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/generic/vector.h>
@@ -168,6 +171,38 @@ inline void NotifyDatabasePath(TTestContext& tc, const TString& path = "/Root") 
     auto event = MakeHolder<TEvTxProxySchemeCache::TEvWatchNotifyUpdated>(0, path, TPathId{}, cres);
     ForwardToTablet(*tc.Runtime, tc.BalancerTabletId, tc.Edge, event.Release());
     DispatchFor(tc, TDuration::MilliSeconds(200));
+}
+
+struct TProposeCapture {
+    std::vector<NKikimrTxUserProxy::TEvProposeTransaction> Records;
+};
+
+class TCapturingTxProxy : public NActors::TActor<TCapturingTxProxy> {
+public:
+    explicit TCapturingTxProxy(TProposeCapture* cap)
+        : TActor(&TThis::State)
+        , Cap(cap)
+    {}
+
+    STRICT_STFUNC(State,
+        hFunc(TEvTxUserProxy::TEvProposeTransaction, Handle);
+    )
+
+private:
+    void Handle(TEvTxUserProxy::TEvProposeTransaction::TPtr& ev) {
+        Cap->Records.push_back(ev->Get()->Record);
+    }
+
+    TProposeCapture* Cap;
+};
+
+inline void InstallProposeCapture(TTestContext& tc, TProposeCapture& cap) {
+    auto id = tc.Runtime->Register(new TCapturingTxProxy(&cap));
+    tc.Runtime->RegisterService(MakeTxProxyID(), id);
+}
+
+inline void WaitProposes(TTestContext& tc, TProposeCapture& cap, size_t n = 1) {
+    tc.Runtime->WaitFor("TEvProposeTransaction", [&] { return cap.Records.size() >= n; }, TDuration::Seconds(10));
 }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/scale_and_mirror_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/scale_and_mirror_ut.cpp
@@ -6,12 +6,34 @@
 #include <ydb/core/persqueue/pqrb/mirror_describer_factory.h>
 #include <ydb/core/persqueue/pqrb/mirror_describer.h>
 #include <ydb/core/persqueue/pqrb/partition_scale_request.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/library/actors/core/events.h>
+#include <util/generic/yexception.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h>
 
 namespace NKikimr::NPQ {
+
+namespace {
+
+void DropScaleRequestNoise(TTestContext& tc) {
+    const TActorId edge = tc.Edge;
+    tc.Runtime->SetObserverFunc([edge](TAutoPtr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvTxUserProxy::TEvProposeTransaction::EventType) {
+            return TTestActorRuntimeBase::EEventAction::DROP;
+        }
+        if ((ev->GetTypeRewrite() == TEvTabletPipe::TEvClientConnected::EventType ||
+             ev->GetTypeRewrite() == TEvTabletPipe::TEvClientDestroyed::EventType) &&
+            ev->Sender != edge)
+        {
+            return TTestActorRuntimeBase::EEventAction::DROP;
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+}
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(TPqrbScaleRequest) {
 
@@ -20,12 +42,7 @@ Y_UNIT_TEST(PoisonPillStopsActorWithoutDone) {
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
 
-    tc.Runtime->SetObserverFunc([](TAutoPtr<IEventHandle>& ev) {
-        if (ev->CastAsLocal<TEvTxUserProxy::TEvProposeTransaction>()) {
-            return TTestActorRuntimeBase::EEventAction::DROP;
-        }
-        return TTestActorRuntimeBase::EEventAction::PROCESS;
-    });
+    DropScaleRequestNoise(tc);
 
     auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
         "topic",
@@ -61,12 +78,7 @@ Y_UNIT_TEST(ForeignPipeDestroyedIsIgnored) {
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
 
-    tc.Runtime->SetObserverFunc([](TAutoPtr<IEventHandle>& ev) {
-        if (ev->CastAsLocal<TEvTxUserProxy::TEvProposeTransaction>()) {
-            return TTestActorRuntimeBase::EEventAction::DROP;
-        }
-        return TTestActorRuntimeBase::EEventAction::PROCESS;
-    });
+    DropScaleRequestNoise(tc);
 
     auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
         "topic",
@@ -109,12 +121,7 @@ Y_UNIT_TEST(ProposeStatusSendsDoneOnlyOnce) {
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
 
-    tc.Runtime->SetObserverFunc([](TAutoPtr<IEventHandle>& ev) {
-        if (ev->CastAsLocal<TEvTxUserProxy::TEvProposeTransaction>()) {
-            return TTestActorRuntimeBase::EEventAction::DROP;
-        }
-        return TTestActorRuntimeBase::EEventAction::PROCESS;
-    });
+    DropScaleRequestNoise(tc);
 
     auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
         "topic",
@@ -220,17 +227,316 @@ Y_UNIT_TEST(ScaleRequestInflightIsClearedWhenSplitMergeDisabled) {
     UNIT_ASSERT_GT_C(scaleRequestActors, afterReenable, "A new scale request must be sent after split/merge is re-enabled");
 }
 
+Y_UNIT_TEST(FillProposeRequestSerializesSplitsMergesAndBoundaries) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    NKikimrSchemeOp::TPersQueueGroupDescription_TPartitionSplit split;
+    split.SetPartition(0);
+    split.SetSplitBoundary("mid");
+
+    NKikimrSchemeOp::TPersQueueGroupDescription_TPartitionMerge merge;
+    merge.SetPartition(1);
+    merge.SetAdjacentPartition(2);
+
+    NKikimrSchemeOp::TPersQueueGroupDescription_TPartitionBoundary boundary;
+    boundary.SetPartition(3);
+    boundary.MutableKeyRange()->SetFromBound("aa");
+    boundary.MutableKeyRange()->SetToBound("zz");
+    boundary.SetCreatePartition(true);
+
+    TProposeCapture captured;
+    InstallProposeCapture(tc, captured);
+
+    auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
+        "topic",
+        "/Root/topic",
+        "/Root",
+        /*pathId=*/7,
+        /*pathVersion=*/0,
+        {split},
+        {merge},
+        {boundary},
+        tc.Edge
+    ));
+    tc.Runtime->EnableScheduleForActor(actorId);
+    WaitProposes(tc, captured);
+
+    const auto& record = captured.Records.front();
+    UNIT_ASSERT_VALUES_EQUAL(record.GetDatabaseName(), "/Root");
+    const auto& modify = record.GetTransaction().GetModifyScheme();
+    UNIT_ASSERT(modify.GetInternal());
+    UNIT_ASSERT_VALUES_EQUAL(modify.GetWorkingDir(), "/Root/");
+    UNIT_ASSERT_VALUES_EQUAL(modify.GetApplyIf(0).GetPathId(), 7u);
+    UNIT_ASSERT_VALUES_EQUAL(modify.GetApplyIf(0).GetPathVersion(), 1u);
+    const auto& group = modify.GetAlterPersQueueGroup();
+    UNIT_ASSERT_VALUES_EQUAL(group.GetName(), "topic");
+    UNIT_ASSERT_VALUES_EQUAL(group.SplitSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(group.GetSplit(0).GetPartition(), 0u);
+    UNIT_ASSERT_VALUES_EQUAL(group.MergeSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(group.GetMerge(0).GetAdjacentPartition(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(group.RootPartitionBoundariesSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(group.GetRootPartitionBoundaries(0).GetPartition(), 3u);
+    UNIT_ASSERT(group.GetRootPartitionBoundaries(0).GetCreatePartition());
+}
+
+Y_UNIT_TEST(DirectExecCompleteFromTxProxySendsDone) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    DropScaleRequestNoise(tc);
+
+    auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
+        "topic", "/Root/topic", "/Root", 1, 2, {}, {}, {}, tc.Edge
+    ));
+    tc.Runtime->EnableScheduleForActor(actorId);
+
+    ui32 childActors = 0;
+    tc.Runtime->SetRegistrationObserverFunc(
+        [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& id) {
+            runtime.EnableScheduleForActor(id);
+            if (parentId == actorId) {
+                ++childActors;
+            }
+        }
+    );
+    DispatchFor(tc);
+
+    auto status = MakeHolder<TEvTxUserProxy::TEvProposeTransactionStatus>(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete
+    );
+    tc.Runtime->Send(new IEventHandle(actorId, tc.Edge, status.Release()));
+
+    auto done = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(TDuration::Seconds(10));
+    UNIT_ASSERT(done);
+    UNIT_ASSERT_EQUAL(
+        done->Status,
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete
+    );
+    UNIT_ASSERT_VALUES_EQUAL_C(childActors, 0u, "Immediate ExecComplete must not open a SchemeShard pipe");
+}
+
+Y_UNIT_TEST(ExecInProgressPipeConnectErrorRepliesUnavailable) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    DropScaleRequestNoise(tc);
+
+    auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
+        "topic", "/Root/topic", "/Root", 1, 2, {}, {}, {}, tc.Edge
+    ));
+    tc.Runtime->EnableScheduleForActor(actorId);
+
+    TActorId pipeActor;
+    auto prev = tc.Runtime->SetRegistrationObserverFunc(
+        [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& id) {
+            runtime.EnableScheduleForActor(id);
+            if (parentId == actorId) {
+                pipeActor = id;
+            }
+        }
+    );
+    Y_UNUSED(prev);
+    DispatchFor(tc);
+
+    auto status = MakeHolder<TEvTxUserProxy::TEvProposeTransactionStatus>(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress
+    );
+    status->Record.SetSchemeShardTabletId(999);
+    status->Record.SetTxId(42);
+    tc.Runtime->Send(new IEventHandle(actorId, tc.Edge, status.Release()));
+    DispatchFor(tc);
+    UNIT_ASSERT(pipeActor);
+
+    tc.Runtime->Send(new IEventHandle(
+        actorId,
+        tc.Edge,
+        new TEvTabletPipe::TEvClientConnected(
+            999, NKikimrProto::ERROR, pipeActor, TActorId(1, 2, 3, 4), true, false, 1
+        )
+    ));
+
+    auto done = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(TDuration::Seconds(10));
+    UNIT_ASSERT(done);
+    UNIT_ASSERT_EQUAL(
+        done->Status,
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ProxyShardNotAvailable
+    );
+}
+
+Y_UNIT_TEST(ExecInProgressNotifyCompletionSendsExecComplete) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    DropScaleRequestNoise(tc);
+
+    auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
+        "topic", "/Root/topic", "/Root", 1, 2, {}, {}, {}, tc.Edge
+    ));
+    tc.Runtime->EnableScheduleForActor(actorId);
+
+    TActorId pipeActor;
+    tc.Runtime->SetRegistrationObserverFunc(
+        [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& id) {
+            runtime.EnableScheduleForActor(id);
+            if (parentId == actorId) {
+                pipeActor = id;
+            }
+        }
+    );
+    DispatchFor(tc);
+
+    auto status = MakeHolder<TEvTxUserProxy::TEvProposeTransactionStatus>(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress
+    );
+    status->Record.SetSchemeShardTabletId(999);
+    status->Record.SetTxId(42);
+    tc.Runtime->Send(new IEventHandle(actorId, tc.Edge, status.Release()));
+    DispatchFor(tc);
+    UNIT_ASSERT(pipeActor);
+
+    tc.Runtime->Send(new IEventHandle(
+        actorId,
+        tc.Edge,
+        new TEvTabletPipe::TEvClientConnected(
+            999, NKikimrProto::OK, pipeActor, TActorId(1, 2, 3, 4), true, false, 1
+        )
+    ));
+    DispatchFor(tc);
+
+    auto early = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(
+        TDuration::MilliSeconds(50)
+    );
+    UNIT_ASSERT_C(!early, "Successful pipe connect must wait for tx completion");
+
+    tc.Runtime->Send(new IEventHandle(
+        actorId,
+        tc.Edge,
+        new NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult(42)
+    ));
+
+    auto done = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(TDuration::Seconds(10));
+    UNIT_ASSERT(done);
+    UNIT_ASSERT_EQUAL(
+        done->Status,
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete
+    );
+}
+
+Y_UNIT_TEST(OurPipeDestroyedRepliesUnavailable) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    DropScaleRequestNoise(tc);
+
+    auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
+        "topic", "/Root/topic", "/Root", 1, 2, {}, {}, {}, tc.Edge
+    ));
+    tc.Runtime->EnableScheduleForActor(actorId);
+
+    TActorId pipeActor;
+    tc.Runtime->SetRegistrationObserverFunc(
+        [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& id) {
+            runtime.EnableScheduleForActor(id);
+            if (parentId == actorId) {
+                pipeActor = id;
+            }
+        }
+    );
+    DispatchFor(tc);
+
+    auto status = MakeHolder<TEvTxUserProxy::TEvProposeTransactionStatus>(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress
+    );
+    status->Record.SetSchemeShardTabletId(999);
+    status->Record.SetTxId(42);
+    tc.Runtime->Send(new IEventHandle(actorId, tc.Edge, status.Release()));
+    DispatchFor(tc);
+    UNIT_ASSERT(pipeActor);
+
+    tc.Runtime->Send(new IEventHandle(
+        actorId,
+        tc.Edge,
+        new TEvTabletPipe::TEvClientDestroyed(999, pipeActor, TActorId(1, 2, 3, 4))
+    ));
+
+    auto done = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(TDuration::Seconds(10));
+    UNIT_ASSERT(done);
+    UNIT_ASSERT_EQUAL(
+        done->Status,
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ProxyShardNotAvailable
+    );
+}
+
+Y_UNIT_TEST(ForeignPipeConnectedIsIgnored) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    DropScaleRequestNoise(tc);
+
+    auto actorId = tc.Runtime->Register(new TPartitionScaleRequest(
+        "topic", "/Root/topic", "/Root", 1, 2, {}, {}, {}, tc.Edge
+    ));
+    tc.Runtime->EnableScheduleForActor(actorId);
+    DispatchFor(tc);
+
+    tc.Runtime->Send(new IEventHandle(
+        actorId,
+        tc.Edge,
+        new TEvTabletPipe::TEvClientConnected(
+            1, NKikimrProto::ERROR, TActorId(1, 1, 1, 1), TActorId(1, 1, 2, 1), true, false, 1
+        )
+    ));
+
+    auto early = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(
+        TDuration::MilliSeconds(200)
+    );
+    UNIT_ASSERT_C(!early, "ClientConnected for an unknown pipe must be ignored");
+
+    auto err = MakeHolder<TEvTxUserProxy::TEvProposeTransactionStatus>(
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecError
+    );
+    err->Record.AddIssues()->set_message("denied");
+    tc.Runtime->Send(new IEventHandle(actorId, tc.Edge, err.Release()));
+
+    auto done = tc.Runtime->GrabEdgeEvent<TPartitionScaleRequest::TEvPartitionScaleRequestDone>(TDuration::Seconds(10));
+    UNIT_ASSERT(done);
+}
+
 } // Y_UNIT_TEST_SUITE(TPqrbScaleRequest)
 
 class TControllableMirrorFactory : public IPersQueueMirrorReaderFactory {
 public:
     mutable ui32 DescribeCalls = 0;
+    mutable ui32 CredCalls = 0;
+    bool ThrowCredentials = false;
+    bool ImmediateCredentials = true;
     mutable std::vector<NThreading::TPromise<NYdb::NTopic::TDescribeTopicResult>> DescribePromises;
+    mutable std::vector<NThreading::TPromise<NYdb::TCredentialsProviderFactoryPtr>> CredPromises;
+    mutable std::vector<TString> CredTokens;
+    mutable NYdb::TCredentialsProviderFactoryPtr LastDescribeCredentials;
+    mutable TString LastDescribeTopic;
 
     NThreading::TFuture<NYdb::TCredentialsProviderFactoryPtr> GetCredentialsProviderImpl(
-        const NKikimrPQ::TMirrorPartitionConfig::TCredentials&
+        const NKikimrPQ::TMirrorPartitionConfig::TCredentials& cred
     ) const override {
-        return NThreading::MakeFuture(NYdb::CreateInsecureCredentialsProviderFactory());
+        CredTokens.push_back(TString{cred.GetOauthToken()});
+        ++CredCalls;
+        if (ThrowCredentials) {
+            ythrow yexception() << "cred-fail";
+        }
+        if (ImmediateCredentials) {
+            return NThreading::MakeFuture(NYdb::CreateInsecureCredentialsProviderFactory());
+        }
+        auto promise = NThreading::NewPromise<NYdb::TCredentialsProviderFactoryPtr>();
+        CredPromises.push_back(promise);
+        return promise.GetFuture();
     }
 
     std::shared_ptr<NYdb::NTopic::IReadSession> GetReadSession(
@@ -244,9 +550,11 @@ public:
     }
 
     NThreading::TFuture<NYdb::NTopic::TDescribeTopicResult> GetTopicDescription(
-        const NKikimrPQ::TMirrorPartitionConfig&,
-        std::shared_ptr<NYdb::ICredentialsProviderFactory>
+        const NKikimrPQ::TMirrorPartitionConfig& config,
+        std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory
     ) const override {
+        LastDescribeCredentials = credentialsProviderFactory;
+        LastDescribeTopic = config.GetTopic();
         ++DescribeCalls;
         auto promise = NThreading::NewPromise<NYdb::NTopic::TDescribeTopicResult>();
         DescribePromises.push_back(promise);
@@ -263,6 +571,28 @@ public:
     }
 };
 
+NKikimrPQ::TMirrorPartitionConfig MakeMirrorConfig(const TString& topic = "src-topic") {
+    NKikimrPQ::TMirrorPartitionConfig config;
+    config.SetEndpoint("src");
+    config.SetEndpointPort(2135);
+    config.SetTopic(topic);
+    return config;
+}
+
+TActorId StartDescriber(TTestContext& tc, TControllableMirrorFactory& factory, const NKikimrPQ::TMirrorPartitionConfig& config) {
+    tc.Runtime->GetAppData(0).PersQueueMirrorReaderFactory = &factory;
+    auto describer = tc.Runtime->Register(CreateMirrorDescriber(1, tc.Edge, "topic", config));
+    tc.Runtime->EnableScheduleForActor(describer);
+    DispatchFor(tc);
+    return describer;
+}
+
+void FireDescribeWakeup(TTestContext& tc, TDuration delay = TDuration::Seconds(1)) {
+    tc.Runtime->ResetScheduledCount();
+    tc.Runtime->AdvanceCurrentTime(delay);
+    DispatchFor(tc);
+}
+
 Y_UNIT_TEST_SUITE(TPqrbMirrorDescriber) {
 
 Y_UNIT_TEST(ConfigChangeDuringInflightDescribeDoesNotStuck) {
@@ -270,33 +600,14 @@ Y_UNIT_TEST(ConfigChangeDuringInflightDescribeDoesNotStuck) {
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
 
-    auto factory = std::make_shared<TControllableMirrorFactory>();
-    tc.Runtime->GetAppData(0).PersQueueMirrorReaderFactory = factory.get();
-
-    NKikimrPQ::TMirrorPartitionConfig mirrorConfig;
-    mirrorConfig.SetEndpoint("src");
-    mirrorConfig.SetEndpointPort(2135);
-    mirrorConfig.SetTopic("src-topic");
-
-    auto describer = tc.Runtime->Register(CreateMirrorDescriber(
-        /*tabletId=*/1,
-        tc.Edge,
-        "topic",
-        mirrorConfig
-    ));
-    tc.Runtime->EnableScheduleForActor(describer);
-    DispatchFor(tc);
-
-    tc.Runtime->ResetScheduledCount();
-    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(1));
-    DispatchFor(tc);
-    UNIT_ASSERT_VALUES_EQUAL(factory->DescribeCalls, 1u);
-    UNIT_ASSERT_VALUES_EQUAL(factory->DescribePromises.size(), 1u);
+    TControllableMirrorFactory factory;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribePromises.size(), 1u);
 
     NKikimrPQ::TPQTabletConfig newConfig;
-    newConfig.MutablePartitionConfig()->MutableMirrorFrom()->SetEndpoint("src-2");
-    newConfig.MutablePartitionConfig()->MutableMirrorFrom()->SetEndpointPort(2135);
-    newConfig.MutablePartitionConfig()->MutableMirrorFrom()->SetTopic("src-topic-2");
+    newConfig.MutablePartitionConfig()->MutableMirrorFrom()->CopyFrom(MakeMirrorConfig("src-topic-2"));
     tc.Runtime->Send(new IEventHandle(
         describer,
         tc.Edge,
@@ -304,16 +615,239 @@ Y_UNIT_TEST(ConfigChangeDuringInflightDescribeDoesNotStuck) {
     ));
     DispatchFor(tc);
 
-    factory->DescribePromises[0].SetValue(NYdb::NTopic::TDescribeTopicResult(
+    factory.DescribePromises[0].SetValue(NYdb::NTopic::TDescribeTopicResult(
         NYdb::TStatus(NYdb::EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()),
         Ydb::Topic::DescribeTopicResult{}
     ));
     DispatchFor(tc);
 
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_GT_C(factory.DescribeCalls, 1u, "Mirror describer must start a new describe after config change");
+}
+
+Y_UNIT_TEST(ConfigChangeDuringInflightCredentialsIgnoresStaleReply) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    factory.ImmediateCredentials = false;
+
+    auto oldMirror = MakeMirrorConfig("src-topic");
+    oldMirror.MutableCredentials()->SetOauthToken("old-token");
+    auto describer = StartDescriber(tc, factory, oldMirror);
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredCalls, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredPromises.size(), 1u);
+
+    NKikimrPQ::TPQTabletConfig newTabletConfig;
+    auto newMirror = MakeMirrorConfig("src-topic-2");
+    newMirror.MutableCredentials()->SetOauthToken("new-token");
+    newTabletConfig.MutablePartitionConfig()->MutableMirrorFrom()->CopyFrom(newMirror);
+    tc.Runtime->Send(new IEventHandle(
+        describer,
+        tc.Edge,
+        new TEvPQ::TEvChangePartitionConfig(nullptr, newTabletConfig)
+    ));
+    DispatchFor(tc);
+
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredCalls, 2u);
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredPromises.size(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredTokens[0], "old-token");
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredTokens[1], "new-token");
+
+    auto oldCreds = NYdb::CreateInsecureCredentialsProviderFactory();
+    auto newCreds = NYdb::CreateInsecureCredentialsProviderFactory();
+    factory.CredPromises[0].SetValue(oldCreds);
+    DispatchFor(tc);
+    factory.CredPromises[1].SetValue(newCreds);
+    DispatchFor(tc);
+
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(factory.LastDescribeTopic, "src-topic-2");
+    UNIT_ASSERT_C(
+        factory.LastDescribeCredentials == newCreds,
+        "Stale credentials from the previous MirrorFrom config must not be used after a config change"
+    );
+}
+
+Y_UNIT_TEST(EqualConfigChangeIsIgnored) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+
+    NKikimrPQ::TPQTabletConfig sameConfig;
+    sameConfig.MutablePartitionConfig()->MutableMirrorFrom()->CopyFrom(MakeMirrorConfig());
+    tc.Runtime->Send(new IEventHandle(
+        describer,
+        tc.Edge,
+        new TEvPQ::TEvChangePartitionConfig(nullptr, sameConfig)
+    ));
+    DispatchFor(tc);
+
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+}
+
+Y_UNIT_TEST(SuccessfulDescribeIsForwardedToTablet) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    StartDescriber(tc, factory, MakeMirrorConfig());
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribePromises.size(), 1u);
+
+    Ydb::Topic::DescribeTopicResult proto;
+    auto* part = proto.add_partitions();
+    part->set_partition_id(0);
+    part->set_active(true);
+    factory.DescribePromises[0].SetValue(NYdb::NTopic::TDescribeTopicResult(
+        NYdb::TStatus(NYdb::EStatus::SUCCESS, NYdb::NIssue::TIssues()),
+        std::move(proto)
+    ));
+
+    auto forwarded = tc.Runtime->GrabEdgeEvent<TEvPQ::TEvMirrorTopicDescription>(TDuration::Seconds(10));
+    UNIT_ASSERT(forwarded);
+    UNIT_ASSERT(forwarded->Description.has_value());
+    UNIT_ASSERT(forwarded->Description->IsSuccess());
+}
+
+Y_UNIT_TEST(FailedDescribeRetriesAndSecondWakeupIsInflight) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+
+    factory.DescribePromises[0].SetValue(NYdb::NTopic::TDescribeTopicResult(
+        NYdb::TStatus(NYdb::EStatus::UNAVAILABLE, NYdb::NIssue::TIssues()),
+        Ydb::Topic::DescribeTopicResult{}
+    ));
+    DispatchFor(tc);
+
+    FireDescribeWakeup(tc, TDuration::Seconds(3));
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 2u);
+
+    tc.Runtime->Send(new IEventHandle(describer, tc.Edge, new TEvents::TEvWakeup()));
+    DispatchFor(tc);
+    UNIT_ASSERT_VALUES_EQUAL_C(factory.DescribeCalls, 2u, "Second wakeup must be ignored while describe is inflight");
+
+    factory.DescribePromises[1].SetException(std::make_exception_ptr(std::runtime_error("describe-boom")));
+    DispatchFor(tc);
+}
+
+Y_UNIT_TEST(SuccessfulDescribeReschedulesAfterMaxTimeout) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    StartDescriber(tc, factory, MakeMirrorConfig());
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribePromises.size(), 1u);
+
+    Ydb::Topic::DescribeTopicResult proto;
+    proto.add_partitions()->set_partition_id(0);
+    factory.DescribePromises[0].SetValue(NYdb::NTopic::TDescribeTopicResult(
+        NYdb::TStatus(NYdb::EStatus::SUCCESS, NYdb::NIssue::TIssues()),
+        std::move(proto)
+    ));
+    UNIT_ASSERT(tc.Runtime->GrabEdgeEvent<TEvPQ::TEvMirrorTopicDescription>(TDuration::Seconds(10)));
+
+    FireDescribeWakeup(tc, TDuration::Seconds(241));
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 2u);
+}
+
+Y_UNIT_TEST(StaleDescribeIsIgnored) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+
+    tc.Runtime->Send(new IEventHandle(
+        describer,
+        describer,
+        new TEvPQ::TEvMirrorTopicDescription(TString("stale")),
+        0,
+        /*cookie=*/0
+    ));
+    DispatchFor(tc);
+
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+}
+
+Y_UNIT_TEST(CredentialsErrorRetriesThenSucceeds) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    factory.ThrowCredentials = true;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredCalls, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 0u);
+
+    factory.ThrowCredentials = false;
     tc.Runtime->ResetScheduledCount();
     tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(1));
     DispatchFor(tc);
-    UNIT_ASSERT_GT_C(factory->DescribeCalls, 1u, "Mirror describer must start a new describe after config change");
+    UNIT_ASSERT_GT(factory.CredCalls, 1u);
+
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_GT(factory.DescribeCalls, 0u);
+    Y_UNUSED(describer);
+}
+
+Y_UNIT_TEST(DuplicateInitCredentialsIsIgnoredWhileInflight) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    factory.ImmediateCredentials = false;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredCalls, 1u);
+
+    tc.Runtime->Send(new IEventHandle(describer, tc.Edge, new TEvPQ::TEvInitCredentials()));
+    DispatchFor(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.CredCalls, 1u);
+
+    factory.CredPromises[0].SetValue(NYdb::CreateInsecureCredentialsProviderFactory());
+    DispatchFor(tc);
+    FireDescribeWakeup(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 1u);
+}
+
+Y_UNIT_TEST(UnknownEventsAndPoisonPill) {
+    TTestContext tc;
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(10000);
+
+    TControllableMirrorFactory factory;
+    factory.ImmediateCredentials = false;
+    auto describer = StartDescriber(tc, factory, MakeMirrorConfig());
+
+    tc.Runtime->Send(new IEventHandle(describer, tc.Edge, new TEvents::TEvWakeup()));
+    DispatchFor(tc);
+
+    tc.Runtime->Send(new IEventHandle(describer, tc.Edge, new TEvents::TEvPoisonPill()));
+    DispatchFor(tc);
+
+    factory.CredPromises[0].SetValue(NYdb::CreateInsecureCredentialsProviderFactory());
+    DispatchFor(tc);
+    UNIT_ASSERT_VALUES_EQUAL(factory.DescribeCalls, 0u);
 }
 
 } // Y_UNIT_TEST_SUITE(TPqrbMirrorDescriber)

--- a/ydb/core/persqueue/pqrb/ut/ya.make
+++ b/ydb/core/persqueue/pqrb/ut/ya.make
@@ -9,12 +9,14 @@ SIZE(MEDIUM)
 FORK_SUBTESTS()
 
 SRCS(
+    balancing_app_ut.cpp
     balancing_ut.cpp
     describes_ut.cpp
     graph_cmp_ut.cpp
     metrics_ut.cpp
     mlp_ut.cpp
     partition_scale_manager_graph_cmp_ut.cpp
+    partition_scale_manager_ut.cpp
     partitions_location_queue_ut.cpp
     scale_and_mirror_ut.cpp
     sdk_balancing_ut.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a race in mirrored topic describe: a config change while credentials were still in flight could leave the describer on the old credentials. Added unit tests for pqrb scale, mirror and balancing.

### Description for reviewers <!-- (optional) description for those who read this PR -->

- `TMirrorDescriber` now tags credentials init/complete with `DescribeGeneration` and ignores stale replies (including in `StateWork`).
- `TPartitionScaleRequest` no longer logs `ExecComplete`/`ExecAlready` as a SchemaShard error; only actual failures are logged at error level.
- Monitoring HTML: `commited` → `committed`.
- Tests cover scale request, scale manager, graph comparison, mirror describer and balancing app; dead unused helpers (`GetCurrentState`, undeclared `SplitPath`) are removed.