### PR TITLE
NBS-7513: Add DBG-level host states persistence (pt1)

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -205,6 +205,7 @@ TDirectBlockGroup::TDirectBlockGroup(
     size_t directBlockGroupIndex,
     const TVector<NBsController::TDDiskId>& ddisksIds,
     const TVector<NBsController::TDDiskId>& pbufferIds,
+    const TVector<std::pair<EHostState, bool>>& initialHostStates,
     NTransport::TStorageTransportPtr storageTransport,
     NMonitoring::TDynamicCounterPtr counters)
     : ActorSystem(actorSystem)
@@ -221,7 +222,7 @@ TDirectBlockGroup::TDirectBlockGroup(
               .TabletId = diskDescription.TabletId,
               .Generation = diskDescription.Generation,
               .DBGIndex = DirectBlockGroupIndex})
-    , Oracle(StorageConfig, this)
+    , Oracle(StorageConfig, this, initialHostStates)
     , Counters(std::move(counters))
 {
     Y_ASSERT(pbufferIds.size() == ddisksIds.size());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -54,6 +54,7 @@ public:
         size_t directBlockGroupIndex,
         const TVector<NKikimr::NBsController::TDDiskId>& ddisksIds,
         const TVector<NKikimr::NBsController::TDDiskId>& pbufferIds,
+        const TVector<std::pair<EHostState, bool>>& initialHostStates,
         NTransport::TStorageTransportPtr storageTransport,
         NMonitoring::TDynamicCounterPtr counters);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -165,6 +165,7 @@ TDBGFixture::MakeDirectBlockGroup(
         directBlockGroupIndex,
         ddisksIds,
         pbufferIds,
+        TVector(ddisksIds.size(), std::make_pair(EHostState::Online, false)),
         std::move(transport),
         nullptr);
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -140,7 +140,8 @@ private:
 
 TOracle::TOracle(
     TStorageConfigPtr storageConfig,
-    IHostStateController* hostStateController)
+    IHostStateController* hostStateController,
+    const TVector<std::pair<EHostState, bool>>& initialStates)
     : StorageConfig(std::move(storageConfig))
     , OracleConfig(std::make_shared<TOracleConfig>(StorageConfig))
     , HostStateController(hostStateController)
@@ -153,10 +154,11 @@ TOracle::TOracle(
     , DefaultFlushRequestTimeout(StorageConfig->GetFlushRequestTimeout())
     , DefaultEraseRequestTimeout(StorageConfig->GetEraseRequestTimeout())
     , DefaultWriteMode(GetWriteModeFromProto(StorageConfig->GetWriteMode()))
-    , HostStatistics(DirectBlockGroupHostCount)
-    , HostStates(DirectBlockGroupHostCount)
+    , HostStatistics(initialStates.size())
+    , HostStates(initialStates.size())
+    , HostsHealths(initialStates.size())
     , HostsReconnectDelays(
-          DirectBlockGroupHostCount,
+          initialStates.size(),
           TBackoffDelayProvider(MinReconnectDelay, MaxReconnectDelay))
     , TimePredictors(
           OperationCount,
@@ -164,9 +166,21 @@ TOracle::TOracle(
               OracleConfig->GetTimePredictionHistorySize(),
               OracleConfig->GetTimePredictionNthFromEnd()))
 {
-    HostsHealths.resize(HostStates.size());
-    for (auto& healths: HostsHealths) {
-        healths = EHostHealth::Online;
+    for (size_t i = 0; i < initialStates.size(); ++i) {
+        const auto [state, isBroken] = initialStates[i];
+        HostStates[i].State = state;
+        switch (state) {
+            case EHostState::Online:
+                HostsHealths[i] = EHostHealth::Online;
+                break;
+            case EHostState::TemporaryOffline:
+                HostsHealths[i] = EHostHealth::TemporaryOffline;
+                break;
+            case EHostState::Offline:
+                HostsHealths[i] =
+                    isBroken ? EHostHealth::Broken : EHostHealth::Offline;
+                break;
+        }
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
@@ -83,9 +83,12 @@ public:
 class TOracle: public IOracle
 {
 public:
+    /// @param initialStates <EHostState, isBroken> for each host. isBroken is
+    /// meaningful iff EHostState == Offline
     TOracle(
         TStorageConfigPtr storageConfig,
-        IHostStateController* hostStateController);
+        IHostStateController* hostStateController,
+        const TVector<std::pair<EHostState, bool>>& initialStates);
     ~TOracle() override;
 
     void Think(TInstant now);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -57,6 +57,10 @@ TStorageConfigPtr MakeStorageConfig()
     return std::make_shared<TStorageConfig>(rawConfig);
 }
 
+const auto DefaultInitialStates = TVector(
+    DirectBlockGroupHostCount,
+    std::make_pair(EHostState::Online, false));
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -70,7 +74,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const auto hosts = THostMask::MakeAll(5);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
         const auto now = TInstant::Now();
@@ -99,7 +103,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const auto hosts = THostMask::MakeOne(3);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
         const auto now = TInstant::Now();
@@ -132,7 +136,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         hosts.Set(0);
         hosts.Set(3);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         const auto now = TInstant::Now();
         for (THostIndex hostIndex: {0, 0, 3}) {
@@ -167,7 +171,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         hosts.Set(2);
         hosts.Set(4);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         std::map<THostIndex, size_t> counts;
         const size_t iterations = 3000;
@@ -203,7 +207,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         // picked - only ties at the global minimum are randomized.
         const auto hosts = THostMask::MakeAll(5);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
         const auto now = TInstant::Now();
@@ -232,7 +236,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -300,7 +304,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -343,7 +347,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -390,7 +394,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         oracle.Think(now);
@@ -428,7 +432,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         // No read requests recorded -> predictor returns zero -> fallback to
         // default. Default ReadHedgingDelay is 1ms when not set in config.
@@ -446,7 +450,7 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         auto storageConfig = MakeStorageConfig();
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // Feed DDisk reads with 100ms, 200ms on host 0.
@@ -499,7 +503,7 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         auto storageConfig = MakeStorageConfig();
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         // No write requests recorded -> predictor returns zero -> fallback to
         // default. Default WriteHedgingDelay is 1ms when not set in config.
@@ -517,7 +521,7 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         auto storageConfig = MakeStorageConfig();
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // WriteToPBuffer (direct): [100, 200] -> predict 100ms.
@@ -555,7 +559,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
 
         // No errors recorded on any host -> no cooldown.
         UNIT_ASSERT_VALUES_EQUAL(
@@ -568,7 +572,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
         const auto now = TInstant::Now();
 
         // Each consecutive error adds a 10ms penalty on host 0.
@@ -599,7 +603,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
         const auto now = TInstant::Now();
 
         // Host 1: two consecutive errors -> 20ms.
@@ -637,7 +641,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         NProto::TStorageServiceConfig rawConfig;
         auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
 
-        TOracle oracle(storageConfig, nullptr);
+        TOracle oracle(storageConfig, nullptr, DefaultInitialStates);
         const auto now = TInstant::Now();
 
         // The cooldown grows by 10ms per consecutive error and is capped at
@@ -671,7 +675,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
 
         // With the default set of DirectBlockGroupHostCount online hosts, the
         // alive count equals the required count, so no new host is requested.
@@ -690,7 +694,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // Push host 0 into the TemporaryOffline state.
@@ -719,7 +723,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // Generate a single error on host 0.
@@ -759,7 +763,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // Drive host 0 to Offline.
@@ -794,7 +798,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // Drive host 0 to Offline so a new host is requested.
@@ -820,7 +824,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         const auto now = TInstant::Now();
 
         // Initially there are DirectBlockGroupHostCount hosts.
@@ -846,7 +850,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         const auto now = TInstant::Now();
 
         // An index that already exists must not change the host count.
@@ -867,7 +871,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = MakeStorageConfig();
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         // A broken device forces the host offline and requests a replacement.
@@ -900,7 +904,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         auto config = MakeStorageConfig();
 
         THostStateControllerMock hostStateController;
-        TOracle oracle(config, &hostStateController);
+        TOracle oracle(config, &hostStateController, DefaultInitialStates);
         auto now = TInstant::Now();
 
         oracle.OnDDiskBroken(0);
@@ -927,6 +931,46 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const auto stats = oracle.BuildHostStats(now);
         UNIT_ASSERT_EQUAL(EHostHealth::Broken, stats[0].Health);
+    }
+
+    Y_UNIT_TEST(ConstructorSetsInitialStates)
+    {
+        const TVector initialStates{
+            std::pair{EHostState::Online, false},
+            std::pair{EHostState::TemporaryOffline, false},
+            std::pair{EHostState::Offline, false},
+            std::pair{EHostState::Online, false},
+            std::pair{EHostState::Offline, true},
+        };
+
+        const TVector expectedHealth{
+            EHostHealth::Online,
+            EHostHealth::TemporaryOffline,
+            EHostHealth::Offline,
+            EHostHealth::Online,
+            EHostHealth::Broken,
+        };
+
+        auto config = MakeStorageConfig();
+
+        THostStateControllerMock hostStateController;
+        TOracle oracle(config, &hostStateController, initialStates);
+        auto now = TInstant::Now();
+
+        auto stats = oracle.BuildHostStats(now);
+
+        UNIT_ASSERT_VALUES_EQUAL(initialStates.size(), stats.size());
+
+        for (size_t i = 0; i < initialStates.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                initialStates[i].first,
+                stats[i].State,
+                "host #" << i);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedHealth[i],
+                stats[i].Health,
+                "host #" << i);
+        }
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_add_host_to_dbg.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_add_host_to_dbg.cpp
@@ -100,6 +100,9 @@ NProto::TError AddConnection(
         result->MutableDirectBlockGroupConnections(dbgId)->AddConnections();
     connection->MutableDDiskId()->CopyFrom(newDDiskId);
     connection->MutablePersistentBufferDDiskId()->CopyFrom(newPBufferId);
+    connection->SetState(PartitionDirect::NProto::EHostState::Online);
+    connection->SetIsBroken(false);
+
     return {};
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -29,6 +29,24 @@
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
+namespace {
+
+EHostState ProtoToHostState(const PartitionDirect::NProto::EHostState state)
+{
+    switch (state) {
+        case PartitionDirect::NProto::Online:
+            return EHostState::Online;
+        case PartitionDirect::NProto::TemporaryOffline:
+            return EHostState::TemporaryOffline;
+        case PartitionDirect::NProto::Offline:
+            return EHostState::Offline;
+        default:
+            Y_ABORT("unexpected proto host state: %d", state);
+    }
+}
+
+}   // namespace
+
 using namespace NKikimr;
 using namespace NActors;
 
@@ -327,6 +345,12 @@ TVector<IDirectBlockGroupPtr> TPartitionActor::CreateDirectBlockGroups(
             persistentBufferDDiskIds.push_back(NBsController::TDDiskId(
                 connection.GetPersistentBufferDDiskId()));
         }
+        TVector<std::pair<EHostState, bool>> initialHostStates;
+        for (const auto& connection: conn.GetConnections()) {
+            initialHostStates.emplace_back(
+                ProtoToHostState(connection.GetState()),
+                connection.GetIsBroken());
+        }
 
         // Session counters are aggregated at the disk level: all direct block
         // groups of this tablet share the same counters chain, so per-group
@@ -350,6 +374,7 @@ TVector<IDirectBlockGroupPtr> TPartitionActor::CreateDirectBlockGroups(
             dbgIndex,
             std::move(ddiskIds),
             std::move(persistentBufferDDiskIds),
+            std::move(initialHostStates),
             std::move(transport),
             dbgCountersRoot);
 
@@ -641,6 +666,9 @@ void TPartitionActor::HandleInitialAllocationResult(
                 connection->MutableDDiskId()->CopyFrom(node.GetDDiskId());
                 connection->MutablePersistentBufferDDiskId()->CopyFrom(
                     node.GetPersistentBufferDDiskId());
+                connection->SetState(
+                    PartitionDirect::NProto::EHostState::Online);
+                connection->SetIsBroken(false);
             }
         }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/host.proto
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/host.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package NYdb.NBS.PartitionDirect.NProto;
+option java_package = "ru.yandex.ydb.core.nbs.partition_direct.proto";
+
+enum EHostState
+{
+    Online = 0;
+    TemporaryOffline = 1;
+    Offline = 2;
+};

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.proto
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "ydb/core/protos/blobstorage_ddisk.proto";
 import "ydb/core/protos/blockstore_config.proto";
 import "ydb/core/nbs/cloud/blockstore/config/protos/storage.proto";
+import "ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/host.proto";
 
 package NYdb.NBS.PartitionDirect.NProto;
 option java_package = "ru.yandex.ydb.core.nbs.partition_direct.proto";
@@ -11,6 +12,8 @@ message TDirectBlockGroupConnections {
     message TConnection {
         NKikimrBlobStorage.NDDisk.TDDiskId DDiskId = 1;
         NKikimrBlobStorage.NDDisk.TDDiskId PersistentBufferDDiskId = 2;
+        EHostState State = 3;
+        bool IsBroken = 4; // Meaningful iff State == EHostState::Offline
     }
     repeated TConnection Connections = 1;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/ya.make
@@ -4,6 +4,7 @@ EXCLUDE_TAGS(GO_PROTO)
 
 SRCS(
     dirty_map.proto
+    host.proto
     partition_direct.proto
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- В DirectBlockGroupsConnections добавлена информация о состояниях хостов
- Реализована загрузка этой информации при инициализации Oracle

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Сохранение состояний хостов будет в части 2
- Поведение пока не изменилось, т.к. в базу сохраняются дефолтные состояния хостов

