### PR TITLE
Handle dictionaries with index type wider than dictated by their number of values.

### DIFF
--- a/ydb/core/formats/arrow/accessor/dictionary/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/dictionary/accessor.cpp
@@ -90,24 +90,31 @@ std::shared_ptr<IChunkedArray> TDictionaryArray::DoISlice(const ui32 offset, con
         }
         dictArray = NArrow::TStatusValidator::GetValid(arrow::Concatenate(parts));
     }
-    // Remap positions to indices into the filtered dictionary.
-    std::unique_ptr<arrow::ArrayBuilder> positionsBuilder = NArrow::MakeBuilder(positionsNew->type());
+    // Remap positions to indices into the filtered dictionary and choose their width based on new dictionary size.
+    const auto positionsTargetType = NDictionary::TConstructor::GetTypeByVariantsCount(dictArray->length());
+    std::unique_ptr<arrow::ArrayBuilder> positionsBuilder = NArrow::MakeBuilder(positionsTargetType);
     AFL_VERIFY(SwitchType(positionsNew->type()->id(), [&](const auto& type) {
         using TRecordsWrap = std::decay_t<decltype(type)>;
         using TRecordsArray = typename arrow::TypeTraits<typename TRecordsWrap::T>::ArrayType;
         if constexpr (TRecordsWrap::IsIndexType()) {
             const auto* arrPositionsImpl = static_cast<const TRecordsArray*>(positionsNew.get());
-            auto* builder = type.CastBuilder(positionsBuilder.get());
-            using CType = typename TRecordsWrap::ValueType;
-            for (int64_t i = 0; i < arrPositionsImpl->length(); ++i) {
-                if (arrPositionsImpl->IsNull(i)) {
-                    TStatusValidator::Validate(builder->AppendNull());
-                } else {
-                    const ui32 oldIdx = arrPositionsImpl->Value(i);
-                    TStatusValidator::Validate(builder->Append(static_cast<CType>(oldToNew[oldIdx])));
+            return SwitchType(positionsTargetType->id(), [&](const auto& targetType) {
+                using TTargetWrap = std::decay_t<decltype(targetType)>;
+                if constexpr (TTargetWrap::IsIndexType()) {
+                    auto* builder = targetType.CastBuilder(positionsBuilder.get());
+                    using CType = typename TTargetWrap::ValueType;
+                    for (int64_t i = 0; i < arrPositionsImpl->length(); ++i) {
+                        if (arrPositionsImpl->IsNull(i)) {
+                            TStatusValidator::Validate(builder->AppendNull());
+                        } else {
+                            const ui32 oldIdx = arrPositionsImpl->Value(i);
+                            TStatusValidator::Validate(builder->Append(static_cast<CType>(oldToNew[oldIdx])));
+                        }
+                    }
+                    return true;
                 }
-            }
-            return true;
+                return false;
+            });
         }
         return false;
     }));

--- a/ydb/core/formats/arrow/accessor/dictionary/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/dictionary/accessor.cpp
@@ -91,7 +91,9 @@ std::shared_ptr<IChunkedArray> TDictionaryArray::DoISlice(const ui32 offset, con
         dictArray = NArrow::TStatusValidator::GetValid(arrow::Concatenate(parts));
     }
     // Remap positions to indices into the filtered dictionary and choose their width based on new dictionary size.
-    const auto positionsTargetType = NDictionary::TConstructor::GetTypeByVariantsCount(dictArray->length());
+    AFL_VERIFY(dictArray->length() <= Max<ui32>())("dictionary_length", dictArray->length());
+    const ui32 dictionaryLength = dictArray->length();
+    const auto positionsTargetType = NDictionary::TConstructor::GetTypeByVariantsCount(dictionaryLength);
     std::unique_ptr<arrow::ArrayBuilder> positionsBuilder = NArrow::MakeBuilder(positionsTargetType);
     AFL_VERIFY(SwitchType(positionsNew->type()->id(), [&](const auto& type) {
         using TRecordsWrap = std::decay_t<decltype(type)>;

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
@@ -134,7 +134,9 @@ void CopyIndices(const TInput* values, const i64 length, const TStringBuf validi
             outputPosition += size;
         } else {
             for (i64 i = 0; i < count; ++i) {
-                const TOutput value = values[position + i];
+                const TInput input = values[position + i];
+                AFL_VERIFY(input <= Max<TOutput>())("value", input)("max", Max<TOutput>());
+                const TOutput value = input;
                 memcpy(output + outputPosition, &value, sizeof(value));
                 outputPosition += sizeof(value);
             }

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/encoding.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/formats/arrow/arrow_helpers.h>
+#include <ydb/library/formats/arrow/switch/switch_type.h>
 #include <ydb/library/formats/arrow/validation/validation.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/data.h>
@@ -12,6 +13,8 @@
 #include <contrib/libs/apache/arrow/cpp/src/arrow/util/byte_stream_split.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/util/compression.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/util/endian.h>
+
+#include <type_traits>
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
@@ -119,6 +122,30 @@ ui32 CountSetBits(const TStringBuf bitmap, const ui32 count) {
 
 ui32 GetIndexByteWidth(const arrow::FixedWidthType& type) {
     return type.bit_width() / CHAR_BIT;
+}
+
+template <class TOutput, class TInput>
+void CopyIndices(const TInput* values, const i64 length, const TStringBuf validity, char* output, size_t& outputPosition) {
+    // If types are different, each value must be converted
+    const auto copyRun = [&](const i64 position, const i64 count) {
+        if constexpr (std::is_same_v<TOutput, TInput>) {
+            const size_t size = count * sizeof(TOutput);
+            memcpy(output + outputPosition, values + position, size);
+            outputPosition += size;
+        } else {
+            for (i64 i = 0; i < count; ++i) {
+                const TOutput value = values[position + i];
+                memcpy(output + outputPosition, &value, sizeof(value));
+                outputPosition += sizeof(value);
+            }
+        }
+    };
+    if (validity.empty()) {
+        copyRun(0, length);
+    } else {
+        arrow::internal::VisitSetBitRunsVoid(
+            GetBitmapData(validity), 0, length, [&](const i64 position, const i64 count) { copyRun(position, count); });
+    }
 }
 
 std::shared_ptr<arrow::Buffer> CopyToBuffer(const void* data, size_t size) {
@@ -353,9 +380,7 @@ std::shared_ptr<arrow::BinaryArray> DeserializeBinaryArray(
 TString SerializeIndices(const std::shared_ptr<arrow::Array>& positions, const std::shared_ptr<arrow::FixedWidthType>& indexType,
     const std::shared_ptr<arrow::util::Codec>& codec) {
     VerifyLittleEndian();
-    AFL_VERIFY(positions->type()->Equals(*indexType))("positions_type", positions->type()->ToString())("index_type", indexType->ToString());
     const ui32 width = GetIndexByteWidth(*indexType);
-    const auto& data = *positions->data();
     const i64 length = positions->length();
 
     const TValidityBitmap validity(*positions);
@@ -372,16 +397,24 @@ TString SerializeIndices(const std::shared_ptr<arrow::Array>& positions, const s
         outputPosition += validityData.size();
     }
     if (length) {
-        const ui8* values = data.buffers[1]->data() + data.offset * width;
-        if (!hasNulls) {
-            memcpy(output + outputPosition, values, width * length);
-        } else {
-            arrow::internal::VisitSetBitRunsVoid(GetBitmapData(validityData), 0, length, [&](const i64 position, const i64 count) {
-                const size_t bytes = count * width;
-                memcpy(output + outputPosition, values + position * width, bytes);
-                outputPosition += bytes;
-            });
-        }
+        AFL_VERIFY(SwitchType(positions->type_id(), [&](const auto type) {
+            if constexpr (type.IsIndexType()) {
+                const auto* source = type.CastArray(positions.get());
+                if (indexType->id() == arrow::Type::UINT8) {
+                    CopyIndices<ui8>(source->raw_values(), length, validityData, output, outputPosition);
+                    return true;
+                }
+                if (indexType->id() == arrow::Type::UINT16) {
+                    CopyIndices<ui16>(source->raw_values(), length, validityData, output, outputPosition);
+                    return true;
+                }
+                if (indexType->id() == arrow::Type::UINT32) {
+                    CopyIndices<ui32>(source->raw_values(), length, validityData, output, outputPosition);
+                    return true;
+                }
+            }
+            return false;
+        }))("positions_type", positions->type()->ToString())("index_type", indexType->ToString());
     }
     return FrameCompress(payload, codec);
 }

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/ut/ut_dense_encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/ut/ut_dense_encoding.cpp
@@ -168,10 +168,13 @@ Y_UNIT_TEST_SUITE(DenseEncoding) {
         UNIT_ASSERT(restored->GetPositions()->Equals(*positions));
     }
 
-    // Dictionary has <256 positions, but uint16 index - index will be encoded as uint8
+    // Dictionary has one value but UInt16 positions; dense encoding narrows them to UInt8.
     Y_UNIT_TEST(DictionaryWithWidePositionsRoundTrips) {
         const auto dictionary = MakeBinary({ "alpha" });
         arrow::UInt16Builder positionsBuilder;
+        UNIT_ASSERT(positionsBuilder.Append(0).ok());
+        // Exercise null preservation while converting wide positions.
+        UNIT_ASSERT(positionsBuilder.AppendNull().ok());
         UNIT_ASSERT(positionsBuilder.Append(0).ok());
         std::shared_ptr<arrow::UInt16Array> positions;
         UNIT_ASSERT(positionsBuilder.Finish(&positions).ok());
@@ -187,20 +190,22 @@ Y_UNIT_TEST_SUITE(DenseEncoding) {
         UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(restored->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT8));
     }
 
-    // Dictionary has 256 positions, but after slicing it has less and index fits uint8
+    // A 256-value dictionary uses UInt16 positions; the slice has one value and uses UInt8.
     Y_UNIT_TEST(DictionarySliceWithWidePositionsRoundTrips) {
-        auto builder = NAccessor::TTrivialArray::MakeBuilderBinary(256, 1024);
-        for (ui32 i = 0; i < 256; ++i) {
+        auto builder = NAccessor::TTrivialArray::MakeBuilderBinary(257, 1024);
+        // Exercise null preservation while remapping slice positions.
+        builder.AddNull(0);
+        for (ui32 i = 1; i <= 256; ++i) {
             builder.AddRecord(i, ToString(i));
         }
-        const auto source = builder.Finish(256);
+        const auto source = builder.Finish(257);
         const auto serializer = NSerialization::TSerializerContainer::GetDefaultSerializer();
         const NAccessor::TChunkConstructionData sourceData(source->GetRecordsCount(), nullptr, arrow::binary(), serializer);
         const auto dictionary = std::static_pointer_cast<NAccessor::TDictionaryArray>(
             NAccessor::NDictionary::TConstructor().Construct(source, sourceData).DetachResult());
         UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(dictionary->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT16));
 
-        const auto slice = std::static_pointer_cast<NAccessor::TDictionaryArray>(dictionary->ISlice(0, 1));
+        const auto slice = std::static_pointer_cast<NAccessor::TDictionaryArray>(dictionary->ISlice(0, 2));
         UNIT_ASSERT_VALUES_EQUAL(slice->GetDictionary()->length(), 1);
         UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(slice->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT8));
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/ut/ut_dense_encoding.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/dense_encoding/ut/ut_dense_encoding.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
 #include <ydb/core/formats/arrow/accessor/common/additional_data.h>
 #include <ydb/core/formats/arrow/accessor/dictionary/accessor.h>
+#include <ydb/core/formats/arrow/accessor/dictionary/constructor.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/accessor.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/constructor.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/data_extractor.h>
@@ -165,6 +166,51 @@ Y_UNIT_TEST_SUITE(DenseEncoding) {
             constructor.DeserializeFromString(blobAndMeta.Blob, constructionData.WithAdditionalAccessorData(blobAndMeta.Meta)).DetachResult());
         UNIT_ASSERT(restored->GetDictionary()->Equals(*dictionary));
         UNIT_ASSERT(restored->GetPositions()->Equals(*positions));
+    }
+
+    // Dictionary has <256 positions, but uint16 index - index will be encoded as uint8
+    Y_UNIT_TEST(DictionaryWithWidePositionsRoundTrips) {
+        const auto dictionary = MakeBinary({ "alpha" });
+        arrow::UInt16Builder positionsBuilder;
+        UNIT_ASSERT(positionsBuilder.Append(0).ok());
+        std::shared_ptr<arrow::UInt16Array> positions;
+        UNIT_ASSERT(positionsBuilder.Finish(&positions).ok());
+        const auto array = std::make_shared<NAccessor::TDictionaryArray>(dictionary, positions);
+        const auto serializer = NSerialization::TSerializerContainer::GetDefaultSerializer();
+        const NAccessor::TChunkConstructionData constructionData(array->GetRecordsCount(), nullptr, arrow::binary(), serializer);
+        const TDictionaryDenseConstructor constructor;
+
+        const auto blobAndMeta = constructor.SerializeToBlobAndMeta(array, constructionData);
+        const auto restored = std::static_pointer_cast<NAccessor::TDictionaryArray>(
+            constructor.DeserializeFromString(blobAndMeta.Blob, constructionData.WithAdditionalAccessorData(blobAndMeta.Meta)).DetachResult());
+        UNIT_ASSERT(restored->GetChunkedArray()->Equals(*array->GetChunkedArray()));
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(restored->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT8));
+    }
+
+    // Dictionary has 256 positions, but after slicing it has less and index fits uint8
+    Y_UNIT_TEST(DictionarySliceWithWidePositionsRoundTrips) {
+        auto builder = NAccessor::TTrivialArray::MakeBuilderBinary(256, 1024);
+        for (ui32 i = 0; i < 256; ++i) {
+            builder.AddRecord(i, ToString(i));
+        }
+        const auto source = builder.Finish(256);
+        const auto serializer = NSerialization::TSerializerContainer::GetDefaultSerializer();
+        const NAccessor::TChunkConstructionData sourceData(source->GetRecordsCount(), nullptr, arrow::binary(), serializer);
+        const auto dictionary = std::static_pointer_cast<NAccessor::TDictionaryArray>(
+            NAccessor::NDictionary::TConstructor().Construct(source, sourceData).DetachResult());
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(dictionary->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT16));
+
+        const auto slice = std::static_pointer_cast<NAccessor::TDictionaryArray>(dictionary->ISlice(0, 1));
+        UNIT_ASSERT_VALUES_EQUAL(slice->GetDictionary()->length(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(slice->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT8));
+
+        const NAccessor::TChunkConstructionData sliceData(slice->GetRecordsCount(), nullptr, arrow::binary(), serializer);
+        const TDictionaryDenseConstructor constructor;
+        const auto blobAndMeta = constructor.SerializeToBlobAndMeta(slice, sliceData);
+        const auto restored = std::static_pointer_cast<NAccessor::TDictionaryArray>(
+            constructor.DeserializeFromString(blobAndMeta.Blob, sliceData.WithAdditionalAccessorData(blobAndMeta.Meta)).DetachResult());
+        UNIT_ASSERT(restored->GetChunkedArray()->Equals(*slice->GetChunkedArray()));
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(restored->GetPositions()->type_id()), static_cast<int>(arrow::Type::UINT8));
     }
 
 }


### PR DESCRIPTION
It could happen when a dictionary was sliced to a smaller set of values, but index width did not change.
Both places are fixed - type for index is re-selected on slicing and the encoding handles a wider index path (although slower, because each value has to be converted).
Thus a dictionary with uint16 index can round-trip to a dictionary with uint8 index - seems ok because those are internal in-memory objects.
