### PR TITLE
WIP Выборка по strict jsonpath без постфильтрации

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -2390,6 +2390,19 @@ TMaybeNode<TExprBase> KqpSelectJsonIndex(const NYql::NNodes::TExprBase& node, NY
         .Settings(expectedSettings->Settings.BuildNode(ctx, node.Pos()))
         .Done();
 
+    if (expectedSettings->Covered) {
+        auto maybeIf = flatMap.Lambda().Body().Maybe<TCoOptionalIf>();
+        if (maybeIf) {
+            return Build<TCoMap>(ctx, node.Pos())
+                .Input(newInput)
+                .Lambda<TCoLambda>()
+                    .Args(flatMap.Lambda().Args())
+                    .Body(maybeIf.Cast().Value())
+                    .Build()
+                .Done();
+        }
+    }
+
     return Build<TCoFlatMap>(ctx, node.Pos())
         .Input(newInput)
         .Lambda(flatMap.Lambda())
@@ -2450,6 +2463,19 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(
         .QueryColumns(searchColumns.Ptr())
         .Settings(jsonIndexSettings.Settings.BuildNode(ctx, node.Pos()))
         .Done();
+
+    if (expectedSettings->Covered) {
+        auto maybeIf = flatMap.Lambda().Body().Maybe<TCoOptionalIf>();
+        if (maybeIf) {
+            return Build<TCoMap>(ctx, node.Pos())
+                .Input(newInput)
+                .Lambda<TCoLambda>()
+                    .Args(flatMap.Lambda().Args())
+                    .Body(maybeIf.Cast().Value())
+                    .Build()
+                .Done();
+        }
+    }
 
     return Build<TCoFlatMap>(ctx, node.Pos())
         .Input(newInput)

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -483,19 +483,27 @@ TPredicateCollectResult AppendComparisonValue(
     const TString& columnName, TCollectResult collectResult, std::optional<TExprBase> comparisonValue) {
     YQL_ENSURE(!collectResult.IsError(), "Expected valid collect result");
 
-    auto& tokens = collectResult.GetTokens();
-    if (collectResult.CanCollect() && comparisonValue.has_value()) {
-        YQL_ENSURE(tokens.size() == 1, "Expected exactly one token");
-        auto node = tokens.extract(tokens.begin());
-
+    if (comparisonValue.has_value() && collectResult.CanAppendLiteral()) {
+        TString paramName;
+        TString literal;
         if (comparisonValue->Maybe<TCoParameter>()) {
-            const auto paramName = TString(comparisonValue->Cast<TCoParameter>().Name().Value());
-            node.value().ParamName = paramName;
+            paramName = TString(comparisonValue->Cast<TCoParameter>().Name().Value());
         } else if (const auto encodedValue = EncodeValueToJsonPath(*comparisonValue)) {
-            node.value().PathToken += *encodedValue;
+            literal = *encodedValue;
         }
 
-        tokens.insert(std::move(node));
+        auto& tokens = collectResult.GetTokens();
+        TTokens updated;
+        for (const auto& token : tokens) {
+            TToken newToken = token;
+            if (!paramName.empty()) {
+                newToken.ParamName = paramName;
+            } else {
+                newToken.PathToken += literal;
+            }
+            updated.insert(std::move(newToken));
+        }
+        tokens = std::move(updated);
         collectResult.StopCollecting();
     }
 
@@ -645,26 +653,12 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
             return MakeCollectError(ctx, param.Pos(), "Unsupported parameter type in SQL IN");
         }
 
-        auto baseResult = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, std::nullopt, ctx, jsonLookup.Pos());
-        if (baseResult.Collect.IsError()) {
-            return baseResult;
+        auto result = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, TExprBase(param.Ptr()), ctx, jsonLookup.Pos());
+        if (!result.Collect.IsError()) {
+            result.Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
         }
 
-        if (baseResult.Collect.CanCollect()) {
-            auto& tokens = baseResult.Collect.GetTokens();
-            YQL_ENSURE(tokens.size() == 1);
-
-            auto paramName = TString(param.Name().Value());
-
-            auto nodeHandle = tokens.extract(tokens.begin());
-            nodeHandle.value().ParamName = std::move(paramName);
-            tokens.insert(std::move(nodeHandle));
-
-            baseResult.Collect.StopCollecting();
-            baseResult.Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
-        }
-
-        return baseResult;
+        return result;
     }
 
     std::vector<TExprBase> items;
@@ -696,11 +690,6 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
         return MakeCollectError(ctx, collection.Pos(), "Unsupported collection type in SQL IN");
     }
 
-    auto baseResult = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, std::nullopt, ctx, jsonLookup.Pos());
-    if (baseResult.Collect.IsError()) {
-        return baseResult;
-    }
-
     std::optional<TPredicateCollectResult> acc;
     for (const auto& item : items) {
         const auto literal = UnwrapValue(item);
@@ -709,7 +698,7 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
             return MakeCollectError(ctx, literal.Pos(), extracted.error());
         }
 
-        auto itemResult = AppendComparisonValue(baseResult.ColumnName, baseResult.Collect, *extracted);
+        auto itemResult = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, *extracted, ctx, literal.Pos());
         if (!acc.has_value()) {
             acc = std::move(itemResult);
         } else {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -68,7 +68,8 @@ bool IsJsonValueReturningNonIndexable(std::optional<EDataSlot> slot) {
     }
 }
 
-TExprBase UnwrapPredicate(TExprBase node) {
+std::pair<TExprBase, bool> UnwrapPredicate(TExprBase node) {
+    bool covered = true;
     while (true) {
         if (const auto just = node.Maybe<TCoJust>()) {
             node = just.Cast().Input();
@@ -83,11 +84,12 @@ TExprBase UnwrapPredicate(TExprBase node) {
             node = castNode.Predicate();
         } else if (const auto optionalIf = node.Maybe<TCoOptionalIf>()) {
             node = optionalIf.Cast().Predicate();
+            covered = false;
         } else {
             break;
         }
     }
-    return node;
+    return std::make_pair(node, covered);
 }
 
 // Returns true if a cast/convert from `from` to `to` is allowed for JSON index predicate extraction
@@ -445,10 +447,12 @@ std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPred
     // AND semantics: one of the operands must be valid
     if (mode == TCollectResult::ETokensMode::And) {
         if (leftValid) {
+            left->Collect.SetNotCovered();
             return left;
         }
 
         if (rightValid) {
+            right->Collect.SetNotCovered();
             return right;
         }
 
@@ -544,6 +548,12 @@ std::expected<std::optional<TExprBase>, TString> TryExtractComparisonValue(const
 
 std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(
     const TExprBase& node, const TExprBase& left, TExprBase right, TExprContext& ctx, const THashSet<TString>& indexedColumns) {
+    // Never covered because:
+    // json_value {a:x} $.a = x
+    // json_value [{a:x}] $.a = x
+    // json_value [{a:x},{a:y}] $.a = null
+    // => we can't just search on token "a=x"
+
     auto jsonSide = UnwrapValue(left);
     auto otherSide = UnwrapValue(std::move(right));
 
@@ -592,13 +602,22 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(
     auto leftResult = ParseAndCollectJson(*leftParams, ECallableType::JsonValue, comparisonValue, ctx, left.Pos());
     if (rightParams.has_value()) {
         auto rightResult = ParseAndCollectJson(*rightParams, ECallableType::JsonValue, std::nullopt, ctx, otherSide.Pos());
-        return MergePredicateResults(std::move(leftResult), std::move(rightResult), TCollectResult::ETokensMode::And, ctx, otherSide.Pos());
+        auto res = MergePredicateResults(std::move(leftResult), std::move(rightResult), TCollectResult::ETokensMode::And, ctx, otherSide.Pos());
+        res->Collect.SetNotCovered();
+        return res;
     }
 
+    leftResult.Collect.SetNotCovered();
     return leftResult;
 }
 
 std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExprContext& ctx, const THashSet<TString>& indexedColumns) {
+    // Never covered because:
+    // json_value {a:x} $.a = x
+    // json_value [{a:x}] $.a = x
+    // json_value [{a:x},{a:y}] $.a = null
+    // => we can't just search on token "a=x"
+
     auto lookup = UnwrapValue(node.Lookup());
     auto collection = UnwrapValue(node.Collection());
 
@@ -664,6 +683,7 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
             baseResult.Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
         }
 
+        baseResult.Collect.SetNotCovered();
         return baseResult;
     }
 
@@ -717,6 +737,9 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
         }
     }
 
+    if (acc.has_value()) {
+        acc->Collect.SetNotCovered();
+    }
     return acc;
 }
 
@@ -762,7 +785,9 @@ std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TEx
 
 std::optional<TPredicateCollectResult> VisitJsonPredicate(
     const TExprBase& predicate, TExprContext& ctx, const THashSet<TString>& indexedColumns) {
-    auto node = UnwrapPredicate(predicate);
+    auto nodeCovered = UnwrapPredicate(predicate);
+    auto node = nodeCovered.first;
+    auto covered = nodeCovered.second;
 
     if (const auto maybeAnd = node.Maybe<TCoAnd>()) {
         auto andNode = maybeAnd.Cast();
@@ -775,6 +800,9 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(
             auto nextNode = andNode.Arg(i);
             auto nextResult = VisitJsonPredicate(nextNode, ctx, indexedColumns);
             result = MergePredicateResults(std::move(result), std::move(nextResult), TCollectResult::ETokensMode::And, ctx, nextNode.Pos());
+        }
+        if (!covered && result.has_value()) {
+            result->Collect.SetNotCovered();
         }
 
         return result;
@@ -792,15 +820,24 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(
             auto nextResult = VisitJsonPredicate(nextNode, ctx, indexedColumns);
             result = MergePredicateResults(std::move(result), std::move(nextResult), TCollectResult::ETokensMode::Or, ctx, nextNode.Pos());
         }
+        if (!covered && result.has_value()) {
+            result->Collect.SetNotCovered();
+        }
 
         return result;
     }
 
     if (auto jsonExists = VisitJsonExists(node, ctx, indexedColumns)) {
+        if (!covered) {
+            jsonExists->Collect.SetNotCovered();
+        }
         return jsonExists;
     }
 
     if (auto jsonValue = VisitJsonValue(node, ctx, indexedColumns)) {
+        if (!covered) {
+            jsonValue->Collect.SetNotCovered();
+        }
         return jsonValue;
     }
 
@@ -910,6 +947,7 @@ std::expected<TJsonIndexSettings, TIssue> CollectJsonIndexPredicate(
     return TJsonIndexSettings{
         .ColumnName = std::move(result->ColumnName),
         .Settings = std::move(settings),
+        .Covered = collectResult.IsCovered(),
     };
 }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -483,27 +483,19 @@ TPredicateCollectResult AppendComparisonValue(
     const TString& columnName, TCollectResult collectResult, std::optional<TExprBase> comparisonValue) {
     YQL_ENSURE(!collectResult.IsError(), "Expected valid collect result");
 
-    if (comparisonValue.has_value() && collectResult.CanAppendLiteral()) {
-        TString paramName;
-        TString literal;
+    auto& tokens = collectResult.GetTokens();
+    if (collectResult.CanCollect() && comparisonValue.has_value()) {
+        YQL_ENSURE(tokens.size() == 1, "Expected exactly one token");
+        auto node = tokens.extract(tokens.begin());
+
         if (comparisonValue->Maybe<TCoParameter>()) {
-            paramName = TString(comparisonValue->Cast<TCoParameter>().Name().Value());
+            const auto paramName = TString(comparisonValue->Cast<TCoParameter>().Name().Value());
+            node.value().ParamName = paramName;
         } else if (const auto encodedValue = EncodeValueToJsonPath(*comparisonValue)) {
-            literal = *encodedValue;
+            node.value().PathToken += *encodedValue;
         }
 
-        auto& tokens = collectResult.GetTokens();
-        TTokens updated;
-        for (const auto& token : tokens) {
-            TToken newToken = token;
-            if (!paramName.empty()) {
-                newToken.ParamName = paramName;
-            } else {
-                newToken.PathToken += literal;
-            }
-            updated.insert(std::move(newToken));
-        }
-        tokens = std::move(updated);
+        tokens.insert(std::move(node));
         collectResult.StopCollecting();
     }
 
@@ -653,12 +645,26 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
             return MakeCollectError(ctx, param.Pos(), "Unsupported parameter type in SQL IN");
         }
 
-        auto result = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, TExprBase(param.Ptr()), ctx, jsonLookup.Pos());
-        if (!result.Collect.IsError()) {
-            result.Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
+        auto baseResult = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, std::nullopt, ctx, jsonLookup.Pos());
+        if (baseResult.Collect.IsError()) {
+            return baseResult;
         }
 
-        return result;
+        if (baseResult.Collect.CanCollect()) {
+            auto& tokens = baseResult.Collect.GetTokens();
+            YQL_ENSURE(tokens.size() == 1);
+
+            auto paramName = TString(param.Name().Value());
+
+            auto nodeHandle = tokens.extract(tokens.begin());
+            nodeHandle.value().ParamName = std::move(paramName);
+            tokens.insert(std::move(nodeHandle));
+
+            baseResult.Collect.StopCollecting();
+            baseResult.Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
+        }
+
+        return baseResult;
     }
 
     std::vector<TExprBase> items;
@@ -690,6 +696,11 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
         return MakeCollectError(ctx, collection.Pos(), "Unsupported collection type in SQL IN");
     }
 
+    auto baseResult = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, std::nullopt, ctx, jsonLookup.Pos());
+    if (baseResult.Collect.IsError()) {
+        return baseResult;
+    }
+
     std::optional<TPredicateCollectResult> acc;
     for (const auto& item : items) {
         const auto literal = UnwrapValue(item);
@@ -698,7 +709,7 @@ std::optional<TPredicateCollectResult> VisitJsonSqlIn(const TCoSqlIn& node, TExp
             return MakeCollectError(ctx, literal.Pos(), extracted.error());
         }
 
-        auto itemResult = ParseAndCollectJson(*jsonParams, ECallableType::JsonValue, *extracted, ctx, literal.Pos());
+        auto itemResult = AppendComparisonValue(baseResult.ColumnName, baseResult.Collect, *extracted);
         if (!acc.has_value()) {
             acc = std::move(itemResult);
         } else {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.h
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.h
@@ -13,6 +13,7 @@ namespace NKikimr::NKqp::NOpt {
 struct TJsonIndexSettings {
     TString ColumnName;
     NYql::TKqpReadTableFullTextIndexSettings Settings;
+    bool Covered = false;
 };
 
 enum class EJsonIndexSelectionMode {

--- a/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.cpp
+++ b/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.cpp
@@ -295,7 +295,6 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate,
     auto success = NJson::ReadJsonTree(*plan, &planJson, true);
     UNIT_ASSERT_C(success, "Failed to read plan as JSON");
 
-    auto defaultOp = defaultOperator.empty() ? (expected.size() == 1 || predicate.find("strict ") != std::string::npos ? "and" : "or") : defaultOperator;
     auto op = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["DefaultOperator"].GetString();
     UNIT_ASSERT_VALUES_EQUAL_C(op, '"' + defaultOperator + '"', "for predicate = " << predicate);
 

--- a/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.cpp
+++ b/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.cpp
@@ -295,6 +295,7 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate,
     auto success = NJson::ReadJsonTree(*plan, &planJson, true);
     UNIT_ASSERT_C(success, "Failed to read plan as JSON");
 
+    auto defaultOp = defaultOperator.empty() ? (expected.size() == 1 || predicate.find("strict ") != std::string::npos ? "and" : "or") : defaultOperator;
     auto op = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["DefaultOperator"].GetString();
     UNIT_ASSERT_VALUES_EQUAL_C(op, '"' + defaultOperator + '"', "for predicate = " << predicate);
 
@@ -565,10 +566,10 @@ void TestJsonCorpus(TTestJsonCorpusOptions tOpts, TPredicateBuilderOptions pOpts
         } else {
             UNIT_ASSERT_C(idxResult.IsSuccess(), "INDEX query failed for predicate: " << p.Sql << " err: " << idxResult.GetIssues().ToString());
             UNIT_ASSERT_C(mainResult.IsSuccess(), "MAIN query failed for predicate: " << p.Sql << " err: " << mainResult.GetIssues().ToString());
+            Cerr << p.Sql << ", size: " << idxResult.GetResultSet(0).RowsCount() << Endl;
+
             CompareYson(FormatResultSetYson(mainResult.GetResultSet(0)), FormatResultSetYson(idxResult.GetResultSet(0)));
             ++okCount;
-
-            Cerr << p.Sql << ", size: " << idxResult.GetResultSet(0).RowsCount() << Endl;
         }
     }
 

--- a/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h
+++ b/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h
@@ -61,10 +61,10 @@ void FillDataColumn(NYdb::NQuery::TQueryClient& db);
 
 void ValidateTokens(NYdb::NQuery::TQueryClient& db, const std::string& predicate,
     std::vector<NJsonIndex::TToken> expected, NYdb::TParams params,
-    const std::string& defaultOperator = "and");
+    const std::string& defaultOperator = "");
 
 void ValidateTokens(NYdb::NQuery::TQueryClient& db, const std::string& predicate, std::vector<std::string> expected,
-    const std::string& defaultOperator = "and");
+    const std::string& defaultOperator = "");
 
 NYdb::NQuery::TExecuteQueryResult WriteJsonIndexWithKeys(NYdb::NQuery::TQueryClient& db, const std::string& stmt,
     const std::string& tableName, const std::string& jsonType, const std::vector<std::pair<ui64, ui64>>& values,

--- a/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h
+++ b/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h
@@ -61,10 +61,10 @@ void FillDataColumn(NYdb::NQuery::TQueryClient& db);
 
 void ValidateTokens(NYdb::NQuery::TQueryClient& db, const std::string& predicate,
     std::vector<NJsonIndex::TToken> expected, NYdb::TParams params,
-    const std::string& defaultOperator = "");
+    const std::string& defaultOperator = "and");
 
 void ValidateTokens(NYdb::NQuery::TQueryClient& db, const std::string& predicate, std::vector<std::string> expected,
-    const std::string& defaultOperator = "");
+    const std::string& defaultOperator = "and");
 
 NYdb::NQuery::TExecuteQueryResult WriteJsonIndexWithKeys(NYdb::NQuery::TQueryClient& db, const std::string& stmt,
     const std::string& tableName, const std::string& jsonType, const std::vector<std::pair<ui64, ui64>>& values,

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_tokens_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_tokens_ut.cpp
@@ -17,11 +17,11 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
     Y_UNIT_TEST(JsonExists) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Basic path exists cases
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key'))", {"\4key"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\3k1\3k2" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))", {"\3k1" + trueSuffix, "\3k2" + falseSuffix}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))", {"\3k1" + nullSuffix, "\3k2" + strSuffix("str")}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') == true)", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key'))", {"\x13key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\x12k1\x12k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))", {"\x12k1" + trueSuffix, "\x12k2" + falseSuffix}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))", {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str")}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') == true)", {"\x13key"});
 
             // Negated JSON_EXISTS is not supported by JSON index
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key') == false)");
@@ -32,97 +32,97 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // AND combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "and");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
 
             // OR combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
+                {"\x12k1" + nullSuffix, "\x12k2" + strSuffix("str"), "\x12k3" + trueSuffix, "\x12k4" + falseSuffix}, "or");
 
             // Mixed combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "or");
+                {"\x12k1", "\x12k2", "\x12k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "or");
+                {"\x12k1", "\x12k2", "\x12k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "or");
+                {"\x12k1", "\x12k2", "\x12k3"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND (JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3')))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') AND JSON_EXISTS(Text, '$.k4')))",
-                {"\3k1", "\3k2", "\3k3", "\3k4"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3", "\x12k4"}, "and");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "or");
+                {"\x12k1", "\x12k2", "\x12k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')))",
-                {"\3k1", "\3k2", "\3k3"}, "or");
+                {"\x12k1", "\x12k2", "\x12k3"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') OR JSON_EXISTS(Text, '$.k4')))",
-                {"\3k1", "\3k2", "\3k3", "\3k4"}, "or");
+                {"\x12k1", "\x12k2", "\x12k3", "\x12k4"}, "or");
 
             // AND with non-indexable predicate
             ValidateTokens(db,
                 R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND Data = "d1")",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1'))",
-                {"\3k1"}, "and");
+                {"\x12k1"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1")",
-                {"\3k1"}, "and");
+                {"\x12k1"}, "and");
             ValidateTokens(db,
                 R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND Data = "d1" AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3') AND Data = "d1")",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
 
             // OR with non-indexable predicate - not extractable
             ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
@@ -142,10 +142,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" OR JSON_EXISTS(Text, '$.k2'))");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND Data = "d1")", {"\3k1", "\3k2"}, "or");
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND Data = "d1")", {"\3k1", "\3k2"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND Data = "d1")", {"\x12k1", "\x12k2"}, "or");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND Data = "d1")", {"\x12k1", "\x12k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" OR JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
 
             // NOT JSON_EXISTS and wrapped-NOT forms fall through to "nothing to extract"
             ValidateError(db, R"(NOT JSON_EXISTS(Text, '$.k1'))");
@@ -153,111 +153,111 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))");
 
             // Filter equality - covers every literal type, the token carries the value suffix
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == null)'))", {"\3k1\3k2" + nullSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == true)'))", {"\3k1\3k2" + trueSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == false)'))", {"\3k1\3k2" + falseSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == "abc")'))", {"\3k1\3k2" + strSuffix("abc")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 42)'))", {"\3k1\3k2" + numSuffix(42)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == -1.5)'))", {"\3k1\3k2" + numSuffix(-1.5)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 == @.k2)'))", {"\3k1\3k2" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("s" == @.k2)'))", {"\3k1\3k2" + strSuffix("s")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == null)'))", {"\x12k1\x12k2" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == true)'))", {"\x12k1\x12k2" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == false)'))", {"\x12k1\x12k2" + falseSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == "abc")'))", {"\x12k1\x12k2" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 42)'))", {"\x12k1\x12k2" + numSuffix(42)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == -1.5)'))", {"\x12k1\x12k2" + numSuffix(-1.5)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 == @.k2)'))", {"\x12k1\x12k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("s" == @.k2)'))", {"\x12k1\x12k2" + strSuffix("s")});
 
             // Filter inequality / range - path only, no value suffix
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != 2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > 2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < 2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 >= 2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 <= 2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != null)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != "abc")'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 > @.k2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 < @.k2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 >= @.k2)'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 <= @.k2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != 2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > 2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < 2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 >= 2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 <= 2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != null)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != "abc")'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 > @.k2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 < @.k2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 >= @.k2)'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 <= @.k2)'))", {"\x12k1\x12k2"});
 
             // Filter path-vs-path comparisons - two tokens, AND mode (value suffix dropped)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == @.k2)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 != @.k2)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > @.k2)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 < @.k2)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= @.k2)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 <= @.k2)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == @.k2)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 != @.k2)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > @.k2)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 < @.k2)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= @.k2)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 <= @.k2)'))", {"\x12k1", "\x12k2"}, "and");
 
             // Filter arithmetic (path vs literal) - path only, no value suffix
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - 1 == 0)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 == 4)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / 2 == 1)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % 2 == 0)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 > 2)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 != 4)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - 1 == 0)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 == 4)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / 2 == 1)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % 2 == 0)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 > 2)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 != 4)'))", {"\x12k1"});
 
             // Filter arithmetic (path vs path) - two tokens, AND mode
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - @.k2 > 0)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * @.k2 < 10)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / @.k2 >= 1)'))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % @.k2 != 0)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - @.k2 > 0)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * @.k2 < 10)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / @.k2 >= 1)'))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % @.k2 != 0)'))", {"\x12k1", "\x12k2"}, "and");
 
             // Filter unary operators - path only
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (+@.k1 == 1)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 > 0)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() > 5)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() == 3)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() > 0)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1.abs() == -1)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() - @.k2.abs() == 0)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (+@.k1 == 1)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 > 0)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() > 5)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() == 3)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() > 0)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1.abs() == -1)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() - @.k2.abs() == 0)'))", {"\x12k1", "\x12k2"}, "and");
 
             // && / || inside jsonpath - mode propagates from inner operator
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 != 2)'))",
-                {"\3k1" + numSuffix(1), "\3k2"}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 != 2)'))",
-                {"\3k1" + numSuffix(1), "\3k2"}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > 0 && @.k2 < 10)'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > 0 || @.k2 < 10)'))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2 && @.k2 * 2 == 4)'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2 || @.k2 * 2 == 4)'))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1 && @.k2.size() > 0)'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1 || @.k2 % 2 == 0)'))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
 
             // Three-way && / || inside jsonpath
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2 && @.k3 == 3)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 == 2 || @.k3 == 3)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
 
             // Mixed && and || inside jsonpath
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@.k1 == 1 && @.k2 == 2) || @.k3 == 3)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || (@.k2 == 2 && @.k3 == 3))'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@.k1 > 0 && @.k2 != null) || @.k3 == "text")'))",
-                {"\3k1", "\3k2", "\3k3" + strSuffix("text")}, "or");
+                {"\x12k1", "\x12k2", "\x12k3" + strSuffix("text")}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5 && @.k3 == "text" || @.k4 == null)'))",
-                {"\3k1", "\3k2", "\3k3" + strSuffix("text"), "\3k4" + nullSuffix}, "or");
+                {"\x12k1", "\x12k2", "\x12k3" + strSuffix("text"), "\x12k4" + nullSuffix}, "or");
 
             // Outer SQL AND/OR over filters with &&/|| inside
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2)') AND JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3"}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 == 2)') AND JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3"}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2)') OR JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3"}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)') AND JSON_EXISTS(Text, '$ ? (-@.k3 == -3)'))",
-                {"\3k1", "\3k2", "\3k3"}, "and");
+                {"\x12k1", "\x12k2", "\x12k3"}, "and");
 
             // Outer range comparison with bool literal (non-equality): errors
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > true)");
@@ -276,8 +276,8 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(true != JSON_EXISTS(Text, '$.k1'))");
 
             // JSON_EXISTS comparison with true rewrites to JSON_EXISTS without boolean comparison
-            ValidateTokens(db, R"(true == JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
-            ValidateTokens(db, R"(false != JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
+            ValidateTokens(db, R"(true == JSON_EXISTS(Text, '$.k1'))", {"\x12k1"});
+            ValidateTokens(db, R"(false != JSON_EXISTS(Text, '$.k1'))", {"\x12k1"});
 
             // JSON_EXISTS comparison with false rewrites to NOT JSON_EXISTS
             ValidateError(db, R"(false == JSON_EXISTS(Text, '$.k1'))");
@@ -295,12 +295,12 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2') <= true)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false OR JSON_EXISTS(Text, '$.k2') < true)");
             // AND: non-indexable range cmp on k1, but standalone JE($.k2) IS indexable - post-filter applies
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))", {"\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))", {"\x12k2"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true OR JSON_EXISTS(Text, '$.k2') == true)");
 
             // Outer AND/OR over cross JSON_EXISTS comparisons
             // AND: JE1 > JE2 not indexable, but standalone JE($.k3) IS indexable - post-filter applies
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\3k3"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\x12k3"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') != JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') >= JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') <= JSON_EXISTS(Text, '$.k4')))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') != JSON_EXISTS(Text, '$.k4')))");
@@ -327,15 +327,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$ ? (@.k1 == 1 && @.k2 == 2)') == true)");
 
             // AND: JE in JSON_QUERY + indexable JE -> extract indexable
-            ValidateTokens(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\x12k2"});
             // OR: indexable JE + JE in JSON_QUERY -> error
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b'))");
 
             // JSON_EXISTS with TRUE ON ERROR is negation
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key' TRUE ON ERROR))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' FALSE ON ERROR))", {"\4key"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' ERROR ON ERROR))", {"\4key"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' UNKNOWN ON ERROR))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' FALSE ON ERROR))", {"\x13key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' ERROR ON ERROR))", {"\x13key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' UNKNOWN ON ERROR))", {"\x13key"});
         });
     }
 
@@ -362,9 +362,9 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"((JSON_QUERY(Text, '$.k1') IS NOT NULL) AND (JSON_QUERY(Text, '$.k2') IS NOT NULL) OR (JSON_QUERY(Text, '$.k3') IS NOT NULL))");
             ValidateError(db, R"(((JSON_QUERY(Text, '$.k1') IS NOT NULL) AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)) OR (JSON_QUERY(Text, '$.k3') IS NOT NULL))");
 
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))", {"\3k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))", {"\x12k1"});
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_QUERY(Text, '$.k2') IS NOT NULL)))");
-            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Utf8) = "1") AND (JSON_QUERY(Text, '$.k2') IS NOT NULL))", {"\3k1" + strSuffix("1")});
+            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Utf8) = "1") AND (JSON_QUERY(Text, '$.k2') IS NOT NULL))", {"\x12k1" + strSuffix("1")});
         });
     }
 
@@ -383,35 +383,35 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1.type()') == "v"u)", kErr);
 
             // One JSON_VALUE is indexable
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == JSON_VALUE(Text, '$.k2'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == JSON_VALUE(Text, '$.k2'))", {"\x12k1"}, "and");
 
             // With RETURNING
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "v"u)", {"\3k1" + strSuffix("v")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "v"s)", {"\3k1" + strSuffix("v")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "v"u)", {"\x12k1" + strSuffix("v")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "v"s)", {"\x12k1" + strSuffix("v")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\x12k1" + trueSuffix});
         });
     }
 
     Y_UNIT_TEST(JsonValue) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Supported RETURNING types
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == 1t)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == 1ut)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == 1s)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) == 1us)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) == 1u)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 1ul)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) == 1.0f)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "value"s)", {"\3k1" + strSuffix("value")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "value"u)", {"\3k1" + strSuffix("value")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == 1t)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == 1ut)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == 1s)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) == 1us)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) == 1u)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 1ul)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) == 1.0f)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "value"s)", {"\x12k1" + strSuffix("value")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "value"u)", {"\x12k1" + strSuffix("value")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\x12k1" + trueSuffix});
 
             // Not supported RETURNING types
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))");
@@ -419,18 +419,18 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Timestamp) == Timestamp("2021-01-01T00:00:00Z"))");
 
             // Explicit RETURNING Utf8 (implicit default no longer allowed)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "1")", {"\3k1" + strSuffix("1")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "string")", {"\3k1" + strSuffix("string")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "1")", {"\x12k1" + strSuffix("1")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "string")", {"\x12k1" + strSuffix("string")});
 
             // Negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8) IS NULL)");
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8) IS NOT NULL)"); 
 
             // JV(...) == true is equivalent to standalone JV(...) - collects trueSuffix token
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(true == JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(true == JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\x12k1" + trueSuffix});
 
             // JV comparison with false rewrites to NOT JSON_VALUE
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)");
@@ -449,41 +449,41 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) <= false)");
 
             // Comparison with other literals
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 10)", {"\3k1" + numSuffix(10)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 10)", {"\x12k1" + numSuffix(10)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\x12k1"});
 
             // JV op JV - both collectable
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k2' RETURNING Int32) == JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) != JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) > JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) >= JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) < JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k1", "\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) <= JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) != JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) > JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) >= JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) < JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k1", "\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) <= JSON_VALUE(Text, '$.k2' RETURNING Utf8))", {"\x12k1", "\x12k2"}, "and");
 
             // JSON_VALUE RETURNING Bool comparison is not supported
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool))");
@@ -497,92 +497,92 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) > JSON_VALUE(Text, '$.k2' RETURNING Bool)))");
 
             // For some nodes inside the path, the collected result cannot be combined with == operator
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"' RETURNING Utf8) == "true")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Int32) == 2)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 2)", {"\3k1" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + 1' RETURNING Int32) == 2)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\3k1" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"' RETURNING Utf8) == "true")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Int32) == 2)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 2)", {"\x12k1" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + 1' RETURNING Int32) == 2)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\x12k1" + numSuffix(2)});
 
             // BETWEEN clause (replaces with JSON_VALUE >= 1 AND JSON_VALUE <= 10)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\x12k1"});
 
             // AND/OR combinations - numeric equality
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2)",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2)}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2)",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2)}, "or");
 
             // AND/OR combinations - string equality
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "b")",
-                {"\3k1" + strSuffix("a"), "\3k2" + strSuffix("b")}, "and");
+                {"\x12k1" + strSuffix("a"), "\x12k2" + strSuffix("b")}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "b")",
-                {"\3k1" + strSuffix("a"), "\3k2" + strSuffix("b")}, "or");
+                {"\x12k1" + strSuffix("a"), "\x12k2" + strSuffix("b")}, "or");
 
             // AND/OR with range comparisons - path-only tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 5 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) < 10)",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 5 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) < 10)",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
 
             // AND/OR mixing equality and range
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_VALUE(Text, '$.k2' RETURNING Int32) > 0)",
-                {"\3k1" + strSuffix("a"), "\3k2"}, "and");
+                {"\x12k1" + strSuffix("a"), "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_VALUE(Text, '$.k2' RETURNING Int32) > 0)",
-                {"\3k1" + strSuffix("a"), "\3k2"}, "or");
+                {"\x12k1" + strSuffix("a"), "\x12k2"}, "or");
 
             // Three-way AND/OR
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 AND JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 OR JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
 
             // Mixed AND/OR (AND binds tighter): both cases produce "or"
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 OR JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 AND JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
 
             // Comparison operators with strings - path-only token (no value suffix for non-equality)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) > "abc")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) < "xyz")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) >= "abc")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) <= "xyz")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) != "abc")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) > "abc")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) < "xyz")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) >= "abc")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) <= "xyz")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) != "abc")", {"\x12k1"});
 
             // Flipped operand order - string comparisons
-            ValidateTokens(db, R"("abc" < JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\3k1"});
-            ValidateTokens(db, R"("abc" > JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\3k1"});
-            ValidateTokens(db, R"("abc" != JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\3k1"});
+            ValidateTokens(db, R"("abc" < JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\x12k1"});
+            ValidateTokens(db, R"("abc" > JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\x12k1"});
+            ValidateTokens(db, R"("abc" != JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\x12k1"});
 
             // Flipped operand order - numeric comparisons
-            ValidateTokens(db, R"(10 < JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
-            ValidateTokens(db, R"(10 > JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
-            ValidateTokens(db, R"(10 >= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
-            ValidateTokens(db, R"(10 <= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
-            ValidateTokens(db, R"(10 != JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
+            ValidateTokens(db, R"(10 < JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\x12k1"});
+            ValidateTokens(db, R"(10 > JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\x12k1"});
+            ValidateTokens(db, R"(10 >= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\x12k1"});
+            ValidateTokens(db, R"(10 <= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\x12k1"});
+            ValidateTokens(db, R"(10 != JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\x12k1"});
 
             // STARTS WITH - path only token
-            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "prefix"))", {"\3k1"});
-            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "prefix") AND JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a")", {"\3k1" + strSuffix("a")});
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "prefix"))", {"\x12k1"});
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "prefix") AND JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a")", {"\x12k1" + strSuffix("a")});
 
             // ENDS WITH - path only token
-            ValidateTokens(db, R"(EndsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "suffix"))", {"\3k1"});
+            ValidateTokens(db, R"(EndsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "suffix"))", {"\x12k1"});
 
             // LIKE - path only token / ILIKE - not extractable (Re2)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) LIKE "pattern%")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) LIKE "pattern%")", {"\x12k1"});
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) ILIKE "pattern%")"); // udf
 
             // REGEXP - not extractable (Re2)
@@ -592,7 +592,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // If JV1 is the only JSON node - nothing to extract
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Utf8) || "suffix") == "value_suffix")");
             // AND: JV1 inside concat is non-indexable, but JV2 == "b" IS indexable - post-filter applies
-            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Utf8) || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "b")", {"\3k2" + strSuffix("b")});
+            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Utf8) || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "b")", {"\x12k2" + strSuffix("b")});
 
             // Nested JSON_QUERY as JSON source for JSON_VALUE - not extractable
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.k1' WITHOUT ARRAY WRAPPER), '$.k2' RETURNING Int32) == 1)");
@@ -607,19 +607,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e' RETURNING Int32) == 1)");
 
             // AND: JV1 inside JSON_QUERY is non-indexable, but JV2 == "w" IS indexable - post-filter applies
-            ValidateTokens(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b' RETURNING Utf8) == "w")", {"\2b" + strSuffix("w")});
+            ValidateTokens(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b' RETURNING Utf8) == "w")", {"\x{11}b" + strSuffix("w")});
             // OR: JV1 inside JSON_QUERY is non-indexable, but JV2 == "w" IS indexable - post-filter does not apply
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u OR JSON_VALUE(Text, '$.b' RETURNING Utf8) == "w")");
 
             // DEFAULT ON EMPTY with non-NULL value is negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY) > 10)");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON EMPTY) > 10)", {"\4key"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON EMPTY) > 10)", {"\4key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON EMPTY) > 10)", {"\x13key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON EMPTY) > 10)", {"\x13key"});
 
             // DEFAULT ON ERROR with non-NULL value is negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON ERROR) > 10)");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON ERROR) > 10)", {"\4key"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON ERROR) > 10)", {"\4key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON ERROR) > 10)", {"\x13key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON ERROR) > 10)", {"\x13key"});
 
             // Both DEFAULT ON EMPTY and DEFAULT ON ERROR with non-NULL value are negation too
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10)");
@@ -634,35 +634,35 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Positive side: supported 2^53 - 1 / 2^53 and rounded 2^53 + 1
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 9007199254740991l)",
-                {"\3k1" + numSuffix(rounded - 1.0)});
+                {"\x12k1" + numSuffix(rounded - 1.0)});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 9007199254740991ul)",
-                {"\3k1" + numSuffix(rounded - 1.0)});
+                {"\x12k1" + numSuffix(rounded - 1.0)});
 
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 9007199254740992l)",
-                {"\3k1" + numSuffix(rounded)});
+                {"\x12k1" + numSuffix(rounded)});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 9007199254740992ul)",
-                {"\3k1" + numSuffix(rounded)});
+                {"\x12k1" + numSuffix(rounded)});
 
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 9007199254740993l)",
-                {"\3k1"});
+                {"\x12k1"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 9007199254740993ul)",
-                {"\3k1"});
+                {"\x12k1"});
 
             // Negative side: supported -(2^53 - 1) / -2^53 and rounded -(2^53 + 1)
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == -9007199254740991l)",
-                {"\3k1" + numSuffix(-rounded + 1.0)});
+                {"\x12k1" + numSuffix(-rounded + 1.0)});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == -9007199254740992l)",
-                {"\3k1" + numSuffix(-rounded)});
+                {"\x12k1" + numSuffix(-rounded)});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == -9007199254740993l)",
-                {"\3k1"});
+                {"\x12k1"});
         });
     }
 
@@ -673,10 +673,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"((Data = "a"u) OR (Data = "b"u))");
 
             // JSON_* only (tokens in explain are successful)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\x12k1"});
 
             // JSON_* together with a non-JSON column
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u)))", {"\3k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u)))", {"\x12k1"});
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u)))");
 
             // JSONPath that cannot be parsed for index extraction
@@ -684,75 +684,75 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // OR: an indexable branch and a non-indexable branch (JSON_VALUE in an arithmetic expression)
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))", {"\x12k1"});
 
             ValidateError(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) OR JSON_EXISTS(Text, '$.k1'))");
-            ValidateTokens(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
+            ValidateTokens(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"});
 
             // AND: indexable JSON with unsupported JSON (RETURNING Date) - collect error
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))", {"\3k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))", {"\x12k1"});
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))");
 
             // OR: one disjunct is indexable, the other is not
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR ((JSON_VALUE(Text, '$.k1' RETURNING Int32) + 10) > 11)))");
             ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND ((JSON_VALUE(Text, '$.k1' RETURNING Int32) + 10) > 11)))",
-                {"\3k1" + numSuffix(1)}, "and");
+                {"\x12k1" + numSuffix(1)}, "and");
 
             // AND: several indexable JSON_* in one filter
             ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)))",
-                {"\3k1" + numSuffix(1)});
+                {"\x12k1" + numSuffix(1)});
             ValidateTokens(db, R"((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0)))",
-                {"\2a", "\2b" + numSuffix(0)});
+                {"\x{11}a", "\x{11}b" + numSuffix(0)});
 
             // OR: only JSON_*; three-way
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2) OR (JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
 
             // OR: a non-JSON disjunct
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (Key = 1ul)))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (Key = 1ul)))");
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\3k1"}, "or");
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\3k1" + numSuffix(1)}, "and");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\x12k1" + numSuffix(1)}, "and");
 
             // (indexable subexpression) OR (indexable) - "or" mode for tokens
             ValidateTokens(db,
                 R"(((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0)) OR (JSON_EXISTS(Text, '$.c'))))",
-                {"\2a", "\2b" + numSuffix(0), "\2c"}, "or");
+                {"\x{11}a", "\x{11}b" + numSuffix(0), "\x{11}c"}, "or");
 
             // AND: three indexable JSON_* in one filter
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0) AND (JSON_VALUE(Text, '$.c' RETURNING Utf8) == "z"u)))",
-                {"\2a", "\2b" + numSuffix(0), "\2c" + strSuffix("z")}, "and");
+                {"\x{11}a", "\x{11}b" + numSuffix(0), "\x{11}c" + strSuffix("z")}, "and");
 
             // AND with JSON_QUERY in the same predicate
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))", {"\3k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))", {"\x12k1"});
 
             // (OR of indexable predicates) AND (non-indexable JSON predicate) - OR lookup + post-filter
             // Case 1: non-indexable is arithmetic JSON_VALUE
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             // Case 2: symmetric (non-indexable first)
             ValidateTokens(db,
                 R"(((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0) AND (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             // Case 3: non-indexable is RETURNING Date (treated as post-filter)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND (JSON_VALUE(Text, '$.k3' RETURNING Date) == Date("2021-01-01")))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             // Case 4: OR branch contains (indexable AND non-indexable)
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0)))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             // Case 5: symmetric (non-indexable-AND first)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0)) OR JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             // Case 6: OR of two indexable JV comparisons AND a non-indexable RETURNING Date JV
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2) AND (JSON_VALUE(Text, '$.k3' RETURNING Date) == Date("2021-01-01")))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2)}, "or");
 
             // Non-indexable RETURNING types now caught by whitelist (Date, Datetime, Timestamp already tested above)
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Date) > Date("2021-01-01"))");
@@ -765,184 +765,184 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // JSON_EXISTS TRUE ON ERROR + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             // Symmetric: error operand on right -> JE tokens
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))",
-                {"\2a"});
+                {"\x{11}a"});
 
             // JSON_VALUE DEFAULT 12 ON EMPTY + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY) > 10 AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY) > 10)",
-                {"\2a"});
+                {"\x{11}a"});
 
             // JSON_VALUE DEFAULT 12 ON ERROR + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10 AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10)",
-                {"\2a"});
+                {"\x{11}a"});
 
             // Both ON EMPTY and ON ERROR with non-NULL DEFAULT
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10))",
-                {"\2a"});
+                {"\x{11}a"});
 
             // Multiple non-indexable JV forms AND'd with a single JPRED
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.a')
                    AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                     AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR))",
-                {"\2a"});
+                {"\x{11}a"});
 
             // JV(... RETURNING Bool) == literal + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)",
-                {"\2a"});
+                {"\x{11}a"});
 
             // Range comparison on Bool + JE
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > true AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Bool) > true)",
-                {"\2a"});
+                {"\x{11}a"});
 
             // JV(Bool) compared with another JV(Bool) + JE
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool))",
-                {"\2a"});
+                {"\x{11}a"});
 
             // both error-producing returning types should behave identically inside AND
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\3k1" + trueSuffix, "\2a"});
+                {"\x12k1" + trueSuffix, "\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\3k1" + trueSuffix, "\2a"});
+                {"\x12k1" + trueSuffix, "\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
-                {"\3k1" + trueSuffix, "\2a"});
+                {"\x12k1" + trueSuffix, "\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01"))",
-                {"\3k1" + trueSuffix, "\2a"});
+                {"\x12k1" + trueSuffix, "\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01"))",
-                {"\3k1" + trueSuffix, "\2a"});
+                {"\x12k1" + trueSuffix, "\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
-                {"\3k1" + trueSuffix, "\2a"});
+                {"\x12k1" + trueSuffix, "\x{11}a"});
 
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a", "\3k1" + trueSuffix});
+                {"\x{11}a", "\x12k1" + trueSuffix});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false))",
-                {"\2a", "\3k1" + trueSuffix});
+                {"\x{11}a", "\x12k1" + trueSuffix});
 
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a", "\3k1" + trueSuffix});
+                {"\x{11}a", "\x12k1" + trueSuffix});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false))",
-                {"\2a", "\3k1" + trueSuffix});
+                {"\x{11}a", "\x12k1" + trueSuffix});
             ValidateTokens(db,
                 R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false))",
-                {"\2a"});
+                {"\x{11}a"});
 
             // Same shape but with a comparison form that is supported alone -
             // proves that NOT does not change tokens regardless of inner form
             ValidateTokens(db,
                 R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1))",
-                {"\2a"});
+                {"\x{11}a"});
 
             // Inner OR: JE OR (non-JSON column predicate)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             // Inner OR: JE OR (arithmetic JV - nullopt branch)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             // Inner OR: JE OR (RETURNING Bool comparison - error branch)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k2' RETURNING Bool) != true))
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2a"});
+                {"\x{11}a"});
             // Symmetric: outer AND has the bad OR on the right
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u)))",
-                {"\2a"});
+                {"\x{11}a"});
             // Two valid JPREDs combined with the bad OR: tokens of both JPREDs
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))
                    AND JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0))",
-                {"\2a", "\2b" + numSuffix(0)});
+                {"\x{11}a", "\x{11}b" + numSuffix(0)});
 
             // Same forms alone 
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
@@ -989,7 +989,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             */
 
             // J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // P -> ERROR
             ValidateError(db, R"((Data = "d1"u))");
             // PJ -> ERROR
@@ -999,15 +999,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // OR rule: all sides must be indexable
 
             // J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "and");
             // J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\x12k1"}, "and");
             // P AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1"}, "and");
             // PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // P AND P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u))");
             // P AND PJ -> ERROR
@@ -1018,7 +1018,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
 
             // J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
             // P OR J -> ERROR
@@ -1037,79 +1037,79 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
 
             // J AND J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\x12k1", "\x12k2", "\x12k3"}, "and");
             // J AND J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\x12k1", "\x12k2"}, "and");
             // J AND J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1", "\x12k2"}, "and");
             // J AND P AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "and");
             // J AND P AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND (Data = "d1"u))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND (Data = "d1"u))", {"\x12k1"}, "and");
             // J AND P AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1"}, "and");
             // J AND PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "and");
             // J AND PJ AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))", {"\x12k1"}, "and");
             // J AND PJ AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1"}, "and");
             // P AND J AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "and");
             // P AND J AND P -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\3k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\x12k1"}, "and");
             // P AND J AND PJ -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1"}, "and");
             // P AND P AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // P AND P AND P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) AND (Data = "d1"u))");
             // P AND P AND PJ -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // P AND PJ AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // P AND PJ AND P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
             // P AND PJ AND PJ -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // PJ AND J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "and");
             // PJ AND J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\x12k1"}, "and");
             // PJ AND J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1"}, "and");
             // PJ AND P AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // PJ AND P AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND (Data = "d1"u))");
             // PJ AND P AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // PJ AND PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
             // PJ AND PJ AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
             // PJ AND PJ AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J AND J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\x12k1", "\x12k2", "\x12k3"}, "or");
             // J AND J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR (Data = "d1"u))");
             // J AND J OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J AND P OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // J AND P OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR (Data = "d1"u))");
             // J AND P OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J AND PJ OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // J AND PJ OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
             // J AND PJ OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // P AND J OR J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // P AND J OR P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
             // P AND J OR PJ -> ERROR
@@ -1127,7 +1127,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // P AND PJ OR PJ -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // PJ AND J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // PJ AND J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
             // PJ AND J OR PJ -> ERROR
@@ -1145,19 +1145,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // PJ AND PJ OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J OR J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\x12k1", "\x12k2", "\x12k3"}, "or");
             // J OR J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\x12k1", "\x12k2"}, "or");
             // J OR J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\x12k1", "\x12k2"}, "or");
             // J OR P AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // J OR P AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND (Data = "d1"u))");
             // J OR P AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J OR PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\x12k1", "\x12k2"}, "or");
             // J OR PJ AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
             // J OR PJ AND PJ -> ERROR
@@ -1199,7 +1199,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // PJ OR PJ AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J OR J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\x12k1", "\x12k2", "\x12k3"}, "or");
             // J OR J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR (Data = "d1"u))");
             // J OR J OR PJ -> ERROR
@@ -1258,42 +1258,42 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
     Y_UNIT_TEST(PassingVariables) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // JSON_VALUE: variable on right side, equality, all scalar types
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING 1 AS var RETURNING Bool))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING -1 AS var RETURNING Bool))", {"\3k1" + numSuffix(-1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING 1.0 AS var RETURNING Bool))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING -1.0 AS var RETURNING Bool))", {"\3k1" + numSuffix(-1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING "123"u AS var RETURNING Bool))", {"\3k1" + strSuffix("123")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING true AS var RETURNING Bool))", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING false AS var RETURNING Bool))", {"\3k1" + falseSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING NULL AS var RETURNING Bool))", {"\3k1" + nullSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING 1 AS var RETURNING Bool))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING -1 AS var RETURNING Bool))", {"\x12k1" + numSuffix(-1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING 1.0 AS var RETURNING Bool))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING -1.0 AS var RETURNING Bool))", {"\x12k1" + numSuffix(-1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING "123"u AS var RETURNING Bool))", {"\x12k1" + strSuffix("123")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING true AS var RETURNING Bool))", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING false AS var RETURNING Bool))", {"\x12k1" + falseSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING NULL AS var RETURNING Bool))", {"\x12k1" + nullSuffix});
 
             // JSON_VALUE: variable on left side
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING 1 AS var RETURNING Bool))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING "hello"u AS var RETURNING Bool))", {"\3k1" + strSuffix("hello")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING true AS var RETURNING Bool))", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING NULL AS var RETURNING Bool))", {"\3k1" + nullSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING 1 AS var RETURNING Bool))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING "hello"u AS var RETURNING Bool))", {"\x12k1" + strSuffix("hello")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING true AS var RETURNING Bool))", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$var == $.k1' PASSING NULL AS var RETURNING Bool))", {"\x12k1" + nullSuffix});
 
             // JSON_VALUE: non-equality operators with variable -> path only (literal dropped)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 != $var' PASSING 5 AS var RETURNING Bool))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 < $var' PASSING 5 AS var RETURNING Bool))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 <= $var' PASSING 5 AS var RETURNING Bool))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 > $var' PASSING 0 AS var RETURNING Bool))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 >= $var' PASSING 0 AS var RETURNING Bool))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 != $var' PASSING 5 AS var RETURNING Bool))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 < $var' PASSING 5 AS var RETURNING Bool))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 <= $var' PASSING 5 AS var RETURNING Bool))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 > $var' PASSING 0 AS var RETURNING Bool))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 >= $var' PASSING 0 AS var RETURNING Bool))", {"\x12k1"});
 
             // JSON_VALUE: multiple variables in AND
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '($.k1 == $v1) && ($.k2 == $v2)' PASSING "x"u AS v1, 1 AS v2 RETURNING Bool))",
-                {"\3k1" + strSuffix("x"), "\3k2" + numSuffix(1)}, "and");
+                {"\x12k1" + strSuffix("x"), "\x12k2" + numSuffix(1)}, "and");
 
             // JSON_VALUE: multiple variables in OR
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '($.k1 == $v1) || ($.k2 == $v2)' PASSING "x"u AS v1, 1 AS v2 RETURNING Bool))",
-                {"\3k1" + strSuffix("x"), "\3k2" + numSuffix(1)}, "or");
+                {"\x12k1" + strSuffix("x"), "\x12k2" + numSuffix(1)}, "or");
 
             // JSON_VALUE: mixed variable and literal
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '($.k1 == $var) && ($.k2 == 42)' PASSING "x"u AS var RETURNING Bool))",
-                {"\3k1" + strSuffix("x"), "\3k2" + numSuffix(42)}, "and");
+                {"\x12k1" + strSuffix("x"), "\x12k2" + numSuffix(42)}, "and");
 
             // JSON_VALUE: non-literal PASSING types -> error
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING Json('123') AS var RETURNING Bool))");
@@ -1301,28 +1301,28 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING Date("2021-01-01") AS var RETURNING Bool))");
 
             // JSON_EXISTS: filter with variable, equality, all scalar types
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING 1 AS var))", {"\3k1\3k2" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING "hello"u AS var))", {"\3k1\3k2" + strSuffix("hello")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING true AS var))", {"\3k1\3k2" + trueSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING false AS var))", {"\3k1\3k2" + falseSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING NULL AS var))", {"\3k1\3k2" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING 1 AS var))", {"\x12k1\x12k2" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING "hello"u AS var))", {"\x12k1\x12k2" + strSuffix("hello")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING true AS var))", {"\x12k1\x12k2" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING false AS var))", {"\x12k1\x12k2" + falseSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING NULL AS var))", {"\x12k1\x12k2" + nullSuffix});
 
             // JSON_EXISTS: variable on left side in filter equality
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ($var == @.k2)' PASSING "val"u AS var))", {"\3k1\3k2" + strSuffix("val")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ($var == @.k2)' PASSING "val"u AS var))", {"\x12k1\x12k2" + strSuffix("val")});
 
             // JSON_EXISTS: non-equality filter operators with variable -> path only
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < $var)' PASSING 10 AS var))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != $var)' PASSING "x"u AS var))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < $var)' PASSING 10 AS var))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != $var)' PASSING "x"u AS var))", {"\x12k1\x12k2"});
 
             // JSON_EXISTS: multiple variables in filter AND
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v1 && @.k3 == $v2)' PASSING "x"u AS v1, 1 AS v2))",
-                {"\3k1\3k2" + strSuffix("x"), "\3k1\3k3" + numSuffix(1)}, "and");
+                {"\x12k1\x12k2" + strSuffix("x"), "\x12k1\x12k3" + numSuffix(1)}, "and");
 
             // JSON_EXISTS: multiple variables in filter OR
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ((@.k2 == $v1) || (@.k2 == $v2))' PASSING "a"u AS v1, "b"u AS v2))",
-                {"\3k1\3k2" + strSuffix("a"), "\3k1\3k2" + strSuffix("b")}, "or");
+                {"\x12k1\x12k2" + strSuffix("a"), "\x12k1\x12k2" + strSuffix("b")}, "or");
 
             // JSON_EXISTS: non-literal PASSING types -> error
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING Json('123') AS var))");
@@ -1330,11 +1330,11 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING Date("2021-01-01") AS var))");
 
             // Variable not referenced
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' RETURNING Bool))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING 10 AS var2 RETURNING Bool))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' RETURNING Bool))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == $var' PASSING 10 AS var2 RETURNING Bool))", {"\x12k1"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $var && $.k2 == $var2' PASSING 10 AS var2 RETURNING Bool))",
-                {"\3k1", "\3k2" + numSuffix(10)}, "and");
+                {"\x12k1", "\x12k2" + numSuffix(10)}, "and");
         });
     }
 
@@ -1351,46 +1351,46 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Basic path expansion
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\4key", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x13key", "$param"}}, utfParam("param"));
 
             // Deep member access
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.a.b' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\2a\2b", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{11}a\x{11}b", "$param"}}, utfParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.a.b.c' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\2a\2b\2c", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{11}a\x{11}b\x{11}c", "$param"}}, utfParam("param"));
 
             // Quoted key
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.aba."caba"' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\4aba\5caba", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{13}aba\x{14}caba", "$param"}}, utfParam("param"));
 
             // Reversed operand order
             ValidateTokens(db, R"($param == JSON_VALUE(Text, '$.k1' RETURNING Utf8))",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
             ValidateTokens(db, R"($param == JSON_VALUE(Text, '$.a.b.c' RETURNING Utf8))",
-                {NJsonIndex::TToken{"\2a\2b\2c", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{11}a\x{11}b\x{11}c", "$param"}}, utfParam("param"));
 
             // Different RETURNING types
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, intParam("param"));
 
             // Non-equality operators drop the param suffix (path only)
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
 
             // Multiple external params AND
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1 AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $p2)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1400,7 +1400,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Multiple external params OR
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1 OR JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $p2)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1410,7 +1410,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Mixed param and literal
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1 AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "x"u)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2" + strSuffix("x"), ""}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2" + strSuffix("x"), ""}},
                 TParamsBuilder().AddParam("$p1").Utf8("a").Build().Build(),
                 "and");
 
@@ -1419,44 +1419,44 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Basic path expansion via PASSING
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$param"}}, utfParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.key ? (@ == $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\4key", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x13key", "$param"}}, utfParam("param"));
 
             // Deep filter path
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a.b ? (@.c == $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\2a\2b\2c", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{11}a\x{11}b\x{11}c", "$param"}}, utfParam("param"));
 
             // Reversed order inside filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ($v == @.k2)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$param"}}, utfParam("param"));
 
             // JSON_VALUE with PASSING param
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $v' PASSING $param AS v RETURNING Bool))",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$v == $.k1' PASSING $param AS v RETURNING Bool))",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.a.b.c == $v' PASSING $param AS v RETURNING Bool))",
-                {NJsonIndex::TToken{"\2a\2b\2c", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{11}a\x{11}b\x{11}c", "$param"}}, utfParam("param"));
 
             // Non-equality in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
 
             // Multiple PASSING params AND in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v1 && @.k3 == $v2)' PASSING $p1 AS v1, $p2 AS v2))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p1"}, NJsonIndex::TToken{"\3k1\3k3", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p1"}, NJsonIndex::TToken{"\x12k1\x12k3", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1466,7 +1466,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Multiple PASSING params OR in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ((@.k2 == $v1) || (@.k2 == $v2))' PASSING $p1 AS v1, $p2 AS v2))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p1"}, NJsonIndex::TToken{"\3k1\3k2", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p1"}, NJsonIndex::TToken{"\x12k1\x12k2", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1489,17 +1489,17 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Array subscripts don't stop param collection
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.key[0]' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\4key", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x13key", "$param"}}, utfParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.a.b[0].c' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\2a\2b\2c", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x{11}a\x{11}b\x{11}c", "$param"}}, utfParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[last]' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
 
             // Wildcard member access stops param collection
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, utfParam("param"));
 
             // Top-level wildcard member access
             ValidateError(db, R"(JSON_VALUE(Text, '$.*' RETURNING Utf8) == $param)", utfParam("param"),
@@ -1507,23 +1507,23 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Methods stop param collection
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.type()' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, utfParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.abs()' RETURNING Double) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, dblParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, dblParam("param"));
 
             // Unary arithmetic stops param collection
             ValidateTokens(db, R"(JSON_VALUE(Text, '-$.k1' RETURNING Double) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, dblParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, dblParam("param"));
             ValidateTokens(db, R"(JSON_VALUE(Text, '+$.k1' RETURNING Double) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}}, dblParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, dblParam("param"));
 
             // Binary arithmetic of two paths
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + $.k2' RETURNING Double) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}, NJsonIndex::TToken{"\3k2", ""}}, dblParam("param"), "and");
+                {NJsonIndex::TToken{"\x12k1", ""}, NJsonIndex::TToken{"\x12k2", ""}}, dblParam("param"), "and");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 - $.k2' RETURNING Double) == $param)",
-                {NJsonIndex::TToken{"\3k1", ""}, NJsonIndex::TToken{"\3k2", ""}}, dblParam("param"), "and");
+                {NJsonIndex::TToken{"\x12k1", ""}, NJsonIndex::TToken{"\x12k2", ""}}, dblParam("param"), "and");
 
             // Context object as path
             ValidateTokens(db, R"(JSON_VALUE(Text, '$' RETURNING Utf8) == $param)",
@@ -1531,53 +1531,53 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Empty key name
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.""' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x10", "$param"}}, utfParam("param"));
 
             // Reversed non-equality operators (param on the left)
             ValidateTokens(db, R"($param != JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"($param < JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"($param <= JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"($param > JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
             ValidateTokens(db, R"($param >= JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {NJsonIndex::TToken{"\3k1", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1", ""}}, intParam("param"));
         });
     }
 
     Y_UNIT_TEST(ReturningTypes) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Int8(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Int16(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Int64(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Uint8(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Uint16(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Uint32(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Uint64(1).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Float(1.0f).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").Double(1.0).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == $param)",
-                {NJsonIndex::TToken{"\3k1", "$param"}},
+                {NJsonIndex::TToken{"\x12k1", "$param"}},
                 TParamsBuilder().AddParam("$param").String("v").Build().Build());
         });
     }
@@ -1591,7 +1591,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Mixed param and literal OR
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1 OR JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "x"u)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2" + strSuffix("x"), ""}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2" + strSuffix("x"), ""}},
                 TParamsBuilder().AddParam("$p1").Utf8("a").Build().Build(),
                 "or");
 
@@ -1600,7 +1600,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1
                     AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $p2
                     AND JSON_VALUE(Text, '$.k3' RETURNING Utf8) == $p3)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2", "$p2"}, NJsonIndex::TToken{"\3k3", "$p3"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2", "$p2"}, NJsonIndex::TToken{"\x12k3", "$p3"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1613,7 +1613,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1
                     OR JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $p2
                     OR JSON_VALUE(Text, '$.k3' RETURNING Utf8) == $p3)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2", "$p2"}, NJsonIndex::TToken{"\3k3", "$p3"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2", "$p2"}, NJsonIndex::TToken{"\x12k3", "$p3"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1626,7 +1626,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1
                     AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $p2
                     OR  JSON_VALUE(Text, '$.k3' RETURNING Utf8) == $p3)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k2", "$p2"}, NJsonIndex::TToken{"\3k3", "$p3"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k2", "$p2"}, NJsonIndex::TToken{"\x12k3", "$p3"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1637,13 +1637,13 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Param AND non-indexable predicate
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $param AND Data == "d1"u)",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
 
             // Two params for the same field AND (both kept)
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1
                     AND JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p2)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k1", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k1", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1654,7 +1654,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p1
                     OR JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p2)",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k1", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k1", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1665,7 +1665,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $p
                     AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $p)",
-                {NJsonIndex::TToken{"\3k1", "$p"}, NJsonIndex::TToken{"\3k2", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}, NJsonIndex::TToken{"\x12k2", "$p"}},
                 TParamsBuilder().AddParam("$p").Utf8("a").Build().Build(),
                 "and");
         });
@@ -1683,15 +1683,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Array subscript in filter path doesn't stop collection
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2[0] == $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$param"}}, utfParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2[*] == $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$param"}}, utfParam("param"));
 
             // Filter on context object
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1", "$param"}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1", "$param"}}, utfParam("param"));
 
             // Wildcard in outer path before filter
             ValidateError(db,
@@ -1701,34 +1701,34 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Non-equality operators in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 >= $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 <= $v)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ($v > @.k2)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ($v >= @.k2)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ($v < @.k2)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ($v <= @.k2)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ($v != @.k2)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, intParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, intParam("param"));
 
             // Three PASSING params AND in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v1 && @.k3 == $v2 && @.k4 == $v3)'
                     PASSING $p1 AS v1, $p2 AS v2, $p3 AS v3))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p1"}, NJsonIndex::TToken{"\3k1\3k3", "$p2"}, NJsonIndex::TToken{"\3k1\3k4", "$p3"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p1"}, NJsonIndex::TToken{"\x12k1\x12k3", "$p2"}, NJsonIndex::TToken{"\x12k1\x12k4", "$p3"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1740,7 +1740,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ((@.k2 == $v1) || (@.k3 == $v2) || (@.k4 == $v3))'
                     PASSING $p1 AS v1, $p2 AS v2, $p3 AS v3))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p1"}, NJsonIndex::TToken{"\3k1\3k3", "$p2"}, NJsonIndex::TToken{"\3k1\3k4", "$p3"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p1"}, NJsonIndex::TToken{"\x12k1\x12k3", "$p2"}, NJsonIndex::TToken{"\x12k1\x12k4", "$p3"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1752,7 +1752,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v1 && @.k3 == $v2 || @.k4 == $v3)'
                     PASSING $p1 AS v1, $p2 AS v2, $p3 AS v3))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p1"}, NJsonIndex::TToken{"\3k1\3k3", "$p2"}, NJsonIndex::TToken{"\3k1\3k4", "$p3"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p1"}, NJsonIndex::TToken{"\x12k1\x12k3", "$p2"}, NJsonIndex::TToken{"\x12k1\x12k4", "$p3"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1763,26 +1763,26 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // PASSING param and literal AND in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v && @.k3 == 42)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$param"}, NJsonIndex::TToken{"\3k1\3k3" + numSuffix(42), ""}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$param"}, NJsonIndex::TToken{"\x12k1\x12k3" + numSuffix(42), ""}},
                 utfParam("param"),
                 "and");
 
             // PASSING param and literal OR in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ((@.k2 == $v) || (@.k3 == 42))' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$param"}, NJsonIndex::TToken{"\3k1\3k3" + numSuffix(42), ""}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$param"}, NJsonIndex::TToken{"\x12k1\x12k3" + numSuffix(42), ""}},
                 utfParam("param"),
                 "or");
 
             // Variable defined in PASSING but not used in filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 5)' PASSING $param AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2" + numSuffix(5), ""}}, utfParam("param"));
+                {NJsonIndex::TToken{"\x12k1\x12k2" + numSuffix(5), ""}}, utfParam("param"));
 
             // Two variables defined, only one used
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v1)' PASSING $p1 AS v1, $p2 AS v2))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p1"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p1"}},
                 TParamsBuilder()
                     .AddParam("$p1").Utf8("a").Build()
                     .AddParam("$p2").Utf8("b").Build()
@@ -1791,10 +1791,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Variable missing from PASSING
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v)'))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}}, TParamsBuilder().Build());
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}}, TParamsBuilder().Build());
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v)' PASSING $p AS differentName))",
-                {NJsonIndex::TToken{"\3k1\3k2", ""}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", ""}},
                 TParamsBuilder().AddParam("$p").Utf8("a").Build().Build());
         });
     }
@@ -1809,7 +1809,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $pExt
                     AND JSON_EXISTS(Text, '$.k2 ? (@.k3 == $v)' PASSING $pPass AS v))",
-                {NJsonIndex::TToken{"\3k1", "$pExt"}, NJsonIndex::TToken{"\3k2\3k3", "$pPass"}},
+                {NJsonIndex::TToken{"\x12k1", "$pExt"}, NJsonIndex::TToken{"\x12k2\x12k3", "$pPass"}},
                 TParamsBuilder()
                     .AddParam("$pExt").Utf8("a").Build()
                     .AddParam("$pPass").Utf8("b").Build()
@@ -1820,7 +1820,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $pExt
                     OR JSON_EXISTS(Text, '$.k2 ? (@.k3 == $v)' PASSING $pPass AS v))",
-                {NJsonIndex::TToken{"\3k1", "$pExt"}, NJsonIndex::TToken{"\3k2\3k3", "$pPass"}},
+                {NJsonIndex::TToken{"\x12k1", "$pExt"}, NJsonIndex::TToken{"\x12k2\x12k3", "$pPass"}},
                 TParamsBuilder()
                     .AddParam("$pExt").Utf8("a").Build()
                     .AddParam("$pPass").Utf8("b").Build()
@@ -1832,7 +1832,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $pExt
                     AND JSON_EXISTS(Text, '$.k2 ? (@.k3 == $v)' PASSING $pPass AS v)
                     AND JSON_EXISTS(Text, '$.k4'))",
-                {NJsonIndex::TToken{"\3k1", "$pExt"}, NJsonIndex::TToken{"\3k2\3k3", "$pPass"}, NJsonIndex::TToken{"\3k4", ""}},
+                {NJsonIndex::TToken{"\x12k1", "$pExt"}, NJsonIndex::TToken{"\x12k2\x12k3", "$pPass"}, NJsonIndex::TToken{"\x12k4", ""}},
                 TParamsBuilder()
                     .AddParam("$pExt").Utf8("a").Build()
                     .AddParam("$pPass").Utf8("b").Build()
@@ -1844,7 +1844,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == $pExt
                     OR JSON_EXISTS(Text, '$.k2 ? (@.k3 == $v)' PASSING $pPass AS v)
                     OR JSON_EXISTS(Text, '$.k4'))",
-                {NJsonIndex::TToken{"\3k1", "$pExt"}, NJsonIndex::TToken{"\3k2\3k3", "$pPass"}, NJsonIndex::TToken{"\3k4", ""}},
+                {NJsonIndex::TToken{"\x12k1", "$pExt"}, NJsonIndex::TToken{"\x12k2\x12k3", "$pPass"}, NJsonIndex::TToken{"\x12k4", ""}},
                 TParamsBuilder()
                     .AddParam("$pExt").Utf8("a").Build()
                     .AddParam("$pPass").Utf8("b").Build()
@@ -1855,7 +1855,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k1 == $v)' PASSING $param AS v)
                     AND JSON_VALUE(Text, '$.k2' RETURNING Utf8) == $param)",
-                {NJsonIndex::TToken{"\3k1\3k1", "$param"}, NJsonIndex::TToken{"\3k2", "$param"}},
+                {NJsonIndex::TToken{"\x12k1\x12k1", "$param"}, NJsonIndex::TToken{"\x12k2", "$param"}},
                 utfParam("param"),
                 "and");
         });
@@ -1928,9 +1928,9 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             validateFullRangeError(R"(JSON_EXISTS(Text, '$'))");
 
             // Empty key
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.""'))", {"\1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.""'))", {"\3k1\1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."".k1'))", {"\1\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.""'))", {"\x10"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.""'))", {"\x12k1\x10"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."".k1'))", {"\x10\x12k1"});
 
             // Array access at the root
             validateFullRangeError(R"(JSON_EXISTS(Text, '$[0]'))");
@@ -1941,116 +1941,116 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             validateFullRangeError(R"(JSON_EXISTS(Text, '$[*]'))");
 
             // Array access after a key - should not stop collection
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[3]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[last].k2'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[1 to 3]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0, 3]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0 to last].k2'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[3]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[last].k2'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[1 to 3]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0, 3]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0 to last].k2'))", {"\x12k1\x12k2"});
 
             // Chains of array access
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*][0]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0][*]'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*][0]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0][*]'))", {"\x12k1"});
             validateFullRangeError(R"(JSON_EXISTS(Text, '$[0][0][0]'))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[*].k1'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[0].k1'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[last].k1'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*].k2'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0].k2.k3'))", {"\3k1\3k2\3k3"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[*].k1'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[0].k1'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[last].k1'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*].k2'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0].k2.k3'))", {"\x12k1\x12k2\x12k3"});
 
             // Wildcard member access stops collection
             validateFullRangeError(R"(JSON_EXISTS(Text, '$.*'))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.*'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2.*'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.*.k2'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.*.*'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.*'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2.*'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.*.k2'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.*.*'))", {"\x12k1"});
             validateFullRangeError(R"(JSON_EXISTS(Text, '$.*.k1'))");
             validateFullRangeError(R"(JSON_EXISTS(Text, '$.*[0].k1'))");
 
             // Methods stop collection
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.type()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.double()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.ceiling()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.floor()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue()'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.type()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.double()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.ceiling()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.floor()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue()'))", {"\x12k1"});
 
             // Methods chained with member access after them
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue().name'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue().value'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size().double()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs().ceiling()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs().floor().type()'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue().value.size()'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue().name'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue().value'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size().double()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs().ceiling()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs().floor().type()'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue().value.size()'))", {"\x12k1"});
 
             // Methods at the root
             validateFullRangeError(R"(JSON_EXISTS(Text, '$.size()'))");
             validateFullRangeError(R"(JSON_EXISTS(Text, '$.type()'))");
 
             // Quoted keys preserve content as-is (no nested splitting on dots)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."key with spaces"'))", {"\x10key with spaces"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."key.with.dot"'))", {"\rkey.with.dot"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."key.with.dot".sub'))", {"\rkey.with.dot\4sub"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."key with spaces"'))", {"\x1fkey with spaces"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."key.with.dot"'))", {"\1ckey.with.dot"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."key.with.dot".sub'))", {"\1ckey.with.dot\x13sub"});
 
             // SQL-keyword names work as ordinary keys
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.to'))", {"\3to"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.last'))", {"\5last"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.exists'))", {"\7exists"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.size'))", {"\5size"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.type'))", {"\5type"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.flag'))", {"\5flag"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.to'))", {"\x12to"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.last'))", {"\x14last"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.exists'))", {"\x{16}exists"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.size'))", {"\x14size"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.type'))", {"\x14type"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.flag'))", {"\x{14}flag"});
 
             // lax / strict prefixes
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $.k1'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $.k1'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $.k1[*]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $.k1[*]'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $.k1.*'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $.k1.*'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $ ? (@.k1 == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $ ? (@.k1 == 1)'))", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $.k1'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $.k1'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $.k1[*]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $.k1[*]'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $.k1.*'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $.k1.*'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'lax $ ? (@.k1 == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, 'strict $ ? (@.k1 == 1)'))", {"\x12k1" + numSuffix(1)});
         });
     }
 
     Y_UNIT_TEST(JsonValuePaths) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Array variants after a key, with literal RHS
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[last]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[1 to 3]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0, 3]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0 to last]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[last]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[1 to 3]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0, 3]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0 to last]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
 
             // Array variants with numeric literal RHS
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0]' RETURNING Int32) == 5)", {"\3k1" + numSuffix(5)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[last]' RETURNING Int32) == 5)", {"\3k1" + numSuffix(5)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 5)", {"\3k1" + numSuffix(5)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0]' RETURNING Int32) == 5)", {"\x12k1" + numSuffix(5)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[last]' RETURNING Int32) == 5)", {"\x12k1" + numSuffix(5)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 5)", {"\x12k1" + numSuffix(5)});
 
             // Reversed operand order
-            ValidateTokens(db, R"("x" == JSON_VALUE(Text, '$.k1[0]' RETURNING Utf8))", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(5 == JSON_VALUE(Text, '$.k1[*]' RETURNING Int32))", {"\3k1" + numSuffix(5)});
+            ValidateTokens(db, R"("x" == JSON_VALUE(Text, '$.k1[0]' RETURNING Utf8))", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(5 == JSON_VALUE(Text, '$.k1[*]' RETURNING Int32))", {"\x12k1" + numSuffix(5)});
 
             // Chains of array access with trailing key
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*][0]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0][*]' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$[0].k1' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$[*].k1' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$[last].k1' RETURNING Utf8) == "x")", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0].k2' RETURNING Utf8) == "x")", {"\3k1\3k2" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*].k2.k3' RETURNING Utf8) == "x")", {"\3k1\3k2\3k3" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*][0]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0][*]' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$[0].k1' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$[*].k1' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$[last].k1' RETURNING Utf8) == "x")", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[0].k2' RETURNING Utf8) == "x")", {"\x12k1\x12k2" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*].k2.k3' RETURNING Utf8) == "x")", {"\x12k1\x12k2\x12k3" + strSuffix("x")});
 
             // keyvalue() and chains with member access after keyvalue()
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.keyvalue().name' RETURNING Utf8) == "x")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.keyvalue().value' RETURNING Utf8) == "x")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.keyvalue().value.size()' RETURNING Int32) == 1)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.keyvalue().name' RETURNING Utf8) == "x")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.keyvalue().value' RETURNING Utf8) == "x")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.keyvalue().value.size()' RETURNING Int32) == 1)", {"\x12k1"});
 
             // Filter inside the path - filter stops collection, the outer literal is dropped
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 ? (@.k2 == 2)' RETURNING Int32) == 5)", {"\3k1\3k2" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$ ? (@.k1 == 1)' RETURNING Utf8) == "x")", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 ? (@.k2 == "y")' RETURNING Utf8) == "x")", {"\3k1\3k2" + strSuffix("y")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 ? (@.k2 == 2)' RETURNING Int32) == 5)", {"\x12k1\x12k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$ ? (@.k1 == 1)' RETURNING Utf8) == "x")", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 ? (@.k2 == "y")' RETURNING Utf8) == "x")", {"\x12k1\x12k2" + strSuffix("y")});
 
             // Context object as path with literal
             ValidateTokens(db, R"(JSON_VALUE(Text, '$' RETURNING Utf8) == "abc")", {"" + strSuffix("abc")});
@@ -2059,33 +2059,33 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$' RETURNING Bool) == true)", {"" + trueSuffix});
 
             // Empty key as path with literal
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.""' RETURNING Utf8) == "abc")", {"\1" + strSuffix("abc")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.""' RETURNING Int32) == 7)", {"\1" + numSuffix(7)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$."".k1' RETURNING Utf8) == "v")", {"\1\3k1" + strSuffix("v")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.""' RETURNING Utf8) == "abc")", {"\x10" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.""' RETURNING Int32) == 7)", {"\x10" + numSuffix(7)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$."".k1' RETURNING Utf8) == "v")", {"\x10\x12k1" + strSuffix("v")});
         });
     }
 
     Y_UNIT_TEST(JsonExistsFilters) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // starts with
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 starts with "ab")'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "abc")'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2.k3 starts with "x")'))", {"\3k1\3k2\3k3"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ starts with "x")'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 starts with "ab")'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "abc")'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2.k3 starts with "x")'))", {"\x12k1\x12k2\x12k3"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ starts with "x")'))", {"\x12k1"});
 
             // like_regex
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 like_regex "[a-z]+")'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 like_regex "[a-z]+")'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 like_regex "p" flag "i")'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ like_regex "x")'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 like_regex "[a-z]+")'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 like_regex "[a-z]+")'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 like_regex "p" flag "i")'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ like_regex "x")'))", {"\x12k1"});
 
             // exists(@.path) inside a filter
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (exists(@.k1))'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2))'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2.k3))'))", {"\3k1\3k2\3k3"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@))'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2[0]))'))", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2[*]))'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (exists(@.k1))'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2))'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2.k3))'))", {"\x12k1\x12k2\x12k3"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@))'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2[0]))'))", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2[*]))'))", {"\x12k1\x12k2"});
 
             // unary not and comparison - error, predicate inside predicate
             ValidateError(db, R"(JSON_EXISTS(Text, '$ ? (!(@.k1 == 1))'))");
@@ -2116,54 +2116,54 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$ ? (exists(@.k1 starts with "x"))'))");
 
             // Filter-predicate combined with the outer JE(...) == TRUE rewrite
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "x")') == true)", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2))') == true)", {"\3k1\3k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1)') == true)", {"\3k1\3k2" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "x")') == true)", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2))') == true)", {"\x12k1\x12k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1)') == true)", {"\x12k1\x12k2" + numSuffix(1)});
 
             // Filter-predicate combined with AND/OR
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "a")') AND JSON_EXISTS(Text, '$.k3 ? (exists(@.k4))'))",
-                {"\3k1\3k2", "\3k3\3k4"}, "and");
+                {"\x12k1\x12k2", "\x12k3\x12k4"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "a")') OR JSON_EXISTS(Text, '$.k3 ? (@.k4 == 1)'))",
-                {"\3k1\3k2", "\3k3\3k4" + numSuffix(1)}, "or");
+                {"\x12k1\x12k2", "\x12k3\x12k4" + numSuffix(1)}, "or");
         });
     }
 
     Y_UNIT_TEST(JsonExistsFilterPaths) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Deep paths inside filter with literal-equality
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2.k3 == 1)'))", {"\3k1\3k2\3k3" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2.k3.k4 == "x")'))", {"\3k1\3k2\3k3\3k4" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.k2.k3.k4 == "x")'))", {"\3k1\3k2\3k3\3k4" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? (@.k3.k4 == null)'))", {"\3k1\3k2\3k3\3k4" + nullSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? (@.k3.k4 == true)'))", {"\3k1\3k2\3k3\3k4" + trueSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? (@.k3.k4 == false)'))", {"\3k1\3k2\3k3\3k4" + falseSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2.k3 == 1)'))", {"\x12k1\x12k2\x12k3" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2.k3.k4 == "x")'))", {"\x12k1\x12k2\x12k3\x12k4" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.k2.k3.k4 == "x")'))", {"\x12k1\x12k2\x12k3\x12k4" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? (@.k3.k4 == null)'))", {"\x12k1\x12k2\x12k3\x12k4" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? (@.k3.k4 == true)'))", {"\x12k1\x12k2\x12k3\x12k4" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? (@.k3.k4 == false)'))", {"\x12k1\x12k2\x12k3\x12k4" + falseSuffix});
             // Reversed-order literal/path
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (1 == @.k2.k3)'))", {"\3k1\3k2\3k3" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("x" == @.k2.k3.k4)'))", {"\3k1\3k2\3k3\3k4" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (1 == @.k2.k3)'))", {"\x12k1\x12k2\x12k3" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("x" == @.k2.k3.k4)'))", {"\x12k1\x12k2\x12k3\x12k4" + strSuffix("x")});
 
             // Array access inside filter path
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[0] == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[*] == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[last] == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[1 to 3] == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[0, 3] == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2[0].k3 == "x")'))", {"\3k1\3k2\3k3" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2[*].k3 == "x")'))", {"\3k1\3k2\3k3" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[0] == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[*] == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[last] == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[1 to 3] == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1[0, 3] == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2[0].k3 == "x")'))", {"\x12k1\x12k2\x12k3" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2[*].k3 == "x")'))", {"\x12k1\x12k2\x12k3" + strSuffix("x")});
 
             // @ as filter root with all literal types
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == 1)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == -1.5)'))", {"\3k1" + numSuffix(-1.5)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == "x")'))", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == null)'))", {"\3k1" + nullSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == true)'))", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == false)'))", {"\3k1" + falseSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == 1)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == -1.5)'))", {"\x12k1" + numSuffix(-1.5)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == "x")'))", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == null)'))", {"\x12k1" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == true)'))", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@ == false)'))", {"\x12k1" + falseSuffix});
             // Reversed order
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (1 == @)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("x" == @)'))", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (true == @)'))", {"\3k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (null == @)'))", {"\3k1" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (1 == @)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("x" == @)'))", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (true == @)'))", {"\x12k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (null == @)'))", {"\x12k1" + nullSuffix});
 
             // $ root filter with literal: empty path token plus suffix
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@ == 1)'))", {"" + numSuffix(1)});
@@ -2173,201 +2173,201 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@ == false)'))", {"" + falseSuffix});
 
             // Empty key inside / before filter
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."" == 1)'))", {"\1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."" == null)'))", {"\1" + nullSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."" == "x")'))", {"\1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."" ? (@.k1 == 1)'))", {"\1\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@."" == 1)'))", {"\3k1\1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."" ? (@."" == 1)'))", {"\1\1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."" == 1)'))", {"\x10" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."" == null)'))", {"\x10" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."" == "x")'))", {"\x10" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."" ? (@.k1 == 1)'))", {"\x10\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@."" == 1)'))", {"\x12k1\x10" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."" ? (@."" == 1)'))", {"\x10\x10" + numSuffix(1)});
 
             // Outer array access before filter (does not stop collection)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0] ? (@.k2 == 1)'))", {"\3k1\3k2" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*] ? (@.k2 == 1)'))", {"\3k1\3k2" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[last] ? (@.k2 == 1)'))", {"\3k1\3k2" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[0] ? (@.k1 == "x")'))", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[*] ? (@.k1 == "x")'))", {"\3k1" + strSuffix("x")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[last] ? (@.k1 == "x")'))", {"\3k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[0] ? (@.k2 == 1)'))", {"\x12k1\x12k2" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*] ? (@.k2 == 1)'))", {"\x12k1\x12k2" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[last] ? (@.k2 == 1)'))", {"\x12k1\x12k2" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[0] ? (@.k1 == "x")'))", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[*] ? (@.k1 == "x")'))", {"\x12k1" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[last] ? (@.k1 == "x")'))", {"\x12k1" + strSuffix("x")});
 
             // Outer wildcard / method before filter
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.* ? (@.k2 == 1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.* ? (@.k2 == 1)'))", {"\x12k1"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.* ? (@.k1 == 1)'))",
                 "JSON index cannot be used: full-range search cannot be performed using full-text search");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ > 0)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue() ? (@.name == "k")'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs() ? (@ == 1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ > 0)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.keyvalue() ? (@.name == "k")'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.abs() ? (@ == 1)'))", {"\x12k1"});
         });
     }
 
     Y_UNIT_TEST(JsonExistsNestedFilters) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Basic nested filter
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == 2)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == "x")'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == "a")).k2 == "b")'))", {"\3k1" + strSuffix("a")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == null)).k2 == 2)'))", {"\3k1" + nullSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == true)).k2 == false)'))", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == 2)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == "x")'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == "a")).k2 == "b")'))", {"\x12k1" + strSuffix("a")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == null)).k2 == 2)'))", {"\x12k1" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == true)).k2 == false)'))", {"\x12k1" + trueSuffix});
 
             // Outer prefix carried through to inner filter
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ((@ ? (@.k1 == 10)).k1 == 10)'))", {"\3k1\3k1" + numSuffix(10)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? ((@ ? (@.k3 == "x")).k4 == "y")'))", {"\3k1\3k2\3k3" + strSuffix("x")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ((@ ? (@.k1 == 10)).k1 == 10)'))", {"\x12k1\x12k1" + numSuffix(10)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2 ? ((@ ? (@.k3 == "x")).k4 == "y")'))", {"\x12k1\x12k2\x12k3" + strSuffix("x")});
 
             // Outer array before nested filter
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[*] ? ((@ ? (@.k1 == 1)).k2 == 2)'))", {"\3k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*] ? ((@ ? (@.k1 == 10)).k1 == 10)'))", {"\3k1\3k1" + numSuffix(10)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$[*] ? ((@ ? (@.k1 == 1)).k2 == 2)'))", {"\x12k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1[*] ? ((@ ? (@.k1 == 10)).k1 == 10)'))", {"\x12k1\x12k1" + numSuffix(10)});
 
             // Nested filter with AND/OR inside the inner predicate
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1 && @.k2 == 2)).k3 == 3)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2)}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1 || @.k2 == 2)).k3 == 3)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == "a" && @.k2 == "b")).k3 == "c")'))",
-                {"\3k1" + strSuffix("a"), "\3k2" + strSuffix("b")}, "and");
+                {"\x12k1" + strSuffix("a"), "\x12k2" + strSuffix("b")}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == true || @.k2 == null)).k3 == 3)'))",
-                {"\3k1" + trueSuffix, "\3k2" + nullSuffix}, "or");
+                {"\x12k1" + trueSuffix, "\x12k2" + nullSuffix}, "or");
 
             // Three-way AND/OR inside nested filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1 && @.k2 == 2 && @.k3 == 3)).k4 == 4)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1 || @.k2 == 2 || @.k3 == 3)).k4 == 4)'))",
-                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k2" + numSuffix(2), "\x12k3" + numSuffix(3)}, "or");
 
             // Double-nested filter
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? ((@ ? ((@ ? (@.k1 == 0)).k4 == true)).k5 == null)'))",
-                {"\3k1" + numSuffix(0)});
+                {"\x12k1" + numSuffix(0)});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ((@ ? ((@ ? (@.k1 == 10)).k1 == 10)).k1 > 0)'))",
-                {"\3k1\3k1" + numSuffix(10)});
+                {"\x12k1\x12k1" + numSuffix(10)});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? ((@ ? ((@ ? (@.k1 <= 10)).k1 == 10)).k1 > 0)'))",
-                {"\3k1\3k1"});
+                {"\x12k1\x12k1"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? ((@ ? ((@ ? (@.k1 == "a" && @.k2 == "b")).k3 == 0)).k4 == 1)'))",
-                {"\3k1" + strSuffix("a"), "\3k2" + strSuffix("b")}, "and");
+                {"\x12k1" + strSuffix("a"), "\x12k2" + strSuffix("b")}, "and");
 
             // Nested filter combined with the outer JE == TRUE rewrite
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == 2)') == true)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == 2)') == true)", {"\x12k1" + numSuffix(1)});
 
             // Nested filter combined with AND/OR at SQL level
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == 2)')
                    AND JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1" + numSuffix(1), "\3k3"}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 == 1)).k2 == 2)')
                    OR JSON_EXISTS(Text, '$.k3'))",
-                {"\3k1" + numSuffix(1), "\3k3"}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k3"}, "or");
 
             // Inner nested filter with non-equality operators
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 != 1)).k2 == 2)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 > 0)).k2 == 2)'))", {"\3k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 < 0)).k2 == 2)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 != 1)).k2 == 2)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 > 0)).k2 == 2)'))", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@ ? (@.k1 < 0)).k2 == 2)'))", {"\x12k1"});
         });
     }
 
     Y_UNIT_TEST(JsonExistsFilterChain) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1) ? (@.k3 == 2)'))",
-                {"\3k1\3k2" + numSuffix(1), "\3k1\3k3" + numSuffix(2)}, "and");
+                {"\x12k1\x12k2" + numSuffix(1), "\x12k1\x12k3" + numSuffix(2)}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1 && @.k3 == 2)'))",
-                {"\3k1\3k2" + numSuffix(1), "\3k1\3k3" + numSuffix(2)}, "and");
+                {"\x12k1\x12k2" + numSuffix(1), "\x12k1\x12k3" + numSuffix(2)}, "and");
 
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= 10) ? (@.k2 <= 20)'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1) ? (@.k3 == 2) ? (@.k4 == 3)'))",
-                {"\3k1\3k2" + numSuffix(1), "\3k1\3k3" + numSuffix(2), "\3k1\3k4" + numSuffix(3)}, "and");
+                {"\x12k1\x12k2" + numSuffix(1), "\x12k1\x12k3" + numSuffix(2), "\x12k1\x12k4" + numSuffix(3)}, "and");
 
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1 || @.k3 == 2) ? (@.k4 == 3)'))",
-                {"\3k1\3k2" + numSuffix(1), "\3k1\3k3" + numSuffix(2), "\3k1\3k4" + numSuffix(3)}, "or");
+                {"\x12k1\x12k2" + numSuffix(1), "\x12k1\x12k3" + numSuffix(2), "\x12k1\x12k4" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1) ? (@.k3 == 2 || @.k4 == 3)'))",
-                {"\3k1\3k2" + numSuffix(1), "\3k1\3k3" + numSuffix(2), "\3k1\3k4" + numSuffix(3)}, "or");
+                {"\x12k1\x12k2" + numSuffix(1), "\x12k1\x12k3" + numSuffix(2), "\x12k1\x12k4" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 1 && @.k3 == 2) ? (@.k4 == 3 || @.k5 == 4)'))",
-                {"\3k1\3k2" + numSuffix(1), "\3k1\3k3" + numSuffix(2), "\3k1\3k4" + numSuffix(3), "\3k1\3k5" + numSuffix(4)},
+                {"\x12k1\x12k2" + numSuffix(1), "\x12k1\x12k3" + numSuffix(2), "\x12k1\x12k4" + numSuffix(3), "\x12k1\x12k5" + numSuffix(4)},
                 "or");
 
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2)) ? (@.k3 > 0)'))",
-                {"\3k1\3k2", "\3k1\3k3"}, "and");
+                {"\x12k1\x12k2", "\x12k1\x12k3"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 starts with "a") ? (@.k3 == 1)'))",
-                {"\3k1\3k2", "\3k1\3k3" + numSuffix(1)}, "and");
+                {"\x12k1\x12k2", "\x12k1\x12k3" + numSuffix(1)}, "and");
 
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.items[*] ? (exists(@.id)) ? (@.id > 0)'))",
-                {"\6items\3id"}, "and");
+                {"\x15items\x12id"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.items[*] ? (exists(@.id)) ? (@.id == 1).id' RETURNING Int64) = 1)",
-                {"\6items\3id" + numSuffix(1)}, "and");
+                {"\x15items\x12id" + numSuffix(1)}, "and");
         });
     }
 
     Y_UNIT_TEST(JsonPruningPrefixRelationships) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // OR pruning between distinct paths
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1.k2'))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') OR JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1.k2') OR JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') OR JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\3k1\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1.k2'))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') OR JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1.k2') OR JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') OR JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\x12k1\x12k2"}, "or");
 
             // AND pruning between distinct paths
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1.k2'))", {"\3k1\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') AND JSON_EXISTS(Text, '$.k1'))", {"\3k1\3k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\3k1\3k2\3k3"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1.k2') AND JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\3k1\3k2\3k3"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') AND JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\3k1\3k2\3k3"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1.k2'))", {"\x12k1\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1\x12k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\x12k1\x12k2\x12k3"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1.k2') AND JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\x12k1\x12k2\x12k3"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.k2') AND JSON_EXISTS(Text, '$.k1.k2.k3'))", {"\x12k1\x12k2\x12k3"}, "and");
 
             // OR pruning when one operand carries a literal-suffix
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_EXISTS(Text, '$.k1.k2'))", {"\3k1" + strSuffix("a"), "\3k1\3k2"}, "or");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_EXISTS(Text, '$.k1.k2'))", {"\3k1" + numSuffix(1), "\3k1\3k2"}, "or");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_EXISTS(Text, '$.k1.k2'))", {"\3k1" + strSuffix("a"), "\3k1\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_EXISTS(Text, '$.k1.k2'))", {"\x12k1" + strSuffix("a"), "\x12k1\x12k2"}, "or");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_EXISTS(Text, '$.k1.k2'))", {"\x12k1" + numSuffix(1), "\x12k1\x12k2"}, "or");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_EXISTS(Text, '$.k1.k2'))", {"\x12k1" + strSuffix("a"), "\x12k1\x12k2"}, "and");
 
             // Distinct literal suffixes on the same path
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "b")",
-                {"\3k1" + strSuffix("a"), "\3k1" + strSuffix("b")}, "and");
+                {"\x12k1" + strSuffix("a"), "\x12k1" + strSuffix("b")}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "b")",
-                {"\3k1" + strSuffix("a"), "\3k1" + strSuffix("b")}, "or");
+                {"\x12k1" + strSuffix("a"), "\x12k1" + strSuffix("b")}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2)",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "and");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2)",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // AND with a nested OR that contains a prefix-related path
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND (JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k1.k2')))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k1.k2')) AND JSON_EXISTS(Text, '$.k1'))",
-                {"\3k1", "\3k2"}, "or");
+                {"\x12k1", "\x12k2"}, "or");
 
             // OR pruning across same-jsonpath filter alternatives
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k1 == 2)'))", {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k1 == 2)'))", {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k1 == 2)'))", {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k1 == 2)'))", {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "and");
 
             // Prefix relationships inside a single jsonpath
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2) || exists(@))'))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2) && exists(@))'))", {"\3k1\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2) || exists(@))'))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (exists(@.k2) && exists(@))'))", {"\x12k1\x12k2"}, "and");
         });
     }
 
     Y_UNIT_TEST(JsonValueBetweenAndIn) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // BETWEEN - expands to (<= a) AND (>= b)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) BETWEEN 1l AND 10l)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) BETWEEN 1.0 AND 10.0)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) BETWEEN "a" AND "z")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) BETWEEN "a" AND "z")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) BETWEEN 1l AND 10l)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) BETWEEN 1.0 AND 10.0)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) BETWEEN "a" AND "z")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) BETWEEN "a" AND "z")", {"\x12k1"});
             // BETWEEN with a deeper path
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.k2' RETURNING Int32) BETWEEN 1 AND 10)", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.k2' RETURNING Int32) BETWEEN 1 AND 10)", {"\x12k1\x12k2"});
 
             // NOT BETWEEN - expands to (< a) OR (> b)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) NOT BETWEEN 1 AND 10)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) NOT BETWEEN "a" AND "z")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) NOT BETWEEN 1 AND 10)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) NOT BETWEEN "a" AND "z")", {"\x12k1"});
 
             // NOT IN - negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) NOT IN ("a", "b", "c"))");
@@ -2377,82 +2377,82 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // IN
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN ("a", "b", "c"))",
-                {"\3k1" + strSuffix("a"), "\3k1" + strSuffix("b"), "\3k1" + strSuffix("c")}, "or");
+                {"\x12k1" + strSuffix("a"), "\x12k1" + strSuffix("b"), "\x12k1" + strSuffix("c")}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2, 3))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k1" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k1" + numSuffix(3)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN ("a", "b"))",
-                {"\3k1" + strSuffix("a"), "\3k1" + strSuffix("b")}, "or");
+                {"\x12k1" + strSuffix("a"), "\x12k1" + strSuffix("b")}, "or");
 
             // IN with all supported scalars
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) IN (1t, 2t))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) IN (1ut, 2ut))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) IN (1s, 2s))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) IN (1us, 2us))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) IN (1u, 2u))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) IN (1l, 2l))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) IN (1ul, 2ul))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) IN (1.0f, 2.5f))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2.5)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2.5)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) IN (1.0, -2.5))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(-2.5)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(-2.5)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN ("x"s, "y"s))",
-                {"\3k1" + strSuffix("x"), "\3k1" + strSuffix("y")}, "or");
+                {"\x12k1" + strSuffix("x"), "\x12k1" + strSuffix("y")}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.k2' RETURNING Int32) IN (7, 8))",
-                {"\3k1\3k2" + numSuffix(7), "\3k1\3k2" + numSuffix(8)}, "or");
+                {"\x12k1\x12k2" + numSuffix(7), "\x12k1\x12k2" + numSuffix(8)}, "or");
 
             // IN with Just (unwrapped transparently)
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (42))",
-                {"\3k1" + numSuffix(42)});
+                {"\x12k1" + numSuffix(42)});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (Just(5), 6))",
-                {"\3k1" + numSuffix(5), "\3k1" + numSuffix(6)}, "or");
+                {"\x12k1" + numSuffix(5), "\x12k1" + numSuffix(6)}, "or");
 
             // Supported CAST
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) IN (CAST(7 AS Float), 8.0f))",
-                {"\3k1" + numSuffix(7), "\3k1" + numSuffix(8)}, "or");
+                {"\x12k1" + numSuffix(7), "\x12k1" + numSuffix(8)}, "or");
             // Unsupported CAST
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (CAST("7" AS Int32), 8))",
-                {"\3k1"}, "or");
+                {"\x12k1"}, "or");
 
             // IN with mixed types
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2u, 3l))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k1" + numSuffix(3)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k1" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN ("x", "y"u))",
-                {"\3k1" + strSuffix("x"), "\3k1" + strSuffix("y")}, "or");
+                {"\x12k1" + strSuffix("x"), "\x12k1" + strSuffix("y")}, "or");
 
             // IN with AND/OR and other indexed predicates
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2, 3)
                    AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k1" + numSuffix(3), "\3k2"}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k1" + numSuffix(3), "\x12k2"}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2)
                    OR JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k2"}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k2"}, "or");
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2))
                    OR (JSON_VALUE(Text, '$.k2' RETURNING Int32) IN (10, 20)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k2" + numSuffix(10), "\3k2" + numSuffix(20)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k2" + numSuffix(10), "\x12k2" + numSuffix(20)}, "or");
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2))
                    AND (JSON_VALUE(Text, '$.k2' RETURNING Int32) IN (10, 20)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k2" + numSuffix(10), "\3k2" + numSuffix(20)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k2" + numSuffix(10), "\x12k2" + numSuffix(20)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2)
                    OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 5)",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k2" + numSuffix(5)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k2" + numSuffix(5)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 3
                    AND JSON_VALUE(Text, '$.k2' RETURNING Int32) IN (7, 8))",
-                {"\3k1" + numSuffix(3), "\3k2" + numSuffix(7), "\3k2" + numSuffix(8)}, "or");
+                {"\x12k1" + numSuffix(3), "\x12k2" + numSuffix(7), "\x12k2" + numSuffix(8)}, "or");
 
             // RETURNING Bool with IN
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) IN (true, false))",
@@ -2465,65 +2465,65 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (NULL, NULL))");
 
             // Members in list
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN ("1"u, Data))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (Data, "2"u))", {"\3k1"}, "or");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (Data))", {"\3k1"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (Data, Data || "data"u))", {"\3k1"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN ("1"u, Data))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (Data, "2"u))", {"\x12k1"}, "or");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (Data))", {"\x12k1"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (Data, Data || "data"u))", {"\x12k1"}, "and");
 
             // Parameters in list
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN ($p))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Int32(1).Build().Build());
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, $p))",
-                {NJsonIndex::TToken{"\3k1", "$p"}, NJsonIndex::TToken{"\3k1" + numSuffix(1)}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}, NJsonIndex::TToken{"\x12k1" + numSuffix(1)}},
                 TParamsBuilder().AddParam("$p").Int32(2).Build().Build(), "or");
 
             // BETWEEN combined with other indexable predicates
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10
                    AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10
                    AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 5)",
-                {"\3k1", "\3k2" + numSuffix(5)}, "and");
+                {"\x12k1", "\x12k2" + numSuffix(5)}, "and");
 
             // NOT BETWEEN combined with other indexable predicate
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) NOT BETWEEN 1 AND 10
                    AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1", "\3k2"}, "and");
+                {"\x12k1", "\x12k2"}, "and");
         });
     }
 
     Y_UNIT_TEST(JsonValueComparisons) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // = (single equals) is parsed as ==
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) = "abc")", {"\3k1" + strSuffix("abc")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) = 5)", {"\3k1" + numSuffix(5)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) = true)", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) = "abc")", {"\x12k1" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) = 5)", {"\x12k1" + numSuffix(5)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) = true)", {"\x12k1" + trueSuffix});
 
             // <> as alias of !=, path-only
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) <> "abc")", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <> 5)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) <> "abc")", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <> 5)", {"\x12k1"});
 
             // CAST in the literal position - YQL collapses CAST of a literal
             // back to the typed literal, so the token carries the value suffix
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST("10" AS Int32))", {"\3k1" + numSuffix(10)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST(10 AS Utf8))", {"\3k1" + strSuffix("10")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST("10" AS Int32))", {"\x12k1" + numSuffix(10)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST(10 AS Utf8))", {"\x12k1" + strSuffix("10")});
             // CAST of a non-literal column - not a TCoDataCtor on RHS, path-only
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST(Data AS Utf8))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST(Data AS Utf8))", {"\x12k1"});
 
             // Just(...) wrapper unwrapped
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == Just("abc"u))", {"\3k1" + strSuffix("abc")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == Just(5))", {"\3k1" + numSuffix(5)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == Just("abc"u))", {"\x12k1" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == Just(5))", {"\x12k1" + numSuffix(5)});
 
             // column reference on RHS - not a TCoDataCtor, path-only token
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == Data)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == Data)", {"\x12k1"});
             // Reversed order
-            ValidateTokens(db, R"(Data == JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\3k1"});
+            ValidateTokens(db, R"(Data == JSON_VALUE(Text, '$.k1' RETURNING Utf8))", {"\x12k1"});
 
             // UDF on the JSON_VALUE side - the JSON predicate itself is wrapped, not extractable
             ValidateError(db, R"(String::AsciiToUpper(JSON_VALUE(Text, '$.k1' RETURNING Utf8)) == "ABC")");
@@ -2533,22 +2533,22 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
     Y_UNIT_TEST(JsonValueHandlerVariants) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // DEFAULT NULL ON EMPTY / ON ERROR - allowed (equivalent to no handler)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON ERROR) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY DEFAULT NULL ON ERROR) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8 DEFAULT NULL ON EMPTY) == "v")", {"\4key" + strSuffix("v")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8 DEFAULT NULL ON ERROR) == "v")", {"\4key" + strSuffix("v")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY DEFAULT NULL ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8 DEFAULT NULL ON EMPTY) == "v")", {"\x13key" + strSuffix("v")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Utf8 DEFAULT NULL ON ERROR) == "v")", {"\x13key" + strSuffix("v")});
 
             // Range comparison with DEFAULT NULL - path-only
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY) > 10)", {"\4key"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON ERROR) > 10)", {"\4key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY) > 10)", {"\x13key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON ERROR) > 10)", {"\x13key"});
 
             // Combinations of NULL / ERROR / DEFAULT NULL handlers - all allowed
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 NULL ON EMPTY ERROR ON ERROR) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 ERROR ON EMPTY NULL ON ERROR) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 NULL ON EMPTY DEFAULT NULL ON ERROR) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY ERROR ON ERROR) == 1)", {"\4key" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 ERROR ON EMPTY DEFAULT NULL ON ERROR) == 1)", {"\4key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 NULL ON EMPTY ERROR ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 ERROR ON EMPTY NULL ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 NULL ON EMPTY DEFAULT NULL ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT NULL ON EMPTY ERROR ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 ERROR ON EMPTY DEFAULT NULL ON ERROR) == 1)", {"\x13key" + numSuffix(1)});
 
             // Mixed - non-NULL DEFAULT on either side blocks extraction
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 DEFAULT 12 ON EMPTY NULL ON ERROR) == 1)");
@@ -2559,8 +2559,8 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int32 ERROR ON EMPTY DEFAULT 12 ON ERROR) == 1)");
 
             // Handler combinations with the JSON_VALUE itself as Bool predicate
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Bool DEFAULT NULL ON EMPTY))", {"\4key" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Bool DEFAULT NULL ON ERROR))", {"\4key" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Bool DEFAULT NULL ON EMPTY))", {"\x13key" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Bool DEFAULT NULL ON ERROR))", {"\x13key" + trueSuffix});
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Bool DEFAULT true ON ERROR))");
         });
     }
@@ -2583,22 +2583,22 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // CAST around a scalar literal in PASSING - unwrapped, literal binds
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $v' PASSING CAST(10 AS Int32) AS v RETURNING Bool))",
-                {"\3k1" + numSuffix(10)});
+                {"\x12k1" + numSuffix(10)});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $v' PASSING CAST("abc" AS Utf8) AS v RETURNING Bool))",
-                {"\3k1" + strSuffix("abc")});
+                {"\x12k1" + strSuffix("abc")});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v)' PASSING CAST(10 AS Int32) AS v))",
-                {"\3k1\3k2" + numSuffix(10)});
+                {"\x12k1\x12k2" + numSuffix(10)});
 
             // CAST around a parameter in PASSING - unwrapped, param binds
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $v' PASSING CAST($p AS Utf8) AS v RETURNING Bool))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Utf8("a").Build().Build());
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v)' PASSING CAST($p AS Int32) AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p"}},
                 TParamsBuilder().AddParam("$p").Int32(5).Build().Build());
 
             // SQL keywords as PASSING variable names
@@ -2616,43 +2616,43 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
     Y_UNIT_TEST(SafeCast) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Supported literal casts: YQL folds CAST of a literal to the target typed literal
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST(10 AS Int32))", {"\3k1" + numSuffix(10)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == CAST(5 AS Int64))", {"\3k1" + numSuffix(5)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == CAST(1.0f AS Double))", {"\3k1" + numSuffix(1.0)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST("abc" AS Utf8))", {"\3k1" + strSuffix("abc")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == CAST("abc"u AS String))", {"\3k1" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST(10 AS Int32))", {"\x12k1" + numSuffix(10)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == CAST(5 AS Int64))", {"\x12k1" + numSuffix(5)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == CAST(1.0f AS Double))", {"\x12k1" + numSuffix(1.0)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST("abc" AS Utf8))", {"\x12k1" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == CAST("abc"u AS String))", {"\x12k1" + strSuffix("abc")});
 
             // Supported literal casts in SQL IN
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (CAST(7 AS Int32), 8))",
-                {"\3k1" + numSuffix(7), "\3k1" + numSuffix(8)}, "or");
+                {"\x12k1" + numSuffix(7), "\x12k1" + numSuffix(8)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) IN (CAST(1 AS Int32), CAST(2 AS Int64)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) IN (CAST(1 AS Int32), CAST(2.5f AS Float)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2.5)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2.5)}, "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (CAST("x"s AS Utf8), CAST("y"u AS Utf8)))",
-                {"\3k1" + strSuffix("x"), "\3k1" + strSuffix("y")}, "or");
+                {"\x12k1" + strSuffix("x"), "\x12k1" + strSuffix("y")}, "or");
 
             // Supported parameter casts
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST($p AS Int32))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Int32(10).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == CAST($p AS Int64))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Int32(5).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == CAST($p AS Double))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Float(1.5f).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST($p AS Utf8))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Utf8("abc").Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == CAST($p AS String))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").String("abc").Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (CAST($p AS Int32), 2))",
-                {NJsonIndex::TToken{"\3k1", "$p"}, NJsonIndex::TToken{"\3k1" + numSuffix(2)}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}, NJsonIndex::TToken{"\x12k1" + numSuffix(2)}},
                 TParamsBuilder().AddParam("$p").Int32(1).Build().Build(), "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) IN (CAST($p AS Int64), CAST($q AS Int32)))",
-                {NJsonIndex::TToken{"\3k1", "$p"}, NJsonIndex::TToken{"\3k1", "$q"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}, NJsonIndex::TToken{"\x12k1", "$q"}},
                 TParamsBuilder()
                     .AddParam("$p").Int64(10).Build()
                     .AddParam("$q").Int32(20).Build()
@@ -2660,36 +2660,36 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Unsupported parameter casts
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST($p AS Int32))",
-                {NJsonIndex::TToken("\3k1", "")},
+                {NJsonIndex::TToken("\x12k1", "")},
                 TParamsBuilder().AddParam("$p").Double(2.5).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == CAST($p AS Int32))",
-                {NJsonIndex::TToken("\3k1", "")},
+                {NJsonIndex::TToken("\x12k1", "")},
                 TParamsBuilder().AddParam("$p").Float(2.5f).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST($p AS Utf8))",
-                {NJsonIndex::TToken("\3k1", "")},
+                {NJsonIndex::TToken("\x12k1", "")},
                 TParamsBuilder().AddParam("$p").Int32(10).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == CAST($p AS String))",
-                {NJsonIndex::TToken("\3k1", "")},
+                {NJsonIndex::TToken("\x12k1", "")},
                 TParamsBuilder().AddParam("$p").Int64(10).Build().Build());
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (CAST($p AS Int32), 2))",
-                {NJsonIndex::TToken("\3k1", "")},
+                {NJsonIndex::TToken("\x12k1", "")},
                 TParamsBuilder().AddParam("$p").Double(2.5).Build().Build(), "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN (CAST($p AS Utf8), "x"))",
-                {NJsonIndex::TToken("\3k1", "")},
+                {NJsonIndex::TToken("\x12k1", "")},
                 TParamsBuilder().AddParam("$p").Int32(10).Build().Build(), "or");
 
             // PASSING: supported parameter casts
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $v' PASSING CAST($p AS Int32) AS v RETURNING Bool))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Int32(10).Build().Build());
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1 == $v' PASSING CAST($p AS Int64) AS v RETURNING Bool))",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").Int32(5).Build().Build());
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $v)' PASSING CAST($p AS Utf8) AS v))",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p"}},
                 TParamsBuilder().AddParam("$p").Utf8("abc").Build().Build());
 
             // PASSING: unsupported parameter casts
@@ -2701,7 +2701,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
                 TParamsBuilder().AddParam("$p").Int32(10).Build().Build());
 
             // Allowed cast of a column reference unwraps to the column
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST(Data AS Utf8))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == CAST(Data AS Utf8))", {"\x12k1"});
         });
     }
 
@@ -2745,42 +2745,42 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
         }
 
         // AND/OR of indexable predicates on different JSON columns
-        ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text2, '$.k2'))", {"\3k1"}, "and");
+        ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text2, '$.k2'))", {"\x12k1"}, "and");
         ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text2, '$.k2'))");
-        ValidateTokens(db, R"(JSON_EXISTS(Text2, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k2"}, "and");
+        ValidateTokens(db, R"(JSON_EXISTS(Text2, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\x12k2"}, "and");
         ValidateError(db, R"(JSON_EXISTS(Text2, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
 
         ValidateTokens(db,
             R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_VALUE(Text2, '$.k2' RETURNING Utf8) == "b")",
-            {"\3k1" + strSuffix("a")}, "and");
+            {"\x12k1" + strSuffix("a")}, "and");
         ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_VALUE(Text2, '$.k2' RETURNING Utf8) == "b")");
-        ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_VALUE(Text2, '$.k2' RETURNING Utf8) == "b")", {"\3k1"}, "and");
+        ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_VALUE(Text2, '$.k2' RETURNING Utf8) == "b")", {"\x12k1"}, "and");
         ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_VALUE(Text2, '$.k2' RETURNING Utf8) == "b")");
 
         // Same predicate on different columns combined with non-indexable
         ValidateTokens(db,
             R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text2, '$.k2') AND Data = "x"u)",
-            {"\3k1"}, "and");
+            {"\x12k1"}, "and");
 
         // Cross-column comparison directly between JSON columns
         ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == JSON_VALUE(Text2, '$.k2' RETURNING Utf8))",
-            {"\3k1"}, "and");
+            {"\x12k1"}, "and");
         ValidateTokens(db, R"(JSON_VALUE(Text2, '$.k1' RETURNING Utf8) == JSON_VALUE(Text, '$.k2' RETURNING Utf8))",
-            {"\3k2"}, "and");
+            {"\x12k2"}, "and");
 
         // One of predicates is not indexable
-        ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text3, '$.k2'))", {"\3k1"}, "and");
-        ValidateTokens(db, R"(JSON_EXISTS(Text3, '$.k2') AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
+        ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text3, '$.k2'))", {"\x12k1"}, "and");
+        ValidateTokens(db, R"(JSON_EXISTS(Text3, '$.k2') AND JSON_EXISTS(Text, '$.k1'))", {"\x12k1"}, "and");
 
         ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text2, '$.k2'))");
         ValidateError(db, R"(JSON_EXISTS(Text3, '$.k2') OR JSON_EXISTS(Text, '$.k1'))");
 
         ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" AND JSON_VALUE(Text3, '$.k2' RETURNING Utf8) == "b")",
-            {"\3k1" + strSuffix("a")}, "and");
+            {"\x12k1" + strSuffix("a")}, "and");
         ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a" OR JSON_VALUE(Text2, '$.k2' RETURNING Utf8) == "b")");
 
         ValidateTokens(db, R"(JSON_VALUE(Text3, '$.k2' RETURNING Utf8) == "b" AND JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a")",
-            {"\3k1" + strSuffix("a")}, "and");
+            {"\x12k1" + strSuffix("a")}, "and");
         ValidateError(db, R"(JSON_VALUE(Text3, '$.k2' RETURNING Utf8) == "b" OR JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "a")");
     }
 
@@ -2789,7 +2789,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Collectable path
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) IN $p)",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Int64(1)
                     .AddListItem().Int64(0)
@@ -2798,7 +2798,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Deep path
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.k2' RETURNING Utf8) IN $p)",
-                {NJsonIndex::TToken{"\3k1\3k2", "$p"}},
+                {NJsonIndex::TToken{"\x12k1\x12k2", "$p"}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Utf8("a")
                     .EndList().Build().Build(),
@@ -2806,7 +2806,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Non-collectable path 1
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.type()' RETURNING Utf8) IN $p)",
-                {NJsonIndex::TToken{"\3k1", ""}},
+                {NJsonIndex::TToken{"\x12k1", ""}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Utf8("string")
                     .EndList().Build().Build(),
@@ -2814,7 +2814,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Non-collectable path 2
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Utf8) IN $p)",
-                {NJsonIndex::TToken{"\3k1", ""}},
+                {NJsonIndex::TToken{"\x12k1", ""}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Utf8("v")
                     .EndList().Build().Build(),
@@ -2822,19 +2822,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Supported scalar item types in list
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) IN $p)",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Utf8("x")
                     .EndList().Build().Build(),
                 "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN $p)",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Int32(1)
                     .EndList().Build().Build(),
                 "or");
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) IN $p)",
-                {NJsonIndex::TToken{"\3k1", "$p"}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Double(1.5)
                     .EndList().Build().Build(),
@@ -2848,7 +2848,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // AND with another predicate: OR wins (list param carries OR mode into merge)
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) IN $p AND JSON_EXISTS(Text, '$.k2'))",
-                {NJsonIndex::TToken{"\3k1", "$p"}, NJsonIndex::TToken{"\3k2", ""}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}, NJsonIndex::TToken{"\x12k2", ""}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Int64(1)
                     .EndList().Build().Build(),
@@ -2856,7 +2856,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // OR with another predicate: stays OR
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) IN $p OR JSON_EXISTS(Text, '$.k2'))",
-                {NJsonIndex::TToken{"\3k1", "$p"}, NJsonIndex::TToken{"\3k2", ""}},
+                {NJsonIndex::TToken{"\x12k1", "$p"}, NJsonIndex::TToken{"\x12k2", ""}},
                 TParamsBuilder().AddParam("$p").BeginList()
                     .AddListItem().Int64(1)
                     .EndList().Build().Build(),
@@ -2868,31 +2868,31 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // List<String?>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN ['1', '2']",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN [Just('1'), '2']",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN [Just('1'), Just('2')]",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
 
             // List<String?>?
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN Just(['1', '2'])",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN Just([Just('1'), Just('2')])",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
 
             // AsList[Strict]
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN AsList('1', '2')",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN AsListStrict('1', '2')",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN Just(AsList('1', '2'))",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN Just(AsListStrict('1', '2'))",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN Just(AsList(Just('1'), Just('2')))",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN Just(AsListStrict(Just('1'), Just('2')))",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
 
             // Empty list -> always false, index not applicable
             ValidateError(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN ListCreate(String)");
@@ -2904,7 +2904,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Parameters
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN [$p1, $p2]",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k1", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k1", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").String("1").Build()
                     .AddParam("$p2").String("2").Build()
@@ -2920,7 +2920,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Elements longer than 16 bytes
             ValidateTokens(db,
                 std::format("JSON_VALUE(Text, '$.k1' RETURNING String) IN ['{}', '{}']", kFirstLongSqlInValue, kSecondLongSqlInValue),
-                {"\3k1" + strSuffix(kFirstLongSqlInValue), "\3k1" + strSuffix(kSecondLongSqlInValue)}, "or");
+                {"\x12k1" + strSuffix(kFirstLongSqlInValue), "\x12k1" + strSuffix(kSecondLongSqlInValue)}, "or");
         });
     }
 
@@ -2928,7 +2928,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // List<String>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p1",
-                {NJsonIndex::TToken{"\3k1", "$p1"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}},
                 TParamsBuilder()
                     .AddParam("$p1")
                         .BeginList()
@@ -2977,7 +2977,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Empty list
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p5",
-                {NJsonIndex::TToken{"\3k1", "$p5"}},
+                {NJsonIndex::TToken{"\x12k1", "$p5"}},
                 TParamsBuilder()
                     .AddParam("$p5")
                         .EmptyList(TTypeBuilder().Primitive(EPrimitiveType::String).Build())
@@ -2986,7 +2986,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // List parameter with elements longer than 16 bytes
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p6",
-                {NJsonIndex::TToken{"\3k1", "$p6"}},
+                {NJsonIndex::TToken{"\x12k1", "$p6"}},
                 TParamsBuilder()
                     .AddParam("$p6")
                         .BeginList()
@@ -3003,34 +3003,34 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Tuple<Int32, Int32>
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, 2))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Tuple<Int32?, Int32?>
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (Just(1), Just(2)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Tuple<Int32?, Int32?>?
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just((Just(1), Just(2))))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // AsTuple
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsTuple(1, 2))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsTuple(Just(1), Just(2)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just(AsTuple(Just(1), Just(2))))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Different integers
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsTuple(1t, 2s, 3, 4l, 5u, 6.0f, 7.0))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k1" + numSuffix(3),
-                 "\3k1" + numSuffix(4), "\3k1" + numSuffix(5), "\3k1" + numSuffix(6), "\3k1" + numSuffix(7)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k1" + numSuffix(3),
+                 "\x12k1" + numSuffix(4), "\x12k1" + numSuffix(5), "\x12k1" + numSuffix(6), "\x12k1" + numSuffix(7)}, "or");
 
             // NULL in tuple -> negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN (1, NULL))");
@@ -3040,7 +3040,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Elements longer than 16 bytes
             ValidateTokens(db,
                 std::format(R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN ('{}', '{}'))", kFirstLongSqlInValue, kSecondLongSqlInValue),
-                {"\3k1" + strSuffix(kFirstLongSqlInValue), "\3k1" + strSuffix(kSecondLongSqlInValue)}, "or");
+                {"\x12k1" + strSuffix(kFirstLongSqlInValue), "\x12k1" + strSuffix(kSecondLongSqlInValue)}, "or");
         });
     }
 
@@ -3048,7 +3048,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Tuple<String, String>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p1",
-                {NJsonIndex::TToken{"\3k1", "$p1"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}},
                 TParamsBuilder()
                     .AddParam("$p1")
                         .BeginTuple()
@@ -3060,7 +3060,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Tuple<Int32, Int32>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING Int32) IN $p1",
-                {NJsonIndex::TToken{"\3k1", "$p1"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}},
                 TParamsBuilder()
                     .AddParam("$p1")
                         .BeginTuple()
@@ -3072,7 +3072,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Tuple<Int32, Int64, Float, Double>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING Int32) IN $p2",
-                {NJsonIndex::TToken{"\3k1", ""}},
+                {NJsonIndex::TToken{"\x12k1", ""}},
                 TParamsBuilder()
                     .AddParam("$p2")
                         .BeginTuple()
@@ -3123,7 +3123,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Tuple parameter with elements longer than 16 bytes
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p6",
-                {NJsonIndex::TToken{"\3k1", "$p6"}},
+                {NJsonIndex::TToken{"\x12k1", "$p6"}},
                 TParamsBuilder()
                     .AddParam("$p6")
                         .BeginTuple()
@@ -3140,41 +3140,41 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Dict<String, Int32>
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN {'1': 10, '2': 20})",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
 
             // Dict<Int32, String>
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN {1: 'a', 2: 'b'})",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Dict<Int32?, String> -> optional literal keys are OK
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN {Just(1): 'a', Just(2): 'b'})",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Just(Dict<...>) -> outer optional unwraps
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just({1: 'a', 2: 'b'}))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // AsDict
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsDict(AsTuple(1, 'a'), AsTuple(2, 'b')))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsDictStrict(AsTuple(1, 'a'), AsTuple(2, 'b')))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsDict(AsTuple(Just(1), 'a'), AsTuple(Just(2), 'b')))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just(AsDict(AsTuple(Just(1), 'a'), AsTuple(Just(2), 'b'))))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Different integer key types
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsDict(AsTuple(1t, 'a'), AsTuple(2s, 'b'), AsTuple(3, 'c'), AsTuple(4l, 'd')))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k1" + numSuffix(3), "\3k1" + numSuffix(4)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k1" + numSuffix(3), "\x12k1" + numSuffix(4)}, "or");
 
             // Empty dict -> always false, index not applicable
             ValidateError(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN DictCreate(String, String)");
@@ -3187,12 +3187,12 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // NULL value in dict is allowed (we only care about keys)
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsDict(AsTuple(1, Just('a')), AsTuple(2, Nothing(Optional<String>))))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Parameters as keys
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN AsDict(AsTuple($p1, 'a'), AsTuple($p2, 'b')))",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k1", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k1", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").String("1").Build()
                     .AddParam("$p2").String("2").Build()
@@ -3209,7 +3209,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Keys longer than 16 bytes
             ValidateTokens(db,
                 std::format(R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN {{'{}': 1, '{}': 2}})", kFirstLongSqlInValue, kSecondLongSqlInValue),
-                {"\3k1" + strSuffix(kFirstLongSqlInValue), "\3k1" + strSuffix(kSecondLongSqlInValue)}, "or");
+                {"\x12k1" + strSuffix(kFirstLongSqlInValue), "\x12k1" + strSuffix(kSecondLongSqlInValue)}, "or");
         });
     }
 
@@ -3217,7 +3217,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Dict<String, Int32>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p1",
-                {NJsonIndex::TToken{"\3k1", "$p1"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}},
                 TParamsBuilder()
                     .AddParam("$p1")
                         .BeginDict()
@@ -3229,7 +3229,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Dict<Int32, String>
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING Int32) IN $p1",
-                {NJsonIndex::TToken{"\3k1", "$p1"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}},
                 TParamsBuilder()
                     .AddParam("$p1")
                         .BeginDict()
@@ -3278,7 +3278,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Empty dict
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p5",
-                {NJsonIndex::TToken{"\3k1", "$p5"}},
+                {NJsonIndex::TToken{"\x12k1", "$p5"}},
                 TParamsBuilder()
                     .AddParam("$p5")
                         .EmptyDict(
@@ -3289,7 +3289,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
 
             // Dict parameter with keys longer than 16 bytes
             ValidateTokens(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN $p6",
-                {NJsonIndex::TToken{"\3k1", "$p6"}},
+                {NJsonIndex::TToken{"\x12k1", "$p6"}},
                 TParamsBuilder()
                     .AddParam("$p6")
                         .BeginDict()
@@ -3306,45 +3306,45 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Set<String> via {} syntax
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN {'1', '2'})",
-                {"\3k1" + strSuffix("1"), "\3k1" + strSuffix("2")}, "or");
+                {"\x12k1" + strSuffix("1"), "\x12k1" + strSuffix("2")}, "or");
 
             // Set<Int32>
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN {1, 2})",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Set<Int32?> -> optional literal keys are OK
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN {Just(1), Just(2)})",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Just(Set<...>) -> outer optional unwraps
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just({1, 2}))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // AsSet
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsSet(1, 2))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsSetStrict(1, 2))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsSet(Just(1), Just(2)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just(AsSet(1, 2)))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN Just(AsSet(Just(1), Just(2))))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2)}, "or");
 
             // Different integer types
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) IN AsSet(1t, 2s, 3, 4l, 5u, 6.0f, 7.0))",
-                {"\3k1" + numSuffix(1), "\3k1" + numSuffix(2), "\3k1" + numSuffix(3),
-                 "\3k1" + numSuffix(4), "\3k1" + numSuffix(5), "\3k1" + numSuffix(6), "\3k1" + numSuffix(7)}, "or");
+                {"\x12k1" + numSuffix(1), "\x12k1" + numSuffix(2), "\x12k1" + numSuffix(3),
+                 "\x12k1" + numSuffix(4), "\x12k1" + numSuffix(5), "\x12k1" + numSuffix(6), "\x12k1" + numSuffix(7)}, "or");
 
             // Empty set -> always false, index not applicable
             ValidateError(db, "JSON_VALUE(Text, '$.k1' RETURNING String) IN SetCreate(String)");
@@ -3358,7 +3358,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Parameters as keys
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN AsSet($p1, $p2))",
-                {NJsonIndex::TToken{"\3k1", "$p1"}, NJsonIndex::TToken{"\3k1", "$p2"}},
+                {NJsonIndex::TToken{"\x12k1", "$p1"}, NJsonIndex::TToken{"\x12k1", "$p2"}},
                 TParamsBuilder()
                     .AddParam("$p1").String("1").Build()
                     .AddParam("$p2").String("2").Build()
@@ -3375,7 +3375,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Elements longer than 16 bytes
             ValidateTokens(db,
                 std::format(R"(JSON_VALUE(Text, '$.k1' RETURNING String) IN AsSet('{}', '{}'))", kFirstLongSqlInValue, kSecondLongSqlInValue),
-                {"\3k1" + strSuffix(kFirstLongSqlInValue), "\3k1" + strSuffix(kSecondLongSqlInValue)}, "or");
+                {"\x12k1" + strSuffix(kFirstLongSqlInValue), "\x12k1" + strSuffix(kSecondLongSqlInValue)}, "or");
         });
     }
 
@@ -3394,19 +3394,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // AND with this non-indexable form + indexable JE
             ValidateTokens(db,
                 R"(("prefix:" || JSON_VALUE(Text, '$.k1' RETURNING Utf8)) == "prefix:abc" AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k2"});
+                {"\x12k2"});
 
             // large numeric literals inside a JSON_EXISTS filter
             constexpr double rounded = 9007199254740992.0;
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 9007199254740993)'))",
-                {"\3k1\3k2" + numSuffix(rounded)});
+                {"\x12k1\x12k2" + numSuffix(rounded)});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == -9007199254740993)'))",
-                {"\3k1\3k2" + numSuffix(-rounded)});
+                {"\x12k1\x12k2" + numSuffix(-rounded)});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 9007199254740992)'))",
-                {"\3k1\3k2" + numSuffix(rounded)});
+                {"\x12k1\x12k2" + numSuffix(rounded)});
 
             // JSON_QUERY as a source for JSON_EXISTS
             ValidateError(db,
@@ -3425,68 +3425,68 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesTokens) {
             // Unicode string VALUE in JSON (ASCII key, Unicode value)
             // Equality in JSONPath filter: path + strSuffix with unicode bytes
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key ? (@ == "Привет")'))",
-                {"\4key" + strSuffix("Привет")});
+                {"\x13key" + strSuffix("Привет")});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.key == "Мир")'))",
-                {"\4key" + strSuffix("Мир")});
+                {"\x13key" + strSuffix("Мир")});
             // Inequality/range in JSONPath filter: path only (no value suffix)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key ? (@ != "Привет")'))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key ? (@ != "Привет")'))", {"\x13key"});
 
             // Unicode string value at YQL level (JSON_VALUE equality)
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "Привет"u)",
-                {"\3k1" + strSuffix("Привет")});
+                {"\x12k1" + strSuffix("Привет")});
             // Inequality at YQL level: path only
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) != "Привет"u)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) != "Привет"u)", {"\x12k1"});
 
             // Unicode KEY in JSONPath (quoted key form, no unquoted Unicode identifiers)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."кл"'))", {"\5кл"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."кл"'))", {"\x14кл"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$."кл"' RETURNING Utf8) == "val"u)",
-                {"\5кл" + strSuffix("val")});
+                {"\x14кл" + strSuffix("val")});
 
             // Unicode KEY and unicode VALUE together
             ValidateTokens(db, R"(JSON_VALUE(Text, '$."кл"' RETURNING Utf8) == "значение"u)",
-                {"\5кл" + strSuffix("значение")});
+                {"\x14кл" + strSuffix("значение")});
 
             // Nested unicode keys: $."ключ"."поле"
             ValidateTokens(db, R"(JSON_VALUE(Text, '$."ключ"."поле"' RETURNING Utf8) == "v"u)",
-                {"\x09ключ\x09поле" + strSuffix("v")});
+                {"\x18ключ\x18поле" + strSuffix("v")});
 
             // Unicode in JSONPath filter: starts with (not equality -> path only)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.key starts with "При")'))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.key starts with "При")'))", {"\x13key"});
 
             // Unicode in JSONPath filter: like_regex (pattern match -> path only)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.key like_regex "При.*")'))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.key like_regex "При.*")'))", {"\x13key"});
 
             // Unicode value via PASSING variable
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == $var)' PASSING "Привет"u AS var))",
-                {"\3k1\3k2" + strSuffix("Привет")});
+                {"\x12k1\x12k2" + strSuffix("Привет")});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != $var)' PASSING "Привет"u AS var))",
-                {"\3k1\3k2"});
+                {"\x12k1\x12k2"});
 
             // Unicode at YQL level: range comparisons (path only)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) > "А"u)", {"\3k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) < "Я"u)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) > "А"u)", {"\x12k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) < "Я"u)", {"\x12k1"});
 
             // Unicode at YQL level: BETWEEN
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) BETWEEN "А"u AND "Я"u)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) BETWEEN "А"u AND "Я"u)", {"\x12k1"});
 
             // Unicode at YQL level: StartsWith (path only)
-            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "При"u))", {"\3k1"});
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1' RETURNING Utf8), "При"u))", {"\x12k1"});
 
             // Unicode values in AND/OR combinations
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "Привет"u AND JSON_EXISTS(Text, '$.k2'))",
-                {"\3k1" + strSuffix("Привет"), "\3k2"}, "and");
+                {"\x12k1" + strSuffix("Привет"), "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "Привет"u OR JSON_VALUE(Text, '$.k2' RETURNING Utf8) == "Мир"u)",
-                {"\3k1" + strSuffix("Привет"), "\3k2" + strSuffix("Мир")}, "or");
+                {"\x12k1" + strSuffix("Привет"), "\x12k2" + strSuffix("Мир")}, "or");
 
             // Unicode key with AND/OR
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$."кл"' RETURNING Utf8) == "a"u AND JSON_EXISTS(Text, '$.k2'))",
-                {"\5кл" + strSuffix("a"), "\3k2"}, "and");
+                {"\x14кл" + strSuffix("a"), "\x12k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$."кл"' RETURNING Utf8) == "значение"u OR JSON_EXISTS(Text, '$.k2'))",
-                {"\5кл" + strSuffix("значение"), "\3k2"}, "or");
+                {"\x14кл" + strSuffix("значение"), "\x12k2"}, "or");
         });
     }
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2574,8 +2574,8 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         }
 
         CompareYsonUnordered(R"([
-            [[1u];"\x09ключ"];
-            [[1u];"\x09ключ\0\3я mop"]
+            [[1u];"\x18ключ"];
+            [[1u];"\x18ключ\0\3я mop"]
         ])", FormatFulltextIndex(kikimr));
     }
 
@@ -2598,23 +2598,23 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             // JE: Cyrillic key in jsonpath
             ValidatePredicate(db, R"(JSON_EXISTS(Text, '$."ключ"'))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."ключ"'))", {"\x09ключ"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$."ключ"'))", {"\x18ключ"});
 
             // JE: Cyrillic key with Cyrillic string value in equality filter
             ValidatePredicate(db, R"(JSON_EXISTS(Text, '$ ? (@."ключ" == "Я моп")'))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."ключ" == "Я моп")'))", {std::string("\x09ключ") + strSuffix("Я моп")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."ключ" == "Я моп")'))", {std::string("\x18ключ") + strSuffix("Я моп")});
 
             ValidatePredicate(db, R"(JSON_EXISTS(Text, '$ ? (@."ключ" starts with "Я")'))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."ключ" starts with "Я")'))", {"\x09ключ"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@."ключ" starts with "Я")'))", {"\x18ключ"});
 
             // JV: Cyrillic key compared to Cyrillic Utf8 literal
             ValidatePredicate(db, R"(JSON_VALUE(Text, '$."ключ"' RETURNING Utf8) == "Я моп"u)");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$."ключ"' RETURNING Utf8) == "Я моп"u)", {std::string("\x09ключ") + strSuffix("Я моп")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$."ключ"' RETURNING Utf8) == "Я моп"u)", {std::string("\x18ключ") + strSuffix("Я моп")});
 
             // JV: Cyrillic key compared to external Utf8 parameter
             auto cyrParam = TParamsBuilder().AddParam("$p").Utf8("я").Build().Build();
             ValidatePredicate(db, R"(JSON_VALUE(Text, '$."ключ"' RETURNING Utf8) == $p)", cyrParam);
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$."ключ"' RETURNING Utf8) == $p)", {NJsonIndex::TToken{"\x09ключ", "$p"}}, cyrParam);
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$."ключ"' RETURNING Utf8) == $p)", {NJsonIndex::TToken{"\x18ключ", "$p"}}, cyrParam);
         });
     }
 

--- a/ydb/library/json_index/json_index.cpp
+++ b/ydb/library/json_index/json_index.cpp
@@ -38,11 +38,10 @@ NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
 
 // Keys may contain binary data (e.g. a zero byte), so we prefix each key with its
 // varint-encoded length (LEB128). This allows unambiguous prefix-scan queries.
-// Key lengths are encoded as (actual_length + 1) so that the encoded length byte is never
-// zero. This reserves \x00 exclusively for the literal separator used in AppendJsonIndexLiteral,
-// preventing ambiguity between an empty-key path component and the start of a literal suffix
+// Key lengths are encoded as (actual_length + PathSep::Max) so that the encoded length
+// byte is never zero and some extra values are reserved for special separators
 void AppendKey(TString& prefix, TStringBuf key) {
-    size_t size = key.size() + 1;
+    size_t size = key.size() + (ui8)EPathSeparator::Max;
     while (size > 0) {
         if (size < 0x80) {
             prefix.push_back(static_cast<char>(size));
@@ -52,6 +51,10 @@ void AppendKey(TString& prefix, TStringBuf key) {
         size >>= 7;
     };
     prefix += key;
+}
+
+void AppendArrayItem(TString& prefix) {
+    prefix += static_cast<char>(EPathSeparator::ArrayItem);
 }
 
 bool IsSuffixType(EJsonPathItemType type) {
@@ -88,26 +91,39 @@ bool IsPredicateType(EJsonPathItemType type) {
     }
 }
 
+static bool ReadPathKey(TStringBuf path, size_t& pos, TStringBuf& key) {
+    if ((ui8)path[pos] < (ui8)EPathSeparator::Max) {
+        return false;
+    }
+    size_t encodedSize = 0;
+    size_t shift = 0;
+    while (pos < path.size()) {
+        const ui8 byte = (ui8)path[pos++];
+        encodedSize |= (size_t)(byte & 0x7F) << shift;
+        if ((byte & 0x80) == 0) {
+            break;
+        }
+        shift += 7;
+    }
+    if (encodedSize == 0 || encodedSize - (ui8)EPathSeparator::Max > path.size() - pos) {
+        return false;
+    }
+    key = TStringBuf(path.data() + pos, encodedSize - (ui8)EPathSeparator::Max);
+    pos += encodedSize - (ui8)EPathSeparator::Max;
+    return true;
+}
+
 TStringBuf GetPathPrefix(TStringBuf pathToken) {
     size_t pos = 0;
     while (pos < pathToken.size()) {
-        size_t encodedSize = 0;
-        size_t shift = 0;
-        while (pos < pathToken.size()) {
-            const ui8 byte = static_cast<ui8>(pathToken[pos++]);
-            if (byte == 0) {
-                return pathToken.SubStr(0, pos - 1);
-            }
-            encodedSize |= static_cast<size_t>(byte & 0x7F) << shift;
-            if ((byte & 0x80) == 0) {
-                break;
-            }
-            shift += 7;
+        if ((ui8)pathToken[pos] == (ui8)EPathSeparator::ArrayItem) {
+            pos++;
+            continue;
         }
-        if (encodedSize == 0 || encodedSize - 1 > pathToken.size() - pos) {
-            return pathToken;
+        TStringBuf key;
+        if (!ReadPathKey(pathToken, pos, key)) {
+            return pathToken.substr(0, pos);
         }
-        pos += encodedSize - 1;
     }
     return pathToken;
 }
@@ -131,12 +147,7 @@ bool IsPathPrefixAncestor(const TToken& ancestor, const TToken& descendant) {
 // AND -> keep leaves (maximal tokens): if token A is a prefix of token B, A is redundant
 //        because requiring both A and B is satisfied by B alone (descendant implies ancestor)
 //
-// Path prefix comparison uses only the portion before the literal separator (\x00):
-//   1. AppendKey encodes key lengths as (actual_length + 1), so no key-length byte is ever \x00
-//   2. AppendJsonIndexLiteral always starts the literal suffix with \x00
-// Therefore \x00 can only appear at the start of a literal suffix, never inside the path portion.
-// Literal suffix bytes must not participate in StartsWith, or tokens with the same path but
-// different values could be collapsed when their encoded literals share a byte prefix.
+// Path prefix comparison uses only the portion before the literal separator (PathSep::Literal)
 void PruneRedundantTokens(TTokens& tokens, TCollectResult::ETokensMode mode) {
     if (tokens.size() <= 1 || mode == TCollectResult::ETokensMode::NotSet) {
         return;
@@ -251,11 +262,16 @@ public:
         : Reader(path)
         , CallableType(callableType)
         , Variables(variables)
-        , ParamVariables(paramVariables.begin(), paramVariables.end()) {
+        , ParamVariables(paramVariables.begin(), paramVariables.end())
+        , Lax(Reader.GetMode() == EJsonPathMode::Lax) {
     }
 
     TCollectResult Collect() {
         return Collect(Reader.ReadFirst(), EMode::Context);
+    }
+
+    bool IsLax() const {
+        return Lax;
     }
 
 private:
@@ -296,6 +312,7 @@ private:
     std::unordered_map<TString, TString> Variables;
     std::unordered_map<TString, TString> ParamVariables;
     TVector<TString> FilterObjectPrefixes;
+    bool Lax;
 };
 
 TCollectResult TQueryCollector::Collect(const TJsonPathItem& item, EMode mode) {
@@ -419,7 +436,18 @@ TCollectResult TQueryCollector::WildcardMemberAccess(const TJsonPathItem& item, 
 }
 
 TCollectResult TQueryCollector::ArrayAccess(const TJsonPathItem& item, EMode mode) {
-    return Collect(Reader.ReadInput(item), mode);
+    auto result = Collect(Reader.ReadInput(item), mode);
+    if (!result.CanCollect()) {
+        return result;
+    }
+    auto& tokens = result.GetTokens();
+    TTokens prefixedTokens;
+    for (auto node: tokens) {
+        AppendArrayItem(node.PathToken);
+        prefixedTokens.insert(std::move(node));
+    }
+    std::swap(tokens, prefixedTokens);
+    return result;
 }
 
 TCollectResult TQueryCollector::UnaryArithmeticOp(const TJsonPathItem& item, EMode mode) {
@@ -711,16 +739,25 @@ TString TokenizeJsonNextPrefix(const TString& prefix, TStringBuf key) {
     return newPrefix;
 }
 
+TString TokenizeJsonArrayPrefix(const TString& prefix) {
+    TString newPrefix = prefix;
+    AppendArrayItem(newPrefix);
+    return newPrefix;
+}
+
 void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens) {
     switch (root.GetType()) {
         case NBinaryJson::EContainerType::TopLevelScalar:
             TokenizeBinaryJson(root.GetElement(0), prefix, tokens);
             break;
-        case NBinaryJson::EContainerType::Array:
+        case NBinaryJson::EContainerType::Array: {
+            TString nextPrefix = TokenizeJsonArrayPrefix(prefix);
+            tokens.push_back(nextPrefix);
             for (ui32 pos = 0; pos < root.GetSize(); pos++) {
-                TokenizeBinaryJson(root.GetElement(pos), prefix, tokens);
+                TokenizeBinaryJson(root.GetElement(pos), nextPrefix, tokens);
             }
             break;
+        }
         case NBinaryJson::EContainerType::Object:
             auto it = root.GetObjectIterator();
             while (it.HasNext()) {
@@ -737,7 +774,7 @@ void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString
 }   // namespace
 
 void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringBuf stringPayload, const double* numberPayload) {
-    out.push_back(0);
+    out.push_back(static_cast<char>(EPathSeparator::Literal));
     out.push_back(static_cast<char>(type));
     switch (type) {
         case NBinaryJson::EEntryType::String:
@@ -798,6 +835,10 @@ bool TCollectResult::CanCollect() const {
     return !IsError() && !Stopped && GetTokens().size() == 1;
 }
 
+bool TCollectResult::CanAppendLiteral() const {
+    return !IsError() && !Stopped && !GetTokens().empty();
+}
+
 TCollectResult::ETokensMode TCollectResult::GetTokensMode() const {
     return TokensMode;
 }
@@ -827,12 +868,82 @@ TVector<TString> TokenizeJson(TStringBuf text, TString& error) {
     return TokenizeBinaryJson(TStringBuf(buffer.data(), buffer.size()));
 }
 
+TTokens ExpandLaxToken(const TToken& token) {
+    // Generate all variants of the path portion. In lax mode a member access
+    // implicitly descends one array level, so an array-item marker may optionally
+    // precede each key segment.
+    TVector<TString> variants{ "" };
+    auto multiply = [&](TStringBuf segment) {
+        TVector<TString> nextVariants;
+        nextVariants.reserve(variants.size() * 2);
+        for (auto& variant : variants) {
+            nextVariants.push_back(variant + segment);
+            nextVariants.push_back(variant + (char)EPathSeparator::ArrayItem + segment);
+        }
+        variants = std::move(nextVariants);
+    };
+
+    size_t pos = 0;
+    bool inArray = false;
+    TStringBuf literal;
+    while (pos < token.PathToken.size()) {
+        if (token.PathToken[pos] == (char)EPathSeparator::ArrayItem) {
+            multiply("");
+            pos++;
+            inArray = true;
+            continue;
+        }
+        TStringBuf segment;
+        const size_t segmentStart = pos;
+        if (!ReadPathKey(token.PathToken, pos, segment)) {
+            literal = TStringBuf(token.PathToken.data() + segmentStart, token.PathToken.size() - segmentStart);
+            break;
+        }
+        segment = TStringBuf(token.PathToken.data() + segmentStart, pos - segmentStart);
+        if (inArray) {
+            // Already in array item, don't unpack second time
+            for (auto& variant : variants) {
+                variant += segment;
+            }
+            inArray = false;
+        } else {
+            multiply(segment);
+        }
+    }
+    if (!inArray) {
+        multiply("");
+    }
+
+    TTokens result;
+    for (auto& variant : variants) {
+        result.emplace(variant + literal, token.ParamName);
+    }
+    return result;
+}
+
+TTokens ExpandLaxTokens(const TTokens& tokens) {
+    TTokens result;
+    for (const auto& token : tokens) {
+        auto expanded = ExpandLaxToken(token);
+        result.insert(expanded.begin(), expanded.end());
+    }
+    return result;
+}
+
 TCollectResult CollectJsonPath(const TJsonPathPtr& path, ECallableType callableType, const std::unordered_map<TString, TString>& variables,
     const std::unordered_map<TString, TString>& paramVariables) {
-    auto result = TQueryCollector(path, callableType, variables, paramVariables).Collect();
+    TQueryCollector collector(path, callableType, variables, paramVariables);
+    auto result = collector.Collect();
     if (!result.IsError()) {
         if (result.GetTokens().empty()) {
             result = TCollectResult(TIssue("Cannot collect tokens for the given JSON path"));
+        } else {
+            if (collector.IsLax()) {
+                result.GetTokens() = ExpandLaxTokens(result.GetTokens());
+                if (result.GetTokens().size() > 1) {
+                    result.SetTokensMode(TCollectResult::ETokensMode::Or);
+                }
+            }
         }
 
         if (callableType != ECallableType::JsonValue) {
@@ -856,20 +967,26 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
     NJson::TJsonWriter writer(&ss, /* formatOutput */ false);
     writer.OpenMap();
 
-    size_t nullPos = pathToken.find('\0');
-    size_t pathEnd = (nullPos == TString::npos) ? pathToken.size() : nullPos;
+    const TStringBuf pathPart = GetPathPrefix(pathToken);
+    const bool hasLiteral = pathPart.size() != pathToken.size();
 
-    // Decode LEB128-prefixed key segments from the path portion
-    if (pathEnd > 0) {
+    // Decode LEB128-prefixed key segments and array-item markers from the path portion
+    if (!pathPart.empty()) {
         std::vector<TString> path;
         size_t pos = 0;
 
-        while (pos < pathEnd) {
+        while (pos < pathPart.size()) {
+            if (pathPart[pos] == (char)EPathSeparator::ArrayItem) {
+                path.push_back("[*]");
+                pos++;
+                continue;
+            }
+
             size_t encodedLength = 0;
             int shift = 0;
-            while (pos < pathEnd) {
-                ui8 byte = static_cast<ui8>(pathToken[pos++]);
-                encodedLength |= static_cast<size_t>(byte & 0x7F) << shift;
+            while (pos < pathPart.size()) {
+                ui8 byte = (ui8)pathPart[pos++];
+                encodedLength |= (size_t)(byte & 0x7F) << shift;
                 shift += 7;
                 if (!(byte & 0x80)) {
                     break;
@@ -880,12 +997,12 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
                 break;
             }
 
-            size_t keyLength = encodedLength - 1;
-            if (pos + keyLength > pathEnd) {
+            size_t keyLength = encodedLength - (ui8)EPathSeparator::Max;
+            if (pos + keyLength > pathPart.size()) {
                 break;
             }
 
-            path.push_back(pathToken.substr(pos, keyLength));
+            path.push_back(TString(pathPart.substr(pos, keyLength)));
             pos += keyLength;
         }
 
@@ -895,8 +1012,9 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
     }
 
     // Decode literal suffix
-    if (nullPos != TString::npos && nullPos + 1 < pathToken.size()) {
-        auto typeCode = static_cast<NBinaryJson::EEntryType>(static_cast<ui8>(pathToken[nullPos + 1]));
+    if (hasLiteral && pathPart.size() + 1 < pathToken.size()) {
+        auto typeCode = (NBinaryJson::EEntryType)pathToken[pathPart.size() + 1];
+        const size_t payloadPos = pathPart.size() + 2;
 
         switch (typeCode) {
             case NBinaryJson::EEntryType::BoolFalse:
@@ -909,12 +1027,12 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
                 writer.Write("literal", NJson::TJsonValue(NJson::JSON_NULL));
                 break;
             case NBinaryJson::EEntryType::String:
-                writer.Write("literal", pathToken.substr(nullPos + 2));
+                writer.Write("literal", pathToken.substr(payloadPos));
                 break;
             case NBinaryJson::EEntryType::Number:
-                if (nullPos + 2 + sizeof(double) <= pathToken.size()) {
+                if (payloadPos + sizeof(double) <= pathToken.size()) {
                     double d = 0.0;
-                    memcpy(&d, pathToken.data() + nullPos + 2, sizeof(double));
+                    memcpy(&d, pathToken.data() + payloadPos, sizeof(double));
                     writer.Write("literal", d);
                 }
                 break;

--- a/ydb/library/json_index/json_index.cpp
+++ b/ydb/library/json_index/json_index.cpp
@@ -196,9 +196,16 @@ TCollectResult MergeBooleanOperands(
         }
     }
 
+    if (!right.IsCovered()) {
+        left.SetNotCovered();
+    }
+
     leftTokens.insert(rightTokens.begin(), rightTokens.end());
     if (leftTokens.size() > 1) {
         auto finalMode = hasMix ? TCollectResult::ETokensMode::Or : combinedMode;
+        if (hasMix) {
+            left.SetNotCovered();
+        }
         left.SetTokensMode(finalMode);
         PruneRedundantTokens(leftTokens, finalMode);
     }
@@ -223,10 +230,15 @@ TCollectResult MergeComparisonPathResults(TCollectResult left, TCollectResult ri
         }
     }
 
+    if (!right.IsCovered()) {
+        left.SetNotCovered();
+    }
+
     leftTokens.insert(rightTokens.begin(), rightTokens.end());
     if (leftTokens.size() > 1) {
         left.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : TCollectResult::ETokensMode::And);
     }
+    left.SetNotCovered();
     left.StopCollecting();
     return left;
 }
@@ -420,18 +432,24 @@ TCollectResult TQueryCollector::MemberAccess(const TJsonPathItem& item, EMode mo
     auto node = tokens.extract(tokens.begin());
     AppendKey(node.value().PathToken, item.GetString());
     tokens.insert(std::move(node));
+    if (Reader.GetMode() == EJsonPathMode::Strict) {
+        result.SetNotCovered();
+    }
     return result;
 }
 
 TCollectResult TQueryCollector::WildcardMemberAccess(const TJsonPathItem& item, EMode mode) {
     auto result = Collect(Reader.ReadInput(item), mode);
+    result.SetNotCovered();
     result.StopCollecting();
     return result;
 }
 
 TCollectResult TQueryCollector::ArrayAccess(const TJsonPathItem& item, EMode mode) {
     if (IsLax()) {
-        return Collect(Reader.ReadInput(item), mode);
+        auto result = Collect(Reader.ReadInput(item), mode);
+        result.SetNotCovered();
+        return result;
     }
     auto result = Collect(Reader.ReadInput(item), mode);
     if (!result.CanCollect()) {
@@ -461,6 +479,7 @@ TCollectResult TQueryCollector::UnaryArithmeticOp(const TJsonPathItem& item, EMo
     }
 
     auto result = Collect(Reader.ReadInput(item), mode);
+    result.SetNotCovered();
     result.StopCollecting();
     return result;
 }
@@ -539,7 +558,11 @@ TCollectResult TQueryCollector::FilterObject(const TJsonPathItem& item, EMode mo
     if (FilterObjectPrefixes.empty()) {
         return TCollectResult(TIssue("'@' is only allowed inside filters"));
     }
-    return TCollectResult(TString(FilterObjectPrefixes.back()));
+    auto result = TCollectResult(TString(FilterObjectPrefixes.back()));
+    if (Reader.GetMode() == EJsonPathMode::Strict) {
+        result.SetNotCovered();
+    }
+    return result;
 }
 
 TCollectResult TQueryCollector::FilterPredicate(const TJsonPathItem& item, EMode mode) {
@@ -576,6 +599,9 @@ TCollectResult TQueryCollector::FilterPredicate(const TJsonPathItem& item, EMode
         auto current = Collect(*predicateItem, EMode::Filter);
         if (current.IsError()) {
             FilterObjectPrefixes.pop_back();
+            if (Reader.GetMode() == EJsonPathMode::Strict) {
+                current.SetNotCovered();
+            }
             return current;
         }
 
@@ -589,6 +615,9 @@ TCollectResult TQueryCollector::FilterPredicate(const TJsonPathItem& item, EMode
     FilterObjectPrefixes.pop_back();
 
     predicateResult->StopCollecting();
+    if (Reader.GetMode() == EJsonPathMode::Strict) {
+        predicateResult->SetNotCovered();
+    }
     return *predicateResult;
 }
 
@@ -596,11 +625,13 @@ TCollectResult TQueryCollector::Methods(const TJsonPathItem& item, EMode mode) {
     const auto& input = Reader.ReadInput(item);
     if (IsSuffixType(input.Type) || EvaluteNumericLiteral(input).has_value()) {
         TCollectResult result(TTokens{});
+        result.SetNotCovered();
         result.StopCollecting();
         return result;
     }
 
     auto result = Collect(input, mode);
+    result.SetNotCovered();
     result.StopCollecting();
     return result;
 }
@@ -611,6 +642,7 @@ TCollectResult TQueryCollector::Predicates(const TJsonPathItem& item, EMode mode
     }
 
     auto result = Collect(Reader.ReadInput(item), EMode::Predicate);
+    result.SetNotCovered();
     result.StopCollecting();
     return result;
 }
@@ -641,6 +673,13 @@ TCollectResult TQueryCollector::CollectEqualOperands(const TJsonPathItem& leftIt
         }
 
         pathTokens.insert(std::move(node));
+
+        if (Reader.GetMode() == EJsonPathMode::Strict) {
+            pathResult.SetNotCovered();
+        }
+    } else {
+        // Literal not appended (e.g. path not collectable or no literal resolved)
+        pathResult.SetNotCovered();
     }
 
     pathResult.StopCollecting();
@@ -798,7 +837,8 @@ void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringB
 }
 
 TCollectResult::TCollectResult(TTokens&& tokens)
-    : Result(std::move(tokens)) {
+    : Result(std::move(tokens))
+    , Covered(tokens.size()) {
 }
 
 TCollectResult::TCollectResult(TString&& token) {
@@ -844,6 +884,14 @@ TCollectResult::ETokensMode TCollectResult::GetTokensMode() const {
 
 void TCollectResult::SetTokensMode(ETokensMode mode) {
     TokensMode = mode;
+}
+
+bool TCollectResult::IsCovered() const {
+    return Covered;
+}
+
+void TCollectResult::SetNotCovered() {
+    Covered = false;
 }
 
 TVector<TString> TokenizeBinaryJson(TStringBuf text) {

--- a/ydb/library/json_index/json_index.cpp
+++ b/ydb/library/json_index/json_index.cpp
@@ -91,39 +91,33 @@ bool IsPredicateType(EJsonPathItemType type) {
     }
 }
 
-static bool ReadPathKey(TStringBuf path, size_t& pos, TStringBuf& key) {
-    if ((ui8)path[pos] < (ui8)EPathSeparator::Max) {
-        return false;
-    }
-    size_t encodedSize = 0;
-    size_t shift = 0;
-    while (pos < path.size()) {
-        const ui8 byte = (ui8)path[pos++];
-        encodedSize |= (size_t)(byte & 0x7F) << shift;
-        if ((byte & 0x80) == 0) {
-            break;
-        }
-        shift += 7;
-    }
-    if (encodedSize == 0 || encodedSize - (ui8)EPathSeparator::Max > path.size() - pos) {
-        return false;
-    }
-    key = TStringBuf(path.data() + pos, encodedSize - (ui8)EPathSeparator::Max);
-    pos += encodedSize - (ui8)EPathSeparator::Max;
-    return true;
-}
-
 TStringBuf GetPathPrefix(TStringBuf pathToken) {
     size_t pos = 0;
+    if (pos < pathToken.size() && (ui8)pathToken[pos] == (ui8)EPathSeparator::LaxMarker) {
+        pos++;
+    }
     while (pos < pathToken.size()) {
         if ((ui8)pathToken[pos] == (ui8)EPathSeparator::ArrayItem) {
             pos++;
             continue;
         }
-        TStringBuf key;
-        if (!ReadPathKey(pathToken, pos, key)) {
-            return pathToken.substr(0, pos);
+        if ((ui8)pathToken[pos] < (ui8)EPathSeparator::Max) {
+            return pathToken.SubStr(0, pos);
         }
+        size_t encodedSize = 0;
+        size_t shift = 0;
+        while (pos < pathToken.size()) {
+            const ui8 byte = static_cast<ui8>(pathToken[pos++]);
+            encodedSize |= static_cast<size_t>(byte & 0x7F) << shift;
+            if ((byte & 0x80) == 0) {
+                break;
+            }
+            shift += 7;
+        }
+        if (encodedSize < (ui8)EPathSeparator::Max || encodedSize - (ui8)EPathSeparator::Max > pathToken.size() - pos) {
+            return pathToken;
+        }
+        pos += encodedSize - (ui8)EPathSeparator::Max;
     }
     return pathToken;
 }
@@ -436,6 +430,9 @@ TCollectResult TQueryCollector::WildcardMemberAccess(const TJsonPathItem& item, 
 }
 
 TCollectResult TQueryCollector::ArrayAccess(const TJsonPathItem& item, EMode mode) {
+    if (IsLax()) {
+        return Collect(Reader.ReadInput(item), mode);
+    }
     auto result = Collect(Reader.ReadInput(item), mode);
     if (!result.CanCollect()) {
         return result;
@@ -704,11 +701,11 @@ bool TQueryCollector::ArePredicatesAllowed(EMode mode) const {
     }
 }
 
-void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens);
+void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, bool lax, TVector<TString>& tokens);
 
-void TokenizeBinaryJson(const NBinaryJson::TEntryCursor& element, const TString& prefix, TVector<TString>& tokens) {
+void TokenizeBinaryJson(const NBinaryJson::TEntryCursor& element, const TString& prefix, bool lax, TVector<TString>& tokens) {
     if (element.GetType() == NBinaryJson::EEntryType::Container) {
-        TokenizeBinaryJson(element.GetContainer(), prefix, tokens);
+        TokenizeBinaryJson(element.GetContainer(), prefix, lax, tokens);
         return;
     }
     TString token = prefix;
@@ -745,16 +742,22 @@ TString TokenizeJsonArrayPrefix(const TString& prefix) {
     return newPrefix;
 }
 
-void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens) {
+void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, bool lax, TVector<TString>& tokens) {
     switch (root.GetType()) {
         case NBinaryJson::EContainerType::TopLevelScalar:
-            TokenizeBinaryJson(root.GetElement(0), prefix, tokens);
+            TokenizeBinaryJson(root.GetElement(0), prefix, lax, tokens);
             break;
         case NBinaryJson::EContainerType::Array: {
-            TString nextPrefix = TokenizeJsonArrayPrefix(prefix);
-            tokens.push_back(nextPrefix);
-            for (ui32 pos = 0; pos < root.GetSize(); pos++) {
-                TokenizeBinaryJson(root.GetElement(pos), nextPrefix, tokens);
+            if (lax) {
+                for (ui32 pos = 0; pos < root.GetSize(); pos++) {
+                    TokenizeBinaryJson(root.GetElement(pos), prefix, lax, tokens);
+                }
+            } else {
+                TString nextPrefix = TokenizeJsonArrayPrefix(prefix);
+                tokens.push_back(nextPrefix);
+                for (ui32 pos = 0; pos < root.GetSize(); pos++) {
+                    TokenizeBinaryJson(root.GetElement(pos), nextPrefix, lax, tokens);
+                }
             }
             break;
         }
@@ -765,7 +768,7 @@ void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString
                 Y_ENSURE(kv.first.GetType() == NBinaryJson::EEntryType::String);
                 TString nextPrefix = TokenizeJsonNextPrefix(prefix, kv.first.GetString());
                 tokens.push_back(nextPrefix);
-                TokenizeBinaryJson(kv.second, nextPrefix, tokens);
+                TokenizeBinaryJson(kv.second, nextPrefix, lax, tokens);
             }
             break;
     }
@@ -835,10 +838,6 @@ bool TCollectResult::CanCollect() const {
     return !IsError() && !Stopped && GetTokens().size() == 1;
 }
 
-bool TCollectResult::CanAppendLiteral() const {
-    return !IsError() && !Stopped && !GetTokens().empty();
-}
-
 TCollectResult::ETokensMode TCollectResult::GetTokensMode() const {
     return TokensMode;
 }
@@ -853,7 +852,8 @@ TVector<TString> TokenizeBinaryJson(TStringBuf text) {
         return tokens;
     }
     auto reader = NKikimr::NBinaryJson::TBinaryJsonReader::Make(text);
-    TokenizeBinaryJson(reader->GetRootCursor(), "", tokens);
+    TokenizeBinaryJson(reader->GetRootCursor(), "", false, tokens);
+    TokenizeBinaryJson(reader->GetRootCursor(), TString((char)EPathSeparator::LaxMarker), true, tokens);
     return tokens;
 }
 
@@ -868,68 +868,6 @@ TVector<TString> TokenizeJson(TStringBuf text, TString& error) {
     return TokenizeBinaryJson(TStringBuf(buffer.data(), buffer.size()));
 }
 
-TTokens ExpandLaxToken(const TToken& token) {
-    // Generate all variants of the path portion. In lax mode a member access
-    // implicitly descends one array level, so an array-item marker may optionally
-    // precede each key segment.
-    TVector<TString> variants{ "" };
-    auto multiply = [&](TStringBuf segment) {
-        TVector<TString> nextVariants;
-        nextVariants.reserve(variants.size() * 2);
-        for (auto& variant : variants) {
-            nextVariants.push_back(variant + segment);
-            nextVariants.push_back(variant + (char)EPathSeparator::ArrayItem + segment);
-        }
-        variants = std::move(nextVariants);
-    };
-
-    size_t pos = 0;
-    bool inArray = false;
-    TStringBuf literal;
-    while (pos < token.PathToken.size()) {
-        if (token.PathToken[pos] == (char)EPathSeparator::ArrayItem) {
-            multiply("");
-            pos++;
-            inArray = true;
-            continue;
-        }
-        TStringBuf segment;
-        const size_t segmentStart = pos;
-        if (!ReadPathKey(token.PathToken, pos, segment)) {
-            literal = TStringBuf(token.PathToken.data() + segmentStart, token.PathToken.size() - segmentStart);
-            break;
-        }
-        segment = TStringBuf(token.PathToken.data() + segmentStart, pos - segmentStart);
-        if (inArray) {
-            // Already in array item, don't unpack second time
-            for (auto& variant : variants) {
-                variant += segment;
-            }
-            inArray = false;
-        } else {
-            multiply(segment);
-        }
-    }
-    if (!inArray) {
-        multiply("");
-    }
-
-    TTokens result;
-    for (auto& variant : variants) {
-        result.emplace(variant + literal, token.ParamName);
-    }
-    return result;
-}
-
-TTokens ExpandLaxTokens(const TTokens& tokens) {
-    TTokens result;
-    for (const auto& token : tokens) {
-        auto expanded = ExpandLaxToken(token);
-        result.insert(expanded.begin(), expanded.end());
-    }
-    return result;
-}
-
 TCollectResult CollectJsonPath(const TJsonPathPtr& path, ECallableType callableType, const std::unordered_map<TString, TString>& variables,
     const std::unordered_map<TString, TString>& paramVariables) {
     TQueryCollector collector(path, callableType, variables, paramVariables);
@@ -937,13 +875,16 @@ TCollectResult CollectJsonPath(const TJsonPathPtr& path, ECallableType callableT
     if (!result.IsError()) {
         if (result.GetTokens().empty()) {
             result = TCollectResult(TIssue("Cannot collect tokens for the given JSON path"));
-        } else {
-            if (collector.IsLax()) {
-                result.GetTokens() = ExpandLaxTokens(result.GetTokens());
-                if (result.GetTokens().size() > 1) {
-                    result.SetTokensMode(TCollectResult::ETokensMode::Or);
+        } else if (collector.IsLax()) {
+            TTokens prefixed;
+            for (const auto& token : result.GetTokens()) {
+                if (token.PathToken != "") {
+                    prefixed.emplace(TString((char)EPathSeparator::LaxMarker) + token.PathToken, token.ParamName);
+                } else {
+                    prefixed.insert(token);
                 }
             }
+            result.GetTokens() = std::move(prefixed);
         }
 
         if (callableType != ECallableType::JsonValue) {
@@ -967,16 +908,20 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
     NJson::TJsonWriter writer(&ss, /* formatOutput */ false);
     writer.OpenMap();
 
-    const TStringBuf pathPart = GetPathPrefix(pathToken);
-    const bool hasLiteral = pathPart.size() != pathToken.size();
+    size_t nullPos = pathToken.find('\0');
+    size_t pathEnd = (nullPos == TString::npos) ? pathToken.size() : nullPos;
 
     // Decode LEB128-prefixed key segments and array-item markers from the path portion
-    if (!pathPart.empty()) {
+    if (pathEnd > 0) {
         std::vector<TString> path;
         size_t pos = 0;
 
-        while (pos < pathPart.size()) {
-            if (pathPart[pos] == (char)EPathSeparator::ArrayItem) {
+        if (pos < pathEnd && pathToken[pos] == (char)EPathSeparator::LaxMarker) {
+            pos++;
+        }
+
+        while (pos < pathEnd) {
+            if (pathToken[pos] == (char)EPathSeparator::ArrayItem) {
                 path.push_back("[*]");
                 pos++;
                 continue;
@@ -984,25 +929,25 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
 
             size_t encodedLength = 0;
             int shift = 0;
-            while (pos < pathPart.size()) {
-                ui8 byte = (ui8)pathPart[pos++];
-                encodedLength |= (size_t)(byte & 0x7F) << shift;
+            while (pos < pathEnd) {
+                ui8 byte = static_cast<ui8>(pathToken[pos++]);
+                encodedLength |= static_cast<size_t>(byte & 0x7F) << shift;
                 shift += 7;
                 if (!(byte & 0x80)) {
                     break;
                 }
             }
 
-            if (encodedLength == 0) {
+            if (encodedLength < (ui8)EPathSeparator::Max) {
                 break;
             }
 
             size_t keyLength = encodedLength - (ui8)EPathSeparator::Max;
-            if (pos + keyLength > pathPart.size()) {
+            if (pos + keyLength > pathEnd) {
                 break;
             }
 
-            path.push_back(TString(pathPart.substr(pos, keyLength)));
+            path.push_back(pathToken.substr(pos, keyLength));
             pos += keyLength;
         }
 
@@ -1012,9 +957,8 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
     }
 
     // Decode literal suffix
-    if (hasLiteral && pathPart.size() + 1 < pathToken.size()) {
-        auto typeCode = (NBinaryJson::EEntryType)pathToken[pathPart.size() + 1];
-        const size_t payloadPos = pathPart.size() + 2;
+    if (nullPos != TString::npos && nullPos + 1 < pathToken.size()) {
+        auto typeCode = static_cast<NBinaryJson::EEntryType>(static_cast<ui8>(pathToken[nullPos + 1]));
 
         switch (typeCode) {
             case NBinaryJson::EEntryType::BoolFalse:
@@ -1027,12 +971,12 @@ TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName)
                 writer.Write("literal", NJson::TJsonValue(NJson::JSON_NULL));
                 break;
             case NBinaryJson::EEntryType::String:
-                writer.Write("literal", pathToken.substr(payloadPos));
+                writer.Write("literal", pathToken.substr(nullPos + 2));
                 break;
             case NBinaryJson::EEntryType::Number:
-                if (payloadPos + sizeof(double) <= pathToken.size()) {
+                if (nullPos + 2 + sizeof(double) <= pathToken.size()) {
                     double d = 0.0;
-                    memcpy(&d, pathToken.data() + payloadPos, sizeof(double));
+                    memcpy(&d, pathToken.data() + nullPos + 2, sizeof(double));
                     writer.Write("literal", d);
                 }
                 break;

--- a/ydb/library/json_index/json_index.h
+++ b/ydb/library/json_index/json_index.h
@@ -92,10 +92,17 @@ public:
     // Sets the tokens mode
     void SetTokensMode(ETokensMode mode);
 
+    // Returns true if the collected tokens exactly represent the predicate (no false positives)
+    bool IsCovered() const;
+
+    // Marks the result as not fully covered (tokens may produce false positives)
+    void SetNotCovered();
+
 private:
     std::variant<TTokens, TError> Result;
     ETokensMode TokensMode = ETokensMode::NotSet;
     bool Stopped = false;
+    bool Covered = true;
 };
 
 // Type of the callable function that is used for the JSON index collection

--- a/ydb/library/json_index/json_index.h
+++ b/ydb/library/json_index/json_index.h
@@ -81,6 +81,11 @@ public:
     // It does not affect collecting multiple tokens (AND, OR, etc.)
     bool CanCollect() const;
 
+    // Returns true if the collected tokens can be extended with a literal suffix or a
+    // parameter name. Unlike CanCollect(), it does not require the result to contain
+    // exactly one token, since lax-mode array expansion may produce several tokens.
+    bool CanAppendLiteral() const;
+
     // Stops the collection process
     // It means that the result token is completed and cannot be extended
     // It does not affect collecting multiple tokens (AND, OR, etc.)
@@ -106,6 +111,13 @@ enum class ECallableType : ui8 {
     JsonQuery = 2,
 };
 
+enum class EPathSeparator : ui8 {
+    Literal = 0,
+    ArrayItem = 1,
+    // 2-15 are reserved for future use
+    Max = 0x10,
+};
+
 // Tokenizes the given JSON string into a list of tokens
 // The tokenization result is filled into the JSON index table
 TVector<TString> TokenizeJson(TStringBuf text, TString& error);
@@ -128,16 +140,29 @@ TCollectResult MergeOr(TCollectResult left, TCollectResult right);
 // Appends NULL, binary JSON entry type byte, and scalar payload (the index token layout)
 void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringBuf stringPayload = {}, const double* numberPayload = nullptr);
 
+// Expands a collected token for lax-mode array auto-unwrapping.
+// In lax mode a member access and a comparison each implicitly descend one array
+// level, so an array-item marker may optionally precede each key segment and the
+// literal suffix (or the end of the path for parametric tokens, whose value is
+// appended at runtime). Returns the input token as a singleton when there is
+// nothing to expand (empty path without a literal suffix).
+TTokens ExpandLaxToken(const TToken& token);
+
+// Expands every token in the set for lax-mode array auto-unwrapping (see ExpandLaxToken).
+TTokens ExpandLaxTokens(const TTokens& tokens);
+
 // Formats an index token and optional parameter name as a JSON-like object string.
 // The path portion is decoded from length-prefixed key segments joined by '.'.
-// A literal suffix (after the \0 separator) is decoded by its EEntryType byte.
+// Array-item markers are rendered as "[*]" segments.
+// A literal suffix (after EPathSeparator::Literal) is decoded by its EEntryType byte.
 // Examples:
-//   ("\3k1\3k2", "")     -> {"path": "k1.k2"}
-//   ("\3k1\3k2\0\1", "") -> {"path": "k1.k2", "literal": true}
-//   ("\3k1\3k2", "$p")   -> {"path": "k1.k2", "param": "$p"}
-//   ("\0\0", "")         -> {"literal": false}
-//   ("", "$p")           -> {"param": "$p"}
-//   ("", "")             -> {}
+//   ("\x13k1\x13k2", "")      -> {"path": "k1.k2"}
+//   ("\x13k1\x13k2\0\1", "")  -> {"path": "k1.k2", "literal": true}
+//   ("\x13k1\x01\x13k2", "")  -> {"path": "k1.[*].k2"}
+//   ("\x13k1\x13k2", "$p")    -> {"path": "k1.k2", "param": "$p"}
+//   ("\0\0", "")              -> {"literal": false}
+//   ("", "$p")                -> {"param": "$p"}
+//   ("", "")                  -> {}
 TString FormatJsonIndexToken(const TString& pathToken, const TString& paramName);
 
 }   // namespace NKikimr::NJsonIndex

--- a/ydb/library/json_index/json_index.h
+++ b/ydb/library/json_index/json_index.h
@@ -81,11 +81,6 @@ public:
     // It does not affect collecting multiple tokens (AND, OR, etc.)
     bool CanCollect() const;
 
-    // Returns true if the collected tokens can be extended with a literal suffix or a
-    // parameter name. Unlike CanCollect(), it does not require the result to contain
-    // exactly one token, since lax-mode array expansion may produce several tokens.
-    bool CanAppendLiteral() const;
-
     // Stops the collection process
     // It means that the result token is completed and cannot be extended
     // It does not affect collecting multiple tokens (AND, OR, etc.)
@@ -114,7 +109,8 @@ enum class ECallableType : ui8 {
 enum class EPathSeparator : ui8 {
     Literal = 0,
     ArrayItem = 1,
-    // 2-15 are reserved for future use
+    LaxMarker = 2,
+    // 3-15 are reserved for future use
     Max = 0x10,
 };
 
@@ -139,17 +135,6 @@ TCollectResult MergeOr(TCollectResult left, TCollectResult right);
 
 // Appends NULL, binary JSON entry type byte, and scalar payload (the index token layout)
 void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringBuf stringPayload = {}, const double* numberPayload = nullptr);
-
-// Expands a collected token for lax-mode array auto-unwrapping.
-// In lax mode a member access and a comparison each implicitly descend one array
-// level, so an array-item marker may optionally precede each key segment and the
-// literal suffix (or the end of the path for parametric tokens, whose value is
-// appended at runtime). Returns the input token as a singleton when there is
-// nothing to expand (empty path without a literal suffix).
-TTokens ExpandLaxToken(const TToken& token);
-
-// Expands every token in the set for lax-mode array auto-unwrapping (see ExpandLaxToken).
-TTokens ExpandLaxTokens(const TTokens& tokens);
 
 // Formats an index token and optional parameter name as a JSON-like object string.
 // The path portion is decoded from length-prefixed key segments joined by '.'.

--- a/ydb/library/json_index/ut/json_index_ut.cpp
+++ b/ydb/library/json_index/ut/json_index_ut.cpp
@@ -3345,4 +3345,172 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     }
 }
 
+Y_UNIT_TEST_SUITE(Covered) {
+    // Helper: parse, collect, and return IsCovered()
+    bool CheckCovered(const TString& jsonPath, ECallableType callableType,
+        const TVarMap& variables = {}, const TVarMap& paramVariables = {})
+    {
+        NYql::TIssues issues;
+        const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
+        UNIT_ASSERT_C(issues.Empty(), "Parse errors for path: " + jsonPath + ": " + issues.ToOneLineString());
+
+        auto result = CollectJsonPath(path, callableType, variables, paramVariables);
+        UNIT_ASSERT_C(!result.IsError(), "Collect errors for path: " + jsonPath + ": " + result.GetError().GetMessage());
+
+        return result.IsCovered();
+    }
+
+    // --- Covered = true ---
+
+    Y_UNIT_TEST(JsonExistsSimpleKey) {
+        // $.key for JSON_EXISTS -> token \4key = exact existence check
+        UNIT_ASSERT(CheckCovered("$.key", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(JsonExistsNestedKey) {
+        UNIT_ASSERT(CheckCovered("$.a.b.c", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(EqualStringLiteral) {
+        // $.key == "val" -> path + literal suffix = exact value match
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.key == "val"))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(EqualNumberLiteral) {
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.key == 42))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(EqualBoolLiteral) {
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.key == true))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(EqualNullLiteral) {
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.key == null))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(EqualVariable) {
+        // $.key == $param -> path + param = exact value match at runtime
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.key == $var))", ECallableType::JsonExists,
+            {{"var", strSuffix("hello")}}, {}));
+    }
+
+    Y_UNIT_TEST(EqualParamVariable) {
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.key == $p))", ECallableType::JsonExists,
+            {}, {{"p", "$p"}}));
+    }
+
+    Y_UNIT_TEST(AndOfCoveredPredicates) {
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.a == "x" && @.b == "y"))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(OrOfCoveredPredicates) {
+        UNIT_ASSERT(CheckCovered(R"($ ? (@.a == "x" || @.b == "y"))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(JsonValueEqualLiteral) {
+        UNIT_ASSERT(CheckCovered(R"($.key == "val")", ECallableType::JsonValue));
+    }
+
+    // --- Covered = false ---
+
+    Y_UNIT_TEST(WildcardMember) {
+        // $.* -> prefix token = matches all members
+        UNIT_ASSERT(!CheckCovered("$.*", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(ArrayAccess) {
+        // $.key[0] -> array subscript not in token
+        UNIT_ASSERT(!CheckCovered("$.key[0]", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(WildcardArrayAccess) {
+        UNIT_ASSERT(!CheckCovered("$.key[*]", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(MethodSize) {
+        // $.key.size() -> method result not in token
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key.size() == 1))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(LessThan) {
+        // $.key < 5 -> range not encodable
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key < 5))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(GreaterThan) {
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key > 5))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(LessEqual) {
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key <= 5))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(GreaterEqual) {
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key >= 5))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(NotEqual) {
+        // $.key != "x" -> negation not encodable
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key != "x"))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(ExistsPredicate) {
+        // exists($.key) is a predicate wrapping, not a simple path
+        UNIT_ASSERT(!CheckCovered(R"($ ? (exists(@.key)))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(StartsWithPredicate) {
+        // startsWith is a predicate that loses precision
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.key starts with "val"))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(PathEqualPath) {
+        // $.a == $.b -> path==path, no literal
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.a == @.b))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(AndWithNotCovered) {
+        // AND where one operand is not covered
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.a == "x" && @.b > 5))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(OrWithNotCovered) {
+        // OR where one operand is not covered
+        UNIT_ASSERT(!CheckCovered(R"($ ? (@.a == "x" || @.b > 5))", ECallableType::JsonExists));
+    }
+
+    Y_UNIT_TEST(MergeAndCoverage) {
+        // MergeAnd of two covered results should be covered
+        auto left = MakeTokens({"a"});
+        auto right = MakeTokens({"b"});
+        auto result = MergeAnd(std::move(left), std::move(right));
+        UNIT_ASSERT(result.IsCovered());
+    }
+
+    Y_UNIT_TEST(MergeAndNotCoveredPropagates) {
+        // MergeAnd where right is not covered
+        auto left = MakeTokens({"a"});
+        auto right = MakeTokens({"b"});
+        right.SetNotCovered();
+        auto result = MergeAnd(std::move(left), std::move(right));
+        UNIT_ASSERT(!result.IsCovered());
+    }
+
+    Y_UNIT_TEST(MergeOrCoverage) {
+        // MergeOr of two covered results should be covered
+        auto left = MakeTokens({"a"});
+        auto right = MakeTokens({"b"});
+        auto result = MergeOr(std::move(left), std::move(right));
+        UNIT_ASSERT(result.IsCovered());
+    }
+
+    Y_UNIT_TEST(MergeOrNotCoveredPropagates) {
+        auto left = MakeTokens({"a"});
+        auto right = MakeTokens({"b"});
+        right.SetNotCovered();
+        auto result = MergeOr(std::move(left), std::move(right));
+        UNIT_ASSERT(!result.IsCovered());
+    }
+}
+
 }  // namespace NKikimr::NJsonIndex

--- a/ydb/library/json_index/ut/json_index_ut.cpp
+++ b/ydb/library/json_index/ut/json_index_ut.cpp
@@ -24,10 +24,11 @@ TString numSuffix(double v) {
 const TString boolTrueSuffix = TString("\0\1", 2);
 const TString boolFalseSuffix = TString("\0\0", 2);
 const TString nullSuffix = TString("\0\2", 2);
+const TString arrayItemSuffix = TString("\1");
 
 TString encodeKey(TStringBuf key) {
     TString result;
-    size_t size = key.size() + 1;
+    size_t size = key.size() + (ui8)EPathSeparator::Max;
     do {
         if (size < 0x80) {
             result.push_back(static_cast<char>(size));
@@ -92,7 +93,7 @@ void ValidateTokens(const TString& jsonPath, const std::vector<TToken>& expected
     auto result = ParseAndCollect(jsonPath, callableType, variables, paramVariables, tokensMode);
 
     for (const auto& token : result) {
-        UNIT_ASSERT_C(expectedTokens.contains(token), "for path = " << jsonPath);
+        UNIT_ASSERT_C(expectedTokens.contains(token), token.PathToken << " for path = " << jsonPath);
     }
     UNIT_ASSERT_VALUES_EQUAL_C(result.size(), expectedTokens.size(), "for path = " << jsonPath);
 }
@@ -213,7 +214,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[]", error), TVector<TString>{});
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[]", error), TVector<TString>{arrayItemSuffix});
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("42", error), (TVector<TString>{numSuffix(42)}));
@@ -227,60 +228,60 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     }
 
     Y_UNIT_TEST(CollectPath_ContextObject) {
-        ValidateJsonExists("$", {""});
+        ValidateJsonExists("strict $", {""});
     }
 
     Y_UNIT_TEST(CollectPath_MemberAccess) {
-        ValidateJsonExists("$.a", {"\2a"});
-        ValidateJsonExists("$.a.b.c", {"\2a\2b\2c"});
-        ValidateJsonExists("$.aba.\"caba\"", {"\4aba\5caba"});
-        ValidateJsonExists("$.\"\".abc", {"\1\4abc"});
-        ValidateJsonExists("$.*", {""});
-        ValidateJsonExists("$.a.*", {"\2a"});
-        ValidateJsonExists("$.a.*.c", {"\2a"});
+        ValidateJsonExists("strict $.a", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.b.c", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
+        ValidateJsonExists("strict $.aba.\"caba\"", {encodeKey("aba") + encodeKey("caba")});
+        ValidateJsonExists("strict $.\"\".abc", {encodeKey("") + encodeKey("abc")});
+        ValidateJsonExists("strict $.*", {""});
+        ValidateJsonExists("strict $.a.*", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.*.c", {encodeKey("a")});
     }
 
     Y_UNIT_TEST(CollectPath_ArrayAccess) {
-        ValidateJsonExists("$[0]", {""});
-        ValidateJsonExists("$[1, 2, 3]", {""});
-        ValidateJsonExists("$[1 to 3]", {""});
-        ValidateJsonExists("$[last]", {""});
-        ValidateJsonExists("$[0, 2 to last]", {""});
-        ValidateJsonExists("$[0 to 1].key", {"\4key"});
-        ValidateJsonExists("$.key[0]", {"\4key"});
-        ValidateJsonExists("$.key1[last].key2", {"\5key1\5key2"});
-        ValidateJsonExists("$.arr[2 to last]", {"\4arr"});
-        ValidateJsonExists("$.*[2 to last].key", {""});
-        ValidateJsonExists("$.key[0].*", {"\4key"});
+        ValidateJsonExists("strict $[0]", {arrayItemSuffix});
+        ValidateJsonExists("strict $[1, 2, 3]", {arrayItemSuffix});
+        ValidateJsonExists("strict $[1 to 3]", {arrayItemSuffix});
+        ValidateJsonExists("strict $[last]", {arrayItemSuffix});
+        ValidateJsonExists("strict $[0, 2 to last]", {arrayItemSuffix});
+        ValidateJsonExists("strict $[0 to 1].key", {arrayItemSuffix + encodeKey("key")});
+        ValidateJsonExists("strict $.key[0]", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonExists("strict $.key1[last].key2", {encodeKey("key1") + arrayItemSuffix + encodeKey("key2")});
+        ValidateJsonExists("strict $.arr[2 to last]", {encodeKey("arr") + arrayItemSuffix});
+        ValidateJsonExists("strict $.*[2 to last].key", {""});
+        ValidateJsonExists("strict $.key[0].*", {encodeKey("key") + arrayItemSuffix});
     }
 
     // Methods stop further path extraction: operand path only
     Y_UNIT_TEST(CollectPath_Methods) {
-        ValidateJsonExists("$.abs()", {""});
-        ValidateJsonExists("$.*.floor()", {""});
-        ValidateJsonExists("$[1, 2, 3].ceiling()", {""});
-        ValidateJsonExists("$.key.abs()", {"\4key"});
-        ValidateJsonExists("$.key.floor()", {"\4key"});
-        ValidateJsonExists("$.key.ceiling()", {"\4key"});
-        ValidateJsonExists("$.key.double()", {"\4key"});
-        ValidateJsonExists("$.key.type()", {"\4key"});
-        ValidateJsonExists("$.key.size()", {"\4key"});
-        ValidateJsonExists("$.key.keyvalue()", {"\4key"});
-        ValidateJsonExists("$.*.keyvalue()", {""});
-        ValidateJsonExists("$.key[1, 2, 3].value.size().floor()", {"\4key\6value"});
-        ValidateJsonExists("$.key.keyvalue().name", {"\4key"});
+        ValidateJsonExists("strict $.abs()", {""});
+        ValidateJsonExists("strict $.*.floor()", {""});
+        ValidateJsonExists("strict $[1, 2, 3].ceiling()", {arrayItemSuffix});
+        ValidateJsonExists("strict $.key.abs()", {encodeKey("key")});
+        ValidateJsonExists("strict $.key.floor()", {encodeKey("key")});
+        ValidateJsonExists("strict $.key.ceiling()", {encodeKey("key")});
+        ValidateJsonExists("strict $.key.double()", {encodeKey("key")});
+        ValidateJsonExists("strict $.key.type()", {encodeKey("key")});
+        ValidateJsonExists("strict $.key.size()", {encodeKey("key")});
+        ValidateJsonExists("strict $.key.keyvalue()", {encodeKey("key")});
+        ValidateJsonExists("strict $.*.keyvalue()", {""});
+        ValidateJsonExists("strict $.key[1, 2, 3].value.size().floor()", {encodeKey("key") + arrayItemSuffix + encodeKey("value")});
+        ValidateJsonExists("strict $.key.keyvalue().name", {encodeKey("key")});
     }
 
     // StartsWith predicates stop further path extraction: operand path only
     Y_UNIT_TEST(CollectPath_StartsWithPredicate) {
-        ValidateJsonValue("$ starts with \"lol\"", {""});
-        ValidateJsonValue("$[1 to last] starts with \"lol\"", {""});
-        ValidateJsonValue("$[*] starts with \"lol\"", {""});
-        ValidateJsonValue("$.key starts with \"abc\"", {"\4key"});
-        ValidateJsonValue("$.a.b.c[1, 2, 3] starts with \"abc\"", {"\2a\2b\2c"});
-        ValidateJsonValue("$.key.type().name starts with \"abc\"", {"\4key"});
-        ValidateJsonValue("$.* starts with \"abc\"", {""});
-        ValidateJsonValue("$.a.*.c[1, 2, 3] starts with \"abc\"", {"\2a"});
+        ValidateJsonValue("strict $ starts with \"lol\"", {""});
+        ValidateJsonValue("strict $[1 to last] starts with \"lol\"", {arrayItemSuffix});
+        ValidateJsonValue("strict $[*] starts with \"lol\"", {arrayItemSuffix});
+        ValidateJsonValue("strict $.key starts with \"abc\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.a.b.c[1, 2, 3] starts with \"abc\"", {encodeKey("a") + encodeKey("b") + encodeKey("c") + arrayItemSuffix});
+        ValidateJsonValue("strict $.key.type().name starts with \"abc\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.* starts with \"abc\"", {""});
+        ValidateJsonValue("strict $.a.*.c[1, 2, 3] starts with \"abc\"", {encodeKey("a")});
 
         // For JSON_EXISTS, the result is always true even if the path does not exist
         ValidateError("$.key starts with \"lol\"", "Predicates are not allowed in this context", {}, {}, ECallableType::JsonExists);
@@ -288,15 +289,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     // LikeRegex predicates stop further path extraction: operand path only
     Y_UNIT_TEST(CollectPath_LikeRegexPredicate) {
-        ValidateJsonValue("$ like_regex \"abc\"", {""});
-        ValidateJsonValue("$[1 to 2] like_regex \"abc\"", {""});
-        ValidateJsonValue("$[*] like_regex \"abc\"", {""});
-        ValidateJsonValue("$.key like_regex \"abc\"", {"\4key"});
-        ValidateJsonValue("$.* like_regex \"abc\"", {""});
-        ValidateJsonValue("$.key[1, 2, 3] like_regex \"abc\"", {"\4key"});
-        ValidateJsonValue("$.key.keyvalue() like_regex \"abc\"", {"\4key"});
-        ValidateJsonValue("$.key like_regex \"a.c\"", {"\4key"});
-        ValidateJsonValue("$.key like_regex \".*\"", {"\4key"});
+        ValidateJsonValue("strict $ like_regex \"abc\"", {""});
+        ValidateJsonValue("strict $[1 to 2] like_regex \"abc\"", {arrayItemSuffix});
+        ValidateJsonValue("strict $[*] like_regex \"abc\"", {arrayItemSuffix});
+        ValidateJsonValue("strict $.key like_regex \"abc\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.* like_regex \"abc\"", {""});
+        ValidateJsonValue("strict $.key[1, 2, 3] like_regex \"abc\"", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonValue("strict $.key.keyvalue() like_regex \"abc\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.key like_regex \"a.c\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.key like_regex \".*\"", {encodeKey("key")});
 
         // For JSON_EXISTS, the result is always true even if the path does not exist
         ValidateError("$.key like_regex \"abc\"", "Predicates are not allowed in this context", {}, {}, ECallableType::JsonExists);
@@ -304,11 +305,11 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     // Exists predicates stop further path extraction: operand path only
     Y_UNIT_TEST(CollectPath_ExistsPredicate) {
-        ValidateJsonValue("exists($)", {""});
-        ValidateJsonValue("exists($.key)", {"\4key"});
-        ValidateJsonValue("exists($.key[1, 2, 3])", {"\4key"});
-        ValidateJsonValue("exists($[*].size())", {""});
-        ValidateJsonValue("exists($.key.keyvalue().name)", {"\4key"});
+        ValidateJsonValue("strict exists($)", {""});
+        ValidateJsonValue("strict exists($.key)", {encodeKey("key")});
+        ValidateJsonValue("strict exists($.key[1, 2, 3])", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonValue("strict exists($[*].size())", {arrayItemSuffix});
+        ValidateJsonValue("strict exists($.key.keyvalue().name)", {encodeKey("key")});
 
         // For JSON_EXISTS, the result is always true even if the path does not exist
         ValidateError("exists($)", "Predicates are not allowed in this context", {}, {}, ECallableType::JsonExists);
@@ -417,36 +418,36 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     // Unary +/- stop further path extraction (same as methods): operand path only
     Y_UNIT_TEST(CollectPath_UnaryPlusMinus) {
-        ValidateJsonExists("-$.key", {"\4key"});
-        ValidateJsonExists("+$.key", {"\4key"});
+        ValidateJsonExists("strict -$.key", {encodeKey("key")});
+        ValidateJsonExists("strict +$.key", {encodeKey("key")});
 
-        ValidateJsonExists("-$", {""});
-        ValidateJsonExists("+$", {""});
+        ValidateJsonExists("strict -$", {""});
+        ValidateJsonExists("strict +$", {""});
 
-        ValidateJsonExists("-$.a.b.c", {"\2a\2b\2c"});
-        ValidateJsonExists("+$.a.b.c", {"\2a\2b\2c"});
+        ValidateJsonExists("strict -$.a.b.c", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
+        ValidateJsonExists("strict +$.a.b.c", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
 
-        ValidateJsonExists("-$.*", {""});
-        ValidateJsonExists("+$.*", {""});
-        ValidateJsonExists("-$.a.*", {"\2a"});
-        ValidateJsonExists("+$.a.*", {"\2a"});
+        ValidateJsonExists("strict -$.*", {""});
+        ValidateJsonExists("strict +$.*", {""});
+        ValidateJsonExists("strict -$.a.*", {encodeKey("a")});
+        ValidateJsonExists("strict +$.a.*", {encodeKey("a")});
 
-        ValidateJsonExists("-$.key[0]", {"\4key"});
-        ValidateJsonExists("+$.key[last]", {"\4key"});
+        ValidateJsonExists("strict -$.key[0]", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonExists("strict +$.key[last]", {encodeKey("key") + arrayItemSuffix});
 
-        ValidateJsonExists("-$.key.abs()", {"\4key"});
-        ValidateJsonExists("+$.key.type()", {"\4key"});
+        ValidateJsonExists("strict -$.key.abs()", {encodeKey("key")});
+        ValidateJsonExists("strict +$.key.type()", {encodeKey("key")});
 
-        ValidateJsonExists("-(-$.key)", {"\4key"});
-        ValidateJsonExists("-(+$.key)", {"\4key"});
-        ValidateJsonExists("+(-$.key)", {"\4key"});
-        ValidateJsonExists("+(+$.key)", {"\4key"});
+        ValidateJsonExists("strict -(-$.key)", {encodeKey("key")});
+        ValidateJsonExists("strict -(+$.key)", {encodeKey("key")});
+        ValidateJsonExists("strict +(-$.key)", {encodeKey("key")});
+        ValidateJsonExists("strict +(+$.key)", {encodeKey("key")});
 
-        ValidateJsonValue("exists(-$.a.b)", {"\2a\2b"});
-        ValidateJsonValue("exists(+$.a.b)", {"\2a\2b"});
+        ValidateJsonValue("strict exists(-$.a.b)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonValue("strict exists(+$.a.b)", {encodeKey("a") + encodeKey("b")});
 
-        ValidateJsonValue("-($.double())", {""});
-        ValidateJsonValue("+($.double())", {""});
+        ValidateJsonValue("strict -($.double())", {""});
+        ValidateJsonValue("strict +($.double())", {""});
     }
 
     // Literals are not supported without a preceding ContextObject
@@ -462,268 +463,268 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Binary arithmetic operators extract tokens from both operands and finish
     Y_UNIT_TEST(CollectPath_BinaryArithmetic) {
         // Path on the left, literal on the right - only left token
-        ValidateTokens("$.key + 1", {"\4key"});
-        ValidateTokens("$.key - 1", {"\4key"});
-        ValidateTokens("$.key - (-1)", {"\4key"});
-        ValidateTokens("$.key * 2", {"\4key"});
-        ValidateTokens("$.key / 2", {"\4key"});
-        ValidateTokens("$.key % 2", {"\4key"});
+        ValidateTokens("strict $.key + 1", {encodeKey("key")});
+        ValidateTokens("strict $.key - 1", {encodeKey("key")});
+        ValidateTokens("strict $.key - (-1)", {encodeKey("key")});
+        ValidateTokens("strict $.key * 2", {encodeKey("key")});
+        ValidateTokens("strict $.key / 2", {encodeKey("key")});
+        ValidateTokens("strict $.key % 2", {encodeKey("key")});
 
         // Literal on the left, path on the right - only right token
-        ValidateTokens("1 + $.key", {"\4key"});
-        ValidateTokens("-1 - $.key", {"\4key"});
-        ValidateTokens("1 * $.key", {"\4key"});
-        ValidateTokens("(+(-1)) / $.key", {"\4key"});
-        ValidateTokens("1 % $.key", {"\4key"});
+        ValidateTokens("strict 1 + $.key", {encodeKey("key")});
+        ValidateTokens("strict -1 - $.key", {encodeKey("key")});
+        ValidateTokens("strict 1 * $.key", {encodeKey("key")});
+        ValidateTokens("strict (+(-1)) / $.key", {encodeKey("key")});
+        ValidateTokens("strict 1 % $.key", {encodeKey("key")});
 
         // Context object on the left
-        ValidateTokens("$ + 1", {""});
-        ValidateTokens("$ * 2", {""});
+        ValidateTokens("strict $ + 1", {""});
+        ValidateTokens("strict $ * 2", {""});
 
         // Deeper paths as left operand
-        ValidateTokens("$.a.b.c + 1", {"\2a\2b\2c"});
-        ValidateTokens("$.a.b - 1", {"\2a\2b"});
+        ValidateTokens("strict $.a.b.c + 1", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
+        ValidateTokens("strict $.a.b - 1", {encodeKey("a") + encodeKey("b")});
 
         // Array access on the left operand
-        ValidateTokens("$.key[0] + 1", {"\4key"});
-        ValidateTokens("$.arr[last] * 2", {"\4arr"});
+        ValidateTokens("strict $.key[0] + 1", {encodeKey("key") + arrayItemSuffix});
+        ValidateTokens("strict $.arr[last] * 2", {encodeKey("arr") + arrayItemSuffix});
 
         // Wildcard on the left - collection already finished by wildcard
-        ValidateTokens("$.* + 1", {""});
-        ValidateTokens("$.* + (-1)", {""});
-        ValidateTokens("$.a.* - 1", {"\2a"});
+        ValidateTokens("strict $.* + 1", {""});
+        ValidateTokens("strict $.* + (-1)", {""});
+        ValidateTokens("strict $.a.* - 1", {encodeKey("a")});
 
         // Both operands are paths - tokens from both are collected (AND)
-        ValidateTokens("$.a + $.b", {"\2a", "\2b"});
-        ValidateTokens("$.a.b - $.c.d", {"\2a\2b", "\2c\2d"});
-        ValidateTokens("$.a.b - (-$.c.d)", {"\2a\2b", "\2c\2d"});
+        ValidateTokens("strict $.a + $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict $.a.b - $.c.d", {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")});
+        ValidateTokens("strict $.a.b - (-$.c.d)", {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")});
 
         // Both operands are literals - no path to collect
         ValidateError("1 + 2", emptyError);
         ValidateError("(+(-1.5)) * 2.0", emptyError);
 
         // Wildcard on left, path on right - both collected
-        ValidateJsonExists("$.a.* + $.b", {"\2a", "\2b"});
-        ValidateJsonExists("$.* + $.b", {"", "\2b"});
-        ValidateJsonExists("$.* - $.a.b", {"", "\2a\2b"});
+        ValidateJsonExists("strict $.a.* + $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonExists("strict $.* + $.b", {"", encodeKey("b")});
+        ValidateJsonExists("strict $.* - $.a.b", {"", encodeKey("a") + encodeKey("b")});
 
         // Path on left, wildcard on right
-        ValidateJsonExists("$.a + $.*", {"\2a", ""});
-        ValidateJsonExists("$.a.b + $.*", {"\2a\2b", ""});
+        ValidateJsonExists("strict $.a + $.*", {encodeKey("a"), ""});
+        ValidateJsonExists("strict $.a.b + $.*", {encodeKey("a") + encodeKey("b"), ""});
 
         // Wildcard on both sides - two wildcard tokens collected
-        ValidateJsonExists("$.* + $.*", {""});
-        ValidateJsonExists("$.a.* + $.*", {"\2a", ""});
-        ValidateJsonExists("$.* + $.a.*", {"", "\2a"});
-        ValidateJsonExists("$.a.b.*.c + $.a.b.*.d", {"\2a\2b"});
+        ValidateJsonExists("strict $.* + $.*", {""});
+        ValidateJsonExists("strict $.a.* + $.*", {encodeKey("a"), ""});
+        ValidateJsonExists("strict $.* + $.a.*", {"", encodeKey("a")});
+        ValidateJsonExists("strict $.a.b.*.c + $.a.b.*.d", {encodeKey("a") + encodeKey("b")});
 
         // Variable on left - propagated immediately, right not collected
-        ValidateJsonExists("$var + $.b", {"\2b"});
-        ValidateJsonExists("$var - $.b", {"\2b"});
-        ValidateJsonExists("$var * $.b", {"\2b"});
-        ValidateJsonExists("$var / $.b", {"\2b"});
-        ValidateJsonExists("$var % $.b", {"\2b"});
+        ValidateJsonExists("strict $var + $.b", {encodeKey("b")});
+        ValidateJsonExists("strict $var - $.b", {encodeKey("b")});
+        ValidateJsonExists("strict $var * $.b", {encodeKey("b")});
+        ValidateJsonExists("strict $var / $.b", {encodeKey("b")});
+        ValidateJsonExists("strict $var % $.b", {encodeKey("b")});
 
         // Variable on right - left tokens lost, variable not collected
-        ValidateJsonExists("$.a + $var", {"\2a"});
-        ValidateJsonExists("$.a - $var", {"\2a"});
-        ValidateJsonExists("$.a * $var", {"\2a"});
+        ValidateJsonExists("strict $.a + $var", {encodeKey("a")});
+        ValidateJsonExists("strict $.a - $var", {encodeKey("a")});
+        ValidateJsonExists("strict $.a * $var", {encodeKey("a")});
 
         // Variable propagates through chained binary: ($.a + $var) + $.c
-        ValidateJsonExists("$.a + $var + $.c", {"\2a", "\2c"});
+        ValidateJsonExists("strict $.a + $var + $.c", {encodeKey("a"), encodeKey("c")});
     }
 
     // Non-trivial combinations of unary and binary arithmetic operators
     Y_UNIT_TEST(CollectPath_ArithmeticCombinations) {
         // Unary applied to binary: tokens from both binary operands, then Finish
-        ValidateTokens("-($.a + 1)", {"\2a"});
-        ValidateTokens("+($.a - 1)", {"\2a"});
-        ValidateTokens("-($.a * $.b)", {"\2a", "\2b"});
-        ValidateTokens("-(1 + $.b)", {"\2b"});
+        ValidateTokens("strict -($.a + 1)", {encodeKey("a")});
+        ValidateTokens("strict +($.a - 1)", {encodeKey("a")});
+        ValidateTokens("strict -($.a * $.b)", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict -(1 + $.b)", {encodeKey("b")});
 
         // Binary with unary left operand
-        ValidateTokens("-$.a + $.b", {"\2a", "\2b"});
-        ValidateTokens("+$.a - $.b", {"\2a", "\2b"});
-        ValidateTokens("-$.key + 1", {"\4key"});
-        ValidateTokens("+$.key * 2", {"\4key"});
+        ValidateTokens("strict -$.a + $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict +$.a - $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict -$.key + 1", {encodeKey("key")});
+        ValidateTokens("strict +$.key * 2", {encodeKey("key")});
 
         // Binary with unary right operand - right token still collected
-        ValidateTokens("$.a + (-$.b)", {"\2a", "\2b"});
-        ValidateTokens("$.a * (+$.b)", {"\2a", "\2b"});
-        ValidateTokens("1 + (-$.b)", {"\2b"});
+        ValidateTokens("strict $.a + (-$.b)", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict $.a * (+$.b)", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict 1 + (-$.b)", {encodeKey("b")});
 
         // Chained binary (left-associative): all three path tokens collected
-        ValidateTokens("$.a + $.b + $.c", {"\2a", "\2b", "\2c"});
-        ValidateTokens("$.a - $.b - $.c", {"\2a", "\2b", "\2c"});
-        ValidateTokens("$.a * $.b * $.c", {"\2a", "\2b", "\2c"});
+        ValidateTokens("strict $.a + $.b + $.c", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
+        ValidateTokens("strict $.a - $.b - $.c", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
+        ValidateTokens("strict $.a * $.b * $.c", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
 
         // Mixed precedence: * binds tighter than +, but all paths still collected
-        ValidateTokens("$.a + $.b * $.c", {"\2a", "\2b", "\2c"});
-        ValidateTokens("$.a * $.b + $.c", {"\2a", "\2b", "\2c"});
+        ValidateTokens("strict $.a + $.b * $.c", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
+        ValidateTokens("strict $.a * $.b + $.c", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
 
         // Double unary combined with binary
-        ValidateTokens("-(-$.a) + $.b", {"\2a", "\2b"});
-        ValidateTokens("-(+$.a) * 2", {"\2a"});
+        ValidateTokens("strict -(-$.a) + $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateTokens("strict -(+$.a) * 2", {encodeKey("a")});
 
         // Longer paths on both sides
-        ValidateTokens("$.a.b.c + $.x.y.z", {"\2a\2b\2c", "\2x\2y\2z"});
-        ValidateTokens("-($.a.*.c) + $.x.y.*", {"\2a", "\2x\2y"});
-        ValidateTokens("$.a.b.c * 3.14", {"\2a\2b\2c"});
+        ValidateTokens("strict $.a.b.c + $.x.y.z", {encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("x") + encodeKey("y") + encodeKey("z")});
+        ValidateTokens("strict -($.a.*.c) + $.x.y.*", {encodeKey("a"), encodeKey("x") + encodeKey("y")});
+        ValidateTokens("strict $.a.b.c * 3.14", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
 
         // Method result used as operand of binary - method finishes, but token still collected
-        ValidateTokens("$.key.size() + 1", {"\4key"});
-        ValidateTokens("$.key.abs() * 2", {"\4key"});
-        ValidateTokens("$.a.size() + $.b.floor()", {"\2a", "\2b"});
+        ValidateTokens("strict $.key.size() + 1", {encodeKey("key")});
+        ValidateTokens("strict $.key.abs() * 2", {encodeKey("key")});
+        ValidateTokens("strict $.a.size() + $.b.floor()", {encodeKey("a"), encodeKey("b")});
     }
 
     // Arithmetic operators (two-path operands produce And mode) combined with && and ||
     Y_UNIT_TEST(CollectPath_ArithmeticWithBooleanOps) {
         // Two-path arithmetic result (And mode) in AND chain: stays And
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a - $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a * $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a / $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a % $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.c == 1) && ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a - $.b == \"x\") && ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a * $.b == \"x\") && ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a / $.b == \"x\") && ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a % $.b == \"x\") && ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.c == 1) && ($.a + $.b == \"x\")", {encodeKey("c") + numSuffix(1), encodeKey("a"), encodeKey("b")}, TCollectResult::ETokensMode::And);
 
         // Two arithmetic results combined via AND: stays And
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a - $.b == \"x\") && ($.c * $.d == \"y\") && ($.e == 1)", {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)},
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c + $.d == \"y\")", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a - $.b == \"x\") && ($.c * $.d == \"y\") && ($.e == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e") + numSuffix(1)},
             TCollectResult::ETokensMode::And);
 
         // Two-path arithmetic result (And mode) in OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a - $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a * $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a / $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a % $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.c == 1) || ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a - $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a * $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a / $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a % $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.c == 1) || ($.a + $.b == \"x\")", {encodeKey("c") + numSuffix(1), encodeKey("a"), encodeKey("b")}, TCollectResult::ETokensMode::Or);
 
         // Two arithmetic results combined via OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c + $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a - $.b == \"x\") || ($.c * $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a / $.b == \"x\") || ($.c % $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c + $.d == \"y\")", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a - $.b == \"x\") || ($.c * $.d == \"y\")", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a / $.b == \"x\") || ($.c % $.d == \"y\")", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
 
         // Three-way OR of arithmetic results: all become OR
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c + $.d == \"y\") || ($.e == 1)",
-            {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c + $.d == \"y\") || ($.e == 1)",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e") + numSuffix(1)}, TCollectResult::ETokensMode::Or);
 
         // Arithmetic result with comparison (single-path, NotSet) via AND: compatible, stays And
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c < 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.c < 5) && ($.a + $.b == \"x\")", {"\2c", "\2a", "\2b"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c < 5)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.c < 5) && ($.a + $.b == \"x\")", {encodeKey("c"), encodeKey("a"), encodeKey("b")}, TCollectResult::ETokensMode::And);
 
         // Arithmetic result with comparison via OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c < 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.c < 5) || ($.a + $.b == \"x\")", {"\2c", "\2a", "\2b"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c < 5)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.c < 5) || ($.a + $.b == \"x\")", {encodeKey("c"), encodeKey("a"), encodeKey("b")}, TCollectResult::ETokensMode::Or);
 
         // Arithmetic result with starts with / like_regex / exists in AND: compatible
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c starts with \"abc\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c like_regex \".*\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a + $.b == \"x\") && exists($.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c starts with \"abc\")", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c like_regex \".*\")", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && exists($.c)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
 
         // Arithmetic result with starts with / like_regex / exists in OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c starts with \"abc\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c like_regex \".*\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a + $.b == \"x\") || exists($.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c starts with \"abc\")", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c like_regex \".*\")", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || exists($.c)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
 
         // Deeper paths in arithmetic operands
-        ValidateJsonValue("($.a.b.c + $.x.y.z == \"val\") && ($.key == 1)", {"\2a\2b\2c", "\2x\2y\2z", "\4key" + numSuffix(1)},
+        ValidateJsonValue("strict ($.a.b.c + $.x.y.z == \"val\") && ($.key == 1)", {encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("x") + encodeKey("y") + encodeKey("z"), encodeKey("key") + numSuffix(1)},
             TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a.b.c + $.x.y.z == \"val\") || ($.key == 1)", {"\2a\2b\2c", "\2x\2y\2z", "\4key" + numSuffix(1)},
+        ValidateJsonValue("strict ($.a.b.c + $.x.y.z == \"val\") || ($.key == 1)", {encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("x") + encodeKey("y") + encodeKey("z"), encodeKey("key") + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
 
         // Filter: arithmetic with two paths combined via OR with plain path
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 || @.c == 1)", {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1)},
+        ValidateJsonExists("strict $.key ? (@.a + @.b == 5 || @.c == 1)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c") + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
         // Filter: two arithmetic results in OR
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 || @.c + @.d == 3)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d"},
+        ValidateJsonExists("strict $.key ? (@.a + @.b == 5 || @.c + @.d == 3)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c"), encodeKey("key") + encodeKey("d")},
             TCollectResult::ETokensMode::Or);
         // Filter: AND chain with OR appended - OR wins
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 && @.c == 1 || @.d == 2)",
-            {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1), "\4key\2d" + numSuffix(2)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonExists("strict $.key ? (@.a + @.b == 5 && @.c == 1 || @.d == 2)",
+            {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c") + numSuffix(1), encodeKey("key") + encodeKey("d") + numSuffix(2)}, TCollectResult::ETokensMode::Or);
     }
 
     Y_UNIT_TEST(CollectPath_EqualityOperator) {
         // Path == literal, all literal types
-        ValidateJsonValue("$.key == \"hello\"", {"\4key" + strSuffix("hello")});
-        ValidateJsonValue("$.key == \"\"", {"\4key" + strSuffix("")});
-        ValidateJsonValue("$.key == 42", {"\4key" + numSuffix(42)});
-        ValidateJsonValue("$.key == 0", {"\4key" + numSuffix(0)});
-        ValidateJsonValue("$.key == 3.14", {"\4key" + numSuffix(3.14)});
-        ValidateJsonValue("$.key == true", {"\4key" + boolTrueSuffix});
-        ValidateJsonValue("$.key == false", {"\4key" + boolFalseSuffix});
-        ValidateJsonValue("$.key == null", {"\4key" + nullSuffix});
+        ValidateJsonValue("strict $.key == \"hello\"", {encodeKey("key") + strSuffix("hello")});
+        ValidateJsonValue("strict $.key == \"\"", {encodeKey("key") + strSuffix("")});
+        ValidateJsonValue("strict $.key == 42", {encodeKey("key") + numSuffix(42)});
+        ValidateJsonValue("strict $.key == 0", {encodeKey("key") + numSuffix(0)});
+        ValidateJsonValue("strict $.key == 3.14", {encodeKey("key") + numSuffix(3.14)});
+        ValidateJsonValue("strict $.key == true", {encodeKey("key") + boolTrueSuffix});
+        ValidateJsonValue("strict $.key == false", {encodeKey("key") + boolFalseSuffix});
+        ValidateJsonValue("strict $.key == null", {encodeKey("key") + nullSuffix});
 
         // Reversed order: literal == path (identical result)
-        ValidateJsonValue("\"hello\" == $.key", {"\4key" + strSuffix("hello")});
-        ValidateJsonValue("42 == $.key", {"\4key" + numSuffix(42)});
-        ValidateJsonValue("true == $.key", {"\4key" + boolTrueSuffix});
-        ValidateJsonValue("null == $.key", {"\4key" + nullSuffix});
+        ValidateJsonValue("strict \"hello\" == $.key", {encodeKey("key") + strSuffix("hello")});
+        ValidateJsonValue("strict 42 == $.key", {encodeKey("key") + numSuffix(42)});
+        ValidateJsonValue("strict true == $.key", {encodeKey("key") + boolTrueSuffix});
+        ValidateJsonValue("strict null == $.key", {encodeKey("key") + nullSuffix});
 
         // Context object as path (empty prefix)
-        ValidateJsonValue("$ == \"hello\"", {strSuffix("hello")});
-        ValidateJsonValue("$ == 42", {numSuffix(42)});
-        ValidateJsonValue("$ == true", {boolTrueSuffix});
-        ValidateJsonValue("$ == null", {nullSuffix});
-        ValidateJsonValue("\"hello\" == $", {strSuffix("hello")});
+        ValidateJsonValue("strict $ == \"hello\"", {strSuffix("hello")});
+        ValidateJsonValue("strict $ == 42", {numSuffix(42)});
+        ValidateJsonValue("strict $ == true", {boolTrueSuffix});
+        ValidateJsonValue("strict $ == null", {nullSuffix});
+        ValidateJsonValue("strict \"hello\" == $", {strSuffix("hello")});
 
         // Deeper paths
-        ValidateJsonValue("$.a.b == \"x\"", {"\2a\2b" + strSuffix("x")});
-        ValidateJsonValue("$.a.b.c == null", {"\2a\2b\2c" + nullSuffix});
-        ValidateJsonValue("\"x\" == $.a.b.c", {"\2a\2b\2c" + strSuffix("x")});
-        ValidateJsonValue("$.aba.\"caba\" == true", {"\4aba\5caba" + boolTrueSuffix});
-        ValidateJsonValue("$.a.b.c.d == 0", {"\2a\2b\2c\2d" + numSuffix(0)});
-        ValidateJsonValue("$.\"\".\"\" == 0", {"\1\1" + numSuffix(0)});
+        ValidateJsonValue("strict $.a.b == \"x\"", {encodeKey("a") + encodeKey("b") + strSuffix("x")});
+        ValidateJsonValue("strict $.a.b.c == null", {encodeKey("a") + encodeKey("b") + encodeKey("c") + nullSuffix});
+        ValidateJsonValue("strict \"x\" == $.a.b.c", {encodeKey("a") + encodeKey("b") + encodeKey("c") + strSuffix("x")});
+        ValidateJsonValue("strict $.aba.\"caba\" == true", {encodeKey("aba") + encodeKey("caba") + boolTrueSuffix});
+        ValidateJsonValue("strict $.a.b.c.d == 0", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d") + numSuffix(0)});
+        ValidateJsonValue("strict $.\"\".\"\" == 0", {encodeKey("") + encodeKey("") + numSuffix(0)});
 
         // Array subscript
-        ValidateJsonValue("$.key[0] == \"x\"", {"\4key" + strSuffix("x")});
-        ValidateJsonValue("$.key[last] == true", {"\4key" + boolTrueSuffix});
-        ValidateJsonValue("$.key[1, 2, 3] == null", {"\4key" + nullSuffix});
-        ValidateJsonValue("$.key[0 to last] == 42", {"\4key" + numSuffix(42)});
-        ValidateJsonValue("$.key[0].sub == \"x\"", {"\4key\4sub" + strSuffix("x")});
-        ValidateJsonValue("$.a.b[0].c == \"x\"", {"\2a\2b\2c" + strSuffix("x")});
-        ValidateJsonValue("$.key[*] == \"x\"", {"\4key" + strSuffix("x")});
+        ValidateJsonValue("strict $.key[0] == \"x\"", {encodeKey("key") + arrayItemSuffix + strSuffix("x")});
+        ValidateJsonValue("strict $.key[last] == true", {encodeKey("key") + arrayItemSuffix + boolTrueSuffix});
+        ValidateJsonValue("strict $.key[1, 2, 3] == null", {encodeKey("key") + arrayItemSuffix + nullSuffix});
+        ValidateJsonValue("strict $.key[0 to last] == 42", {encodeKey("key") + arrayItemSuffix + numSuffix(42)});
+        ValidateJsonValue("strict $.key[0].sub == \"x\"", {encodeKey("key") + arrayItemSuffix + encodeKey("sub") + strSuffix("x")});
+        ValidateJsonValue("strict $.a.b[0].c == \"x\"", {encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c") + strSuffix("x")});
+        ValidateJsonValue("strict $.key[*] == \"x\"", {encodeKey("key") + arrayItemSuffix + strSuffix("x")});
 
         // Wildcard member access finishes the path
-        ValidateJsonValue("$.* == \"x\"", {""});
-        ValidateJsonValue("$.a.* == \"x\"", {"\2a"});
-        ValidateJsonValue("$.a.b.* == \"x\"", {"\2a\2b"});
-        ValidateJsonValue("\"x\" == $.*", {""});
-        ValidateJsonValue("\"x\" == $.a.*", {"\2a"});
+        ValidateJsonValue("strict $.* == \"x\"", {""});
+        ValidateJsonValue("strict $.a.* == \"x\"", {encodeKey("a")});
+        ValidateJsonValue("strict $.a.b.* == \"x\"", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonValue("strict \"x\" == $.*", {""});
+        ValidateJsonValue("strict \"x\" == $.a.*", {encodeKey("a")});
 
         // Methods finish the path
-        ValidateJsonValue("$.key.size() == 3", {"\4key"});
-        ValidateJsonValue("$.key.abs() == 1", {"\4key"});
-        ValidateJsonValue("$.key.type() == \"number\"", {"\4key"});
-        ValidateJsonValue("$.a.b.floor() == 0", {"\2a\2b"});
-        ValidateJsonValue("$.key.keyvalue().name == \"x\"", {"\4key"});
+        ValidateJsonValue("strict $.key.size() == 3", {encodeKey("key")});
+        ValidateJsonValue("strict $.key.abs() == 1", {encodeKey("key")});
+        ValidateJsonValue("strict $.key.type() == \"number\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.a.b.floor() == 0", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonValue("strict $.key.keyvalue().name == \"x\"", {encodeKey("key")});
 
         // Unary arithmetic on path finishes the path
-        ValidateJsonValue("-$.key == 1", {"\4key"});
-        ValidateJsonValue("+$.key == 1", {"\4key"});
-        ValidateJsonValue("-$.a.b == null", {"\2a\2b"});
+        ValidateJsonValue("strict -$.key == 1", {encodeKey("key")});
+        ValidateJsonValue("strict +$.key == 1", {encodeKey("key")});
+        ValidateJsonValue("strict -$.a.b == null", {encodeKey("a") + encodeKey("b")});
 
         // Literal numeric value folded from unary + / - (same suffix as a plain number literal)
-        ValidateJsonValue("$.a == -10", {"\2a" + numSuffix(-10)});
-        ValidateJsonValue("$.k == +(-(+(-3)))", {"\2k" + numSuffix(3)});
-        ValidateJsonValue("$.key == +42", {"\4key" + numSuffix(42)});
-        ValidateJsonValue("$.key == -(-42)", {"\4key" + numSuffix(42)});
-        ValidateJsonValue("$.key == +(-15)", {"\4key" + numSuffix(-15)});
-        ValidateJsonValue("$.a.b == -(-(-2))", {"\2a\2b" + numSuffix(-2)});
-        ValidateJsonValue("$ == +(-(-7))", {numSuffix(7)});
-        ValidateJsonValue("-10 == $.a", {"\2a" + numSuffix(-10)});
-        ValidateJsonValue("+(-(+(-3))) == $.k", {"\2k" + numSuffix(3)});
+        ValidateJsonValue("strict $.a == -10", {encodeKey("a") + numSuffix(-10)});
+        ValidateJsonValue("strict $.k == +(-(+(-3)))", {encodeKey("k") + numSuffix(3)});
+        ValidateJsonValue("strict $.key == +42", {encodeKey("key") + numSuffix(42)});
+        ValidateJsonValue("strict $.key == -(-42)", {encodeKey("key") + numSuffix(42)});
+        ValidateJsonValue("strict $.key == +(-15)", {encodeKey("key") + numSuffix(-15)});
+        ValidateJsonValue("strict $.a.b == -(-(-2))", {encodeKey("a") + encodeKey("b") + numSuffix(-2)});
+        ValidateJsonValue("strict $ == +(-(-7))", {numSuffix(7)});
+        ValidateJsonValue("strict -10 == $.a", {encodeKey("a") + numSuffix(-10)});
+        ValidateJsonValue("strict +(-(+(-3))) == $.k", {encodeKey("k") + numSuffix(3)});
 
         // Arithmetic produces multiple tokens
-        ValidateJsonValue("($.a + $.b) == \"x\"", {"\2a", "\2b"});
-        ValidateJsonValue("\"x\" == ($.a + $.b)", {"\2a", "\2b"});
-        ValidateJsonValue("$.key + 1 == \"x\"", {"\4key"});
-        ValidateJsonValue("1 + $.key == \"x\"", {"\4key"});
+        ValidateJsonValue("strict ($.a + $.b) == \"x\"", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict \"x\" == ($.a + $.b)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $.key + 1 == \"x\"", {encodeKey("key")});
+        ValidateJsonValue("strict 1 + $.key == \"x\"", {encodeKey("key")});
 
         // Parenthesized path - no effect
-        ValidateJsonValue("($.a.b) == \"x\"", {"\2a\2b" + strSuffix("x")});
-        ValidateJsonValue("\"x\" == ($.a.b)", {"\2a\2b" + strSuffix("x")});
-        ValidateJsonValue("(((((($).a).b))) == (\"x\"))", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonValue("strict ($.a.b) == \"x\"", {encodeKey("a") + encodeKey("b") + strSuffix("x")});
+        ValidateJsonValue("strict \"x\" == ($.a.b)", {encodeKey("a") + encodeKey("b") + strSuffix("x")});
+        ValidateJsonValue("strict (((((($).a).b))) == (\"x\"))", {encodeKey("a") + encodeKey("b") + strSuffix("x")});
 
         // Predicates with equality operator -> nested predicates are not allowed
         ValidateError("exists($.key) == true", predError, {}, {}, ECallableType::JsonValue);
@@ -739,10 +740,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("false == ($.key == 10)", "Predicates are not allowed in this context", {}, {}, ECallableType::JsonExists);
 
         // Both operands are paths: merge index tokens with AND (same as comparison ops)
-        ValidateJsonValue("$.a == $.b", {"\2a", "\2b"});
-        ValidateJsonValue("$.key == $", {"\4key", ""});
-        ValidateJsonValue("$ == $", {""});
-        ValidateJsonValue("$.a.b == $.c.d", {"\2a\2b", "\2c\2d"});
+        ValidateJsonValue("strict $.a == $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $.key == $", {encodeKey("key"), ""});
+        ValidateJsonValue("strict $ == $", {""});
+        ValidateJsonValue("strict $.a.b == $.c.d", {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")});
 
         // Literals only
         ValidateError("\"x\" == \"y\"", compError, {}, {}, ECallableType::JsonValue);
@@ -758,77 +759,77 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$var == \"x\"", compError, {}, {}, ECallableType::JsonValue);
         ValidateError("\"x\" == $var", compError, {}, {}, ECallableType::JsonValue);
         ValidateError("$var == $var", compError, {}, {}, ECallableType::JsonValue);
-        ValidateJsonValue("$ == $var", {""});
+        ValidateJsonValue("strict $ == $var", {""});
     }
 
     // Comparison operators <, <=, >, >=, != collect path tokens from both operands; literals are silently dropped.
     // Mode is set to And only when more than one token is collected (same rule as BinaryArithmeticOp).
     Y_UNIT_TEST(CollectPath_ComparisonOperators) {
         // Literal on the right is dropped, only the path token is returned.
-        ValidateJsonValue("$.key < 10", {"\4key"});
-        ValidateJsonValue("$.key <= 10", {"\4key"});
-        ValidateJsonValue("$.key > 10", {"\4key"});
-        ValidateJsonValue("$.key >= 10", {"\4key"});
-        ValidateJsonValue("$.key != 10", {"\4key"});
-        ValidateJsonValue("$.key != -10", {"\4key"});
-        ValidateJsonValue("$.key >= -(+(-10))", {"\4key"});
-        ValidateJsonValue("$.key < \"hello\"", {"\4key"});
-        ValidateJsonValue("$.key != \"\"", {"\4key"});
-        ValidateJsonValue("$.key > 3.14", {"\4key"});
-        ValidateJsonValue("$.key >= true", {"\4key"});
-        ValidateJsonValue("$.key < null", {"\4key"});
+        ValidateJsonValue("strict $.key < 10", {encodeKey("key")});
+        ValidateJsonValue("strict $.key <= 10", {encodeKey("key")});
+        ValidateJsonValue("strict $.key > 10", {encodeKey("key")});
+        ValidateJsonValue("strict $.key >= 10", {encodeKey("key")});
+        ValidateJsonValue("strict $.key != 10", {encodeKey("key")});
+        ValidateJsonValue("strict $.key != -10", {encodeKey("key")});
+        ValidateJsonValue("strict $.key >= -(+(-10))", {encodeKey("key")});
+        ValidateJsonValue("strict $.key < \"hello\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.key != \"\"", {encodeKey("key")});
+        ValidateJsonValue("strict $.key > 3.14", {encodeKey("key")});
+        ValidateJsonValue("strict $.key >= true", {encodeKey("key")});
+        ValidateJsonValue("strict $.key < null", {encodeKey("key")});
 
         // Literal on the left, path on the right - literal dropped, path token returned
-        ValidateJsonValue("10 < $.key", {"\4key"});
-        ValidateJsonValue("10 <= $.key", {"\4key"});
-        ValidateJsonValue("10 > $.key", {"\4key"});
-        ValidateJsonValue("10 >= $.key", {"\4key"});
-        ValidateJsonValue("10 != $.key", {"\4key"});
-        ValidateJsonValue("-10 != $.key", {"\4key"});
-        ValidateJsonValue("-(+(-10)) != $.key", {"\4key"});
+        ValidateJsonValue("strict 10 < $.key", {encodeKey("key")});
+        ValidateJsonValue("strict 10 <= $.key", {encodeKey("key")});
+        ValidateJsonValue("strict 10 > $.key", {encodeKey("key")});
+        ValidateJsonValue("strict 10 >= $.key", {encodeKey("key")});
+        ValidateJsonValue("strict 10 != $.key", {encodeKey("key")});
+        ValidateJsonValue("strict -10 != $.key", {encodeKey("key")});
+        ValidateJsonValue("strict -(+(-10)) != $.key", {encodeKey("key")});
 
         // Context object as path (empty prefix)
-        ValidateJsonValue("$ < 5", {""});
-        ValidateJsonValue("$ > \"x\"", {""});
-        ValidateJsonValue("$ != null", {""});
+        ValidateJsonValue("strict $ < 5", {""});
+        ValidateJsonValue("strict $ > \"x\"", {""});
+        ValidateJsonValue("strict $ != null", {""});
 
         // Deeper member access paths
-        ValidateJsonValue("$.a.b.c < 42", {"\2a\2b\2c"});
-        ValidateJsonValue("$.a.b > -1", {"\2a\2b"});
-        ValidateJsonValue("$.aba.\"caba\" != false", {"\4aba\5caba"});
-        ValidateJsonValue("$.a.b.c.d >= 0", {"\2a\2b\2c\2d"});
+        ValidateJsonValue("strict $.a.b.c < 42", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
+        ValidateJsonValue("strict $.a.b > -1", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonValue("strict $.aba.\"caba\" != false", {encodeKey("aba") + encodeKey("caba")});
+        ValidateJsonValue("strict $.a.b.c.d >= 0", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d")});
 
         // Array access
-        ValidateJsonValue("$.key[0] < 5", {"\4key"});
-        ValidateJsonValue("$.key[last] > true", {"\4key"});
-        ValidateJsonValue("$.key[1, 2, 3] != null", {"\4key"});
-        ValidateJsonValue("$.key[0 to last] >= 1", {"\4key"});
-        ValidateJsonValue("$.a.b[0].c <= \"x\"", {"\2a\2b\2c"});
+        ValidateJsonValue("strict $.key[0] < 5", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonValue("strict $.key[last] > true", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonValue("strict $.key[1, 2, 3] != null", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonValue("strict $.key[0 to last] >= 1", {encodeKey("key") + arrayItemSuffix});
+        ValidateJsonValue("strict $.a.b[0].c <= \"x\"", {encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c")});
 
         // Wildcard member access finishes the path (literal not appended, but still dropped)
-        ValidateJsonValue("$.* < 5", {""});
-        ValidateJsonValue("$.a.* > 1", {"\2a"});
-        ValidateJsonValue("$.a.b.* != \"x\"", {"\2a\2b"});
+        ValidateJsonValue("strict $.* < 5", {""});
+        ValidateJsonValue("strict $.a.* > 1", {encodeKey("a")});
+        ValidateJsonValue("strict $.a.b.* != \"x\"", {encodeKey("a") + encodeKey("b")});
 
         // Wildcard array access
-        ValidateJsonValue("$.key[*] < 5", {"\4key"});
+        ValidateJsonValue("strict $.key[*] < 5", {encodeKey("key") + arrayItemSuffix});
 
         // Methods finish the path
-        ValidateJsonValue("$.key.size() < -3", {"\4key"});
-        ValidateJsonValue("$.key.abs() >= 1", {"\4key"});
-        ValidateJsonValue("$.a.b.floor() != 0", {"\2a\2b"});
-        ValidateJsonValue("$.key.keyvalue().name > \"x\"", {"\4key"});
+        ValidateJsonValue("strict $.key.size() < -3", {encodeKey("key")});
+        ValidateJsonValue("strict $.key.abs() >= 1", {encodeKey("key")});
+        ValidateJsonValue("strict $.a.b.floor() != 0", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonValue("strict $.key.keyvalue().name > \"x\"", {encodeKey("key")});
 
         // Unary arithmetic on path finishes the path
-        ValidateJsonValue("-$.key < 1", {"\4key"});
-        ValidateJsonValue("+$.key >= 0", {"\4key"});
+        ValidateJsonValue("strict -$.key < 1", {encodeKey("key")});
+        ValidateJsonValue("strict +$.key >= 0", {encodeKey("key")});
 
         // Both sides are paths - tokens from both collected (mode=And)
-        ValidateJsonValue("$.a < $.b", {"\2a", "\2b"});
-        ValidateJsonValue("$.a.b > $.c.d", {"\2a\2b", "\2c\2d"});
-        ValidateJsonValue("$.key != $.other", {"\4key", "\6other"});
-        ValidateJsonValue("$ <= $.a", {"", "\2a"});
-        ValidateJsonValue("$.a >= $", {"\2a", ""});
+        ValidateJsonValue("strict $.a < $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $.a.b > $.c.d", {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")});
+        ValidateJsonValue("strict $.key != $.other", {encodeKey("key"), encodeKey("other")});
+        ValidateJsonValue("strict $ <= $.a", {"", encodeKey("a")});
+        ValidateJsonValue("strict $.a >= $", {encodeKey("a"), ""});
 
         // Both sides are literals - error
         ValidateError("1 < 2", emptyError, {}, {}, ECallableType::JsonValue);
@@ -837,10 +838,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         // Arithmetic expression as operand (same as BinaryArithmeticOp behavior)
         // $.a + $.b produces mode=And, comparison also sets And - compatible
-        ValidateJsonValue("$.a + $.b < -5", {"\2a", "\2b"});
-        ValidateJsonValue("1 < $.a + $.b", {"\2a", "\2b"});
-        ValidateJsonValue("$.key + 1 >= 5", {"\4key"});
-        ValidateJsonValue("$.a.size() + $.b.abs() != 0", {"\2a", "\2b"});
+        ValidateJsonValue("strict $.a + $.b < -5", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict 1 < $.a + $.b", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $.key + 1 >= 5", {encodeKey("key")});
+        ValidateJsonValue("strict $.a.size() + $.b.abs() != 0", {encodeKey("a"), encodeKey("b")});
 
         // Comparison predicate nested inside another comparison
         ValidateError("($.a == -10) < -5", predError, {}, {}, ECallableType::JsonValue);
@@ -866,23 +867,23 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$.key != -10", predError, {}, {}, ECallableType::JsonExists);
 
         // Single-path comparison produces 1 token, NotSet mode, can appear in AND or OR
-        ValidateJsonValue("($.a < 5) && ($.b > 1)", {"\2a", "\2b"});
-        ValidateJsonValue("($.a <= 5) && ($.b >= 1)", {"\2a", "\2b"});
-        ValidateJsonValue("($.a != 5) && ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
-        ValidateJsonValue("($.a < 5) && ($.b > 1) && ($.c != 3)", {"\2a", "\2b", "\2c"});
+        ValidateJsonValue("strict ($.a < 5) && ($.b > 1)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a <= 5) && ($.b >= 1)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a != 5) && ($.b == 1)", {encodeKey("a"), encodeKey("b") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a < 5) && ($.b > 1) && ($.c != 3)", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
 
-        ValidateJsonValue("($.a < 5) || ($.b > 1)", {"\2a", "\2b"});
-        ValidateJsonValue("($.a >= 5) || ($.b != -1)", {"\2a", "\2b"});
-        ValidateJsonValue("($.a != 5) || ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
-        ValidateJsonValue("($.a < -5) || ($.b > 1) || ($.c != 3)", {"\2a", "\2b", "\2c"});
+        ValidateJsonValue("strict ($.a < 5) || ($.b > 1)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a >= 5) || ($.b != -1)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a != 5) || ($.b == 1)", {encodeKey("a"), encodeKey("b") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a < -5) || ($.b > 1) || ($.c != 3)", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
 
         // Two-path comparison (And mode) mixed with OR: OR wins
-        ValidateJsonValue("($.a < $.b) || ($.c > 1)", {"\2a", "\2b", "\2c"});
-        ValidateJsonValue("($.a != $.b) || ($.c == -1)", {"\2a", "\2b", "\2c" + numSuffix(-1)});
+        ValidateJsonValue("strict ($.a < $.b) || ($.c > 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
+        ValidateJsonValue("strict ($.a != $.b) || ($.c == -1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(-1)});
 
         // AND chain with OR: OR wins, all tokens become OR
-        ValidateJsonValue("($.a < -5) && ($.b == 1) || ($.c > 2)", {"\2a", "\2b" + numSuffix(1), "\2c"});
-        ValidateJsonValue("($.a < -5) && ($.b > -1) || ($.c != 3)", {"\2a", "\2b", "\2c"});
+        ValidateJsonValue("strict ($.a < -5) && ($.b == 1) || ($.c > 2)", {encodeKey("a"), encodeKey("b") + numSuffix(1), encodeKey("c")});
+        ValidateJsonValue("strict ($.a < -5) && ($.b > -1) || ($.c != 3)", {encodeKey("a"), encodeKey("b"), encodeKey("c")});
 
         // Variables
         ValidateError("$var < 5", emptyError, {}, {}, ECallableType::JsonValue);
@@ -893,59 +894,59 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Comparison operators inside filter predicates (EMode::Filter allows predicates)
     Y_UNIT_TEST(CollectPath_ComparisonOperators_InFilter) {
         // Basic filter with each comparison op
-        ValidateJsonExists("$.a ? (@.b < 10)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b <= -10)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b > 10)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b >= +10)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b != 10)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b < 10)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b <= -10)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b > 10)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b >= +10)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b != 10)", {encodeKey("a") + encodeKey("b")});
 
         // All literal types as right operand (dropped)
-        ValidateJsonExists("$.a ? (@.b < \"hello\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b > -3.14)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b != true)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b >= null)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b < \"hello\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b > -3.14)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b != true)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b >= null)", {encodeKey("a") + encodeKey("b")});
 
         // Literal on the left, @ path on the right
-        ValidateJsonExists("$.a ? (10 < @.b)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (\"x\" != @.b)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (10 < @.b)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (\"x\" != @.b)", {encodeKey("a") + encodeKey("b")});
 
         // @ itself (filter object) as operand
-        ValidateJsonExists("$.a ? (@ < 10)", {"\2a"});
-        ValidateJsonExists("$.a ? (@ != \"x\")", {"\2a"});
-        ValidateJsonExists("$.a.b ? (@ > 0)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@ < 10)", {encodeKey("a")});
+        ValidateJsonExists("strict $.a ? (@ != \"x\")", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.b ? (@ > 0)", {encodeKey("a") + encodeKey("b")});
 
         // Deeper filter-object paths
-        ValidateJsonExists("$.a ? (@.b.c < -(+(-5)))", {"\2a\2b\2c"});
-        ValidateJsonExists("$.a.b ? (@.c.d != null)", {"\2a\2b\2c\2d"});
+        ValidateJsonExists("strict $.a ? (@.b.c < -(+(-5)))", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
+        ValidateJsonExists("strict $.a.b ? (@.c.d != null)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d")});
 
         // Method on filter-object path (finishes, literal dropped)
-        ValidateJsonExists("$.a ? (@.b.size() < -3)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.abs() >= 0)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b.size() < -3)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.abs() >= 0)", {encodeKey("a") + encodeKey("b")});
 
         // Unary on filter-object path (finishes, literal dropped)
-        ValidateJsonExists("$.a ? (-@.b < 5)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (+@.b >= 0)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (-@.b < 5)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (+@.b >= 0)", {encodeKey("a") + encodeKey("b")});
 
         // Both operands are @-paths (both tokens collected)
-        ValidateJsonExists("$.key ? (@.a < @.b)", {"\4key\2a", "\4key\2b"});
-        ValidateJsonExists("$.key ? (@.x != @.y)", {"\4key\2x", "\4key\2y"});
+        ValidateJsonExists("strict $.key ? (@.a < @.b)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
+        ValidateJsonExists("strict $.key ? (@.x != @.y)", {encodeKey("key") + encodeKey("x"), encodeKey("key") + encodeKey("y")});
 
         // Wildcard on filter-object path
-        ValidateJsonExists("$.a ? (@.* < 5)", {"\2a"});
-        ValidateJsonExists("$.a ? (@.b.* != 1)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.* < 5)", {encodeKey("a")});
+        ValidateJsonExists("strict $.a ? (@.b.* != 1)", {encodeKey("a") + encodeKey("b")});
 
         // Comparison in AND inside filter
-        ValidateJsonExists("$.a ? (@.b < +10 && @.c == 1)", {"\2a\2b", "\2a\2c" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (@.b > 0 && @.b < 100)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b != 5 && @.c >= 0 && @.d <= -10)", {"\2a\2b", "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("strict $.a ? (@.b < +10 && @.c == 1)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c") + numSuffix(1)});
+        ValidateJsonExists("strict $.a ? (@.b > 0 && @.b < 100)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b != 5 && @.c >= 0 && @.d <= -10)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
 
         // Comparison in OR inside filter
-        ValidateJsonExists("$.a ? ((@.b < 5) || (@.c > 10))", {"\2a\2b", "\2a\2c"});
-        ValidateJsonExists("$.a ? ((@.b != 1) || (@.c != 2))", {"\2a\2b", "\2a\2c"});
+        ValidateJsonExists("strict $.a ? ((@.b < 5) || (@.c > 10))", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
+        ValidateJsonExists("strict $.a ? ((@.b != 1) || (@.c != 2))", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
 
         // Mixing AND and OR inside filter: OR wins
-        ValidateJsonExists("$.a ? ((@.b < 5) && ((@.c > 1) || (@.d > 2)))", {"\2a\2b", "\2a\2c", "\2a\2d"});
-        ValidateJsonExists("$.a ? (((@.b < 5) || (@.c > 1)) && @.d > 2)", {"\2a\2b", "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("strict $.a ? ((@.b < 5) && ((@.c > 1) || (@.d > 2)))", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
+        ValidateJsonExists("strict $.a ? (((@.b < 5) || (@.c > 1)) && @.d > 2)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
 
         // Nested predicate in filter operand is blocked (EMode::Predicate on operand)
         ValidateError("$.a ? (($.b == 1) < 5)", predError, {}, {}, ECallableType::JsonExists);
@@ -958,146 +959,146 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$.a ? ((@.b != 1) is unknown)", predError, {}, {}, ECallableType::JsonExists);
 
         // Arithmetic expression as comparison operand in filter
-        ValidateJsonExists("$.key ? (@.a + @.b < +5)", {"\4key\2a", "\4key\2b"});
-        ValidateJsonExists("$.key ? (@.a * 2 != 0)", {"\4key\2a"});
+        ValidateJsonExists("strict $.key ? (@.a + @.b < +5)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
+        ValidateJsonExists("strict $.key ? (@.a * 2 != 0)", {encodeKey("key") + encodeKey("a")});
 
         // JsonValue also supports comparison in filter
-        ValidateJsonValue("$.a ? (@.b < -10)", {"\2a\2b"});
-        ValidateJsonValue("$.a ? (@.b != null && @.c >= 1)", {"\2a\2b", "\2a\2c"});
+        ValidateJsonValue("strict $.a ? (@.b < -10)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonValue("strict $.a ? (@.b != null && @.c >= 1)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
     }
 
     // Comparison operators (path vs path produce And mode) combined with && and ||
     Y_UNIT_TEST(CollectPath_ComparisonWithBooleanOps) {
         // Two-path comparison (And mode) in AND chain: compatible, stays And
-        ValidateJsonValue("($.a < $.b) && ($.c > $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a <= $.b) && ($.c >= $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a != $.b) && ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a == $.b) && ($.c < $.d) && ($.e > $.f)", {"\2a", "\2b", "\2c", "\2d", "\2e", "\2f"},
+        ValidateJsonValue("strict ($.a < $.b) && ($.c > $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a <= $.b) && ($.c >= $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a != $.b) && ($.c == $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a == $.b) && ($.c < $.d) && ($.e > $.f)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e"), encodeKey("f")},
             TCollectResult::ETokensMode::And);
 
         // Two-path comparison (And mode) in OR: OR wins
-        ValidateJsonValue("($.a < $.b) || ($.c > $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a <= $.b) || ($.c >= $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a != $.b) || ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a < $.b) || ($.c > $.d) || ($.e != $.f)", {"\2a", "\2b", "\2c", "\2d", "\2e", "\2f"},
+        ValidateJsonValue("strict ($.a < $.b) || ($.c > $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a <= $.b) || ($.c >= $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a != $.b) || ($.c == $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a < $.b) || ($.c > $.d) || ($.e != $.f)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e"), encodeKey("f")},
             TCollectResult::ETokensMode::Or);
 
         // Single-path comparison (NotSet mode) in AND chain
-        ValidateJsonValue("($.a < 5) && ($.b > 3) && ($.c <= 10)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a > 0) && ($.b >= 1) && ($.c != 0) && ($.d == 2)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(2)},
+        ValidateJsonValue("strict ($.a < 5) && ($.b > 3) && ($.c <= 10)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a > 0) && ($.b >= 1) && ($.c != 0) && ($.d == 2)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d") + numSuffix(2)},
             TCollectResult::ETokensMode::And);
 
         // Single-path comparison in OR chain
-        ValidateJsonValue("($.a < 5) || ($.b > 3) || ($.c <= 10)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a > 0) || ($.b >= 1) || ($.c != 0) || ($.d == 2)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(2)}, 
+        ValidateJsonValue("strict ($.a < 5) || ($.b > 3) || ($.c <= 10)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a > 0) || ($.b >= 1) || ($.c != 0) || ($.d == 2)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d") + numSuffix(2)}, 
             TCollectResult::ETokensMode::Or);
 
         // Mix of single-path and two-path comparisons in AND: compatible (neither has Or)
-        ValidateJsonValue("($.a < 5) && ($.b > $.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a < $.b) && ($.c > 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a < 5) && ($.b > $.c) && ($.d == 1)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(1)}, 
+        ValidateJsonValue("strict ($.a < 5) && ($.b > $.c)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a < $.b) && ($.c > 5)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a < 5) && ($.b > $.c) && ($.d == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d") + numSuffix(1)}, 
             TCollectResult::ETokensMode::And);
 
         // Mix of single-path and two-path comparisons in OR: OR wins
-        ValidateJsonValue("($.a < 5) || ($.b > $.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a < $.b) || ($.c > 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a < 5) || ($.b > $.c)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a < $.b) || ($.c > 5)", {encodeKey("a"), encodeKey("b"), encodeKey("c")}, TCollectResult::ETokensMode::Or);
 
         // AND chain then OR: OR wins
-        ValidateJsonValue("($.a < $.b) && ($.c > 1) || ($.d != 0)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a < 5) && ($.b > $.c) || ($.d == 1)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(1)},
+        ValidateJsonValue("strict ($.a < $.b) && ($.c > 1) || ($.d != 0)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a < 5) && ($.b > $.c) || ($.d == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d") + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
 
         // Two-path equality combined via AND and OR
-        ValidateJsonValue("($.a == $.b) && ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a == $.b) || ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("strict ($.a == $.b) && ($.c == $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict ($.a == $.b) || ($.c == $.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")}, TCollectResult::ETokensMode::Or);
 
         // Filter: two-path comparison combined with AND/OR
-        ValidateJsonExists("$.key ? (@.a < @.b && @.c > 1)", {"\4key\2a", "\4key\2b", "\4key\2c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.key ? (@.a < @.b || @.c > 1)", {"\4key\2a", "\4key\2b", "\4key\2c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.key ? (@.a < @.b && @.c > @.d)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.key ? (@.a < @.b || @.c > @.d)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonExists("strict $.key ? (@.a < @.b && @.c > 1)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c")}, TCollectResult::ETokensMode::And);
+        ValidateJsonExists("strict $.key ? (@.a < @.b || @.c > 1)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c")}, TCollectResult::ETokensMode::Or);
+        ValidateJsonExists("strict $.key ? (@.a < @.b && @.c > @.d)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c"), encodeKey("key") + encodeKey("d")}, TCollectResult::ETokensMode::And);
+        ValidateJsonExists("strict $.key ? (@.a < @.b || @.c > @.d)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c"), encodeKey("key") + encodeKey("d")}, TCollectResult::ETokensMode::Or);
 
         // Filter: AND chain with OR - OR wins
-        ValidateJsonExists("$.key ? (@.a < @.b && @.c > @.d || @.e == 1)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d", "\4key\2e" + numSuffix(1)},
+        ValidateJsonExists("strict $.key ? (@.a < @.b && @.c > @.d || @.e == 1)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c"), encodeKey("key") + encodeKey("d"), encodeKey("key") + encodeKey("e") + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
     }
 
     Y_UNIT_TEST(CollectPath_BinaryAnd) {
         // Basic equality on both sides, all literal types
-        ValidateJsonValue("($.a == 10) && ($.b == \"hello\")", {"\2a" + numSuffix(10), "\2b" + strSuffix("hello")});
-        ValidateJsonValue("(42 == $.key) && ($.val == true)", {"\4key" + numSuffix(42), "\4val" + boolTrueSuffix});
-        ValidateJsonValue("($.x == null) && ($.y == false)", {"\2x" + nullSuffix, "\2y" + boolFalseSuffix});
-        ValidateJsonValue("($.a == 0) && ($.b == 3.14)", {"\2a" + numSuffix(0), "\2b" + numSuffix(3.14)});
-        ValidateJsonValue("(\"hello\" == $.a) && (null == $.b)", {"\2a" + strSuffix("hello"), "\2b" + nullSuffix});
+        ValidateJsonValue("strict ($.a == 10) && ($.b == \"hello\")", {encodeKey("a") + numSuffix(10), encodeKey("b") + strSuffix("hello")});
+        ValidateJsonValue("strict (42 == $.key) && ($.val == true)", {encodeKey("key") + numSuffix(42), encodeKey("val") + boolTrueSuffix});
+        ValidateJsonValue("strict ($.x == null) && ($.y == false)", {encodeKey("x") + nullSuffix, encodeKey("y") + boolFalseSuffix});
+        ValidateJsonValue("strict ($.a == 0) && ($.b == 3.14)", {encodeKey("a") + numSuffix(0), encodeKey("b") + numSuffix(3.14)});
+        ValidateJsonValue("strict (\"hello\" == $.a) && (null == $.b)", {encodeKey("a") + strSuffix("hello"), encodeKey("b") + nullSuffix});
 
         // Deeper member access paths
-        ValidateJsonValue("($.a.b.c == 1) && ($.x.y == \"z\")", {"\2a\2b\2c" + numSuffix(1), "\2x\2y" + strSuffix("z")});
-        ValidateJsonValue("($.aba.\"caba\" == true) && ($.d.e.f == 0)", {"\4aba\5caba" + boolTrueSuffix, "\2d\2e\2f" + numSuffix(0)});
-        ValidateJsonValue("($.a.b.c.d == 0) && ($.p.q == null)", {"\2a\2b\2c\2d" + numSuffix(0), "\2p\2q" + nullSuffix});
+        ValidateJsonValue("strict ($.a.b.c == 1) && ($.x.y == \"z\")", {encodeKey("a") + encodeKey("b") + encodeKey("c") + numSuffix(1), encodeKey("x") + encodeKey("y") + strSuffix("z")});
+        ValidateJsonValue("strict ($.aba.\"caba\" == true) && ($.d.e.f == 0)", {encodeKey("aba") + encodeKey("caba") + boolTrueSuffix, encodeKey("d") + encodeKey("e") + encodeKey("f") + numSuffix(0)});
+        ValidateJsonValue("strict ($.a.b.c.d == 0) && ($.p.q == null)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d") + numSuffix(0), encodeKey("p") + encodeKey("q") + nullSuffix});
 
         // Context object as path (empty prefix)
-        ValidateJsonValue("($ == \"root\") && ($.b == 2)", {strSuffix("root"), "\2b" + numSuffix(2)});
-        ValidateJsonValue("($ == null) && ($ == 42)", {nullSuffix, numSuffix(42)});
+        ValidateJsonValue("strict ($ == \"root\") && ($.b == 2)", {strSuffix("root"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($ == null) && ($ == 42)", {nullSuffix, numSuffix(42)});
 
         // Array access
-        ValidateJsonValue("($.key[0] == 1) && ($.arr[last] == true)", {"\4key" + numSuffix(1), "\4arr" + boolTrueSuffix});
-        ValidateJsonValue("($.key[1, 2, 3] == null) && ($.b[0 to last] == \"x\")", {"\4key" + nullSuffix, "\2b" + strSuffix("x")});
-        ValidateJsonValue("($.a.b[0].c == \"x\") && ($.d.e == false)", {"\2a\2b\2c" + strSuffix("x"), "\2d\2e" + boolFalseSuffix});
-        ValidateJsonValue("($.key[0].sub == \"x\") && ($.v == 1)", {"\4key\4sub" + strSuffix("x"), "\2v" + numSuffix(1)});
+        ValidateJsonValue("strict ($.key[0] == 1) && ($.arr[last] == true)", {encodeKey("key") + arrayItemSuffix + numSuffix(1), encodeKey("arr") + arrayItemSuffix + boolTrueSuffix});
+        ValidateJsonValue("strict ($.key[1, 2, 3] == null) && ($.b[0 to last] == \"x\")", {encodeKey("key") + arrayItemSuffix + nullSuffix, encodeKey("b") + arrayItemSuffix + strSuffix("x")});
+        ValidateJsonValue("strict ($.a.b[0].c == \"x\") && ($.d.e == false)", {encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c") + strSuffix("x"), encodeKey("d") + encodeKey("e") + boolFalseSuffix});
+        ValidateJsonValue("strict ($.key[0].sub == \"x\") && ($.v == 1)", {encodeKey("key") + arrayItemSuffix + encodeKey("sub") + strSuffix("x"), encodeKey("v") + numSuffix(1)});
 
         // Wildcard member access (finishes collection, no literal suffix appended)
-        ValidateJsonValue("($.a.* == \"x\") && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.* == \"x\") && ($.b == 2)", {"\2b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) && ($.b.* == \"z\")", {"\2a" + numSuffix(1), "\2b"});
-        ValidateJsonValue("($.a.b.* == true) && ($.c.* == null)", {"\2a\2b", "\2c"});
+        ValidateJsonValue("strict ($.a.* == \"x\") && ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.* == \"x\") && ($.b == 2)", {encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == 1) && ($.b.* == \"z\")", {encodeKey("a") + numSuffix(1), encodeKey("b")});
+        ValidateJsonValue("strict ($.a.b.* == true) && ($.c.* == null)", {encodeKey("a") + encodeKey("b"), encodeKey("c")});
 
         // Wildcard array access
-        ValidateJsonValue("($.key[*] == \"x\") && ($.b == 2)", {"\4key" + strSuffix("x"), "\2b" + numSuffix(2)});
+        ValidateJsonValue("strict ($.key[*] == \"x\") && ($.b == 2)", {encodeKey("key") + arrayItemSuffix + strSuffix("x"), encodeKey("b") + numSuffix(2)});
 
         // Methods (finish the path, no literal suffix appended)
-        ValidateJsonValue("($.key.size() == 3) && ($.val == 1)", {"\4key", "\4val" + numSuffix(1)});
-        ValidateJsonValue("($.a == \"x\") && ($.key.abs() == 2)", {"\2a" + strSuffix("x"), "\4key"});
-        ValidateJsonValue("($.a.floor() == 0) && ($.b.type() == \"number\")", {"\2a", "\2b"});
-        ValidateJsonValue("($.key.keyvalue().name == \"x\") && ($.v == true)", {"\4key", "\2v" + boolTrueSuffix});
-        ValidateJsonValue("($.a.size() == 5) && ($.b.ceiling() == 3)", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($.key.size() == 3) && ($.val == 1)", {encodeKey("key"), encodeKey("val") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a == \"x\") && ($.key.abs() == 2)", {encodeKey("a") + strSuffix("x"), encodeKey("key")});
+        ValidateJsonValue("strict ($.a.floor() == 0) && ($.b.type() == \"number\")", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.key.keyvalue().name == \"x\") && ($.v == true)", {encodeKey("key"), encodeKey("v") + boolTrueSuffix});
+        ValidateJsonValue("strict ($.a.size() == 5) && ($.b.ceiling() == 3)", {encodeKey("a"), encodeKey("b")});
 
         // StartsWith predicate on left and right
-        ValidateJsonValue("($.a starts with \"x\") && ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
-        ValidateJsonValue("($.a == 1) && ($.b starts with \"y\")", {"\2a" + numSuffix(1), "\2b"});
-        ValidateJsonValue("($.a.b.c starts with \"abc\") && ($.d[0] == null)", {"\2a\2b\2c", "\2d" + nullSuffix});
-        ValidateJsonValue("($.a starts with \"x\") && ($.b starts with \"y\")", {"\2a", "\2b"});
-        ValidateJsonValue("($.a.* starts with \"x\") && ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
+        ValidateJsonValue("strict ($.a starts with \"x\") && ($.b == 1)", {encodeKey("a"), encodeKey("b") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a == 1) && ($.b starts with \"y\")", {encodeKey("a") + numSuffix(1), encodeKey("b")});
+        ValidateJsonValue("strict ($.a.b.c starts with \"abc\") && ($.d[0] == null)", {encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("d") + arrayItemSuffix + nullSuffix});
+        ValidateJsonValue("strict ($.a starts with \"x\") && ($.b starts with \"y\")", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a.* starts with \"x\") && ($.b == 1)", {encodeKey("a"), encodeKey("b") + numSuffix(1)});
 
         // LikeRegex predicate on left and right
-        ValidateJsonValue("($.a like_regex \".*\") && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.a == \"x\") && ($.b like_regex \"[a-z]+\")", {"\2a" + strSuffix("x"), "\2b"});
-        ValidateJsonValue("($.a like_regex \"x.*\") && ($.b like_regex \"y.*\")", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($.a like_regex \".*\") && ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == \"x\") && ($.b like_regex \"[a-z]+\")", {encodeKey("a") + strSuffix("x"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a like_regex \"x.*\") && ($.b like_regex \"y.*\")", {encodeKey("a"), encodeKey("b")});
 
         // Exists predicate on left and right
-        ValidateJsonValue("exists($.a) && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) && exists($.b.c)", {"\2a" + numSuffix(1), "\2b\2c"});
-        ValidateJsonValue("exists($.a.b[0]) && exists($.c.*)", {"\2a\2b", "\2c"});
-        ValidateJsonValue("exists($.a.key.size()) && ($.b == true)", {"\2a\4key", "\2b" + boolTrueSuffix});
+        ValidateJsonValue("strict exists($.a) && ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == 1) && exists($.b.c)", {encodeKey("a") + numSuffix(1), encodeKey("b") + encodeKey("c")});
+        ValidateJsonValue("strict exists($.a.b[0]) && exists($.c.*)", {encodeKey("a") + encodeKey("b") + arrayItemSuffix, encodeKey("c")});
+        ValidateJsonValue("strict exists($.a.key.size()) && ($.b == true)", {encodeKey("a") + encodeKey("key"), encodeKey("b") + boolTrueSuffix});
 
         // Unary arithmetic operand (finishes, no literal suffix)
-        ValidateJsonValue("(-$.a == 1) && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) && (+$.b.c == 0)", {"\2a" + numSuffix(1), "\2b\2c"});
-        ValidateJsonValue("(-$.a.b.* == 1) && ($.c == 2)", {"\2a\2b", "\2c" + numSuffix(2)});
+        ValidateJsonValue("strict (-$.a == 1) && ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == 1) && (+$.b.c == 0)", {encodeKey("a") + numSuffix(1), encodeKey("b") + encodeKey("c")});
+        ValidateJsonValue("strict (-$.a.b.* == 1) && ($.c == 2)", {encodeKey("a") + encodeKey("b"), encodeKey("c") + numSuffix(2)});
 
         // Binary arithmetic with two paths as AND operand (two path tokens, And mode, compatible with AND)
         // $.a + $.b == "x" is parsed as ($.a + $.b) == "x", arithmetic finishes, literal not appended
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
-        ValidateJsonValue("($.c == 1) && ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"});
-        ValidateJsonValue("($.a.size() + $.b.abs() == 5) && ($.c == null)", {"\2a", "\2b", "\2c" + nullSuffix});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
+        ValidateJsonValue("strict ($.c == 1) && ($.a + $.b == \"x\")", {encodeKey("c") + numSuffix(1), encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a.size() + $.b.abs() == 5) && ($.c == null)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + nullSuffix});
 
         // Chained AND (left-associative)
-        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3) && ($.d == 4)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
-        ValidateJsonValue("($.a starts with \"x\") && ($.b == 1) && exists($.c.d)", {"\2a", "\2b" + numSuffix(1), "\2c\2d"});
-        ValidateJsonValue("($.a like_regex \".*\") && ($.b.* == 2) && ($.c.size() == 3) && exists($.d)", {"\2a", "\2b", "\2c", "\2d"});
+        ValidateJsonValue("strict ($.a == 1) && ($.b == 2) && ($.c == 3)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict ($.a == 1) && ($.b == 2) && ($.c == 3) && ($.d == 4)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
+        ValidateJsonValue("strict ($.a starts with \"x\") && ($.b == 1) && exists($.c.d)", {encodeKey("a"), encodeKey("b") + numSuffix(1), encodeKey("c") + encodeKey("d")});
+        ValidateJsonValue("strict ($.a like_regex \".*\") && ($.b.* == 2) && ($.c.size() == 3) && exists($.d)", {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")});
 
         // Same path on both sides (two different equality conditions)
-        ValidateJsonValue("($.a == 1) && ($.a == 2)", {"\2a" + numSuffix(1), "\2a" + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == 1) && ($.a == 2)", {encodeKey("a") + numSuffix(1), encodeKey("a") + numSuffix(2)});
 
         // Variables with literals
         ValidateError("($var == 1) && ($.b == 2)", compError, {}, {}, ECallableType::JsonValue);
@@ -1110,10 +1111,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("exists($.a) && exists($.b)", predError, {}, {}, ECallableType::JsonExists);
 
         // Mixing AND and OR: OR wins, all tokens become OR
-        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) || (($.b == 2) && ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) && (($.b == 2) || ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("strict (($.a == 1) && ($.b == 2)) || ($.c == 3)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict ($.a == 1) || (($.b == 2) && ($.c == 3))", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict ($.a == 1) && (($.b == 2) || ($.c == 3))", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict (($.a == 1) || ($.b == 2)) && ($.c == 3)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
 
         // Nested predicates: AND appears in predicate position (inside exists / is unknown / == literal)
         // BinaryAnd inherits EMode::Predicate and its operands (==, starts with, like_regex, exists) are blocked
@@ -1127,58 +1128,58 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     Y_UNIT_TEST(CollectPath_BinaryOr) {
         // Basic equality on both sides, all literal types
-        ValidateJsonValue("($.a == 10) || ($.b == \"hello\")", {"\2a" + numSuffix(10), "\2b" + strSuffix("hello")});
-        ValidateJsonValue("(42 == $.key) || ($.val == true)", {"\4key" + numSuffix(42), "\4val" + boolTrueSuffix});
-        ValidateJsonValue("($.x == null) || ($.y == false)", {"\2x" + nullSuffix, "\2y" + boolFalseSuffix});
-        ValidateJsonValue("($.a == 0) || ($.b == 3.14)", {"\2a" + numSuffix(0), "\2b" + numSuffix(3.14)});
-        ValidateJsonValue("($ == \"root\") || ($.b == 2)", {strSuffix("root"), "\2b" + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == 10) || ($.b == \"hello\")", {encodeKey("a") + numSuffix(10), encodeKey("b") + strSuffix("hello")});
+        ValidateJsonValue("strict (42 == $.key) || ($.val == true)", {encodeKey("key") + numSuffix(42), encodeKey("val") + boolTrueSuffix});
+        ValidateJsonValue("strict ($.x == null) || ($.y == false)", {encodeKey("x") + nullSuffix, encodeKey("y") + boolFalseSuffix});
+        ValidateJsonValue("strict ($.a == 0) || ($.b == 3.14)", {encodeKey("a") + numSuffix(0), encodeKey("b") + numSuffix(3.14)});
+        ValidateJsonValue("strict ($ == \"root\") || ($.b == 2)", {strSuffix("root"), encodeKey("b") + numSuffix(2)});
 
         // Deeper member access paths
-        ValidateJsonValue("($.a.b.c == 1) || ($.x.y == \"z\")", {"\2a\2b\2c" + numSuffix(1), "\2x\2y" + strSuffix("z")});
-        ValidateJsonValue("($.aba.\"caba\" == true) || ($.d.e.f == 0)", {"\4aba\5caba" + boolTrueSuffix, "\2d\2e\2f" + numSuffix(0)});
+        ValidateJsonValue("strict ($.a.b.c == 1) || ($.x.y == \"z\")", {encodeKey("a") + encodeKey("b") + encodeKey("c") + numSuffix(1), encodeKey("x") + encodeKey("y") + strSuffix("z")});
+        ValidateJsonValue("strict ($.aba.\"caba\" == true) || ($.d.e.f == 0)", {encodeKey("aba") + encodeKey("caba") + boolTrueSuffix, encodeKey("d") + encodeKey("e") + encodeKey("f") + numSuffix(0)});
 
         // Array access
-        ValidateJsonValue("($.key[0] == 1) || ($.arr[last] == true)", {"\4key" + numSuffix(1), "\4arr" + boolTrueSuffix});
-        ValidateJsonValue("($.key[1, 2, 3] == null) || ($.b[0 to last] == \"x\")", {"\4key" + nullSuffix, "\2b" + strSuffix("x")});
-        ValidateJsonValue("($.a.b[0].c == \"x\") || ($.d.e == false)", {"\2a\2b\2c" + strSuffix("x"), "\2d\2e" + boolFalseSuffix});
+        ValidateJsonValue("strict ($.key[0] == 1) || ($.arr[last] == true)", {encodeKey("key") + arrayItemSuffix + numSuffix(1), encodeKey("arr") + arrayItemSuffix + boolTrueSuffix});
+        ValidateJsonValue("strict ($.key[1, 2, 3] == null) || ($.b[0 to last] == \"x\")", {encodeKey("key") + arrayItemSuffix + nullSuffix, encodeKey("b") + arrayItemSuffix + strSuffix("x")});
+        ValidateJsonValue("strict ($.a.b[0].c == \"x\") || ($.d.e == false)", {encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c") + strSuffix("x"), encodeKey("d") + encodeKey("e") + boolFalseSuffix});
 
         // Wildcard member and array access (finishes, no literal suffix)
-        ValidateJsonValue("($.a.* == \"x\") || ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.* == \"x\") || ($.b == 2)", {""});
-        ValidateJsonValue("($.a == 1) || ($.b.* == \"z\")", {"\2a" + numSuffix(1), "\2b"});
-        ValidateJsonValue("($.key[*] == \"x\") || ($.b == 2)", {"\4key" + strSuffix("x"), "\2b" + numSuffix(2)});
+        ValidateJsonValue("strict ($.a.* == \"x\") || ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.* == \"x\") || ($.b == 2)", {""});
+        ValidateJsonValue("strict ($.a == 1) || ($.b.* == \"z\")", {encodeKey("a") + numSuffix(1), encodeKey("b")});
+        ValidateJsonValue("strict ($.key[*] == \"x\") || ($.b == 2)", {encodeKey("key") + arrayItemSuffix + strSuffix("x"), encodeKey("b") + numSuffix(2)});
 
         // Methods (finish the path, no literal suffix)
-        ValidateJsonValue("($.key.size() == 3) || ($.val == 1)", {"\4key", "\4val" + numSuffix(1)});
-        ValidateJsonValue("($.a == \"x\") || ($.key.abs() == 2)", {"\2a" + strSuffix("x"), "\4key"});
-        ValidateJsonValue("($.a.floor() == 0) || ($.b.type() == \"number\")", {"\2a", "\2b"});
-        ValidateJsonValue("($.key.keyvalue().name == \"x\") || ($.v == true)", {"\4key", "\2v" + boolTrueSuffix});
+        ValidateJsonValue("strict ($.key.size() == 3) || ($.val == 1)", {encodeKey("key"), encodeKey("val") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a == \"x\") || ($.key.abs() == 2)", {encodeKey("a") + strSuffix("x"), encodeKey("key")});
+        ValidateJsonValue("strict ($.a.floor() == 0) || ($.b.type() == \"number\")", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.key.keyvalue().name == \"x\") || ($.v == true)", {encodeKey("key"), encodeKey("v") + boolTrueSuffix});
 
         // StartsWith predicate
-        ValidateJsonValue("($.a starts with \"x\") || ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
-        ValidateJsonValue("($.a == 1) || ($.b starts with \"y\")", {"\2a" + numSuffix(1), "\2b"});
-        ValidateJsonValue("($.a starts with \"x\") || ($.b starts with \"y\")", {"\2a", "\2b"});
-        ValidateJsonValue("($.a.* starts with \"x\") || ($.b[0] == 1)", {"\2a", "\2b" + numSuffix(1)});
+        ValidateJsonValue("strict ($.a starts with \"x\") || ($.b == 1)", {encodeKey("a"), encodeKey("b") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a == 1) || ($.b starts with \"y\")", {encodeKey("a") + numSuffix(1), encodeKey("b")});
+        ValidateJsonValue("strict ($.a starts with \"x\") || ($.b starts with \"y\")", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a.* starts with \"x\") || ($.b[0] == 1)", {encodeKey("a"), encodeKey("b") + arrayItemSuffix + numSuffix(1)});
 
         // LikeRegex predicate
-        ValidateJsonValue("($.a like_regex \".*\") || ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.a == \"x\") || ($.b like_regex \"[a-z]+\")", {"\2a" + strSuffix("x"), "\2b"});
-        ValidateJsonValue("($.a like_regex \"x.*\") || ($.b like_regex \"y.*\")", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($.a like_regex \".*\") || ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == \"x\") || ($.b like_regex \"[a-z]+\")", {encodeKey("a") + strSuffix("x"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a like_regex \"x.*\") || ($.b like_regex \"y.*\")", {encodeKey("a"), encodeKey("b")});
 
         // Exists predicate
-        ValidateJsonValue("exists($.a) || ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) || exists($.b.c)", {"\2a" + numSuffix(1), "\2b\2c"});
-        ValidateJsonValue("exists($.a.b[0]) || exists($.c.*)", {"\2a\2b", "\2c"});
+        ValidateJsonValue("strict exists($.a) || ($.b == 2)", {encodeKey("a"), encodeKey("b") + numSuffix(2)});
+        ValidateJsonValue("strict ($.a == 1) || exists($.b.c)", {encodeKey("a") + numSuffix(1), encodeKey("b") + encodeKey("c")});
+        ValidateJsonValue("strict exists($.a.b[0]) || exists($.c.*)", {encodeKey("a") + encodeKey("b") + arrayItemSuffix, encodeKey("c")});
 
         // Same path on both sides, different values
-        ValidateJsonValue("($.a == 1) || ($.a == 2)", {"\2a" + numSuffix(1), "\2a" + numSuffix(2)});
-        ValidateJsonValue("($.key == \"a\") || ($.key == \"b\") || ($.key == \"c\")",
-            {"\4key" + strSuffix("a"), "\4key" + strSuffix("b"), "\4key" + strSuffix("c")});
+        ValidateJsonValue("strict ($.a == 1) || ($.a == 2)", {encodeKey("a") + numSuffix(1), encodeKey("a") + numSuffix(2)});
+        ValidateJsonValue("strict ($.key == \"a\") || ($.key == \"b\") || ($.key == \"c\")",
+            {encodeKey("key") + strSuffix("a"), encodeKey("key") + strSuffix("b"), encodeKey("key") + strSuffix("c")});
 
         // Chained OR (left-associative)
-        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3)",{"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3) || ($.d == 4)",{"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
-        ValidateJsonValue("($.a starts with \"x\") || ($.b == 1) || exists($.c.d)",{"\2a", "\2b" + numSuffix(1), "\2c\2d"});
+        ValidateJsonValue("strict ($.a == 1) || ($.b == 2) || ($.c == 3)",{encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict ($.a == 1) || ($.b == 2) || ($.c == 3) || ($.d == 4)",{encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
+        ValidateJsonValue("strict ($.a starts with \"x\") || ($.b == 1) || exists($.c.d)",{encodeKey("a"), encodeKey("b") + numSuffix(1), encodeKey("c") + encodeKey("d")});
 
         // Variable on left or right side
         ValidateError("($var == 1) || ($.b == 2)", compError, {}, {}, ECallableType::JsonValue);
@@ -1191,15 +1192,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("exists($.a) || exists($.b)", predError, {}, {}, ECallableType::JsonExists);
 
         // Arithmetic with multiple paths (And mode) mixed with OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
-        ValidateJsonValue("($.c == 1) || ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"});
-        ValidateJsonValue("($.a.size() + $.b.abs() == 5) || ($.c == null)", {"\2a", "\2b", "\2c" + nullSuffix});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
+        ValidateJsonValue("strict ($.c == 1) || ($.a + $.b == \"x\")", {encodeKey("c") + numSuffix(1), encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a.size() + $.b.abs() == 5) || ($.c == null)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + nullSuffix});
 
         // Mixing AND and OR: OR wins
-        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) || (($.b == 2) && ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) && (($.b == 2) || ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
-        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("strict (($.a == 1) && ($.b == 2)) || ($.c == 3)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict ($.a == 1) || (($.b == 2) && ($.c == 3))", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict ($.a == 1) && (($.b == 2) || ($.c == 3))", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
+        ValidateJsonValue("strict (($.a == 1) || ($.b == 2)) && ($.c == 3)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3)});
 
         // Nested predicates: OR appears in predicate position (inside exists / is unknown / == literal)
         ValidateError("exists(($.a == 1) || ($.b == 2))", predError, {}, {}, ECallableType::JsonValue);
@@ -1214,327 +1215,327 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // and that mix errors are detected regardless of nesting depth or structure
     Y_UNIT_TEST(CollectPath_ModePropagation) {
         // ((A && B) && (C && D)) - And+And combined at top level
-        ValidateJsonValue("(($.a == 1) && ($.b == 2)) && (($.c == 3) && ($.d == 4))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict (($.a == 1) && ($.b == 2)) && (($.c == 3) && ($.d == 4))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // ((A || B) || (C || D)) - Or+Or combined at top level
-        ValidateJsonValue("(($.a == 1) || ($.b == 2)) || (($.c == 3) || ($.d == 4))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict (($.a == 1) || ($.b == 2)) || (($.c == 3) || ($.d == 4))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // A && (B && (C && D))
-        ValidateJsonValue("($.a == 1) && (($.b == 2) && (($.c == 3) && ($.d == 4)))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) && (($.b == 2) && (($.c == 3) && ($.d == 4)))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // A || (B || (C || D))
-        ValidateJsonValue("($.a == 1) || (($.b == 2) || (($.c == 3) || ($.d == 4)))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) || (($.b == 2) || (($.c == 3) || ($.d == 4)))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
 
         // Arithmetic with two paths (mode=And) is compatible with AND chains
         // Two arithmetic operands inside AND: ($.a+$.b == "x") && ($.c+$.d == "y")
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\")",
-            {"\2a", "\2b", "\2c", "\2d"});
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\") && ($.e == 1)",
-            {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c + $.d == \"y\")",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c + $.d == \"y\") && ($.e == 1)",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e") + numSuffix(1)});
 
         // (A && B) || (C && D): OR wins, all tokens become OR
-        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || (($.c == 3) && ($.d == 4))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict (($.a == 1) && ($.b == 2)) || (($.c == 3) && ($.d == 4))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // (A || B) && (C || D): OR wins, all tokens become OR
-        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && (($.c == 3) || ($.d == 4))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict (($.a == 1) || ($.b == 2)) && (($.c == 3) || ($.d == 4))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
 
         // A && (B || (C || D)): OR wins
-        ValidateJsonValue("($.a == 1) && (($.b == 2) || (($.c == 3) || ($.d == 4)))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) && (($.b == 2) || (($.c == 3) || ($.d == 4)))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // A && (B && (C || D)): OR wins
-        ValidateJsonValue("($.a == 1) && (($.b == 2) && (($.c == 3) || ($.d == 4)))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) && (($.b == 2) && (($.c == 3) || ($.d == 4)))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
 
         // A || (B && (C && D)): OR wins
-        ValidateJsonValue("($.a == 1) || (($.b == 2) && (($.c == 3) && ($.d == 4)))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) || (($.b == 2) && (($.c == 3) && ($.d == 4)))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // A || (B || (C && D)): OR wins
-        ValidateJsonValue("($.a == 1) || (($.b == 2) || (($.c == 3) && ($.d == 4)))",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) || (($.b == 2) || (($.c == 3) && ($.d == 4)))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
 
         // && binds tighter than ||
         // A && B && C || D  =>  ((A && B) && C) || D: OR wins
-        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3) || ($.d == 4)",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) && ($.b == 2) && ($.c == 3) || ($.d == 4)",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // A || B || C && D  =>  (A || B) || (C && D): OR wins
-        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3) && ($.d == 4)",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) || ($.b == 2) || ($.c == 3) && ($.d == 4)",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
         // A || B && C || D  =>  A || (B && C) || D  =>  (A || (B && C)) || D: OR wins
-        ValidateJsonValue("($.a == 1) || ($.b == 2) && ($.c == 3) || ($.d == 4)",
-            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("strict ($.a == 1) || ($.b == 2) && ($.c == 3) || ($.d == 4)",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2), encodeKey("c") + numSuffix(3), encodeKey("d") + numSuffix(4)});
 
         // ($.a + $.b == "x") has mode=And, nested as part of OR: OR wins
-        ValidateJsonValue("(($.a + $.b == \"x\") || ($.c == 1)) && ($.d == 2)",
-            {"\2a", "\2b", "\2c" + numSuffix(1), "\2d" + numSuffix(2)});
-        ValidateJsonValue("($.d == 2) && (($.a + $.b == \"x\") || ($.c == 1))",
-            {"\2d" + numSuffix(2), "\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("strict (($.a + $.b == \"x\") || ($.c == 1)) && ($.d == 2)",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1), encodeKey("d") + numSuffix(2)});
+        ValidateJsonValue("strict ($.d == 2) && (($.a + $.b == \"x\") || ($.c == 1))",
+            {encodeKey("d") + numSuffix(2), encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
 
         // ($.a[0].b == 1) && ((-$.c.d == 2) && ($.e.* starts with "x"))
-        // -$.c.d == 2: unary makes path Finished, no literal appended, token "\2c\2d"
-        // $.e.* starts with "x": wildcard makes path Finished, token "\2e"
-        ValidateJsonValue("($.a[0].b == 1) && ((-$.c.d == 2) && ($.e.* starts with \"x\"))",
-            {"\2a\2b" + numSuffix(1), "\2c\2d", "\2e"});
+        // -$.c.d == 2: unary makes path Finished, no literal appended, token encodeKey("c") + encodeKey("d")
+        // $.e.* starts with "x": wildcard makes path Finished, token encodeKey("e")
+        ValidateJsonValue("strict ($.a[0].b == 1) && ((-$.c.d == 2) && ($.e.* starts with \"x\"))",
+            {encodeKey("a") + arrayItemSuffix + encodeKey("b") + numSuffix(1), encodeKey("c") + encodeKey("d"), encodeKey("e")});
 
         // ($.a.b.c starts with "x") && ($.d.size() == 3) && ($.e[0] + $.f.abs() == 5)
         // $.e[0] + $.f.abs(): both sub-paths collected, mode=And, arithmetic Finished, no literal appended
-        ValidateJsonValue("($.a.b.c starts with \"x\") && ($.d.size() == 3) && ($.e[0] + $.f.abs() == 5)",
-            {"\2a\2b\2c", "\2d", "\2e", "\2f"});
+        ValidateJsonValue("strict ($.a.b.c starts with \"x\") && ($.d.size() == 3) && ($.e[0] + $.f.abs() == 5)",
+            {encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("d"), encodeKey("e") + arrayItemSuffix, encodeKey("f")});
 
         // (exists($.a.b[0]) && ($.c.d == "x")) && (($.e like_regex ".*") && (+$.f.g.h == 0))
-        // +$.f.g.h == 0: unary makes path Finished, no literal appended, token "\2f\2g\2h"
-        ValidateJsonValue("(exists($.a.b[0]) && ($.c.d == \"x\")) && (($.e like_regex \".*\") && (+$.f.g.h == 0))",
-            {"\2a\2b", "\2c\2d" + strSuffix("x"), "\2e", "\2f\2g\2h"});
+        // +$.f.g.h == 0: unary makes path Finished, no literal appended, token encodeKey("f") + encodeKey("g") + encodeKey("h")
+        ValidateJsonValue("strict (exists($.a.b[0]) && ($.c.d == \"x\")) && (($.e like_regex \".*\") && (+$.f.g.h == 0))",
+            {encodeKey("a") + encodeKey("b") + arrayItemSuffix, encodeKey("c") + encodeKey("d") + strSuffix("x"), encodeKey("e"), encodeKey("f") + encodeKey("g") + encodeKey("h")});
 
         // All five binary arithmetic ops as AND operands - each produces mode=And, all compatible
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c - $.d == \"y\") && ($.e * $.f == \"z\")",
-            {"\2a", "\2b", "\2c", "\2d", "\2e", "\2f"});
-        ValidateJsonValue("($.a / $.b == \"x\") && ($.c % $.d == \"y\") && ($.e == 1)",
-            {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && ($.c - $.d == \"y\") && ($.e * $.f == \"z\")",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e"), encodeKey("f")});
+        ValidateJsonValue("strict ($.a / $.b == \"x\") && ($.c % $.d == \"y\") && ($.e == 1)",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e") + numSuffix(1)});
 
         // Unary on both sides of AND - each makes path Finished, literal not appended
-        ValidateJsonValue("(-$.a.b == 1) && (+$.c.d.e == 2) && (-$.f[0] == 3)",
-            {"\2a\2b", "\2c\2d\2e", "\2f"});
+        ValidateJsonValue("strict (-$.a.b == 1) && (+$.c.d.e == 2) && (-$.f[0] == 3)",
+            {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d") + encodeKey("e"), encodeKey("f") + arrayItemSuffix});
 
         // ($.a.size() == 3) || (($.b[0] == "x") || (-$.c.d.e == 1))
         // Right inner OR: two NotSet operands, Or, outer OR: left=NotSet, right=Or, Or
-        ValidateJsonValue("($.a.size() == 3) || (($.b[0] == \"x\") || (-$.c.d.e == 1))",
-            {"\2a", "\2b" + strSuffix("x"), "\2c\2d\2e"});
+        ValidateJsonValue("strict ($.a.size() == 3) || (($.b[0] == \"x\") || (-$.c.d.e == 1))",
+            {encodeKey("a"), encodeKey("b") + arrayItemSuffix + strSuffix("x"), encodeKey("c") + encodeKey("d") + encodeKey("e")});
 
         // ($.a starts with "x") || ($.b.* == "y") || exists($.c.d[0])
-        // $.b.* == "y": wildcard Finished, no literal, token "\2b"
-        ValidateJsonValue("($.a starts with \"x\") || ($.b.* == \"y\") || exists($.c.d[0])",
-            {"\2a", "\2b", "\2c\2d"});
+        // $.b.* == "y": wildcard Finished, no literal, token encodeKey("b")
+        ValidateJsonValue("strict ($.a starts with \"x\") || ($.b.* == \"y\") || exists($.c.d[0])",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c") + encodeKey("d") + arrayItemSuffix});
 
         // ($.a[1 to 3].b like_regex ".*") || ((-$.c == 0) || ($.d.e.keyvalue() == "f"))
-        // $.d.e.keyvalue() == "f": method Finished, no literal, token "\2d\2e"
-        ValidateJsonValue("($.a[1 to 3].b like_regex \".*\") || ((-$.c == 0) || ($.d.e.keyvalue() == \"f\"))",
-            {"\2a\2b", "\2c", "\2d\2e"});
+        // $.d.e.keyvalue() == "f": method Finished, no literal, token encodeKey("d") + encodeKey("e")
+        ValidateJsonValue("strict ($.a[1 to 3].b like_regex \".*\") || ((-$.c == 0) || ($.d.e.keyvalue() == \"f\"))",
+            {encodeKey("a") + arrayItemSuffix + encodeKey("b"), encodeKey("c"), encodeKey("d") + encodeKey("e")});
 
         // Unary on both sides of OR
-        ValidateJsonValue("(-$.a.b == 1) || (+$.c.d == 2) || (-$.e.f.g == 3)",
-            {"\2a\2b", "\2c\2d", "\2e\2f\2g"});
+        ValidateJsonValue("strict (-$.a.b == 1) || (+$.c.d == 2) || (-$.e.f.g == 3)",
+            {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d"), encodeKey("e") + encodeKey("f") + encodeKey("g")});
 
         // ((-$.a.b == 1) && ($.c.size() == 2)) || (exists($.d) && ($.e starts with "x")): OR wins
-        ValidateJsonValue("((-$.a.b == 1) && ($.c.size() == 2)) || (exists($.d) && ($.e starts with \"x\"))",
-            {"\2a\2b", "\2c", "\2d", "\2e"});
+        ValidateJsonValue("strict ((-$.a.b == 1) && ($.c.size() == 2)) || (exists($.d) && ($.e starts with \"x\"))",
+            {encodeKey("a") + encodeKey("b"), encodeKey("c"), encodeKey("d"), encodeKey("e")});
 
         // ($.a like_regex "x.*") || (($.b.abs() == 1) && ($.c[0] starts with "y")): OR wins
-        ValidateJsonValue("($.a like_regex \"x.*\") || ($.b.abs() == 1) && ($.c[0] starts with \"y\")",
-            {"\2a", "\2b", "\2c"});
+        ValidateJsonValue("strict ($.a like_regex \"x.*\") || ($.b.abs() == 1) && ($.c[0] starts with \"y\")",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c") + arrayItemSuffix});
 
         // (($.a + $.b == "x") && (-$.c.d == 1)) || ($.e.f == 2): OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") && (-$.c.d == 1) || ($.e.f == 2)",
-            {"\2a", "\2b", "\2c\2d", "\2e\2f" + numSuffix(2)});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") && (-$.c.d == 1) || ($.e.f == 2)",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c") + encodeKey("d"), encodeKey("e") + encodeKey("f") + numSuffix(2)});
 
         // ($.a[0] starts with "x") || (($.b.c + $.d.e == 3) && exists($.f.g.*)): OR wins
-        ValidateJsonValue("($.a[0] starts with \"x\") || ($.b.c + $.d.e == 3) && exists($.f.g.*)",
-            {"\2a", "\2b\2c", "\2d\2e", "\2f\2g"});
+        ValidateJsonValue("strict ($.a[0] starts with \"x\") || ($.b.c + $.d.e == 3) && exists($.f.g.*)",
+            {encodeKey("a") + arrayItemSuffix, encodeKey("b") + encodeKey("c"), encodeKey("d") + encodeKey("e"), encodeKey("f") + encodeKey("g")});
 
         // (($.a.b[0].c == 1) && ($.d.* starts with "x")) || (-$.e.f.g == 2): OR wins
-        ValidateJsonValue("($.a.b[0].c == 1) && ($.d.* starts with \"x\") || (-$.e.f.g == 2)",
-            {"\2a\2b\2c" + numSuffix(1), "\2d", "\2e\2f\2g"});
+        ValidateJsonValue("strict ($.a.b[0].c == 1) && ($.d.* starts with \"x\") || (-$.e.f.g == 2)",
+            {encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c") + numSuffix(1), encodeKey("d"), encodeKey("e") + encodeKey("f") + encodeKey("g")});
 
         // (($.a like_regex ".*") && ($.b.size() == 0) && ($.c[last] == true)) || ($.d.floor() == 0): OR wins
-        ValidateJsonValue("($.a like_regex \".*\") && ($.b.size() == 0) && ($.c[last] == true) || ($.d.floor() == 0)",
-            {"\2a", "\2b", "\2c" + boolTrueSuffix, "\2d"});
+        ValidateJsonValue("strict ($.a like_regex \".*\") && ($.b.size() == 0) && ($.c[last] == true) || ($.d.floor() == 0)",
+            {encodeKey("a"), encodeKey("b"), encodeKey("c") + arrayItemSuffix + boolTrueSuffix, encodeKey("d")});
 
         // ($.a == 1) || ((-$.b.c.d == 2) && ($.e.size() == 3)): OR wins
-        ValidateJsonValue("($.a == 1) || ((-$.b.c.d == 2) && ($.e.size() == 3))",
-            {"\2a" + numSuffix(1), "\2b\2c\2d", "\2e"});
+        ValidateJsonValue("strict ($.a == 1) || ((-$.b.c.d == 2) && ($.e.size() == 3))",
+            {encodeKey("a") + numSuffix(1), encodeKey("b") + encodeKey("c") + encodeKey("d"), encodeKey("e")});
 
         // All five arithmetic ops with two paths inside OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
-        ValidateJsonValue("($.a - $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
-        ValidateJsonValue("($.a * $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
-        ValidateJsonValue("($.a / $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
-        ValidateJsonValue("($.a % $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("strict ($.a + $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a - $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a * $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a / $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
+        ValidateJsonValue("strict ($.a % $.b == \"x\") || ($.c == 1)", {encodeKey("a"), encodeKey("b"), encodeKey("c") + numSuffix(1)});
     }
 
     // Filter predicates allow the collector to use predicate constraints for path narrowing
-    // $.a ? (@.b == 10)  =>  ["\2a\2b" + numSuffix(10)]
+    // $.a ? (@.b == 10)  =>  [encodeKey("a") + encodeKey("b") + numSuffix(10)]
     Y_UNIT_TEST(CollectPath_FilterPredicate) {
         // Basic: simple path before ?, simple equality predicate
-        ValidateJsonExists("$.a ? (@.b == 10)", {"\2a\2b" + numSuffix(10)});
-        ValidateJsonExists("$.a ? (@.b == -(+10))", {"\2a\2b" + numSuffix(-10)});
-        ValidateJsonExists("$.a ? (@.b == \"hello\")", {"\2a\2b" + strSuffix("hello")});
-        ValidateJsonExists("$.a ? (@.b == true)", {"\2a\2b" + boolTrueSuffix});
-        ValidateJsonExists("$.a ? (@.b == false)", {"\2a\2b" + boolFalseSuffix});
-        ValidateJsonExists("$.a ? (@.b == null)", {"\2a\2b" + nullSuffix});
-        ValidateJsonExists("$.a ? (-10 == @.b)", {"\2a\2b" + numSuffix(-10)});
-        ValidateJsonExists("$.a ? (\"hello\" == @.b)", {"\2a\2b" + strSuffix("hello")});
-        ValidateJsonExists("$ ? (@.a == 1)", {"\2a" + numSuffix(1)});
-        ValidateJsonExists("$ ? (@.key == \"x\")", {"\4key" + strSuffix("x")});
+        ValidateJsonExists("strict $.a ? (@.b == 10)", {encodeKey("a") + encodeKey("b") + numSuffix(10)});
+        ValidateJsonExists("strict $.a ? (@.b == -(+10))", {encodeKey("a") + encodeKey("b") + numSuffix(-10)});
+        ValidateJsonExists("strict $.a ? (@.b == \"hello\")", {encodeKey("a") + encodeKey("b") + strSuffix("hello")});
+        ValidateJsonExists("strict $.a ? (@.b == true)", {encodeKey("a") + encodeKey("b") + boolTrueSuffix});
+        ValidateJsonExists("strict $.a ? (@.b == false)", {encodeKey("a") + encodeKey("b") + boolFalseSuffix});
+        ValidateJsonExists("strict $.a ? (@.b == null)", {encodeKey("a") + encodeKey("b") + nullSuffix});
+        ValidateJsonExists("strict $.a ? (-10 == @.b)", {encodeKey("a") + encodeKey("b") + numSuffix(-10)});
+        ValidateJsonExists("strict $.a ? (\"hello\" == @.b)", {encodeKey("a") + encodeKey("b") + strSuffix("hello")});
+        ValidateJsonExists("strict $ ? (@.a == 1)", {encodeKey("a") + numSuffix(1)});
+        ValidateJsonExists("strict $ ? (@.key == \"x\")", {encodeKey("key") + strSuffix("x")});
 
         // @ == literal: equality on the filter object itself, prefix becomes the full token
-        ValidateJsonExists("$.a ? (@ == \"hello\")", {"\2a" + strSuffix("hello")});
-        ValidateJsonExists("$.a ? (@ == -42)", {"\2a" + numSuffix(-42)});
-        ValidateJsonExists("$.a ? (@ == true)", {"\2a" + boolTrueSuffix});
-        ValidateJsonExists("$.a ? (@ == null)", {"\2a" + nullSuffix});
-        ValidateJsonExists("$.a.b ? (@ == \"x\")", {"\2a\2b" + strSuffix("x")});
-        ValidateJsonExists("$ ? (@ == 0)", {numSuffix(0)});
+        ValidateJsonExists("strict $.a ? (@ == \"hello\")", {encodeKey("a") + strSuffix("hello")});
+        ValidateJsonExists("strict $.a ? (@ == -42)", {encodeKey("a") + numSuffix(-42)});
+        ValidateJsonExists("strict $.a ? (@ == true)", {encodeKey("a") + boolTrueSuffix});
+        ValidateJsonExists("strict $.a ? (@ == null)", {encodeKey("a") + nullSuffix});
+        ValidateJsonExists("strict $.a.b ? (@ == \"x\")", {encodeKey("a") + encodeKey("b") + strSuffix("x")});
+        ValidateJsonExists("strict $ ? (@ == 0)", {numSuffix(0)});
 
         // @ starts with / like_regex: predicate on the filter object itself
-        ValidateJsonExists("$.a ? (@ starts with \"x\")", {"\2a"});
-        ValidateJsonExists("$.a.b ? (@ starts with \"hello\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@ like_regex \"[a-z]+\")", {"\2a"});
-        ValidateJsonExists("$.a.b.c ? (@ like_regex \".*\")", {"\2a\2b\2c"});
+        ValidateJsonExists("strict $.a ? (@ starts with \"x\")", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.b ? (@ starts with \"hello\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@ like_regex \"[a-z]+\")", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.b.c ? (@ like_regex \".*\")", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
 
         // exists(@): filter predicate is exists on the filter object
-        ValidateJsonExists("$.a ? (exists(@))", {"\2a"});
-        ValidateJsonExists("$.a.b ? (exists(@))", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (exists(@))", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.b ? (exists(@))", {encodeKey("a") + encodeKey("b")});
 
         // @[0].b: array subscript on filter object, then member access
-        ValidateJsonExists("$.a ? (@[0].b == 1)", {"\2a\2b" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (@[last].b == \"x\")", {"\2a\2b" + strSuffix("x")});
-        ValidateJsonExists("$.a ? (@[*].b == true)", {"\2a\2b" + boolTrueSuffix});
+        ValidateJsonExists("strict $.a ? (@[0].b == 1)", {encodeKey("a") + arrayItemSuffix + encodeKey("b") + numSuffix(1)});
+        ValidateJsonExists("strict $.a ? (@[last].b == \"x\")", {encodeKey("a") + arrayItemSuffix + encodeKey("b") + strSuffix("x")});
+        ValidateJsonExists("strict $.a ? (@[*].b == true)", {encodeKey("a") + arrayItemSuffix + encodeKey("b") + boolTrueSuffix});
 
         // FilterObject via wildcard member access, finishes the path, so literal is not appended
-        ValidateJsonExists("$.a ? (@.* == \"x\")", {"\2a"});
-        ValidateJsonExists("$.a ? (@.b.* starts with \"x\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.* == 1)", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.* == \"x\")", {encodeKey("a")});
+        ValidateJsonExists("strict $.a ? (@.b.* starts with \"x\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.* == 1)", {encodeKey("a") + encodeKey("b")});
 
         // Methods finish the path, so literal is not appended
-        ValidateJsonExists("$.a ? (@.b.size() == 3)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.abs() == 1)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.floor() == 0)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.ceiling() == 5)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.type() == \"number\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.double() == 1)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.keyvalue() == \"x\")", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b.size() == 3)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.abs() == 1)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.floor() == 0)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.ceiling() == 5)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.type() == \"number\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.double() == 1)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.keyvalue() == \"x\")", {encodeKey("a") + encodeKey("b")});
         // method result checked in AND: both paths collected
-        ValidateJsonExists("$.a ? (@.b.size() == +3 && @.c == -1)", {"\2a\2b", "\2a\2c" + numSuffix(-1)});
+        ValidateJsonExists("strict $.a ? (@.b.size() == +3 && @.c == -1)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c") + numSuffix(-1)});
 
         // Unary finishes the path, so literal is not appended
-        ValidateJsonExists("$.a ? (-@.b == 5)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (+@.b == 5)", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (-@.b.c.d == 0)", {"\2a\2b\2c\2d"});
-        ValidateJsonExists("$.a ? (-@.b == 5 && @.c == 1)", {"\2a\2b", "\2a\2c" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (-@.b == 5 || +@.c == 2)", {"\2a\2b", "\2a\2c"});
+        ValidateJsonExists("strict $.a ? (-@.b == 5)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (+@.b == 5)", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (-@.b.c.d == 0)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d")});
+        ValidateJsonExists("strict $.a ? (-@.b == 5 && @.c == 1)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c") + numSuffix(1)});
+        ValidateJsonExists("strict $.a ? (-@.b == 5 || +@.c == 2)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
 
         // All five arithmetic operators: path + path, both tokens, no literal suffix
-        ValidateJsonExists("$.key ? (@.a + @.b == +5)", {"\4key\2a", "\4key\2b"});
-        ValidateJsonExists("$.key ? (@.a - @.b == 0)", {"\4key\2a", "\4key\2b"});
-        ValidateJsonExists("$.key ? (@.a * @.b == 10)", {"\4key\2a", "\4key\2b"});
-        ValidateJsonExists("$.key ? (@.a / @.b == 2)", {"\4key\2a", "\4key\2b"});
-        ValidateJsonExists("$.key ? (@.a % @.b == 1)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("strict $.key ? (@.a + @.b == +5)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
+        ValidateJsonExists("strict $.key ? (@.a - @.b == 0)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
+        ValidateJsonExists("strict $.key ? (@.a * @.b == 10)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
+        ValidateJsonExists("strict $.key ? (@.a / @.b == 2)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
+        ValidateJsonExists("strict $.key ? (@.a % @.b == 1)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b")});
         // path + literal: literal side dropped by CollectArithmeticOperand, only path token
-        ValidateJsonExists("$.key ? (@.a + 1 == 5)", {"\4key\2a"});
-        ValidateJsonExists("$.key ? (1 - @.a == 5)", {"\4key\2a"});
-        ValidateJsonExists("$.key ? (@.a * (-2) == -10)", {"\4key\2a"});
+        ValidateJsonExists("strict $.key ? (@.a + 1 == 5)", {encodeKey("key") + encodeKey("a")});
+        ValidateJsonExists("strict $.key ? (1 - @.a == 5)", {encodeKey("key") + encodeKey("a")});
+        ValidateJsonExists("strict $.key ? (@.a * (-2) == -10)", {encodeKey("key") + encodeKey("a")});
         // three paths via chained arithmetic
-        ValidateJsonExists("$.key ? (@.a + @.b + @.c == 0)", {"\4key\2a", "\4key\2b", "\4key\2c"});
+        ValidateJsonExists("strict $.key ? (@.a + @.b + @.c == 0)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c")});
         // arithmetic with deeper filter object paths
-        ValidateJsonExists("$.x ? (@.a.b + @.c.d == 0)", {"\2x\2a\2b", "\2x\2c\2d"});
+        ValidateJsonExists("strict $.x ? (@.a.b + @.c.d == 0)", {encodeKey("x") + encodeKey("a") + encodeKey("b"), encodeKey("x") + encodeKey("c") + encodeKey("d")});
         // arithmetic with two paths produces mode=And, compatible with AND
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 && @.c == 1)", {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1)});
+        ValidateJsonExists("strict $.key ? (@.a + @.b == 5 && @.c == 1)", {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c") + numSuffix(1)});
 
         // StartsWith finishes the path
-        ValidateJsonExists("$.a ? (@.b starts with \"x\")", {"\2a\2b"});
-        ValidateJsonExists("$.a.b.c ? (@.d starts with \"abc\")", {"\2a\2b\2c\2d"});
-        ValidateJsonValue("$.a ? (@.b starts with \"x\")", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b starts with \"x\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a.b.c ? (@.d starts with \"abc\")", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d")});
+        ValidateJsonValue("strict $.a ? (@.b starts with \"x\")", {encodeKey("a") + encodeKey("b")});
 
         // LikeRegex finishes the path
-        ValidateJsonExists("$.a ? (@.b like_regex \".*\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b.c like_regex \"[0-9]+\")", {"\2a\2b\2c"});
-        ValidateJsonValue("$.a ? (@.b like_regex \"[a-z]+\")", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b like_regex \".*\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b.c like_regex \"[0-9]+\")", {encodeKey("a") + encodeKey("b") + encodeKey("c")});
+        ValidateJsonValue("strict $.a ? (@.b like_regex \"[a-z]+\")", {encodeKey("a") + encodeKey("b")});
 
         // Exists finishes the path
-        ValidateJsonExists("$.a ? (exists(@.b))", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (exists(@.b.c.d))", {"\2a\2b\2c\2d"});
-        ValidateJsonExists("$.a ? (exists(@.b[0]))", {"\2a\2b"});
-        ValidateJsonValue("$.a ? (exists(@.b))", {"\2a\2b"});
+        ValidateJsonExists("strict $.a ? (exists(@.b))", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (exists(@.b.c.d))", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d")});
+        ValidateJsonExists("strict $.a ? (exists(@.b[0]))", {encodeKey("a") + encodeKey("b") + arrayItemSuffix});
+        ValidateJsonValue("strict $.a ? (exists(@.b))", {encodeKey("a") + encodeKey("b")});
 
         // Deeper paths before and inside filter
-        ValidateJsonExists("$.a.b ? (@.c == \"x\")", {"\2a\2b\2c" + strSuffix("x")});
-        ValidateJsonExists("$.a ? (@.b.c == true)", {"\2a\2b\2c" + boolTrueSuffix});
-        ValidateJsonExists("$.a.b.c ? (@.d.e == null)", {"\2a\2b\2c\2d\2e" + nullSuffix});
-        ValidateJsonExists("$.a ? (@.b.c.d == 3.14)", {"\2a\2b\2c\2d" + numSuffix(3.14)});
+        ValidateJsonExists("strict $.a.b ? (@.c == \"x\")", {encodeKey("a") + encodeKey("b") + encodeKey("c") + strSuffix("x")});
+        ValidateJsonExists("strict $.a ? (@.b.c == true)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + boolTrueSuffix});
+        ValidateJsonExists("strict $.a.b.c ? (@.d.e == null)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d") + encodeKey("e") + nullSuffix});
+        ValidateJsonExists("strict $.a ? (@.b.c.d == 3.14)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d") + numSuffix(3.14)});
 
         // Array access in the input path
-        ValidateJsonExists("$.a[0] ? (@.b == 1)", {"\2a\2b" + numSuffix(1)});
-        ValidateJsonExists("$.key[1, 2, 3] ? (@.sub == \"x\")", {"\4key\4sub" + strSuffix("x")});
-        ValidateJsonExists("$.a[0 to last] ? (@.b == true)", {"\2a\2b" + boolTrueSuffix});
+        ValidateJsonExists("strict $.a[0] ? (@.b == 1)", {encodeKey("a") + arrayItemSuffix + encodeKey("b") + numSuffix(1)});
+        ValidateJsonExists("strict $.key[1, 2, 3] ? (@.sub == \"x\")", {encodeKey("key") + arrayItemSuffix + encodeKey("sub") + strSuffix("x")});
+        ValidateJsonExists("strict $.a[0 to last] ? (@.b == true)", {encodeKey("a") + arrayItemSuffix + encodeKey("b") + boolTrueSuffix});
 
 
         // AND: Two equality conditions
-        ValidateJsonExists("$.a ? (@.b == +10 && @.c == +13)", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
-        ValidateJsonExists("$.a.b ? (@.c == \"x\" && @.d == 1)", {"\2a\2b\2c" + strSuffix("x"), "\2a\2b\2d" + numSuffix(1)});
-        ValidateJsonExists("$ ? (@.x == null && @.y == true)", {"\2x" + nullSuffix, "\2y" + boolTrueSuffix});
+        ValidateJsonExists("strict $.a ? (@.b == +10 && @.c == +13)", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c") + numSuffix(13)});
+        ValidateJsonExists("strict $.a.b ? (@.c == \"x\" && @.d == 1)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + strSuffix("x"), encodeKey("a") + encodeKey("b") + encodeKey("d") + numSuffix(1)});
+        ValidateJsonExists("strict $ ? (@.x == null && @.y == true)", {encodeKey("x") + nullSuffix, encodeKey("y") + boolTrueSuffix});
 
         // AND: Three conditions chained with AND
-        ValidateJsonExists("$.key ? (@.a == 1 && @.b == -2 && @.c == 3)", {"\4key\2a" + numSuffix(1), "\4key\2b" + numSuffix(-2), "\4key\2c" + numSuffix(3)});
+        ValidateJsonExists("strict $.key ? (@.a == 1 && @.b == -2 && @.c == 3)", {encodeKey("key") + encodeKey("a") + numSuffix(1), encodeKey("key") + encodeKey("b") + numSuffix(-2), encodeKey("key") + encodeKey("c") + numSuffix(3)});
 
         // AND: Four conditions chained with AND (two pairs)
-        ValidateJsonExists("$.a ? ((@.b == 1 && @.c == 2) && (@.d == 3 && @.e == 4))",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2),
-             "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)});
+        ValidateJsonExists("strict $.a ? ((@.b == 1 && @.c == 2) && (@.d == 3 && @.e == 4))",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2),
+             encodeKey("a") + encodeKey("d") + numSuffix(3), encodeKey("a") + encodeKey("e") + numSuffix(4)});
 
         // AND: mixing predicate types
-        ValidateJsonExists("$.a ? ((@.b == 1) && (@.c starts with \"x\") && (@.d like_regex \"y.*\") && exists(@.e))",
-            {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d", "\2a\2e"});
+        ValidateJsonExists("strict $.a ? ((@.b == 1) && (@.c starts with \"x\") && (@.d like_regex \"y.*\") && exists(@.e))",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d"), encodeKey("a") + encodeKey("e")});
 
         // AND: mixing methods, unary, wildcard, equality
-        ValidateJsonExists("$.key ? ((@.a == 1) && (@.b.size() == 3) && (-@.c == 0) && (@.d.* starts with \"x\"))",
-            {"\4key\2a" + numSuffix(1), "\4key\2b", "\4key\2c", "\4key\2d"});
+        ValidateJsonExists("strict $.key ? ((@.a == 1) && (@.b.size() == 3) && (-@.c == 0) && (@.d.* starts with \"x\"))",
+            {encodeKey("key") + encodeKey("a") + numSuffix(1), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c"), encodeKey("key") + encodeKey("d")});
 
         // OR: Two equality conditions
-        ValidateJsonExists("$.a ? ((@.b == 10) || (@.c == 13))", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
-        ValidateJsonExists("$.key ? ((@.x == \"a\") || (@.y == \"b\"))", {"\4key\2x" + strSuffix("a"), "\4key\2y" + strSuffix("b")});
+        ValidateJsonExists("strict $.a ? ((@.b == 10) || (@.c == 13))", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c") + numSuffix(13)});
+        ValidateJsonExists("strict $.key ? ((@.x == \"a\") || (@.y == \"b\"))", {encodeKey("key") + encodeKey("x") + strSuffix("a"), encodeKey("key") + encodeKey("y") + strSuffix("b")});
 
         // OR: Three conditions chained with OR
-        ValidateJsonExists("$.a ? ((@.b == 1) || (@.c == 2) || (@.d == 3))", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? ((@.b == 1) || (@.c == 2) || (@.d == 3))", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)});
 
         // OR: Four conditions chained with OR (two pairs)
-        ValidateJsonExists("$.a ? ((@.b == 1 || @.c == 2) || (@.d == 3 || @.e == 4))",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2),
-             "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)});
+        ValidateJsonExists("strict $.a ? ((@.b == 1 || @.c == 2) || (@.d == 3 || @.e == 4))",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2),
+             encodeKey("a") + encodeKey("d") + numSuffix(3), encodeKey("a") + encodeKey("e") + numSuffix(4)});
 
         // OR: mixing predicate types
-        ValidateJsonExists("$.a ? ((@.b == 1) || (@.c starts with \"x\") || (@.d like_regex \"y.*\") || exists(@.e))",
-            {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d", "\2a\2e"});
+        ValidateJsonExists("strict $.a ? ((@.b == 1) || (@.c starts with \"x\") || (@.d like_regex \"y.*\") || exists(@.e))",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d"), encodeKey("a") + encodeKey("e")});
 
         // AND on left of OR: OR wins
-        ValidateJsonExists("$.a ? ((@.b == 1 && @.c == 2) || @.d == 3)", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? ((@.b == 1 && @.c == 2) || @.d == 3)", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)});
         // OR on right of AND: OR wins
-        ValidateJsonExists("$.a ? (@.b == 1 && ((@.c == 2) || (@.d == 3)))", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? (@.b == 1 && ((@.c == 2) || (@.d == 3)))", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)});
         // Arithmetic with two paths (mode=And) on left of OR: OR wins
-        ValidateJsonExists("$.a ? ((@.b + @.c == 5) || @.d == 3)", {"\2a\2b", "\2a\2c", "\2a\2d" + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? ((@.b + @.c == 5) || @.d == 3)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d") + numSuffix(3)});
         // Arithmetic with two paths (mode=And) on right of OR: OR wins
-        ValidateJsonExists("$.a ? (@.b == 1 || (@.c + @.d == 5))", {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("strict $.a ? (@.b == 1 || (@.c + @.d == 5))", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
         // (A || B) inside AND chain: OR wins
-        ValidateJsonExists("$.a ? (((@.b == 1) || (@.c == 2)) && @.d == 3)", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? (((@.b == 1) || (@.c == 2)) && @.d == 3)", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)});
 
         // Finished input path (wildcard/method) - filter predicate can't narrow
-        ValidateJsonExists("$.* ? (@.b == 1)", {""});
-        ValidateJsonExists("$.a.* ? (@.b == 1)", {"\2a"});
-        ValidateJsonExists("$.a.b.* ? (@.c == \"x\")", {"\2a\2b"});
+        ValidateJsonExists("strict $.* ? (@.b == 1)", {""});
+        ValidateJsonExists("strict $.a.* ? (@.b == 1)", {encodeKey("a")});
+        ValidateJsonExists("strict $.a.b.* ? (@.c == \"x\")", {encodeKey("a") + encodeKey("b")});
 
         // Filter is Finished - further member access is dropped
-        ValidateJsonExists("$.a ? (@.b == 10) .c", {"\2a\2b" + numSuffix(10)});
+        ValidateJsonExists("strict $.a ? (@.b == 10) .c", {encodeKey("a") + encodeKey("b") + numSuffix(10)});
 
         // JsonExists explicitly: filter allows all predicate types even though
-        ValidateJsonExists("$.a ? (@.b == 10)", {"\2a\2b" + numSuffix(10)});
-        ValidateJsonExists("$.a ? (@.b starts with \"x\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b like_regex \".*\")", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (exists(@.b))", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b == 10 && @.c starts with \"x\" && exists(@.d))", {"\2a\2b" + numSuffix(10), "\2a\2c", "\2a\2d"});
-        ValidateJsonExists("$.a ? ((@.b == 10) || (@.c starts with \"x\") || exists(@.d))", {"\2a\2b" + numSuffix(10), "\2a\2c", "\2a\2d"});
-        ValidateJsonExists("$.a ? (@.b + @.c == 5)", {"\2a\2b", "\2a\2c"});
+        ValidateJsonExists("strict $.a ? (@.b == 10)", {encodeKey("a") + encodeKey("b") + numSuffix(10)});
+        ValidateJsonExists("strict $.a ? (@.b starts with \"x\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b like_regex \".*\")", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (exists(@.b))", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b == 10 && @.c starts with \"x\" && exists(@.d))", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
+        ValidateJsonExists("strict $.a ? ((@.b == 10) || (@.c starts with \"x\") || exists(@.d))", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
+        ValidateJsonExists("strict $.a ? (@.b + @.c == 5)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
 
         // JsonValue also works (filter allowed predicates in both callable types)
-        ValidateJsonValue("$.a ? (@.b == 10)", {"\2a\2b" + numSuffix(10)});
-        ValidateJsonValue("$.a ? (@.b == 10 && @.c == 13)", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
-        ValidateJsonValue("$.a ? ((@.b == 10) || (@.c == 13))", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
-        ValidateJsonValue("$.a ? (@.b + @.c == 5)", {"\2a\2b", "\2a\2c"});
-        ValidateJsonValue("$.a ? (@.b == @.c)", {"\2a\2b", "\2a\2c"});
-        ValidateJsonValue("$.a ? (@.b == $.c)", {"\2a\2b", "\2c"});
-        ValidateJsonValue("$.a ? (@ == @.b)", {"\2a", "\2a\2b"});
+        ValidateJsonValue("strict $.a ? (@.b == 10)", {encodeKey("a") + encodeKey("b") + numSuffix(10)});
+        ValidateJsonValue("strict $.a ? (@.b == 10 && @.c == 13)", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c") + numSuffix(13)});
+        ValidateJsonValue("strict $.a ? ((@.b == 10) || (@.c == 13))", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c") + numSuffix(13)});
+        ValidateJsonValue("strict $.a ? (@.b + @.c == 5)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
+        ValidateJsonValue("strict $.a ? (@.b == @.c)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
+        ValidateJsonValue("strict $.a ? (@.b == $.c)", {encodeKey("a") + encodeKey("b"), encodeKey("c")});
+        ValidateJsonValue("strict $.a ? (@ == @.b)", {encodeKey("a"), encodeKey("a") + encodeKey("b")});
 
         // Nested filter: exists(@.b ? (@.c == 1)) inside an outer filter
-        ValidateJsonExists("$.a ? (exists(@.b ? (@.c == 1)))", {"\2a\2b\2c" + numSuffix(1)});
-        ValidateJsonExists("$.key ? (exists(@.sub ? (@.val == \"x\")))", {"\4key\4sub\4val" + strSuffix("x")});
+        ValidateJsonExists("strict $.a ? (exists(@.b ? (@.c == 1)))", {encodeKey("a") + encodeKey("b") + encodeKey("c") + numSuffix(1)});
+        ValidateJsonExists("strict $.key ? (exists(@.sub ? (@.val == \"x\")))", {encodeKey("key") + encodeKey("sub") + encodeKey("val") + strSuffix("x")});
 
         // @ outside filter context is an error
         ValidateError("@", filterError);
@@ -1544,9 +1545,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("@ starts with \"x\"", filterError, {}, {}, ECallableType::JsonValue);
 
         // Both sides of == are paths: AND-merge of filter-relative paths
-        ValidateJsonExists("$.a ? (@.b == @.c)", {"\2a\2b", "\2a\2c"});
-        ValidateJsonExists("$.a ? (@.b == $.c)", {"\2a\2b", "\2c"});
-        ValidateJsonExists("$.a ? (@ == @.b)", {"\2a", "\2a\2b"});
+        ValidateJsonExists("strict $.a ? (@.b == @.c)", {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")});
+        ValidateJsonExists("strict $.a ? (@.b == $.c)", {encodeKey("a") + encodeKey("b"), encodeKey("c")});
+        ValidateJsonExists("strict $.a ? (@ == @.b)", {encodeKey("a"), encodeKey("a") + encodeKey("b")});
         // Both sides are literals
         ValidateError("$.a ? (1 == 2)", compError, {}, {}, ECallableType::JsonExists);
         ValidateError("$.a ? (\"x\" == \"y\")", compError, {}, {}, ECallableType::JsonExists);
@@ -1608,255 +1609,255 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Chained filters -> AND
     Y_UNIT_TEST(CollectPath_FilterChain) {
         // Basic comparisons
-        ValidateJsonExists("$.key ? (@.v1 >= 10) ? (@.v2 <= 20)", {"\4key\3v1", "\4key\3v2"}, TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.key ? (@.v1 >= 10 && @.v2 <= 20)", {"\4key\3v1", "\4key\3v2"}, TCollectResult::ETokensMode::And);
+        ValidateJsonExists("strict $.key ? (@.v1 >= 10) ? (@.v2 <= 20)", {encodeKey("key") + encodeKey("v1"), encodeKey("key") + encodeKey("v2")}, TCollectResult::ETokensMode::And);
+        ValidateJsonExists("strict $.key ? (@.v1 >= 10 && @.v2 <= 20)", {encodeKey("key") + encodeKey("v1"), encodeKey("key") + encodeKey("v2")}, TCollectResult::ETokensMode::And);
 
         // Equality with literals
-        ValidateJsonExists("$.key ? (@.v1 == 10) ? (@.v2 == 20)", {"\4key\3v1" + numSuffix(10), "\4key\3v2" + numSuffix(20)});
-        ValidateJsonExists("$.key ? (@.v1 == 10 && @.v2 == 20)", {"\4key\3v1" + numSuffix(10), "\4key\3v2" + numSuffix(20)});
+        ValidateJsonExists("strict $.key ? (@.v1 == 10) ? (@.v2 == 20)", {encodeKey("key") + encodeKey("v1") + numSuffix(10), encodeKey("key") + encodeKey("v2") + numSuffix(20)});
+        ValidateJsonExists("strict $.key ? (@.v1 == 10 && @.v2 == 20)", {encodeKey("key") + encodeKey("v1") + numSuffix(10), encodeKey("key") + encodeKey("v2") + numSuffix(20)});
 
         // Three filters in a chain
-        ValidateJsonExists("$.a ? (@.b == 1) ? (@.c == 2) ? (@.d == 3)", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
-        ValidateJsonExists("$.a ? (@.b == 1 && @.c == 2 && @.d == 3)", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? (@.b == 1) ? (@.c == 2) ? (@.d == 3)", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)});
+        ValidateJsonExists("strict $.a ? (@.b == 1 && @.c == 2 && @.d == 3)", {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)});
 
         // Mixed predicate types
-        ValidateJsonExists("$.a ? (@.b == 10) ? (@.c starts with \"x\") ? (exists(@.d))", {"\2a\2b" + numSuffix(10), "\2a\2c", "\2a\2d"});
-        ValidateJsonExists("$.a ? (@.b == 10 && @.c starts with \"x\" && exists(@.d))", {"\2a\2b" + numSuffix(10), "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("strict $.a ? (@.b == 10) ? (@.c starts with \"x\") ? (exists(@.d))", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
+        ValidateJsonExists("strict $.a ? (@.b == 10 && @.c starts with \"x\" && exists(@.d))", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d")});
 
         // @ on filter object itself
-        ValidateJsonExists("$.a ? (@ == \"x\") ? (@.b == 1)", {"\2a" + strSuffix("x"), "\2a\2b" + numSuffix(1)});
+        ValidateJsonExists("strict $.a ? (@ == \"x\") ? (@.b == 1)", {encodeKey("a") + strSuffix("x"), encodeKey("a") + encodeKey("b") + numSuffix(1)});
 
         // Deeper input path
-        ValidateJsonExists("$.a.b ? (@.c == 1) ? (@.d == 2)", {"\2a\2b\2c" + numSuffix(1), "\2a\2b\2d" + numSuffix(2)});
+        ValidateJsonExists("strict $.a.b ? (@.c == 1) ? (@.d == 2)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + numSuffix(1), encodeKey("a") + encodeKey("b") + encodeKey("d") + numSuffix(2)});
 
         // JsonValue
-        ValidateJsonValue("$.key ? (@.v1 > 0) ? (@.v2 < 10)", {"\4key\3v1", "\4key\3v2"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("strict $.key ? (@.v1 > 0) ? (@.v2 < 10)", {encodeKey("key") + encodeKey("v1"), encodeKey("key") + encodeKey("v2")}, TCollectResult::ETokensMode::And);
 
         // Chained filter then member access
-        ValidateJsonValue("$.a ? (@.b == 10) ? (@.c == 20).d", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(20)});
+        ValidateJsonValue("strict $.a ? (@.b == 10) ? (@.c == 20).d", {encodeKey("a") + encodeKey("b") + numSuffix(10), encodeKey("a") + encodeKey("c") + numSuffix(20)});
 
         // Wildcard in first filter, equality in second
-        ValidateJsonExists("$.a ? (@.* == \"x\") ? (@.b == 1)", {"\2a\2b" + numSuffix(1)});
+        ValidateJsonExists("strict $.a ? (@.* == \"x\") ? (@.b == 1)", {encodeKey("a") + encodeKey("b") + numSuffix(1)});
 
         // && inside jsonpath
-        ValidateJsonExists("$.a ? (@.b == 1 && @.c == 2) ? (@.d == 3)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)},
+        ValidateJsonExists("strict $.a ? (@.b == 1 && @.c == 2) ? (@.d == 3)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)},
             TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.a ? (@.b == 1) ? (@.c == 2 && @.d == 3)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)},
+        ValidateJsonExists("strict $.a ? (@.b == 1) ? (@.c == 2 && @.d == 3)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)},
             TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.a ? (@.b == 1 && @.c == 2) ? (@.d == 3 && @.e == 4)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)},
+        ValidateJsonExists("strict $.a ? (@.b == 1 && @.c == 2) ? (@.d == 3 && @.e == 4)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3), encodeKey("a") + encodeKey("e") + numSuffix(4)},
             TCollectResult::ETokensMode::And);
 
         // || inside jsonpath
-        ValidateJsonExists("$.a ? (@.b == 1 || @.c == 2) ? (@.d == 3)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)},
+        ValidateJsonExists("strict $.a ? (@.b == 1 || @.c == 2) ? (@.d == 3)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.a ? (@.b == 1) ? (@.c == 2 || @.d == 3)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)},
+        ValidateJsonExists("strict $.a ? (@.b == 1) ? (@.c == 2 || @.d == 3)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.a ? (@.b == 1 || @.c == 2) ? (@.d == 3 || @.e == 4)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)},
+        ValidateJsonExists("strict $.a ? (@.b == 1 || @.c == 2) ? (@.d == 3 || @.e == 4)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3), encodeKey("a") + encodeKey("e") + numSuffix(4)},
             TCollectResult::ETokensMode::Or);
 
         // Mixed && and || inside
-        ValidateJsonExists("$.a ? (@.b == 1 && @.c == 2) ? (@.d == 3 || @.e == 4)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)},
+        ValidateJsonExists("strict $.a ? (@.b == 1 && @.c == 2) ? (@.d == 3 || @.e == 4)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3), encodeKey("a") + encodeKey("e") + numSuffix(4)},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.a ? (@.b == 1 || @.c == 2) ? (@.d == 3 && @.e == 4)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)},
+        ValidateJsonExists("strict $.a ? (@.b == 1 || @.c == 2) ? (@.d == 3 && @.e == 4)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3), encodeKey("a") + encodeKey("e") + numSuffix(4)},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.a ? ((@.b < 5) && ((@.c > 1) || (@.d > 2))) ? (@.e == 0)",
-            {"\2a\2b", "\2a\2c", "\2a\2d", "\2a\2e" + numSuffix(0)},
+        ValidateJsonExists("strict $.a ? ((@.b < 5) && ((@.c > 1) || (@.d > 2))) ? (@.e == 0)",
+            {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d"), encodeKey("a") + encodeKey("e") + numSuffix(0)},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.a ? (@.b == 1) ? (((@.c < 5) || (@.d > 1)) && @.e > 2)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d", "\2a\2e"},
+        ValidateJsonExists("strict $.a ? (@.b == 1) ? (((@.c < 5) || (@.d > 1)) && @.e > 2)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c"), encodeKey("a") + encodeKey("d"), encodeKey("a") + encodeKey("e")},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.key ? (@.a < @.b || @.c > @.d) ? (@.e == 1)",
-            {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d", "\4key\2e" + numSuffix(1)},
+        ValidateJsonExists("strict $.key ? (@.a < @.b || @.c > @.d) ? (@.e == 1)",
+            {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c"), encodeKey("key") + encodeKey("d"), encodeKey("key") + encodeKey("e") + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("$.a ? (@.b == 1 && @.c == 2) ? (@.d == 3)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)},
+        ValidateJsonValue("strict $.a ? (@.b == 1 && @.c == 2) ? (@.d == 3)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)},
             TCollectResult::ETokensMode::And);
-        ValidateJsonValue("$.a ? (@.b == 1 || @.c == 2) ? (@.d == 3)",
-            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)},
+        ValidateJsonValue("strict $.a ? (@.b == 1 || @.c == 2) ? (@.d == 3)",
+            {encodeKey("a") + encodeKey("b") + numSuffix(1), encodeKey("a") + encodeKey("c") + numSuffix(2), encodeKey("a") + encodeKey("d") + numSuffix(3)},
             TCollectResult::ETokensMode::Or);
 
         // Arithmetic two-path in chain
-        ValidateJsonExists("$.key ? (@.a + @.b == 5) ? (@.c == 1 || @.d == 2)",
-            {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1), "\4key\2d" + numSuffix(2)},
+        ValidateJsonExists("strict $.key ? (@.a + @.b == 5) ? (@.c == 1 || @.d == 2)",
+            {encodeKey("key") + encodeKey("a"), encodeKey("key") + encodeKey("b"), encodeKey("key") + encodeKey("c") + numSuffix(1), encodeKey("key") + encodeKey("d") + numSuffix(2)},
             TCollectResult::ETokensMode::Or);
     }
 
     // Nested filter: (@ ? (predicate)).member == value
     Y_UNIT_TEST(CollectPath_NestedFilter) {
         // Basic: inner == predicate, outer comparison dropped
-        ValidateJsonExists("$ ? ((@ ? (@.a == 1)).b == 2)", {"\2a" + numSuffix(1)});
-        ValidateJsonExists("$ ? ((@ ? (@.a == \"x\")).b == \"y\")", {"\2a" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? (@.a == true)).b == false)", {"\2a" + boolTrueSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == false)).b == true)", {"\2a" + boolFalseSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == null)).b == null)", {"\2a" + nullSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == -3.14)).b == 0)", {"\2a" + numSuffix(-3.14)});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == 1)).b == 2)", {encodeKey("a") + numSuffix(1)});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == \"x\")).b == \"y\")", {encodeKey("a") + strSuffix("x")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == true)).b == false)", {encodeKey("a") + boolTrueSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == false)).b == true)", {encodeKey("a") + boolFalseSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == null)).b == null)", {encodeKey("a") + nullSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == -3.14)).b == 0)", {encodeKey("a") + numSuffix(-3.14)});
 
         // Reversed literal in inner predicate (literal == @.path)
-        ValidateJsonExists("$ ? ((@ ? (1 == @.a)).b == 2)", {"\2a" + numSuffix(1)});
-        ValidateJsonExists("$ ? ((@ ? (\"x\" == @.a)).b == \"y\")", {"\2a" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? (null == @.a)).b == 0)", {"\2a" + nullSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (1 == @.a)).b == 2)", {encodeKey("a") + numSuffix(1)});
+        ValidateJsonExists("strict $ ? ((@ ? (\"x\" == @.a)).b == \"y\")", {encodeKey("a") + strSuffix("x")});
+        ValidateJsonExists("strict $ ? ((@ ? (null == @.a)).b == 0)", {encodeKey("a") + nullSuffix});
 
         // Outer path contributes to the index prefix
-        ValidateJsonExists("$.key ? ((@ ? (@.sub == \"x\")).other == \"y\")", {"\4key\4sub" + strSuffix("x")});
-        ValidateJsonExists("$.a.b ? ((@ ? (@.c == true)).d == false)", {"\2a\2b\2c" + boolTrueSuffix});
-        ValidateJsonExists("$.arr ? ((@ ? (@.id == 9)).name == \"x\")", {"\4arr\3id" + numSuffix(9)});
-        ValidateJsonExists("$.items ? ((@ ? (@.type == null)).value > 0)", {"\6items\5type" + nullSuffix});
+        ValidateJsonExists("strict $.key ? ((@ ? (@.sub == \"x\")).other == \"y\")", {encodeKey("key") + encodeKey("sub") + strSuffix("x")});
+        ValidateJsonExists("strict $.a.b ? ((@ ? (@.c == true)).d == false)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + boolTrueSuffix});
+        ValidateJsonExists("strict $.arr ? ((@ ? (@.id == 9)).name == \"x\")", {encodeKey("arr") + encodeKey("id") + numSuffix(9)});
+        ValidateJsonExists("strict $.items ? ((@ ? (@.type == null)).value > 0)", {encodeKey("items") + encodeKey("type") + nullSuffix});
 
         // Comparison operators != == in inner predicate: literal not appended, only path
-        ValidateJsonExists("$ ? ((@ ? (@.n < 10)).label == \"x\")", {"\2n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n > 0)).label == \"x\")", {"\2n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n != 0)).label == \"x\")", {"\2n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n >= 0)).label == \"x\")", {"\2n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n <= 100)).label == \"x\")", {"\2n"});
-        ValidateJsonExists("$.arr ? ((@ ? (@.score >= 5)).rank == 1)", {"\4arr\6score"});
+        ValidateJsonExists("strict $ ? ((@ ? (@.n < 10)).label == \"x\")", {encodeKey("n")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.n > 0)).label == \"x\")", {encodeKey("n")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.n != 0)).label == \"x\")", {encodeKey("n")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.n >= 0)).label == \"x\")", {encodeKey("n")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.n <= 100)).label == \"x\")", {encodeKey("n")});
+        ValidateJsonExists("strict $.arr ? ((@ ? (@.score >= 5)).rank == 1)", {encodeKey("arr") + encodeKey("score")});
 
         // Deeper inner path
-        ValidateJsonExists("$ ? ((@ ? (@.a.b == 1)).c == 2)", {"\2a\2b" + numSuffix(1)});
-        ValidateJsonExists("$.key ? ((@ ? (@.a.b.c == \"x\")).d == \"y\")", {"\4key\2a\2b\2c" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? (@.x.y == null)).z == true)", {"\2x\2y" + nullSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a.b == 1)).c == 2)", {encodeKey("a") + encodeKey("b") + numSuffix(1)});
+        ValidateJsonExists("strict $.key ? ((@ ? (@.a.b.c == \"x\")).d == \"y\")", {encodeKey("key") + encodeKey("a") + encodeKey("b") + encodeKey("c") + strSuffix("x")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.x.y == null)).z == true)", {encodeKey("x") + encodeKey("y") + nullSuffix});
 
         // Array subscript in inner predicate path: subscript is dropped for the index
-        ValidateJsonExists("$ ? ((@ ? (@.a[0] == 1)).b == 2)", {"\2a" + numSuffix(1)});
-        ValidateJsonExists("$ ? ((@ ? (@.a[last] == true)).b == null)", {"\2a" + boolTrueSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a[0].b == \"x\")).c == 1)", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a[0] == 1)).b == 2)", {encodeKey("a") + arrayItemSuffix + numSuffix(1)});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a[last] == true)).b == null)", {encodeKey("a") + arrayItemSuffix + boolTrueSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a[0].b == \"x\")).c == 1)", {encodeKey("a") + arrayItemSuffix + encodeKey("b") + strSuffix("x")});
 
         // Array subscript on @ before inner filter: subscript is dropped for the index
-        ValidateJsonExists("$ ? ((@[0] ? (@.id == 9)).name == \"x\")", {"\3id" + numSuffix(9)});
-        ValidateJsonExists("$ ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {"\4tag" + strSuffix("foo")});
-        ValidateJsonExists("$.items ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {"\6items\4tag" + strSuffix("foo")});
-        ValidateJsonExists("$.k ? ((@[1] ? (@.x == true)).y == false)", {"\2k\2x" + boolTrueSuffix});
+        ValidateJsonExists("strict $ ? ((@[0] ? (@.id == 9)).name == \"x\")", {arrayItemSuffix + encodeKey("id") + numSuffix(9)});
+        ValidateJsonExists("strict $ ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {arrayItemSuffix + encodeKey("tag") + strSuffix("foo")});
+        ValidateJsonExists("strict $.items ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {encodeKey("items") + arrayItemSuffix + encodeKey("tag") + strSuffix("foo")});
+        ValidateJsonExists("strict $.k ? ((@[1] ? (@.x == true)).y == false)", {encodeKey("k") + arrayItemSuffix + encodeKey("x") + boolTrueSuffix});
 
         // Wildcard in inner predicate: path finishes, literal not appended
-        ValidateJsonExists("$ ? ((@ ? (@.* == 1)).x == 2)", {""});
-        ValidateJsonExists("$.key ? ((@ ? (@.* == \"x\")).y == 1)", {"\4key"});
-        ValidateJsonExists("$ ? ((@ ? (@.a.* == null)).b == 1)", {"\2a"});
+        ValidateJsonExists("strict $ ? ((@ ? (@.* == 1)).x == 2)", {""});
+        ValidateJsonExists("strict $.key ? ((@ ? (@.* == \"x\")).y == 1)", {encodeKey("key")});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a.* == null)).b == 1)", {encodeKey("a")});
 
         // Inner AND: both tokens propagate (filter result has multiple tokens)
-        ValidateJsonExists("$ ? ((@ ? (@.a == 1 && @.b == 2)).c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2)});
-        ValidateJsonExists("$.key ? ((@ ? (@.x == \"v\" && @.y == true)).z == null)", {"\4key\2x" + strSuffix("v"), "\4key\2y" + boolTrueSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == null && @.b == false)).c == 1)", {"\2a" + nullSuffix, "\2b" + boolFalseSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == 1 && @.b == 2)).c == 3)", {encodeKey("a") + numSuffix(1), encodeKey("b") + numSuffix(2)});
+        ValidateJsonExists("strict $.key ? ((@ ? (@.x == \"v\" && @.y == true)).z == null)", {encodeKey("key") + encodeKey("x") + strSuffix("v"), encodeKey("key") + encodeKey("y") + boolTrueSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == null && @.b == false)).c == 1)", {encodeKey("a") + nullSuffix, encodeKey("b") + boolFalseSuffix});
 
         // Inner OR: both tokens propagate
-        ValidateJsonExists("$ ? ((@ ? (@.a == 1 || @.a == 2)).b == \"x\")", {"\2a" + numSuffix(1), "\2a" + numSuffix(2)});
-        ValidateJsonExists("$ ? ((@ ? (@.tag == \"foo\" || @.tag == \"bar\")).value == 0)", {"\4tag" + strSuffix("foo"), "\4tag" + strSuffix("bar")});
-        ValidateJsonExists("$.arr ? ((@ ? (@.id == 1 || @.id == 2)).val == true)", {"\4arr\3id" + numSuffix(1), "\4arr\3id" + numSuffix(2)});
+        ValidateJsonExists("strict $ ? ((@ ? (@.a == 1 || @.a == 2)).b == \"x\")", {encodeKey("a") + numSuffix(1), encodeKey("a") + numSuffix(2)});
+        ValidateJsonExists("strict $ ? ((@ ? (@.tag == \"foo\" || @.tag == \"bar\")).value == 0)", {encodeKey("tag") + strSuffix("foo"), encodeKey("tag") + strSuffix("bar")});
+        ValidateJsonExists("strict $.arr ? ((@ ? (@.id == 1 || @.id == 2)).val == true)", {encodeKey("arr") + encodeKey("id") + numSuffix(1), encodeKey("arr") + encodeKey("id") + numSuffix(2)});
 
         // Double nesting: only deepest (innermost) inner filter determines the tokens
-        ValidateJsonExists("$ ? ((@ ? ((@ ? (@.z == 1)).w == 2)).val == 3)", {"\2z" + numSuffix(1)});
-        ValidateJsonExists("$.a ? ((@ ? ((@ ? (@.b == \"x\")).c == \"y\")).d == \"z\")", {"\2a\2b" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? ((@ ? (@.p == null)).q == true)).r == false)", {"\2p" + nullSuffix});
+        ValidateJsonExists("strict $ ? ((@ ? ((@ ? (@.z == 1)).w == 2)).val == 3)", {encodeKey("z") + numSuffix(1)});
+        ValidateJsonExists("strict $.a ? ((@ ? ((@ ? (@.b == \"x\")).c == \"y\")).d == \"z\")", {encodeKey("a") + encodeKey("b") + strSuffix("x")});
+        ValidateJsonExists("strict $ ? ((@ ? ((@ ? (@.p == null)).q == true)).r == false)", {encodeKey("p") + nullSuffix});
     }
 
     Y_UNIT_TEST(CollectPath_Variables) {
         // Equality: variable on the right side, all scalar types
-        ValidateTokens("$.key == $var", {"\4key" + strSuffix("hello")}, {{"var", strSuffix("hello")}});
-        ValidateTokens("$.key == $var", {"\4key" + strSuffix("")}, {{"var", strSuffix("")}});
-        ValidateTokens("$.key == $var", {"\4key" + numSuffix(42)}, {{"var", numSuffix(42)}});
-        ValidateTokens("$.key == $var", {"\4key" + numSuffix(0)}, {{"var", numSuffix(0)}});
-        ValidateTokens("$.key == $var", {"\4key" + numSuffix(3.14)}, {{"var", numSuffix(3.14)}});
-        ValidateTokens("$.key == $var", {"\4key" + numSuffix(-10)}, {{"var", numSuffix(-10)}});
-        ValidateTokens("$.key == $var", {"\4key" + boolTrueSuffix}, {{"var", boolTrueSuffix}});
-        ValidateTokens("$.key == $var", {"\4key" + boolFalseSuffix}, {{"var", boolFalseSuffix}});
-        ValidateTokens("$.key == $var", {"\4key" + nullSuffix}, {{"var", nullSuffix}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + strSuffix("hello")}, {{"var", strSuffix("hello")}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + strSuffix("")}, {{"var", strSuffix("")}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + numSuffix(42)}, {{"var", numSuffix(42)}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + numSuffix(0)}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + numSuffix(3.14)}, {{"var", numSuffix(3.14)}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + numSuffix(-10)}, {{"var", numSuffix(-10)}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + boolTrueSuffix}, {{"var", boolTrueSuffix}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + boolFalseSuffix}, {{"var", boolFalseSuffix}});
+        ValidateTokens("strict $.key == $var", {encodeKey("key") + nullSuffix}, {{"var", nullSuffix}});
 
         // Equality: variable on the left side
-        ValidateTokens("$var == $.key", {"\4key" + strSuffix("hello")}, {{"var", strSuffix("hello")}});
-        ValidateTokens("$var == $.key", {"\4key" + numSuffix(5)}, {{"var", numSuffix(5)}});
-        ValidateTokens("$var == $.key", {"\4key" + boolTrueSuffix}, {{"var", boolTrueSuffix}});
-        ValidateTokens("$var == $.key", {"\4key" + nullSuffix}, {{"var", nullSuffix}});
+        ValidateTokens("strict $var == $.key", {encodeKey("key") + strSuffix("hello")}, {{"var", strSuffix("hello")}});
+        ValidateTokens("strict $var == $.key", {encodeKey("key") + numSuffix(5)}, {{"var", numSuffix(5)}});
+        ValidateTokens("strict $var == $.key", {encodeKey("key") + boolTrueSuffix}, {{"var", boolTrueSuffix}});
+        ValidateTokens("strict $var == $.key", {encodeKey("key") + nullSuffix}, {{"var", nullSuffix}});
 
         // Context object as path
-        ValidateTokens("$ == $var", {strSuffix("root")}, {{"var", strSuffix("root")}});
-        ValidateTokens("$var == $", {numSuffix(0)}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $ == $var", {strSuffix("root")}, {{"var", strSuffix("root")}});
+        ValidateTokens("strict $var == $", {numSuffix(0)}, {{"var", numSuffix(0)}});
 
         // Deeper member access paths
-        ValidateTokens("$.a.b == $var", {"\2a\2b" + strSuffix("x")}, {{"var", strSuffix("x")}});
-        ValidateTokens("$.a.b.c == $var", {"\2a\2b\2c" + numSuffix(1)}, {{"var", numSuffix(1)}});
-        ValidateTokens("$.aba.\"caba\" == $var", {"\4aba\5caba" + boolTrueSuffix}, {{"var", boolTrueSuffix}});
-        ValidateTokens("$var == $.a.b.c", {"\2a\2b\2c" + nullSuffix}, {{"var", nullSuffix}});
+        ValidateTokens("strict $.a.b == $var", {encodeKey("a") + encodeKey("b") + strSuffix("x")}, {{"var", strSuffix("x")}});
+        ValidateTokens("strict $.a.b.c == $var", {encodeKey("a") + encodeKey("b") + encodeKey("c") + numSuffix(1)}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $.aba.\"caba\" == $var", {encodeKey("aba") + encodeKey("caba") + boolTrueSuffix}, {{"var", boolTrueSuffix}});
+        ValidateTokens("strict $var == $.a.b.c", {encodeKey("a") + encodeKey("b") + encodeKey("c") + nullSuffix}, {{"var", nullSuffix}});
 
         // Array access
-        ValidateTokens("$.key[0] == $var", {"\4key" + strSuffix("x")}, {{"var", strSuffix("x")}});
-        ValidateTokens("$.key[last] == $var", {"\4key" + boolTrueSuffix}, {{"var", boolTrueSuffix}});
-        ValidateTokens("$.key[1, 2, 3] == $var", {"\4key" + nullSuffix}, {{"var", nullSuffix}});
-        ValidateTokens("$.a.b[0].c == $var", {"\2a\2b\2c" + numSuffix(7)}, {{"var", numSuffix(7)}});
+        ValidateTokens("strict $.key[0] == $var", {encodeKey("key") + arrayItemSuffix + strSuffix("x")}, {{"var", strSuffix("x")}});
+        ValidateTokens("strict $.key[last] == $var", {encodeKey("key") + arrayItemSuffix + boolTrueSuffix}, {{"var", boolTrueSuffix}});
+        ValidateTokens("strict $.key[1, 2, 3] == $var", {encodeKey("key") + arrayItemSuffix + nullSuffix}, {{"var", nullSuffix}});
+        ValidateTokens("strict $.a.b[0].c == $var", {encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c") + numSuffix(7)}, {{"var", numSuffix(7)}});
 
         // Wildcard member access: path finishes, literal not appended
-        ValidateTokens("$.* == $var", {""}, {{"var", strSuffix("x")}});
-        ValidateTokens("$.a.* == $var", {"\2a"}, {{"var", numSuffix(1)}});
-        ValidateTokens("$var == $.*", {""}, {{"var", strSuffix("x")}});
-        ValidateTokens("$var == $.a.*", {"\2a"}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $.* == $var", {""}, {{"var", strSuffix("x")}});
+        ValidateTokens("strict $.a.* == $var", {encodeKey("a")}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $var == $.*", {""}, {{"var", strSuffix("x")}});
+        ValidateTokens("strict $var == $.a.*", {encodeKey("a")}, {{"var", numSuffix(1)}});
 
         // Methods: path finishes, literal not appended
-        ValidateTokens("$.key.size() == $var", {"\4key"}, {{"var", numSuffix(3)}});
-        ValidateTokens("$.key.abs() == $var", {"\4key"}, {{"var", numSuffix(1)}});
-        ValidateTokens("$.key.type() == $var", {"\4key"}, {{"var", strSuffix("number")}});
-        ValidateTokens("$.a.b.floor() == $var", {"\2a\2b"}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $.key.size() == $var", {encodeKey("key")}, {{"var", numSuffix(3)}});
+        ValidateTokens("strict $.key.abs() == $var", {encodeKey("key")}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $.key.type() == $var", {encodeKey("key")}, {{"var", strSuffix("number")}});
+        ValidateTokens("strict $.a.b.floor() == $var", {encodeKey("a") + encodeKey("b")}, {{"var", numSuffix(0)}});
 
         // Unary arithmetic on path: path finishes, literal not appended
-        ValidateTokens("-$.key == $var", {"\4key"}, {{"var", numSuffix(1)}});
-        ValidateTokens("+$.key == $var", {"\4key"}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict -$.key == $var", {encodeKey("key")}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict +$.key == $var", {encodeKey("key")}, {{"var", numSuffix(0)}});
 
         // Multiple variables: AND
-        ValidateTokens("($.a == $v1) && ($.b == $v2)",
-            {"\2a" + strSuffix("x"), "\2b" + numSuffix(1)},
+        ValidateTokens("strict ($.a == $v1) && ($.b == $v2)",
+            {encodeKey("a") + strSuffix("x"), encodeKey("b") + numSuffix(1)},
             {{"v1", strSuffix("x")}, {"v2", numSuffix(1)}}, {},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == $v) && ($.b == $v)",
-            {"\2a" + nullSuffix, "\2b" + nullSuffix},
+        ValidateTokens("strict ($.a == $v) && ($.b == $v)",
+            {encodeKey("a") + nullSuffix, encodeKey("b") + nullSuffix},
             {{"v", nullSuffix}}, {},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == $v1) && ($.b == $v2) && ($.c == $v3)",
-            {"\2a" + strSuffix("a"), "\2b" + numSuffix(2), "\2c" + boolTrueSuffix},
+        ValidateTokens("strict ($.a == $v1) && ($.b == $v2) && ($.c == $v3)",
+            {encodeKey("a") + strSuffix("a"), encodeKey("b") + numSuffix(2), encodeKey("c") + boolTrueSuffix},
             {{"v1", strSuffix("a")}, {"v2", numSuffix(2)}, {"v3", boolTrueSuffix}}, {},
             ECallableType::JsonValue, EMode::And);
 
         // Multiple variables: OR
-        ValidateTokens("($.a == $v1) || ($.b == $v2)",
-            {"\2a" + strSuffix("x"), "\2b" + numSuffix(1)},
+        ValidateTokens("strict ($.a == $v1) || ($.b == $v2)",
+            {encodeKey("a") + strSuffix("x"), encodeKey("b") + numSuffix(1)},
             {{"v1", strSuffix("x")}, {"v2", numSuffix(1)}}, {},
             ECallableType::JsonValue, EMode::Or);
-        ValidateTokens("($.key == $v1) || ($.key == $v2)",
-            {"\4key" + strSuffix("a"), "\4key" + strSuffix("b")},
+        ValidateTokens("strict ($.key == $v1) || ($.key == $v2)",
+            {encodeKey("key") + strSuffix("a"), encodeKey("key") + strSuffix("b")},
             {{"v1", strSuffix("a")}, {"v2", strSuffix("b")}}, {},
             ECallableType::JsonValue, EMode::Or);
-        ValidateTokens("($.a == $v1) || ($.b == $v2) || ($.c == $v3)",
-            {"\2a" + boolTrueSuffix, "\2b" + nullSuffix, "\2c" + numSuffix(0)},
+        ValidateTokens("strict ($.a == $v1) || ($.b == $v2) || ($.c == $v3)",
+            {encodeKey("a") + boolTrueSuffix, encodeKey("b") + nullSuffix, encodeKey("c") + numSuffix(0)},
             {{"v1", boolTrueSuffix}, {"v2", nullSuffix}, {"v3", numSuffix(0)}}, {},
             ECallableType::JsonValue, EMode::Or);
 
         // Mixed: variable and literal
-        ValidateTokens("($.a == $var) && ($.b == 42)",
-            {"\2a" + strSuffix("x"), "\2b" + numSuffix(42)},
+        ValidateTokens("strict ($.a == $var) && ($.b == 42)",
+            {encodeKey("a") + strSuffix("x"), encodeKey("b") + numSuffix(42)},
             {{"var", strSuffix("x")}}, {},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == \"hello\") && ($.b == $var)",
-            {"\2a" + strSuffix("hello"), "\2b" + numSuffix(3.14)},
+        ValidateTokens("strict ($.a == \"hello\") && ($.b == $var)",
+            {encodeKey("a") + strSuffix("hello"), encodeKey("b") + numSuffix(3.14)},
             {{"var", numSuffix(3.14)}}, {},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == $var) || ($.b == true)",
-            {"\2a" + nullSuffix, "\2b" + boolTrueSuffix},
+        ValidateTokens("strict ($.a == $var) || ($.b == true)",
+            {encodeKey("a") + nullSuffix, encodeKey("b") + boolTrueSuffix},
             {{"var", nullSuffix}}, {},
             ECallableType::JsonValue, EMode::Or);
 
         // Variable not in map
-        ValidateTokens("$.key == $var", {"\4key"}, {}, {}, ECallableType::JsonValue);
-        ValidateTokens("$var == $.key", {"\4key"}, {}, {}, ECallableType::JsonValue);
+        ValidateTokens("strict $.key == $var", {encodeKey("key")}, {}, {}, ECallableType::JsonValue);
+        ValidateTokens("strict $var == $.key", {encodeKey("key")}, {}, {}, ECallableType::JsonValue);
 
         // Variable exists but queried variable is missing
-        ValidateTokens("$.key == $missing", {"\4key"},
+        ValidateTokens("strict $.key == $missing", {encodeKey("key")},
             {{"other", strSuffix("x")}}, {}, ECallableType::JsonValue);
 
         // One variable present, other missing in AND
-        ValidateTokens("($.a == $v1) && ($.b == $v2)", {"\2a" + strSuffix("x"), "\2b"},
+        ValidateTokens("strict ($.a == $v1) && ($.b == $v2)", {encodeKey("a") + strSuffix("x"), encodeKey("b")},
             {{"v1", strSuffix("x")}}, {}, ECallableType::JsonValue, EMode::And);
 
         // Variable in non-literal context: standalone path
@@ -1866,30 +1867,30 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$var.a.b.c", varContextError, {{"var", strSuffix("x")}});
 
         // Variable in arithmetic: treated as empty literal, path only
-        ValidateTokens("$.key + $var", {"\4key"}, {{"var", numSuffix(1)}});
-        ValidateTokens("$var + $.key", {"\4key"}, {{"var", numSuffix(1)}});
-        ValidateTokens("$.key - $var", {"\4key"}, {{"var", numSuffix(1)}});
-        ValidateTokens("$.key * $var", {"\4key"}, {{"var", numSuffix(2)}});
-        ValidateTokens("$.key / $var", {"\4key"}, {{"var", numSuffix(2)}});
-        ValidateTokens("$.key % $var", {"\4key"}, {{"var", numSuffix(2)}});
-        ValidateTokens("$.a.b + $var", {"\2a\2b"}, {{"var", numSuffix(5)}});
+        ValidateTokens("strict $.key + $var", {encodeKey("key")}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $var + $.key", {encodeKey("key")}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $.key - $var", {encodeKey("key")}, {{"var", numSuffix(1)}});
+        ValidateTokens("strict $.key * $var", {encodeKey("key")}, {{"var", numSuffix(2)}});
+        ValidateTokens("strict $.key / $var", {encodeKey("key")}, {{"var", numSuffix(2)}});
+        ValidateTokens("strict $.key % $var", {encodeKey("key")}, {{"var", numSuffix(2)}});
+        ValidateTokens("strict $.a.b + $var", {encodeKey("a") + encodeKey("b")}, {{"var", numSuffix(5)}});
 
         // Both sides are variables: treated as two empty literals -> emptyError
         ValidateError("$v1 + $v2", emptyError, {{"v1", numSuffix(1)}, {"v2", numSuffix(2)}});
         ValidateError("$v1 * $v2", emptyError, {{"v1", numSuffix(3)}, {"v2", numSuffix(4)}});
 
         // Variable in comparison operators: variable is treated as a dropped literal
-        ValidateTokens("$.key < $var", {"\4key"}, {{"var", numSuffix(5)}});
-        ValidateTokens("$.key <= $var", {"\4key"}, {{"var", numSuffix(5)}});
-        ValidateTokens("$.key > $var", {"\4key"}, {{"var", numSuffix(0)}});
-        ValidateTokens("$.key >= $var", {"\4key"}, {{"var", numSuffix(0)}});
-        ValidateTokens("$.key != $var", {"\4key"}, {{"var", strSuffix("x")}});
+        ValidateTokens("strict $.key < $var", {encodeKey("key")}, {{"var", numSuffix(5)}});
+        ValidateTokens("strict $.key <= $var", {encodeKey("key")}, {{"var", numSuffix(5)}});
+        ValidateTokens("strict $.key > $var", {encodeKey("key")}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $.key >= $var", {encodeKey("key")}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $.key != $var", {encodeKey("key")}, {{"var", strSuffix("x")}});
 
         // Variable on left side
-        ValidateTokens("$var < $.key", {"\4key"}, {{"var", numSuffix(5)}});
-        ValidateTokens("$var > $.key", {"\4key"}, {{"var", numSuffix(0)}});
-        ValidateTokens("$var != $.key", {"\4key"}, {{"var", strSuffix("x")}});
-        ValidateTokens("$var <= $.a.b", {"\2a\2b"}, {{"var", numSuffix(3)}});
+        ValidateTokens("strict $var < $.key", {encodeKey("key")}, {{"var", numSuffix(5)}});
+        ValidateTokens("strict $var > $.key", {encodeKey("key")}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $var != $.key", {encodeKey("key")}, {{"var", strSuffix("x")}});
+        ValidateTokens("strict $var <= $.a.b", {encodeKey("a") + encodeKey("b")}, {{"var", numSuffix(3)}});
 
         // Both sides variables: emptyError
         ValidateError("$v1 < $v2", emptyError,
@@ -1898,172 +1899,172 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             {{"v1", strSuffix("a")}, {"v2", strSuffix("b")}}, {}, ECallableType::JsonValue);
 
         // Filter predicate with variable
-        ValidateTokens("$.a ? (@.b == $var)", {"\2a\2b" + strSuffix("x")},
+        ValidateTokens("strict $.a ? (@.b == $var)", {encodeKey("a") + encodeKey("b") + strSuffix("x")},
             {{"var", strSuffix("x")}}, {}, ECallableType::JsonExists);
-        ValidateTokens("$.a ? (@.b == $var)", {"\2a\2b" + numSuffix(42)},
+        ValidateTokens("strict $.a ? (@.b == $var)", {encodeKey("a") + encodeKey("b") + numSuffix(42)},
             {{"var", numSuffix(42)}}, {}, ECallableType::JsonExists);
-        ValidateTokens("$.a ? (@.b == $var)", {"\2a\2b" + boolTrueSuffix},
+        ValidateTokens("strict $.a ? (@.b == $var)", {encodeKey("a") + encodeKey("b") + boolTrueSuffix},
             {{"var", boolTrueSuffix}}, {}, ECallableType::JsonExists);
-        ValidateTokens("$.a ? (@.b == $var)", {"\2a\2b" + nullSuffix},
+        ValidateTokens("strict $.a ? (@.b == $var)", {encodeKey("a") + encodeKey("b") + nullSuffix},
             {{"var", nullSuffix}}, {}, ECallableType::JsonExists);
 
         // Variable on left side in filter equality
-        ValidateTokens("$.a ? ($var == @.b)", {"\2a\2b" + strSuffix("x")},
+        ValidateTokens("strict $.a ? ($var == @.b)", {encodeKey("a") + encodeKey("b") + strSuffix("x")},
             {{"var", strSuffix("x")}}, {}, ECallableType::JsonExists);
 
         // Deeper filter paths
-        ValidateTokens("$.a.b ? (@.c == $var)", {"\2a\2b\2c" + numSuffix(1)},
+        ValidateTokens("strict $.a.b ? (@.c == $var)", {encodeKey("a") + encodeKey("b") + encodeKey("c") + numSuffix(1)},
             {{"var", numSuffix(1)}}, {}, ECallableType::JsonExists);
-        ValidateTokens("$.key ? (@.sub == $var)", {"\4key\4sub" + strSuffix("val")},
+        ValidateTokens("strict $.key ? (@.sub == $var)", {encodeKey("key") + encodeKey("sub") + strSuffix("val")},
             {{"var", strSuffix("val")}}, {}, ECallableType::JsonExists);
 
         // Variable in filter comparison (dropped, path only)
-        ValidateTokens("$.a ? (@.b < $var)", {"\2a\2b"},
+        ValidateTokens("strict $.a ? (@.b < $var)", {encodeKey("a") + encodeKey("b")},
             {{"var", numSuffix(10)}}, {}, ECallableType::JsonExists);
-        ValidateTokens("$.a ? (@.b != $var)", {"\2a\2b"},
+        ValidateTokens("strict $.a ? (@.b != $var)", {encodeKey("a") + encodeKey("b")},
             {{"var", strSuffix("x")}}, {}, ECallableType::JsonExists);
 
         // Multiple variables in filter AND
-        ValidateTokens("$.a ? (@.b == $v1 && @.c == $v2)",
-            {"\2a\2b" + strSuffix("x"), "\2a\2c" + numSuffix(1)},
+        ValidateTokens("strict $.a ? (@.b == $v1 && @.c == $v2)",
+            {encodeKey("a") + encodeKey("b") + strSuffix("x"), encodeKey("a") + encodeKey("c") + numSuffix(1)},
             {{"v1", strSuffix("x")}, {"v2", numSuffix(1)}}, {}, ECallableType::JsonExists);
 
         // Multiple variables in filter OR
-        ValidateTokens("$.a ? ((@.b == $v1) || (@.b == $v2))",
-            {"\2a\2b" + strSuffix("a"), "\2a\2b" + strSuffix("b")},
+        ValidateTokens("strict $.a ? ((@.b == $v1) || (@.b == $v2))",
+            {encodeKey("a") + encodeKey("b") + strSuffix("a"), encodeKey("a") + encodeKey("b") + strSuffix("b")},
             {{"v1", strSuffix("a")}, {"v2", strSuffix("b")}}, {}, ECallableType::JsonExists);
 
         // Missing variable in filter -> skipped
-        ValidateTokens("$.a ? (@.b == $var)", {"\2a\2b"}, {}, {}, ECallableType::JsonExists);
+        ValidateTokens("strict $.a ? (@.b == $var)", {encodeKey("a") + encodeKey("b")}, {}, {}, ECallableType::JsonExists);
     }
 
     // ParamVariables map: var name -> YQL param name (e.g. "$value")
     Y_UNIT_TEST(CollectPath_ParamVariables) {
         // Basic
-        ValidateTokens("$.key == $var", {TToken{"\4key", "$value"}}, {}, {{"var", "$value"}});
-        ValidateTokens("$.key == $var", {TToken{"\4key", "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $.key == $var", {TToken{encodeKey("key"), "$value"}}, {}, {{"var", "$value"}});
+        ValidateTokens("strict $.key == $var", {TToken{encodeKey("key"), "$p"}}, {}, {{"var", "$p"}});
 
         // Reversed order
-        ValidateTokens("$var == $.key", {TToken{"\4key", "$value"}}, {}, {{"var", "$value"}});
+        ValidateTokens("strict $var == $.key", {TToken{encodeKey("key"), "$value"}}, {}, {{"var", "$value"}});
 
         // Context object as path
-        ValidateTokens("$ == $var", {TToken{"", "$p"}}, {}, {{"var", "$p"}});
-        ValidateTokens("$var == $", {TToken{"", "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $ == $var", {TToken{"", "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $var == $", {TToken{"", "$p"}}, {}, {{"var", "$p"}});
 
         // Deeper member access paths
-        ValidateTokens("$.a.b == $var", {TToken{"\2a\2b", "$p"}}, {}, {{"var", "$p"}});
-        ValidateTokens("$.a.b.c == $var", {TToken{"\2a\2b\2c", "$param"}}, {}, {{"var", "$param"}});
-        ValidateTokens("$.aba.\"caba\" == $var", {TToken{"\4aba\5caba", "$val"}}, {}, {{"var", "$val"}});
-        ValidateTokens("$var == $.a.b.c", {TToken{"\2a\2b\2c", "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $.a.b == $var", {TToken{encodeKey("a") + encodeKey("b"), "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $.a.b.c == $var", {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$param"}}, {}, {{"var", "$param"}});
+        ValidateTokens("strict $.aba.\"caba\" == $var", {TToken{encodeKey("aba") + encodeKey("caba"), "$val"}}, {}, {{"var", "$val"}});
+        ValidateTokens("strict $var == $.a.b.c", {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, {}, {{"var", "$p"}});
 
         // Array access
-        ValidateTokens("$.key[0] == $var", {TToken{"\4key", "$v"}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.key[last] == $var", {TToken{"\4key", "$v"}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.key[1, 2, 3] == $var", {TToken{"\4key", "$v"}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.a.b[0].c == $var", {TToken{"\2a\2b\2c", "$v"}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.key[0] == $var", {TToken{encodeKey("key") + arrayItemSuffix, "$v"}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.key[last] == $var", {TToken{encodeKey("key") + arrayItemSuffix, "$v"}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.key[1, 2, 3] == $var", {TToken{encodeKey("key") + arrayItemSuffix, "$v"}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.a.b[0].c == $var", {TToken{encodeKey("a") + encodeKey("b") + arrayItemSuffix + encodeKey("c"), "$v"}}, {}, {{"var", "$v"}});
 
         // Wildcard member access
-        ValidateTokens("$.* == $var", {TToken{"", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.a.* == $var", {TToken{"\2a", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("$var == $.*", {TToken{"", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("$var == $.a.*", {TToken{"\2a", ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.* == $var", {TToken{"", ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.a.* == $var", {TToken{encodeKey("a"), ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $var == $.*", {TToken{"", ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $var == $.a.*", {TToken{encodeKey("a"), ""}}, {}, {{"var", "$v"}});
 
         // Methods finish the path
-        ValidateTokens("$.key.size() == $var", {TToken{"\4key", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.key.abs() == $var", {TToken{"\4key", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.key.type() == $var", {TToken{"\4key", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("$.a.b.floor() == $var", {TToken{"\2a\2b", ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.key.size() == $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.key.abs() == $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.key.type() == $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict $.a.b.floor() == $var", {TToken{encodeKey("a") + encodeKey("b"), ""}}, {}, {{"var", "$v"}});
 
         // Unary arithmetic on path
-        ValidateTokens("-$.key == $var", {TToken{"\4key", ""}}, {}, {{"var", "$v"}});
-        ValidateTokens("+$.key == $var", {TToken{"\4key", ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict -$.key == $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$v"}});
+        ValidateTokens("strict +$.key == $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$v"}});
 
         // Multiple param variables: AND
-        ValidateTokens("($.a == $v1) && ($.b == $v2)",
-            {TToken{"\2a", "$p1"}, TToken{"\2b", "$p2"}}, {},
+        ValidateTokens("strict ($.a == $v1) && ($.b == $v2)",
+            {TToken{encodeKey("a"), "$p1"}, TToken{encodeKey("b"), "$p2"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == $v) && ($.b == $v)",
-            {TToken{"\2a", "$p"}, TToken{"\2b", "$p"}}, {},
+        ValidateTokens("strict ($.a == $v) && ($.b == $v)",
+            {TToken{encodeKey("a"), "$p"}, TToken{encodeKey("b"), "$p"}}, {},
             {{"v", "$p"}},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == $v1) && ($.b == $v2) && ($.c == $v3)",
-            {TToken{"\2a", "$p1"}, TToken{"\2b", "$p2"}, TToken{"\2c", "$p3"}}, {},
+        ValidateTokens("strict ($.a == $v1) && ($.b == $v2) && ($.c == $v3)",
+            {TToken{encodeKey("a"), "$p1"}, TToken{encodeKey("b"), "$p2"}, TToken{encodeKey("c"), "$p3"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}, {"v3", "$p3"}},
             ECallableType::JsonValue, EMode::And);
 
         // Multiple param variables: OR
-        ValidateTokens("($.a == $v1) || ($.b == $v2)",
-            {TToken{"\2a", "$p1"}, TToken{"\2b", "$p2"}}, {},
+        ValidateTokens("strict ($.a == $v1) || ($.b == $v2)",
+            {TToken{encodeKey("a"), "$p1"}, TToken{encodeKey("b"), "$p2"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}},
             ECallableType::JsonValue, EMode::Or);
-        ValidateTokens("($.key == $v1) || ($.key == $v2)",
-            {TToken{"\4key", "$p1"}, TToken{"\4key", "$p2"}}, {},
+        ValidateTokens("strict ($.key == $v1) || ($.key == $v2)",
+            {TToken{encodeKey("key"), "$p1"}, TToken{encodeKey("key"), "$p2"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}},
             ECallableType::JsonValue, EMode::Or);
-        ValidateTokens("($.a == $v1) || ($.b == $v2) || ($.c == $v3)",
-            {TToken{"\2a", "$p1"}, TToken{"\2b", "$p2"}, TToken{"\2c", "$p3"}}, {},
+        ValidateTokens("strict ($.a == $v1) || ($.b == $v2) || ($.c == $v3)",
+            {TToken{encodeKey("a"), "$p1"}, TToken{encodeKey("b"), "$p2"}, TToken{encodeKey("c"), "$p3"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}, {"v3", "$p3"}},
             ECallableType::JsonValue, EMode::Or);
 
         // Mixed: param variable and plain literal in AND
-        ValidateTokens("($.a == $var) && ($.b == 42)",
-            {TToken{"\2a", "$p"}, TToken{"\2b" + numSuffix(42), ""}}, {},
+        ValidateTokens("strict ($.a == $var) && ($.b == 42)",
+            {TToken{encodeKey("a"), "$p"}, TToken{encodeKey("b") + numSuffix(42), ""}}, {},
             {{"var", "$p"}},
             ECallableType::JsonValue, EMode::And);
-        ValidateTokens("($.a == \"hello\") && ($.b == $var)",
-            {TToken{"\2a" + strSuffix("hello"), ""}, TToken{"\2b", "$p"}}, {},
+        ValidateTokens("strict ($.a == \"hello\") && ($.b == $var)",
+            {TToken{encodeKey("a") + strSuffix("hello"), ""}, TToken{encodeKey("b"), "$p"}}, {},
             {{"var", "$p"}},
             ECallableType::JsonValue, EMode::And);
 
         // Mixed: param variable and plain literal in OR
-        ValidateTokens("($.a == $var) || ($.b == true)",
-            {TToken{"\2a", "$p"}, TToken{"\2b" + boolTrueSuffix, ""}}, {},
+        ValidateTokens("strict ($.a == $var) || ($.b == true)",
+            {TToken{encodeKey("a"), "$p"}, TToken{encodeKey("b") + boolTrueSuffix, ""}}, {},
             {{"var", "$p"}},
             ECallableType::JsonValue, EMode::Or);
 
         // Param variable in filter predicate
-        ValidateTokens("$.a ? (@.b == $var)", {TToken{"\2a\2b", "$p"}}, {},
+        ValidateTokens("strict $.a ? (@.b == $var)", {TToken{encodeKey("a") + encodeKey("b"), "$p"}}, {},
             {{"var", "$p"}}, ECallableType::JsonExists);
-        ValidateTokens("$.a ? ($var == @.b)", {TToken{"\2a\2b", "$p"}}, {},
+        ValidateTokens("strict $.a ? ($var == @.b)", {TToken{encodeKey("a") + encodeKey("b"), "$p"}}, {},
             {{"var", "$p"}}, ECallableType::JsonExists);
 
         // Deeper filter paths
-        ValidateTokens("$.a.b ? (@.c == $var)", {TToken{"\2a\2b\2c", "$p"}}, {},
+        ValidateTokens("strict $.a.b ? (@.c == $var)", {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, {},
             {{"var", "$p"}}, ECallableType::JsonExists);
-        ValidateTokens("$.key ? (@.sub == $var)", {TToken{"\4key\4sub", "$p"}}, {},
+        ValidateTokens("strict $.key ? (@.sub == $var)", {TToken{encodeKey("key") + encodeKey("sub"), "$p"}}, {},
             {{"var", "$p"}}, ECallableType::JsonExists);
 
         // Param variable in filter comparison
-        ValidateTokens("$.a ? (@.b < $var)", {TToken{"\2a\2b", ""}}, {},
+        ValidateTokens("strict $.a ? (@.b < $var)", {TToken{encodeKey("a") + encodeKey("b"), ""}}, {},
             {{"var", "$p"}}, ECallableType::JsonExists);
-        ValidateTokens("$.a ? (@.b != $var)", {TToken{"\2a\2b", ""}}, {},
+        ValidateTokens("strict $.a ? (@.b != $var)", {TToken{encodeKey("a") + encodeKey("b"), ""}}, {},
             {{"var", "$p"}}, ECallableType::JsonExists);
 
         // Multiple param variables in filter AND
-        ValidateTokens("$.a ? (@.b == $v1 && @.c == $v2)",
-            {TToken{"\2a\2b", "$p1"}, TToken{"\2a\2c", "$p2"}}, {},
+        ValidateTokens("strict $.a ? (@.b == $v1 && @.c == $v2)",
+            {TToken{encodeKey("a") + encodeKey("b"), "$p1"}, TToken{encodeKey("a") + encodeKey("c"), "$p2"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}},
             ECallableType::JsonExists, EMode::And);
 
         // Multiple param variables in filter OR
-        ValidateTokens("$.a ? ((@.b == $v1) || (@.b == $v2))",
-            {TToken{"\2a\2b", "$p1"}, TToken{"\2a\2b", "$p2"}}, {},
+        ValidateTokens("strict $.a ? ((@.b == $v1) || (@.b == $v2))",
+            {TToken{encodeKey("a") + encodeKey("b"), "$p1"}, TToken{encodeKey("a") + encodeKey("b"), "$p2"}}, {},
             {{"v1", "$p1"}, {"v2", "$p2"}},
             ECallableType::JsonExists, EMode::Or);
 
         // Param variable in arithmetic
-        ValidateTokens("$.key + $var", {TToken{"\4key", ""}}, {}, {{"var", "$p"}}, ECallableType::JsonExists);
-        ValidateTokens("$var + $.key", {TToken{"\4key", ""}}, {}, {{"var", "$p"}}, ECallableType::JsonExists);
+        ValidateTokens("strict $.key + $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$p"}}, ECallableType::JsonExists);
+        ValidateTokens("strict $var + $.key", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$p"}}, ECallableType::JsonExists);
 
         // Param variable in comparison operators
-        ValidateTokens("$.key < $var", {TToken{"\4key", ""}}, {}, {{"var", "$p"}}, ECallableType::JsonValue);
-        ValidateTokens("$.key != $var", {TToken{"\4key", ""}}, {}, {{"var", "$p"}}, ECallableType::JsonValue);
-        ValidateTokens("$var < $.key", {TToken{"\4key", ""}}, {}, {{"var", "$p"}}, ECallableType::JsonValue);
+        ValidateTokens("strict $.key < $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$p"}}, ECallableType::JsonValue);
+        ValidateTokens("strict $.key != $var", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$p"}}, ECallableType::JsonValue);
+        ValidateTokens("strict $var < $.key", {TToken{encodeKey("key"), ""}}, {}, {{"var", "$p"}}, ECallableType::JsonValue);
 
         // Param variable not in the map: variable is ignored
-        ValidateTokens("$.key == $var", {TToken{"\4key", ""}});
-        ValidateTokens("$var == $.key", {TToken{"\4key", ""}});
+        ValidateTokens("strict $.key == $var", {TToken{encodeKey("key"), ""}});
+        ValidateTokens("strict $var == $.key", {TToken{encodeKey("key"), ""}});
 
         // Variable in non-literal context is still an error with paramVariables
         ValidateError("$var", varContextError, {}, {{"var", "$p"}}, ECallableType::JsonValue);
@@ -2073,15 +2074,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$v1 == $v2", compError, {}, {{"v1", "$p1"}, {"v2", "$p2"}}, ECallableType::JsonValue);
 
         // Deduplication
-        ValidateTokens("($.a.b.c == $var) && ($.a.b.c == $var)",
-            {TToken{"\2a\2b\2c", "$p"}}, {}, {{"var", "$p"}});
-        ValidateTokens("($.a.b.c == $var) || ($.a.b.c == $var)",
-            {TToken{"\2a\2b\2c", "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict ($.a.b.c == $var) && ($.a.b.c == $var)",
+            {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, {}, {{"var", "$p"}});
+        ValidateTokens("strict ($.a.b.c == $var) || ($.a.b.c == $var)",
+            {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, {}, {{"var", "$p"}});
 
-        ValidateTokens("($.key == $v1) && ($.key == $v2)",
-            {TToken{"\4key", "$p"}}, {}, {{"v1", "$p"}, {"v2", "$p"}});
-        ValidateTokens("($.key == $v1) || ($.key == $v2)",
-            {TToken{"\4key", "$p"}}, {}, {{"v1", "$p"}, {"v2", "$p"}});
+        ValidateTokens("strict ($.key == $v1) && ($.key == $v2)",
+            {TToken{encodeKey("key"), "$p"}}, {}, {{"v1", "$p"}, {"v2", "$p"}});
+        ValidateTokens("strict ($.key == $v1) || ($.key == $v2)",
+            {TToken{encodeKey("key"), "$p"}}, {}, {{"v1", "$p"}, {"v2", "$p"}});
     }
 
     // Method calls on literal values (string, number, bool, null) and on variables
@@ -2111,89 +2112,89 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$var.abs()", emptyError, {}, {{"var", "$p"}});
 
         // Comparison: path == literal.method()
-        ValidateJsonValue("$.key == \"hello\".type()", {"\4key"});
-        ValidateJsonValue("\"hello\".type() == $.key", {"\4key"});
-        ValidateJsonValue("$.key == 42.0.abs()", {"\4key"});
-        ValidateJsonValue("$.a == true.type()", {"\2a"});
-        ValidateJsonValue("$.a == null.type()", {"\2a"});
-        ValidateJsonValue("$.a.b == (-1).abs()", {"\2a\2b"});
+        ValidateJsonValue("strict $.key == \"hello\".type()", {encodeKey("key")});
+        ValidateJsonValue("strict \"hello\".type() == $.key", {encodeKey("key")});
+        ValidateJsonValue("strict $.key == 42.0.abs()", {encodeKey("key")});
+        ValidateJsonValue("strict $.a == true.type()", {encodeKey("a")});
+        ValidateJsonValue("strict $.a == null.type()", {encodeKey("a")});
+        ValidateJsonValue("strict $.a.b == (-1).abs()", {encodeKey("a") + encodeKey("b")});
 
         // Comparison: path.method() == literal.method()
-        ValidateJsonValue("$.key.abs() == \"hello\".type()", {"\4key"});
-        ValidateJsonValue("$.a.b.floor() == 42.0.abs()", {"\2a\2b"});
+        ValidateJsonValue("strict $.key.abs() == \"hello\".type()", {encodeKey("key")});
+        ValidateJsonValue("strict $.a.b.floor() == 42.0.abs()", {encodeKey("a") + encodeKey("b")});
 
         // Comparison: path == variable.method()
-        ValidateTokens("$.key == $var.type()", {"\4key"}, {{"var", strSuffix("number")}});
-        ValidateTokens("$var.type() == $.key", {"\4key"}, {{"var", strSuffix("number")}});
-        ValidateTokens("$.key == $var.abs()", {"\4key"}, {{"var", numSuffix(5)}});
-        ValidateTokens("$.a.b == $var.floor()", {"\2a\2b"}, {{"var", numSuffix(0)}});
+        ValidateTokens("strict $.key == $var.type()", {encodeKey("key")}, {{"var", strSuffix("number")}});
+        ValidateTokens("strict $var.type() == $.key", {encodeKey("key")}, {{"var", strSuffix("number")}});
+        ValidateTokens("strict $.key == $var.abs()", {encodeKey("key")}, {{"var", numSuffix(5)}});
+        ValidateTokens("strict $.a.b == $var.floor()", {encodeKey("a") + encodeKey("b")}, {{"var", numSuffix(0)}});
 
         // Comparison: path == param-variable.method()
-        ValidateTokens("$.key == $var.type()", {"\4key"}, {}, {{"var", "$p"}});
-        ValidateTokens("$var.type() == $.key", {"\4key"}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $.key == $var.type()", {encodeKey("key")}, {}, {{"var", "$p"}});
+        ValidateTokens("strict $var.type() == $.key", {encodeKey("key")}, {}, {{"var", "$p"}});
 
         // Both sides non-path (literal.method() == literal)
-        ValidateError(R"("hello".type() == "string")", emptyError);
+        ValidateError(R"(strict "hello".type() == "string")", emptyError);
         ValidateError("42.0.abs() == 42", emptyError);
 
         // Filter: @.b == literal.method()
-        ValidateJsonExists("$.a ? (@.b == \"hello\".type())", {"\2a\2b"});
-        ValidateJsonExists("$.a ? (@.b == 42.0.abs())", {"\2a\2b"});
-        ValidateTokens("$.a ? (@.b == $var.type())", {"\2a\2b"}, {{"var", strSuffix("x")}}, {}, ECallableType::JsonExists);
+        ValidateJsonExists("strict $.a ? (@.b == \"hello\".type())", {encodeKey("a") + encodeKey("b")});
+        ValidateJsonExists("strict $.a ? (@.b == 42.0.abs())", {encodeKey("a") + encodeKey("b")});
+        ValidateTokens("strict $.a ? (@.b == $var.type())", {encodeKey("a") + encodeKey("b")}, {{"var", strSuffix("x")}}, {}, ECallableType::JsonExists);
     }
 
     Y_UNIT_TEST(CollectPath_MultiTokenSuffix) {
         // MemberAccess
-        ValidateJsonValue("($.a + $.b).c == 1", {"\2a", "\2b"});
-        ValidateJsonValue("exists(($.a + $.b).c)", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($.a + $.b).c == 1", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict exists(($.a + $.b).c)", {encodeKey("a"), encodeKey("b")});
 
         // WildcardMemberAccess
-        ValidateJsonValue("exists(($.a + $.b).*)", {"\2a", "\2b"});
-        ValidateJsonValue("($.a + $.b).* starts with \"x\"", {"\2a", "\2b"});
+        ValidateJsonValue("strict exists(($.a + $.b).*)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a + $.b).* starts with \"x\"", {encodeKey("a"), encodeKey("b")});
 
         // ArrayAccess
-        ValidateJsonValue("exists(($.a + $.b)[0])", {"\2a", "\2b"});
-        ValidateJsonValue("exists(($.a + $.b)[0].key)", {"\2a", "\2b"});
-        ValidateJsonValue("exists(($.a + $.b)[*])", {"\2a", "\2b"});
+        ValidateJsonValue("strict exists(($.a + $.b)[0])", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict exists(($.a + $.b)[0].key)", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict exists(($.a + $.b)[*])", {encodeKey("a"), encodeKey("b")});
 
         // Binary operations
-        ValidateJsonValue("($.a + $.b) == 3", {"\2a", "\2b"});
-        ValidateJsonValue("($.a - $.b) == true", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($.a + $.b) == 3", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($.a - $.b) == true", {encodeKey("a"), encodeKey("b")});
 
         // Filter
-        ValidateJsonValue("($ ? (@.a > 0) ? (@.b < 10)).c", {"\2a", "\2b"});
-        ValidateJsonValue("($ ? (@.a > 0) ? (@.b < 10)) == 1", {"\2a", "\2b"});
-        ValidateJsonValue("$ ? (@.a > 0 && @.b < 10).c", {"\2a", "\2b"});
-        ValidateJsonValue("$ ? (@.a > 0 && @.b < 10) == 1", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($ ? (@.a > 0) ? (@.b < 10)).c", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict ($ ? (@.a > 0) ? (@.b < 10)) == 1", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $ ? (@.a > 0 && @.b < 10).c", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $ ? (@.a > 0 && @.b < 10) == 1", {encodeKey("a"), encodeKey("b")});
 
         // Methods
-        ValidateJsonValue("($.k1 > $.k2).abs()", {"\3k1", "\3k2"});
-        ValidateJsonValue("$ ? (@.a > 0 && @.b < 10).type()", {"\2a", "\2b"});
-        ValidateJsonValue("$ ? (@.a > 0 && @.b < 10).type() == \"object\"", {"\2a", "\2b"});
+        ValidateJsonValue("strict ($.k1 > $.k2).abs()", {encodeKey("k1"), encodeKey("k2")});
+        ValidateJsonValue("strict $ ? (@.a > 0 && @.b < 10).type()", {encodeKey("a"), encodeKey("b")});
+        ValidateJsonValue("strict $ ? (@.a > 0 && @.b < 10).type() == \"object\"", {encodeKey("a"), encodeKey("b")});
     }
 
     // Tokens with no ancestor–descendant relation survive both AND and OR merge intact.
     Y_UNIT_TEST(MergeAndOr_DisjointPaths) {
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2c\2d"})),
-            {"\2a\2b", "\2c\2d"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("c") + encodeKey("d")})),
+            {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2c\2d"})),
-            {"\2a\2b", "\2c\2d"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("c") + encodeKey("d")})),
+            {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")}, EMode::Or);
 
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a", "\2b"}, EMode::And), MakeTokens({"\2c"})),
-            {"\2a", "\2b", "\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a"), encodeKey("b")}, EMode::And), MakeTokens({encodeKey("c")})),
+            {encodeKey("a"), encodeKey("b"), encodeKey("c")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a", "\2b"}, EMode::Or), MakeTokens({"\2c"})),
-            {"\2a", "\2b", "\2c"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a"), encodeKey("b")}, EMode::Or), MakeTokens({encodeKey("c")})),
+            {encodeKey("a"), encodeKey("b"), encodeKey("c")}, EMode::Or);
 
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b", "\2c\2d"}, EMode::And),
-                     MakeTokens({"\2e\2f", "\2g\2h"}, EMode::And)),
-            {"\2a\2b", "\2c\2d", "\2e\2f", "\2g\2h"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d")}, EMode::And),
+                     MakeTokens({encodeKey("e") + encodeKey("f"), encodeKey("g") + encodeKey("h")}, EMode::And)),
+            {encodeKey("a") + encodeKey("b"), encodeKey("c") + encodeKey("d"), encodeKey("e") + encodeKey("f"), encodeKey("g") + encodeKey("h")}, EMode::And);
 
     }
 
@@ -2201,53 +2202,53 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(MergeAndOr_DirectAncestorDescendant) {
         // parent in left operand
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b\2c"})),
-            {"\2a\2b\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")})),
+            {encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And);
 
         // parent in right operand
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b\2c"}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And);
 
         // grandparent pruned (two levels up)
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a"}), MakeTokens({"\2a\2b\2c"})),
-            {"\2a\2b\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a")}), MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")})),
+            {encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b\2c"})),
-            {"\2a\2b"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::Or);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b\2c"}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::Or);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a"}), MakeTokens({"\2a\2b\2c"})),
-            {"\2a"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a")}), MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")})),
+            {encodeKey("a")}, EMode::Or);
     }
 
     // Identical tokens collapse to a single entry; equal tokens are NOT each other's prefix.
     Y_UNIT_TEST(MergeAndOr_IdenticalTokens) {
         // single-token sets: set deduplication leaves 1 token -> mode stays NotSet
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b"}, EMode::NotSet);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::NotSet);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b"}, EMode::NotSet);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::NotSet);
 
         // multi-token sets: deduplication, no pruning (b and c are siblings, not prefix-related)
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b", "\2c"}, EMode::And),
-                     MakeTokens({"\2a\2b", "\2c"}, EMode::And)),
-            {"\2a\2b", "\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("c")}, EMode::And),
+                     MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("c")}, EMode::And)),
+            {encodeKey("a") + encodeKey("b"), encodeKey("c")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b", "\2c"}, EMode::Or),
-                    MakeTokens({"\2a\2b", "\2c"}, EMode::Or)),
-            {"\2a\2b", "\2c"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("c")}, EMode::Or),
+                    MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("c")}, EMode::Or)),
+            {encodeKey("a") + encodeKey("b"), encodeKey("c")}, EMode::Or);
     }
 
     // The five-term example from the task description.
@@ -2265,36 +2266,36 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // AND -> leaves: a.b.c.e, a.d, e.f
     // OR  -> roots:  a.b,     a.d, e.f
     Y_UNIT_TEST(MergeAndOr_FullExample) {
-        auto left = MakeTokens({"\2a\2b", "\2a\2b\2c", "\2a\2d"}, EMode::And);
-        auto right = MakeTokens({"\2a\2b\2c\2e", "\2e\2f"}, EMode::And);
+        auto left = MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("a") + encodeKey("d")}, EMode::And);
+        auto right = MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("e"), encodeKey("e") + encodeKey("f")}, EMode::And);
         CheckMerge(
             MergeAnd(std::move(left), std::move(right)),
-            {"\2a\2b\2c\2e", "\2a\2d", "\2e\2f"}, EMode::And);
+            {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("e"), encodeKey("a") + encodeKey("d"), encodeKey("e") + encodeKey("f")}, EMode::And);
 
-        left = MakeTokens({"\2a\2b", "\2a\2b\2c", "\2a\2d"}, EMode::Or);
-        right = MakeTokens({"\2a\2b\2c\2e", "\2e\2f"}, EMode::Or);
+        left = MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("a") + encodeKey("d")}, EMode::Or);
+        right = MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("e"), encodeKey("e") + encodeKey("f")}, EMode::Or);
         CheckMerge(
             MergeOr(std::move(left), std::move(right)),
-            {"\2a\2b", "\2a\2d", "\2e\2f"}, EMode::Or);
+            {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("d"), encodeKey("e") + encodeKey("f")}, EMode::Or);
     }
 
     // Two completely independent subtrees each with an ancestor–descendant pair.
     Y_UNIT_TEST(MergeAndOr_MultipleBranches) {
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b", "\2a\2b\2c"}, EMode::And),
-                     MakeTokens({"\2x\2y", "\2x\2y\2z"}, EMode::And)),
-            {"\2a\2b\2c", "\2x\2y\2z"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And),
+                     MakeTokens({encodeKey("x") + encodeKey("y"), encodeKey("x") + encodeKey("y") + encodeKey("z")}, EMode::And)),
+            {encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("x") + encodeKey("y") + encodeKey("z")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b", "\2a\2b\2c"}, EMode::Or),
-                    MakeTokens({"\2x\2y", "\2x\2y\2z"}, EMode::Or)),
-            {"\2a\2b", "\2x\2y"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::Or),
+                    MakeTokens({encodeKey("x") + encodeKey("y"), encodeKey("x") + encodeKey("y") + encodeKey("z")}, EMode::Or)),
+            {encodeKey("a") + encodeKey("b"), encodeKey("x") + encodeKey("y")}, EMode::Or);
     }
 
     // A path-only token is a string prefix of a path+literal token for the same field.
     // AND should keep the value-specific (longer) token; OR should keep the path-only (shorter).
     Y_UNIT_TEST(MergeAndOr_LiteralSuffix) {
-        const TString ab = "\2a\2b";
+        const TString ab = encodeKey("a") + encodeKey("b");
         const TString abNum = ab + numSuffix(5.0);
         const TString abNum2 = ab + numSuffix(7.0);
 
@@ -2320,121 +2321,121 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(MergeAndOr_ParamTokens) {
         // Deduplication: two equal param tokens -> 1 entry
         CheckMergeFull(
-            MergeAnd(MakeParamTokens({TToken{"\2a\2b", "$p"}}),
-                     MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b", "$p"}}, EMode::NotSet, "AND dedup: equal param tokens collapse to one");
+            MergeAnd(MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}}),
+                     MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), "$p"}}, EMode::NotSet, "AND dedup: equal param tokens collapse to one");
 
         CheckMergeFull(
-            MergeOr(MakeParamTokens({TToken{"\2a\2b", "$p"}}),
-                    MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b", "$p"}}, EMode::NotSet, "OR dedup: equal param tokens collapse to one");
+            MergeOr(MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}}),
+                    MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), "$p"}}, EMode::NotSet, "OR dedup: equal param tokens collapse to one");
 
         // Same path, same Param, in a multi-token set: dedup still collapses them.
         CheckMergeFull(
-            MergeAnd(MakeParamTokens({TToken{"\2a", "$p"}, TToken{"\2b", "$q"}}, EMode::And),
-                     MakeParamTokens({TToken{"\2a", "$p"}, TToken{"\2b", "$q"}}, EMode::And)),
-            {TToken{"\2a", "$p"}, TToken{"\2b", "$q"}}, EMode::And, "AND dedup: multi-token param set collapses duplicates");
+            MergeAnd(MakeParamTokens({TToken{encodeKey("a"), "$p"}, TToken{encodeKey("b"), "$q"}}, EMode::And),
+                     MakeParamTokens({TToken{encodeKey("a"), "$p"}, TToken{encodeKey("b"), "$q"}}, EMode::And)),
+            {TToken{encodeKey("a"), "$p"}, TToken{encodeKey("b"), "$q"}}, EMode::And, "AND dedup: multi-token param set collapses duplicates");
 
         // AND pruning with param as leaf
         CheckMergeFull(
-            MergeAnd(MakeTokens({"\2a\2b"}),
-                     MakeParamTokens({TToken{"\2a\2b\2c", "$p"}})),
-            {TToken{"\2a\2b\2c", "$p"}}, EMode::And, "AND pruning: non-param ancestor dropped, param leaf kept");
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                     MakeParamTokens({TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, EMode::And, "AND pruning: non-param ancestor dropped, param leaf kept");
 
         CheckMergeFull(
-            MergeAnd(MakeTokens({"\2a\2b"}),
-                     MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b", "$p"}}, EMode::And, "AND pruning: path-only token dropped, param token kept");
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                     MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), "$p"}}, EMode::And, "AND pruning: path-only token dropped, param token kept");
 
         // Order does not matter for AND
         CheckMergeFull(
-            MergeAnd(MakeParamTokens({TToken{"\2a\2b\2c", "$p"}}),
-                     MakeTokens({"\2a\2b"})),
-            {TToken{"\2a\2b\2c", "$p"}}, EMode::And, "AND pruning: order reversed, non-param ancestor still dropped");
+            MergeAnd(MakeParamTokens({TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}),
+                     MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, EMode::And, "AND pruning: order reversed, non-param ancestor still dropped");
 
         // Two levels up
         CheckMergeFull(
-            MergeAnd(MakeTokens({"\2a"}),
-                     MakeParamTokens({TToken{"\2a\2b\2c", "$p"}})),
-            {TToken{"\2a\2b\2c", "$p"}}, EMode::And, "AND pruning: grandparent non-param dropped by param grandchild");
+            MergeAnd(MakeTokens({encodeKey("a")}),
+                     MakeParamTokens({TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}, EMode::And, "AND pruning: grandparent non-param dropped by param grandchild");
 
         // OR pruning with non-param ancestor
         CheckMergeFull(
-            MergeOr(MakeTokens({"\2a\2b"}),
-                    MakeParamTokens({TToken{"\2a\2b\2c", "$p"}})),
-            {TToken{"\2a\2b", ""}}, EMode::Or, "OR pruning: non-param ancestor kept, param descendant dropped");
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                    MakeParamTokens({TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), ""}}, EMode::Or, "OR pruning: non-param ancestor kept, param descendant dropped");
 
         CheckMergeFull(
-            MergeOr(MakeTokens({"\2a\2b"}),
-                    MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b"}}, EMode::Or, "OR pruning: path-only token kept, param token dropped");
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                    MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b")}}, EMode::Or, "OR pruning: path-only token kept, param token dropped");
 
         // Order does not matter for OR
         CheckMergeFull(
-            MergeOr(MakeParamTokens({TToken{"\2a\2b\2c", "$p"}}),
-                    MakeTokens({"\2a\2b"})),
-            {TToken{"\2a\2b", ""}}, EMode::Or, "OR pruning: order reversed, non-param ancestor still kept");
+            MergeOr(MakeParamTokens({TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}}),
+                    MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {TToken{encodeKey("a") + encodeKey("b"), ""}}, EMode::Or, "OR pruning: order reversed, non-param ancestor still kept");
 
         // Two levels down
         CheckMergeFull(
-            MergeOr(MakeTokens({"\2a"}),
-                    MakeParamTokens({TToken{"\2a\2b\2c", "$p"}})),
-            {TToken{"\2a", ""}}, EMode::Or, "OR pruning: root non-param kept, two-level-deep param descendant dropped");
+            MergeOr(MakeTokens({encodeKey("a")}),
+                    MakeParamTokens({TToken{encodeKey("a") + encodeKey("b") + encodeKey("c"), "$p"}})),
+            {TToken{encodeKey("a"), ""}}, EMode::Or, "OR pruning: root non-param kept, two-level-deep param descendant dropped");
 
         // Disjoint paths
         CheckMergeFull(
-            MergeAnd(MakeTokens({"\2a\2b"}),
-                     MakeParamTokens({TToken{"\2c\2d", "$p"}})),
-            {TToken{"\2a\2b", ""}, TToken{"\2c\2d", "$p"}}, EMode::And, "AND disjoint: unrelated paths both kept");
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                     MakeParamTokens({TToken{encodeKey("c") + encodeKey("d"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), ""}, TToken{encodeKey("c") + encodeKey("d"), "$p"}}, EMode::And, "AND disjoint: unrelated paths both kept");
 
         CheckMergeFull(
-            MergeOr(MakeTokens({"\2a\2b"}),
-                    MakeParamTokens({TToken{"\2c\2d", "$p"}})),
-            {TToken{"\2a\2b", ""}, TToken{"\2c\2d", "$p"}}, EMode::Or, "OR disjoint: unrelated paths both kept");
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                    MakeParamTokens({TToken{encodeKey("c") + encodeKey("d"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), ""}, TToken{encodeKey("c") + encodeKey("d"), "$p"}}, EMode::Or, "OR disjoint: unrelated paths both kept");
 
         // Disjoint param tokens
         CheckMergeFull(
-            MergeAnd(MakeParamTokens({TToken{"\2a", "$p1"}}),
-                     MakeParamTokens({TToken{"\2b", "$p2"}})),
-            {TToken{"\2a", "$p1"}, TToken{"\2b", "$p2"}}, EMode::And, "AND disjoint params: two unrelated param tokens both kept");
+            MergeAnd(MakeParamTokens({TToken{encodeKey("a"), "$p1"}}),
+                     MakeParamTokens({TToken{encodeKey("b"), "$p2"}})),
+            {TToken{encodeKey("a"), "$p1"}, TToken{encodeKey("b"), "$p2"}}, EMode::And, "AND disjoint params: two unrelated param tokens both kept");
 
         CheckMergeFull(
-            MergeOr(MakeParamTokens({TToken{"\2a", "$p1"}}),
-                    MakeParamTokens({TToken{"\2b", "$p2"}})),
-            {TToken{"\2a", "$p1"}, TToken{"\2b", "$p2"}}, EMode::Or, "OR disjoint params: two unrelated param tokens both kept");
+            MergeOr(MakeParamTokens({TToken{encodeKey("a"), "$p1"}}),
+                    MakeParamTokens({TToken{encodeKey("b"), "$p2"}})),
+            {TToken{encodeKey("a"), "$p1"}, TToken{encodeKey("b"), "$p2"}}, EMode::Or, "OR disjoint params: two unrelated param tokens both kept");
 
         // Same path, different Params
         CheckMergeFull(
-            MergeOr(MakeParamTokens({TToken{"\4key", "$p1"}}),
-                    MakeParamTokens({TToken{"\4key", "$p2"}})),
-            {TToken{"\4key", "$p1"}, TToken{"\4key", "$p2"}}, EMode::Or, "OR same path different params: both kept as distinct constraints");
+            MergeOr(MakeParamTokens({TToken{encodeKey("key"), "$p1"}}),
+                    MakeParamTokens({TToken{encodeKey("key"), "$p2"}})),
+            {TToken{encodeKey("key"), "$p1"}, TToken{encodeKey("key"), "$p2"}}, EMode::Or, "OR same path different params: both kept as distinct constraints");
 
         CheckMergeFull(
-            MergeAnd(MakeParamTokens({TToken{"\4key", "$p1"}}),
-                     MakeParamTokens({TToken{"\4key", "$p2"}})),
-            {TToken{"\4key", "$p1"}, TToken{"\4key", "$p2"}}, EMode::And, "AND same path different params: both kept as distinct constraints");
+            MergeAnd(MakeParamTokens({TToken{encodeKey("key"), "$p1"}}),
+                     MakeParamTokens({TToken{encodeKey("key"), "$p2"}})),
+            {TToken{encodeKey("key"), "$p1"}, TToken{encodeKey("key"), "$p2"}}, EMode::And, "AND same path different params: both kept as distinct constraints");
 
         // Param token with literal-suffixed non-param sibling on the same path
         CheckMergeFull(
-            MergeAnd(MakeTokens({"\2a\2b" + numSuffix(5.0)}),
-                     MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b", "$p"}, TToken{"\2a\2b" + numSuffix(5.0), ""}}, EMode::And, "AND literal-suffix sibling: param and literal-suffixed token both kept");
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b") + numSuffix(5.0)}),
+                     MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), "$p"}, TToken{encodeKey("a") + encodeKey("b") + numSuffix(5.0), ""}}, EMode::And, "AND literal-suffix sibling: param and literal-suffixed token both kept");
 
         CheckMergeFull(
-            MergeOr(MakeTokens({"\2a\2b" + numSuffix(5.0)}),
-                    MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b", "$p"}, TToken{"\2a\2b" + numSuffix(5.0), ""}}, EMode::Or, "OR literal-suffix sibling: param and literal-suffixed token both kept");
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b") + numSuffix(5.0)}),
+                    MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), "$p"}, TToken{encodeKey("a") + encodeKey("b") + numSuffix(5.0), ""}}, EMode::Or, "OR literal-suffix sibling: param and literal-suffixed token both kept");
 
         // Non-param path-only token is a prefix of the literal-suffixed token AND of the param token with the same base path
         CheckMergeFull(
-            MergeAnd(MakeTokens({"\2a\2b", "\2a\2b" + numSuffix(5.0)}, EMode::And),
-                     MakeParamTokens({TToken{"\2a\2b", "$p"}})),
-            {TToken{"\2a\2b", "$p"}, TToken{"\2a\2b" + numSuffix(5.0), ""}}, EMode::And, "AND prefix+literal+param: path-only prefix dropped, leaf and param kept");
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + numSuffix(5.0)}, EMode::And),
+                     MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}})),
+            {TToken{encodeKey("a") + encodeKey("b"), "$p"}, TToken{encodeKey("a") + encodeKey("b") + numSuffix(5.0), ""}}, EMode::And, "AND prefix+literal+param: path-only prefix dropped, leaf and param kept");
 
         CheckMergeFull(
-            MergeOr(MakeTokens({"\2a\2b"}),
-                    MakeParamTokens({TToken{"\2a\2b", "$p"}, TToken{"\2a\2b" + numSuffix(5.0), ""}})),
-            {TToken{"\2a\2b", ""}}, EMode::Or, "OR prefix+literal+param: root non-param kept, descendants dropped");
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}),
+                    MakeParamTokens({TToken{encodeKey("a") + encodeKey("b"), "$p"}, TToken{encodeKey("a") + encodeKey("b") + numSuffix(5.0), ""}})),
+            {TToken{encodeKey("a") + encodeKey("b"), ""}}, EMode::Or, "OR prefix+literal+param: root non-param kept, descendants dropped");
     }
 
     // When one operand carries an incompatible mode, the merge falls back to OR mode,
@@ -2442,67 +2443,67 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(MergeAnd_ModeMixAppliesOrPruning) {
         // Left has Or mode -> hasMix -> final mode Or -> OR pruning keeps the shorter token
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b"}, EMode::Or),
-                     MakeTokens({"\2a\2b\2c"}, EMode::And)),
-            {"\2a\2b"}, EMode::Or);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}, EMode::Or),
+                     MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And)),
+            {encodeKey("a") + encodeKey("b")}, EMode::Or);
 
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b\2c"}, EMode::And),
-                     MakeTokens({"\2a\2b"}, EMode::Or)),
-            {"\2a\2b"}, EMode::Or);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And),
+                     MakeTokens({encodeKey("a") + encodeKey("b")}, EMode::Or)),
+            {encodeKey("a") + encodeKey("b")}, EMode::Or);
     }
 
     // A chain of three levels (grandparent -> parent -> child) in a single merge call.
     Y_UNIT_TEST(MergeAndOr_DeepChain) {
         // AND: grandparent and parent are both prefixes of child -> only child survives
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a", "\2a\2b"}, EMode::And),
-                     MakeTokens({"\2a\2b\2c"})),
-            {"\2a\2b\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a"), encodeKey("a") + encodeKey("b")}, EMode::And),
+                     MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c")})),
+            {encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::And);
 
         // OR: root covers all -> only root survives
         CheckMerge(
-            MergeOr(MakeTokens({"\2a"}),
-                    MakeTokens({"\2a\2b", "\2a\2b\2c"}, EMode::Or)),
-            {"\2a"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a")}),
+                    MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + encodeKey("c")}, EMode::Or)),
+            {encodeKey("a")}, EMode::Or);
     }
 
     // Hierarchical tokens mixed with completely unrelated tokens.
     Y_UNIT_TEST(MergeAndOr_MixedHierarchyAndDisjoint) {
         // {a.b, a.b.c, x} AND {a.b.c.d, y} -> {a.b.c.d, x, y}
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b", "\2a\2b\2c", "\2x"}, EMode::And),
-                     MakeTokens({"\2a\2b\2c\2d", "\2y"}, EMode::And)),
-            {"\2a\2b\2c\2d", "\2x", "\2y"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("x")}, EMode::And),
+                     MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d"), encodeKey("y")}, EMode::And)),
+            {encodeKey("a") + encodeKey("b") + encodeKey("c") + encodeKey("d"), encodeKey("x"), encodeKey("y")}, EMode::And);
 
         // {a, a.b, x} OR {a.b.c, y} -> {a, x, y}
         CheckMerge(
-            MergeOr(MakeTokens({"\2a", "\2a\2b", "\2x"}, EMode::Or),
-                    MakeTokens({"\2a\2b\2c", "\2y"}, EMode::Or)),
-            {"\2a", "\2x", "\2y"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a"), encodeKey("a") + encodeKey("b"), encodeKey("x")}, EMode::Or),
+                    MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("c"), encodeKey("y")}, EMode::Or)),
+            {encodeKey("a"), encodeKey("x"), encodeKey("y")}, EMode::Or);
     }
 
     Y_UNIT_TEST(MergeAndOr_EmptyOperands) {
         // One operand is empty: result is the other operand's single token, NotSet mode
         CheckMerge(
-            MergeAnd(MakeTokens({}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b"}, EMode::NotSet);
+            MergeAnd(MakeTokens({}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::NotSet);
 
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({})),
-            {"\2a\2b"}, EMode::NotSet);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({})),
+            {encodeKey("a") + encodeKey("b")}, EMode::NotSet);
 
         CheckMerge(
             MergeAnd(MakeTokens({}), MakeTokens({})),
             {}, EMode::NotSet);
 
         CheckMerge(
-            MergeOr(MakeTokens({}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b"}, EMode::NotSet);
+            MergeOr(MakeTokens({}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::NotSet);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({})),
-            {"\2a\2b"}, EMode::NotSet);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({})),
+            {encodeKey("a") + encodeKey("b")}, EMode::NotSet);
 
         CheckMerge(
             MergeOr(MakeTokens({}), MakeTokens({})),
@@ -2511,22 +2512,22 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     Y_UNIT_TEST(MergeAndOr_ErrorPropagation) {
         {
-            auto r = MergeAnd(MakeError("left error"), MakeTokens({"\2a\2b"}));
+            auto r = MergeAnd(MakeError("left error"), MakeTokens({encodeKey("a") + encodeKey("b")}));
             UNIT_ASSERT_C(r.IsError(), "AND: expected error from left");
             UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "left error");
         }
         {
-            auto r = MergeAnd(MakeTokens({"\2a\2b"}), MakeError("right error"));
+            auto r = MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeError("right error"));
             UNIT_ASSERT_C(r.IsError(), "AND: expected error from right");
             UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "right error");
         }
         {
-            auto r = MergeOr(MakeError("left error"), MakeTokens({"\2a\2b"}));
+            auto r = MergeOr(MakeError("left error"), MakeTokens({encodeKey("a") + encodeKey("b")}));
             UNIT_ASSERT_C(r.IsError(), "OR: expected error from left");
             UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "left error");
         }
         {
-            auto r = MergeOr(MakeTokens({"\2a\2b"}), MakeError("right error"));
+            auto r = MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeError("right error"));
             UNIT_ASSERT_C(r.IsError(), "OR: expected error from right");
             UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "right error");
         }
@@ -2536,46 +2537,46 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(MergeAndOr_Siblings) {
         // a.b and a.c share ancestor a but neither is a prefix of the other
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2c"})),
-            {"\2a\2b", "\2a\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("a") + encodeKey("c")})),
+            {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2c"})),
-            {"\2a\2b", "\2a\2c"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b")}), MakeTokens({encodeKey("a") + encodeKey("c")})),
+            {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")}, EMode::Or);
 
         // Mix: one sibling has a deeper descendant
         // {a.b, a.c} AND {a.b.d, a.c} -> AND: a.b.d covers a.b; a.c deduplicates -> {a.b.d, a.c}
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b", "\2a\2c"}, EMode::And),
-                     MakeTokens({"\2a\2b\2d", "\2a\2c"}, EMode::And)),
-            {"\2a\2b\2d", "\2a\2c"}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")}, EMode::And),
+                     MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("d"), encodeKey("a") + encodeKey("c")}, EMode::And)),
+            {encodeKey("a") + encodeKey("b") + encodeKey("d"), encodeKey("a") + encodeKey("c")}, EMode::And);
 
         // {a.b, a.c} OR {a.b.d, a.c} -> OR: a.b covers a.b.d; a.c deduplicates -> {a.b, a.c}
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b", "\2a\2c"}, EMode::Or),
-                    MakeTokens({"\2a\2b\2d", "\2a\2c"}, EMode::Or)),
-            {"\2a\2b", "\2a\2c"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")}, EMode::Or),
+                    MakeTokens({encodeKey("a") + encodeKey("b") + encodeKey("d"), encodeKey("a") + encodeKey("c")}, EMode::Or)),
+            {encodeKey("a") + encodeKey("b"), encodeKey("a") + encodeKey("c")}, EMode::Or);
     }
 
     Y_UNIT_TEST(MergeAndOr_ValueTokens) {
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b" + strSuffix("x")}), MakeTokens({"\2a\2b" + strSuffix("xyz")})),
-            {"\2a\2b" + strSuffix("x"), "\2a\2b" + strSuffix("xyz")}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b") + strSuffix("x")}), MakeTokens({encodeKey("a") + encodeKey("b") + strSuffix("xyz")})),
+            {encodeKey("a") + encodeKey("b") + strSuffix("x"), encodeKey("a") + encodeKey("b") + strSuffix("xyz")}, EMode::And);
         CheckMerge(
-            MergeAnd(MakeTokens({"\2a\2b" + strSuffix("x")}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b" + strSuffix("x")}, EMode::And);
+            MergeAnd(MakeTokens({encodeKey("a") + encodeKey("b") + strSuffix("x")}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b") + strSuffix("x")}, EMode::And);
 
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b" + strSuffix("x")}), MakeTokens({"\2a\2b" + strSuffix("xyz")})),
-            {"\2a\2b" + strSuffix("x"), "\2a\2b" + strSuffix("xyz")}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b") + strSuffix("x")}), MakeTokens({encodeKey("a") + encodeKey("b") + strSuffix("xyz")})),
+            {encodeKey("a") + encodeKey("b") + strSuffix("x"), encodeKey("a") + encodeKey("b") + strSuffix("xyz")}, EMode::Or);
         CheckMerge(
-            MergeOr(MakeTokens({"\2a\2b" + strSuffix("x")}), MakeTokens({"\2a\2b"})),
-            {"\2a\2b"}, EMode::Or);
+            MergeOr(MakeTokens({encodeKey("a") + encodeKey("b") + strSuffix("x")}), MakeTokens({encodeKey("a") + encodeKey("b")})),
+            {encodeKey("a") + encodeKey("b")}, EMode::Or);
     }
 
     // Literal suffixes at a path and at root ($); bool false is \0\0 (must not be confused with path bytes).
     Y_UNIT_TEST(MergeAndOr_LiteralValues) {
-        const TString ab = "\2a\2b";
+        const TString ab = encodeKey("a") + encodeKey("b");
         const TString abStrX = ab + strSuffix("x");
         const TString abStrXyz = ab + strSuffix("xyz");
         const TString abStrEmpty = ab + strSuffix("");
@@ -2741,8 +2742,8 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(MergeAndOr_DifferentLengthKeys) {
         // \2a\2b  = path $.a.b  (keys "a" and "b", each 1 char, encoded as 2)
         // \3ab\2c = path $.ab.c (key "ab" is 2 chars, encoded as 3)
-        const TString pathAB  = "\2a\2b";
-        const TString pathABC = "\3ab\2c";  // $.ab.c — unrelated to $.a.b
+        const TString pathAB  = encodeKey("a") + encodeKey("b");
+        const TString pathABC = encodeKey("ab") + encodeKey("c");  // $.ab.c — unrelated to $.a.b
 
         CheckMerge(
             MergeAnd(MakeTokens({pathAB}), MakeTokens({pathABC})),
@@ -2769,9 +2770,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // The empty string token ("") represents the root context object ($)
     Y_UNIT_TEST(MergeAndOr_EmptyPathToken) {
         const TString root = "";
-        const TString a = "\2a";
-        const TString ab = "\2a\2b";
-        const TString b = "\2b";
+        const TString a = encodeKey("a");
+        const TString ab = encodeKey("a") + encodeKey("b");
+        const TString b = encodeKey("b");
 
         // OR: root token covers any other token -> only root survives
         CheckMerge(
@@ -2850,18 +2851,19 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             encodeKey("brand"),
             encodeKey("brand") + strSuffix("bricks"),
             encodeKey("parts"),
-            encodePath({"parts", "id"}),
-            encodePath({"parts", "id"}),
-            encodePath({"parts", "id"}) + numSuffix(32526),
-            encodePath({"parts", "id"}) + numSuffix(32523),
-            encodePath({"parts", "name"}),
-            encodePath({"parts", "name"}),
-            encodePath({"parts", "name"}) + strSuffix("1x3"),
-            encodePath({"parts", "name"}) + strSuffix("3x5"),
-            encodePath({"parts", "count"}),
-            encodePath({"parts", "count"}),
-            encodePath({"parts", "count"}) + numSuffix(7),
-            encodePath({"parts", "count"}) + numSuffix(17),
+            encodeKey("parts") + arrayItemSuffix,
+            encodeKey("parts") + arrayItemSuffix + encodeKey("id"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("id"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("id") + numSuffix(32526),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("id") + numSuffix(32523),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("name"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("name"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("name") + strSuffix("1x3"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("name") + strSuffix("3x5"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("count"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("count"),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("count") + numSuffix(7),
+            encodeKey("parts") + arrayItemSuffix + encodeKey("count") + numSuffix(17),
             encodeKey("price"),
             encodeKey("price") + nullSuffix,
             encodeKey("part_count"),
@@ -2894,7 +2896,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Empty array has no indexable tokens
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[]", error), TVector<TString>{});
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[]", error), TVector<TString>{arrayItemSuffix});
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Root-level number literal
@@ -2914,36 +2916,63 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         // Root-level array: elements are tokenized at the root prefix (no key added for array indices)
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[1, 2, 3]", error), (TVector<TString>{
-            numSuffix(1), numSuffix(2), numSuffix(3),
+            arrayItemSuffix,
+            arrayItemSuffix + numSuffix(1),
+            arrayItemSuffix + numSuffix(2),
+            arrayItemSuffix + numSuffix(3),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Array of arrays: nested arrays are flattened to the same path prefix
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[[1, 2], [3, 4]]", error), (TVector<TString>{
-            numSuffix(1), numSuffix(2), numSuffix(3), numSuffix(4),
+            arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix + numSuffix(1),
+            arrayItemSuffix + arrayItemSuffix + numSuffix(2),
+            arrayItemSuffix + arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix + numSuffix(3),
+            arrayItemSuffix + arrayItemSuffix + numSuffix(4),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Deeply nested arrays
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[[1, [2, 3]], 4]", error), (TVector<TString>{
-            numSuffix(1), numSuffix(2), numSuffix(3), numSuffix(4),
+            arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix + numSuffix(1),
+            arrayItemSuffix + arrayItemSuffix + arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix + arrayItemSuffix + numSuffix(2),
+            arrayItemSuffix + arrayItemSuffix + arrayItemSuffix + numSuffix(3),
+            arrayItemSuffix + numSuffix(4),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Mixed-type array
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[1, \"hello\", true, false, null]", error), (TVector<TString>{
-            numSuffix(1), strSuffix("hello"), boolTrueSuffix, boolFalseSuffix, nullSuffix,
+            arrayItemSuffix,
+            arrayItemSuffix + numSuffix(1),
+            arrayItemSuffix + strSuffix("hello"),
+            arrayItemSuffix + boolTrueSuffix,
+            arrayItemSuffix + boolFalseSuffix,
+            arrayItemSuffix + nullSuffix,
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Array of empty containers has no indexable tokens
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[[], {}, []]", error), TVector<TString>{});
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[[], {}, []]", error), (TVector<TString>{
+            arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix,
+            arrayItemSuffix + arrayItemSuffix,
+        }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Array of objects: each object's keys appear at the same path depth (array adds no prefix)
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[{\"a\":1},{\"a\":2}]", error), (TVector<TString>{
-            encodeKey("a"), encodeKey("a") + numSuffix(1),
-            encodeKey("a"), encodeKey("a") + numSuffix(2),
+            arrayItemSuffix,
+            arrayItemSuffix + encodeKey("a"),
+            arrayItemSuffix + encodeKey("a") + numSuffix(1),
+            arrayItemSuffix + encodeKey("a"),
+            arrayItemSuffix + encodeKey("a") + numSuffix(2),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2981,7 +3010,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         // Object whose values are empty containers: only path-prefix tokens, no value tokens
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"a\":{},\"b\":[]}", error), (TVector<TString>{
-            encodeKey("a"), encodeKey("b"),
+            encodeKey("a"),
+            encodeKey("b"),
+            encodeKey("b") + arrayItemSuffix,
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -3042,13 +3073,18 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         // Unicode value in array
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[\"Привет\",\"Мир\"]", error), (TVector<TString>{
-            strSuffix("Привет"), strSuffix("Мир"),
+            arrayItemSuffix,
+            arrayItemSuffix + strSuffix("Привет"),
+            arrayItemSuffix + strSuffix("Мир"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Array with unicode values under unicode key
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":[\"а\",\"б\"]}", error), (TVector<TString>{
-            encodeKey("ключ"), encodeKey("ключ") + strSuffix("а"), encodeKey("ключ") + strSuffix("б"),
+            encodeKey("ключ"),
+            encodeKey("ключ") + arrayItemSuffix,
+            encodeKey("ключ") + arrayItemSuffix + strSuffix("а"),
+            encodeKey("ключ") + arrayItemSuffix + strSuffix("б"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -3132,80 +3168,80 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(Unicode) {
         // Unicode string VALUE in JSONPath (ASCII key, Unicode value)
         // Equality: path + strSuffix with unicode bytes
-        ValidateJsonValue(R"($.key == "Привет")", {encodePath({"key"}) + strSuffix("Привет")});
-        ValidateJsonValue(R"("Привет" == $.key)", {encodePath({"key"}) + strSuffix("Привет")});
-        ValidateJsonValue(R"($.key == "Мир")", {encodePath({"key"}) + strSuffix("Мир")});
+        ValidateJsonValue(R"(strict $.key == "Привет")", {encodePath({"key"}) + strSuffix("Привет")});
+        ValidateJsonValue(R"(strict "Привет" == $.key)", {encodePath({"key"}) + strSuffix("Привет")});
+        ValidateJsonValue(R"(strict $.key == "Мир")", {encodePath({"key"}) + strSuffix("Мир")});
         // Inequality / range: path only (literal dropped)
-        ValidateJsonValue(R"($.key != "Привет")", {encodePath({"key"})});
-        ValidateJsonValue(R"($.key < "Я")", {encodePath({"key"})});
-        ValidateJsonValue(R"($.key > "А")", {encodePath({"key"})});
-        ValidateJsonValue(R"($.key <= "Я")", {encodePath({"key"})});
-        ValidateJsonValue(R"($.key >= "А")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $.key != "Привет")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $.key < "Я")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $.key > "А")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $.key <= "Я")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $.key >= "А")", {encodePath({"key"})});
 
         // Unicode KEY in JSONPath (quoted key)
         // $."ключ" — the JSONPath parser strips the quotes, key = "ключ"
-        ValidateJsonExists(R"($."ключ")", {encodePath({"ключ"})});
-        ValidateJsonValue(R"($."ключ" == "val")", {encodePath({"ключ"}) + strSuffix("val")});
-        ValidateJsonValue(R"($."ключ" != "val")", {encodePath({"ключ"})});
+        ValidateJsonExists(R"(strict $."ключ")", {encodePath({"ключ"})});
+        ValidateJsonValue(R"(strict $."ключ" == "val")", {encodePath({"ключ"}) + strSuffix("val")});
+        ValidateJsonValue(R"(strict $."ключ" != "val")", {encodePath({"ключ"})});
         // starts with / like_regex with unicode key: path only
-        ValidateJsonValue(R"($."ключ" starts with "пр")", {encodePath({"ключ"})});
-        ValidateJsonValue(R"($."ключ" like_regex "пр.*")", {encodePath({"ключ"})});
+        ValidateJsonValue(R"(strict $."ключ" starts with "пр")", {encodePath({"ключ"})});
+        ValidateJsonValue(R"(strict $."ключ" like_regex "пр.*")", {encodePath({"ключ"})});
 
         // Unicode KEY and unicode VALUE
-        ValidateJsonValue(R"($."ключ" == "значение")", {encodePath({"ключ"}) + strSuffix("значение")});
-        ValidateJsonValue(R"("значение" == $."ключ")", {encodePath({"ключ"}) + strSuffix("значение")});
+        ValidateJsonValue(R"(strict $."ключ" == "значение")", {encodePath({"ключ"}) + strSuffix("значение")});
+        ValidateJsonValue(R"(strict "значение" == $."ключ")", {encodePath({"ключ"}) + strSuffix("значение")});
 
         // Nested unicode keys: $."ключ"."поле"
-        ValidateJsonExists(R"($."ключ"."поле")", {encodePath({"ключ", "поле"})});
-        ValidateJsonValue(R"($."ключ"."поле" == "v")", {encodePath({"ключ", "поле"}) + strSuffix("v")});
-        ValidateJsonValue(R"($."ключ"."поле" == "значение")", {encodePath({"ключ", "поле"}) + strSuffix("значение")});
+        ValidateJsonExists(R"(strict $."ключ"."поле")", {encodePath({"ключ", "поле"})});
+        ValidateJsonValue(R"(strict $."ключ"."поле" == "v")", {encodePath({"ключ", "поле"}) + strSuffix("v")});
+        ValidateJsonValue(R"(strict $."ключ"."поле" == "значение")", {encodePath({"ключ", "поле"}) + strSuffix("значение")});
 
         // Unicode value in filter equality (JSON_EXISTS)
-        ValidateJsonExists(R"($.key ? (@ == "Привет"))", {encodePath({"key"}) + strSuffix("Привет")});
-        ValidateJsonExists(R"($ ? (@.key == "Мир"))", {encodePath({"key"}) + strSuffix("Мир")});
-        ValidateJsonExists(R"($ ? (@."ключ" == "значение"))", {encodePath({"ключ"}) + strSuffix("значение")});
+        ValidateJsonExists(R"(strict $.key ? (@ == "Привет"))", {encodePath({"key"}) + strSuffix("Привет")});
+        ValidateJsonExists(R"(strict $ ? (@.key == "Мир"))", {encodePath({"key"}) + strSuffix("Мир")});
+        ValidateJsonExists(R"(strict $ ? (@."ключ" == "значение"))", {encodePath({"ключ"}) + strSuffix("значение")});
         // Inequality in filter: path only
-        ValidateJsonExists(R"($.key ? (@ != "Привет"))", {encodePath({"key"})});
-        ValidateJsonExists(R"($ ? (@.key != "Привет"))", {encodePath({"key"})});
+        ValidateJsonExists(R"(strict $.key ? (@ != "Привет"))", {encodePath({"key"})});
+        ValidateJsonExists(R"(strict $ ? (@.key != "Привет"))", {encodePath({"key"})});
 
         // Unicode value in filter starts with / like_regex (path only)
-        ValidateJsonExists(R"($.a ? (@.key starts with "При"))", {encodePath({"a", "key"})});
-        ValidateJsonExists(R"($.a ? (@.key like_regex "При.*"))", {encodePath({"a", "key"})});
-        ValidateJsonExists(R"($.a ? (@ starts with "При"))", {encodePath({"a"})});
-        ValidateJsonExists(R"($.a ? (@ like_regex "При.*"))", {encodePath({"a"})});
+        ValidateJsonExists(R"(strict $.a ? (@.key starts with "При"))", {encodePath({"a", "key"})});
+        ValidateJsonExists(R"(strict $.a ? (@.key like_regex "При.*"))", {encodePath({"a", "key"})});
+        ValidateJsonExists(R"(strict $.a ? (@ starts with "При"))", {encodePath({"a"})});
+        ValidateJsonExists(R"(strict $.a ? (@ like_regex "При.*"))", {encodePath({"a"})});
 
         // Unicode key with filter predicate
-        ValidateJsonExists(R"($."ключ" ? (@ == "значение"))", {encodePath({"ключ"}) + strSuffix("значение")});
-        ValidateJsonExists(R"($."ключ" ? (@."поле" == "v"))", {encodePath({"ключ", "поле"}) + strSuffix("v")});
+        ValidateJsonExists(R"(strict $."ключ" ? (@ == "значение"))", {encodePath({"ключ"}) + strSuffix("значение")});
+        ValidateJsonExists(R"(strict $."ключ" ? (@."поле" == "v"))", {encodePath({"ключ", "поле"}) + strSuffix("v")});
 
         // Unicode in filter AND/OR
-        ValidateJsonExists(R"($ ? (@.key == "Привет" && @.other == "Мир"))",
+        ValidateJsonExists(R"(strict $ ? (@.key == "Привет" && @.other == "Мир"))",
             {encodePath({"key"}) + strSuffix("Привет"), encodePath({"other"}) + strSuffix("Мир")});
-        ValidateJsonExists(R"($ ? ((@.key == "Привет") || (@.key == "Мир")))",
+        ValidateJsonExists(R"(strict $ ? ((@.key == "Привет") || (@.key == "Мир")))",
             {encodePath({"key"}) + strSuffix("Привет"), encodePath({"key"}) + strSuffix("Мир")});
-        ValidateJsonExists(R"($ ? (@."ключ" == "а" && @."поле" == "б"))",
+        ValidateJsonExists(R"(strict $ ? (@."ключ" == "а" && @."поле" == "б"))",
             {encodePath({"ключ"}) + strSuffix("а"), encodePath({"поле"}) + strSuffix("б")});
 
         // Unicode in starts with / like_regex at JsonValue path level (path only)
-        ValidateJsonValue(R"($.key starts with "При")", {encodePath({"key"})});
-        ValidateJsonValue(R"($.key like_regex "При.*")", {encodePath({"key"})});
-        ValidateJsonValue(R"($."ключ" starts with "При")", {encodePath({"ключ"})});
-        ValidateJsonValue(R"($."ключ" like_regex "При.*")", {encodePath({"ключ"})});
+        ValidateJsonValue(R"(strict $.key starts with "При")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $.key like_regex "При.*")", {encodePath({"key"})});
+        ValidateJsonValue(R"(strict $."ключ" starts with "При")", {encodePath({"ключ"})});
+        ValidateJsonValue(R"(strict $."ключ" like_regex "При.*")", {encodePath({"ключ"})});
 
         // Unicode value via variables (PASSING): variable map value is the encoded suffix
-        ValidateTokens(R"($.key == $var)", {encodePath({"key"}) + strSuffix("Привет")},
+        ValidateTokens(R"(strict $.key == $var)", {encodePath({"key"}) + strSuffix("Привет")},
             {{"var", strSuffix("Привет")}});
-        ValidateTokens(R"($.k1 ? (@.k2 == $var))", {encodePath({"k1", "k2"}) + strSuffix("Привет")},
+        ValidateTokens(R"(strict $.k1 ? (@.k2 == $var))", {encodePath({"k1", "k2"}) + strSuffix("Привет")},
             {{"var", strSuffix("Привет")}}, {}, ECallableType::JsonExists);
-        ValidateTokens(R"($ ? (@."ключ" == $var))", {encodePath({"ключ"}) + strSuffix("значение")},
+        ValidateTokens(R"(strict $ ? (@."ключ" == $var))", {encodePath({"ключ"}) + strSuffix("значение")},
             {{"var", strSuffix("значение")}}, {}, ECallableType::JsonExists);
 
         // Unicode AND/OR at JsonValue level
-        ValidateJsonValue(R"(($.k1 == "Привет") && ($.k2 == "Мир"))",
+        ValidateJsonValue(R"(strict ($.k1 == "Привет") && ($.k2 == "Мир"))",
             {encodePath({"k1"}) + strSuffix("Привет"), encodePath({"k2"}) + strSuffix("Мир")});
-        ValidateJsonValue(R"(($.k1 == "Привет") || ($.k2 == "Мир"))",
+        ValidateJsonValue(R"(strict ($.k1 == "Привет") || ($.k2 == "Мир"))",
             {encodePath({"k1"}) + strSuffix("Привет"), encodePath({"k2"}) + strSuffix("Мир")});
-        ValidateJsonValue(R"(($."ключ" == "значение") && ($.k2 == "val"))",
+        ValidateJsonValue(R"(strict ($."ключ" == "значение") && ($.k2 == "val"))",
             {encodePath({"ключ"}) + strSuffix("значение"), encodePath({"k2"}) + strSuffix("val")});
     }
 }

--- a/ydb/library/json_index/ut/json_index_ut.cpp
+++ b/ydb/library/json_index/ut/json_index_ut.cpp
@@ -25,6 +25,7 @@ const TString boolTrueSuffix = TString("\0\1", 2);
 const TString boolFalseSuffix = TString("\0\0", 2);
 const TString nullSuffix = TString("\0\2", 2);
 const TString arrayItemSuffix = TString("\1");
+const TString laxMarker = TString("\2");
 
 TString encodeKey(TStringBuf key) {
     TString result;
@@ -211,13 +212,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(R"({"a":1})", error), (TVector<TString>{
             encodeKey("a"), encodeKey("a") + numSuffix(1),
+
+            laxMarker + encodeKey("a"), laxMarker + encodeKey("a") + numSuffix(1),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("[]", error), TVector<TString>{arrayItemSuffix});
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("42", error), (TVector<TString>{numSuffix(42)}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("42", error), (TVector<TString>{numSuffix(42), laxMarker + numSuffix(42)}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
     }
 
@@ -2838,7 +2841,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"invalid json", error), TVector<TString>{});
         UNIT_ASSERT(!error.empty());
 
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"literal string\"", error), (TVector<TString>{strSuffix("literal string")}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"literal string\"", error), (TVector<TString>{strSuffix("literal string"), laxMarker + strSuffix("literal string")}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         TString obj = "{\"id\":42042,\"brand\":\"bricks\",\"part_count\":1401,\"price\":null,\"parts\":"
@@ -2846,6 +2849,28 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         auto tokens = TokenizeJson(obj, error);
         std::sort(tokens.begin(), tokens.end());
         UNIT_ASSERT_VALUES_EQUAL(tokens, (TVector<TString>{
+            laxMarker + encodeKey("id"),
+            laxMarker + encodeKey("id") + numSuffix(42042),
+            laxMarker + encodeKey("brand"),
+            laxMarker + encodeKey("brand") + strSuffix("bricks"),
+            laxMarker + encodeKey("parts"),
+            laxMarker + encodeKey("parts") + encodeKey("id"),
+            laxMarker + encodeKey("parts") + encodeKey("id"),
+            laxMarker + encodeKey("parts") + encodeKey("id") + numSuffix(32526),
+            laxMarker + encodeKey("parts") + encodeKey("id") + numSuffix(32523),
+            laxMarker + encodeKey("parts") + encodeKey("name"),
+            laxMarker + encodeKey("parts") + encodeKey("name"),
+            laxMarker + encodeKey("parts") + encodeKey("name") + strSuffix("1x3"),
+            laxMarker + encodeKey("parts") + encodeKey("name") + strSuffix("3x5"),
+            laxMarker + encodeKey("parts") + encodeKey("count"),
+            laxMarker + encodeKey("parts") + encodeKey("count"),
+            laxMarker + encodeKey("parts") + encodeKey("count") + numSuffix(7),
+            laxMarker + encodeKey("parts") + encodeKey("count") + numSuffix(17),
+            laxMarker + encodeKey("price"),
+            laxMarker + encodeKey("price") + nullSuffix,
+            laxMarker + encodeKey("part_count"),
+            laxMarker + encodeKey("part_count") + numSuffix(1401),
+
             encodeKey("id"),
             encodeKey("id") + numSuffix(42042),
             encodeKey("brand"),
@@ -2876,6 +2901,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             encodeKey(""),
             encodePath({"", "a"}),
             encodePath({"", "a"}) + strSuffix("b"),
+
+            laxMarker + encodeKey(""),
+            laxMarker + encodePath({"", "a"}),
+            laxMarker + encodePath({"", "a"}) + strSuffix("b"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2888,6 +2917,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             encodeKey(longKey),
             encodePath({longKey, "short"}),
             encodePath({longKey, "short"}) + strSuffix("b"),
+
+            laxMarker + encodeKey(longKey),
+            laxMarker + encodePath({longKey, "short"}),
+            laxMarker + encodePath({longKey, "short"}) + strSuffix("b"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2900,18 +2933,18 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Root-level number literal
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("42", error), (TVector<TString>{numSuffix(42)}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("42", error), (TVector<TString>{numSuffix(42), laxMarker + numSuffix(42)}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Root-level boolean literals
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("true", error), (TVector<TString>{boolTrueSuffix}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("true", error), (TVector<TString>{boolTrueSuffix, laxMarker + boolTrueSuffix}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("false", error), (TVector<TString>{boolFalseSuffix}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("false", error), (TVector<TString>{boolFalseSuffix, laxMarker + boolFalseSuffix}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Root-level null literal
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("null", error), (TVector<TString>{nullSuffix}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("null", error), (TVector<TString>{nullSuffix, laxMarker + nullSuffix}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Root-level array: elements are tokenized at the root prefix (no key added for array indices)
@@ -2920,6 +2953,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             arrayItemSuffix + numSuffix(1),
             arrayItemSuffix + numSuffix(2),
             arrayItemSuffix + numSuffix(3),
+
+            laxMarker + numSuffix(1),
+            laxMarker + numSuffix(2),
+            laxMarker + numSuffix(3),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2932,6 +2969,11 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             arrayItemSuffix + arrayItemSuffix,
             arrayItemSuffix + arrayItemSuffix + numSuffix(3),
             arrayItemSuffix + arrayItemSuffix + numSuffix(4),
+
+            laxMarker + numSuffix(1),
+            laxMarker + numSuffix(2),
+            laxMarker + numSuffix(3),
+            laxMarker + numSuffix(4),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2944,6 +2986,11 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             arrayItemSuffix + arrayItemSuffix + arrayItemSuffix + numSuffix(2),
             arrayItemSuffix + arrayItemSuffix + arrayItemSuffix + numSuffix(3),
             arrayItemSuffix + numSuffix(4),
+
+            laxMarker + numSuffix(1),
+            laxMarker + numSuffix(2),
+            laxMarker + numSuffix(3),
+            laxMarker + numSuffix(4),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2955,6 +3002,12 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             arrayItemSuffix + boolTrueSuffix,
             arrayItemSuffix + boolFalseSuffix,
             arrayItemSuffix + nullSuffix,
+
+            laxMarker + numSuffix(1),
+            laxMarker + strSuffix("hello"),
+            laxMarker + boolTrueSuffix,
+            laxMarker + boolFalseSuffix,
+            laxMarker + nullSuffix,
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2973,12 +3026,19 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             arrayItemSuffix + encodeKey("a") + numSuffix(1),
             arrayItemSuffix + encodeKey("a"),
             arrayItemSuffix + encodeKey("a") + numSuffix(2),
+
+            laxMarker + encodeKey("a"),
+            laxMarker + encodeKey("a") + numSuffix(1),
+            laxMarker + encodeKey("a"),
+            laxMarker + encodeKey("a") + numSuffix(2),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Simple root-level object
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"a\":1}", error), (TVector<TString>{
             encodeKey("a"), encodeKey("a") + numSuffix(1),
+
+            laxMarker + encodeKey("a"), laxMarker + encodeKey("a") + numSuffix(1),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -2991,6 +3051,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
                 encodeKey("b"), encodeKey("b") + boolTrueSuffix,
                 encodeKey("n"), encodeKey("n") + nullSuffix,
                 encodeKey("s"), encodeKey("s") + strSuffix("val"),
+
+                laxMarker + encodeKey("b"), laxMarker + encodeKey("b") + boolTrueSuffix,
+                laxMarker + encodeKey("n"), laxMarker + encodeKey("n") + nullSuffix,
+                laxMarker + encodeKey("s"), laxMarker + encodeKey("s") + strSuffix("val"),
             };
             std::sort(expected.begin(), expected.end());
             UNIT_ASSERT_VALUES_EQUAL(objAllTypes, expected);
@@ -2999,12 +3063,16 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         // Empty key with a scalar value
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"\":42}", error), (TVector<TString>{
             encodeKey(""), encodeKey("") + numSuffix(42),
+
+            laxMarker + encodeKey(""), laxMarker + encodeKey("") + numSuffix(42),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Object with an empty string value
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"a\":\"\"}", error), (TVector<TString>{
             encodeKey("a"), encodeKey("a") + strSuffix(""),
+
+            laxMarker + encodeKey("a"), laxMarker + encodeKey("a") + strSuffix(""),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -3013,12 +3081,17 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             encodeKey("a"),
             encodeKey("b"),
             encodeKey("b") + arrayItemSuffix,
+
+            laxMarker + encodeKey("a"),
+            laxMarker + encodeKey("b"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Unicode string value (ASCII key, Unicode value)
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"key\":\"Привет\"}", error), (TVector<TString>{
             encodeKey("key"), encodeKey("key") + strSuffix("Привет"),
+
+            laxMarker + encodeKey("key"), laxMarker + encodeKey("key") + strSuffix("Привет"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -3030,6 +3103,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             TVector<TString> expected{
                 encodeKey("a"), encodeKey("a") + strSuffix("Привет"),
                 encodeKey("b"), encodeKey("b") + strSuffix("Мир"),
+
+                laxMarker + encodeKey("a"), laxMarker + encodeKey("a") + strSuffix("Привет"),
+                laxMarker + encodeKey("b"), laxMarker + encodeKey("b") + strSuffix("Мир"),
             };
             std::sort(expected.begin(), expected.end());
             UNIT_ASSERT_VALUES_EQUAL(unicodeVals, expected);
@@ -3038,36 +3114,52 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         // Unicode key (ASCII value)
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":\"val\"}", error), (TVector<TString>{
             encodeKey("ключ"), encodeKey("ключ") + strSuffix("val"),
+
+            laxMarker + encodeKey("ключ"), laxMarker + encodeKey("ключ") + strSuffix("val"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Unicode key and unicode value
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":\"значение\"}", error), (TVector<TString>{
             encodeKey("ключ"), encodeKey("ключ") + strSuffix("значение"),
+
+            laxMarker + encodeKey("ключ"), laxMarker + encodeKey("ключ") + strSuffix("значение"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Nested unicode key
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":{\"поле\":\"v\"}}", error), (TVector<TString>{
-            encodeKey("ключ"), encodePath({"ключ", "поле"}), encodePath({"ключ", "поле"}) + strSuffix("v"),
+            encodeKey("ключ"),
+            encodePath({"ключ", "поле"}),
+            encodePath({"ключ", "поле"}) + strSuffix("v"),
+
+            laxMarker + encodeKey("ключ"),
+            laxMarker + encodePath({"ключ", "поле"}),
+            laxMarker + encodePath({"ключ", "поле"}) + strSuffix("v"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Unicode key with numeric value
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":42}", error), (TVector<TString>{
             encodeKey("ключ"), encodeKey("ключ") + numSuffix(42),
+
+            laxMarker + encodeKey("ключ"), laxMarker + encodeKey("ключ") + numSuffix(42),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Unicode key with boolean value
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":true}", error), (TVector<TString>{
             encodeKey("ключ"), encodeKey("ключ") + boolTrueSuffix,
+
+            laxMarker + encodeKey("ключ"), laxMarker + encodeKey("ключ") + boolTrueSuffix,
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Unicode key with null value
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("{\"ключ\":null}", error), (TVector<TString>{
             encodeKey("ключ"), encodeKey("ключ") + nullSuffix,
+
+            laxMarker + encodeKey("ключ"), laxMarker + encodeKey("ключ") + nullSuffix,
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -3076,6 +3168,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             arrayItemSuffix,
             arrayItemSuffix + strSuffix("Привет"),
             arrayItemSuffix + strSuffix("Мир"),
+
+            laxMarker + strSuffix("Привет"),
+            laxMarker + strSuffix("Мир"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -3085,11 +3180,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             encodeKey("ключ") + arrayItemSuffix,
             encodeKey("ключ") + arrayItemSuffix + strSuffix("а"),
             encodeKey("ключ") + arrayItemSuffix + strSuffix("б"),
+
+            laxMarker + encodeKey("ключ"),
+            laxMarker + encodeKey("ключ") + strSuffix("а"),
+            laxMarker + encodeKey("ключ") + strSuffix("б"),
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         // Root-level unicode string literal
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"Привет\"", error), (TVector<TString>{strSuffix("Привет")}));
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"Привет\"", error), (TVector<TString>{strSuffix("Привет"), laxMarker + strSuffix("Привет")}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
     }
 


### PR DESCRIPTION
### Description for reviewers

Незаконченная реализация, которую, думаю, нет смысла вливать, но для истории сохраню.

В общем, у меня возникала идея - сделать выборку по json индексам без постфильтрации. Для этого отслеживать флаг "покрывается ли полностью запрос фултекст токенами". Потом пришло понимание, что это сделать не получится без изменения индексации, потому что дефолтный lax режим дурацкий и автоматически распаковывает/упаковывает 1 уровень массивов на каждом шаге пути.

Ну ок думаю, сейчас быстренько поменяю индексацию и сделаю... А не тут-то было. Получается, что нужно либо продублировать все токены - для lax (такие же, как сейчас) и для strict (в них включить спуск в массив как компоненту пути). Либо просто поменять все токены на такие, как для strict (с компонентами массива), а для lax токены размножать.

Даже попробовал сделать оба варианта, и пришёл к выводу, что оба варианта - плохие. :smile: здесь в ветке сейчас первый, с дублированием.

В общем, правильный ответ на эту задачу такой - не нужно сейчас менять никакую индексацию. В логику JsonPath идея никак не ложится, по крайней мере пока есть странный дефолтный lax режим. И если такое делать, это нужен другой режим поиска. Может быть, JsonContains или ещё что-то в этом духе. Там где-то рядом бегает задачка про пересечение массивов (#50003), вот может быть это куда-то туда же. Для связи - #50925.