### PR TITLE
Fix duplicate Accept header in OIDC proxy requests

### DIFF
--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -1647,6 +1647,47 @@ static void NavigationRequestTest(const TString& rawRequest, bool expectedNaviga
 }
 
 Y_UNIT_TEST_SUITE(Utils) {
+    Y_UNIT_TEST(CreateProxiedRequestForwardsSingleAcceptHeader) {
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest,
+            "GET /resource HTTP/1.1\r\n"
+            "Host: oidcproxy.net\r\n"
+            "Accept: multipart/form-data\r\n\r\n");
+
+        const TProxiedRequestParams params{
+            incomingRequest,
+            {},
+            false,
+            NMVP::TCrackedPage("http://" + ALLOWED_PROXY_HOST + "/resource"),
+            TOpenIdConnectSettings{},
+        };
+        const auto outgoingRequest = CreateProxiedRequest(params);
+        const NHttp::THeaders headers(outgoingRequest->Headers);
+
+        UNIT_ASSERT_VALUES_EQUAL(headers.Headers.count("Accept"), 1);
+        UNIT_ASSERT_STRINGS_EQUAL(headers.Get("Accept"), "multipart/form-data");
+    }
+
+    Y_UNIT_TEST(CreateProxiedRequestAddsSingleDefaultAcceptHeader) {
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest,
+            "GET /resource HTTP/1.1\r\n"
+            "Host: oidcproxy.net\r\n\r\n");
+
+        const TProxiedRequestParams params{
+            incomingRequest,
+            {},
+            false,
+            NMVP::TCrackedPage("http://" + ALLOWED_PROXY_HOST + "/resource"),
+            TOpenIdConnectSettings{},
+        };
+        const auto outgoingRequest = CreateProxiedRequest(params);
+        const NHttp::THeaders headers(outgoingRequest->Headers);
+
+        UNIT_ASSERT_VALUES_EQUAL(headers.Headers.count("Accept"), 1);
+        UNIT_ASSERT_STRINGS_EQUAL(headers.Get("Accept"), "*/*");
+    }
+
     Y_UNIT_TEST(OpenIdConnectStateRoundTrip) {
         TPortManager tp;
         auto settings = BuildBaseSettings(tp);

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -327,12 +327,15 @@ TString MakeXForwardedFor(const TProxiedRequestParams& params) {
 }
 
 NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams& params) {
-    auto outRequest = NHttp::THttpOutgoingRequest::CreateRequest(params.Request->Method, params.ProtectedPage.Url);
+    NHttp::THttpOutgoingRequestPtr outRequest = new NHttp::THttpOutgoingRequest(params.Request->Method, params.ProtectedPage.Url, "HTTP", "1.1");
     NHttp::THeaders headers(params.Request->Headers);
     for (const auto& header : params.Settings.REQUEST_HEADERS_WHITE_LIST) {
         if (headers.Has(header)) {
             outRequest->Set(header, headers.Get(header));
         }
+    }
+    if (!headers.Has("Accept")) {
+        outRequest->Set("Accept", "*/*");
     }
     outRequest->Set("Accept-Encoding", "deflate");
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The OIDC proxy produced two `Accept` headers when forwarding a request:

1. `THttpOutgoingRequest::CreateRequest()` added the default `Accept: */*` header.
2. The OIDC proxy copied the client-provided header, such as `Accept: multipart/form-data`.

The YDB Viewer read the first value, `*/*`, and rejected streaming query requests with:

> 400 Bad Request: Multipart request must accept multipart content-type

This affected requests to `/viewer/query` with `schema=multipart`, even though the browser sent the correct `Accept: multipart/form-data` header.

## Fix

Construct proxied requests without the implicit default `Accept` header.

The proxy now:

- forwards the client-provided `Accept` header as a single header;
- falls back to `Accept: */*` when the client does not provide one;
- preserves existing request forwarding behavior for other headers and request bodies.

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://nda.ya.ru/t/xDsHPvNP7pEnTJ
