### PR TITLE
[ICB] Track overrides independently of default values

### DIFF
--- a/ydb/core/control/immediate_control_board_actor.cpp
+++ b/ydb/core/control/immediate_control_board_actor.cpp
@@ -19,12 +19,15 @@ class TImmediateControlActor : public TActorBootstrapped<TImmediateControlActor>
         TString ParamName;
         TAtomicBase PrevValue;
         TAtomicBase NewValue;
+        // Operator action, including transitions that keep the same numeric value.
+        TString Action;
 
-        TLogRecord(TInstant timestamp, TString paramName, TAtomicBase prevValue, TAtomicBase newValue)
+        TLogRecord(TInstant timestamp, TString paramName, TAtomicBase prevValue, TAtomicBase newValue, TString action)
             : Timestamp(timestamp)
             , ParamName(paramName)
             , PrevValue(prevValue)
             , NewValue(newValue)
+            , Action(action)
         {}
 
         TString TimestampToStr() {
@@ -71,32 +74,57 @@ public:
     }
 
 private:
+    // Record numeric changes and override transitions from the same mutation.
+    void RecordChange(const TString& name, const TControlMutation& mutation) {
+        if (mutation.Before.Value == mutation.After.Value &&
+                mutation.Before.Overridden == mutation.After.Overridden)
+        {
+            return;
+        }
+        HistoryLog.emplace_back(
+            TInstant::Now(),
+            name,
+            mutation.Before.Value,
+            mutation.After.Value,
+            mutation.After.Overridden ? "Set override" : "Restore default");
+    }
+
     void HandlePostParams(const TCgiParameters &cgi) {
+        if (cgi.Has("restoreDefault")) {
+            const TString& controlName = cgi.Get("restoreDefault");
+            TControlMutation mutation;
+            bool controlExists = false;
+            if (auto control = Icb->GetControlByName(controlName)) {
+                mutation = control->RestoreDefault();
+                controlExists = true;
+            } else {
+                controlExists = Dcb->RestoreDefault(controlName, mutation);
+            }
+            if (controlExists) {
+                RecordChange(controlName, mutation);
+            }
+            return;
+        }
         if (cgi.Has("restoreDefaults")) {
             Icb->RestoreDefaults();
             Dcb->RestoreDefaults();
-            HistoryLog.emplace_back(TInstant::Now(), "RestoreDefaults", 0, 0);
-            *HasChanged = 0;
-            *ChangedCount = 0;
+            HistoryLog.emplace_back(TInstant::Now(), "RestoreDefaults", 0, 0, "Restore defaults");
         }
         for (const auto& [paramName, paramValue] : cgi) {
-            TAtomicBase newValue = strtoull(paramValue.data(), nullptr, 10);
-            TAtomicBase prevValue = newValue;
-            bool isDefault = false;
-            if (auto control = Icb->GetControlByName(paramName)) {
-                prevValue = control->SetFromHtmlRequest(newValue);
-                isDefault = control->IsDefault();
-            } else {
-                isDefault = Dcb->SetValue(paramName, newValue, prevValue);
+            if (paramName == "restoreDefaults") {
+                continue;
             }
-            if (prevValue != newValue) {
-                HistoryLog.emplace_back(TInstant::Now(), paramName, prevValue, newValue);
-                if (isDefault) {
-                    ChangedCount->Dec();
-                } else {
-                    ChangedCount->Inc();
-                }
-                *HasChanged = (ui64)ChangedCount->Val() > 0;
+            TControlMutation mutation;
+            bool controlExists = false;
+            const TAtomicBase newValue = strtoull(paramValue.data(), nullptr, 10);
+            if (auto control = Icb->GetControlByName(paramName)) {
+                mutation = control->SetFromHtmlRequestWithState(newValue);
+                controlExists = true;
+            } else {
+                controlExists = Dcb->SetValue(paramName, newValue, mutation);
+            }
+            if (controlExists) {
+                RecordChange(paramName, mutation);
             }
         }
     }
@@ -114,6 +142,10 @@ private:
         renderer.AddNewTable("Dynamic Controls");
         Dcb->RenderAsHtml(renderer);
 
+        const ui64 count = renderer.GetOverriddenCount();
+        *ChangedCount = count;
+        *HasChanged = count > 0;
+
         str << renderer.GetHtml();
         HTML(str) {
             str << "<h3>History</h3>";
@@ -124,6 +156,7 @@ private:
                         TABLEH() {str << "Parameter"; }
                         TABLEH() {str << "PrevValue"; }
                         TABLEH() {str << "NewValue"; }
+                        TABLEH() {str << "Action"; }
                     }
                 }
                 TABLEBODY() {
@@ -133,6 +166,7 @@ private:
                             TABLED() { str << record.ParamName; }
                             TABLED() { str << record.PrevValue; }
                             TABLED() { str << record.NewValue; }
+                            TABLED() { str << record.Action; }
                         }
                     }
                 }

--- a/ydb/core/control/immediate_control_board_actor_ut.cpp
+++ b/ydb/core/control/immediate_control_board_actor_ut.cpp
@@ -305,16 +305,61 @@ class TTestHttpGetResponse : public TBaseTest {
         VERBOSE_COUT("Test step " << TestStep);
         switch (TestStep) {
             case 0:
+                // Request the ICB page through the monitoring HTTP event.
                 VERBOSE_COUT("Sending TEvHttpInfo");
                 ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
                 break;
             case 10:
+            {
+                // Verify that the actor returned an HTTP response with
+                // non-empty page content.
                 ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
                         "Unexpected response message type, expected HttpInfoRes");
                 ASSERT_YTHROW(LastResponse.HttpResult->Answer.size() > 0, "Html page cannot have zero size");
-                VERBOSE_COUT("Done");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 20:
+            {
+                // Install an equal-to-default override outside the HTTP actor
+                // and request rendering of the updated board state.
+                TControlWrapper control(10, 0, 20);
+                control.SetOverride(10);
+                Dcb->RegisterSharedControl(control, "externalOverride");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            }
+            case 30:
+            {
+                // Verify that GET discovers the external override while rendering.
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(counters->GetCounter("Icb/ChangedControlsCount")->Val() == 1,
+                        "GET did not count an external equal-to-default override");
+                ASSERT_YTHROW(counters->GetCounter("Icb/HasChangedContol")->Val() == 1,
+                        "GET did not report an external override");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 40:
+            {
+                // Clear the override outside the HTTP actor and request
+                // rendering of the updated board state.
+                Dcb->RestoreDefault("externalOverride");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            }
+            case 50:
+            {
+                // Verify that GET discovers the external reset and clears both
+                // override gauges.
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(counters->GetCounter("Icb/ChangedControlsCount")->Val() == 0,
+                        "GET did not reflect an external reset");
+                ASSERT_YTHROW(counters->GetCounter("Icb/HasChangedContol")->Val() == 0,
+                        "GET did not clear the external override indicator");
                 SignalDoneEvent();
                 break;
+            }
             default:
                 ythrow TWithBackTrace<yexception>() << "Unexpected TestStep " << TestStep << Endl;
                 break;
@@ -330,6 +375,8 @@ public:
 };
 
 class TTestHttpPostReaction : public TBaseTest {
+    // Shared control used by explicit-override scenarios.
+    TControlWrapper Control{10};
     TAutoPtr<THttpRequest> HttpRequest;
     NMonitoring::TMonService2HttpRequest MonService2HttpRequest;
 
@@ -338,21 +385,31 @@ class TTestHttpPostReaction : public TBaseTest {
         VERBOSE_COUT("Test step " << TestStep);
         switch (TestStep) {
             case 0:
+                // Submit an unknown parameter.
                 VERBOSE_COUT("Testing POST request with an unexistentParameter");
                 HttpRequest->CgiParameters.emplace("unexistentParameter", "10");
                 ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
                 break;
             case 10:
             {
+                // Verify that POST did not create the unknown parameter.
                 ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
                         "Unexpected response message type, expected is HttpInfoRes");
                 bool isControlExists;
                 TAtomicBase value;
                 Dcb->GetValue("unexistentParameter", value, isControlExists);
                 ASSERT_YTHROW(!isControlExists, "Parameter mustn't be created by POST request");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 20:
+            {
+                // Register a dynamic control and submit a value for it.
                 VERBOSE_COUT("Testing POST request with an existentParameter");
                 TControlWrapper control(10);
                 Dcb->RegisterSharedControl(control, "existentParameter");
+                bool isControlExists;
+                TAtomicBase value;
                 Dcb->GetValue("existentParameter", value, isControlExists);
                 ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
                 ASSERT_YTHROW(value == 10, "Error in control creation and registration");
@@ -361,8 +418,9 @@ class TTestHttpPostReaction : public TBaseTest {
                 ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
                 break;
             }
-            case 20:
+            case 30:
             {
+                // Verify that POST changed the registered control.
                 ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
                         "Unexpected response message type, expected is HttpInfoRes");
                 bool isControlExists;
@@ -370,14 +428,21 @@ class TTestHttpPostReaction : public TBaseTest {
                 Dcb->GetValue("existentParameter", value, isControlExists);
                 ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
                 ASSERT_YTHROW(value == 15, "Parameter haven't changed by POST request");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 40:
+            {
+                // Submit the bulk restore command.
                 VERBOSE_COUT("Test of restoreDefaults POST request");
                 HttpRequest->CgiParameters.clear();
                 HttpRequest->CgiParameters.emplace("restoreDefaults", "");
                 ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
                 break;
             }
-            case 30:
+            case 50:
             {
+                // Verify that bulk restore returned the control to its default.
                 ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
                         "Unexpected response message type, expected is HttpInfoRes");
                 bool isControlExists;
@@ -385,11 +450,19 @@ class TTestHttpPostReaction : public TBaseTest {
                 Dcb->GetValue("existentParameter", value, isControlExists);
                 ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
                 ASSERT_YTHROW(value == 10,  "Parameter haven't restored default value");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 60:
+            {
+                // Submit values outside the bounds of two dynamic controls.
                 VERBOSE_COUT("Test is bounds pulling wokrs");
                 TControlWrapper control1(10, 5, 15);
                 TControlWrapper control2(10, 5, 15);
                 Dcb->RegisterSharedControl(control1, "existentParameterWithBoundsLower");
                 Dcb->RegisterSharedControl(control2, "existentParameterWithBoundsUpper");
+                bool isControlExists;
+                TAtomicBase value;
                 Dcb->GetValue("existentParameterWithBoundsLower", value, isControlExists);
                 ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
                 ASSERT_YTHROW(value == 10, "Error in control creation and registration");
@@ -402,8 +475,9 @@ class TTestHttpPostReaction : public TBaseTest {
                 ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
                 break;
             }
-            case 40:
+            case 70:
             {
+                // Verify that both submitted values were clamped to their bounds.
                 ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
                         "Unexpected response message type, expected is HttpInfoRes");
                 bool isControlExists;
@@ -416,11 +490,215 @@ class TTestHttpPostReaction : public TBaseTest {
                 Dcb->GetValue("existentParameterWithBoundsUpper", value, isControlExists);
                 ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
                 ASSERT_YTHROW(value == 15, "Pulling value to bounds doesn't work");
-
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 80:
+                // Clear state left by the bounds checks before testing explicit
+                // override actions.
+                Dcb->RestoreDefaults();
+                TestStep += 10;
+                [[fallthrough]];
+            case 90:
+            {
+                // Submit the default value to create an explicit override.
+                Dcb->RegisterSharedControl(Control, "overrideParameter");
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("overrideParameter", "10");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            }
+            case 100:
+            {
+                // Verify that a flag-only assignment created and counted an override.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                bool isControlExists;
+                TAtomicBase value;
+                Dcb->GetValue("overrideParameter", value, isControlExists);
+                ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
+                ASSERT_YTHROW(value == 10, "Default value changed after POST request");
+                const auto override = Control.GetOverride();
+                ASSERT_YTHROW(override && *override == 10, "Explicit override was not recorded");
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(
+                    counters->GetCounter("Icb/ChangedControlsCount")->Val() == 1,
+                    "A flag-only assignment was not counted");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 110:
+                // Restore the equal-to-default override for one control.
+                VERBOSE_COUT("Testing a flag-only restore");
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("restoreDefault", "overrideParameter");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            case 120:
+            {
+                // Verify the flag-only restore, counters, and history action labels.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                bool isControlExists;
+                TAtomicBase value;
+                Dcb->GetValue("overrideParameter", value, isControlExists);
+                ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
+                ASSERT_YTHROW(value == 10, "Restore changed an equal-to-default value");
+                ASSERT_YTHROW(!Control.GetOverride(), "Restore did not clear the override");
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(
+                    counters->GetCounter("Icb/ChangedControlsCount")->Val() == 0,
+                    "Unexpected counter after a flag-only restore");
+                const TString& answer = LastResponse.HttpResult->Answer;
+                const size_t historyPos = answer.find("<h3>History</h3>");
+                ASSERT_YTHROW(historyPos != TString::npos, "History section is missing");
+                ui32 historyRecords = 0;
+                size_t recordPos = historyPos;
+                while ((recordPos = answer.find("overrideParameter", recordPos)) != TString::npos) {
+                    ++historyRecords;
+                    ++recordPos;
+                }
+                ASSERT_YTHROW(historyRecords == 2, "Flag-only restore was not added to history");
+                ASSERT_YTHROW(answer.find("<td>Set override</td>", historyPos) != TString::npos,
+                        "History does not identify override assignment");
+                ASSERT_YTHROW(answer.find("<td>Restore default</td>", historyPos) != TString::npos,
+                        "History does not identify default restoration");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 130:
+                // Submit a non-default override before updating an active override.
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("overrideParameter", "15");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            case 140:
+            {
+                // Verify the initial active override and its counter.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                const auto override = Control.GetOverride();
+                ASSERT_YTHROW(override && *override == 15, "Explicit override was not set");
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(
+                    counters->GetCounter("Icb/ChangedControlsCount")->Val() == 1,
+                    "Override was not counted before update");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 150:
+                // Submit a different value for the active override.
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("overrideParameter", "16");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            case 160:
+            {
+                // Verify that the override changed without increasing its count.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                bool isControlExists;
+                TAtomicBase value;
+                Dcb->GetValue("overrideParameter", value, isControlExists);
+                ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
+                ASSERT_YTHROW(value == 16, "Parameter hasn't changed by POST request");
+                const auto override = Control.GetOverride();
+                ASSERT_YTHROW(override && *override == 16, "Active override was not updated");
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(
+                    counters->GetCounter("Icb/ChangedControlsCount")->Val() == 1,
+                    "Updating an active override changed the active-control count");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 170:
+                // Restore a non-default override for one control.
+                VERBOSE_COUT("Testing the per-control restore action");
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("restoreDefault", "overrideParameter");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            case 180:
+            {
+                // Verify that per-control restore recovered the numeric default.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                bool isControlExists;
+                TAtomicBase value;
+                Dcb->GetValue("overrideParameter", value, isControlExists);
+                ASSERT_YTHROW(isControlExists, "Error in control creation and registration");
+                ASSERT_YTHROW(value == 10, "Per-control restore hasn't restored the default value");
+                ASSERT_YTHROW(!Control.GetOverride(), "Per-control restore did not clear the override");
+                auto counters = GetServiceCounters(Counters, "utils");
+                ASSERT_YTHROW(
+                    counters->GetCounter("Icb/ChangedControlsCount")->Val() == 0,
+                    "Restore did not clear the active-control count");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 190:
+            {
+                // Submit a change for a name present in both control boards.
+                TControlWrapper staticControl(10, 0, 20);
+                TControlBoard::RegisterLocalControl(staticControl, Icb->DataShardControls.MaxTxInFly);
+                Control.SetOverride(15);
+                Dcb->RegisterSharedControl(Control, "DataShardControls.MaxTxInFly");
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("DataShardControls.MaxTxInFly", "12");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            }
+            case 200:
+            {
+                // Verify that change selected the static control first.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                const auto control = Icb->DataShardControls.MaxTxInFly.AtomicLoad();
+                ASSERT_YTHROW(control->GetOverride() && *control->GetOverride() == 12,
+                        "Change did not select the static control first");
+                ASSERT_YTHROW(Control.GetOverride() && *Control.GetOverride() == 15,
+                        "Change modified the dynamic control with the same name");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 210:
+                // Restore a name present in both control boards.
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace(
+                    "restoreDefault",
+                    "DataShardControls.MaxTxInFly");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            case 220:
+            {
+                // Verify that restore selected the static control first.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                ASSERT_YTHROW(!Icb->DataShardControls.MaxTxInFly.AtomicLoad()->GetOverride(),
+                        "Restore did not select the static control first");
+                ASSERT_YTHROW(Control.GetOverride() && *Control.GetOverride() == 15,
+                        "Restore modified the dynamic control with the same name");
+                TestStep += 10;
+                [[fallthrough]];
+            }
+            case 230:
+                // Restore an unknown control name.
+                HttpRequest->CgiParameters.clear();
+                HttpRequest->CgiParameters.emplace("restoreDefault", "unknown");
+                ctx.Send(IcbActor, new NMon::TEvHttpInfo(MonService2HttpRequest));
+                break;
+            case 240:
+                // Verify that an unknown restore did not modify another control.
+                ASSERT_YTHROW(LastResponse.HttpResult && LastResponse.HttpResult->Type() == NActors::NMon::HttpInfoRes,
+                        "Unexpected response message type, expected is HttpInfoRes");
+                ASSERT_YTHROW(Control.GetOverride() && *Control.GetOverride() == 15,
+                        "Restore of an unknown name modified another control");
+                TestStep += 10;
+                [[fallthrough]];
+            case 250:
                 VERBOSE_COUT("Done");
                 SignalDoneEvent();
                 break;
-            }
             default:
                 ythrow TWithBackTrace<yexception>() << "Unexpected TestStep " << TestStep << Endl;
                 break;

--- a/ydb/core/control/lib/base/immediate_control_board_control.cpp
+++ b/ydb/core/control/lib/base/immediate_control_board_control.cpp
@@ -1,5 +1,6 @@
 #include "immediate_control_board_control.h"
 #include <util/stream/str.h>
+#include <util/system/guard.h>
 
 namespace NKikimr {
 
@@ -8,30 +9,71 @@ TControl::TControl(TAtomicBase defaultValue, TAtomicBase lowerBound, TAtomicBase
       , Default(defaultValue)
       , LowerBound(lowerBound)
       , UpperBound(upperBound)
+      , Overridden(0)
+      , Sequence(0)
 {}
 
 void TControl::Set(TAtomicBase newValue) {
+    TGuard<TAdaptiveLock> guard(StateLock);
+    AtomicIncrement(Sequence);
     AtomicSet(Value, newValue);
     AtomicSet(Default, newValue);
+    AtomicSet(Overridden, 0);
+    AtomicIncrement(Sequence);
 }
 
 void TControl::Reset(TAtomicBase defaultValue, TAtomicBase lowerBound, TAtomicBase upperBound) {
+    TGuard<TAdaptiveLock> guard(StateLock);
+    AtomicIncrement(Sequence);
     AtomicSet(Value, defaultValue);
-    Default = defaultValue;
+    AtomicSet(Default, defaultValue);
+    AtomicSet(Overridden, 0);
     LowerBound = lowerBound;
     UpperBound = upperBound;
+    AtomicIncrement(Sequence);
+}
+
+void TControl::UpdateDefault(TAtomicBase newDefault) {
+    TGuard<TAdaptiveLock> guard(StateLock);
+    AtomicIncrement(Sequence);
+    const bool overridden = AtomicGet(Overridden);
+    AtomicSet(Default, newDefault);
+    if (!overridden) {
+        AtomicSet(Value, newDefault);
+    }
+    AtomicIncrement(Sequence);
+}
+
+TControlMutation TControl::SetOverride(TAtomicBase newValue) {
+    TGuard<TAdaptiveLock> guard(StateLock);
+    AtomicIncrement(Sequence);
+    const TControlState before = GetStateUnsafe();
+    newValue = Max(newValue, LowerBound);
+    newValue = Min(newValue, UpperBound);
+    AtomicSet(Value, newValue);
+    AtomicSet(Overridden, 1);
+    const TControlState after = GetStateUnsafe();
+    AtomicIncrement(Sequence);
+    return {before, after};
+}
+
+TControlMutation TControl::SetFromHtmlRequestWithState(TAtomicBase newValue) {
+    TGuard<TAdaptiveLock> guard(StateLock);
+    AtomicIncrement(Sequence);
+    const TControlState before = GetStateUnsafe();
+    if (newValue != before.Default) {
+        newValue = Max(newValue, LowerBound);
+        newValue = Min(newValue, UpperBound);
+    }
+    AtomicSet(Value, newValue);
+    AtomicSet(Overridden, 1);
+    const TControlState after = GetStateUnsafe();
+    AtomicIncrement(Sequence);
+    return {before, after};
 }
 
 TAtomicBase TControl::SetFromHtmlRequest(TAtomicBase newValue) {
-    TAtomicBase prevValue = AtomicGet(Value);
-    if (newValue == AtomicGet(Default)) {
-        AtomicSet(Value, newValue);
-    } else {
-        newValue = Max(newValue, LowerBound);
-        newValue = Min(newValue, UpperBound);
-        AtomicSet(Value, newValue);
-    }
-    return prevValue;
+    return SetFromHtmlRequestWithState(newValue).Before.Value;
 }
 
 TAtomicBase TControl::Get() const {
@@ -42,18 +84,60 @@ TAtomicBase TControl::GetDefault() const {
     return AtomicGet(Default);
 }
 
-void TControl::RestoreDefault() {
-    AtomicSet(Value, Default);
+// Return a coherent control snapshot, using Sequence to validate one
+// optimistic sample before falling back to StateLock.
+TControlState TControl::GetState() const {
+    // Accept the sample only if no writer was active or completed during it.
+    const TAtomicBase sequence = AtomicGet(Sequence);
+    if (!(sequence & 1)) {
+        const TControlState state = GetStateUnsafe();
+        if (sequence == AtomicGet(Sequence)) {
+            return state;
+        }
+    }
+
+    // Serialize with a writer after an overlapping mutation.
+    TGuard<TAdaptiveLock> guard(StateLock);
+    return GetStateUnsafe();
+}
+
+// Return the active override from a coherent complete state snapshot.
+std::optional<TAtomicBase> TControl::GetOverride() const {
+    const TControlState state = GetState();
+    return state.Overridden
+        ? std::optional<TAtomicBase>(state.Value)
+        : std::nullopt;
+}
+
+TControlMutation TControl::RestoreDefault() {
+    TGuard<TAdaptiveLock> guard(StateLock);
+    AtomicIncrement(Sequence);
+    const TControlState before = GetStateUnsafe();
+    AtomicSet(Value, before.Default);
+    AtomicSet(Overridden, 0);
+    const TControlState after = GetStateUnsafe();
+    AtomicIncrement(Sequence);
+    return {before, after};
 }
 
 bool TControl::IsDefault() const {
-    return AtomicGet(Value) == AtomicGet(Default);
+    return !AtomicGet(Overridden);
 }
 
 TString TControl::RangeAsString() const {
     TStringStream str;
     str << "[" << LowerBound << ", " << UpperBound << "]";
     return str.Str();
+}
+
+// Read one unvalidated state sample; callers must hold StateLock or verify
+// that Sequence stayed even and unchanged.
+TControlState TControl::GetStateUnsafe() const {
+    return {
+        AtomicGet(Value),
+        AtomicGet(Default),
+        static_cast<bool>(AtomicGet(Overridden)),
+    };
 }
 
 }

--- a/ydb/core/control/lib/base/immediate_control_board_control.h
+++ b/ydb/core/control/lib/base/immediate_control_board_control.h
@@ -2,14 +2,58 @@
 
 #include <util/generic/ptr.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
+#include <util/system/spinlock.h>
+
+#include <optional>
 
 namespace NKikimr {
 
+// Coherent value, default, and override-presence snapshot of an ICB control.
+struct TControlState {
+    // Effective value returned by the control at the snapshot point.
+    TAtomicBase Value;
+
+    // Registry default used when no explicit override is active.
+    TAtomicBase Default;
+
+    // Override state distinguishing an explicit value from the registry default.
+    bool Overridden;
+};
+
+// State transition produced by one serialized control mutation.
+struct TControlMutation {
+    // Control state immediately before the mutation.
+    TControlState Before;
+
+    // Control state immediately after the mutation.
+    TControlState After;
+};
+
+// Immediate control with a fast effective-value read and coherent state snapshots.
 class TControl : public TThrRefBase {
+    // Effective value returned by the numeric Get() API.
     TAtomic Value;
+
+    // Registry default used when no explicit override is active.
     TAtomic Default;
+
+    // Inclusive lower bound used for explicit overrides.
     TAtomicBase LowerBound;
+
+    // Inclusive upper bound used for explicit overrides.
     TAtomicBase UpperBound;
+
+    // Override presence stored as zero or one.
+    TAtomic Overridden;
+
+    // Serialization for mutations and complete state snapshots.
+    mutable TAdaptiveLock StateLock;
+
+    // State version: odd during a mutation and even after publication.
+    TAtomic Sequence;
+
+    // Read the atomic fields without validating cross-field coherence.
+    TControlState GetStateUnsafe() const;
 
 public:
     TControl(TAtomicBase defaultValue, TAtomicBase lowerBound, TAtomicBase upperBound);
@@ -17,13 +61,29 @@ public:
     void Set(TAtomicBase newValue);
     void Reset(TAtomicBase defaultValue, TAtomicBase lowerBound, TAtomicBase upperBound);
 
+    // Update the registry default without replacing an active override.
+    void UpdateDefault(TAtomicBase newDefault);
+
+    // Set a bounded override, even when equal to the default, and return its transition.
+    TControlMutation SetOverride(TAtomicBase newValue);
+
+    // Set an HTML override; accept the current default outside bounds and return the transition.
+    TControlMutation SetFromHtmlRequestWithState(TAtomicBase newValue);
+
     TAtomicBase SetFromHtmlRequest(TAtomicBase newValue);
 
     TAtomicBase Get() const;
 
     TAtomicBase GetDefault() const;
 
-    void RestoreDefault();
+    // Return one coherent snapshot of the complete control state.
+    TControlState GetState() const;
+
+    // Return the explicit override or an empty value when the default is active.
+    std::optional<TAtomicBase> GetOverride() const;
+
+    // Restore the current default, clear the override, and return the transition.
+    TControlMutation RestoreDefault();
 
     bool IsDefault() const;
 

--- a/ydb/core/control/lib/dynamic_control_board_impl.cpp
+++ b/ydb/core/control/lib/dynamic_control_board_impl.cpp
@@ -38,19 +38,35 @@ void TDynamicControlBoard::RestoreDefaults() {
 }
 
 void TDynamicControlBoard::RestoreDefault(TString name) {
+    TControlMutation mutation;
+    RestoreDefault(std::move(name), mutation);
+}
+
+bool TDynamicControlBoard::RestoreDefault(TString name, TControlMutation& outMutation) {
     TIntrusivePtr<TControl> control;
     if (Board.Get(name, control)) {
-        control->RestoreDefault();
+        outMutation = control->RestoreDefault();
+        return true;
     }
+    return false;
 }
 
 bool TDynamicControlBoard::SetValue(TString name, TAtomic value, TAtomic &outPrevValue) {
-    TIntrusivePtr<TControl> control;
-    if (Board.Get(name, control)) {
-        outPrevValue = control->SetFromHtmlRequest(value);
-        return control->IsDefault();
+    TControlMutation mutation;
+    if (SetValue(std::move(name), value, mutation)) {
+        outPrevValue = mutation.Before.Value;
+        return !mutation.After.Overridden;
     }
     return true;
+}
+
+bool TDynamicControlBoard::SetValue(TString name, TAtomic value, TControlMutation& outMutation) {
+    TIntrusivePtr<TControl> control;
+    if (Board.Get(name, control)) {
+        outMutation = control->SetFromHtmlRequestWithState(value);
+        return true;
+    }
+    return false;
 }
 
 // Only for tests

--- a/ydb/core/control/lib/dynamic_control_board_impl.h
+++ b/ydb/core/control/lib/dynamic_control_board_impl.h
@@ -20,7 +20,13 @@ public:
 
     void RestoreDefault(TString name);
 
+    // Restore the default; return false for an unknown name without changing output.
+    bool RestoreDefault(TString name, TControlMutation& outMutation);
+
     bool SetValue(TString name, TAtomic value, TAtomic &outPrevValue);
+
+    // Apply an HTML-style value; return false for an unknown name without changing output.
+    bool SetValue(TString name, TAtomic value, TControlMutation& outMutation);
 
     // Only for tests
     void GetValue(TString name, TAtomic &outValue, bool &outIsControlExists) const;

--- a/ydb/core/control/lib/immediate_control_board_html_renderer.cpp
+++ b/ydb/core/control/lib/immediate_control_board_html_renderer.cpp
@@ -33,32 +33,42 @@ void TControlBoardTableHtmlRenderer::AddNewTable(const TString& caption) {
 
 void TControlBoardTableHtmlRenderer::AddTableItem(const TString& name, TIntrusivePtr<TControl> control) {
     Y_ENSURE(!!TableBody);
+    const TControlState state = control->GetState();
+    OverriddenCount += state.Overridden;
     auto& __stream = *Html;
     TABLER() {
         TABLED() { HtmlStrm << name; }
         TABLED() { HtmlStrm << control->RangeAsString(); }
         TABLED() {
-            if (control->IsDefault()) {
-                HtmlStrm << "<p>" << control->Get() << "</p>";
+            if (!state.Overridden) {
+                HtmlStrm << "<p>" << state.Value << "</p>";
             } else {
-                HtmlStrm << "<p style='color:red;'><b>" << control->Get() << " </b></p>";
+                HtmlStrm << "<p style='color:red;'><b>" << state.Value << "</b>";
+                if (state.Value == state.Default) {
+                    HtmlStrm << "<br/><span>(overridden)</span>";
+                }
+                HtmlStrm << "</p>";
             }
         }
         TABLED() {
-            if (control->IsDefault()) {
-                HtmlStrm << "<p>" << control->GetDefault() << "</p>";
+            if (!state.Overridden) {
+                HtmlStrm << "<p>" << state.Default << "</p>";
             } else {
-                HtmlStrm << "<p style='color:red;'><b>" << control->GetDefault() << " </b></p>";
+                HtmlStrm << "<p style='color:red;'><b>" << state.Default << " </b></p>";
             }
         }
         TABLED() {
-            HtmlStrm << "<form class='form_horizontal' method='post'>";
-            HtmlStrm << "<input name='" << name << "' type='text' value='"
-                << control->Get() << "'/>";
-            HtmlStrm  << "<button type='submit' style='color:red;'><b>Change</b></button>";
-            HtmlStrm  << "</form>";
+            HtmlStrm << "<form class='form_horizontal' method='post' style='margin:0;'>";
+            HtmlStrm << "<input name='" << name << "' type='text' value='" << state.Value << "'/>";
+            HtmlStrm << "<button type='submit' style='color:red;'>" << "<b>Change</b></button>";
+            if (state.Overridden) {
+                HtmlStrm << "<button type='submit' name='restoreDefault' value='" << name << "'"
+                    << " style='color:green; margin-left:4px; white-space:nowrap;'>"
+                    << "<b>Restore Default</b></button>";
+            }
+            HtmlStrm << "</form>";
         }
-        TABLED() { HtmlStrm << !control->IsDefault(); }
+        TABLED() { HtmlStrm << state.Overridden; }
     }
 }
 
@@ -66,10 +76,14 @@ TString TControlBoardTableHtmlRenderer::GetHtml() {
     TableBody.Clear();
     Table.Clear();
     HtmlStrm << "<form class='form_horizontal' method='post'>";
-    HtmlStrm << "<button type='submit' name='restoreDefaults' style='color:green;'><b>Restore Default</b></button>";
+    HtmlStrm << "<button type='submit' name='restoreDefaults' style='color:green;'><b>Restore Defaults</b></button>";
     HtmlStrm << "</form>";
     Html.Clear();
     return HtmlStrm.Str();
+}
+
+ui64 TControlBoardTableHtmlRenderer::GetOverriddenCount() const {
+    return OverriddenCount;
 }
 
 } // NKikimr

--- a/ydb/core/control/lib/immediate_control_board_html_renderer.h
+++ b/ydb/core/control/lib/immediate_control_board_html_renderer.h
@@ -15,11 +15,17 @@ private:
     TMaybe<NMonitoring::TOutputStreamRef> Html;
     TMaybe<NMonitoring::TTable> Table;
     TMaybe<NMonitoring::TTableBody> TableBody;
+
+    // Controls with an active override in the snapshots rendered across all tables.
+    ui64 OverriddenCount = 0;
 public:
     TControlBoardTableHtmlRenderer();
     void AddNewTable(const TString& caption);
     void AddTableItem(const TString& name, TIntrusivePtr<TControl> control);
     TString GetHtml();
+
+    // Return the number of rendered controls with an active override.
+    ui64 GetOverriddenCount() const;
 };
 
 }

--- a/ydb/core/control/lib/immediate_control_board_ut.cpp
+++ b/ydb/core/control/lib/immediate_control_board_ut.cpp
@@ -1,6 +1,9 @@
 #include "immediate_control_board_impl.h"
 #include "immediate_control_board_wrapper.h"
 #include "dynamic_control_board_impl.h"
+#include "immediate_control_board_html_renderer.h"
+
+#include <ydb/core/protos/config.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/random/mersenne64.h>
@@ -8,6 +11,9 @@
 #include <util/string/printf.h>
 #include <util/system/thread.h>
 #include <array>
+#include <atomic>
+#include <barrier>
+#include <thread>
 
 namespace NKikimr {
 
@@ -57,6 +63,338 @@ Y_UNIT_TEST_SUITE(ControlImplementationTests) {
             UNIT_ASSERT_EQUAL(control->Get(), defaultValue);
             UNIT_ASSERT_EQUAL(control->GetDefault(), defaultValue);
         }
+    }
+
+    // Verify override-presence transitions across equal values, default
+    // updates, bounds clamping, repeated assignments, and restoration.
+    Y_UNIT_TEST(TestExplicitOverrideLifecycle) {
+        constexpr i64 defaultValue = 10;
+        TIntrusivePtr<TControl> control(new TControl(defaultValue, 0, 20));
+
+        // Assign the current default through HTML and verify that the
+        // assignment creates an override without changing the numeric value.
+        UNIT_ASSERT(control->IsDefault());
+        UNIT_ASSERT_VALUES_EQUAL(control->SetFromHtmlRequest(defaultValue), defaultValue);
+        UNIT_ASSERT(!control->IsDefault());
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), defaultValue);
+        control->RestoreDefault();
+
+        // Set a non-default value and inspect both sides of the mutation.
+        const TControlMutation overridden = control->SetFromHtmlRequestWithState(15);
+        UNIT_ASSERT(!overridden.Before.Overridden);
+        UNIT_ASSERT(overridden.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(overridden.After.Value, 15);
+
+        // Move the default to the active value and verify that this does not
+        // implicitly clear the override.
+        control->UpdateDefault(15);
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), 15);
+        UNIT_ASSERT_VALUES_EQUAL(control->GetDefault(), 15);
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), 15);
+
+        // Repeat the equal value and keep the explicit override active.
+        const TControlMutation equalToDefault =
+            control->SetFromHtmlRequestWithState(15);
+        UNIT_ASSERT(equalToDefault.Before.Overridden);
+        UNIT_ASSERT(equalToDefault.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(equalToDefault.After.Value, 15);
+
+        // Clear only override presence when the value already equals default.
+        const TControlMutation clearedByDefault = control->RestoreDefault();
+        UNIT_ASSERT(clearedByDefault.Before.Overridden);
+        UNIT_ASSERT(!clearedByDefault.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(
+            clearedByDefault.Before.Value,
+            clearedByDefault.After.Value);
+
+        // Clamp an out-of-range HTML value and retain override presence.
+        const TControlMutation clamped =
+            control->SetFromHtmlRequestWithState(25);
+        UNIT_ASSERT_VALUES_EQUAL(clamped.Before.Value, 15);
+        UNIT_ASSERT(!clamped.Before.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(clamped.After.Value, 20);
+        UNIT_ASSERT(clamped.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), 20);
+
+        // Repeat the effective value and verify that no state component changes.
+        const TControlMutation repeated =
+            control->SetFromHtmlRequestWithState(20);
+        UNIT_ASSERT_VALUES_EQUAL(repeated.Before.Value, repeated.After.Value);
+        UNIT_ASSERT_VALUES_EQUAL(repeated.Before.Default, repeated.After.Default);
+        UNIT_ASSERT_VALUES_EQUAL(repeated.Before.Overridden, repeated.After.Overridden);
+
+        // Keep a clamped override active when it equals the updated default.
+        control->UpdateDefault(20);
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), 20);
+        const TControlMutation clampedToDefault =
+            control->SetFromHtmlRequestWithState(25);
+        UNIT_ASSERT(clampedToDefault.Before.Overridden);
+        UNIT_ASSERT(clampedToDefault.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(clampedToDefault.After.Value, 20);
+        UNIT_ASSERT(!control->IsDefault());
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), 20);
+
+        // Change the default under an active override, then restore the latest
+        // default rather than the value used when the override was created.
+        control->UpdateDefault(5);
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), 20);
+        control->RestoreDefault();
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), 5);
+        UNIT_ASSERT_VALUES_EQUAL(control->GetDefault(), 5);
+    }
+
+    // Verify that programmatic overrides preserve registry defaults, apply
+    // bounds, and expose flag-only transitions.
+    Y_UNIT_TEST(TestSetOverridePreservesDefaultAndPresence) {
+        TIntrusivePtr<TControl> control(new TControl(10, 0, 20));
+
+        // Create an equal-to-default override and inspect its complete state.
+        const auto equal = control->SetOverride(10);
+        UNIT_ASSERT(!equal.Before.Overridden);
+        UNIT_ASSERT(equal.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(equal.After.Value, 10);
+        UNIT_ASSERT_VALUES_EQUAL(equal.After.Default, 10);
+        UNIT_ASSERT(control->GetOverride());
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), 10);
+
+        // Update the default while preserving the programmatic override value.
+        control->UpdateDefault(15);
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), 10);
+        UNIT_ASSERT_VALUES_EQUAL(control->GetDefault(), 15);
+
+        // Clamp an override above the upper bound without changing the default.
+        const auto upper = control->SetOverride(30);
+        UNIT_ASSERT_VALUES_EQUAL(upper.After.Value, 20);
+        UNIT_ASSERT_VALUES_EQUAL(upper.After.Default, 15);
+        UNIT_ASSERT(upper.After.Overridden);
+
+        // Make the clamped value equal to default and clear only its presence.
+        control->UpdateDefault(20);
+        const auto clampedToDefault = control->SetOverride(30);
+        UNIT_ASSERT_VALUES_EQUAL(clampedToDefault.After.Value, 20);
+        UNIT_ASSERT(clampedToDefault.After.Overridden);
+
+        const auto restored = control->RestoreDefault();
+        UNIT_ASSERT(restored.Before.Overridden);
+        UNIT_ASSERT(!restored.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(restored.Before.Value, restored.After.Value);
+        UNIT_ASSERT_VALUES_EQUAL(restored.After.Default, 20);
+        UNIT_ASSERT(!control->GetOverride());
+
+        // Clamp an override below the lower bound.
+        const auto lower = control->SetOverride(-1);
+        UNIT_ASSERT_VALUES_EQUAL(lower.After.Value, 0);
+        UNIT_ASSERT_VALUES_EQUAL(lower.After.Default, 20);
+        UNIT_ASSERT(lower.After.Overridden);
+
+        // Preserve an out-of-bounds default while applying bounds only to the
+        // override, then restore that exact default.
+        control->UpdateDefault(30);
+        const auto outsideBounds = control->SetOverride(30);
+        UNIT_ASSERT_VALUES_EQUAL(outsideBounds.After.Value, 20);
+        UNIT_ASSERT_VALUES_EQUAL(outsideBounds.After.Default, 30);
+        UNIT_ASSERT(outsideBounds.After.Overridden);
+        control->RestoreDefault();
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), 30);
+        UNIT_ASSERT(!control->GetOverride());
+    }
+
+    // Verify that copied wrappers mutate and observe the same control state.
+    Y_UNIT_TEST(TestWrapperSetOverrideUpdatesSharedControl) {
+        TControlWrapper control(10, 0, 20);
+        TControlWrapper shared = control;
+
+        // Set the override through one wrapper and observe it through the other.
+        const auto mutation = shared.SetOverride(10);
+        UNIT_ASSERT(!mutation.Before.Overridden);
+        UNIT_ASSERT(mutation.After.Overridden);
+
+        // Update the default through the first wrapper and verify that both
+        // wrappers retain the shared override and default.
+        control.UpdateDefault(15);
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<i64>(control), 10);
+        UNIT_ASSERT(control.GetOverride());
+        UNIT_ASSERT_VALUES_EQUAL(*control.GetOverride(), 10);
+        UNIT_ASSERT_VALUES_EQUAL(shared.GetDefault(), 15);
+    }
+
+    // Verify that generated config field presence sets an override and field
+    // absence clears it.
+    Y_UNIT_TEST(TestGeneratedConfigPresenceSetsAndClearsOverride) {
+        TControlBoard controlBoard;
+        controlBoard.CreateConfigControls(false);
+        auto control = controlBoard.DataShardControls.MaxTxInFly.AtomicLoad();
+        UNIT_ASSERT(control);
+
+        const TAtomicBase defaultValue = control->GetDefault();
+        NKikimrConfig::TImmediateControlsConfig config;
+
+        // Apply a present non-default field and record it as an override.
+        config.MutableDataShardControls()->SetMaxTxInFly(defaultValue + 1);
+        controlBoard.UpdateControls(config);
+
+        const auto override = control->GetOverride();
+        UNIT_ASSERT(override);
+        UNIT_ASSERT_VALUES_EQUAL(*override, defaultValue + 1);
+
+        // Apply a present equal-to-default field and keep explicit presence.
+        config.MutableDataShardControls()->SetMaxTxInFly(defaultValue);
+        controlBoard.UpdateControls(config);
+        UNIT_ASSERT(!control->IsDefault());
+        UNIT_ASSERT_VALUES_EQUAL(*control->GetOverride(), defaultValue);
+
+        // Move the default away and back to prove that the equal-value override
+        // remains independent from default updates.
+        control->UpdateDefault(defaultValue + 2);
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), defaultValue);
+        control->UpdateDefault(defaultValue);
+
+        // Apply a config without the field and restore the current default.
+        controlBoard.UpdateControls({});
+
+        UNIT_ASSERT(!control->GetOverride());
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), defaultValue);
+    }
+
+    // Verify coherent snapshots while concurrent writers set overrides, clear
+    // them, and update defaults.
+    Y_UNIT_TEST(TestConcurrentSetClearAndDefaultUpdatesKeepSnapshotsCoherent) {
+        constexpr ui32 writerCount = 3;
+        constexpr ui32 iterationCount = 1000;
+
+        TIntrusivePtr<TControl> control(new TControl(0, -100000, 100000));
+        std::atomic<ui32> writersDone = 0;
+        std::barrier startBarrier(writerCount + 1);
+
+        // Alternate a fixed override with restoration from two writers.
+        auto writeOverrides = [&](TAtomicBase overrideValue) {
+            startBarrier.arrive_and_wait();
+            for (ui32 i = 0; i < iterationCount; ++i) {
+                control->SetOverride(overrideValue);
+                control->RestoreDefault();
+            }
+            ++writersDone;
+        };
+
+        // Move the default between two values while override writers run.
+        auto writeDefaults = [&] {
+            startBarrier.arrive_and_wait();
+            for (ui32 i = 0; i < iterationCount; ++i) {
+                control->UpdateDefault(3);
+                control->UpdateDefault(4);
+            }
+            ++writersDone;
+        };
+
+        // Construct all writers before releasing the shared start barrier.
+        std::thread firstWriter(writeOverrides, 1);
+        std::thread secondWriter(writeOverrides, 2);
+        std::thread defaultWriter(writeDefaults);
+
+        // Release all participants together and accept only complete states
+        // produced by one writer operation.
+        startBarrier.arrive_and_wait();
+        do {
+            const TControlState state = control->GetState();
+            UNIT_ASSERT(
+                state.Default == 0 || state.Default == 3 || state.Default == 4);
+            if (state.Overridden) {
+                UNIT_ASSERT(state.Value == 1 || state.Value == 2);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(state.Value, state.Default);
+            }
+            const auto override = control->GetOverride();
+            UNIT_ASSERT(!override || *override == 1 || *override == 2);
+        } while (writersDone.load() != writerCount);
+
+        // Wait for every writer after the reader observes completion.
+        firstWriter.join();
+        secondWriter.join();
+        defaultWriter.join();
+    }
+
+    // Verify renderer output and counts for an override numerically equal to
+    // its default.
+    Y_UNIT_TEST(TestHtmlShowsOverrideEqualToUpdatedDefault) {
+        TIntrusivePtr<TControl> control(new TControl(10, 0, 20));
+
+        // Create an override, then move the default to the same value.
+        control->SetFromHtmlRequest(20);
+        control->UpdateDefault(20);
+
+        UNIT_ASSERT(!control->IsDefault());
+        UNIT_ASSERT_VALUES_EQUAL(control->Get(), control->GetDefault());
+
+        // Render the active override and verify its marker, restore action, and
+        // aggregate count.
+        TControlBoardTableHtmlRenderer renderer;
+        renderer.AddNewTable("Controls");
+        renderer.AddTableItem("TestControl", control);
+        const TString html = renderer.GetHtml();
+
+        UNIT_ASSERT(html.find("<span>(overridden)</span>") != TString::npos);
+        UNIT_ASSERT(html.find("<b>Restore Default</b>") != TString::npos);
+        UNIT_ASSERT(html.find("name='restoreDefault' value='TestControl'") != TString::npos);
+        UNIT_ASSERT(html.find("<td>1</td></tr>") != TString::npos);
+        UNIT_ASSERT_VALUES_EQUAL(renderer.GetOverriddenCount(), 1);
+
+        // Restore the control and verify that the rendered override indicators
+        // and aggregate count disappear.
+        control->RestoreDefault();
+        TControlBoardTableHtmlRenderer restoredRenderer;
+        restoredRenderer.AddNewTable("Controls");
+        restoredRenderer.AddTableItem("TestControl", control);
+        const TString restoredHtml = restoredRenderer.GetHtml();
+        UNIT_ASSERT(restoredHtml.find("<span>(overridden)</span>") == TString::npos);
+        UNIT_ASSERT(restoredHtml.find("<b>Restore Default</b>") == TString::npos);
+        UNIT_ASSERT(restoredHtml.find("<td>0</td></tr>") != TString::npos);
+        UNIT_ASSERT_VALUES_EQUAL(restoredRenderer.GetOverriddenCount(), 0);
+    }
+
+    // Verify that HTML accepts the exact current default even when it lies
+    // outside the operator bounds.
+    Y_UNIT_TEST(TestHtmlOverrideAcceptsDefaultOutsideBounds) {
+        TControl control(30, 0, 20);
+
+        // Assign the out-of-bounds default and preserve its exact value as an
+        // explicit override.
+        const auto mutation = control.SetFromHtmlRequestWithState(30);
+        UNIT_ASSERT(!mutation.Before.Overridden);
+        UNIT_ASSERT(mutation.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(mutation.After.Value, 30);
+        UNIT_ASSERT_VALUES_EQUAL(mutation.After.Default, 30);
+
+        // Clear presence and keep the same out-of-bounds default value.
+        control.RestoreDefault();
+        UNIT_ASSERT(control.IsDefault());
+        UNIT_ASSERT_VALUES_EQUAL(control.Get(), 30);
+    }
+
+    // Verify DCB equal-default assignment, named restoration, and unknown-name
+    // safety.
+    Y_UNIT_TEST(TestDynamicDefaultOverrideAndNamedRestore) {
+        TDynamicControlBoard board;
+        TControlWrapper control(10, 0, 20);
+        board.RegisterSharedControl(control, "control");
+
+        // Use the compatibility overload to create an equal-default override.
+        TAtomic previous = -1;
+        UNIT_ASSERT(!board.SetValue("control", 10, previous));
+        UNIT_ASSERT_VALUES_EQUAL(previous, 10);
+        UNIT_ASSERT_VALUES_EQUAL(*control.GetOverride(), 10);
+
+        // Restore by name and inspect the flag-only mutation.
+        TControlMutation mutation;
+        UNIT_ASSERT(board.RestoreDefault("control", mutation));
+        UNIT_ASSERT(mutation.Before.Overridden);
+        UNIT_ASSERT(!mutation.After.Overridden);
+        UNIT_ASSERT_VALUES_EQUAL(mutation.Before.Value, mutation.After.Value);
+
+        // Reject an unknown name without changing the last mutation or control.
+        UNIT_ASSERT(!board.RestoreDefault("unknown", mutation));
+        UNIT_ASSERT(mutation.Before.Overridden);
+        UNIT_ASSERT(!mutation.After.Overridden);
+        UNIT_ASSERT(!control.GetOverride());
     }
 
     Y_UNIT_TEST(TestControlWrapperAsI64) {
@@ -142,4 +480,3 @@ Y_UNIT_TEST_SUITE(ControlImplementationTests) {
 }
 
 } // namespace NKikimr
-

--- a/ydb/core/control/lib/immediate_control_board_wrapper.h
+++ b/ydb/core/control/lib/immediate_control_board_wrapper.h
@@ -30,6 +30,26 @@ public:
         return Control->GetDefault();
     }
 
+    // Return a coherent snapshot of the shared control.
+    TControlState GetState() const {
+        return Control->GetState();
+    }
+
+    // Return the active override, or no value for a caller-specific fallback.
+    std::optional<TAtomicBase> GetOverride() const {
+        return Control->GetOverride();
+    }
+
+    // Update the shared default without replacing an active override.
+    void UpdateDefault(TAtomicBase newDefault) {
+        Control->UpdateDefault(newDefault);
+    }
+
+    // Set a bounded override even when it equals the shared default.
+    TControlMutation SetOverride(TAtomicBase value) {
+        return Control->SetOverride(value);
+    }
+
     i64 operator=(i64 value) {
         Control->Set(value);
         return value;


### PR DESCRIPTION
# [ICB] Track overrides independently of default values

### Changelog entry

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

ICB infers override presence from numeric equality with a shared registry default. It cannot preserve an override when a default update makes the numbers equal. The existing API also does not directly support consumers sharing one override while using different base configurations and defaults. NBS dynconfig needs this for consumers holding different configuration snapshots.

This PR tracks override presence explicitly and exposes default updates, explicit override assignment, and optional override reads. A consumer can apply the shared override or fall back to its own base configuration.

### Complexity rationale

Adding one independent `Overridden` flag would not be sufficient because `Value`, `Default`, and override presence form one state with cross-field invariants. A reader must not observe fields from different concurrent mutations, especially during an equal-to-default override or a default update that preserves an active override. The implementation therefore serializes writers, validates optimistic multi-field reads with a sequence counter, and falls back to the writer lock when a coherent lock-free snapshot cannot be obtained.

The implementation also preserves the single atomic-load `Get()` hot path, the existing bounds rules, and the established behavior of baseline setters, wrappers, boards, and generated configuration updates. State-aware mutation results are required by the actor because setting or restoring an equal-to-default override changes only override presence: history and gauges must observe that transition even when the numeric value does not change. The additional synchronization, snapshot, mutation, actor, renderer, and test changes implement these compatibility and observability requirements.

### How controls work before this change

Static ICB controls (`TControlBoard`) and controls registered by name in DCB (`TDynamicControlBoard`) use the same `TControl`. Each control stores an effective `Value`, a registry `Default`, and bounds for submitted values. Override presence is inferred from `Value != Default`; it is not stored separately. An override can come from the HTML page, configuration processing, or another programmatic caller.

`TControl` exposes `Set(v)` and `Reset(v, lower, upper)`. The current `Set(v)` has the same baseline-reset semantics as `Reset(...)`: both set `Value = Default = v` without clamping. `Set()` preserves the existing bounds and is also used by numeric wrapper assignment `operator=(v)`; `Reset()` additionally replaces the bounds and is intended and used for initialization. The wrapper documents this requirement, but no runtime check enforces it. To update `Value` while preserving `Default`, callers use `SetFromHtmlRequest(v)`, either directly or through a board's `SetValue()`. Despite their similar names, `TControl::Set()` and a board's `SetValue()` therefore have different purposes.

| Main method or entry point | Current behavior |
| --- | --- |
| `TControl::Get()` / wrapper conversion to `i64` | Returns the effective `Value` with one atomic read. |
| `TControl::GetDefault()` / wrapper `GetDefault()` | Returns the registry `Default` with one atomic read. |
| `TControl::IsDefault()` / wrapper `IsDefault()` | Compares separately read `Value` and `Default`. Equal numbers mean no override. |
| `TControl::Set(v)` / wrapper numeric `operator=(v)` | Sets `Value = Default = v` without clamping. Removes any existing deviation from the default. `Set()` returns nothing; wrapper assignment returns `v`. |
| `TControl::Reset(d, lower, upper)` / wrapper `Reset(...)` | Sets `Value = Default = d` and replaces the bounds, without clamping `d`. Intended for initialization, as documented by the wrapper; no runtime check enforces this. |
| `TControl::SetFromHtmlRequest(v)` | Keeps `Default`. Accepts the current default directly, even outside the bounds; otherwise clamps `v` to the bounds and stores the result in `Value`. Returns the previous numeric value. A result equal to `Default` means no override. |
| `TControl::RestoreDefault()` | Copies `Default` into `Value`; returns nothing. |
| `TDynamicControlBoard::SetValue(name, v, TAtomic& previous)` | Finds the named control and calls `SetFromHtmlRequest(v)`. Writes its previous value to `previous`, then returns `IsDefault()`. For an unknown name, returns `true` and leaves `previous` unchanged; the return value is not a success flag. |
| `TControlBoard::SetValue(v, controlSlot)` | Applies `SetFromHtmlRequest(v)` to the static control in the supplied slot. Does nothing for an empty slot; returns nothing. |
| `TDynamicControlBoard::RestoreDefault(name)` / either board's `RestoreDefaults()` | Calls `RestoreDefault()` for the named control or all registered controls. An unknown dynamic name is ignored. Bulk restore iterates over controls without a transaction spanning the board. |
| Either board's `RegisterSharedControl()` / `RegisterLocalControl()` | Shared registration makes the supplied wrapper refer to an existing control when present. Local registration replaces the registered control. These operations determine object sharing, not a new configuration default. |
| Generated `UpdateControls(config)` | For each existing control processed by the generated update, a present field calls `SetFromHtmlRequest()`, and an absent field calls `RestoreDefault()`. Configuration values are not installed as new registry defaults. |

Individual values are read and written atomically, but compound updates (updates to both `Value` and `Default`) have no common writer lock or coherent state snapshot API. There is no operation that updates only the default while preserving an active override. In particular, `(Value, Default) = (20, 20)` cannot distinguish an active override of 20 from the absence of an override.

### How controls work after this change

`TControl` now stores `Overridden` independently of `Value` and `Default`. With no override, `Value` follows the registry default. With an override, `Value` remains the override value when the default changes, including when both numbers become equal. For example: default 10 → submit override 20 → update default to 20 → update default to 30 → the effective value stays 20 until the override is cleared, after which it becomes 30.

`TAdaptiveLock` serializes state mutations. Writers mark `Sequence` odd while updating the atomic fields and even when finished. `GetState()` tries once to read all state fields with an unchanged even sequence; on conflict, it reads the state under the same lock. `GetOverride()` derives its result from this coherent snapshot. Bounds are still intended to be set during initialization; `Reset()` remains unsafe to call concurrently with bounds readers.

#### Existing methods and what changes

| Existing method or entry point | Behavior with this change | Change from the current implementation |
| --- | --- | --- |
| `TControl::Get()` / wrapper conversion to `i64` | Not changed | None. |
| `TControl::GetDefault()` / wrapper `GetDefault()` | Not changed | The getter is unchanged; the new `UpdateDefault()` can change its result without removing an override. Separate calls to `Get()` and `GetDefault()` still do not form a coherent snapshot. |
| `TControl::IsDefault()` / wrapper `IsDefault()` | Returns `!Overridden`. | Reports override absence instead of numeric equality. It can return `false` when `Get() == GetDefault()`. |
| `TControl::Set(v)` / wrapper numeric `operator=(v)` | Sets `Value = Default = v` and `Overridden = false`, without clamping. Return values are unchanged. | Preserves the existing baseline-replacement behavior and explicitly clears override presence. The compound mutation is now serialized. This remains a baseline setter, not an override setter. |
| `TControl::Reset(d, lower, upper)` / wrapper `Reset(...)` | Sets `Value = Default = d`, clears override presence, and replaces the bounds. | Initializes the new state fields consistently; the documented initialization requirement and lack of default clamping remain. |
| `TControl::SetFromHtmlRequest(v)` | Preserves `Default`, applies the existing bounds rules, sets override presence, and returns the previous numeric value. | Always creates an override, including when the submitted or clamped value equals the default. Submitting the default no longer resets a control. |
| `TControl::RestoreDefault()` | Sets `Value` to the latest registry default, clears override presence, and returns `TControlMutation`. | Implements the reset directly under the state lock. Its return type changes from `void`; existing callers can ignore the result. The transition records resets that change only override presence. |
| `TDynamicControlBoard::SetValue(name, v, TAtomic& previous)` | Sets an override and writes the previous value when found. Returns `false` for a found control; returns `true` and leaves the output unchanged for an unknown name. | The flag still means override absence, not lookup success. A successful assignment now always creates an override, including assignment of the default. |
| `TControlBoard::SetValue(v, controlSlot)` | Sets an override through `SetFromHtmlRequest(v)` for a populated slot; ignores an empty slot. | The board code is unchanged, but assigning the default now creates an override instead of resetting the control. |
| `TDynamicControlBoard::RestoreDefault(name)` / either board's `RestoreDefaults()` | Not changed | Each control uses the new serialized reset. Lookup behavior and the absence of a board-wide transaction are unchanged. |
| Either board's `RegisterSharedControl()` / `RegisterLocalControl()` | Not changed | None; shared registration does not call `UpdateDefault()` or overwrite an existing control's state. |
| Generated `UpdateControls(config)` | For each existing control processed by the update, a present field creates an override, even when equal to the default; an absent field resets it. | Generated code and Console wiring are unchanged. Explicit presence now survives numeric equality with the default; configuration values do not become new registry defaults. |

#### New methods

`TControlState` contains `Value`, `Default`, and `Overridden`. `TControlMutation` contains the coherent `Before` and `After` states of one serialized mutation.

| New method | Behavior |
| --- | --- |
| `TControl::UpdateDefault(d)` / wrapper `UpdateDefault(d)` | Changes the registry default without clamping. If no override exists, also sets `Value = d`; otherwise preserves both the override value and its presence, including when equal to `d`. Returns nothing. |
| `TControl::GetState()` / wrapper `GetState()` | Returns a coherent `TControlState`. It tries one validated atomic read of the complete state, then takes the writer lock if the sequence changes or a writer is active. |
| `TControl::GetOverride()` / wrapper `GetOverride()` | Returns the active override from a coherent `GetState()` snapshot, including an equal-to-default value, or `nullopt` for a caller-specific configuration fallback. |
| `TControl::SetFromHtmlRequestWithState(v)` | Preserves the default and always sets override presence under the writer lock. Accepts the current default even outside bounds; otherwise clamps the submitted value. Returns `TControlMutation`. |
| `TControl::SetOverride(v)` / wrapper `SetOverride(v)` | Always clamps `v` to the bounds, preserves `Default`, and sets override presence even when the result equals the default. Returns `TControlMutation`. |
| `TDynamicControlBoard::SetValue(name, v, TControlMutation& mutation)` | Looks up the control and applies `SetFromHtmlRequestWithState(v)`. Returns `true` and writes the mutation when found; returns `false` and leaves the output unchanged otherwise. Unlike the existing overload, its boolean reports lookup success. |
| `TDynamicControlBoard::RestoreDefault(name, TControlMutation& mutation)` | Looks up the control and calls its `RestoreDefault()`. Returns `true` and writes the mutation when found; returns `false` and leaves the output unchanged otherwise. |

#### Impact on existing internal consumers

The updated controls preserve the existing configuration application, numeric read/write, registration, and caching logic of the internal consumers listed below. Their production code is unchanged; this PR does not migrate these callers to `UpdateDefault()` or `GetOverride()`.

| Consumer | Existing logic preserved by this PR |
| --- | --- |
| `TImmediateControlsConfigurator` and generated `TControlBoard` | Console still calls `ApplyConfig()` → `UpdateControls()`. A present field applies its value with the existing bounds rules; an absent processed field restores the registry default. Configuration values are not converted into new registry defaults. |
| PDisk | Scheduling and other numeric reads still use wrapper conversion → `TControl::Get()`. Programmatic DCB assignments retain their numeric results and bounds. The inspected sector-rate setters ignore the boolean returned by `SetValue()`, so its changed override-related result does not alter their decisions. |
| `TSchemeShard::ApplyConsoleConfigs()` | The feature-flag path still compares the incoming value with the effective control value and uses numeric wrapper assignment when different. Assignment continues to replace both value and default and clear an override; its priority is not changed to the override-preserving policy of `UpdateDefault()`. |
| `TControlWrapper` and `TMemorizableControlWrapper` | Numeric conversion, initialization, shared control identity, and the existing cache refresh policy remain unchanged. The new explicit APIs are available without changing these existing access paths. |

### Effect on existing users

Numeric reads, baseline assignment, control registration, and existing bounds remain compatible. Override classification intentionally changes: an explicitly submitted default now creates an override, `IsDefault()` reports override absence, and the existing DCB setter's boolean reflects that state. An active override remains effective when `UpdateDefault()` changes the registry default.

On the monitoring page, `Change` always creates an override. Operators and automation that previously submitted the displayed default to clear one control must use its `Restore Default` button instead; bulk `Restore Defaults` remains available. Existing change requests keep the `ControlName=value` format. The new per-control restore request uses `restoreDefault=<ControlName>`.

Console and generated control updates continue to use the existing paths. A present configuration field now creates an override even when its value equals the registry default; an absent processed field restores the default. No persistent format, Console schema, or restart behavior changes.

Components adopting the new API can use `UpdateDefault()` to publish registry defaults and `GetOverride()` to apply a shared override or fall back to their own base configuration. Existing consumers retain their current access paths.

### ICB Actor

The existing actor resolves submitted control names in static-first order, then tries DCB. Submitting the default resets one control; `Restore Default` resets both boards. History records a change when the previous value differs from the submitted number and stores the previous/new numbers. Gauges use numeric `Inc/Dec` updates, so repeated changes to one control can inflate the count and external mutations can leave it incorrect.

With this PR, Change always creates an override, including a value equal to the default. The per-control `Restore Default` action clears it explicitly and sends `restoreDefault=<ControlName>`. Change and Restore use the same static-first lookup. Names are not checked for uniqueness across boards: a dynamic control with a colliding name cannot be addressed independently through these forms.

The actor uses `TControlMutation` to record numeric changes and override-presence transitions from one operation. The history's new `Action` column distinguishes `Set override`, `Restore default`, and bulk restore, including cases where the previous/new numbers are equal. Unknown control names do not change controls or add history records.

On each HTTP request, the actor assigns gauges the number of overrides reported by the renderer. Equal-to-default overrides are counted, repeated changes do not inflate the count, and bulk restore yields zero when no writer intervenes. There is no timer or bootstrap reconciliation. External mutations become visible in gauges on the next HTTP request.

### HTML Renderer

The existing renderer reads the current value and default separately and uses numeric equality to choose highlighting and the `Changed` value. Each row offers a Change form; the page also offers bulk restore.

With this PR, each row uses one coherent `GetState()` snapshot. Highlighting and `Changed` follow `state.Overridden`; an equal-to-default override is additionally marked with `(overridden)` on a separate line. A row with an active override also offers a `Restore Default` button next to `Change`.

While rendering, it counts rows with override presence set across both tables. `GetOverriddenCount()` exposes this count to the actor for gauges, using the same snapshots as the displayed rows and adding no separate board traversal. Each row is coherent; the whole page is not an atomic snapshot of all controls.

<details>
<summary>Existing mon page</summary>

<img width="1388" height="232" alt="image" src="https://github.com/user-attachments/assets/885f6286-84d1-48da-854b-5cec994e7abe" />

<img width="1388" height="232" alt="image" src="https://github.com/user-attachments/assets/c4e6be24-b242-42a3-becb-2cd1e0c5c528" />

<img width="1309" height="424" alt="image" src="https://github.com/user-attachments/assets/30cea49e-3904-411a-9155-f82ef0b9968e" />

</details>

<details>
<summary>New mon page</summary>

<img width="1400" height="241" alt="image" src="https://github.com/user-attachments/assets/d23fd3a0-b72e-4d1c-8519-c5e01dfc8df4" />

<img width="1400" height="241" alt="image" src="https://github.com/user-attachments/assets/24353983-32f3-40c9-a377-144ffe0f9c86" />

`Override` == `Default` is explicitly marked with an `(overridden)` text note.

<img width="1400" height="241" alt="image" src="https://github.com/user-attachments/assets/ff05d132-db17-41ef-9ce6-71b45d3c6808" />

<img width="1313" height="514" alt="image" src="https://github.com/user-attachments/assets/1df19d99-fe32-4f68-8f65-7e78e494e9a9" />

</details>

### Performance

`Get()` keeps one atomic load. Without a concurrent writer, `GetState()` and `GetOverride()` use one optimistic complete-state sample: five atomic loads, with no lock, allocation, reference counting, or retry loop. If the sequence check detects a writer, `GetState()` discards the sample and reads under the same `TAdaptiveLock` used by mutations.

Writes are expected to be rare. Longer waits when reads overlap writes are therefore an accepted tradeoff for simple synchronization and inexpensive reads in the common case. This is a design assumption; performance has not been benchmarked.

### Scope

The change covers the shared control implementation, both boards, and the monitoring page. Override state remains process-local; no persistent or configuration schema changes are introduced.

Related NBS context: https://github.com/ydb-platform/nbs/issues/6927

<details>
<summary>File summaries</summary>

| File or group | Summary |
| --- | --- |
| `lib/base/immediate_control_board_control.{h,cpp}` | Explicit override state, mutation results, and atomic reads with lock fallback. |
| `lib/immediate_control_board_wrapper.h` | Expose snapshots, optional overrides, default updates, and explicit override assignment. |
| `lib/dynamic_control_board_impl.{h,cpp}` | Return coherent mutations from named assignment and restore operations. |
| `lib/immediate_control_board_html_renderer.{h,cpp}` | Render explicit presence, the per-control restore action, and a count of displayed overrides for gauges. |
| `immediate_control_board_actor.cpp` | Handle restore and history actions; refresh gauges from the rendered state on HTTP requests. |
| Control library and actor unit tests | Cover override lifecycle, shared access, concurrent updates, HTML actions, and counters. |

</details>

### Verification

The control library and actor unit-test targets pass all 16 tests. They cover equal-to-default overrides through setters and generated config, bounds, restore visibility, history actions, static-first addressing, external changes observed by HTTP gauges, shared wrappers, and concurrent updates.
