### PR TITLE
Test repeated adjacent pool wakeups

### DIFF
--- a/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer_ut.cpp
@@ -163,6 +163,49 @@ private:
     TManualEvent* const Sent;
 };
 
+class TRepeatedSignalActor : public NActors::TActorBootstrapped<TRepeatedSignalActor> {
+public:
+    TRepeatedSignalActor(
+            TManualEvent* ready,
+            TManualEvent* done,
+            std::atomic<ui32>* executionOwnerPoolIds,
+            size_t eventCount)
+        : Ready(ready)
+        , Done(done)
+        , ExecutionOwnerPoolIds(executionOwnerPoolIds)
+        , EventCount(eventCount)
+    {}
+
+    void Bootstrap() {
+        Become(&TRepeatedSignalActor::StateFunc);
+        Ready->Signal();
+    }
+
+    STFUNC(StateFunc) {
+        Y_VERIFY_S(
+            ev->GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType,
+            "unexpected event type# " << ev->GetTypeRewrite());
+        Y_VERIFY_S(ProcessedEvents < EventCount,
+            "processed events# " << ProcessedEvents << " event count# " << EventCount);
+
+        const size_t eventIndex = ProcessedEvents++;
+        ExecutionOwnerPoolIds[eventIndex].store(
+            NActors::TlsThreadContext->OwnerPoolId(),
+            std::memory_order_release);
+        Done[eventIndex].Signal();
+        if (ProcessedEvents == EventCount) {
+            PassAway();
+        }
+    }
+
+private:
+    TManualEvent* const Ready;
+    TManualEvent* const Done;
+    std::atomic<ui32>* const ExecutionOwnerPoolIds;
+    const size_t EventCount;
+    size_t ProcessedEvents = 0;
+};
+
 THolder<NActors::TActorSystemSetup> CreateActorSystemSetup(
         const NKikimrConfig::TActorSystemConfig& config)
 {
@@ -834,6 +877,93 @@ Y_UNIT_TEST(UnitedPoolFallsBackToForeignThreadWithoutAdjacentOwner) {
         executionOwnerPoolId.load(std::memory_order_acquire),
         WorkerPoolId,
         "activation without an adjacent owner was not executed by the foreign worker");
+}
+
+Y_UNIT_TEST(AutoConfiguredAdjacentPoolWakesAcrossRepeatedIdleCycles) {
+    static constexpr size_t WakeupCount = 5;
+
+    NKikimrConfig::TActorSystemConfig config;
+    config.SetCpuCount(2);
+    config.SetUseSharedThreads(true);
+    config.SetUseUnitedPool(true);
+
+    ApplyAutoConfig(&config, false, false);
+
+    const ui32 ownerPoolId = config.GetSysExecutor();
+    const ui32 adjacentPoolId = config.GetBatchExecutor();
+    auto setup = CreateActorSystemSetup(config);
+
+    const auto& ownerPool = FindBasicPool(setup->CpuManager, ownerPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(ownerPool.DefaultThreadCount, 1);
+    UNIT_ASSERT_VALUES_EQUAL(
+        ownerPool.AdjacentPools,
+        (std::vector<i16>{static_cast<i16>(adjacentPoolId)}));
+
+    const auto& adjacentPool = FindBasicPool(setup->CpuManager, adjacentPoolId);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.DefaultThreadCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(adjacentPool.ForcedForeignSlotCount, 0);
+
+    NActors::TActorSystem actorSystem(setup);
+    actorSystem.Start();
+
+    TManualEvent ready;
+    std::array<TManualEvent, WakeupCount> done;
+    std::array<std::atomic<ui32>, WakeupCount> executionOwnerPoolIds;
+    std::array<bool, WakeupCount> ownerWasParked = {};
+    std::array<bool, WakeupCount> eventWasSent = {};
+    std::array<bool, WakeupCount> completed = {};
+    for (auto& executionOwnerPoolId : executionOwnerPoolIds) {
+        executionOwnerPoolId.store(Max<ui32>(), std::memory_order_relaxed);
+    }
+
+    const NActors::TActorId adjacentActorId = actorSystem.Register(
+        new TRepeatedSignalActor(
+            &ready,
+            done.data(),
+            executionOwnerPoolIds.data(),
+            WakeupCount),
+        NActors::TMailboxType::HTSwap,
+        adjacentPoolId);
+    const bool actorIsReady = ready.WaitT(TDuration::Seconds(5));
+
+    if (actorIsReady) {
+        for (size_t i = 0; i < WakeupCount; ++i) {
+            ownerWasParked[i] = WaitForSharedThreadToPark(
+                actorSystem,
+                ownerPoolId,
+                TDuration::Seconds(5));
+            if (!ownerWasParked[i]) {
+                break;
+            }
+
+            eventWasSent[i] = actorSystem.Send(
+                adjacentActorId,
+                new NActors::TEvents::TEvWakeup());
+            if (!eventWasSent[i]) {
+                break;
+            }
+
+            completed[i] = done[i].WaitT(TDuration::Seconds(5));
+            if (!completed[i]) {
+                break;
+            }
+        }
+    }
+
+    actorSystem.Stop();
+    UNIT_ASSERT_C(actorIsReady, "repeated-wakeup Batch actor did not initialize");
+    for (size_t i = 0; i < WakeupCount; ++i) {
+        UNIT_ASSERT_C(ownerWasParked[i],
+            "adjacent User owner did not become idle before wakeup " << i);
+        UNIT_ASSERT_C(eventWasSent[i],
+            "failed to send adjacent Batch wakeup " << i);
+        UNIT_ASSERT_C(completed[i],
+            "adjacent Batch wakeup " << i << " did not execute");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            executionOwnerPoolIds[i].load(std::memory_order_acquire),
+            ownerPoolId,
+            "adjacent Batch wakeup " << i << " was not executed by its User owner");
+    }
 }
 
 } // Y_UNIT_TEST_SUITE(AutoConfig)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added coverage for repeated adjacent-pool wakeups across idle cycles.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The test drives one Batch actor through five complete owner park, wakeup, and execution cycles and verifies the User owner for every activation.