### PR TITLE
Fix use-of-uninitialized-value and don't copy beyond buffer

### DIFF
--- a/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
+++ b/ydb/core/blobstorage/ddisk/persistent_buffer_barriers_manager.cpp
@@ -45,6 +45,14 @@ namespace NKikimr::NDDisk {
         return result;
     }
 
+    // Uncompact stops at a zero raw LSN / zero LEB128 delta, so unused CompactLsns
+    // bytes have to be zeros rather than leftover / uninitialized padding.
+    static void ZeroCompactLsnsTail(TPersistentBufferFastErases& header, size_t used) {
+        if (used < TPersistentBufferFastErases::ErasesBufferSize) {
+            memset(header.CompactLsns + used, 0, TPersistentBufferFastErases::ErasesBufferSize - used);
+        }
+    }
+
     void TPersistentBufferBarriersManager::Initialize(ui64 uniqueId, ui32 nodeId, ui32 pdiskId, ui32 slotId) {
         PersistentBufferUniqueId = uniqueId;
         NodeId = nodeId;
@@ -235,7 +243,9 @@ namespace NKikimr::NDDisk {
 
         if (cnt * sizeof(oldLsns[0]) <= TPersistentBufferFastErases::ErasesBufferSize) {
             oldLsns = MergeUnique(oldLsns, newLsns);
-            memcpy(header.CompactLsns, oldLsns.data(), oldLsns.size() * sizeof(oldLsns[0]));
+            const size_t used = oldLsns.size() * sizeof(oldLsns[0]);
+            memcpy(header.CompactLsns, oldLsns.data(), used);
+            ZeroCompactLsnsTail(header, used);
             return true;
         }
 
@@ -269,33 +279,36 @@ namespace NKikimr::NDDisk {
         }
         oldLsns = std::move(lsns);
         header.Header.Flags |= TPersistentBufferHeader::IS_ERASE_COMPACT;
+        ZeroCompactLsnsTail(header, resPos);
         return true;
     }
 
     std::vector<ui64> TPersistentBufferBarriersManager::Uncompact(const ui8* data, bool isCompact) {
         std::vector<ui64> res;
+        constexpr size_t lsnSize = sizeof(ui64);
         ui64 first = 0;
-        memcpy(&first, data, sizeof(res[0]));
+        memcpy(&first, data, lsnSize);
         if (first == 0) {
             return res;
         }
         res.push_back(first);
 
         if (!isCompact) {
-            size_t pos = sizeof(res[0]);
-            while (pos < TPersistentBufferFastErases::ErasesBufferSize) {
+            size_t pos = lsnSize;
+            // ErasesBufferSize is not a multiple of 8; never memcpy a ui64 past the buffer.
+            while (pos + lsnSize <= TPersistentBufferFastErases::ErasesBufferSize) {
                 ui64 v = 0;
-                memcpy(&v, data + pos, sizeof(res[0]));
+                memcpy(&v, data + pos, lsnSize);
                 if (v == 0) {
                     return res;
                 }
                 res.push_back(v);
-                pos += sizeof(res[0]);
+                pos += lsnSize;
             }
             return res;
         }
         ui64 prev = first;
-        size_t pos = sizeof(res[0]);
+        size_t pos = lsnSize;
         while (pos < TPersistentBufferFastErases::ErasesBufferSize) {
             ui64 delta = 0;
             int shift = 0;

--- a/ydb/core/blobstorage/ddisk/ut/persistent_buffer_barriers_manager_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/persistent_buffer_barriers_manager_ut.cpp
@@ -49,6 +49,53 @@ Y_UNIT_TEST_SUITE(TPersistentBufferBarriersManagerTest) {
         UNIT_ASSERT_C(
             !(header.Header.Flags & TPersistentBufferHeader::IS_ERASE_COMPACT),
             "IS_ERASE_COMPACT must not be set when data fits in raw storage");
+
+        auto recovered = mgr.Uncompact(header.CompactLsns, false);
+        UNIT_ASSERT_VALUES_EQUAL(recovered.size(), MaxRawLsns);
+        for (ui64 i = 1; i <= MaxRawLsns; i++) {
+            UNIT_ASSERT_VALUES_EQUAL(recovered[i - 1], i * 10);
+        }
+    }
+
+    Y_UNIT_TEST(CompactZerosUnusedTailSoUncompactStops) {
+        auto mgr = MakeManager();
+
+        // Fill CompactLsns with 0xFF so a missing terminator would be decoded as extra LSNs
+        // (and is the same class of bug MSAN reports as use-of-uninitialized-value on restore).
+        TPersistentBufferFastErases header;
+        memset(&header, 0xFF, sizeof(header));
+        header.Header.Flags = 0;
+
+        std::vector<ui64> oldLsns = {10, 20};
+        std::vector<ui64> newLsns = {30};
+        UNIT_ASSERT(mgr.Compact(oldLsns, newLsns, header));
+        UNIT_ASSERT(!(header.Header.Flags & TPersistentBufferHeader::IS_ERASE_COMPACT));
+
+        auto recovered = mgr.Uncompact(header.CompactLsns, false);
+        std::vector<ui64> expected = {10ULL, 20ULL, 30ULL};
+        UNIT_ASSERT_VALUES_EQUAL(recovered, expected);
+    }
+
+    Y_UNIT_TEST(CompactLeb128ZerosUnusedTailSoUncompactStops) {
+        auto mgr = MakeManager();
+
+        TPersistentBufferFastErases header;
+        memset(&header, 0xFF, sizeof(header));
+        header.Header.Flags = 0;
+
+        std::vector<ui64> oldLsns;
+        std::vector<ui64> newLsns;
+        for (ui64 i = 1; i <= 300; i++) oldLsns.push_back(i);
+        for (ui64 i = 301; i <= MaxRawLsns + 1; i++) newLsns.push_back(i);
+
+        UNIT_ASSERT(mgr.Compact(oldLsns, newLsns, header));
+        UNIT_ASSERT(header.Header.Flags & TPersistentBufferHeader::IS_ERASE_COMPACT);
+
+        auto recovered = mgr.Uncompact(header.CompactLsns, true);
+        UNIT_ASSERT_VALUES_EQUAL(recovered.size(), MaxRawLsns + 1);
+        for (ui64 i = 1; i <= MaxRawLsns + 1; i++) {
+            UNIT_ASSERT_VALUES_EQUAL(recovered[i - 1], i);
+        }
     }
 
     Y_UNIT_TEST(CompactSetsFlagWhenExceedsRaw) {


### PR DESCRIPTION
(cherry picked from commit f6ed3b103387f55f147b73901952f63729bf17d8)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
