### PR TITLE
explicitly pin high-impact tablets to nodes

### DIFF
--- a/ydb/core/mind/hive/balancer.cpp
+++ b/ydb/core/mind/hive/balancer.cpp
@@ -231,11 +231,64 @@ protected:
         Tablets.clear();
     }
 
+    bool IsTabletSuitableForBalancing(const TTabletInfo* tablet, TInstant now) const {
+        if (!tablet->IsGoodForBalancer(now)) {
+            return false;
+        }
+        if (Settings.FilterObjectId && tablet->GetObjectId() != *Settings.FilterObjectId) {
+            return false;
+        }
+        if (!tablet->HasMetric(Settings.ResourceToBalance)) {
+            return false;
+        }
+        if (tablet->IsPinnedToNode()) {
+            // The tablet accounts for most of its node's usage, so moving it would only relocate the
+            // load. Leave it where it is and let the balancer drain the rest of the node instead.
+            return false;
+        }
+        if (tablet->IsHighImpact() && Settings.Type != EBalancerType::Emergency) {
+            // Only genuine overload justifies moving a high-impact tablet
+            return false;
+        }
+        return true;
+    }
+
+    // Tablets we would rather not move are ordered last: system tablets because restarting them is
+    // disruptive, high-impact tablets because they are the cause of their node's load, so evicting
+    // their cheaper neighbours is what actually relieves the node.
+    int GetMoveReluctance(const TTabletInfo* tablet) const {
+        if (tablet->IsHighImpact()) {
+            return 2;
+        }
+        if (Hive->GetLessSystemTabletsMoves() && THive::IsSystemTablet(tablet->GetTabletType())) {
+            return 1;
+        }
+        return 0;
+    }
+
+    void BalanceTabletsByStrategy(std::vector<TTabletInfo*>::iterator first, std::vector<TTabletInfo*>::iterator last) {
+        switch (Hive->GetTabletBalanceStrategy()) {
+        case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_OLD_WEIGHTED_RANDOM:
+            BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_OLD_WEIGHTED_RANDOM>(first, last, Settings.ResourceToBalance);
+            break;
+        case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_WEIGHTED_RANDOM:
+            BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_WEIGHTED_RANDOM>(first, last, Settings.ResourceToBalance);
+            break;
+        case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_HEAVIEST:
+            BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_HEAVIEST>(first, last, Settings.ResourceToBalance);
+            break;
+        case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_RANDOM:
+            BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_RANDOM>(first, last, Settings.ResourceToBalance);
+            break;
+        }
+    }
+
     std::optional<TFullTabletId> GetNextTablet(TInstant now) {
         for (; Tablets.empty() || NextTablet == Tablets.end(); ++NextNode) {
             if (NextNode == Nodes.end()) {
                 return std::nullopt;
             }
+            Tablets.clear();
             TNodeInfo* node = Hive->FindNode(*NextNode);
             if (node == nullptr) {
                 continue;
@@ -251,9 +304,7 @@ protected:
             std::vector<TTabletInfo*> tablets;
             tablets.reserve(nodeTablets.size());
             for (TTabletInfo* tablet : nodeTablets) {
-                if (tablet->IsGoodForBalancer(now) &&
-                    (!Settings.FilterObjectId || tablet->GetObjectId() == *Settings.FilterObjectId) &&
-                    tablet->HasMetric(Settings.ResourceToBalance)) {
+                if (IsTabletSuitableForBalancing(tablet, now)) {
                     tablet->UpdateWeight();
                     tablets.emplace_back(tablet);
                 }
@@ -263,39 +314,22 @@ protected:
                 {"nodeId", node->Id},
                 {"tabletsCount", tablets.size()},
                 {"nodeTabletsCount", nodeTablets.size()});
-            if (!tablets.empty()) {
-                // avoid moving system tablets if possible
-                std::vector<TTabletInfo*>::iterator partitionIt;
-                if (Hive->GetLessSystemTabletsMoves()) {
-                    partitionIt = std::partition(tablets.begin(), tablets.end(), [](TTabletInfo* tablet) {
-                        return !THive::IsSystemTablet(tablet->GetTabletType());
-                    });
-                } else {
-                    partitionIt = tablets.end();
-                }
-                switch (Hive->GetTabletBalanceStrategy()) {
-                case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_OLD_WEIGHTED_RANDOM:
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_OLD_WEIGHTED_RANDOM>(tablets.begin(), partitionIt, Settings.ResourceToBalance);
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_OLD_WEIGHTED_RANDOM>(partitionIt, tablets.end(), Settings.ResourceToBalance);
-                    break;
-                case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_WEIGHTED_RANDOM:
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_WEIGHTED_RANDOM>(tablets.begin(), partitionIt, Settings.ResourceToBalance);
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_WEIGHTED_RANDOM>(partitionIt, tablets.end(), Settings.ResourceToBalance);
-                    break;
-                case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_HEAVIEST:
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_HEAVIEST>(tablets.begin(), partitionIt, Settings.ResourceToBalance);
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_HEAVIEST>(partitionIt, tablets.end(), Settings.ResourceToBalance);
-                    break;
-                case NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_RANDOM:
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_RANDOM>(tablets.begin(), partitionIt, Settings.ResourceToBalance);
-                    BalanceTablets<NKikimrConfig::THiveConfig::HIVE_TABLET_BALANCE_STRATEGY_RANDOM>(partitionIt, tablets.end(), Settings.ResourceToBalance);
-                    break;
-                }
-                Tablets.clear();
-                Tablets.reserve(tablets.size());
-                for (auto tablet : tablets) {
-                    Tablets.push_back(tablet->GetFullTabletId());
-                }
+            std::stable_sort(tablets.begin(), tablets.end(), [this](const TTabletInfo* a, const TTabletInfo* b) -> bool {
+                return GetMoveReluctance(a) < GetMoveReluctance(b);
+            });
+            // Order within each reluctance group separately, so that the balancer exhausts the tablets
+            // it is most willing to move before it considers the next group at all.
+            for (auto groupBegin = tablets.begin(); groupBegin != tablets.end();) {
+                int reluctance = GetMoveReluctance(*groupBegin);
+                auto groupEnd = std::find_if(groupBegin, tablets.end(), [&](const TTabletInfo* tablet) -> bool {
+                    return GetMoveReluctance(tablet) != reluctance;
+                });
+                BalanceTabletsByStrategy(groupBegin, groupEnd);
+                groupBegin = groupEnd;
+            }
+            Tablets.reserve(tablets.size());
+            for (auto tablet : tablets) {
+                Tablets.push_back(tablet->GetFullTabletId());
             }
             NextTablet = Tablets.begin();
         }

--- a/ydb/core/mind/hive/balancer.cpp
+++ b/ydb/core/mind/hive/balancer.cpp
@@ -246,10 +246,6 @@ protected:
             // load. Leave it where it is and let the balancer drain the rest of the node instead.
             return false;
         }
-        if (tablet->IsHighImpact() && Settings.Type != EBalancerType::Emergency) {
-            // Only genuine overload justifies moving a high-impact tablet
-            return false;
-        }
         return true;
     }
 

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -1064,6 +1064,14 @@ TTabletInfo* FindTabletEvenInDeleting(TTabletId tabletId, TFollowerId followerId
         return CurrentConfig.GetUseTabletUsageEstimate();
     }
 
+    double GetTabletImpactToIsolate() const {
+        return CurrentConfig.GetTabletImpactToIsolate();
+    }
+
+    double GetTabletImpactShareToPin() const {
+        return CurrentConfig.GetTabletImpactShareToPin();
+    }
+
     TDuration GetBalanceCountersRefreshFrequency() const {
         return TDuration::MilliSeconds(CurrentConfig.GetBalanceCountersRefreshFrequency());
     }

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -1064,8 +1064,8 @@ TTabletInfo* FindTabletEvenInDeleting(TTabletId tabletId, TFollowerId followerId
         return CurrentConfig.GetUseTabletUsageEstimate();
     }
 
-    double GetTabletImpactToIsolate() const {
-        return CurrentConfig.GetTabletImpactToIsolate();
+    double GetTabletImpactToPin() const {
+        return CurrentConfig.GetTabletImpactToPin();
     }
 
     double GetTabletImpactShareToPin() const {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -6008,6 +6008,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             app.HiveConfig.SetResourceChangeReactionPeriod(0);
             app.HiveConfig.SetMinPeriodBetweenEmergencyBalance(0);
             app.HiveConfig.SetMinPeriodBetweenBalance(0);
+            app.HiveConfig.SetMinNetworkScatterToBalance(0.1);
         });
         const int nodeBase = runtime.GetNodeId(0);
         TActorId senderA = runtime.AllocateEdgeActor();
@@ -6238,101 +6239,6 @@ Y_UNIT_TEST_SUITE(THiveTest) {
 
         UNIT_ASSERT_LE(moves, 2);
         UNIT_ASSERT_VALUES_EQUAL(distribution[*nodeWithTablet].size(), 1);
-    }
-
-    Y_UNIT_TEST(TestHiveBalancerEvictsCheapTabletsFirst) {
-        // One high-impact tablet sharing an overloaded node with a crowd of cheap ones, and a single
-        // empty node to move to. The cheap tablets should be the ones that leave.
-        static constexpr ui64 NUM_NODES = 2;
-        static constexpr ui64 NUM_TABLETS = 10;
-        TTestBasicRuntime runtime(NUM_NODES, false);
-        Setup(runtime, true, 1, [](TAppPrepare& app) {
-            app.HiveConfig.SetTabletKickCooldownPeriod(0);
-            app.HiveConfig.SetResourceChangeReactionPeriod(0);
-            app.HiveConfig.SetMinPeriodBetweenEmergencyBalance(0);
-        });
-        const int nodeBase = runtime.GetNodeId(0);
-        TActorId senderA = runtime.AllocateEdgeActor();
-        const ui64 hiveTablet = MakeDefaultHiveID();
-        const ui64 testerTablet = MakeTabletID(false, 1);
-
-        using TDistribution = std::array<std::vector<ui64>, NUM_NODES>;
-        auto getDistribution = [hiveTablet, nodeBase, senderA, &runtime]() -> TDistribution {
-            std::array<std::vector<ui64>, NUM_NODES> nodeTablets = {};
-            {
-                runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvRequestHiveInfo());
-                TAutoPtr<IEventHandle> handle;
-                TEvHive::TEvResponseHiveInfo* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
-                for (const NKikimrHive::TTabletInfo& tablet : response->Record.GetTablets()) {
-                    if (tablet.GetNodeID() == 0) {
-                        continue;
-                    }
-                    UNIT_ASSERT_C(((int)tablet.GetNodeID() - nodeBase >= 0) && (tablet.GetNodeID() - nodeBase < NUM_NODES),
-                            "nodeId# " << tablet.GetNodeID() << " nodeBase# " << nodeBase);
-                    nodeTablets[tablet.GetNodeID() - nodeBase].push_back(tablet.GetTabletID());
-                }
-            }
-            return nodeTablets;
-        };
-
-        auto tabletNode = [](const TDistribution& distribution, ui64 tabletId) -> std::optional<size_t> {
-            auto hasTablet = [tabletId](const std::vector<ui64>& tablets) {
-                return std::find(tablets.begin(), tablets.end(), tabletId) != tablets.end();
-            };
-            auto it = std::find_if(distribution.begin(), distribution.end(), hasTablet);
-            if (it == distribution.end()) {
-                return std::nullopt;
-            }
-            return it - distribution.begin();
-        };
-
-        CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
-
-        {
-            TDispatchOptions options;
-            options.FinalEvents.emplace_back(TEvLocal::EvStatus, NUM_NODES);
-            runtime.DispatchEvents(options);
-        }
-
-        TTabletTypes::EType tabletType = TTabletTypes::Dummy;
-        std::vector<ui64> tablets;
-        tablets.reserve(NUM_TABLETS);
-        for (size_t i = 0; i < NUM_TABLETS; ++i) {
-            THolder<TEvHive::TEvCreateTablet> ev(new TEvHive::TEvCreateTablet(testerTablet, 100500 + i, tabletType, BINDED_CHANNELS));
-            ev->Record.SetObjectId(i);
-            ui64 tabletId = SendCreateTestTablet(runtime, hiveTablet, testerTablet, std::move(ev), 0, true);
-            tablets.push_back(tabletId);
-            MakeSureTabletIsUp(runtime, tabletId, 0);
-        }
-
-        const ui64 highImpactTablet = tablets.front();
-        auto distribution = getDistribution();
-        const size_t loadedNode = *tabletNode(distribution, highImpactTablet);
-        Ctest << "picked tablet " << highImpactTablet << " on node " << loadedNode << Endl;
-
-        for (int i = 0; i < 20; ++i) {
-            for (int j = 0; j < 5; ++j) {
-                for (ui32 node = 0; node < NUM_NODES; ++node) {
-                    TActorId sender = runtime.AllocateEdgeActor(node);
-                    THolder<TEvHive::TEvTabletMetrics> metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
-                    metrics->Record.SetTotalNodeUsage(node == loadedNode ? .95 : .05);
-
-                    runtime.SendToPipe(hiveTablet, sender, metrics.Release(), node);
-                }
-            }
-
-            TDispatchOptions options;
-            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
-            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
-            runtime.AdvanceCurrentTime(TDuration::MilliSeconds(500));
-
-            distribution = getDistribution();
-            Ctest << "distribution: " << distribution[0].size() << " " << distribution[1].size() << Endl;
-        }
-
-        // the high-impact tablet has not been shuffled off to the other node, and its neighbours have
-        UNIT_ASSERT_VALUES_EQUAL(tabletNode(distribution, highImpactTablet), loadedNode);
-        UNIT_ASSERT_VALUES_EQUAL(distribution[loadedNode].size(), 1);
     }
 
     Y_UNIT_TEST(TestHiveBalancerPinnedTabletStaysPut) {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -6007,6 +6007,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             app.HiveConfig.SetTabletKickCooldownPeriod(3);
             app.HiveConfig.SetResourceChangeReactionPeriod(0);
             app.HiveConfig.SetMinPeriodBetweenEmergencyBalance(0);
+            app.HiveConfig.SetMinPeriodBetweenBalance(0);
         });
         const int nodeBase = runtime.GetNodeId(0);
         TActorId senderA = runtime.AllocateEdgeActor();
@@ -6075,6 +6076,11 @@ Y_UNIT_TEST_SUITE(THiveTest) {
                     TActorId sender = runtime.AllocateEdgeActor(node);
                     THolder<TEvHive::TEvTabletMetrics> metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
                     metrics->Record.SetTotalNodeUsage(node == nodeWithTablet ? .99 : .05);
+                    for (ui64 tablet : distribution[node]) {
+                        auto* tabletMetric = metrics->Record.AddTabletMetrics();
+                        tabletMetric->SetTabletID(tablet);
+                        tabletMetric->MutableResourceUsage()->SetNetwork(100'000'000ull);
+                    }
 
                     runtime.SendToPipe(hiveTablet, sender, metrics.Release(), node);
                 }
@@ -6082,7 +6088,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
 
             TDispatchOptions options;
             options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
-            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
+            runtime.DispatchEvents(options, TDuration::MilliSeconds(100));
             runtime.AdvanceCurrentTime(TDuration::MilliSeconds(500));
 
             distribution = getDistribution();
@@ -6117,6 +6123,279 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         Ctest << Endl;
         UNIT_ASSERT_VALUES_EQUAL(distribution[*nodeWithTablet].size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(tabletsOnNodes.size(), 1);
+    }
+
+    Y_UNIT_TEST(TestHiveBalancerIsolatesHighImpactTablet) {
+        // Same shape as TestHiveBalancerOneTabletHighUsage, except the tablet only pushes its node over
+        // the limit some of the time. The usage estimate alone is then not enough to make every other
+        // node look unavailable, so isolation has to come from the balancer treating the tablet as
+        // high-impact rather than from the placement arithmetic.
+        static constexpr ui64 NUM_NODES = 4;
+        static constexpr ui64 NUM_TABLETS = NUM_NODES * NUM_NODES;
+        TTestBasicRuntime runtime(NUM_NODES, false);
+        Setup(runtime, true, 1, [](TAppPrepare& app) {
+            app.HiveConfig.SetTabletKickCooldownPeriod(3);
+            app.HiveConfig.SetResourceChangeReactionPeriod(0);
+            app.HiveConfig.SetMinPeriodBetweenEmergencyBalance(0);
+        });
+        const int nodeBase = runtime.GetNodeId(0);
+        TActorId senderA = runtime.AllocateEdgeActor();
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const ui64 testerTablet = MakeTabletID(false, 1);
+
+        using TDistribution = std::array<std::vector<ui64>, NUM_NODES>;
+        auto getDistribution = [hiveTablet, nodeBase, senderA, &runtime]() -> TDistribution {
+            std::array<std::vector<ui64>, NUM_NODES> nodeTablets = {};
+            {
+                runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvRequestHiveInfo());
+                TAutoPtr<IEventHandle> handle;
+                TEvHive::TEvResponseHiveInfo* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+                for (const NKikimrHive::TTabletInfo& tablet : response->Record.GetTablets()) {
+                    if (tablet.GetNodeID() == 0) {
+                        continue;
+                    }
+                    UNIT_ASSERT_C(((int)tablet.GetNodeID() - nodeBase >= 0) && (tablet.GetNodeID() - nodeBase < NUM_NODES),
+                            "nodeId# " << tablet.GetNodeID() << " nodeBase# " << nodeBase);
+                    nodeTablets[tablet.GetNodeID() - nodeBase].push_back(tablet.GetTabletID());
+                }
+            }
+            return nodeTablets;
+        };
+
+        auto tabletNode = [](const TDistribution& distribution, ui64 tabletId) -> std::optional<size_t> {
+            auto hasTablet = [tabletId](const std::vector<ui64>& tablets) {
+                return std::find(tablets.begin(), tablets.end(), tabletId) != tablets.end();
+            };
+            auto it = std::find_if(distribution.begin(), distribution.end(), hasTablet);
+            if (it == distribution.end()) {
+                return std::nullopt;
+            }
+            return it - distribution.begin();
+        };
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+
+        // wait for creation of nodes
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, NUM_NODES);
+            runtime.DispatchEvents(options);
+        }
+
+        TTabletTypes::EType tabletType = TTabletTypes::Dummy;
+        std::vector<ui64> tablets;
+        tablets.reserve(NUM_TABLETS);
+        for (size_t i = 0; i < NUM_TABLETS; ++i) {
+            THolder<TEvHive::TEvCreateTablet> ev(new TEvHive::TEvCreateTablet(testerTablet, 100500 + i, tabletType, BINDED_CHANNELS));
+            ev->Record.SetObjectId(i);
+            ui64 tabletId = SendCreateTestTablet(runtime, hiveTablet, testerTablet, std::move(ev), 0, true);
+            tablets.push_back(tabletId);
+            MakeSureTabletIsUp(runtime, tabletId, 0);
+        }
+
+        const ui64 highImpactTablet = tablets.front();
+        auto distribution = getDistribution();
+        auto nodeWithTablet = tabletNode(distribution, highImpactTablet);
+        Ctest << "picked tablet " << highImpactTablet << Endl;
+        unsigned moves = 0;
+
+        for (int i = 0; i < 20; ++i) {
+            // over the limit every other round only
+            double highImpactNodeUsage = (i % 2 == 0) ? .95 : .7;
+            for (int j = 0; j < 5; ++j) {
+                for (ui32 node = 0; node < NUM_NODES; ++node) {
+                    TActorId sender = runtime.AllocateEdgeActor(node);
+                    THolder<TEvHive::TEvTabletMetrics> metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
+                    metrics->Record.SetTotalNodeUsage(node == nodeWithTablet ? highImpactNodeUsage : .05);
+
+                    runtime.SendToPipe(hiveTablet, sender, metrics.Release(), node);
+                }
+            }
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
+            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::MilliSeconds(500));
+
+            distribution = getDistribution();
+            auto newNodeWithTablet = tabletNode(distribution, highImpactTablet);
+            if (newNodeWithTablet != nodeWithTablet) {
+                nodeWithTablet = newNodeWithTablet;
+                if (newNodeWithTablet) {
+                    ++moves;
+                }
+            }
+
+            Ctest << "distribution: ";
+            for (size_t i = 0; i < NUM_NODES; ++i) {
+                if (i == nodeWithTablet) {
+                    Ctest << "*";
+                }
+                Ctest << distribution[i].size() << " ";
+            }
+            Ctest << Endl;
+        }
+
+        UNIT_ASSERT_LE(moves, 2);
+        UNIT_ASSERT_VALUES_EQUAL(distribution[*nodeWithTablet].size(), 1);
+    }
+
+    Y_UNIT_TEST(TestHiveBalancerEvictsCheapTabletsFirst) {
+        // One high-impact tablet sharing an overloaded node with a crowd of cheap ones, and a single
+        // empty node to move to. The cheap tablets should be the ones that leave.
+        static constexpr ui64 NUM_NODES = 2;
+        static constexpr ui64 NUM_TABLETS = 10;
+        TTestBasicRuntime runtime(NUM_NODES, false);
+        Setup(runtime, true, 1, [](TAppPrepare& app) {
+            app.HiveConfig.SetTabletKickCooldownPeriod(0);
+            app.HiveConfig.SetResourceChangeReactionPeriod(0);
+            app.HiveConfig.SetMinPeriodBetweenEmergencyBalance(0);
+        });
+        const int nodeBase = runtime.GetNodeId(0);
+        TActorId senderA = runtime.AllocateEdgeActor();
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const ui64 testerTablet = MakeTabletID(false, 1);
+
+        using TDistribution = std::array<std::vector<ui64>, NUM_NODES>;
+        auto getDistribution = [hiveTablet, nodeBase, senderA, &runtime]() -> TDistribution {
+            std::array<std::vector<ui64>, NUM_NODES> nodeTablets = {};
+            {
+                runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvRequestHiveInfo());
+                TAutoPtr<IEventHandle> handle;
+                TEvHive::TEvResponseHiveInfo* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+                for (const NKikimrHive::TTabletInfo& tablet : response->Record.GetTablets()) {
+                    if (tablet.GetNodeID() == 0) {
+                        continue;
+                    }
+                    UNIT_ASSERT_C(((int)tablet.GetNodeID() - nodeBase >= 0) && (tablet.GetNodeID() - nodeBase < NUM_NODES),
+                            "nodeId# " << tablet.GetNodeID() << " nodeBase# " << nodeBase);
+                    nodeTablets[tablet.GetNodeID() - nodeBase].push_back(tablet.GetTabletID());
+                }
+            }
+            return nodeTablets;
+        };
+
+        auto tabletNode = [](const TDistribution& distribution, ui64 tabletId) -> std::optional<size_t> {
+            auto hasTablet = [tabletId](const std::vector<ui64>& tablets) {
+                return std::find(tablets.begin(), tablets.end(), tabletId) != tablets.end();
+            };
+            auto it = std::find_if(distribution.begin(), distribution.end(), hasTablet);
+            if (it == distribution.end()) {
+                return std::nullopt;
+            }
+            return it - distribution.begin();
+        };
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, NUM_NODES);
+            runtime.DispatchEvents(options);
+        }
+
+        TTabletTypes::EType tabletType = TTabletTypes::Dummy;
+        std::vector<ui64> tablets;
+        tablets.reserve(NUM_TABLETS);
+        for (size_t i = 0; i < NUM_TABLETS; ++i) {
+            THolder<TEvHive::TEvCreateTablet> ev(new TEvHive::TEvCreateTablet(testerTablet, 100500 + i, tabletType, BINDED_CHANNELS));
+            ev->Record.SetObjectId(i);
+            ui64 tabletId = SendCreateTestTablet(runtime, hiveTablet, testerTablet, std::move(ev), 0, true);
+            tablets.push_back(tabletId);
+            MakeSureTabletIsUp(runtime, tabletId, 0);
+        }
+
+        const ui64 highImpactTablet = tablets.front();
+        auto distribution = getDistribution();
+        const size_t loadedNode = *tabletNode(distribution, highImpactTablet);
+        Ctest << "picked tablet " << highImpactTablet << " on node " << loadedNode << Endl;
+
+        for (int i = 0; i < 20; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                for (ui32 node = 0; node < NUM_NODES; ++node) {
+                    TActorId sender = runtime.AllocateEdgeActor(node);
+                    THolder<TEvHive::TEvTabletMetrics> metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
+                    metrics->Record.SetTotalNodeUsage(node == loadedNode ? .95 : .05);
+
+                    runtime.SendToPipe(hiveTablet, sender, metrics.Release(), node);
+                }
+            }
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
+            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::MilliSeconds(500));
+
+            distribution = getDistribution();
+            Ctest << "distribution: " << distribution[0].size() << " " << distribution[1].size() << Endl;
+        }
+
+        // the high-impact tablet has not been shuffled off to the other node, and its neighbours have
+        UNIT_ASSERT_VALUES_EQUAL(tabletNode(distribution, highImpactTablet), loadedNode);
+        UNIT_ASSERT_VALUES_EQUAL(distribution[loadedNode].size(), 1);
+    }
+
+    Y_UNIT_TEST(TestHiveBalancerPinnedTabletStaysPut) {
+        // A high-impact tablet already alone on a node that is still over the limit. There is nothing
+        // left to evict and moving it would only relocate the load, so the balancer should leave it be
+        // instead of bouncing it between nodes.
+        static constexpr ui64 NUM_NODES = 3;
+        TTestBasicRuntime runtime(NUM_NODES, false);
+        Setup(runtime, true, 1, [](TAppPrepare& app) {
+            app.HiveConfig.SetTabletKickCooldownPeriod(0);
+            app.HiveConfig.SetResourceChangeReactionPeriod(0);
+            app.HiveConfig.SetMinPeriodBetweenEmergencyBalance(0);
+        });
+        const int nodeBase = runtime.GetNodeId(0);
+        TActorId senderA = runtime.AllocateEdgeActor();
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const ui64 testerTablet = MakeTabletID(false, 1);
+
+        auto tabletNode = [hiveTablet, nodeBase, senderA, &runtime](ui64 tabletId) -> std::optional<size_t> {
+            runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvRequestHiveInfo());
+            TAutoPtr<IEventHandle> handle;
+            TEvHive::TEvResponseHiveInfo* response = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+            for (const NKikimrHive::TTabletInfo& tablet : response->Record.GetTablets()) {
+                if (tablet.GetTabletID() == tabletId && tablet.GetNodeID() != 0) {
+                    return tablet.GetNodeID() - nodeBase;
+                }
+            }
+            return std::nullopt;
+        };
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, NUM_NODES);
+            runtime.DispatchEvents(options);
+        }
+
+        THolder<TEvHive::TEvCreateTablet> ev(new TEvHive::TEvCreateTablet(testerTablet, 100500, TTabletTypes::Dummy, BINDED_CHANNELS));
+        ui64 highImpactTablet = SendCreateTestTablet(runtime, hiveTablet, testerTablet, std::move(ev), 0, true);
+        MakeSureTabletIsUp(runtime, highImpactTablet, 0);
+
+        const size_t loadedNode = *tabletNode(highImpactTablet);
+        Ctest << "tablet " << highImpactTablet << " is on node " << loadedNode << Endl;
+
+        for (int i = 0; i < 10; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                for (ui32 node = 0; node < NUM_NODES; ++node) {
+                    TActorId sender = runtime.AllocateEdgeActor(node);
+                    THolder<TEvHive::TEvTabletMetrics> metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
+                    metrics->Record.SetTotalNodeUsage(node == loadedNode ? .95 : .05);
+
+                    runtime.SendToPipe(hiveTablet, sender, metrics.Release(), node);
+                }
+            }
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
+            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::MilliSeconds(500));
+
+            UNIT_ASSERT_VALUES_EQUAL(tabletNode(highImpactTablet), loadedNode);
+        }
     }
 
     Y_UNIT_TEST(TestNotEnoughResources) {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -6208,6 +6208,11 @@ Y_UNIT_TEST_SUITE(THiveTest) {
                     TActorId sender = runtime.AllocateEdgeActor(node);
                     THolder<TEvHive::TEvTabletMetrics> metrics = MakeHolder<TEvHive::TEvTabletMetrics>();
                     metrics->Record.SetTotalNodeUsage(node == nodeWithTablet ? highImpactNodeUsage : .05);
+                    for (ui64 tablet : distribution[node]) {
+                        auto* tabletMetric = metrics->Record.AddTabletMetrics();
+                        tabletMetric->SetTabletID(tablet);
+                        tabletMetric->MutableResourceUsage()->SetNetwork(100'000'000ull);
+                    }
 
                     runtime.SendToPipe(hiveTablet, sender, metrics.Release(), node);
                 }
@@ -6215,7 +6220,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
 
             TDispatchOptions options;
             options.FinalEvents.emplace_back(NHive::TEvPrivate::EvBalancerOut);
-            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
+            runtime.DispatchEvents(options, TDuration::MilliSeconds(100));
             runtime.AdvanceCurrentTime(TDuration::MilliSeconds(500));
 
             distribution = getDistribution();

--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -640,6 +640,7 @@ public:
         out << "<th>Read</th>";
         out << "<th>Write</th>";
         out << "<th>Usage impact</th>";
+        out << "<th>Isolation</th>";
         out << "</tr>";
         out << "</thead>";
 
@@ -652,7 +653,8 @@ public:
             out << "<tr>";
             out << "<td data-text='" << index << "'><a href='../tablets?TabletID=" << id << "'>" << id << "</a></td>";
             out << GetResourceValuesHtml(tablet.GetResourceValues());
-            out << "<td>" << tablet.UsageImpact << "</td>";
+            out << "<td>" << tablet.GetUsageImpact() << "</td>";
+            out << "<td>" << (tablet.IsPinnedToNode() ? "pinned" : (tablet.IsHighImpact() ? "high-impact" : "")) << "</td>";
             out << "</tr>";
         }
         out <<"</tbody>";
@@ -2814,7 +2816,19 @@ public:
                     jsonNode["Types"] = types;
                 }
                 double nodeUsage = node.GetNodeUsage();
-                jsonNode["Usage"] = GetConditionalRedString(Sprintf("%.3f", nodeUsage), nodeUsage >= 1);
+                TStringBuilder usage;
+                usage << GetConditionalRedString(Sprintf("%.3f", nodeUsage), nodeUsage >= 1);
+                double reservedImpact = node.GetMaxTabletImpact();
+                if (reservedImpact > 0) {
+                    TStringBuilder title;
+                    title << "Reserved for a high-impact tablet: " << Sprintf("%.3f", reservedImpact);
+                    const TTabletInfo* pinned = node.GetPinnedTablet();
+                    if (pinned != nullptr) {
+                        title << ", " << pinned->ToString() << " is pinned here";
+                    }
+                    usage << " <span class='glyphicon glyphicon-pushpin' title='" << title << "'></span>";
+                }
+                jsonNode["Usage"] = usage;
                 jsonNode["ResourceValues"] = GetResourceValuesJson(node.ResourceValues, node.ResourceMaximumValues);
                 jsonNode["StDevResourceValues"] = GetResourceValuesText(node.GetStDevResourceValues());
             }
@@ -4210,7 +4224,9 @@ public:
         result["ResourceMetricsAggregates"] = MakeFrom(tablet.ResourceMetricsAggregates);
         result["ActorsToNotify"] = MakeFrom(tablet.ActorsToNotify);
         result["ActorsToNotifyOnRestart"] = MakeFrom(tablet.ActorsToNotifyOnRestart);
-        result["UsageImpact"] = tablet.UsageImpact;
+        result["UsageImpact"] = tablet.GetUsageImpact();
+        result["HighImpact"] = tablet.IsHighImpact();
+        result["PinnedToNode"] = tablet.IsPinnedToNode();
         return result;
     }
 

--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -2818,10 +2818,10 @@ public:
                 double nodeUsage = node.GetNodeUsage();
                 TStringBuilder usage;
                 usage << GetConditionalRedString(Sprintf("%.3f", nodeUsage), nodeUsage >= 1);
-                double reservedImpact = node.GetMaxTabletImpact();
-                if (reservedImpact > 0) {
+                double maxTabletImpact = node.GetMaxTabletImpact();
+                if (maxTabletImpact > 0) {
                     TStringBuilder title;
-                    title << "Reserved for a high-impact tablet: " << Sprintf("%.3f", reservedImpact);
+                    title << "Max tablet impact: " << Sprintf("%.3f", maxTabletImpact);
                     const TTabletInfo* pinned = node.GetPinnedTablet();
                     if (pinned != nullptr) {
                         title << ", " << pinned->ToString() << " is pinned here";

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -571,6 +571,31 @@ bool TNodeInfo::CanBeDeleted(TInstant now) const {
     }
 }
 
+void TNodeInfo::LowerOverestimatedImpacts(NIceDb::TNiceDb& db) {
+    // A tablet's impact cannot exceed the usage of the node it runs on. That bound is worth little on a
+    // crowded node, but it becomes a direct measurement once the tablet is nearly alone here - which is
+    // precisely the state a high-impact tablet is driven into, and the state in which it is no longer
+    // moved and so is never measured again. Without this, an estimate that was wrong to begin with would
+    // keep the tablet isolated forever.
+    //
+    // This can only ever lower an estimate, so it cannot promote a tablet to high-impact by itself, and
+    // a tablet that really did get heavier is corrected upwards by the usual measurement the next time
+    // it is scheduled somewhere. Only high-impact tablets are checked: they are the ones an overestimate
+    // actually harms, and there are at most a couple of them per node.
+    std::vector<TTabletInfo*> overestimated;
+    for (TTabletInfo* tablet : HighImpactTablets) {
+        if (tablet->GetUsageImpact() > NodeTotalUsage) {
+            overestimated.push_back(tablet);
+        }
+    }
+    for (TTabletInfo* tablet : overestimated) {
+        BLOG_D("Lowering impact estimate of tablet " << tablet->GetFullTabletId()
+                << " from " << tablet->GetUsageImpact() << " to usage of node " << Id << " (" << NodeTotalUsage << ")");
+        tablet->SetUsageImpact(NodeTotalUsage); // updates HighImpactTablets, hence the copy above
+        db.Table<Schema::Metrics>().Key(tablet->GetFullTabletId()).Update<Schema::Metrics::UsageImpact>(NodeTotalUsage);
+    }
+}
+
 void TNodeInfo::UpdateResourceTotalUsage(const NKikimrHive::TEvTabletMetrics& metrics, NIceDb::TNiceDb& db) {
     if (metrics.HasTotalResourceUsage()) {
         AveragedResourceTotalValues.Push(ResourceRawValuesFromMetrics(metrics.GetTotalResourceUsage()));
@@ -603,6 +628,9 @@ void TNodeInfo::UpdateResourceTotalUsage(const NKikimrHive::TEvTabletMetrics& me
             }
         }
         NodeTotalUsage = AveragedNodeTotalUsage.GetValue();
+        if (!LastScheduledTablet) {
+            LowerOverestimatedImpacts(db);
+        }
     }
     if (metrics.HasTotalNodeCpuUsage()) {
         AveragedNodeTotalCpuUsage.Push(metrics.GetTotalNodeCpuUsage());

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -102,7 +102,11 @@ bool TNodeInfo::OnTabletChangeVolatileState(TTabletInfo* tablet, TTabletInfo::EV
         if (Tablets[newState].insert(tablet).second) {
             UpdateResourceValues(tablet, {}, tablet->GetResourceValues());
             if (!IsResourceDrainingState(oldState)) {
-                LastScheduledTablet = {.TabletId = tablet->GetFullTabletId(), .UsageBefore = NodeTotalUsage};
+                LastScheduledTablet = {
+                    .TabletId = tablet->GetFullTabletId(),
+                    .UsageBefore = NodeTotalUsage,
+                    .PriorImpact = tablet->GetUsageImpact(),
+                };
             }
         } else {
             YDB_LOG_WARN("TNodeInfo::OnTabletChangeVolatileState failed to insert tablet",
@@ -111,6 +115,9 @@ bool TNodeInfo::OnTabletChangeVolatileState(TTabletInfo* tablet, TTabletInfo::EV
                 {"tablet", tablet->ToString()},
                 {"newVolatileState", TTabletInfo::EVolatileStateName(newState)});
         }
+        UpdateHighImpactTablet(tablet);
+    } else {
+        HighImpactTablets.erase(tablet);
     }
     if (IsAliveState(newState)) {
         TabletsRunningByType[tablet->GetTabletType()].emplace(tablet);
@@ -122,6 +129,33 @@ bool TNodeInfo::OnTabletChangeVolatileState(TTabletInfo* tablet, TTabletInfo::EV
         }
     }
     return true;
+}
+
+void TNodeInfo::UpdateHighImpactTablet(TTabletInfo* tablet) {
+    if (tablet->IsHighImpact()) {
+        HighImpactTablets.insert(tablet);
+    } else {
+        HighImpactTablets.erase(tablet);
+    }
+}
+
+double TNodeInfo::GetMaxTabletImpact(const TTabletInfo* exclude) const {
+    double result = 0;
+    for (const TTabletInfo* tablet : HighImpactTablets) {
+        if (tablet != exclude) {
+            result = std::max(result, tablet->GetUsageImpact());
+        }
+    }
+    return result;
+}
+
+const TTabletInfo* TNodeInfo::GetPinnedTablet() const {
+    for (const TTabletInfo* tablet : HighImpactTablets) {
+        if (tablet->IsPinnedToNode()) {
+            return tablet;
+        }
+    }
+    return nullptr;
 }
 
 void TNodeInfo::UpdateResourceValues(const TTabletInfo* tablet, const TMetrics& before, const TMetrics& after) {
@@ -457,14 +491,26 @@ double TNodeInfo::GetNodeUsageForTablet(const TTabletInfo& tablet, bool neighbou
     TResourceRawValues nodeValues = GetResourceCurrentValues();
     TResourceRawValues tabletValues = tablet.GetResourceCurrentValues();
     if (Hive.GetUseTabletUsageEstimate()) {
-        auto estimateUsageValues = cast_like(maximum * tablet.UsageImpact, tabletValues);
+        auto estimateUsageValues = cast_like(maximum * tablet.GetUsageImpact(), tabletValues);
         tabletValues = piecewise_max(tabletValues, estimateUsageValues);
     }
     tablet.FilterRawValues(nodeValues);
     tablet.FilterRawValues(tabletValues);
-    auto current = tablet.IsAliveOnLocal(Local) ? nodeValues : nodeValues + tabletValues;
+    bool alreadyHere = tablet.IsAliveOnLocal(Local);
+    auto current = alreadyHere ? nodeValues : nodeValues + tabletValues;
     // basically, this is: return max(a / b);
     double usage = TTabletInfo::GetUsage(current, maximum);
+    // A high-impact tablet loads the node mostly through shared pools, which takes a while to show up
+    // in the node's own metrics. Reserve its estimated share up front so that the window right after it
+    // lands here is not spent filling the node up with other tablets. A max rather than a sum: the
+    // estimate is a marginal effect measured one tablet at a time, so the impacts do not add up.
+    double reserved = GetMaxTabletImpact(&tablet);
+    if (reserved > 0) {
+        if (!alreadyHere) {
+            reserved += TTabletInfo::GetUsage(tabletValues, maximum);
+        }
+        usage = std::max(usage, reserved);
+    }
     if (Hive.GetSpreadNeighbours() && usage < 1 && neighbourPenalty) {
         auto neighbours = GetTabletNeighboursCount(tablet);
         if (neighbours > 0) {
@@ -533,22 +579,27 @@ void TNodeInfo::UpdateResourceTotalUsage(const NKikimrHive::TEvTabletMetrics& me
     if (metrics.HasTotalNodeUsage()) {
         AveragedNodeTotalUsage.Push(metrics.GetTotalNodeUsage());
         if (LastScheduledTablet) {
-            if (LastScheduledTablet->UsageSince.Push(metrics.GetTotalNodeUsage())) {
-                // we kept enough stats for this tablet
+            // we kept enough stats for this tablet once Push reports a shrink
+            bool measurementComplete = LastScheduledTablet->UsageSince.Push(metrics.GetTotalNodeUsage());
+            double measured = LastScheduledTablet->UsageSince.GetValue() - LastScheduledTablet->UsageBefore;
+            measured = std::max<double>(measured, 0);
+            // Until the measurement completes, the estimate carried over from the previous node acts as a
+            // floor, so a tablet already known to be heavy is not treated as free while its load ramps up
+            // here. Once it completes we take the measurement as is, so a tablet that got lighter can
+            // correct downwards.
+            double usageImpact = measurementComplete ? measured : std::max(measured, LastScheduledTablet->PriorImpact);
+            auto* tablet = Hive.FindTablet(LastScheduledTablet->TabletId);
+            if (tablet) {
+                YDB_LOG_DEBUG("TNodeInfo::UpdateResourceTotalUsage estimated tablet usage impact on node",
+                    {"logPrefix", GetLogPrefix()},
+                    {"tabletId", LastScheduledTablet->TabletId},
+                    {"nodeId", Id},
+                    {"usageImpact", usageImpact});
+                tablet->SetUsageImpact(usageImpact);
+                db.Table<Schema::Metrics>().Key(LastScheduledTablet->TabletId).Update<Schema::Metrics::UsageImpact>(usageImpact);
+            }
+            if (measurementComplete) {
                 LastScheduledTablet.reset();
-            } else {
-                double usageImpact = LastScheduledTablet->UsageSince.GetValue() - LastScheduledTablet->UsageBefore;
-                usageImpact = std::max<double>(usageImpact, 0);
-                auto* tablet = Hive.FindTablet(LastScheduledTablet->TabletId);
-                if (tablet) {
-                    YDB_LOG_DEBUG("TNodeInfo::UpdateResourceTotalUsage estimated tablet usage impact on node",
-                        {"logPrefix", GetLogPrefix()},
-                        {"tabletId", LastScheduledTablet->TabletId},
-                        {"nodeId", Id},
-                        {"usageImpact", usageImpact});
-                    tablet->UsageImpact = usageImpact;
-                    db.Table<Schema::Metrics>().Key(LastScheduledTablet->TabletId).Update<Schema::Metrics::UsageImpact>(usageImpact);
-                }
             }
         }
         NodeTotalUsage = AveragedNodeTotalUsage.GetValue();

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -500,12 +500,8 @@ double TNodeInfo::GetNodeUsageForTablet(const TTabletInfo& tablet, bool neighbou
     auto current = alreadyHere ? nodeValues : nodeValues + tabletValues;
     // basically, this is: return max(a / b);
     double usage = TTabletInfo::GetUsage(current, maximum);
-    // A high-impact tablet loads the node mostly through shared pools, which takes a while to show up
-    // in the node's own metrics. Reserve its estimated share up front so that the window right after it
-    // lands here is not spent filling the node up with other tablets. A max rather than a sum: the
-    // estimate is a marginal effect measured one tablet at a time, so the impacts do not add up.
     double reserved = GetMaxTabletImpact(&tablet);
-    if (reserved > 0) {
+    if (reserved > 0 && Hive.GetUseTabletUsageEstimate()) {
         if (!alreadyHere) {
             reserved += TTabletInfo::GetUsage(tabletValues, maximum);
         }
@@ -571,17 +567,10 @@ bool TNodeInfo::CanBeDeleted(TInstant now) const {
     }
 }
 
-void TNodeInfo::LowerOverestimatedImpacts(NIceDb::TNiceDb& db) {
-    // A tablet's impact cannot exceed the usage of the node it runs on. That bound is worth little on a
-    // crowded node, but it becomes a direct measurement once the tablet is nearly alone here - which is
-    // precisely the state a high-impact tablet is driven into, and the state in which it is no longer
-    // moved and so is never measured again. Without this, an estimate that was wrong to begin with would
-    // keep the tablet isolated forever.
-    //
-    // This can only ever lower an estimate, so it cannot promote a tablet to high-impact by itself, and
-    // a tablet that really did get heavier is corrected upwards by the usual measurement the next time
-    // it is scheduled somewhere. Only high-impact tablets are checked: they are the ones an overestimate
-    // actually harms, and there are at most a couple of them per node.
+void TNodeInfo::UpdateUsageImpacts(NIceDb::TNiceDb& db) {
+    // Simple logic: a tablet's usage impact cannot be bigger than total node usage
+    // We need this because we try not to move high-impact tablets, so we need a way to lower the estimate w/o moving the tablet
+    // If a low-impact tablet became high-impact, we will move it and notice it then
     std::vector<TTabletInfo*> overestimated;
     for (TTabletInfo* tablet : HighImpactTablets) {
         if (tablet->GetUsageImpact() > NodeTotalUsage) {
@@ -589,8 +578,6 @@ void TNodeInfo::LowerOverestimatedImpacts(NIceDb::TNiceDb& db) {
         }
     }
     for (TTabletInfo* tablet : overestimated) {
-        BLOG_D("Lowering impact estimate of tablet " << tablet->GetFullTabletId()
-                << " from " << tablet->GetUsageImpact() << " to usage of node " << Id << " (" << NodeTotalUsage << ")");
         tablet->SetUsageImpact(NodeTotalUsage); // updates HighImpactTablets, hence the copy above
         db.Table<Schema::Metrics>().Key(tablet->GetFullTabletId()).Update<Schema::Metrics::UsageImpact>(NodeTotalUsage);
     }
@@ -629,7 +616,7 @@ void TNodeInfo::UpdateResourceTotalUsage(const NKikimrHive::TEvTabletMetrics& me
         }
         NodeTotalUsage = AveragedNodeTotalUsage.GetValue();
         if (!LastScheduledTablet) {
-            LowerOverestimatedImpacts(db);
+            UpdateUsageImpacts(db);
         }
     }
     if (metrics.HasTotalNodeCpuUsage()) {

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -80,8 +80,7 @@ public:
     std::unordered_map<TTabletInfo::EVolatileState, std::unordered_set<TTabletInfo*>> Tablets;
     std::unordered_map<TTabletTypes::EType, std::unordered_set<TTabletInfo*>> TabletsRunningByType;
     std::unordered_map<TFullObjectId, std::unordered_set<TTabletInfo*>> TabletsOfObject;
-    // Resource-draining tablets with a high UsageImpact. Expected to hold zero or one element, which is
-    // what makes GetMaxTabletImpact cheap enough to call from FindBestNode's per-node loop.
+    // Resource-draining tablets with a high UsageImpact. Expected to hold zero or one elements
     std::unordered_set<TTabletInfo*> HighImpactTablets;
     std::vector<TFullTabletId> FrozenTablets;
     TResourceRawValues ResourceValues; // accumulated resources from tablet metrics
@@ -125,7 +124,7 @@ public:
     bool OnTabletChangeVolatileState(TTabletInfo* tablet, TTabletInfo::EVolatileState newState);
     void UpdateResourceValues(const TTabletInfo* tablet, const TMetrics& before, const TMetrics& after);
     void UpdateHighImpactTablet(TTabletInfo* tablet);
-    void LowerOverestimatedImpacts(NIceDb::TNiceDb& db);
+    void UpdateUsageImpacts(NIceDb::TNiceDb& db);
 
     // Largest UsageImpact among the node's high-impact tablets, ignoring `exclude` if given.
     // Used as a floor on the node's expected usage, see GetNodeUsageForTablet.

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -125,6 +125,7 @@ public:
     bool OnTabletChangeVolatileState(TTabletInfo* tablet, TTabletInfo::EVolatileState newState);
     void UpdateResourceValues(const TTabletInfo* tablet, const TMetrics& before, const TMetrics& after);
     void UpdateHighImpactTablet(TTabletInfo* tablet);
+    void LowerOverestimatedImpacts(NIceDb::TNiceDb& db);
 
     // Largest UsageImpact among the node's high-impact tablets, ignoring `exclude` if given.
     // Used as a floor on the node's expected usage, see GetNodeUsageForTablet.

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -65,6 +65,7 @@ public:
         TFullTabletId TabletId;
         NMetrics::TFastRiseAverageValue<double, 20> UsageSince;
         double UsageBefore;
+        double PriorImpact; // estimate carried over from before the move, acts as a floor until this measurement completes
     };
 
     THive& Hive;
@@ -79,6 +80,9 @@ public:
     std::unordered_map<TTabletInfo::EVolatileState, std::unordered_set<TTabletInfo*>> Tablets;
     std::unordered_map<TTabletTypes::EType, std::unordered_set<TTabletInfo*>> TabletsRunningByType;
     std::unordered_map<TFullObjectId, std::unordered_set<TTabletInfo*>> TabletsOfObject;
+    // Resource-draining tablets with a high UsageImpact. Expected to hold zero or one element, which is
+    // what makes GetMaxTabletImpact cheap enough to call from FindBestNode's per-node loop.
+    std::unordered_set<TTabletInfo*> HighImpactTablets;
     std::vector<TFullTabletId> FrozenTablets;
     TResourceRawValues ResourceValues; // accumulated resources from tablet metrics
     TResourceRawValues ResourceTotalValues; // actual used resources from the node (should be greater or equal one above)
@@ -120,6 +124,15 @@ public:
     void ChangeVolatileState(EVolatileState state);
     bool OnTabletChangeVolatileState(TTabletInfo* tablet, TTabletInfo::EVolatileState newState);
     void UpdateResourceValues(const TTabletInfo* tablet, const TMetrics& before, const TMetrics& after);
+    void UpdateHighImpactTablet(TTabletInfo* tablet);
+
+    // Largest UsageImpact among the node's high-impact tablets, ignoring `exclude` if given.
+    // Used as a floor on the node's expected usage, see GetNodeUsageForTablet.
+    double GetMaxTabletImpact(const TTabletInfo* exclude = nullptr) const;
+
+    // The tablet, if any, that accounts for most of this node's usage and is therefore not moved
+    // by the balancer. Diagnostics only.
+    const TTabletInfo* GetPinnedTablet() const;
 
     ui32 GetTabletsScheduled() const {
         auto it = Tablets.find(TTabletInfo::EVolatileState::TABLET_VOLATILE_STATE_STARTING);

--- a/ydb/core/mind/hive/tablet_info.cpp
+++ b/ydb/core/mind/hive/tablet_info.cpp
@@ -228,12 +228,10 @@ void TTabletInfo::SetUsageImpact(double usageImpact) {
 }
 
 bool TTabletInfo::IsHighImpact() const {
-    return Hive.GetUseTabletUsageEstimate() && UsageImpact >= Hive.GetTabletImpactToIsolate();
+    return Hive.GetUseTabletUsageEstimate() && UsageImpact >= Hive.GetTabletImpactToPin();
 }
 
 bool TTabletInfo::IsPinnedToNode() const {
-    // The IsHighImpact() check is what keeps a negligible tablet on a nearly idle node from
-    // satisfying the share test and pinning itself there forever.
     return IsHighImpact()
             && Node != nullptr
             && UsageImpact >= Hive.GetTabletImpactShareToPin() * Node->GetNodeUsage();

--- a/ydb/core/mind/hive/tablet_info.cpp
+++ b/ydb/core/mind/hive/tablet_info.cpp
@@ -220,6 +220,25 @@ bool TTabletInfo::IsGoodForBalancer(TInstant now) const {
             && (now - LastBalancerDecisionTime > Hive.GetTabletKickCooldownPeriod());
 }
 
+void TTabletInfo::SetUsageImpact(double usageImpact) {
+    UsageImpact = usageImpact;
+    if (Node != nullptr && IsResourceDrainingState(VolatileState)) {
+        Node->UpdateHighImpactTablet(this);
+    }
+}
+
+bool TTabletInfo::IsHighImpact() const {
+    return Hive.GetUseTabletUsageEstimate() && UsageImpact >= Hive.GetTabletImpactToIsolate();
+}
+
+bool TTabletInfo::IsPinnedToNode() const {
+    // The IsHighImpact() check is what keeps a negligible tablet on a nearly idle node from
+    // satisfying the share test and pinning itself there forever.
+    return IsHighImpact()
+            && Node != nullptr
+            && UsageImpact >= Hive.GetTabletImpactShareToPin() * Node->GetNodeUsage();
+}
+
 bool TTabletInfo::InitiateBoot(TNodeId node) {
     if (IsStopped()) {
         ChangeVolatileState(EVolatileState::TABLET_VOLATILE_STATE_BOOTING);

--- a/ydb/core/mind/hive/tablet_info.h
+++ b/ydb/core/mind/hive/tablet_info.h
@@ -153,6 +153,10 @@ protected:
     TMetrics ResourceValues; // current values of various metrics
     TTabletMetricsAggregates ResourceMetricsAggregates;
     TResourceNormalizedValues ResourceNormalizedValues;
+    // Estimated share of the node's total usage caused by this tablet, including load it causes
+    // indirectly in shared pools. Only ever changed through SetUsageImpact, which keeps the owning
+    // node's HighImpactTablets in sync.
+    double UsageImpact = 0;
 
 public:
     TVector<TActorId> ActorsToNotify; // ...OnCreation persistent
@@ -166,7 +170,6 @@ public:
     TInstant BootTime;
     TNodeFilter NodeFilter;
     bool InWaitQueue = false;
-    double UsageImpact = 0;
     bool UpdateMetricsEnqueued = false;
 
     TTabletInfo(ETabletRole role, THive& hive);
@@ -234,6 +237,20 @@ public:
     static bool HasAllowedMetric(const TVector<i64>& allowedMetricIds, EResourceToBalance resource);
     bool HasAllowedMetric(EResourceToBalance resource) const;
     bool HasMetric(EResourceToBalance resource) const;
+
+    double GetUsageImpact() const {
+        return UsageImpact;
+    }
+
+    void SetUsageImpact(double usageImpact);
+
+    // A tablet whose indirect load is large enough that the balancer should isolate it rather than
+    // shuffle it around like an ordinary tablet.
+    bool IsHighImpact() const;
+
+    // A high-impact tablet that accounts for most of its node's usage. Moving it elsewhere would only
+    // relocate the load, so the balancer leaves it alone and drains the rest of the node instead.
+    bool IsPinnedToNode() const;
 
     void UpdateResourceUsage(const NKikimrTabletBase::TMetrics& metrics);
     TResourceRawValues GetResourceCurrentValues() const;

--- a/ydb/core/mind/hive/tx__load_everything.cpp
+++ b/ydb/core/mind/hive/tx__load_everything.cpp
@@ -798,7 +798,7 @@ public:
                         leaderOrFollower->MutableResourceMetricsAggregates().MaximumCPU.InitializeFrom(metricsRowset.GetValueOrDefault<Schema::Metrics::MaximumCPU>());
                         leaderOrFollower->MutableResourceMetricsAggregates().MaximumMemory.InitializeFrom(metricsRowset.GetValueOrDefault<Schema::Metrics::MaximumMemory>());
                         leaderOrFollower->MutableResourceMetricsAggregates().MaximumNetwork.InitializeFrom(metricsRowset.GetValueOrDefault<Schema::Metrics::MaximumNetwork>());
-                        leaderOrFollower->UsageImpact = metricsRowset.GetValueOrDefault<Schema::Metrics::UsageImpact>();
+                        leaderOrFollower->SetUsageImpact(metricsRowset.GetValueOrDefault<Schema::Metrics::UsageImpact>());
                         // do not reorder
                         leaderOrFollower->UpdateResourceUsage(metricsRowset.GetValueOrDefault<Schema::Metrics::ProtoMetrics>());
                     }

--- a/ydb/core/mind/hive/tx__start_tablet.cpp
+++ b/ydb/core/mind/hive/tx__start_tablet.cpp
@@ -79,9 +79,6 @@ public:
             } else {
                 db.Table<Schema::TabletFollowerTablet>().Key(TabletId.first, TabletId.second).Update<Schema::TabletFollowerTablet::Statistics>(tablet->Statistics);
             }
-            // usage impact estimate is kept across restarts as a prior - it is a property of the
-            // tablet's workload, not of the node it happens to run on. It is replaced once the
-            // measurement on the new node completes, see TNodeInfo::UpdateResourceTotalUsage.
             if (tablet->IsLeader()) {
                 TLeaderTabletInfo& leader = tablet->AsLeader();
                 if (leader.IsStartingOnNode(Local.NodeId()) || BootingSuppressed && External) {

--- a/ydb/core/mind/hive/tx__start_tablet.cpp
+++ b/ydb/core/mind/hive/tx__start_tablet.cpp
@@ -79,9 +79,9 @@ public:
             } else {
                 db.Table<Schema::TabletFollowerTablet>().Key(TabletId.first, TabletId.second).Update<Schema::TabletFollowerTablet::Statistics>(tablet->Statistics);
             }
-            // reset usage impact estimate on each tablet restart
-            tablet->UsageImpact = 0;
-            db.Table<Schema::Metrics>().Key(tablet->GetFullTabletId()).Update<Schema::Metrics::UsageImpact>(0.);
+            // usage impact estimate is kept across restarts as a prior - it is a property of the
+            // tablet's workload, not of the node it happens to run on. It is replaced once the
+            // measurement on the new node completes, see TNodeInfo::UpdateResourceTotalUsage.
             if (tablet->IsLeader()) {
                 TLeaderTabletInfo& leader = tablet->AsLeader();
                 if (leader.IsStartingOnNode(Local.NodeId()) || BootingSuppressed && External) {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2786,8 +2786,8 @@ message THiveConfig {
     optional uint64 MaxDeleteTabletInProgress = 90 [default = 100];
     optional uint64 DataCenterChangeReactionPeriod = 91 [default = 300]; // seconds
     repeated THiveTabletAllowedMetrics DefaultTabletAllowedMetrics = 92;
-    optional double TabletImpactToIsolate = 93 [default = 0.3]; // UsageImpact at which a tablet is treated as high-impact; above 1.0 disables isolation
-    optional double TabletImpactShareToPin = 94 [default = 0.8]; // share of its node's usage a high-impact tablet must account for to be pinned there
+    optional double TabletImpactToPin = 93 [default = 0.3, (ParamDescription) = "Usage impact at which a tablet is treated as high-impact and is potentially isolated on a node"];
+    optional double TabletImpactShareToPin = 94 [default = 0.5, (ParamDescription) = "Same as above, but relative to node's total usage"];
 }
 
 message THealthCheckConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2786,6 +2786,8 @@ message THiveConfig {
     optional uint64 MaxDeleteTabletInProgress = 90 [default = 100];
     optional uint64 DataCenterChangeReactionPeriod = 91 [default = 300]; // seconds
     repeated THiveTabletAllowedMetrics DefaultTabletAllowedMetrics = 92;
+    optional double TabletImpactToIsolate = 93 [default = 0.3]; // UsageImpact at which a tablet is treated as high-impact; above 1.0 disables isolation
+    optional double TabletImpactShareToPin = 94 [default = 0.8]; // share of its node's usage a high-impact tablet must account for to be pinned there
 }
 
 message THealthCheckConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Pin a tablet to a node if it has high impact both in absolute terms and relative to a node's total usage
* Avoid moving other tablets to a node with a high-impact tablet
