### PR TITLE
If `-H` specified, choose host for updating config from explicitly specified and not cluster settings.

### DIFF
--- a/ydb/tools/ydbd_slice/handlers.py
+++ b/ydb/tools/ydbd_slice/handlers.py
@@ -49,7 +49,7 @@ class Slice:
         self.yav_version = yav_version
         self.walle_provider = walle_provider
         self.__config_client = config_client.ConfigClient(
-            self.cluster_details.hosts[0].hostname,
+            self.nodes.nodes_list[0],
             self.cluster_details.grpc_config.get('port'),
             retry_count=10,
         )

--- a/ydb/tools/ydbd_slice/ut/test_handlers.py
+++ b/ydb/tools/ydbd_slice/ut/test_handlers.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from ydb.tools.ydbd_slice import handlers
+from ydb.tools.ydbd_slice import nodes
+
+
+class SliceTest(TestCase):
+    def test_config_client_uses_selected_host(self):
+        cluster_details = SimpleNamespace(
+            hosts=[SimpleNamespace(hostname='unavailable-host')],
+            grpc_config={'port': 2135},
+        )
+
+        with mock.patch.object(handlers.config_client, 'ConfigClient') as config_client:
+            handlers.Slice({}, nodes.Nodes(['selected-host']), cluster_details)
+
+        config_client.assert_called_once_with('selected-host', 2135, retry_count=10)

--- a/ydb/tools/ydbd_slice/ut/ya.make
+++ b/ydb/tools/ydbd_slice/ut/ya.make
@@ -1,0 +1,11 @@
+PY3TEST()
+
+TEST_SRCS(
+    test_handlers.py
+)
+
+PEERDIR(
+    ydb/tools/ydbd_slice
+)
+
+END()

--- a/ydb/tools/ydbd_slice/ya.make
+++ b/ydb/tools/ydbd_slice/ya.make
@@ -1,5 +1,6 @@
 RECURSE(
     bin
+    ut
 )
 
 PY3_LIBRARY(ydbd_slice)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix ydbd with `-H` option.

