### PR TITLE
[Backport stable-26-3] #50629 + #51443 to stable-26-3

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -28,7 +28,8 @@ TKqpQueryState::TQueryTxId& TKqpQueryState::TQueryTxId::operator=(const TQueryTx
 }
 
 void TKqpQueryState::TQueryTxId::SetValue(const TTxId& id) {
-    YQL_ENSURE(!Id);
+    YQL_ENSURE(!Id, "user tx id is already set to '" << Id->HumanStr
+        << "', attempt to overwrite it with '" << id.HumanStr << "'");
     Id = id.Id;
 }
 
@@ -37,7 +38,7 @@ TTxId TKqpQueryState::TQueryTxId::GetValue() {
 }
 
 void TKqpQueryState::TQueryTxId::Reset() {
-    Id = TTxId();
+    Id.Clear();
 }
 
 bool TKqpQueryState::EnsureTableVersions(const TEvTxProxySchemeCache::TEvNavigateKeySetResult& response) {

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -52,6 +52,9 @@ public:
 
         void SetValue(const TTxId& id);
         TTxId GetValue();
+        bool HasValue() const {
+            return Id.Defined();
+        }
 
         void Reset();
 
@@ -205,6 +208,7 @@ public:
 
     TKqpTempTablesState::TConstPtr TempTablesState;
     TMaybe<TActorId> PoolHandlerActor;
+    bool WaitingForWmAdmission = false;
 
     std::shared_ptr<NYql::TExprContext> SplittedCtx;
     TVector<NYql::TExprNode::TPtr> SplittedExprs;

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -208,7 +208,6 @@ public:
 
     TKqpTempTablesState::TConstPtr TempTablesState;
     TMaybe<TActorId> PoolHandlerActor;
-    bool WaitingForWmAdmission = false;
 
     std::shared_ptr<NYql::TExprContext> SplittedCtx;
     TVector<NYql::TExprNode::TPtr> SplittedExprs;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -349,16 +349,16 @@ public:
             "Cannot send to workload manager: PoolConfig is already resolved");
 
         Send(NWorkloadManager::MakeServiceId(SelfId().NodeId()), new NWorkloadManager::TEvPlaceRequestIntoPool(
+            QueryState->QueryId,
             QueryState->UserRequestContext->DatabaseId,
             SessionId,
             QueryState->UserRequestContext->PoolId,
             QueryState->UserToken,
             QueryState->GetQuery(),
             QueryState->RequestEv->GetWmSessionUpdater()
-        ), IEventHandle::FlagTrackDelivery);
+        ), IEventHandle::FlagTrackDelivery, QueryState->QueryId);
 
         QueryState->PoolHandlerActor = NWorkloadManager::MakeServiceId(SelfId().NodeId());
-        QueryState->WaitingForWmAdmission = true;
         Become(&TKqpSessionActor::ExecuteState);
     }
 
@@ -642,13 +642,11 @@ public:
 
     void Handle(TEvents::TEvUndelivered::TPtr& ev) {
         if (ev->Get()->SourceType == NWorkloadManager::TWorkloadManagerEvents::EvPlaceRequestIntoPool) {
-            if (!AcceptWmAdmissionReply("TEvUndelivered")) {
+            if (!AcceptWmAdmissionReply(ev->Cookie, "TEvUndelivered")) {
                 return;
             }
-            YDB_LOG_WARN("Failed to deliver request to workload service, bypassing WLM",
-                {"marker", "KQPSA"},
-                {"logPrefix", LogPrefix()},
-                {"traceId", TraceId()});
+            STLOG_W("Failed to deliver request to workload service, bypassing WLM",
+                (trace_id, TraceId()));
             ContinueAfterWmAdmission();
             return;
         }
@@ -666,24 +664,25 @@ public:
         }
     }
 
-    // Replies are addressed to the session, not to the query,
-    // so a duplicated or late one would otherwise re-enter the
-    // pipeline of the query that is running now and execute it a second time.
-    bool AcceptWmAdmissionReply(TStringBuf eventName) {
-        if (!QueryState || !QueryState->WaitingForWmAdmission) {
-            YDB_LOG_WARN("Ignoring stale workload manager reply",
-                {"marker", "KQPSA"},
-                {"logPrefix", LogPrefix()},
-                {"event", eventName},
-                {"traceId", TraceId()});
+    // Replies are addressed to the session, not to the query, so a duplicated
+    // or late one would otherwise re-enter the pipeline of a query that is
+    // running now. The reply carries the QueryId of the query that issued
+    // the admission request; a reply is valid only if it matches the current
+    // query and has not already been accepted for it.
+    bool AcceptWmAdmissionReply(ui64 queryId, TStringBuf eventName) {
+        if (!QueryState || queryId != QueryState->QueryId || queryId <= LastAcceptedWmAdmissionQueryId) {
+            STLOG_W("Ignoring stale workload manager reply"
+                << " event=" << eventName
+                << " queryId=" << queryId,
+                (trace_id, TraceId()));
             return false;
         }
-        QueryState->WaitingForWmAdmission = false;
+        LastAcceptedWmAdmissionQueryId = queryId;
         return true;
     }
 
     void Handle(NWorkloadManager::TEvContinueRequest::TPtr& ev) {
-        if (!AcceptWmAdmissionReply("TEvContinueRequest")) {
+        if (!AcceptWmAdmissionReply(ev->Get()->QueryId, "TEvContinueRequest")) {
             return;
         }
         QueryState->ContinueTime = TInstant::Now();
@@ -4082,6 +4081,7 @@ private:
     std::shared_ptr<TKqpQueryState> QueryState;
     std::unique_ptr<TKqpCleanupCtx> CleanupCtx;
     ui32 QueryId = 0;
+    ui64 LastAcceptedWmAdmissionQueryId = 0;
     TIntrusiveConstPtr<TKikimrConfiguration> Config;
     IDataProvider::TFillSettings FillSettings;
     TTransactionsCache Transactions;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -358,6 +358,7 @@ public:
         ), IEventHandle::FlagTrackDelivery);
 
         QueryState->PoolHandlerActor = NWorkloadManager::MakeServiceId(SelfId().NodeId());
+        QueryState->WaitingForWmAdmission = true;
         Become(&TKqpSessionActor::ExecuteState);
     }
 
@@ -641,8 +642,13 @@ public:
 
     void Handle(TEvents::TEvUndelivered::TPtr& ev) {
         if (ev->Get()->SourceType == NWorkloadManager::TWorkloadManagerEvents::EvPlaceRequestIntoPool) {
-            STLOG_W("Failed to deliver request to workload service, bypassing WLM",
-                (trace_id, TraceId()));
+            if (!AcceptWmAdmissionReply("TEvUndelivered")) {
+                return;
+            }
+            YDB_LOG_WARN("Failed to deliver request to workload service, bypassing WLM",
+                {"marker", "KQPSA"},
+                {"logPrefix", LogPrefix()},
+                {"traceId", TraceId()});
             ContinueAfterWmAdmission();
             return;
         }
@@ -660,8 +666,26 @@ public:
         }
     }
 
+    // Replies are addressed to the session, not to the query,
+    // so a duplicated or late one would otherwise re-enter the
+    // pipeline of the query that is running now and execute it a second time.
+    bool AcceptWmAdmissionReply(TStringBuf eventName) {
+        if (!QueryState || !QueryState->WaitingForWmAdmission) {
+            YDB_LOG_WARN("Ignoring stale workload manager reply",
+                {"marker", "KQPSA"},
+                {"logPrefix", LogPrefix()},
+                {"event", eventName},
+                {"traceId", TraceId()});
+            return false;
+        }
+        QueryState->WaitingForWmAdmission = false;
+        return true;
+    }
+
     void Handle(NWorkloadManager::TEvContinueRequest::TPtr& ev) {
-        YQL_ENSURE(QueryState);
+        if (!AcceptWmAdmissionReply("TEvContinueRequest")) {
+            return;
+        }
         QueryState->ContinueTime = TInstant::Now();
 
         if (ev->Get()->Status == Ydb::StatusIds::UNSUPPORTED) {
@@ -1415,7 +1439,7 @@ public:
                     }
                     QueryState->TxCtx = txCtx;
                     QueryState->QueryData = std::make_shared<TQueryData>(QueryState->TxCtx->TxAlloc);
-                    if (hasTxControl && QueryState->TxId.GetValue() == TTxId()) {
+                    if (hasTxControl && !QueryState->TxId.HasValue()) {
                         QueryState->TxId.SetValue(txId);
                     }
                     break;

--- a/ydb/core/kqp/ut/service/kqp_service_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_service_ut.cpp
@@ -130,7 +130,7 @@ Y_UNIT_TEST_SUITE(KqpService) {
             if (ev->GetTypeRewrite() == NWorkloadManager::TEvContinueRequest::EventType && ++continueRequests == 1) {
                 const auto* msg = ev->Get<NWorkloadManager::TEvContinueRequest>();
                 auto copy = std::make_unique<NWorkloadManager::TEvContinueRequest>(
-                    msg->Status, msg->PoolId, msg->PoolConfig, msg->Issues);
+                    msg->QueryId, msg->Status, msg->PoolId, msg->PoolConfig, msg->Issues);
                 runtime.Send(new IEventHandle(ev->Recipient, ev->Sender, copy.release(), ev->Flags, ev->Cookie));
             }
             return TTestActorRuntime::EEventAction::PROCESS;

--- a/ydb/core/kqp/ut/service/kqp_service_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_service_ut.cpp
@@ -6,7 +6,10 @@
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/shutdown/controller.h>
 #include <ydb/core/kqp/node_service/kqp_node_service.h>
+#include <ydb/core/kqp/session_actor/kqp_query_state.h>
+#include <ydb/services/workload_manager/events.h>
 #include <ydb/core/base/counters.h>
+#include <ydb/core/util/ulid.h>
 
 #include <library/cpp/threading/local_executor/local_executor.h>
 #include <library/cpp/iterator/functools.h>
@@ -50,7 +53,7 @@ namespace {
         runtime.SetObserverFunc(grab);
 
         auto shutdownState = new TKqpShutdownState();
-        runtime.Send(new IEventHandle(NKqp::MakeKqpNodeServiceID(nodeId), {}, 
+        runtime.Send(new IEventHandle(NKqp::MakeKqpNodeServiceID(nodeId), {},
                      new TEvKqp::TEvInitiateShutdownRequest(shutdownState)), nodeIndexToShutdown);
 
         auto future = kikimr.RunInThreadPool([&queryClient, &query](){
@@ -67,15 +70,82 @@ namespace {
 
         auto result = runtime.WaitFuture(future);
 
-        UNIT_ASSERT_C(nodeShuttingDownCount >= expectedMinShutdownEvents, 
-            stageDescription << ": Expected at least " << expectedMinShutdownEvents 
+        UNIT_ASSERT_C(nodeShuttingDownCount >= expectedMinShutdownEvents,
+            stageDescription << ": Expected at least " << expectedMinShutdownEvents
             << " NODE_SHUTTING_DOWN responses, got: " << nodeShuttingDownCount);
 
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, 
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus,
             stageDescription << ": Unexpected result status. Got issues: " << result.GetIssues().ToString());
     }
 } // anonymous namespace
+
 Y_UNIT_TEST_SUITE(KqpService) {
+    Y_UNIT_TEST(QueryTxIdResetUnsetsValue) {
+        TULIDGenerator ulidGen;
+        TKqpQueryState::TQueryTxId txId;
+
+        UNIT_ASSERT(!txId.HasValue());
+
+        const auto firstId = ulidGen.Next();
+        txId.SetValue(firstId);
+        UNIT_ASSERT(txId.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(txId.GetValue().GetHumanStr(), firstId.ToString());
+
+        // Reset() must return the id to the unset state. Storing a default constructed
+        // TTxId instead leaves the underlying TMaybe engaged, and then every later
+        // SetValue() fails with "SetValue(): requirement !Id failed".
+        txId.Reset();
+        UNIT_ASSERT(!txId.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(txId.GetValue().GetHumanStr(), "");
+
+        const auto secondId = ulidGen.Next();
+        txId.SetValue(secondId);
+        UNIT_ASSERT(txId.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(txId.GetValue().GetHumanStr(), secondId.ToString());
+    }
+
+    Y_UNIT_TEST(DuplicatedWorkloadManagerContinueRequest) {
+        NKikimrConfig::TAppConfig app;
+        app.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(app)
+            .SetWithSampleTables(false)
+            .SetUseRealThreads(false));
+
+        auto db = kikimr.RunCall([&] { return kikimr.GetQueryClient(); });
+        auto session = kikimr.RunCall([&] { return db.GetSession().GetValueSync().GetSession(); });
+
+        {
+            auto result = kikimr.RunCall([&] {
+                return session.ExecuteQuery(R"(
+                    CREATE RESOURCE POOL test_pool WITH (concurrent_query_limit = 1);
+                )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto& runtime = *kikimr.GetTestServer().GetRuntime();
+        ui32 continueRequests = 0;
+        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == NWorkloadManager::TEvContinueRequest::EventType && ++continueRequests == 1) {
+                const auto* msg = ev->Get<NWorkloadManager::TEvContinueRequest>();
+                auto copy = std::make_unique<NWorkloadManager::TEvContinueRequest>(
+                    msg->Status, msg->PoolId, msg->PoolConfig, msg->Issues);
+                runtime.Send(new IEventHandle(ev->Recipient, ev->Sender, copy.release(), ev->Flags, ev->Cookie));
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        auto result = kikimr.RunCall([&] {
+            return session.ExecuteQuery("SELECT 42;",
+                NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+                NYdb::NQuery::TExecuteQuerySettings().ResourcePool("test_pool")).GetValueSync();
+        });
+
+        UNIT_ASSERT_C(continueRequests > 0, "Query did not go through workload manager admission");
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
     Y_UNIT_TEST(Shutdown) {
         const ui32 Inflight = 50;
         const TDuration WaitDuration = TDuration::Seconds(1);
@@ -889,7 +959,7 @@ struct TDictCase {
     Y_UNIT_TEST(ThreeNodesGradualShutdown) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableShuttingDownNodeState(true);
-        
+
         TKikimrRunner kikimr(TKikimrSettings()
                                         .SetFeatureFlags(featureFlags)
                                         .SetNodeCount(3)

--- a/ydb/services/workload_manager/actors/pool_handlers_actors.cpp
+++ b/ydb/services/workload_manager/actors/pool_handlers_actors.cpp
@@ -108,15 +108,19 @@ protected:
             Canceling   // after TEvCancelRequest
         };
 
-        TRequest(const TActorId& workerActorId, const TString& sessionId, const TString& requestText = "", std::shared_ptr<ISessionUpdater> wmSessionUpdater = nullptr)
+        TRequest(const TActorId& workerActorId, const TString& sessionId, ui64 queryId, const TString& requestText = "", std::shared_ptr<ISessionUpdater> wmSessionUpdater = nullptr)
             : WorkerActorId(workerActorId)
             , SessionId(sessionId)
+            , QueryId(queryId)
             , RequestText(requestText)
             , WmSessionUpdater(wmSessionUpdater)
         {}
 
         const TActorId WorkerActorId;
         const TString SessionId;
+        // Echoed back on TEvContinueRequest so the session actor can drop
+        // stale/duplicate replies (see AcceptWmAdmissionReply).
+        const ui64 QueryId;
         const TString RequestText;
         const TInstant StartTime = TInstant::Now();
         TInstant ContinueTime;
@@ -198,13 +202,14 @@ private:
         this->Send(NWorkloadManager::MakeServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPlaceRequestIntoPoolResponse(DatabaseId, PoolId, sessionId));
 
         const TActorId& workerActorId = event->Sender;
+        const ui64 queryId = event->Get()->QueryId;
         if (!InFlightLimit) {
-            this->Send(workerActorId, new TEvContinueRequest(Ydb::StatusIds::PRECONDITION_FAILED, PoolId, PoolConfig, {NYql::TIssue(TStringBuilder() << "Resource pool " << PoolId << " was disabled due to zero concurrent query limit")}));
+            this->Send(workerActorId, new TEvContinueRequest(queryId, Ydb::StatusIds::PRECONDITION_FAILED, PoolId, PoolConfig, {NYql::TIssue(TStringBuilder() << "Resource pool " << PoolId << " was disabled due to zero concurrent query limit")}));
             return;
         }
 
         if (LocalSessions.contains(sessionId)) {
-            this->Send(workerActorId, new TEvContinueRequest(Ydb::StatusIds::INTERNAL_ERROR, PoolId, PoolConfig, {NYql::TIssue(TStringBuilder() << "Got duplicate session id " << sessionId << " for pool " << PoolId)}));
+            this->Send(workerActorId, new TEvContinueRequest(queryId, Ydb::StatusIds::INTERNAL_ERROR, PoolId, PoolConfig, {NYql::TIssue(TStringBuilder() << "Got duplicate session id " << sessionId << " for pool " << PoolId)}));
             return;
         }
 
@@ -213,7 +218,7 @@ private:
             this->Schedule(cancelAfter, new TEvPrivate::TEvCancelRequest(sessionId));
         }
 
-        TRequest* request = &LocalSessions.insert({sessionId, TRequest(workerActorId, sessionId, requestText, wmSessionUpdater)}).first->second;
+        TRequest* request = &LocalSessions.insert({sessionId, TRequest(workerActorId, sessionId, queryId, requestText, wmSessionUpdater)}).first->second;
         Counters.LocalDelayedRequests->Inc();
 
         if (wmSessionUpdater) {
@@ -312,7 +317,7 @@ public:
     }
 
     void ReplyContinue(TRequest* request, Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, const NYql::TIssues& issues = {}) {
-        this->Send(request->WorkerActorId, new TEvContinueRequest(status, PoolId, PoolConfig, issues));
+        this->Send(request->WorkerActorId, new TEvContinueRequest(request->QueryId, status, PoolId, PoolConfig, issues));
         
         if (request->WmSessionUpdater) {
             request->WmSessionUpdater->SetRequestState(ISessionUpdater::EState::EXITED, TActivationContext::Now());

--- a/ydb/services/workload_manager/events.h
+++ b/ydb/services/workload_manager/events.h
@@ -40,8 +40,9 @@ struct TEvSubscribeOnPoolChanges : public NActors::TEventLocal<TEvSubscribeOnPoo
 };
 
 struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestIntoPool, TWorkloadManagerEvents::EvPlaceRequestIntoPool> {
-    TEvPlaceRequestIntoPool(const TString& databaseId, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& requestText = "", std::shared_ptr<ISessionUpdater> wmSessionUpdater = nullptr)
-        : DatabaseId(databaseId)
+    TEvPlaceRequestIntoPool(ui64 queryId, const TString& databaseId, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& requestText = "", std::shared_ptr<ISessionUpdater> wmSessionUpdater = nullptr)
+        : QueryId(queryId)
+        , DatabaseId(databaseId)
         , SessionId(sessionId)
         , PoolId(poolId)
         , UserToken(userToken)
@@ -49,6 +50,7 @@ struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestInto
         , WmSessionUpdater(wmSessionUpdater)
     {}
 
+    const ui64 QueryId;
     const TString DatabaseId;
     const TString SessionId;
     TString PoolId;  // Can be changed to default pool id
@@ -58,8 +60,9 @@ struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestInto
 };
 
 struct TEvContinueRequest : public NActors::TEventLocal<TEvContinueRequest, TWorkloadManagerEvents::EvContinueRequest> {
-    TEvContinueRequest(Ydb::StatusIds::StatusCode status, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NYql::TIssues issues = {})
-        : Status(status)
+    TEvContinueRequest(ui64 queryId, Ydb::StatusIds::StatusCode status, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NYql::TIssues issues = {})
+        : QueryId(queryId)
+        , Status(status)
         , PoolId(poolId)
         , PoolConfig(poolConfig)
         , Issues(std::move(issues))
@@ -76,6 +79,7 @@ struct TEvContinueRequest : public NActors::TEventLocal<TEvContinueRequest, TWor
             issue.GetCode() == NYql::TIssuesIds::KIKIMR_DISK_GROUP_OUT_OF_SPACE;
     }
 
+    const ui64 QueryId;
     const Ydb::StatusIds::StatusCode Status;
     const TString PoolId;
     const NResourcePool::TPoolSettings PoolConfig;

--- a/ydb/services/workload_manager/service/service.cpp
+++ b/ydb/services/workload_manager/service/service.cpp
@@ -174,7 +174,7 @@ public:
     void Handle(TEvPlaceRequestIntoPool::TPtr& ev) {
         const TActorId& workerActorId = ev->Sender;
         if (!EnabledResourcePools) {
-            ReplyContinueError(workerActorId, Ydb::StatusIds::UNSUPPORTED, "Workload manager is disabled. Please contact your system administrator to enable it");
+            ReplyContinueError(workerActorId, ev->Get()->QueryId, Ydb::StatusIds::UNSUPPORTED, "Workload manager is disabled. Please contact your system administrator to enable it");
             return;
         }
 
@@ -371,7 +371,7 @@ private:
             databaseState->RemovePendingSession(event->Get()->SessionId, [this](TEvCleanupRequest::TPtr event) {
                 ReplyCleanupError(event->Sender, Ydb::StatusIds::NOT_FOUND, TStringBuilder() << "Pool " << event->Get()->PoolId << " not found");
             });
-            ReplyContinueError(event->Sender, ev->Get()->Status, ev->Get()->Issues);
+            ReplyContinueError(event->Sender, event->Get()->QueryId, ev->Get()->Status, ev->Get()->Issues);
             return;
         }
 
@@ -634,17 +634,17 @@ private:
     }
 
 private:
-    void ReplyContinueError(const TActorId& replyActorId, Ydb::StatusIds::StatusCode status, const TString& message) const {
-        ReplyContinueError(replyActorId, status, {NYql::TIssue(message)});
+    void ReplyContinueError(const TActorId& replyActorId, ui64 queryId, Ydb::StatusIds::StatusCode status, const TString& message) const {
+        ReplyContinueError(replyActorId, queryId, status, {NYql::TIssue(message)});
     }
 
-    void ReplyContinueError(const TActorId& replyActorId, Ydb::StatusIds::StatusCode status, NYql::TIssues issues) const {
+    void ReplyContinueError(const TActorId& replyActorId, ui64 queryId, Ydb::StatusIds::StatusCode status, NYql::TIssues issues) const {
         if (status == Ydb::StatusIds::UNSUPPORTED) {
             LOG_T("Reply unsupported to " << replyActorId << ": " << issues.ToOneLineString());
         } else {
             LOG_W("Reply continue error " << status << " to " << replyActorId << ": " << issues.ToOneLineString());
         }
-        Send(replyActorId, new TEvContinueRequest(status, {}, {}, std::move(issues)));
+        Send(replyActorId, new TEvContinueRequest(queryId, status, {}, {}, std::move(issues)));
     }
 
     void ReplyCleanupError(const TActorId& replyActorId, Ydb::StatusIds::StatusCode status, const TString& message) const {

--- a/ydb/services/workload_manager/service/workload_service_impl.h
+++ b/ydb/services/workload_manager/service/workload_service_impl.h
@@ -115,7 +115,8 @@ private:
             RemovePendingSession(ev->Get()->SessionId, [actorSystem = TActivationContext::ActorSystem()](TEvCleanupRequest::TPtr event) {
                 actorSystem->Send(event->Sender, new TEvCleanupResponse(Ydb::StatusIds::NOT_FOUND, NYql::TIssues{NYql::TIssue(TStringBuilder() << "Pool " << event->Get()->PoolId << " not found")}));
             });
-            TActivationContext::Send(ev->Sender, std::make_unique<TEvContinueRequest>(status, TString{}, NResourcePool::TPoolSettings{}, issues));
+            TActivationContext::Send(ev->Sender,
+                std::make_unique<TEvContinueRequest>(ev->Get()->QueryId, status, TString{}, NResourcePool::TPoolSettings{}, issues));
         }
         PendingRequests.clear();
     }

--- a/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
+++ b/ydb/services/workload_manager/ut/workload_service_query_sessions_ut.cpp
@@ -147,6 +147,7 @@ public:
         auto wrapper = std::make_shared<TWmSessionUpdaterWrapper>(FinalState, msg->WmSessionUpdater);
 
         auto* proxyMsg = new NWorkloadManager::TEvPlaceRequestIntoPool(
+            msg->QueryId,
             msg->DatabaseId,
             msg->SessionId,
             msg->PoolId,
@@ -162,7 +163,7 @@ public:
             senderForWorkload = Register(interceptor);
         }
 
-        Send(new IEventHandle(WorkloadServiceId, senderForWorkload, proxyMsg));
+        Send(new IEventHandle(WorkloadServiceId, senderForWorkload, proxyMsg, 0, ev->Cookie));
     }
 
 private:


### PR DESCRIPTION
Backports:
  - #50629 Handle double-continue admission from WM
  - #51443 Fix double-continue admission from WLM using a per-query cookie