### PR TITLE
BlobChecker: add focused end-to-end coverage

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/blob_checker_e2e.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/blob_checker_e2e.cpp
@@ -1,0 +1,127 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h>
+#include <ydb/core/mind/bscontroller/blob_checker_events.h>
+
+#include <utility>
+
+namespace NKikimr::NBsController {
+
+Y_UNIT_TEST_SUITE(BlobCheckerE2E) {
+
+struct TTestCtx : TTestCtxBase {
+    using TCounterPtr = ::NMonitoring::TDynamicCounters::TCounterPtr;
+
+    TTestCtx()
+        : TTestCtxBase(TEnvironmentSetup::TSettings{
+            .NodeCount = 3,
+            .Erasure = TBlobStorageGroupType::ErasureNone,
+            .ControllerNodeId = 3,
+        })
+    {}
+
+    void Setup() {
+        Initialize();
+        WriteCompressedData({
+            .GroupId = GroupId,
+            .TotalBlobs = 1,
+            .BlobSize = 1_KB,
+        });
+    }
+
+    TCounterPtr FindBlobCheckerCounter(TStringBuf name) const {
+        const auto& root = Env->Runtime->GetNode(Env->Settings.ControllerNodeId)->AppData->Counters;
+        const auto service = root->FindSubgroup("counters", "storage_pool_stat");
+        if (!service) {
+            return {};
+        }
+        const auto blobChecker = service->FindSubgroup("subsystem", "blob_checker");
+        return blobChecker ? blobChecker->FindCounter(TString(name)) : TCounterPtr{};
+    }
+
+    ui64 GetBlobCheckerCounter(TStringBuf name) const {
+        const auto counter = FindBlobCheckerCounter(name);
+        return counter ? counter->Val() : 0;
+    }
+
+    template<typename TPredicate>
+    void WaitUntil(TPredicate&& predicate, TStringBuf description,
+            TDuration timeout = TDuration::Minutes(3)) {
+        const TInstant deadline = Env->Now() + timeout;
+        bool done = predicate();
+        while (!done && Env->Now() < deadline) {
+            Env->Sim(TDuration::Seconds(1));
+            done = predicate();
+        }
+        UNIT_ASSERT_C(done, TStringBuilder() << "Timed out waiting for " << description);
+    }
+
+    void SetPeriodicity(TDuration periodicity) {
+        Env->UpdateSettings({
+            .BlobCheckerPeriodicity = periodicity,
+        });
+    }
+};
+
+Y_UNIT_TEST(EnableDisableReenable) {
+    ui32 planRequests = 0;
+    TTestCtx ctx;
+    ctx.Setup();
+
+    ctx.Env->Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvBlobCheckerPlanCheck::EventType) {
+            ++planRequests;
+        }
+        return true;
+    };
+
+    ctx.SetPeriodicity(TDuration::Seconds(1));
+    ctx.WaitUntil([&] { return ctx.GetBlobCheckerCounter("ChecksCompleted") != 0; },
+        "the first BlobChecker pass");
+
+    ctx.SetPeriodicity(TDuration::Zero());
+    // Let the settings notification and any already queued cancellation
+    // acknowledgement settle before measuring the disabled interval.
+    ctx.Env->Sim(TDuration::Zero());
+    const ui32 requestsAtDisable = planRequests;
+    const ui64 completedAtDisable = ctx.GetBlobCheckerCounter("ChecksCompleted");
+    ctx.Env->Sim(TDuration::Minutes(2));
+    UNIT_ASSERT_VALUES_EQUAL(planRequests, requestsAtDisable);
+    UNIT_ASSERT_VALUES_EQUAL(ctx.GetBlobCheckerCounter("ChecksCompleted"), completedAtDisable);
+
+    ctx.SetPeriodicity(TDuration::Seconds(1));
+    ctx.WaitUntil([&] {
+        return planRequests > requestsAtDisable &&
+            ctx.GetBlobCheckerCounter("ChecksCompleted") > completedAtDisable;
+    }, "a BlobChecker pass after re-enabling");
+}
+
+Y_UNIT_TEST(SettingsAndGroupStateSurviveControllerRestart) {
+    ui32 planRequests = 0;
+    bool firstRequestDropped = false;
+    TTestCtx ctx;
+    ctx.Setup();
+
+    ctx.Env->Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvBlobCheckerPlanCheck::EventType) {
+            ++planRequests;
+            if (!std::exchange(firstRequestDropped, true)) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    ctx.SetPeriodicity(TDuration::Seconds(10));
+    ctx.WaitUntil([&] { return firstRequestDropped; }, "the initial planning request");
+    ctx.Env->Sim(TDuration::Seconds(5));
+    UNIT_ASSERT_VALUES_EQUAL(ctx.GetBlobCheckerCounter("ChecksCompleted"), 0);
+
+    ctx.Env->RestartNode(ctx.Env->Settings.ControllerNodeId);
+    ctx.WaitUntil([&] {
+        return planRequests >= 2 && ctx.GetBlobCheckerCounter("ChecksCompleted") != 0;
+    }, "BlobChecker to resume after the controller restart");
+}
+
+} // Y_UNIT_TEST_SUITE(BlobCheckerE2E)
+
+} // namespace NKikimr::NBsController

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -85,6 +85,13 @@ struct TEnvironmentSetup {
         const bool SetupResourceBroker = false;
     };
 
+    struct TBSCSettings {
+        std::optional<bool> EnableSelfHeal;
+        std::optional<bool> EnableDonorMode;
+        std::optional<bool> EnableGroupLayoutSanitizer;
+        std::optional<TDuration> BlobCheckerPeriodicity;
+    };
+
     const TSettings Settings;
 
     class TMockPDiskServiceFactory : public IPDiskServiceFactory {
@@ -1060,15 +1067,32 @@ config:
         }
     }
 
-    void UpdateSettings(bool selfHeal, bool donorMode, bool groupLayoutSanitizer = false) {
+    void UpdateSettings(const TBSCSettings& settings) {
         NKikimrBlobStorage::TConfigRequest request;
         auto *cmd = request.AddCommand();
         auto *us = cmd->MutableUpdateSettings();
-        us->AddEnableSelfHeal(selfHeal);
-        us->AddEnableDonorMode(donorMode);
-        us->AddEnableGroupLayoutSanitizer(groupLayoutSanitizer);
+        if (settings.EnableSelfHeal) {
+            us->AddEnableSelfHeal(*settings.EnableSelfHeal);
+        }
+        if (settings.EnableDonorMode) {
+            us->AddEnableDonorMode(*settings.EnableDonorMode);
+        }
+        if (settings.EnableGroupLayoutSanitizer) {
+            us->AddEnableGroupLayoutSanitizer(*settings.EnableGroupLayoutSanitizer);
+        }
+        if (settings.BlobCheckerPeriodicity) {
+            us->AddBlobCheckerPeriodicitySeconds(settings.BlobCheckerPeriodicity->Seconds());
+        }
         auto response = Invoke(request);
         UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+    }
+
+    void UpdateSettings(bool selfHeal, bool donorMode, bool groupLayoutSanitizer = false) {
+        UpdateSettings(TBSCSettings{
+            .EnableSelfHeal = selfHeal,
+            .EnableDonorMode = donorMode,
+            .EnableGroupLayoutSanitizer = groupLayoutSanitizer,
+        });
     }
 
     void EnableDonorMode() {

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -18,6 +18,7 @@ SRCS(
     backpressure.cpp
     block_race.cpp
     blob_checker.cpp
+    blob_checker_e2e.cpp
     bsc_cache.cpp
     cancellation.cpp
     counting_events.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds focused end-to-end coverage for enable/disable/reenable behavior and controller-restart persistence. 