### PR TITLE
YDB Bench: verify selected local YDB load

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -102,6 +102,7 @@ local-ydb:
       warmup: 10
       duration: 30
       repetitions: 3
+      verification-repetitions: 3
     affinity:
       ydb-cli:
         mode: pack-numa-pack-chiplet-spread-core
@@ -158,6 +159,21 @@ and achieved-rate checks active.
 
 The previous flat `mode`, `start`, and `slo` fields remain accepted for config
 compatibility, but newly generated YAML uses `search` and `objective`.
+
+`measurement.repetitions` controls how many samples contribute to every search
+point. Set `measurement.verification-repetitions` to run additional independent
+samples at the load selected by the search; it defaults to `0` so existing
+configurations keep their previous runtime and is limited to 20. These
+post-search samples contribute to the automatically computed default command
+timeout; `timeout` remains a per-command safety bound rather than an absolute
+profile deadline. Verification never
+changes the selected load or dynamic-node scaling decision. Its holdout samples
+are written separately to `verification-repetitions.csv` and
+`verification-summary.csv`; a completed holdout becomes the reported metric
+source while the search measurements remain intact for diagnostics. Latency
+holdout metrics are evaluated with the same aggregate SLO contract as a search
+point. A throughput holdout is diagnostic: its request-error acceptance,
+throughput drift, and CPU saturation do not claim statistical reproducibility.
 
 During a local YDB run, the CLI reports cluster startup, workload initialization,
 warmup, measurement, cleanup, evaluation, and dynamic-node scaling milestones.

--- a/ydb/tools/ydb_bench/examples/local-ydb-storage.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-storage.yaml
@@ -27,6 +27,7 @@ local-ydb:
       warmup: 10
       duration: 30
       repetitions: 3
+      verification-repetitions: 3
     affinity:
       ydb-cli:
         mode: pack-numa-pack-chiplet-spread-core

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -24,6 +24,7 @@ BACKGROUND_LOAD_MODES = (
     "coherence-all-numa",
 )
 _COMMON_OPTIONAL_FIELDS = ("timeout", "background-load")
+MAX_LOCAL_YDB_VERIFICATION_REPETITIONS = 20
 
 
 class _UniqueKeyLoader(yaml.SafeLoader):
@@ -250,6 +251,11 @@ def _profile_schema(benchmark):
                         "warmup": {"type": "integer", "minimum": 0},
                         "duration": {"type": "integer", "minimum": 1},
                         "repetitions": {"type": "integer", "minimum": 1},
+                        "verification-repetitions": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": MAX_LOCAL_YDB_VERIFICATION_REPETITIONS,
+                        },
                     },
                 },
                 "affinity": {
@@ -812,11 +818,26 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
             )
         load_config["objective"] = parsed_objective
 
-    measurement = _mapping(value.get("measurement"), location + ".measurement", ("warmup", "duration", "repetitions"))
+    measurement = _mapping(
+        value.get("measurement"),
+        location + ".measurement",
+        ("warmup", "duration", "repetitions", "verification-repetitions"),
+    )
+    verification_location = location + ".measurement.verification-repetitions"
+    verification_repetitions = _nonnegative_integer(
+        measurement.get("verification-repetitions", 0),
+        verification_location,
+    )
+    if verification_repetitions > MAX_LOCAL_YDB_VERIFICATION_REPETITIONS:
+        _config_error(
+            verification_location,
+            "must be at most {}".format(MAX_LOCAL_YDB_VERIFICATION_REPETITIONS),
+        )
     measurement_config = {
         "warmup": _nonnegative_integer(measurement.get("warmup", 10), location + ".measurement.warmup"),
         "duration": _positive_integer(measurement.get("duration", 30), location + ".measurement.duration"),
         "repetitions": _positive_integer(measurement.get("repetitions", 3), location + ".measurement.repetitions"),
+        "verification_repetitions": verification_repetitions,
     }
 
     affinity = _mapping(value.get("affinity"), location + ".affinity", ("ydb-cli", "static-nodes", "dynamic-nodes"))
@@ -834,9 +855,8 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     }
 
     attempts = len(load_config.get("values", ())) or 64
-    computed_timeout = 300 + attempts * measurement_config["repetitions"] * (
-        measurement_config["warmup"] + measurement_config["duration"] + 10
-    )
+    measurement_runs = attempts * measurement_config["repetitions"] + measurement_config["verification_repetitions"]
+    computed_timeout = 300 + measurement_runs * (measurement_config["warmup"] + measurement_config["duration"] + 10)
     timeout_explicit = "timeout" in value
     timeout = _timeout(value.get("timeout", computed_timeout), location + ".timeout")
     return RunConfiguration(

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -32,6 +32,52 @@ def _with_decision(metrics, load, passed, reason):
     return {**metrics, "load": load, "passed": bool(passed), "decision": reason}
 
 
+def evaluate_load(config, load, metrics):
+    """Return whether one measured load is feasible and explain the decision."""
+    if "values" in config:
+        errors = metrics["errors"]
+        passed = config.get("allow_errors", False) or not errors
+        if errors:
+            reason = "{} workload errors {}".format(
+                errors,
+                "allowed" if config.get("allow_errors", False) else "reported",
+            )
+        else:
+            reason = "configured point"
+        return passed, reason
+
+    objective = config["objective"]
+    objective_type = objective["type"]
+    if objective_type == "maximize-throughput":
+        errors = metrics["errors"]
+        if errors and not config.get("allow_errors", False):
+            return False, "workload reported errors"
+        if errors:
+            return True, "{} workload errors allowed".format(errors)
+        return True, "workload completed without errors"
+
+    if objective_type == "latency-slo":
+        latency = metrics[objective["percentile"] + "_ms"]
+        if latency > objective["max_ms"]:
+            return False, "{} latency {:.3f} ms exceeds {:.3f} ms".format(
+                objective["percentile"], latency, objective["max_ms"]
+            )
+        if not config.get("allow_errors", False) and metrics["errors"] > objective["max_errors"]:
+            return False, "errors {} exceed {}".format(metrics["errors"], objective["max_errors"])
+        if config["parameter"] == "rate":
+            ratio = metrics["throughput"] / load
+            if ratio < objective["min_achieved_rate_ratio"]:
+                return False, "achieved rate ratio {:.4f} is below {:.4f}".format(
+                    ratio, objective["min_achieved_rate_ratio"]
+                )
+        reason = "latency SLO satisfied"
+        if metrics["errors"]:
+            reason += "; {} workload errors allowed".format(metrics["errors"])
+        return True, reason
+
+    raise BenchmarkError("unsupported load objective: {}".format(objective_type))
+
+
 def _best_throughput(attempts):
     candidates = [item for item in attempts if item["passed"]]
     if not candidates:
@@ -65,15 +111,9 @@ def _append_attempt(attempts, record, on_attempt):
 
 def _run_points(config, measure, on_attempt):
     attempts = []
-    allow_errors = config.get("allow_errors", False)
     for value in config["values"]:
         metrics = measure(value)
-        errors = metrics["errors"]
-        passed = allow_errors or not errors
-        if errors:
-            reason = "{} workload errors {}".format(errors, "allowed" if allow_errors else "reported")
-        else:
-            reason = "configured point"
+        passed, reason = evaluate_load(config, value, metrics)
         _append_attempt(
             attempts,
             _with_decision(metrics, value, passed, reason),
@@ -94,7 +134,6 @@ def _run_throughput(config, measure, on_attempt):
     objective = config["objective"]
     attempts = []
     measured = {}
-    allow_errors = config.get("allow_errors", False)
     failing_load = None
     plateau = 0
     plateau_confirmed = False
@@ -105,10 +144,10 @@ def _run_throughput(config, measure, on_attempt):
             return measured[load]
         metrics = measure(load)
         saturated = _target_cpu(metrics, objective["target_role"]) >= objective["cpu_saturation_percent"]
-        passed = allow_errors or not metrics["errors"]
+        passed, evaluation_reason = evaluate_load(config, load, metrics)
         gain = None if baseline is None else _throughput_gain(baseline["throughput"], metrics["throughput"])
         if not passed:
-            decision = "workload reported errors"
+            decision = evaluation_reason
             failing_load = load if failing_load is None else min(failing_load, load)
         else:
             decision = reason
@@ -117,7 +156,7 @@ def _run_throughput(config, measure, on_attempt):
             elif gain is not None:
                 decision += "; throughput gain {:.3f}%".format(gain)
             if metrics["errors"]:
-                decision += "; {} workload errors allowed".format(metrics["errors"])
+                decision += "; " + evaluation_reason
         search_interval = {}
         if search_low is not None:
             search_interval["search_low"] = search_low
@@ -223,27 +262,6 @@ def _run_throughput(config, measure, on_attempt):
     )
 
 
-def _latency_passes(config, load, metrics):
-    objective = config["objective"]
-    latency = metrics[objective["percentile"] + "_ms"]
-    if latency > objective["max_ms"]:
-        return False, "{} latency {:.3f} ms exceeds {:.3f} ms".format(
-            objective["percentile"], latency, objective["max_ms"]
-        )
-    if not config.get("allow_errors", False) and metrics["errors"] > objective["max_errors"]:
-        return False, "errors {} exceed {}".format(metrics["errors"], objective["max_errors"])
-    if config["parameter"] == "rate":
-        ratio = metrics["throughput"] / load
-        if ratio < objective["min_achieved_rate_ratio"]:
-            return False, "achieved rate ratio {:.4f} is below {:.4f}".format(
-                ratio, objective["min_achieved_rate_ratio"]
-            )
-    reason = "latency SLO satisfied"
-    if metrics["errors"]:
-        reason += "; {} workload errors allowed".format(metrics["errors"])
-    return True, reason
-
-
 def _run_latency(config, measure, on_attempt):
     search = config["search"]
     attempts = []
@@ -253,7 +271,7 @@ def _run_latency(config, measure, on_attempt):
         if load in measured:
             return measured[load]
         metrics = measure(load)
-        passed, reason = _latency_passes(config, load, metrics)
+        passed, reason = evaluate_load(config, load, metrics)
         record = _with_decision(metrics, load, passed, reason)
         _append_attempt(attempts, record, on_attempt)
         measured[load] = record

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -25,7 +25,7 @@ from ydb.tools.ydb_bench.lib.common import (
     atomic_write_text,
 )
 from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
-from ydb.tools.ydb_bench.lib.load_control import search_load
+from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
 from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
 from ydb.tools.ydb_bench.lib.system_info import collect_system_info
@@ -964,6 +964,28 @@ def run_local_ydb(
         if event_sink is not None:
             event_sink({"type": "step-progress", **step, "fields": {"progress": progress}})
 
+    def compact_result_progress():
+        result = manifest.get("result", {})
+        compact = {
+            name: result[name]
+            for name in (
+                "outcome",
+                "objective",
+                "parameter",
+                "search_stage",
+                "dynamic_nodes",
+                "selected_load",
+                "metrics_source",
+                "holdout_accepted",
+            )
+            if name in result
+        }
+        for name in ("selected_metrics", "verified_metrics"):
+            metrics = result.get(name)
+            if isinstance(metrics, dict):
+                compact[name] = {key: value for key, value in metrics.items() if key != "commands"}
+        return compact
+
     cluster = LocalYdbCluster(
         binaries["ydbd"].path,
         binaries["ydb_cli"].path,
@@ -975,6 +997,223 @@ def run_local_ydb(
         cancel_event,
         publish_progress,
     )
+
+    def run_repetition(
+        load,
+        dynamic_nodes,
+        repetition,
+        repetitions,
+        directory,
+        table_path,
+        progress_fields,
+        purpose="search",
+    ):
+        if cancel_event is not None and cancel_event.is_set():
+            raise BenchmarkInterrupted("local YDB benchmark was cancelled")
+        phases = (
+            {
+                "init": "verification-initializing",
+                "warmup": "verification-warmup",
+                "measure": "verification-measuring",
+                "clean": "verification-cleanup",
+            }
+            if purpose == "verification"
+            else {
+                "init": "initializing-workload",
+                "warmup": "warming-up",
+                "measure": "measuring",
+                "clean": "cleaning-workload",
+            }
+        )
+        directory.mkdir(parents=True)
+        fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
+        commands = []
+        init_command = _init_command(cluster, table_path, profile["workload"])
+        publish_progress(
+            phases["init"],
+            **fields,
+            current_command=_command_record(
+                phases["init"],
+                repetition,
+                init_command,
+                affinities["ydb_cli"],
+            ),
+        )
+        init, init_attempts = cluster.init_workload(init_command)
+        commands.extend(
+            _command_record(
+                phases["init"],
+                repetition,
+                init_attempt.command,
+                affinities["ydb_cli"],
+                init_attempt,
+            )
+            for init_attempt in init_attempts
+        )
+        atomic_write_text(directory / "init.stdout.txt", init.stdout)
+        atomic_write_text(directory / "init.stderr.txt", init.stderr)
+        atomic_write_json(
+            directory / "init-attempts.json",
+            [
+                {
+                    "command": [str(part) for part in attempt.command],
+                    "exit_code": attempt.exit_code,
+                    "timed_out": attempt.timed_out,
+                    "duration_seconds": attempt.duration_seconds,
+                    "stdout": attempt.stdout,
+                    "stderr": attempt.stderr,
+                }
+                for attempt in init_attempts
+            ],
+        )
+        run_error = None
+        try:
+            warmup = profile["measurement"]["warmup"]
+            if warmup:
+                warmup_command = _run_workload_command(
+                    cluster,
+                    table_path,
+                    profile["workload"],
+                    profile["load"],
+                    load,
+                    warmup,
+                    profile["client"]["threads"],
+                )
+                publish_progress(
+                    phases["warmup"],
+                    **fields,
+                    phase_duration_seconds=warmup,
+                    current_command=_command_record(
+                        phases["warmup"],
+                        repetition,
+                        warmup_command,
+                        affinities["ydb_cli"],
+                    ),
+                )
+                result = cluster._run(
+                    warmup_command,
+                    timeout=warmup + 30,
+                    cpu_affinity=affinities["ydb_cli"],
+                )
+                commands.append(
+                    _command_record(
+                        phases["warmup"],
+                        repetition,
+                        result.command,
+                        affinities["ydb_cli"],
+                        result,
+                    )
+                )
+                atomic_write_text(directory / "warmup.stdout.txt", result.stdout)
+                atomic_write_text(directory / "warmup.stderr.txt", result.stderr)
+
+            cli_pids = []
+            monitor = LinuxCpuMonitor(
+                {
+                    "static": lambda: cluster.static_pids,
+                    "dynamic": lambda: cluster.dynamic_pids,
+                    "cli": lambda: tuple(cli_pids),
+                },
+                {
+                    "static": _role_capacity(affinities["static_nodes"], topology),
+                    "dynamic": _role_capacity(affinities["dynamic_nodes"], topology),
+                    "cli": _role_capacity(affinities["ydb_cli"], topology),
+                },
+            )
+            monitor.start()
+            try:
+                command = _run_workload_command(
+                    cluster,
+                    table_path,
+                    profile["workload"],
+                    profile["load"],
+                    load,
+                    profile["measurement"]["duration"],
+                    profile["client"]["threads"],
+                )
+                cluster.ensure_running("cannot start workload measurement")
+                publish_progress(
+                    phases["measure"],
+                    **fields,
+                    phase_duration_seconds=profile["measurement"]["duration"],
+                    current_command=_command_record(
+                        phases["measure"],
+                        repetition,
+                        command,
+                        affinities["ydb_cli"],
+                    ),
+                )
+                result = run_command(
+                    command,
+                    {},
+                    profile["measurement"]["duration"] + 30,
+                    cpu_affinity=affinities["ydb_cli"],
+                    cancel_event=cancel_event,
+                    on_process_started=lambda process: cli_pids.append(process.pid),
+                )
+            finally:
+                cpu = monitor.stop()
+            cluster.ensure_running("YDB process exited during workload measurement")
+            commands.append(
+                _command_record(
+                    phases["measure"],
+                    repetition,
+                    result.command,
+                    affinities["ydb_cli"],
+                    result,
+                )
+            )
+            atomic_write_text(directory / "stdout.txt", result.stdout)
+            atomic_write_text(directory / "stderr.txt", result.stderr)
+            atomic_write_json(directory / "cpu-samples.json", list(monitor.records))
+            if result.interrupted:
+                raise BenchmarkInterrupted("YDB CLI workload was interrupted")
+            if result.timed_out or result.exit_code:
+                raise BenchmarkError(
+                    "YDB CLI workload {}".format(
+                        "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
+                    )
+                )
+            metrics = {**benchmark.parse_metrics(result.stdout, benchmark)[0], **cpu}
+            metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
+            return metrics, commands
+        except BaseException as error:
+            run_error = error
+            raise
+        finally:
+            try:
+                clean_command = _clean_workload_command(
+                    cluster,
+                    profile["workload"]["type"],
+                    table_path,
+                )
+                publish_progress(
+                    phases["clean"],
+                    **fields,
+                    current_command=_command_record(
+                        phases["clean"],
+                        repetition,
+                        clean_command,
+                        affinities["ydb_cli"],
+                    ),
+                )
+                clean = cluster._run(clean_command, cpu_affinity=affinities["ydb_cli"])
+                commands.append(
+                    _command_record(
+                        phases["clean"],
+                        repetition,
+                        clean.command,
+                        affinities["ydb_cli"],
+                        clean,
+                    )
+                )
+                atomic_write_text(directory / "clean.stdout.txt", clean.stdout)
+                atomic_write_text(directory / "clean.stderr.txt", clean.stderr)
+            except BenchmarkError as error:
+                atomic_write_text(directory / "clean.error.txt", str(error) + "\n")
+                if run_error is None:
+                    raise
+
     repetition_rows = []
     cluster_stopped = False
     try:
@@ -993,207 +1232,28 @@ def run_local_ydb(
                 attempt_started_monotonic = time.monotonic()
                 samples = []
                 commands = []
-                for repetition in range(1, profile["measurement"]["repetitions"] + 1):
-                    if cancel_event is not None and cancel_event.is_set():
-                        raise BenchmarkInterrupted("local YDB benchmark was cancelled")
+                repetitions = profile["measurement"]["repetitions"]
+                for repetition in range(1, repetitions + 1):
                     directory = geometry_directory / "load-{:08d}".format(load) / "repeat-{:03d}".format(repetition)
-                    directory.mkdir(parents=True)
                     table_path = "ydb_bench_{}_{}_{}".format(dynamic_nodes, load, repetition)
-                    progress_fields = {
-                        "search_stage": search_stage,
-                        "attempt": attempt,
-                        "dynamic_nodes": dynamic_nodes,
-                        "parameter": profile["load"]["parameter"],
-                        "load": load,
-                        "repetition": repetition,
-                        "repetitions": profile["measurement"]["repetitions"],
-                    }
-                    init_command = _init_command(cluster, table_path, profile["workload"])
-                    publish_progress(
-                        "initializing-workload",
-                        **progress_fields,
-                        current_command=_command_record(
-                            "initializing-workload",
-                            repetition,
-                            init_command,
-                            affinities["ydb_cli"],
-                        ),
+                    metrics, repetition_commands = run_repetition(
+                        load,
+                        dynamic_nodes,
+                        repetition,
+                        repetitions,
+                        directory,
+                        table_path,
+                        {
+                            "search_stage": search_stage,
+                            "attempt": attempt,
+                            "dynamic_nodes": dynamic_nodes,
+                            "parameter": profile["load"]["parameter"],
+                            "load": load,
+                        },
                     )
-                    init, init_attempts = cluster.init_workload(init_command)
-                    commands.extend(
-                        _command_record(
-                            "initializing-workload",
-                            repetition,
-                            init_attempt.command,
-                            affinities["ydb_cli"],
-                            init_attempt,
-                        )
-                        for init_attempt in init_attempts
-                    )
-                    atomic_write_text(directory / "init.stdout.txt", init.stdout)
-                    atomic_write_text(directory / "init.stderr.txt", init.stderr)
-                    atomic_write_json(
-                        directory / "init-attempts.json",
-                        [
-                            {
-                                "command": [str(part) for part in attempt.command],
-                                "exit_code": attempt.exit_code,
-                                "timed_out": attempt.timed_out,
-                                "duration_seconds": attempt.duration_seconds,
-                                "stdout": attempt.stdout,
-                                "stderr": attempt.stderr,
-                            }
-                            for attempt in init_attempts
-                        ],
-                    )
-                    run_error = None
-                    try:
-                        warmup = profile["measurement"]["warmup"]
-                        if warmup:
-                            warmup_command = _run_workload_command(
-                                cluster,
-                                table_path,
-                                profile["workload"],
-                                profile["load"],
-                                load,
-                                warmup,
-                                profile["client"]["threads"],
-                            )
-                            publish_progress(
-                                "warming-up",
-                                **progress_fields,
-                                phase_duration_seconds=warmup,
-                                current_command=_command_record(
-                                    "warming-up",
-                                    repetition,
-                                    warmup_command,
-                                    affinities["ydb_cli"],
-                                ),
-                            )
-                            result = cluster._run(
-                                warmup_command,
-                                timeout=warmup + 30,
-                                cpu_affinity=affinities["ydb_cli"],
-                            )
-                            commands.append(
-                                _command_record(
-                                    "warming-up",
-                                    repetition,
-                                    result.command,
-                                    affinities["ydb_cli"],
-                                    result,
-                                )
-                            )
-                            atomic_write_text(directory / "warmup.stdout.txt", result.stdout)
-                            atomic_write_text(directory / "warmup.stderr.txt", result.stderr)
-
-                        cli_pids = []
-                        monitor = LinuxCpuMonitor(
-                            {
-                                "static": lambda: cluster.static_pids,
-                                "dynamic": lambda: cluster.dynamic_pids,
-                                "cli": lambda: tuple(cli_pids),
-                            },
-                            {
-                                "static": _role_capacity(affinities["static_nodes"], topology),
-                                "dynamic": _role_capacity(affinities["dynamic_nodes"], topology),
-                                "cli": _role_capacity(affinities["ydb_cli"], topology),
-                            },
-                        )
-                        monitor.start()
-                        try:
-                            command = _run_workload_command(
-                                cluster,
-                                table_path,
-                                profile["workload"],
-                                profile["load"],
-                                load,
-                                profile["measurement"]["duration"],
-                                profile["client"]["threads"],
-                            )
-                            cluster.ensure_running("cannot start workload measurement")
-                            publish_progress(
-                                "measuring",
-                                **progress_fields,
-                                phase_duration_seconds=profile["measurement"]["duration"],
-                                current_command=_command_record(
-                                    "measuring",
-                                    repetition,
-                                    command,
-                                    affinities["ydb_cli"],
-                                ),
-                            )
-                            result = run_command(
-                                command,
-                                {},
-                                profile["measurement"]["duration"] + 30,
-                                cpu_affinity=affinities["ydb_cli"],
-                                cancel_event=cancel_event,
-                                on_process_started=lambda process: cli_pids.append(process.pid),
-                            )
-                        finally:
-                            cpu = monitor.stop()
-                        cluster.ensure_running("YDB process exited during workload measurement")
-                        commands.append(
-                            _command_record(
-                                "measuring",
-                                repetition,
-                                result.command,
-                                affinities["ydb_cli"],
-                                result,
-                            )
-                        )
-                        atomic_write_text(directory / "stdout.txt", result.stdout)
-                        atomic_write_text(directory / "stderr.txt", result.stderr)
-                        atomic_write_json(directory / "cpu-samples.json", list(monitor.records))
-                        if result.interrupted:
-                            raise BenchmarkInterrupted("YDB CLI workload was interrupted")
-                        if result.timed_out or result.exit_code:
-                            raise BenchmarkError(
-                                "YDB CLI workload {}".format(
-                                    "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
-                                )
-                            )
-                        metrics = {**benchmark.parse_metrics(result.stdout, benchmark)[0], **cpu}
-                        metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
-                        samples.append(metrics)
-                        repetition_rows.append(metrics)
-                    except BaseException as error:
-                        run_error = error
-                        raise
-                    finally:
-                        try:
-                            clean_command = _clean_workload_command(
-                                cluster,
-                                profile["workload"]["type"],
-                                table_path,
-                            )
-                            publish_progress(
-                                "cleaning-workload",
-                                **progress_fields,
-                                current_command=_command_record(
-                                    "cleaning-workload",
-                                    repetition,
-                                    clean_command,
-                                    affinities["ydb_cli"],
-                                ),
-                            )
-                            clean = cluster._run(clean_command, cpu_affinity=affinities["ydb_cli"])
-                            commands.append(
-                                _command_record(
-                                    "cleaning-workload",
-                                    repetition,
-                                    clean.command,
-                                    affinities["ydb_cli"],
-                                    clean,
-                                )
-                            )
-                            atomic_write_text(directory / "clean.stdout.txt", clean.stdout)
-                            atomic_write_text(directory / "clean.stderr.txt", clean.stderr)
-                        except BenchmarkError as error:
-                            atomic_write_text(directory / "clean.error.txt", str(error) + "\n")
-                            if run_error is None:
-                                raise
+                    samples.append(metrics)
+                    repetition_rows.append(metrics)
+                    commands.extend(repetition_commands)
                 aggregated = _aggregate_measurements(samples)
                 aggregated.update(
                     {
@@ -1288,10 +1348,6 @@ def run_local_ydb(
             )
             cluster.add_dynamic_nodes(new_count - dynamic_nodes)
 
-        publish_progress("stopping-cluster", result=manifest["result"])
-        cluster.stop()
-        cluster_stopped = True
-        publish_progress("finishing", result=manifest["result"])
         summary_rows = benchmark.summarize_metrics(repetition_rows, benchmark)
         _write_csv(
             output_directory / "repetitions.csv",
@@ -1299,6 +1355,161 @@ def run_local_ydb(
             [item.name for item in benchmark.dimensions] + ["repetition"] + [item.name for item in benchmark.metrics],
         )
         atomic_write_text(output_directory / "summary.csv", benchmark.render_summary(summary_rows, benchmark))
+
+        verification_repetitions = profile["measurement"].get("verification_repetitions", 0)
+        selected_load = manifest["result"]["selected_load"]
+        manifest["result"]["metrics_source"] = "search"
+        verification = {
+            "status": "disabled" if verification_repetitions == 0 else "pending",
+            "configured_repetitions": verification_repetitions,
+            "completed_repetitions": 0,
+        }
+        manifest["verification"] = verification
+        if verification_repetitions and selected_load is None:
+            verification.update(
+                {
+                    "status": "skipped",
+                    "reason": "search did not select a feasible load",
+                    "accepted": False,
+                }
+            )
+            manifest["result"]["holdout_accepted"] = False
+            write_manifest(manifest_path, manifest)
+        elif verification_repetitions:
+            verification_started_at = _utc_now()
+            verification_started_monotonic = time.monotonic()
+            verification.update(
+                {
+                    "status": "running",
+                    "started_at": verification_started_at,
+                    "load": selected_load,
+                    "dynamic_nodes": dynamic_nodes,
+                }
+            )
+            write_manifest(manifest_path, manifest)
+            verification_rows = []
+            try:
+                for repetition in range(1, verification_repetitions + 1):
+                    directory = output_directory / "verification" / "repeat-{:03d}".format(repetition)
+                    table_path = "ydb_bench_verify_{}_{}_{}".format(dynamic_nodes, selected_load, repetition)
+                    metrics, commands = run_repetition(
+                        selected_load,
+                        dynamic_nodes,
+                        repetition,
+                        verification_repetitions,
+                        directory,
+                        table_path,
+                        {
+                            "search_stage": manifest["result"]["search_stage"],
+                            "verification": True,
+                            "dynamic_nodes": dynamic_nodes,
+                            "parameter": profile["load"]["parameter"],
+                            "load": selected_load,
+                        },
+                        purpose="verification",
+                    )
+                    atomic_write_json(directory / "commands.json", commands)
+                    verification["completed_repetitions"] = repetition
+                    verification_rows.append(metrics)
+                    _write_csv(
+                        output_directory / "verification-repetitions.csv",
+                        verification_rows,
+                        [item.name for item in benchmark.dimensions]
+                        + ["repetition"]
+                        + [item.name for item in benchmark.metrics],
+                    )
+                    partial_summary = benchmark.summarize_metrics(verification_rows, benchmark)
+                    atomic_write_text(
+                        output_directory / "verification-summary.csv",
+                        benchmark.render_summary(partial_summary, benchmark),
+                    )
+                    verification.update(
+                        {
+                            "repetitions_file": "verification-repetitions.csv",
+                            "summary_file": "verification-summary.csv",
+                        }
+                    )
+                    publish_progress(
+                        "verification-evaluating",
+                        verification={
+                            "status": "running",
+                            "configured_repetitions": verification_repetitions,
+                            "completed_repetitions": repetition,
+                        },
+                    )
+            except BaseException as error:
+                verification.update(
+                    {
+                        "status": (
+                            "cancelled" if isinstance(error, (BenchmarkInterrupted, KeyboardInterrupt)) else "failed"
+                        ),
+                        "finished_at": _utc_now(),
+                        "duration_seconds": time.monotonic() - verification_started_monotonic,
+                        "error": str(error),
+                    }
+                )
+                write_manifest(manifest_path, manifest)
+                raise
+
+            verified_metrics = _aggregate_measurements(
+                [
+                    {name: value for name, value in row.items() if name not in ("passed", "decision")}
+                    for row in verification_rows
+                ]
+            )
+            verified_metrics.pop("repetition", None)
+            accepted, decision = evaluate_load(profile["load"], selected_load, verified_metrics)
+            selected_throughput = (manifest["result"].get("selected_metrics") or {}).get("throughput")
+            if selected_throughput:
+                throughput_delta_percent = (verified_metrics["throughput"] / selected_throughput - 1.0) * 100.0
+            elif selected_throughput == 0 and verified_metrics["throughput"] == 0:
+                throughput_delta_percent = 0.0
+            else:
+                throughput_delta_percent = None
+            objective = profile["load"].get("objective", {})
+            evaluation_kind = "objective" if objective.get("type") == "latency-slo" else "validity"
+            target_role = objective.get("target_role")
+            saturation_percent = objective.get("cpu_saturation_percent", 95)
+            saturation_metric = {
+                "static": "static_cpu_mean",
+                "dynamic": "dynamic_cpu_mean",
+                "total": "host_cpu_mean",
+            }.get(target_role)
+            saturated_repetitions = (
+                sum(row[saturation_metric] >= saturation_percent for row in verification_rows)
+                if saturation_metric
+                else 0
+            )
+            verification.update(
+                {
+                    "status": "completed",
+                    "finished_at": _utc_now(),
+                    "duration_seconds": time.monotonic() - verification_started_monotonic,
+                    "accepted": accepted,
+                    "evaluation_kind": evaluation_kind,
+                    "decision": decision,
+                    "throughput_delta_percent": throughput_delta_percent,
+                }
+            )
+            if saturation_metric:
+                verification["saturated_repetitions"] = saturated_repetitions
+            manifest["result"].update(
+                {
+                    "verified_metrics": verified_metrics,
+                    "metrics_source": "verification",
+                    "holdout_accepted": accepted,
+                }
+            )
+            publish_progress(
+                "verification-completed",
+                result=compact_result_progress(),
+                verification=verification,
+            )
+
+        publish_progress("stopping-cluster", result=compact_result_progress())
+        cluster.stop()
+        cluster_stopped = True
+        publish_progress("finishing", result=compact_result_progress())
         manifest.update(
             {
                 "status": "completed",
@@ -1309,18 +1520,21 @@ def run_local_ydb(
                 "summary_rows": len(summary_rows),
             }
         )
-        publish_progress("completed", result=manifest["result"])
+        publish_progress("completed", result=compact_result_progress())
         if event_sink is not None:
+            artifacts = [
+                "run.json",
+                "summary.csv",
+                "repetitions.csv",
+                "cluster/cluster.yaml",
+            ]
+            if verification["status"] == "completed":
+                artifacts += ["verification-summary.csv", "verification-repetitions.csv"]
             event_sink(
                 {
                     "type": "step-artifacts",
                     **step,
-                    "artifacts": [
-                        "run.json",
-                        "summary.csv",
-                        "repetitions.csv",
-                        "cluster/cluster.yaml",
-                    ],
+                    "artifacts": artifacts,
                 }
             )
             event_sink(

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -159,6 +159,11 @@ _CSS = (
 .local-profile-config pre{max-height:24rem;overflow:auto;white-space:pre;margin:.7rem 0 0}
 .attempt-pass{color:var(--good);font-weight:650}.attempt-fail{color:var(--bad);font-weight:650}
 .comparison-delta{font-weight:650}.comparison-delta.good{color:var(--good)}.comparison-delta.bad{color:var(--bad)}
+.verification-badge{display:inline-flex;align-items:center;margin-left:.35rem;padding:.08rem .42rem;border:1px solid #d0d5dd}
+.verification-badge{border-radius:999px;background:var(--panel);color:var(--text);font-size:.75rem;font-weight:650;vertical-align:middle}
+.verification-badge.bad{border-color:#fecdca;background:#fff0f0;color:var(--bad)}
+.verification-summary{margin:.7rem 0;padding:.65rem .8rem;border:1px solid #d0d5dd;border-radius:7px;background:var(--panel);color:var(--text)}
+.verification-summary.bad{border-color:#fecdca;background:#fff0f0;color:var(--bad)}
 @media(max-width:900px){.local-live{grid-template-columns:1fr 1fr}.local-charts{grid-template-columns:1fr}}
 """
     '.status.queued{color:var(--warn)}\n'
@@ -229,7 +234,7 @@ _JS = (
     "function defaultLocalYdb(){return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
     ":{threads:64},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
-    "etitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
+    "etitions:3,verification_repetitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
     "load:','      type: '+workload.type,'      operation: '+workload.operation,'      options:');for(const [key,value] of "
@@ -245,7 +250,8 @@ _JS = (
     "jectiveKeys))lines.push('        '+yamlKey+': '+config.load.objective[key]);else{lines.push('        percentile: '+config.load.o"
     "bjective.percentile);for(const [key,yamlKey] of Object.entries(localYdbSloKeys))lines.push('        '+yamlKey+': '+con"
     "fig.load.objective[key])}}lines.push('    measurement:','      warmup: '+config.measurement.warmup,' "
-    "     duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,'    affinity:');f"
+    "     duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,"
+    "'      verification-repetitions: '+(config.measurement.verification_repetitions??0),'    affinity:');f"
     "or(const [key,yamlKey] of Object.entries(localYdbAffinityKeys)){const role=config.affinity[key];lines.push('      '+yam"
     "lKey+':','        mode: '+role.mode);if(role.cpus!==null&&role.cpus!==undefined)lines.push('        cpus: '+role.cpus)}"
     "if(profile.timeout!==null&&profile.timeout!==undefined&&profile.timeout!=='')lines.push('    timeout: '+profile.timeo"
@@ -401,6 +407,12 @@ function localYdbProfileEditor(profile){
     localField('local-measurement-duration','Duration (seconds)',measurement.duration,'','type=number min=1')+
     localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+
     localField(
+      'local-measurement-verification-repetitions','Verification repetitions',
+      measurement.verification_repetitions??0,
+      'Independent holdout measurements at the selected load; 0 disables verification.',
+      'type=number min=0 max=20'
+    )+
+    localField(
       'local-timeout','Timeout (seconds)',profile.timeout??'','empty selects the computed timeout','type=number min=1'
     )+'</div><h3>Role affinity</h3>'+affinity+
     '<div class=toolbar><button class=danger id=delete-profile>Delete profile</button></div></div>'
@@ -410,7 +422,12 @@ function localNumber(id,minimum=1){
   if(!Number.isFinite(value)||value<minimum)throw Error(id+' must be a number not below '+minimum+'.');
   return value
 }
-function localInteger(id,minimum=1){const value=localNumber(id,minimum);if(!Number.isSafeInteger(value))throw Error(id+' must be an integer.');return value}
+function localInteger(id,minimum=1,maximum=null){
+  const value=localNumber(id,minimum);
+  if(!Number.isSafeInteger(value))throw Error(id+' must be an integer.');
+  if(maximum!==null&&value>maximum)throw Error(id+' must not exceed '+maximum+'.');
+  return value
+}
 function localCpu(id,mode){
   if(mode==='none')return null;
   const raw=document.querySelector('#'+id).value.trim();
@@ -525,7 +542,8 @@ function bindLocalYdbEditor(profile){
     config.measurement={
       warmup:localInteger('local-measurement-warmup',0),
       duration:localInteger('local-measurement-duration'),
-      repetitions:localInteger('local-measurement-repetitions')
+      repetitions:localInteger('local-measurement-repetitions'),
+      verification_repetitions:localInteger('local-measurement-verification-repetitions',0,20)
     };
     for(const key of Object.keys(localYdbAffinityKeys)){
       const mode=document.querySelector('#local-affinity-'+key+'-mode').value;
@@ -1008,6 +1026,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "    'Load values':JSON.stringify(localComparisonStable(load.values??null)),\n"
     "    'Objective':objective.type??'points','Warmup seconds':measurement.warmup??'—',\n"
     "    'Duration seconds':measurement.duration??'—','Repetitions':measurement.repetitions??'—',\n"
+    "    'Verification repetitions':measurement.verification_repetitions??0,\n"
     "    'Geometry preset':geometry.preset??'—','Static nodes':geometry.static_nodes??'—',\n"
     "    'Initial dynamic nodes':geometry.dynamic_nodes??'—','Maximum dynamic nodes':geometry.max_dynamic_nodes??'—',\n"
     "    'Storage groups':geometry.storage_groups??'—','Disk size GiB':geometry.disk_size_gb??'—','YDB CLI threads':client.threads??'—',\n"
@@ -1038,6 +1057,22 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '    workload:parameters.workload||{},parameter:load.parameter,objective:objective.type,\n'
     "    latency_percentile:objective.type==='latency-slo'?objective.percentile:null\n"
     '  })\n'
+    '}\n'
+    'function localResultMetrics(result){\n'
+    "  const verified=Boolean(result?.metrics_source==='verification'&&result?.verified_metrics&&\n"
+    "    typeof result.verified_metrics==='object');\n"
+    "  return {metrics:(verified?result.verified_metrics:result?.selected_metrics)||{},verified,source:verified?'Holdout':'Search'}\n"
+    '}\n'
+    'function localVerificationCount(result,parameters={},verification={}){\n'
+    '  return result?.verification_repetitions??verification?.configured_repetitions??verification?.completed_repetitions??\n'
+    '    parameters?.measurement?.verification_repetitions??0\n'
+    '}\n'
+    'function localVerificationBadge(result,parameters={},verification={}){\n'
+    '  const view=localResultMetrics(result);if(!view.verified)return \'\';\n'
+    '  const repetitions=localVerificationCount(result,parameters,verification);\n'
+    '  const accepted=result?.holdout_accepted??verification?.accepted;\n'
+    "  return '<span class=\"verification-badge '+(accepted===false?'bad':'')+'\" title=\"Independent holdout measurements\">Holdout'+\n"
+    "    (repetitions?' · '+esc(repetitions):'')+'</span>'\n"
     '}\n'
     'function localComparisonDelta(value,baseline,lowerIsBetter=false,compatible=true){\n'
     "  if(!compatible)return '<span class=muted>incompatible</span>';\n"
@@ -1102,16 +1137,20 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '}\n'
     'function mountLocalYdbComparison(container,data,chartData=null){\n'
     "  const entries=data.entries||[];if(!entries.length){container.closest('.card').hidden=true;return}\n"
-    '  const previous=container.dataset.baseline,baseline=entries.find(item=>localComparisonKey(item)===previous)||entries.find(item=>item.result?.selected_metrics)||entries[0];\n'
-    '  container.dataset.baseline=localComparisonKey(baseline);const baselineMetrics=baseline.result?.selected_metrics||{};\n'
+    '  const previous=container.dataset.baseline;\n'
+    '  const baseline=entries.find(item=>localComparisonKey(item)===previous)||\n'
+    '    entries.find(item=>Object.keys(localResultMetrics(item.result).metrics).length)||entries[0];\n'
+    '  container.dataset.baseline=localComparisonKey(baseline);const baselineView=localResultMetrics(baseline.result);\n'
+    '  const baselineMetrics=baselineView.metrics;\n'
     "  const percentile=baseline.parameters?.load?.objective?.percentile||'p99',latencyMetric=percentile+'_ms';\n"
     '  const baselineConfig=localComparisonConfig(baseline),baselineContext=localComparisonContext(baseline);\n'
     '  const baselineBuild=localComparisonBuild(baseline);\n'
     '  const baselineSemantic=JSON.stringify(localComparisonSemantic(baseline));\n'
     '  const rows=entries.map(item=>{\n'
-    '    const metrics=item.result?.selected_metrics||{},config=localComparisonConfig(item);\n'
+    '    const metricView=localResultMetrics(item.result),metrics=metricView.metrics,config=localComparisonConfig(item);\n'
     '    const context=localComparisonContext(item),build=localComparisonBuild(item);\n'
-    '    const compatible=JSON.stringify(localComparisonSemantic(item))===baselineSemantic;\n'
+    '    const semanticCompatible=JSON.stringify(localComparisonSemantic(item))===baselineSemantic;\n'
+    '    const sameMetricSource=metricView.source===baselineView.source,compatible=semanticCompatible&&sameMetricSource;\n'
     '    const differences=[...new Set([...Object.keys(baselineConfig),...Object.keys(config)])].sort()\n'
     '      .filter(name=>String(config[name])!==String(baselineConfig[name]));\n'
     '    const contextDifferences=[...new Set([...Object.keys(baselineContext),...Object.keys(context)])].sort()\n'
@@ -1122,13 +1161,18 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "      ' → '+esc(config[name])+'</li>'),...contextDifferences.map(name=>'<li><strong>'+esc(name)+':</strong> '+\n"
     "      esc(baselineContext[name])+' → '+esc(context[name])+'</li>'),...buildDifferences.map(name=>'<li><strong>'+\n"
     "      esc(name)+':</strong> '+esc(baselineBuild[name])+' → '+esc(build[name])+'</li>')];\n"
-    "    const comparisonState=compatible?(differences.length||contextDifferences.length?'Comparable with warnings':\n"
-    "      'Comparable · build changed'):'Incompatible';\n"
+    "    if(!sameMetricSource)details.unshift('<li><strong>Metric source:</strong> '+esc(baselineView.source)+' → '+\n"
+    "      esc(metricView.source)+'</li>');\n"
+    "    const comparisonState=!semanticCompatible?'Incompatible workload':!sameMetricSource?'Incompatible metric source':\n"
+    "      differences.length||contextDifferences.length?'Comparable with warnings':'Comparable · build changed';\n"
     "    const differenceText=item===baseline?'Baseline':details.length?'<details><summary class=\"'+\n"
     "      (compatible?'':'attempt-fail')+'\">'+comparisonState+' · '+differences.length+' config · '+\n"
-    "      contextDifferences.length+' environment · '+buildDifferences.length+' build</summary><ul>'+\n"
+    "      contextDifferences.length+' environment · '+buildDifferences.length+' build'+\n"
+    "      (sameMetricSource?'':' · metric source')+'</summary><ul>'+\n"
     "      details.join('')+'</ul></details>':'Same configuration, environment and build';\n"
-    "    return '<tr><td>'+esc(localComparisonId(item))+'</td><td>'+esc(item.state??'—')+'</td><td><code>'+\n"
+    "    return '<tr><td>'+esc(localComparisonId(item))+'</td><td>'+esc(item.state??'—')+\n"
+    "      localVerificationBadge(item.result,item.parameters,item.verification)+'</td><td>'+esc(metricView.source)+\n"
+    "      '</td><td><code>'+\n"
     "      esc(String(item.binaries?.ydbd?.sha256??'—').slice(0,12))+'</code></td><td>'+\n"
     "      esc(metricLabel(item.result?.selected_load??'—'))+'</td>'+\n"
     "      '<td>'+esc(metricLabel(metrics.throughput??'—'))+' '+localComparisonDelta(metrics.throughput,baselineMetrics.throughput,false,compatible)+'</td>'+\n"
@@ -1139,9 +1183,9 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '  }).join(\'\');\n'
     "  container.innerHTML='<div class=run-section-title><h2>Local YDB baseline comparison</h2><label>Baseline <select id=local-comparison-baseline>'+\n"
     "    entries.map(item=>'<option value=\"'+esc(localComparisonKey(item))+'\" '+(item===baseline?'selected':'')+'>'+esc(localComparisonId(item))+'</option>').join('')+'</select></label></div>'+\n"
-    "    '<p class=muted>Deltas compare selected search results. Expand configuration differences before interpreting a regression.</p>'+\n"
+    "    '<p class=muted>Deltas compare metrics only when both rows use the same source: search or independent holdout. Expand configuration differences before interpreting a regression.</p>'+\n"
     "    '<div class=local-attempts-scroll><table class=local-attempts><thead><tr><th>Run / profile</th><th>State</th>'+\n"
-    "    '<th>ydbd</th><th>Selected load</th><th>Throughput</th><th>'+esc(percentile)+'</th><th>Errors</th>'+\n"
+    "    '<th>Metric source</th><th>ydbd</th><th>Selected load</th><th>Throughput</th><th>'+esc(percentile)+'</th><th>Errors</th>'+\n"
     "    '<th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th><th>Dynamic nodes</th>'+\n"
     "    '<th>Compatibility</th></tr></thead><tbody>'+rows+'</tbody></table></div>'+\n"
     "    '<div id=local-comparison-curves></div>';\n"
@@ -1158,6 +1202,9 @@ const localPhaseLabels={
   'bootstrapping-cluster':'Bootstrapping cluster','creating-database':'Creating database','starting-dynamic-nodes':'Starting dynamic nodes',
   'waiting-for-database':'Waiting for database','cluster-ready':'Cluster ready','initializing-workload':'Initializing workload',
   'warming-up':'Warming up','measuring':'Measuring','cleaning-workload':'Cleaning workload','evaluating-attempt':'Evaluating attempt',
+  'verification-initializing':'Preparing verification workload','verification-warmup':'Warming up verification',
+  'verification-measuring':'Measuring verification','verification-cleanup':'Cleaning verification workload',
+  'verification-evaluating':'Evaluating verification','verification-completed':'Verification completed',
   'scaling-dynamic-nodes':'Scaling dynamic nodes','stopping-cluster':'Stopping cluster','finishing':'Writing results',
   completed:'Completed',failed:'Failed',cancelled:'Cancelled'
 };
@@ -1187,6 +1234,51 @@ function localProfileDetails(data,open){
     '><summary><strong>Launch parameters</strong> <span class=muted>Normalized profile and effective CPU affinity; '+
     'exact commands are listed per attempt.</span></summary><pre><code>'+esc(JSON.stringify(configuration,null,2))+
     '</code></pre></details>'
+}
+function localVerificationSummary(data){
+  const result=data.result||{},view=localResultMetrics(result);
+  const verification=data.verification||{},repetitions=localVerificationCount(
+    result,data.parameters,verification
+  );
+  if(!view.verified){
+    if(verification.status==='running'||verification.status==='pending'){
+      return '<div class=notice><strong>Verification in progress.</strong> '+
+        esc(verification.completed_repetitions??0)+'/'+esc(repetitions)+
+        ' independent repetitions completed; KPIs still show the search measurement.</div>'
+    }
+    if(verification.status==='skipped'){
+      return '<div class=notice><strong>Search measurement only.</strong> Verification was skipped: '+
+        esc(verification.reason||'no feasible load was selected')+'.</div>'
+    }
+    if(verification.status==='failed'||verification.status==='cancelled'){
+      return '<div class="notice error"><strong>Verification '+esc(verification.status)+'.</strong> '+
+        esc(verification.error||'The independent holdout did not complete')+
+        '. KPIs remain based on the search measurement.</div>'
+    }
+    return '<div class=notice><strong>Search measurement only.</strong> Configure verification repetitions to '+
+      'publish independent holdout metrics.</div>'
+  }
+  const detail=repetitions?
+    repetitions+' independent holdout repetition'+(Number(repetitions)===1?'':'s'):
+    'Independent holdout measurements';
+  const outcomes=[];
+  if(verification.decision){
+    outcomes.push((verification.evaluation_kind==='objective'?'Objective':'Validity check')+': '+verification.decision)
+  }
+  if(verification.throughput_delta_percent!==null&&verification.throughput_delta_percent!==undefined&&
+      Number.isFinite(Number(verification.throughput_delta_percent)))outcomes.push(
+    (Number(verification.throughput_delta_percent)>0?'+':'')+
+      Number(verification.throughput_delta_percent).toFixed(1)+'% throughput vs search'
+  );
+  if(verification.saturated_repetitions!==undefined)outcomes.push(
+    verification.saturated_repetitions+'/'+repetitions+' CPU-saturated'
+  );
+  const failed=(result.holdout_accepted??verification.accepted)===false;
+  return '<div class="verification-summary '+(failed?'bad':'')+'">'+localVerificationBadge(
+    result,data.parameters,verification
+  )+' <strong>Reported metrics come from the independent holdout.</strong> '+esc(detail)+
+    ' at the selected load.'+(outcomes.length?' '+esc(outcomes.join(' · '))+'.':'')+
+    ' Search measurements remain available in the attempt history.</div>'
 }
 function localElapsed(started,finished=null){
   const value=Date.parse(started),end=finished?Date.parse(finished):Date.now();
@@ -1282,10 +1374,11 @@ function renderLocalYdbProfile(container,data){
       '</code></pre></section>'
   }
   if(result){
-    const selected=result.selected_metrics||{};
+    const selected=localResultMetrics(result).metrics;
     const latencyMetric=(loadConfig.objective?.percentile||'p99')+'_ms';
     const selectedLabel=result.selected_load===null||result.selected_load===undefined?
       '—':metricLabel(result.selected_load);
+    html+=localVerificationSummary(data);
     html+='<div class=local-kpis>'+localKpi(
       localOutcomeLabel(result.outcome),selectedLabel,result.parameter||loadConfig.parameter,true
     )+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),'transactions/s')+
@@ -2601,6 +2694,7 @@ class RunService:
             "progress",
             "attempts",
             "searches",
+            "verification",
             "result",
             "error",
         )
@@ -2636,7 +2730,10 @@ class RunService:
             )
             client = project(value.get("client"), ("threads",))
             load = project(value.get("load"), ("parameter", "allow_errors", "values", "search", "objective"))
-            measurement = project(value.get("measurement"), ("warmup", "duration", "repetitions"))
+            measurement = project(
+                value.get("measurement"),
+                ("warmup", "duration", "repetitions", "verification_repetitions"),
+            )
             affinity = project(value.get("affinity"), ("ydb_cli", "static_nodes", "dynamic_nodes"))
             return {
                 name: item
@@ -2719,6 +2816,28 @@ class RunService:
                     "binaries": project_binaries(value.get("binaries")),
                     "platform": project_platform(value.get("platform")),
                     "cpu_topology": project_topology(value.get("cpu_topology")),
+                    "verification": project(
+                        value.get("verification"),
+                        (
+                            "status",
+                            "state",
+                            "started_at",
+                            "finished_at",
+                            "load",
+                            "dynamic_nodes",
+                            "configured_repetitions",
+                            "completed_repetitions",
+                            "accepted",
+                            "evaluation_kind",
+                            "decision",
+                            "outcome",
+                            "reason",
+                            "duration_seconds",
+                            "throughput_delta_percent",
+                            "saturated_repetitions",
+                            "error",
+                        ),
+                    ),
                 }
                 entry.update({name: item for name, item in projections.items() if item})
                 result = value.get("result")
@@ -2734,6 +2853,9 @@ class RunService:
                         "passing_load",
                         "failing_load",
                         "stop_reason",
+                        "metrics_source",
+                        "verification_repetitions",
+                        "holdout_accepted",
                     )
                     compact_result = {name: result[name] for name in result_fields if name in result}
                     metrics = result.get("selected_metrics")
@@ -2742,6 +2864,13 @@ class RunService:
                         metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated"))
                         compact_result["selected_metrics"] = {
                             name: metrics[name] for name in metric_names if name in metrics
+                        }
+                    verified_metrics = result.get("verified_metrics")
+                    if isinstance(verified_metrics, dict):
+                        metric_names = {metric.name for metric in BENCHMARKS["local-ydb"].metrics}
+                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated"))
+                        compact_result["verified_metrics"] = {
+                            name: verified_metrics[name] for name in metric_names if name in verified_metrics
                         }
                     entry["result"] = compact_result
                 try:

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -1,3 +1,4 @@
+import csv
 import hashlib
 import inspect
 import io
@@ -111,6 +112,105 @@ class YdbBenchTest(unittest.TestCase):
             repetitions=repetitions,
             timeout_seconds=timeout,
         )
+
+    def _run_mock_local_ydb(self, configuration, output_name, measurements):
+        def command_result(command, stdout="", exit_code=0, stderr="", interrupted=False, timed_out=False):
+            return runner.CommandResult(
+                command=tuple(str(part) for part in command),
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=exit_code,
+                started_at="2026-08-25T10:00:00+00:00",
+                finished_at="2026-08-25T10:00:01+00:00",
+                duration_seconds=1.0,
+                interrupted=interrupted,
+                timed_out=timed_out,
+            )
+
+        def measurement_stdout(value):
+            if isinstance(value, BaseException):
+                raise value
+            return """
+                Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+                1 {throughput} {throughput} 0 {errors} 1 2 {p99_ms} 4
+            """.format(
+                throughput=value.get("throughput", 10),
+                errors=value.get("errors", 0),
+                p99_ms=value.get("p99_ms", 3),
+            )
+
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            dynamic_nodes=[{}],
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command: (
+            command_result(command),
+            [command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.start.return_value = monitor
+        monitor.stop.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        outputs = iter(measurements)
+
+        def next_measurement(command):
+            value = next(outputs)
+            stdout = measurement_stdout(value)
+            return command_result(
+                command,
+                stdout,
+                exit_code=value.get("exit_code", 0),
+                stderr=value.get("stderr", ""),
+                interrupted=value.get("interrupted", False),
+                timed_out=value.get("timed_out", False),
+            )
+
+        output = self.root / output_name
+        binaries = {
+            name: mock.Mock(path=self.root / name, sha256=name + "-digest", size=1)
+            for name in ("ydbd", "ydb_cli", "process_guard")
+        }
+        events = []
+        self.last_local_ydb_cluster = cluster
+        with mock.patch.object(local_ydb, "LocalYdbCluster", return_value=cluster), mock.patch.object(
+            local_ydb, "LinuxCpuMonitor", return_value=monitor
+        ), mock.patch.object(
+            local_ydb,
+            "discover_topology",
+            return_value=CpuTopology(
+                allowed_cpus=(0,),
+                numa_nodes=((0, (0,)),),
+                chiplets=(),
+                physical_cores=((0,),),
+            ),
+        ), mock.patch.object(
+            local_ydb, "collect_system_info", return_value={}
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: next_measurement(command),
+        ):
+            manifest = local_ydb.run_local_ydb(
+                binaries,
+                configuration,
+                output,
+                tool_revision="test",
+                event_sink=events.append,
+            )
+        return manifest, output, events
 
     def _worker_metrics_benchmark(self):
         return replace(
@@ -246,6 +346,43 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(profile["load"]["objective"]["cpu_saturation_percent"], 80)
         self.assertTrue(profile["load"]["allow_errors"])
         self.assertEqual(profile["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
+        self.assertEqual(profile["measurement"]["verification_repetitions"], 0)
+
+    def test_local_ydb_verification_config_is_optional_bounded_and_counted_in_default_timeout(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              verified:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement:
+                  warmup: 1
+                  duration: 2
+                  repetitions: 1
+                  verification-repetitions: 2
+        """))
+        configuration = loaded.runs[0]
+        self.assertEqual(configuration.parameters["local_ydb"]["measurement"]["verification_repetitions"], 2)
+        self.assertEqual(configuration.timeout_seconds, 300 + 3 * (1 + 2 + 10))
+
+        invalid = self._config("""
+            local-ydb:
+              invalid:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {verification-repetitions: -1}
+        """)
+        with self.assertRaisesRegex(BenchmarkError, "verification-repetitions"):
+            load_config(invalid)
+
+        too_many = self._config("""
+            local-ydb:
+              invalid:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {verification-repetitions: 21}
+        """)
+        with self.assertRaisesRegex(BenchmarkError, "must be at most 20"):
+            load_config(too_many)
 
     def test_local_ydb_allow_errors_defaults_to_false_and_requires_boolean(self):
         loaded = load_config(self._config("""
@@ -353,6 +490,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(profile["local_ydb"]["geometry"]["max_dynamic_nodes"], 4)
         self.assertEqual(profile["local_ydb"]["load"]["values"], [10, 20])
         self.assertTrue(profile["local_ydb"]["load"]["allow_errors"])
+        self.assertEqual(profile["local_ydb"]["measurement"]["verification_repetitions"], 0)
         self.assertEqual(profile["local_ydb"]["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
         self.assertEqual(profile["parameters"], {})
 
@@ -451,7 +589,7 @@ class YdbBenchTest(unittest.TestCase):
               audit:
                 workload: {type: stock, operation: add-rand-order}
                 load: {parameter: threads, values: [8]}
-                measurement: {warmup: 1, duration: 1, repetitions: 1}
+                measurement: {warmup: 1, duration: 1, repetitions: 1, verification-repetitions: 2}
                 affinity:
                   ydb-cli: {mode: none}
                   static-nodes: {mode: none}
@@ -494,10 +632,14 @@ class YdbBenchTest(unittest.TestCase):
             "host_cpu_mean": 7,
             "host_cpu_max": 8,
         }
-        measurement_stdout = """
-            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
-            1 10 10 0 0 1 2 3 4
-        """
+
+        def measurement_stdout(throughput):
+            return """
+                Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+                1 {throughput} {throughput} 0 0 1 2 3 4
+            """.format(throughput=throughput)
+
+        measurement_outputs = iter(measurement_stdout(value) for value in (10, 20, 30))
         events = []
         output = self.root / "command-audit"
         binaries = {
@@ -520,7 +662,7 @@ class YdbBenchTest(unittest.TestCase):
         ), mock.patch.object(
             local_ydb,
             "run_command",
-            side_effect=lambda command, *_args, **_kwargs: command_result(command, measurement_stdout),
+            side_effect=lambda command, *_args, **_kwargs: command_result(command, next(measurement_outputs)),
         ):
             manifest = local_ydb.run_local_ydb(
                 binaries,
@@ -542,6 +684,203 @@ class YdbBenchTest(unittest.TestCase):
         progress = [event["fields"]["progress"] for event in events if event["type"] == "step-progress"]
         running = [item for item in progress if item.get("current_command")]
         self.assertEqual([item["phase"] for item in running[:4]], [command["phase"] for command in commands])
+        self.assertIn("verification-evaluating", [item["phase"] for item in progress])
+        evaluating = next(item for item in progress if item["phase"] == "verification-evaluating")
+        self.assertEqual(
+            set(evaluating["verification"]),
+            {"status", "configured_repetitions", "completed_repetitions"},
+        )
+        verification_completed = next(item for item in progress if item["phase"] == "verification-completed")
+        for item in (evaluating, verification_completed):
+            payload = json.dumps(item)
+            self.assertNotIn('"samples"', payload)
+            self.assertNotIn('"commands"', payload)
+        self.assertEqual(len(manifest["attempts"]), 1)
+        self.assertEqual(manifest["result"]["metrics_source"], "verification")
+        self.assertEqual(manifest["result"]["selected_metrics"]["throughput"], 10)
+        self.assertEqual(manifest["attempts"][0]["throughput"], 10)
+        self.assertEqual(manifest["searches"][0]["selected_metrics"]["throughput"], 10)
+        self.assertEqual(manifest["result"]["verified_metrics"]["throughput"], 25)
+        self.assertTrue(manifest["result"]["holdout_accepted"])
+        self.assertEqual(manifest["verification"]["completed_repetitions"], 2)
+        self.assertTrue(manifest["verification"]["accepted"])
+        self.assertEqual(manifest["verification"]["evaluation_kind"], "validity")
+        self.assertNotIn("samples", manifest["verification"])
+        self.assertTrue((output / "verification-repetitions.csv").is_file())
+        self.assertTrue((output / "verification-summary.csv").is_file())
+        with (output / "repetitions.csv").open(newline="", encoding="utf-8") as stream:
+            search_rows = list(csv.DictReader(stream))
+        with (output / "verification-repetitions.csv").open(newline="", encoding="utf-8") as stream:
+            verification_rows = list(csv.DictReader(stream))
+        with (output / "verification-summary.csv").open(newline="", encoding="utf-8") as stream:
+            verification_summary = list(csv.DictReader(stream))
+        self.assertEqual([float(row["throughput"]) for row in search_rows], [10])
+        self.assertEqual([float(row["throughput"]) for row in verification_rows], [20, 30])
+        self.assertNotIn("passed", verification_rows[0])
+        self.assertEqual(verification_summary[0]["samples"], "2")
+        self.assertEqual(float(verification_summary[0]["median_throughput"]), 25)
+        verification_commands = []
+        for repetition in (1, 2):
+            commands_path = output / "verification" / "repeat-{:03d}".format(repetition) / "commands.json"
+            verification_commands.extend(json.loads(commands_path.read_text(encoding="utf-8")))
+        self.assertEqual(len(verification_commands) + len(commands), 12)
+        self.assertEqual(
+            [item["phase"] for item in verification_commands[:4]],
+            [
+                "verification-initializing",
+                "verification-warmup",
+                "verification-measuring",
+                "verification-cleanup",
+            ],
+        )
+        artifacts = next(event["artifacts"] for event in events if event["type"] == "step-artifacts")
+        self.assertIn("verification-repetitions.csv", artifacts)
+
+    def test_local_ydb_disabled_verification_keeps_search_metrics(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              search-only:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        manifest, output, events = self._run_mock_local_ydb(
+            configuration,
+            "verification-disabled",
+            [{"throughput": 10}],
+        )
+        self.assertEqual(manifest["verification"]["status"], "disabled")
+        self.assertEqual(manifest["result"]["metrics_source"], "search")
+        self.assertNotIn("verified_metrics", manifest["result"])
+        self.assertFalse((output / "verification-repetitions.csv").exists())
+        artifacts = next(event["artifacts"] for event in events if event["type"] == "step-artifacts")
+        self.assertNotIn("verification-repetitions.csv", artifacts)
+
+    def test_local_ydb_verification_is_skipped_without_feasible_load(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              no-feasible:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        manifest, output, _events = self._run_mock_local_ydb(
+            configuration,
+            "verification-skipped",
+            [{"throughput": 10, "errors": 1}],
+        )
+        self.assertIsNone(manifest["result"]["selected_load"])
+        self.assertEqual(manifest["result"]["metrics_source"], "search")
+        self.assertEqual(manifest["verification"]["status"], "skipped")
+        self.assertIn("did not select", manifest["verification"]["reason"])
+        self.assertFalse((output / "verification-repetitions.csv").exists())
+        self.assertTrue((output / "repetitions.csv").is_file())
+
+    def test_local_ydb_latency_verification_reports_failed_holdout_without_changing_search(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              latency:
+                workload: {type: kv, operation: upsert}
+                load:
+                  parameter: threads
+                  search: {start: 10, maximum: 10}
+                  objective: {type: latency-slo, percentile: p99, max-ms: 10}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        manifest, _output, _events = self._run_mock_local_ydb(
+            configuration,
+            "verification-latency-fail",
+            [
+                {"throughput": 10, "p99_ms": 9},
+                {"throughput": 11, "p99_ms": 9},
+                {"throughput": 12, "p99_ms": 13},
+            ],
+        )
+        self.assertEqual(manifest["state"], "passed")
+        self.assertEqual(manifest["result"]["selected_metrics"]["p99_ms"], 9)
+        self.assertEqual(manifest["result"]["verified_metrics"]["p99_ms"], 11)
+        self.assertEqual(manifest["result"]["metrics_source"], "verification")
+        self.assertFalse(manifest["result"]["holdout_accepted"])
+        self.assertFalse(manifest["verification"]["accepted"])
+        self.assertEqual(manifest["verification"]["evaluation_kind"], "objective")
+        self.assertIn("exceeds", manifest["verification"]["decision"])
+        self.assertNotIn("saturated_repetitions", manifest["verification"])
+
+    def test_local_ydb_verification_failure_preserves_search_and_partial_holdout(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              verification-failure:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        output = self.root / "verification-failure"
+        with self.assertRaisesRegex(BenchmarkError, "exited with code 17"):
+            self._run_mock_local_ydb(
+                configuration,
+                output.name,
+                [
+                    {"throughput": 10},
+                    {"throughput": 20},
+                    {"throughput": 0, "exit_code": 17, "stderr": "verification command failed"},
+                ],
+            )
+        manifest = json.loads((output / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["state"], "failed")
+        self.assertEqual(manifest["verification"]["status"], "failed")
+        self.assertEqual(manifest["verification"]["completed_repetitions"], 1)
+        self.assertEqual(manifest["result"]["selected_metrics"]["throughput"], 10)
+        self.assertEqual(manifest["result"]["metrics_source"], "search")
+        self.assertTrue((output / "repetitions.csv").is_file())
+        with (output / "verification-repetitions.csv").open(newline="", encoding="utf-8") as stream:
+            self.assertEqual(len(list(csv.DictReader(stream))), 1)
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
+
+    def test_local_ydb_verification_cancellation_is_durable(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              verification-cancel:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        output = self.root / "verification-cancel"
+        with self.assertRaisesRegex(BenchmarkInterrupted, "workload was interrupted"):
+            self._run_mock_local_ydb(
+                configuration,
+                output.name,
+                [{"throughput": 10}, {"throughput": 0, "interrupted": True}],
+            )
+        manifest = json.loads((output / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["state"], "cancelled")
+        self.assertEqual(manifest["verification"]["status"], "cancelled")
+        self.assertEqual(manifest["verification"]["completed_repetitions"], 0)
+        self.assertEqual(manifest["result"]["selected_metrics"]["throughput"], 10)
+        self.assertNotIn("repetitions_file", manifest["verification"])
+        self.assertNotIn("summary_file", manifest["verification"])
+        self.assertTrue((output / "summary.csv").is_file())
+        self.assertTrue((output / "verification" / "repeat-001" / "stdout.txt").is_file())
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
 
     def test_local_ydb_kv_commands_keep_table_path(self):
         cluster = mock.Mock(
@@ -820,6 +1159,31 @@ class YdbBenchTest(unittest.TestCase):
         self.assertGreater(latency.failing_load, latency.selected_load)
         self.assertTrue(latency.attempts[0]["passed"])
         self.assertIn("latency", latency.attempts[-1]["decision"])
+
+    def test_evaluate_load_reuses_search_acceptance_for_verification(self):
+        points = {"parameter": "threads", "values": [1]}
+        self.assertEqual(load_control.evaluate_load(points, 1, {"errors": 0}), (True, "configured point"))
+        self.assertFalse(load_control.evaluate_load(points, 1, {"errors": 1})[0])
+        self.assertTrue(load_control.evaluate_load({**points, "allow_errors": True}, 1, {"errors": 1})[0])
+
+        latency = {
+            "parameter": "rate",
+            "objective": {
+                "type": "latency-slo",
+                "percentile": "p99",
+                "max_ms": 10,
+                "max_errors": 0,
+                "min_achieved_rate_ratio": 0.98,
+            },
+        }
+        self.assertTrue(load_control.evaluate_load(latency, 100, {"throughput": 100, "errors": 0, "p99_ms": 9})[0])
+        passed, reason = load_control.evaluate_load(
+            latency,
+            100,
+            {"throughput": 100, "errors": 0, "p99_ms": 11},
+        )
+        self.assertFalse(passed)
+        self.assertIn("exceeds", reason)
 
     def test_linux_cpu_summary_weights_intervals_and_ignores_short_spikes_for_max(self):
         monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1}, interval=0.5)
@@ -2759,7 +3123,7 @@ class WebTest(unittest.TestCase):
         (directory / "run.json").write_text(json.dumps(value), encoding="utf-8")
         (directory / "artifact.txt").write_text("artifact", encoding="utf-8")
 
-    def _local_ydb_result(self, directory, throughput, operation="put"):
+    def _local_ydb_result(self, directory, throughput, operation="put", verified=False):
         self._manifest(directory)
         main_path = directory / "run.json"
         main = json.loads(main_path.read_text(encoding="utf-8"))
@@ -2799,6 +3163,37 @@ class WebTest(unittest.TestCase):
             "cli_cpu_mean": 30,
             "commands": [{"argv": ["must", "not", "leak"]}],
         }
+        result = {
+            "outcome": "best-observed",
+            "parameter": "rate",
+            "dynamic_nodes": 1,
+            "selected_load": 100,
+            "selected_metrics": selected_metrics,
+        }
+        verification = None
+        if verified:
+            result.update(
+                {
+                    "metrics_source": "verification",
+                    "holdout_accepted": True,
+                    "verified_metrics": {
+                        **selected_metrics,
+                        "throughput": throughput + 50,
+                        "commands": [{"argv": ["must", "also", "not", "leak"]}],
+                    },
+                }
+            )
+            verification = {
+                "status": "completed",
+                "configured_repetitions": 3,
+                "completed_repetitions": 3,
+                "accepted": True,
+                "evaluation_kind": "validity",
+                "decision": "workload completed without errors",
+                "throughput_delta_percent": 5,
+                "saturated_repetitions": 3,
+                "samples": [{"commands": [{"argv": ["not", "in", "comparison"]}]}],
+            }
         profile = {
             "schema_version": SCHEMA_VERSION,
             "benchmark": "local-ydb",
@@ -2837,14 +3232,10 @@ class WebTest(unittest.TestCase):
             "role_affinity": {"ydb_cli": [0], "static_nodes": [1], "dynamic_nodes": [2]},
             "attempts": [],
             "searches": [],
-            "result": {
-                "outcome": "best-observed",
-                "parameter": "rate",
-                "dynamic_nodes": 1,
-                "selected_load": 100,
-                "selected_metrics": selected_metrics,
-            },
+            "result": result,
         }
+        if verification is not None:
+            profile["verification"] = verification
         (profile_root / "run.json").write_text(json.dumps(profile), encoding="utf-8")
 
     def _portable_archive(self, extra=None, version=SCHEMA_VERSION, corrupt=False, run_updates=None):
@@ -3202,7 +3593,7 @@ class WebTest(unittest.TestCase):
             service.shutdown()
 
     def test_local_ydb_comparison_returns_bounded_profile_results(self):
-        self._local_ydb_result(self.root / "baseline", 1000)
+        self._local_ydb_result(self.root / "baseline", 1000, verified=True)
         self._local_ydb_result(self.root / "candidate", 1100, operation="mixed")
         service = RunService(self.root)
         try:
@@ -3220,6 +3611,11 @@ class WebTest(unittest.TestCase):
             self.assertNotIn("private", comparison["entries"][0]["parameters"])
             self.assertNotIn("attempts", comparison["entries"][0])
             self.assertNotIn("commands", comparison["entries"][0]["result"]["selected_metrics"])
+            self.assertEqual(comparison["entries"][0]["result"]["metrics_source"], "verification")
+            self.assertEqual(comparison["entries"][0]["result"]["verified_metrics"]["throughput"], 1050)
+            self.assertNotIn("commands", comparison["entries"][0]["result"]["verified_metrics"])
+            self.assertTrue(comparison["entries"][0]["verification"]["accepted"])
+            self.assertNotIn("samples", comparison["entries"][0]["verification"])
             self.assertEqual(comparison["entries"][1]["parameters"]["workload"]["operation"], "mixed")
             with self.assertRaisesRegex(BenchmarkError, "between 1 and 20"):
                 service.local_ydb_comparison([])
@@ -3542,6 +3938,15 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"local-load-allow-errors", script)
                 self.assertIn(b"allow-errors: ", script)
                 self.assertIn(b"Failed workload requests are allowed", script)
+                self.assertIn(b"verification-repetitions:", script)
+                self.assertIn(b"local-measurement-verification-repetitions", script)
+                self.assertIn(b"localInteger('local-measurement-verification-repetitions',0,20)", script)
+                self.assertIn(b"function localVerificationSummary", script)
+                self.assertIn(b"metrics_source==='verification'", script)
+                self.assertIn(b"verification-measuring", script)
+                self.assertIn(b"'verification-evaluating':'Evaluating verification'", script)
+                self.assertIn(b"Reported metrics come from the independent holdout", script)
+                self.assertIn(b"Incompatible metric source", script)
                 self.assertIn(b"function localElapsed(started,finished=null)", script)
                 self.assertIn(b"Search process", script)
                 self.assertIn(b"Ternary search progress", script)
@@ -3578,6 +3983,8 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"function mountLocalYdbComparison", script)
                 self.assertIn(b"function mountLocalYdbComparisonCurves", script)
                 self.assertIn(b"function localComparisonSemantic", script)
+                self.assertIn(b"sameMetricSource=metricView.source===baselineView.source", script)
+                self.assertIn(b"<th>Metric source</th>", script)
                 self.assertIn(b"function localComparisonKey", script)
                 self.assertIn(b"Incompatible", script)
                 self.assertIn(b"reference===0", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Feature: Added bounded independent holdout measurements for the load selected by local YDB search.

### Description for reviewers <!-- (optional) description for those who read this PR -->
This is stacked on #51967. The selected load and geometry stay unchanged; completed holdout samples are stored in separate CSV artifacts and become the reported metric source. Latency uses the same aggregate SLO evaluation as search, while throughput holdout remains diagnostic. The web UI shows holdout progress and prevents deltas between Search and Holdout metric sources.