### PR TITLE
Local: retain cut-history requests and replay them to Hive on reconnect

### DIFF
--- a/ydb/core/base/tablet.h
+++ b/ydb/core/base/tablet.h
@@ -844,6 +844,8 @@ struct TEvTablet {
     struct TEvGetCountersResponse : TEventPB<TEvGetCountersResponse, NKikimrTabletBase::TEvGetCountersResponse, EvGetCountersResponse> {};
 
     struct TEvCutTabletHistory : TEventPB<TEvCutTabletHistory, NKikimrTabletBase::TEvCutTabletHistory, EvCutTabletHistory> {
+        using TBase = TEventPB<TEvCutTabletHistory, NKikimrTabletBase::TEvCutTabletHistory, EvCutTabletHistory>;
+        using TBase::TBase;
         TEvCutTabletHistory() = default;
     };
 

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -9785,6 +9785,69 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         });
     }
 
+    Y_UNIT_TEST(TestCutHistoryRetainedAcrossHiveReconnect) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime, true, 2, [](TAppPrepare& app) {
+            app.HiveConfig.SetCutHistoryAllowList("Dummy");
+        });
+
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const TActorId hiveActor = CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(MakeConsoleID(), TTabletTypes::Console), &NConsole::CreateConsole);
+        runtime.EnableScheduleForActor(hiveActor);
+        const TActorId senderA = runtime.AllocateEdgeActor(0);
+        const ui64 testerTablet = MakeTabletID(false, 1);
+
+        bool done = false;
+        auto doneObserver = runtime.AddObserver<TEvHive::TEvShrinkStoragePoolDone>([&](auto&&) { done = true; });
+
+        THolder<TEvHive::TEvCreateTablet> ev(new TEvHive::TEvCreateTablet(testerTablet, 100500, TTabletTypes::Dummy, {3, GetChannelBind("def1")}));
+        ui64 tabletId = SendCreateTestTablet(runtime, hiveTablet, testerTablet, std::move(ev), 0, true);
+
+        // Get the group that Hive wants to vacate: one request, one reply.
+        auto request = std::make_unique<TEvHive::TEvShrinkStoragePool>();
+        request->Record.MutableSubDomain()->SetSchemeShard(TTestTxConfig::SchemeShard);
+        request->Record.MutableSubDomain()->SetPathId(1);
+        request->Record.SetStoragePool("def1");
+        request->Record.SetNewSize(1);
+        request->Record.SetVersion(1);
+        runtime.SendToPipe(hiveTablet, senderA, request.release(), 0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto response = runtime.GrabEdgeEventRethrow<TEvHive::TEvShrinkStoragePoolReply>(handle);
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_C(response->Record.GroupsToRemoveSize() > 0, "Expected at least one group to remove");
+        const ui32 group = response->Record.GetGroupsToRemove(0);
+        UNIT_ASSERT_C(group != 0, "Expected a non-zero group id");
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvTablet::EvMoveData);
+            runtime.DispatchEvents(options);
+        }
+
+        // Reboot Hive while blocking reconnect so the registrar is disconnected
+        TBlockEvents<TEvLocal::TEvPing> blockPing(runtime);
+        RebootTablet(runtime, hiveTablet, senderA);
+        runtime.WaitFor("ping blocked", [&] { return !blockPing.empty(); });
+
+        // Inject CutTabletHistory to the registrar while disconnected
+        const TActorId localRegistrarId = MakeLocalRegistrarID(runtime.GetNodeId(0), hiveTablet);
+        for (ui32 channel = 0; channel < 3; ++channel) {
+            auto cutEv = std::make_unique<TEvTablet::TEvCutTabletHistory>();
+            cutEv->Record.SetTabletID(tabletId);
+            cutEv->Record.SetChannel(channel);
+            cutEv->Record.SetFromGeneration(0);
+            cutEv->Record.SetGroupID(group);
+            runtime.Send(new IEventHandle(localRegistrarId, senderA, cutEv.release()), 0);
+        }
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+
+        // Unblock reconnect; registrar replays retained events and Done fires
+        blockPing.Unblock();
+
+        runtime.WaitFor("TEvShrinkStoragePoolDone after registrar reconnect replayed CutTabletHistory", [&] { return done; });
+    }
+
     Y_UNIT_TEST(TestLockedTabletMetricsAfterHiveRestart) {
         const ui64 hiveTablet = MakeDefaultHiveID();
         const ui64 testerTablet = MakeTabletID(false, 1);

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -368,8 +368,9 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
             if (record.GetPurge()) {
                 for (const auto &x : OnlineTablets) {
                     ctx.Send(x.second.Tablet, new TEvents::TEvPoisonPill());
-                    if (x.first.second == 0) // leader
+                    if (x.first.second == 0) { // leader
                         RetainedCutHistory.erase(x.first.first);
+                    }
                 }
                 OnlineTablets.clear();
             }
@@ -920,8 +921,9 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
                 }
                 InbootTablets.erase(inbootIt);
             }
-            if (onlineIt->first.second == 0) // leader
+            if (onlineIt->first.second == 0) { // leader
                 RetainedCutHistory.erase(onlineIt->first.first);
+            }
             OnlineTablets.erase(onlineIt);
             UpdateEstimate();
             return;
@@ -932,8 +934,9 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         });
         if (inbootIt != InbootTablets.end() && inbootIt->second.Generation <= generation) {
             MarkDeadTablet(inbootIt->first, generation, TEvLocal::TEvTabletStatus::StatusBootFailed, msg->Reason, ctx);
-            if (inbootIt->first.second == 0) // leader
+            if (inbootIt->first.second == 0) { // leader
                 RetainedCutHistory.erase(inbootIt->first.first);
+            }
             InbootTablets.erase(inbootIt);
             return;
         }

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -123,18 +123,17 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
 
     TIntrusivePtr<TDrainProgress> LastDrainRequest;
 
-    // Retained cut-history tuples awaiting forwarding to Hive after reconnect.
-    // Hive sends no ack; TTxCutTabletHistory is a no-op for an already-erased
-    // entry, so replay-on-reconnect is safe.  Memory is bounded by one
-    // incarnation's cut entries (TEvTabletDead cleans up); cost is one no-op
-    // Hive tx per retained tuple per reconnect.
-    struct TCutEntry {
-        ui32 Channel;
-        ui32 FromGeneration;
-        ui32 GroupId;
-    };
+    // Retained cut-history events awaiting forwarding to Hive after reconnect.
+    // One event is kept per (tablet, channel, fromGeneration) tuple; a newer
+    // arrival for the same tuple replaces the stored one.  On reconnect a copy
+    // of each stored event is sent through the pipe; the master copy is kept
+    // for subsequent reconnects.  Hive sends no ack; TTxCutTabletHistory is a
+    // no-op for an already-erased entry, so replay-on-reconnect is safe.
+    // Memory is bounded by one tablet incarnation's cut entries (TEvTabletDead
+    // cleans up).
+    using TCutHistoryEvent = std::unique_ptr<TEvTablet::TEvCutTabletHistory>;
     static constexpr size_t MaxRetainedCutHistoryPerTablet = 1024;
-    THashMap<ui64, TVector<TCutEntry>> RetainedCutHistory;
+    THashMap<ui64, TVector<TCutHistoryEvent>> RetainedCutHistory;
 
     NKikimrTabletBase::TMetrics ResourceLimit;
     TResourceProfilesPtr ResourceProfiles;
@@ -402,14 +401,11 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
 
             Connected = true;
             YDB_LOG_DEBUG_CTX(ctx, "TLocalNodeRegistrar::Handle TEvLocal::TEvPing: connected to hive");
-            for (const auto& [tId, entries] : RetainedCutHistory) {
-                for (const auto& e : entries) {
-                    auto replay = std::make_unique<TEvTablet::TEvCutTabletHistory>();
-                    replay->Record.SetTabletID(tId);
-                    replay->Record.SetChannel(e.Channel);
-                    replay->Record.SetFromGeneration(e.FromGeneration);
-                    replay->Record.SetGroupID(e.GroupId);
-                    NTabletPipe::SendData(ctx, HivePipeClient, replay.release());
+            for (const auto& tabletEntries : RetainedCutHistory) {
+                for (const auto& e : tabletEntries.second) {
+                    auto copy = std::make_unique<TEvTablet::TEvCutTabletHistory>();
+                    copy->Record.CopyFrom(e->Record);
+                    NTabletPipe::SendData(ctx, HivePipeClient, copy.release());
                 }
             }
         }
@@ -820,25 +816,46 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         const ui64 tabletId = record.GetTabletID();
         const ui32 channel = record.GetChannel();
         const ui32 fromGen = record.GetFromGeneration();
-        const ui32 groupId = record.GetGroupID();
         auto& entries = RetainedCutHistory[tabletId];
-        if (auto* existing = FindIfPtr(entries, [&](const TCutEntry& e) {
-                return e.Channel == channel && e.FromGeneration == fromGen;
-            })) {
-            existing->GroupId = groupId;
-        } else if (entries.size() < MaxRetainedCutHistoryPerTablet) {
-            entries.push_back({channel, fromGen, groupId});
-        } else {
-            // The tuple space is sender-controlled; a misbehaving cutter must not grow
-            // this node's memory without bound. Dropping degrades to the pre-fix
-            // behavior for this tuple: the cut is lost until the tablet restarts.
-            YDB_LOG_WARN_CTX(ctx, "TLocalNodeRegistrar: retained cut-history overflow, dropping",
-                {"tabletId", tabletId},
-                {"channel", channel},
-                {"fromGeneration", fromGen});
-        }
-        if (Connected)
+        auto* existing = FindIfPtr(entries, [&](const TCutHistoryEvent& e) {
+            return e->Record.GetChannel() == channel && e->Record.GetFromGeneration() == fromGen;
+        });
+        if (Connected) {
+            // Keep a copy for future reconnects; the original goes to Hive now.
+            auto copy = std::make_unique<TEvTablet::TEvCutTabletHistory>();
+            copy->Record.CopyFrom(record);
+            if (existing) {
+                *existing = std::move(copy);
+            } else if (entries.size() < MaxRetainedCutHistoryPerTablet) {
+                entries.push_back(std::move(copy));
+            } else {
+                // The per-tablet buffer is capped because the tuple space is sender-controlled.
+                // On overflow the copy is not retained; the cut reaches Hive this time but will
+                // not be replayed on reconnect, so it must be re-derived after tablet restart.
+                YDB_LOG_WARN_CTX(ctx, "TLocalNodeRegistrar: retained cut-history overflow, dropping",
+                    {"tabletId", tabletId},
+                    {"channel", channel},
+                    {"fromGeneration", fromGen});
+            }
             NTabletPipe::SendData(ctx, HivePipeClient, ev.Get()->Release().Release());
+        } else {
+            // Not connected: move the event directly into the store (zero copy).
+            auto owned = TCutHistoryEvent(ev.Get()->Release().Release());
+            if (existing) {
+                *existing = std::move(owned);
+            } else if (entries.size() < MaxRetainedCutHistoryPerTablet) {
+                entries.push_back(std::move(owned));
+            } else {
+                // The per-tablet buffer is capped because the tuple space is sender-controlled.
+                // On overflow the request is dropped with a warning; the cut for this
+                // (channel, fromGeneration) entry is delivered to Hive only after the tablet
+                // restarts and re-derives it.
+                YDB_LOG_WARN_CTX(ctx, "TLocalNodeRegistrar: retained cut-history overflow, dropping",
+                    {"tabletId", tabletId},
+                    {"channel", channel},
+                    {"fromGeneration", fromGen});
+            }
+        }
     }
 
     void Handle(TEvTablet::TEvTabletDead::TPtr &ev, const TActorContext &ctx) {

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -18,6 +18,7 @@
 #include <ydb/library/actors/core/log.h>
 
 #include <util/system/info.h>
+#include <util/generic/algorithm.h>
 #include <util/string/vector.h>
 
 #include <unordered_map>
@@ -121,6 +122,19 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
     i32 PrevEstimate = 0;
 
     TIntrusivePtr<TDrainProgress> LastDrainRequest;
+
+    // Retained cut-history tuples awaiting forwarding to Hive after reconnect.
+    // Hive sends no ack; TTxCutTabletHistory is a no-op for an already-erased
+    // entry, so replay-on-reconnect is safe.  Memory is bounded by one
+    // incarnation's cut entries (TEvTabletDead cleans up); cost is one no-op
+    // Hive tx per retained tuple per reconnect.
+    struct TCutEntry {
+        ui32 Channel;
+        ui32 FromGeneration;
+        ui32 GroupId;
+    };
+    static constexpr size_t MaxRetainedCutHistoryPerTablet = 1024;
+    THashMap<ui64, TVector<TCutEntry>> RetainedCutHistory;
 
     NKikimrTabletBase::TMetrics ResourceLimit;
     TResourceProfilesPtr ResourceProfiles;
@@ -353,8 +367,11 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
             }
 
             if (record.GetPurge()) {
-                for (const auto &x : OnlineTablets)
+                for (const auto &x : OnlineTablets) {
                     ctx.Send(x.second.Tablet, new TEvents::TEvPoisonPill());
+                    if (x.first.second == 0) // leader
+                        RetainedCutHistory.erase(x.first.first);
+                }
                 OnlineTablets.clear();
             }
 
@@ -385,6 +402,16 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
 
             Connected = true;
             YDB_LOG_DEBUG_CTX(ctx, "TLocalNodeRegistrar::Handle TEvLocal::TEvPing: connected to hive");
+            for (const auto& [tId, entries] : RetainedCutHistory) {
+                for (const auto& e : entries) {
+                    auto replay = std::make_unique<TEvTablet::TEvCutTabletHistory>();
+                    replay->Record.SetTabletID(tId);
+                    replay->Record.SetChannel(e.Channel);
+                    replay->Record.SetFromGeneration(e.FromGeneration);
+                    replay->Record.SetGroupID(e.GroupId);
+                    NTabletPipe::SendData(ctx, HivePipeClient, replay.release());
+                }
+            }
         }
 
         HiveGeneration = hiveGen;
@@ -789,7 +816,28 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
     }
 
     void Handle(TEvTablet::TEvCutTabletHistory::TPtr &ev, const TActorContext &ctx) {
-        if (Connected) // must be 'connected' check
+        const auto& record = ev->Get()->Record;
+        const ui64 tabletId = record.GetTabletID();
+        const ui32 channel = record.GetChannel();
+        const ui32 fromGen = record.GetFromGeneration();
+        const ui32 groupId = record.GetGroupID();
+        auto& entries = RetainedCutHistory[tabletId];
+        if (auto* existing = FindIfPtr(entries, [&](const TCutEntry& e) {
+                return e.Channel == channel && e.FromGeneration == fromGen;
+            })) {
+            existing->GroupId = groupId;
+        } else if (entries.size() < MaxRetainedCutHistoryPerTablet) {
+            entries.push_back({channel, fromGen, groupId});
+        } else {
+            // The tuple space is sender-controlled; a misbehaving cutter must not grow
+            // this node's memory without bound. Dropping degrades to the pre-fix
+            // behavior for this tuple: the cut is lost until the tablet restarts.
+            YDB_LOG_WARN_CTX(ctx, "TLocalNodeRegistrar: retained cut-history overflow, dropping",
+                {"tabletId", tabletId},
+                {"channel", channel},
+                {"fromGeneration", fromGen});
+        }
+        if (Connected)
             NTabletPipe::SendData(ctx, HivePipeClient, ev.Get()->Release().Release());
     }
 
@@ -858,6 +906,8 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
                 }
                 InbootTablets.erase(inbootIt);
             }
+            if (onlineIt->first.second == 0) // leader
+                RetainedCutHistory.erase(onlineIt->first.first);
             OnlineTablets.erase(onlineIt);
             UpdateEstimate();
             return;
@@ -868,6 +918,8 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         });
         if (inbootIt != InbootTablets.end() && inbootIt->second.Generation <= generation) {
             MarkDeadTablet(inbootIt->first, generation, TEvLocal::TEvTabletStatus::StatusBootFailed, msg->Reason, ctx);
+            if (inbootIt->first.second == 0) // leader
+                RetainedCutHistory.erase(inbootIt->first.first);
             InbootTablets.erase(inbootIt);
             return;
         }

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -403,9 +403,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
             YDB_LOG_DEBUG_CTX(ctx, "TLocalNodeRegistrar::Handle TEvLocal::TEvPing: connected to hive");
             for (const auto& tabletEntries : RetainedCutHistory) {
                 for (const auto& e : tabletEntries.second) {
-                    auto copy = std::make_unique<TEvTablet::TEvCutTabletHistory>();
-                    copy->Record.CopyFrom(e->Record);
-                    NTabletPipe::SendData(ctx, HivePipeClient, copy.release());
+                    NTabletPipe::SendData(ctx, HivePipeClient, new TEvTablet::TEvCutTabletHistory(e->Record));
                 }
             }
         }
@@ -822,8 +820,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         });
         if (Connected) {
             // Keep a copy for future reconnects; the original goes to Hive now.
-            auto copy = std::make_unique<TEvTablet::TEvCutTabletHistory>();
-            copy->Record.CopyFrom(record);
+            auto copy = std::make_unique<TEvTablet::TEvCutTabletHistory>(record);
             if (existing) {
                 *existing = std::move(copy);
             } else if (entries.size() < MaxRetainedCutHistoryPerTablet) {


### PR DESCRIPTION
Issue #51955

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Fixes silent loss of `TEvTablet::TEvCutTabletHistory` on the Local→Hive leg: the registrar forwards it only `if (Connected)` and otherwise destroys it, the tablet latches `CutHistoryStatus = Cut` before delivery is known, and Hive sends no ack — so a cut produced while Hive is restarting or the pipe is down leaves the stale channel-history entry in Hive until the tablet's next restart + GC + snapshot cycle, possibly never for a quiet tablet. Any tablet type with cut-history enabled is affected.

- **Retain and replay in the registrar** (`mind/local.cpp`, no protocol changes): `TLocalNodeRegistrar` records each leader tablet's cut tuples `{channel, fromGeneration, group}` (deduplicated by `{channel, fromGeneration}` — Hive keys history the same way) and replays them after every successful (re)registration, ordered after `TEvSyncTablets` on the same pipe. This covers both the `!Connected` drop and the pipe-death-in-flight race, including a Hive restart that loses an enqueued event.
- **Bounded memory, leader-only cleanup**: retention is one incarnation's cut entries per tablet; erased on the leader's `TEvTabletDead` and on node purge — a co-located follower's death deliberately does not wipe the leader's tuples. Cost is one no-op Hive tx per retained tuple per reconnect. Retention is additionally hard-capped at `MaxRetainedCutHistoryPerTablet = 1024` tuples per tablet, since the tuple space is sender-controlled; on overflow the tuple is dropped with a warning, degrading to the pre-fix behavior for that entry.
- **Why replay is safe**: `TTxCutTabletHistory` is a natural no-op for an already-erased entry (the `History` find misses; no counters, no DB writes), and a duplicate arriving after the tablet's own restart only re-cuts an entry that is still legitimately cuttable.

Test in `mind/hive/hive_ut.cpp`: `TestCutHistoryRetainedAcrossHiveReconnect` — shrink a pool for a Dummy tablet (`CutHistoryAllowList("Dummy")`), hold the registrar disconnected by blocking `TEvLocal::TEvPing` across a Hive reboot, inject the cut requests once, reconnect, and assert `TEvShrinkStoragePoolDone` arrives without restarting the tablet. Fails without the `local.cpp` change; both existing `TestShrinkStoragePool*` tests stay green.
