### PR TITLE
Fix TestAnalyzeRollingUpdate timeout during rolling upgrade

### DIFF
--- a/ydb/tests/compatibility/workloads/test_statistics.py
+++ b/ydb/tests/compatibility/workloads/test_statistics.py
@@ -269,6 +269,12 @@ class TestAnalyzeRollingUpdate(RollingUpgradeAndDowngradeFixture):
             additional_log_configs={
                 'STATISTICS': LogLevels.DEBUG,
             },
+            column_shard_config={
+                "statistics": {
+                    "report_base_statistics_period_ms": 1000,
+                    "report_executor_statistics_period_ms": 1000,
+                },
+            },
         )
 
     def create_tables(self):


### PR DESCRIPTION
Shorten the column-shard report period to 1s (same as the functional ANALYZE test) and cap each call at 30s with no retries; errors are still ignored.

Fixes #48647
