### PR TITLE
Fix incorrect UTF-8 truncation with long full-text queries

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -147,8 +147,10 @@ TString GetExprStr(const TExprBase& scalar, bool quoteStr = true) {
     }
 
     if (literal) {
-        CollapseText(*literal, 32);
-
+        if (literal->size() > 100) {
+            Utf8TruncateInplace(*literal, 96);
+            *literal += " ...";
+        }
         if (quoteStr) {
             return TStringBuilder() << '"' << *literal << '"';
         } else {

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_search_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_search_ut.cpp
@@ -2465,7 +2465,7 @@ Y_UNIT_TEST_QUAD(SelectWithFulltextMatchShorterThanMinNgram, RELEVANCE, UTF8) {
     }
 }
 
-Y_UNIT_TEST(ExplainFulltextIndexContains) {
+Y_UNIT_TEST(ExplainFulltextIndexLongUTF8) {
     auto kikimr = Kikimr();
     auto db = kikimr.GetQueryClient();
     CreateTexts(db);
@@ -2475,30 +2475,38 @@ Y_UNIT_TEST(ExplainFulltextIndexContains) {
     auto tableClient = kikimr.GetTableClient();
     auto session = tableClient.CreateSession().GetValueSync().GetSession();
 
-    TString query = R"sql(
-        SELECT Key, Text
-        FROM `/Root/Texts` VIEW `fulltext_idx`
-        WHERE FulltextMatch(Text, "cats")
-    )sql";
-    auto result = session.ExplainDataQuery(query).ExtractValueSync();
-    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    for (int prefix = 0; prefix < 2; prefix++) {
+        TString query = Sprintf(R"sql(
+            SELECT Key, Text
+            FROM `/Root/Texts` VIEW `fulltext_idx`
+            WHERE FulltextMatch(Text, "%sтетрагидропиранилциклопентилтетрагидропиридопиридиновые")
+        )sql", prefix ? "_" : "");
+        auto result = session.ExplainDataQuery(query).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
-    Cerr << result.GetPlan() << Endl;
+        Cerr << result.GetPlan() << Endl;
 
-    NJson::TJsonValue plan;
-    NJson::ReadJsonTree(result.GetPlan(), &plan, true);
-    UNIT_ASSERT(ValidatePlanNodeIds(plan));
+        NJson::TJsonValue plan;
+        NJson::ReadJsonTree(result.GetPlan(), &plan, true);
+        UNIT_ASSERT(ValidatePlanNodeIds(plan));
 
-    // Verify ReadFullTextIndex operator is present
-    auto readFullTextIndex = FindPlanNodeByKv(plan, "Name", "ReadFullTextIndex");
-    UNIT_ASSERT(readFullTextIndex.IsDefined());
+        // Verify ReadFullTextIndex operator is present
+        auto readFullTextIndex = FindPlanNodeByKv(plan, "Name", "ReadFullTextIndex");
+        UNIT_ASSERT(readFullTextIndex.IsDefined());
 
-    // Verify operator properties
-    const auto& opProps = readFullTextIndex.GetMapSafe();
-    UNIT_ASSERT(opProps.contains("Table"));
-    UNIT_ASSERT(opProps.contains("Index"));
-    UNIT_ASSERT(opProps.contains("Columns"));
-    UNIT_ASSERT_VALUES_EQUAL(opProps.at("Index").GetStringSafe(), "fulltext_idx");
+        // Verify operator properties
+        const auto& opProps = readFullTextIndex.GetMapSafe();
+        UNIT_ASSERT(opProps.contains("Table"));
+        UNIT_ASSERT(opProps.contains("Index"));
+        UNIT_ASSERT(opProps.contains("Columns"));
+        UNIT_ASSERT_VALUES_EQUAL(opProps.at("Index").GetStringSafe(), "fulltext_idx");
+
+        // Verify correct UTF-8 truncation (at odd and even positions)
+        auto expected = prefix
+            ? "\"_тетрагидропиранилциклопентилтетрагидропиридопир ...\""
+            : "\"тетрагидропиранилциклопентилтетрагидропиридопири ...\"";
+        UNIT_ASSERT_VALUES_EQUAL(opProps.at("Query").GetStringSafe(), expected);
+    }
 }
 
 Y_UNIT_TEST(ExplainFulltextIndexRelevance) {


### PR DESCRIPTION
### Description for reviewers

Это очень смешно, но не работали длинные полнотекстовые запросы литералами, если обрезание до 27 байт срабатывало посередине UTF-8 символа. 27 - это 32 минус почему-то 5, хотя потом добавляется 4 символа: пробел и три точки...