### PR TITLE
docs: remove obsolete YQL syntax version setting

### DIFF
--- a/ydb/docs/en/core/devops/deployment-options/manual/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/en/core/devops/deployment-options/manual/initial-deployment/deployment-configuration-v1.md
@@ -72,8 +72,6 @@ Prepare the {{ ydb-short-name }} configuration file according to your chosen top
         node: [1, 2, 3]
         nto_select: 3
         ssid: 1
-    table_service_config:
-    sql_version: 1
     actor_system_config:
     executor:
       - name: System
@@ -259,8 +257,6 @@ Prepare the {{ ydb-short-name }} configuration file according to your chosen top
         node: [1, 2, 3, 4, 5, 6, 7, 8, 9]
         nto_select: 9
         ssid: 1
-  table_service_config:
-    sql_version: 1
   actor_system_config:
     executor:
       - name: System
@@ -446,8 +442,6 @@ Prepare the {{ ydb-short-name }} configuration file according to your chosen top
         node: [1, 2, 3, 4, 5, 6, 7, 8]
         nto_select: 5
         ssid: 1
-  table_service_config:
-    sql_version: 1
   actor_system_config:
     executor:
       - name: System

--- a/ydb/docs/ru/core/devops/deployment-options/manual/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/ru/core/devops/deployment-options/manual/initial-deployment/deployment-configuration-v1.md
@@ -83,8 +83,6 @@
         node: [1, 2, 3]
         nto_select: 3
       ssid: 1
-  table_service_config:
-    sql_version: 1
   actor_system_config:
     executor:
     - name: System
@@ -288,8 +286,6 @@
         node: [1, 2, 3, 4, 5, 6, 7, 8, 9]
         nto_select: 9
       ssid: 1
-  table_service_config:
-    sql_version: 1
   actor_system_config:
     executor:
     - name: System
@@ -488,8 +484,6 @@
         node: [1, 2, 3, 4, 5, 6, 7, 8]
         nto_select: 5
       ssid: 1
-  table_service_config:
-    sql_version: 1
   actor_system_config:
     executor:
     - name: System


### PR DESCRIPTION
### Changelog entry

Removed obsolete `sql_version: 1` entries from YDB deployment configuration examples. YQL v1 is the only supported YQL syntax and remains the default.

### Description for reviewers

[KIKIMR-26968](https://st.yandex-team.ru/KIKIMR-26968)

This documentation-only PR removes the obsolete YQL syntax version setting from the English and Russian deployment configuration examples.

The corresponding code, configuration, counter, and test cleanup is split into [PR #51888](https://github.com/ydb-platform/ydb/pull/51888).

### Testing

Documentation CI only. Local builds and tests were intentionally not run.
