### PR TITLE
[PQ] Drop unused schema helpers and topic-holder fields

### DIFF
--- a/ydb/services/lib/actors/pq_schema_actor.cpp
+++ b/ydb/services/lib/actors/pq_schema_actor.cpp
@@ -1,22 +1,7 @@
 #include "pq_schema_actor.h"
 
-#include <ydb/core/ydb_convert/topic_description.h>
-#include <ydb/public/sdk/cpp/src/library/persqueue/obfuscate/obfuscate.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
-#include <ydb/core/base/feature_flags.h>
-#include <ydb/core/kafka_proxy/kafka_constants.h>
 #include <ydb/core/persqueue/public/constants.h>
-#include <ydb/core/util/proto_duration.h>
-
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/jwt/jwt.h>
-
-#include <ydb/public/api/protos/ydb_topic.pb.h>
-
-#include <yql/essentials/public/decimal/yql_decimal.h>
-
-#include <util/string/vector.h>
-
-#include <library/cpp/digest/md5/md5.h>
 
 #include <expected>
 
@@ -145,87 +130,6 @@ namespace NKikimr::NGRpcProxy::V1 {
         }
 
         return TMsgPqCodes("", Ydb::PersQueue::ErrorCode::OK);
-    }
-
-    TString ProcessAlterConsumer(Ydb::Topic::Consumer& consumer, const Ydb::Topic::AlterConsumer& alter) {
-        if (alter.has_set_important()) {
-            consumer.set_important(alter.set_important());
-        }
-        if (alter.has_set_read_from()) {
-            consumer.mutable_read_from()->CopyFrom(alter.set_read_from());
-        }
-        if (alter.has_set_supported_codecs()) {
-            consumer.mutable_supported_codecs()->CopyFrom(alter.set_supported_codecs());
-        }
-        for (const auto& [attrName, attrValue] : alter.alter_attributes()) {
-            (*consumer.mutable_attributes())[attrName] = attrValue;
-        }
-        if (alter.has_set_availability_period()) {
-            consumer.mutable_availability_period()->CopyFrom(alter.set_availability_period());
-        }
-        if (alter.has_reset_availability_period()) {
-            consumer.clear_availability_period();
-        }
-
-        if (alter.has_alter_streaming_consumer_type()) {
-            if (!consumer.has_streaming_consumer_type()) {
-                return "Cannot alter consumer type";
-            }
-        } else if (alter.has_alter_shared_consumer_type()) {
-            if (!consumer.has_shared_consumer_type()) {
-                return "Cannot alter consumer type";
-            }
-
-            auto* type = consumer.mutable_shared_consumer_type();
-            auto& alterType = alter.alter_shared_consumer_type();
-
-            if (alterType.has_set_default_processing_timeout()) {
-                type->mutable_default_processing_timeout()->CopyFrom(alterType.set_default_processing_timeout());
-            }
-
-            if (alterType.has_set_receive_message_delay()) {
-                type->mutable_receive_message_delay()->CopyFrom(alterType.set_receive_message_delay());
-            }
-
-            if (alterType.has_set_receive_message_wait_time()) {
-                type->mutable_receive_message_wait_time()->CopyFrom(alterType.set_receive_message_wait_time());
-            }
-
-            if (alterType.has_alter_dead_letter_policy()) {
-                auto& alterPolicy = alterType.alter_dead_letter_policy();
-                auto* policy = type->mutable_dead_letter_policy();
-                if (alterPolicy.has_set_enabled()) {
-                    policy->set_enabled(alterPolicy.set_enabled());
-                }
-
-                if (alterPolicy.has_alter_condition()) {
-                    policy->mutable_condition()->set_max_processing_attempts(alterPolicy.alter_condition().set_max_processing_attempts());
-                }
-
-                if (alterPolicy.has_alter_move_action()) {
-                    if (!policy->has_move_action()) {
-                        return "Cannot alter move action";
-                    }
-                    if (alterPolicy.alter_move_action().has_set_dead_letter_queue()) {
-                        if (alterPolicy.alter_move_action().set_dead_letter_queue().empty()) {
-                            return "Dead letter queue cannot be empty";
-                        }
-                        policy->mutable_move_action()->set_dead_letter_queue(alterPolicy.alter_move_action().set_dead_letter_queue());
-                    }
-                } else if (alterPolicy.has_set_move_action()) {
-                    if (alterPolicy.set_move_action().dead_letter_queue().empty()) {
-                        return "Dead letter queue cannot be empty";
-                    }
-                    policy->clear_action();
-                    policy->mutable_move_action()->set_dead_letter_queue(alterPolicy.set_move_action().dead_letter_queue());
-                } else if (alterPolicy.has_set_delete_action()) {
-                    policy->clear_action();
-                    policy->mutable_delete_action();
-                }
-            }
-        }
-
-        return {};
     }
 
     TString RemoveReadRuleFromConfig(

--- a/ydb/services/lib/actors/pq_schema_actor.h
+++ b/ydb/services/lib/actors/pq_schema_actor.h
@@ -11,7 +11,6 @@
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 
@@ -23,20 +22,6 @@ struct TMsgPqCodes {
     TMsgPqCodes(TString const& message, Ydb::PersQueue::ErrorCode::ErrorCode pqCode)
     : Message(message), PQCode(pqCode) {}
 };
-
-struct TYdbPqCodes {
-    Ydb::StatusIds::StatusCode YdbCode;
-    Ydb::PersQueue::ErrorCode::ErrorCode PQCode;
-
-    TYdbPqCodes(Ydb::StatusIds::StatusCode YdbCode, Ydb::PersQueue::ErrorCode::ErrorCode PQCode)
-    : YdbCode(YdbCode),
-        PQCode(PQCode) {}
-};
-
-namespace Ydb::Topic {
-    class CreateTopicRequest;
-    class AlterTopicRequest;
-}
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -573,10 +558,6 @@ namespace NKikimr::NGRpcProxy::V1 {
             return path;
         }
 
-        const TMaybe<TString>& GetCdcStreamName() const {
-            return CdcStreamName;
-        }
-
         void SendDescribeProposeRequest(bool showPrivate = false) {
             return TBase::SendDescribeProposeRequest(this->ActorContext(), showPrivate);
         }
@@ -589,10 +570,6 @@ namespace NKikimr::NGRpcProxy::V1 {
 
             auto& item = ev->Get()->Request->ResultSet[0];
             PQGroupInfo = item.PQGroupInfo;
-            for (const auto& partition : PQGroupInfo->Description.GetPartitions()) {
-                TopicPartitionsIds.insert(partition.GetPartitionId());
-            }
-            Self = item.Self;
 
             return true;
         }
@@ -611,10 +588,9 @@ namespace NKikimr::NGRpcProxy::V1 {
         }
 
         void RespondWithCode(Ydb::StatusIds::StatusCode status, bool notFound = false) override {
-            if (!RespondOverride(status, notFound)) {
-                Response->Status = status;
-                this->ActorContext().Send(Requester, Response.Release());
-            }
+            Response->Status = status;
+            Y_UNUSED(notFound);
+            this->ActorContext().Send(Requester, Response.Release());
             this->Die(this->ActorContext());
             TBase::IsDead = true;
         }
@@ -624,21 +600,11 @@ namespace NKikimr::NGRpcProxy::V1 {
             return Request;
         }
 
-        virtual bool RespondOverride(Ydb::StatusIds::StatusCode status, bool notFound) {
-            Y_UNUSED(status);
-            Y_UNUSED(notFound);
-            return false;
-        }
-
         bool ProcessCdc(const NSchemeCache::TSchemeCacheNavigate::TEntry& response) override {
             if constexpr (THasCdcStreamCompatibility<TDerived>::Value) {
                 if (static_cast<TDerived*>(this)->IsCdcStreamCompatible()) {
                     Y_ABORT_UNLESS(response.ListNodeEntry->Children.size() == 1);
                     PrivateTopicName = response.ListNodeEntry->Children.at(0).Name;
-
-                    if (response.Self) {
-                        CdcStreamName = response.Self->Info.GetName();
-                    }
                     SendDescribeProposeRequest(true);
                     return true;
                 }
@@ -654,10 +620,7 @@ namespace NKikimr::NGRpcProxy::V1 {
     protected:
         THolder<TEvResponse> Response;
         TIntrusiveConstPtr<NSchemeCache::TSchemeCacheNavigate::TPQGroupInfo> PQGroupInfo;
-        TSet<i64> TopicPartitionsIds;
-        TIntrusiveConstPtr<NSchemeCache::TSchemeCacheNavigate::TDirEntryInfo> Self;
         TMaybe<TString> PrivateTopicName;
-        TMaybe<TString> CdcStreamName;
     };
 
 }

--- a/ydb/services/lib/actors/type_definitions.h
+++ b/ydb/services/lib/actors/type_definitions.h
@@ -6,7 +6,6 @@
 #include <ydb/library/actors/core/actor.h>
 
 #include <util/generic/hash.h>
-#include <util/generic/map.h>
 #include <util/generic/maybe.h>
 #include <util/generic/vector.h>
 
@@ -39,7 +38,6 @@ struct TTopicHolderBase {
 
     explicit TTopicHolderBase(const TTopicInitInfo& info) {
         TabletID = info.TabletID;
-        ACLRequestInfly = false;
         CloudId = info.CloudId;
         DbId = info.DbId;
         DbPath = info.DbPath;
@@ -52,7 +50,6 @@ struct TTopicHolderBase {
 
     ui64 TabletID = 0;
     TActorId PipeClient;
-    bool ACLRequestInfly = false;
     TString CloudId;
     TString DbId;
     TString DbPath;

--- a/ydb/services/lib/actors/ya.make
+++ b/ydb/services/lib/actors/ya.make
@@ -8,7 +8,6 @@ SRCS(
 PEERDIR(
     ydb/library/grpc/server
     library/cpp/json
-    library/cpp/digest/md5
     ydb/core/grpc_services
     ydb/core/grpc_services/base
     ydb/core/metering
@@ -16,11 +15,9 @@ PEERDIR(
     ydb/core/protos
     ydb/core/persqueue/public/schema
     ydb/core/util
-    ydb/public/sdk/cpp/src/library/persqueue/obfuscate
     ydb/library/persqueue/topic_parser
     ydb/public/api/grpc
     ydb/public/api/grpc/draft
-    ydb/public/sdk/cpp/src/library/jwt
     ydb/public/sdk/cpp/src/library/operation_id
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Dead-code cleanup in `ydb/services/lib/actors`. No behavior change.

Removed unused pieces:

- `ProcessAlterConsumer` in `pq_schema_actor.cpp` — an unused copy; the live implementation is `NPQ::NSchema::ProcessAlterConsumer`
- `TYdbPqCodes` and unused `Ydb::Topic` forward declarations
- Unused `TPQInternalSchemaActor` members: `GetCdcStreamName` / `CdcStreamName`, `TopicPartitionsIds`, `Self`, `RespondOverride`
- Unused `TTopicHolderBase::ACLRequestInfly`
- Unused includes and `PEERDIR` (`jwt`, `md5`, `obfuscate`, `ydb_topic.pb.h`, …)

`CdcStreamPath` is kept: `TReadInitAndAuthActor` still uses it for CDC stream describe.