### PR TITLE
Fix flaky TestSecondaryIndexFollowers stats check during rolling upgrade

### DIFF
--- a/ydb/tests/compatibility/common/test_followers.py
+++ b/ydb/tests/compatibility/common/test_followers.py
@@ -220,4 +220,4 @@ class TestSecondaryIndexFollowers(RollingUpgradeAndDowngradeFixture):
         for _ in self.roll():
             self.write_data()
             self.read_data()
-            self.check_statistics()
+        self.check_statistics()


### PR DESCRIPTION
## Summary
- `check_statistics()` ran after every rolling-upgrade step. After a node restart, DataShard counters reset and `partition_stats` can stay empty longer than the 50s poll, even though the index reads succeed.
- Keep write/read coverage on each roll step; assert stats once the cluster is stable.

Fixes #48643