### PR TITLE
Skip connect right check for dynamic node registration service accounts

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -677,6 +677,10 @@ private:
     }
 
     std::pair<bool, std::optional<NYql::TIssue>> CheckConnectRight() {
+        if (!AppData()->FeatureFlags.GetCheckDatabaseAccessPermission()) {
+            return {false, std::nullopt};
+        }
+
         if (SkipCheckConnectRights_) {
             YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, AllowYdbRequestsWithoutDatabase is off, there is no db provided from user",
                 {"database", CheckedDatabaseName_},
@@ -684,7 +688,6 @@ private:
                 {"ip", GrpcRequestBaseCtx_->GetPeerName()});
             return {false, std::nullopt};
         }
-
 
         // An empty token at this point means that anonymous access is allowed by the system configuration,
         // as the EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement flags have already been
@@ -720,6 +723,16 @@ private:
             return {false, std::nullopt};
         }
 
+        // service accounts allowed to register dynamic nodes in the cluster
+        // can connect to any database without having connect rights
+        if (IsTokenAllowed(parsedToken.Get(), AppData()->RegisterDynamicNodeAllowedSIDs)) {
+            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, user is a service account for nodes registration",
+                {"database", CheckedDatabaseName_},
+                {"user", TBase::GetUserSID()},
+                {"ip", GrpcRequestBaseCtx_->GetPeerName()});
+            return {false, std::nullopt};
+        }
+
         const ui32 access = NACLib::ConnectDatabase;
         if (parsedToken && SecurityObject_->CheckAccess(access, *parsedToken)) {
             return {false, std::nullopt};
@@ -727,9 +740,6 @@ private:
 
         Counters_->IncDatabaseAccessDenyCounter();
 
-        if (!AppData()->FeatureFlags.GetCheckDatabaseAccessPermission()) {
-            return {false, std::nullopt};
-        }
 
         const TString error = "No permission to connect to the database";
         YDB_LOG_INFO_COMP(NKikimrServices::GRPC_SERVER, error,

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -723,10 +723,12 @@ private:
             return {false, std::nullopt};
         }
 
-        // service accounts allowed to register dynamic nodes in the cluster
-        // can connect to any database without having connect rights
+        // The user-level connect right cannot limit node registration: registration is a
+        // cluster-wide system action (via the discovery service), not a per-database/tenant
+        // one. Requiring here the root database as a cluster alias would add no value and
+        // introduce technical issues.
         if (IsTokenAllowed(parsedToken.Get(), AppData()->RegisterDynamicNodeAllowedSIDs)) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, user is a service account for nodes registration",
+            YDB_LOG_DEBUG_COMP(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, "Skip check permission connect db, user is a special subject for node registration",
                 {"database", CheckedDatabaseName_},
                 {"user", TBase::GetUserSID()},
                 {"ip", GrpcRequestBaseCtx_->GetPeerName()});

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -2327,6 +2327,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         securityConfig.SetEnforceUserTokenCheckRequirement(true);
         securityConfig.AddAdministrationAllowedSIDs(ROOT_TOKEN);
         securityConfig.AddViewerAllowedSIDs("username");
+        securityConfig.AddRegisterDynamicNodeAllowedSIDs(ROOT_TOKEN);
 
         auto grpcSettings = NYdbGrpc::TServerOptions().SetHost("[::1]").SetPort(grpcPort);
         TServer server{settings};

--- a/ydb/services/ydb/ydb_login_ut.cpp
+++ b/ydb/services/ydb/ydb_login_ut.cpp
@@ -133,6 +133,7 @@ private:
         auto& securityConfig = *appConfig.MutableDomainsConfig()->MutableSecurityConfig();
         securityConfig.SetEnforceUserTokenRequirement(true);
         securityConfig.AddAdministrationAllowedSIDs(RootToken);
+        securityConfig.AddRegisterDynamicNodeAllowedSIDs(RootToken);
         securityConfig.SetHideAuthenticationFailureReasons(hideAuthenticationFailureReasons);
 
         appConfig.MutableFeatureFlags()->SetCheckDatabaseAccessPermission(true);

--- a/ydb/services/ydb/ydb_table_ut.cpp
+++ b/ydb/services/ydb/ydb_table_ut.cpp
@@ -774,6 +774,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
         appConfig.MutableFeatureFlags()->SetAllowYdbRequestsWithoutDatabase(false);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenRequirement(true);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddAdministrationAllowedSIDs(clusterAdminToken);
+        appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddRegisterDynamicNodeAllowedSIDs("root@builtin");
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddDefaultUserSIDs("test_user_no_rights@builtin");
         TKikimrWithGrpcAndRootSchemaWithAuth server(appConfig);
 
@@ -872,6 +873,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
         appConfig.MutableFeatureFlags()->SetAllowYdbRequestsWithoutDatabase(true);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenRequirement(false);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddDefaultUserSIDs("test_user_no_rights@builtin");
+        appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddRegisterDynamicNodeAllowedSIDs("root@builtin");
         TKikimrWithGrpcAndRootSchema server(appConfig);
 
         // Make all users except root@builtin non-admins.


### PR DESCRIPTION
Skip connect right check for dynamic node registration service accounts.
