### PR TITLE
ydb-bench: add extensible local YDB workload runtime

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -186,6 +186,12 @@ holdout metrics are evaluated with the same aggregate SLO contract as a search
 point. A throughput holdout is diagnostic: its request-error acceptance,
 throughput drift, and CPU saturation do not claim statistical reproducibility.
 
+Workloads with geometry-scoped datasets initialize and import once for each
+dynamic-node count, reuse that dataset across every search attempt at the same
+geometry, and clean it before adding nodes. The final geometry remains open for
+verification and is cleaned only after the holdout finishes. Shared setup and
+cleanup commands are stored under that geometry's `workload/commands.json`.
+
 During a local YDB run, the CLI reports cluster startup, workload initialization,
 warmup, measurement, cleanup, evaluation, and dynamic-node scaling milestones.
 The web profile page shows the same live phase with elapsed time and a countdown

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -14,7 +14,8 @@ The tool provides four benchmarks:
 - `ping-bench`: pairwise actor ping throughput;
 - `star-ping-bench`: star-topology actor ping throughput.
 - `memory-bandwidth-bench`: mixed sequential-copy and random copy/write memory workload.
-- `local-ydb`: a local static/dynamic YDB cluster driven by `ydb workload kv`.
+- `local-ydb`: a local static/dynamic YDB cluster driven by the `kv`, `stock`,
+  or `log` YDB CLI workload.
 
 Inspect them and print the standard JSON Schema for the YAML configuration:
 
@@ -123,15 +124,20 @@ specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
 
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
-benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. A
-`values` list measures exact points. For adaptive runs, `search` defines the
-range and resolution. `maximize-throughput` uses a discrete ternary search and,
-after confirming a plateau, selects the lowest CPU-saturated load within the
-configured throughput tolerance of the best saturated measurement. A plateau
-is confirmed only when the selected role's CPU is saturated. `latency-slo` uses
-the configured `multiplier` to find the first failing point, then a binary
-search to find the highest load whose millisecond percentile, error count, and
-achieved-rate ratio satisfy the SLO. For example:
+benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. The
+`kv` and `stock` workloads accept either parameter; `log` searches `threads`
+because its CLI does not expose `--rate`. Log throughput is the number of
+successful batches per second; `rows-per-operation` controls how many rows are
+written by each batch. Its default `ttl-minutes: 0` is a zero-minute table TTL,
+not disabled TTL. A `values` list measures exact points. For adaptive runs,
+`search` defines the range and resolution. `maximize-throughput` uses a
+discrete ternary search and, after confirming a plateau, selects the lowest
+CPU-saturated load within the configured throughput tolerance of the best
+saturated measurement. A plateau is confirmed only when the selected role's
+CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
+first failing point, then a binary search to find the highest load whose
+millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
+For example:
 
 ```yaml
     load:

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -158,10 +158,15 @@ For example:
 Set `load.allow-errors: true` when request-level errors reported by
 `ydb workload` are an expected part of the experiment. Such points remain
 eligible for selection and the error counts stay in CSV, manifests, tables,
-and charts. The flag does not hide or tolerate a failed CLI process, timeout,
-malformed output, cluster failure, or workload setup/cleanup failure. For a
-latency SLO, it disables the `max-errors` rejection while keeping the latency
-and achieved-rate checks active.
+and charts, provided every repetition completed at least one successful
+operation. A repetition with zero successful operations makes the whole point
+ineligible, even when errors are allowed. It remains in the raw repetition and
+attempt diagnostics, but is omitted from summary comparison rows and its
+latency is not plotted as a zero. The flag does not hide or tolerate a failed
+CLI process, timeout, malformed output, cluster failure, or workload
+setup/cleanup failure. For a latency SLO, it disables the `max-errors`
+rejection while keeping the successful-operation, latency, and achieved-rate
+checks active.
 
 The previous flat `mode`, `start`, and `slo` fields remain accepted for config
 compatibility, but newly generated YAML uses `search` and `objective`.

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -20,8 +20,8 @@ DIMENSIONS = (
 METRICS = tuple(
     MetricDefinition(name, unit)
     for name, unit in (
-        ("transactions", "transactions"),
-        ("throughput", "transactions/s"),
+        ("transactions", "operations"),
+        ("throughput", "operations/s"),
         ("retries", "retries"),
         ("errors", "errors"),
         ("p50_ms", "ms"),

--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -72,6 +72,8 @@ def parse_cli_metrics(stdout):
                     math.isfinite(result[name]) for name in ("throughput", "p50_ms", "p95_ms", "p99_ms", "pmax_ms")
                 ):
                     raise ValueError("non-finite workload metric")
+                if any(value < 0 for value in result.values()):
+                    raise ValueError("negative workload metric")
                 return result
             except ValueError:
                 break
@@ -106,6 +108,8 @@ def summarize_metrics(repetition_rows, benchmark):
     result = []
     for key in sorted(grouped):
         rows = grouped[key]
+        if any(row["transactions"] == 0 for row in rows):
+            continue
         record = {"affinity_mode": "roles"}
         record.update({item.name: value for item, value in zip(benchmark.dimensions, key)})
         record["samples"] = len(rows)

--- a/ydb/tools/ydb_bench/examples/local-ydb-log.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-log.yaml
@@ -1,0 +1,30 @@
+local-ydb:
+  log-smoke:
+    workload:
+      type: log
+      operation: bulk-upsert
+      options:
+        min-partitions: 1
+        max-partitions: 1
+        partition-size-mb: 128
+        auto-partition: 0
+        rows-per-operation: 16
+    geometry:
+      preset: single
+    client:
+      threads: 8
+    load:
+      parameter: threads
+      values: [1, 2, 4]
+    measurement:
+      warmup: 1
+      duration: 3
+      repetitions: 1
+      verification-repetitions: 0
+    affinity:
+      ydb-cli:
+        mode: none
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -11,6 +11,12 @@ from yaml.constructor import ConstructorError
 from ydb.tools.ydb_bench.benchmarks import BENCHMARKS
 from ydb.tools.ydb_bench.lib.actors_core import RunConfiguration
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
+    allowed_load_parameters,
+    all_load_parameters,
+    normalize_workload,
+    workload_config_schema,
+)
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
 
 PROFILE_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$"
@@ -103,46 +109,7 @@ def _profile_schema(benchmark):
             "additionalProperties": False,
             "required": ["workload", "load"],
             "properties": {
-                "workload": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": ["type", "operation"],
-                    "properties": {
-                        "type": {"enum": ["kv", "stock"]},
-                        "operation": {
-                            "enum": [
-                                "upsert",
-                                "select",
-                                "read-rows",
-                                "mixed",
-                                "user-hist",
-                                "rand-user-hist",
-                                "add-rand-order",
-                                "put-rand-order",
-                                "put-same-order",
-                            ]
-                        },
-                        "options": {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "min-partitions": {"type": "integer", "minimum": 1},
-                                "max-partitions": {"type": "integer", "minimum": 1},
-                                "partition-size-mb": {"type": "integer", "minimum": 1},
-                                "init-upserts": {"type": "integer", "minimum": 0},
-                                "max-first-key": {"type": "integer", "minimum": 1},
-                                "value-size": {"type": "integer", "minimum": 1},
-                                "columns": {"type": "integer", "minimum": 2},
-                                "rows-per-query": {"type": "integer", "minimum": 1},
-                                "products": {"type": "integer", "minimum": 1, "maximum": 500000},
-                                "quantity": {"type": "integer", "minimum": 1},
-                                "orders": {"type": "integer", "minimum": 0},
-                                "auto-partition": {"enum": [0, 1]},
-                                "limit": {"type": "integer", "minimum": 1},
-                            },
-                        },
-                    },
-                },
+                "workload": workload_config_schema(),
                 "geometry": {
                     "type": "object",
                     "additionalProperties": False,
@@ -169,7 +136,7 @@ def _profile_schema(benchmark):
                         # compatibility with configs written before search and
                         # objective became separate concepts.
                         "mode": {"enum": ["points", "maximize-throughput", "latency-slo"]},
-                        "parameter": {"enum": ["rate", "threads"]},
+                        "parameter": {"enum": list(all_load_parameters())},
                         "allow-errors": {"type": "boolean"},
                         "values": {
                             "type": "array",
@@ -539,53 +506,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     if perf_enabled:
         _config_error(location, "does not support --perf; CPU utilization is collected per process role")
 
-    workload = _mapping(value.get("workload"), location + ".workload", ("type", "operation", "options"))
-    for required in ("type", "operation"):
-        if required not in workload:
-            _config_error(location + ".workload", "missing required field: {}".format(required))
-    workload_type = _choice(workload["type"], ("kv", "stock"), location + ".workload.type")
-    operations = {
-        "kv": ("upsert", "select", "read-rows", "mixed"),
-        "stock": ("user-hist", "rand-user-hist", "add-rand-order", "put-rand-order", "put-same-order"),
-    }
-    operation = _choice(workload["operation"], operations[workload_type], location + ".workload.operation")
-    if workload_type == "kv":
-        option_defaults = {
-            "min-partitions": 40,
-            "max-partitions": 1000,
-            "partition-size-mb": 2000,
-            "init-upserts": 0 if operation == "upsert" else 1000,
-            "max-first-key": 65536,
-            "value-size": 64,
-            "columns": 2,
-            "rows-per-query": 1,
-        }
-    else:
-        option_defaults = {
-            "min-partitions": 40,
-            "products": 100,
-            "quantity": 1000,
-            "orders": 100,
-            "auto-partition": 1,
-            "limit": 10,
-        }
-    raw_options = _mapping(workload.get("options"), location + ".workload.options", tuple(option_defaults))
-    options = {}
-    for name, default in option_defaults.items():
-        raw = raw_options.get(name, default)
-        options[name] = (
-            _nonnegative_integer(raw, location + ".workload.options." + name)
-            if name in ("init-upserts", "orders", "auto-partition")
-            else _positive_integer(raw, location + ".workload.options." + name)
-        )
-    if workload_type == "kv" and options["max-partitions"] < options["min-partitions"]:
-        _config_error(location + ".workload.options.max-partitions", "must not be below min-partitions")
-    if workload_type == "kv" and options["columns"] < 2:
-        _config_error(location + ".workload.options.columns", "must be at least 2")
-    if workload_type == "stock" and options["products"] > 500000:
-        _config_error(location + ".workload.options.products", "must not exceed 500000")
-    if workload_type == "stock" and options["auto-partition"] not in (0, 1):
-        _config_error(location + ".workload.options.auto-partition", "must be 0 or 1")
+    workload = normalize_workload(value.get("workload"), location + ".workload")
 
     geometry = _mapping(
         value.get("geometry"),
@@ -652,7 +573,11 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     )
     if "parameter" not in load:
         _config_error(location + ".load", "missing required field: parameter")
-    parameter = _choice(load["parameter"], ("rate", "threads"), location + ".load.parameter")
+    parameter = _choice(
+        load["parameter"],
+        allowed_load_parameters(workload["type"]),
+        location + ".load.parameter",
+    )
     legacy_fields = {
         "mode",
         "start",
@@ -865,7 +790,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         threads=(client_threads,),
         parameters={
             "local_ydb": {
-                "workload": {"type": workload_type, "operation": operation, "options": options},
+                "workload": workload,
                 "geometry": geometry_config,
                 "client": {"threads": client_threads},
                 "load": load_config,

--- a/ydb/tools/ydb_bench/lib/linux_telemetry.py
+++ b/ydb/tools/ydb_bench/lib/linux_telemetry.py
@@ -1,11 +1,21 @@
 """Linux CPU sampling for benchmark process roles."""
 
+import math
 import os
 import threading
 import time
 from pathlib import Path
 
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
 
 
 class LinuxCpuMonitor:
@@ -64,6 +74,7 @@ class LinuxCpuMonitor:
 
     def _sample(self):
         now = time.monotonic()
+        now_unix = time.time()
         host = self._read_host_ticks()
         process_ticks = {
             role: sum(ticks for pid in tuple(provider()) if (ticks := self._read_process_ticks(pid)) is not None)
@@ -94,18 +105,47 @@ class LinuxCpuMonitor:
                 record["host_cpu"] = 100.0 * (total_delta - idle_delta) / total_delta
         if len(record) > 1:
             record["timestamp_monotonic"] = now
+            record["timestamp_unix"] = now_unix
             self._records.append(record)
         self._previous_time = now
         self._previous_host = host
         self._previous_process = process_ticks
 
-    def summary(self):
+    def summary(self, started_at_unix=None, finished_at_unix=None):
+        windowed = started_at_unix is not None or finished_at_unix is not None
+        if windowed:
+            if started_at_unix is None or finished_at_unix is None:
+                raise BenchmarkError("CPU measurement window requires both start and finish")
+            if (
+                not _is_finite_number(started_at_unix)
+                or not _is_finite_number(finished_at_unix)
+                or started_at_unix >= finished_at_unix
+            ):
+                raise BenchmarkError("CPU measurement window must be finite and increasing")
+
+        def inside_measurement_window(record):
+            if started_at_unix is None and finished_at_unix is None:
+                return True
+            timestamp = record.get("timestamp_unix")
+            if timestamp is None:
+                return False
+            interval_started_at = timestamp - record["elapsed_seconds"]
+            if started_at_unix is not None and interval_started_at < started_at_unix:
+                return False
+            if finished_at_unix is not None and timestamp > finished_at_unix:
+                return False
+            return True
+
+        records = [
+            record
+            for record in self._records
+            if record.get("elapsed_seconds", 0) > 0 and inside_measurement_window(record)
+        ]
+        if windowed and not records:
+            raise BenchmarkError("CPU measurement window does not contain a complete sample interval")
+
         def aggregate(name):
-            samples = [
-                (record[name], record["elapsed_seconds"])
-                for record in self._records
-                if name in record and record["elapsed_seconds"] > 0
-            ]
+            samples = [(record[name], record["elapsed_seconds"]) for record in records if name in record]
             if not samples:
                 return 0.0, 0.0
             elapsed = sum(duration for _, duration in samples)

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -32,8 +32,22 @@ def _with_decision(metrics, load, passed, reason):
     return {**metrics, "load": load, "passed": bool(passed), "decision": reason}
 
 
+def _invalid_measurement_reason(metrics):
+    empty_repetitions = metrics.get("empty_repetitions")
+    if empty_repetitions:
+        noun = "repetition" if empty_repetitions == 1 else "repetitions"
+        return "invalid measurement: {} {} completed with zero successful operations".format(empty_repetitions, noun)
+    if metrics.get("transactions") == 0:
+        return "invalid measurement: workload completed with zero successful operations"
+    return None
+
+
 def evaluate_load(config, load, metrics):
     """Return whether one measured load is feasible and explain the decision."""
+    invalid_reason = _invalid_measurement_reason(metrics)
+    if invalid_reason is not None:
+        return False, invalid_reason
+
     if "values" in config:
         errors = metrics["errors"]
         passed = config.get("allow_errors", False) or not errors
@@ -183,7 +197,7 @@ def _run_throughput(config, measure, on_attempt):
         return LoadSearchResult(
             tuple(attempts),
             None,
-            "workload errors at minimum load {}".format(start),
+            "minimum load {} is infeasible: {}".format(start, first["decision"]),
             "no-feasible-point",
             failing_load=start,
         )
@@ -244,8 +258,16 @@ def _run_throughput(config, measure, on_attempt):
             objective["target_role"]
         )
     elif failing_load is not None:
-        outcome = "bounded-by-errors"
-        stop_reason = "workload errors bounded the ternary search below {}".format(failing_load)
+        failing_attempt = measured[failing_load]
+        invalid_reason = _invalid_measurement_reason(failing_attempt)
+        if invalid_reason is not None:
+            outcome = "bounded-by-invalid-sample"
+            stop_reason = "invalid measurement bounded the ternary search below {}: {}".format(
+                failing_load, invalid_reason
+            )
+        else:
+            outcome = "bounded-by-errors"
+            stop_reason = "workload errors bounded the ternary search below {}".format(failing_load)
     elif selected == maximum and measured.get(maximum, {}).get("passed"):
         outcome = "lower-bound"
         stop_reason = "maximum configured load {} remains the best observed point".format(maximum)
@@ -301,7 +323,7 @@ def _run_latency(config, measure, on_attempt):
         return LoadSearchResult(
             tuple(attempts),
             None,
-            "minimum load {} does not satisfy latency SLO".format(first_fail),
+            "minimum load {} is infeasible: {}".format(first_fail, measured[first_fail]["decision"]),
             "no-feasible-point",
             failing_load=first_fail,
         )
@@ -320,12 +342,18 @@ def _run_latency(config, measure, on_attempt):
             high = candidate
 
     selected = low or None
-    reason = "latency SLO bracketed between {} and {}".format(low, high)
+    invalid_reason = _invalid_measurement_reason(measured[high])
+    if invalid_reason is not None:
+        outcome = "bounded-by-invalid-sample"
+        reason = "invalid measurement bounded the latency search above {}: {}".format(low, invalid_reason)
+    else:
+        outcome = "boundary-found"
+        reason = "latency SLO bracketed between {} and {}".format(low, high)
     return LoadSearchResult(
         tuple(attempts),
         selected,
         reason,
-        "boundary-found" if selected is not None else "no-feasible-point",
+        outcome if selected is not None else "no-feasible-point",
         passing_load=selected,
         failing_load=high,
     )

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -824,12 +824,19 @@ class WorkloadLifecycle:
         self._profile_opened = False
         self._profile_closed = False
         self._profile_state = None
+        self._geometry_state = None
 
     @property
     def profile_commands(self):
         if self._profile_state is None:
             return ()
         return tuple(self._profile_state.commands)
+
+    @property
+    def geometry_commands(self):
+        if self._geometry_state is None:
+            return ()
+        return tuple(self._geometry_state.commands)
 
     def _check_cancelled(self):
         if self.cancel_event is not None and self.cancel_event.is_set():
@@ -862,8 +869,8 @@ class WorkloadLifecycle:
         prefix = "verification-" if state.purpose == "verification" else ""
         return prefix + "cleaning-" + name
 
-    def _write_profile_commands(self, state, cleanup_errors=None):
-        if self.definition.dataset_scope != "profile":
+    def _write_shared_commands(self, state, cleanup_errors=None):
+        if state.repetition is not None:
             return
         try:
             atomic_write_json(state.directory / "commands.json", state.commands)
@@ -922,7 +929,7 @@ class WorkloadLifecycle:
                         for attempt in attempts
                     ],
                 )
-                self._write_profile_commands(state)
+                self._write_shared_commands(state)
         except BaseException as error:
             try:
                 self._cleanup_dataset(state, primary_error=error)
@@ -993,7 +1000,7 @@ class WorkloadLifecycle:
                     except BaseException as error:
                         errors.append(error)
             finally:
-                self._write_profile_commands(state, errors)
+                self._write_shared_commands(state, errors)
         if errors and primary_error is None:
             control_flow_error = next(
                 (error for error in errors if isinstance(error, (BenchmarkInterrupted, KeyboardInterrupt))),
@@ -1023,11 +1030,43 @@ class WorkloadLifecycle:
         self._profile_state = state
         self._prepare_dataset(state)
 
+    def open_geometry(self, directory, table_path, dynamic_nodes, progress_fields=None):
+        if not self._profile_opened or self._profile_closed:
+            raise BenchmarkError("workload profile lifecycle is not open")
+        self._check_cancelled()
+        if self.definition.dataset_scope != "geometry":
+            return
+        if isinstance(dynamic_nodes, bool) or not isinstance(dynamic_nodes, int) or dynamic_nodes <= 0:
+            raise BenchmarkError("workload geometry requires a positive dynamic-node count")
+        if self._geometry_state is not None and not self._geometry_state.cleaned:
+            raise BenchmarkError("workload geometry lifecycle is already open")
+        directory = Path(directory)
+        directory.mkdir(parents=True)
+        state = _DatasetState(
+            directory=directory,
+            table_path=table_path,
+            purpose="geometry",
+            repetition=None,
+            fields={**(progress_fields or {}), "geometry_dataset": True, "dynamic_nodes": dynamic_nodes},
+        )
+        self._geometry_state = state
+        self._prepare_dataset(state)
+
+    def close_geometry(self, primary_error=None):
+        if self.definition.dataset_scope != "geometry":
+            return
+        if self._geometry_state is not None:
+            self._cleanup_dataset(self._geometry_state, primary_error=primary_error)
+        if primary_error is None:
+            self._check_cancelled()
+
     def close_profile(self, primary_error=None):
         if self._profile_closed:
             return
         self._profile_closed = True
-        if self._profile_state is not None:
+        if self.definition.dataset_scope == "geometry":
+            self.close_geometry(primary_error=primary_error)
+        elif self._profile_state is not None:
             self._cleanup_dataset(self._profile_state, primary_error=primary_error)
         if primary_error is None:
             self._check_cancelled()
@@ -1179,10 +1218,22 @@ class WorkloadLifecycle:
         if self.definition.dataset_scope == "sample":
             dataset = _DatasetState(directory, table_path, purpose, repetition, fields, commands)
             self._prepare_dataset(dataset)
-        else:
+        elif self.definition.dataset_scope == "profile":
             dataset = self._profile_state
             if dataset is None or dataset.cleaned:
                 raise BenchmarkError("profile-scoped workload dataset is unavailable")
+            dataset = _DatasetState(directory, dataset.table_path, purpose, repetition, fields)
+        else:
+            dataset = self._geometry_state
+            if dataset is None or dataset.cleaned:
+                raise BenchmarkError("geometry-scoped workload dataset is unavailable")
+            geometry_dynamic_nodes = dataset.fields["dynamic_nodes"]
+            if dynamic_nodes != geometry_dynamic_nodes:
+                raise BenchmarkError(
+                    "geometry-scoped workload dataset belongs to {} dynamic nodes, got {}".format(
+                        geometry_dynamic_nodes, dynamic_nodes
+                    )
+                )
             dataset = _DatasetState(directory, dataset.table_path, purpose, repetition, fields)
         run_error = None
         try:
@@ -1336,10 +1387,16 @@ def run_local_ydb(
         while True:
             dynamic_nodes = len(cluster.dynamic_nodes)
             search_stage = len(manifest["searches"]) + 1
-            search_started_at = _utc_now()
-            search_started_monotonic = time.monotonic()
             geometry_directory = output_directory / "dynamic-nodes-{:02d}".format(dynamic_nodes)
             geometry_directory.mkdir()
+            lifecycle.open_geometry(
+                geometry_directory / "workload",
+                "ydb_bench_geometry_{:02d}".format(dynamic_nodes),
+                dynamic_nodes,
+                progress_fields={"search_stage": search_stage},
+            )
+            search_started_at = _utc_now()
+            search_started_monotonic = time.monotonic()
 
             def measure(load):
                 attempt = len(manifest["attempts"]) + 1
@@ -1454,6 +1511,7 @@ def run_local_ydb(
                     "stop_reason": result.stop_reason,
                 }
                 break
+            lifecycle.close_geometry()
             publish_progress(
                 "scaling-dynamic-nodes",
                 search_stage=search_stage,

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -4,11 +4,13 @@ import csv
 import errno
 import io
 import itertools
+import math
 import os
 import socket
 import statistics
 import sys
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,9 +30,10 @@ from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
 from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
 from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     WorkloadCli,
-    build_clean_argv,
-    build_init_argv,
-    build_run_argv,
+    build_cleanup_plan,
+    build_prepare_plan,
+    build_run_plan,
+    workload_definition,
 )
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
 from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
@@ -334,8 +337,9 @@ class LocalYdbCluster:
         if self.cancel_event is not None and self.cancel_event.is_set():
             raise BenchmarkInterrupted("local YDB benchmark was cancelled")
 
-    def _run(self, command, timeout=None, cpu_affinity=None):
-        self._check_cancelled()
+    def _run(self, command, timeout=None, cpu_affinity=None, ignore_cancellation=False):
+        if not ignore_cancellation:
+            self._check_cancelled()
         self.ensure_running("cannot run YDB CLI command")
         result = run_command(
             command,
@@ -343,7 +347,7 @@ class LocalYdbCluster:
             timeout or self.timeout,
             work_dir_hint=self.directory,
             cpu_affinity=cpu_affinity,
-            cancel_event=self.cancel_event,
+            cancel_event=None if ignore_cancellation else self.cancel_event,
         )
         self.ensure_running("YDB process exited while running a CLI command")
         if result.interrupted:
@@ -757,12 +761,439 @@ def _role_capacity(mask, topology):
     return len(mask) if mask is not None else len(topology.allowed_cpus)
 
 
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
 def _write_csv(path, rows, columns):
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=columns, extrasaction="ignore", lineterminator="\n")
     writer.writeheader()
     writer.writerows(rows)
     atomic_write_text(path, output.getvalue())
+
+
+@dataclass
+class _DatasetState:
+    directory: Path
+    table_path: str
+    purpose: str
+    repetition: object
+    fields: dict
+    commands: list = field(default_factory=list)
+    cleanup_armed: bool = False
+    cleaned: bool = False
+
+
+class WorkloadLifecycle:
+    """Execute workload datasets according to declarative lifecycle metadata."""
+
+    def __init__(
+        self,
+        cluster,
+        workload_cli,
+        workload,
+        load_config,
+        measurement,
+        client_threads,
+        benchmark,
+        topology,
+        affinities,
+        cancel_event,
+        progress,
+    ):
+        self.cluster = cluster
+        self.workload_cli = workload_cli
+        self.workload = workload
+        self.load_config = load_config
+        self.measurement = measurement
+        self.client_threads = client_threads
+        self.benchmark = benchmark
+        self.topology = topology
+        self.affinities = affinities
+        self.cancel_event = cancel_event
+        self.progress = progress
+        self.definition = workload_definition(workload["type"])
+        self._profile_opened = False
+        self._profile_closed = False
+        self._profile_state = None
+
+    @property
+    def profile_commands(self):
+        if self._profile_state is None:
+            return ()
+        return tuple(self._profile_state.commands)
+
+    def _check_cancelled(self):
+        if self.cancel_event is not None and self.cancel_event.is_set():
+            raise BenchmarkInterrupted("local YDB benchmark was cancelled")
+
+    def _phases(self, purpose):
+        if purpose == "verification":
+            return {
+                "init": "verification-initializing",
+                "warmup": "verification-warmup",
+                "measure": "verification-measuring",
+                "clean": "verification-cleanup",
+            }
+        return {
+            "init": "initializing-workload",
+            "warmup": "warming-up",
+            "measure": "measuring",
+            "clean": "cleaning-workload",
+        }
+
+    def _prepare_phase(self, state, name):
+        if name == "init":
+            return self._phases(state.purpose)["init"]
+        prefix = "verification-" if state.purpose == "verification" else ""
+        return prefix + "preparing-" + name
+
+    def _cleanup_phase(self, state, name):
+        if name == "clean":
+            return self._phases(state.purpose)["clean"]
+        prefix = "verification-" if state.purpose == "verification" else ""
+        return prefix + "cleaning-" + name
+
+    def _write_profile_commands(self, state, cleanup_errors=None):
+        if self.definition.dataset_scope != "profile":
+            return
+        try:
+            atomic_write_json(state.directory / "commands.json", state.commands)
+        except BaseException as error:
+            if cleanup_errors is None:
+                raise
+            cleanup_errors.append(error)
+
+    @staticmethod
+    def _write_cleanup_error(path, error, cleanup_errors):
+        try:
+            atomic_write_text(path, str(error) + "\n")
+        except BaseException as artifact_error:
+            cleanup_errors.append(artifact_error)
+
+    def _prepare_dataset(self, state):
+        state.cleanup_armed = True
+        try:
+            plans = build_prepare_plan(self.workload_cli, state.table_path, self.workload)
+            for plan in plans:
+                phase = self._prepare_phase(state, plan.name)
+                self.progress(
+                    phase,
+                    **state.fields,
+                    current_command=_command_record(
+                        phase,
+                        state.repetition,
+                        plan.argv,
+                        self.affinities["ydb_cli"],
+                    ),
+                )
+                result, attempts = self.cluster.init_workload(plan.argv, timeout=plan.timeout_seconds)
+                state.commands.extend(
+                    _command_record(
+                        phase,
+                        state.repetition,
+                        attempt.command,
+                        self.affinities["ydb_cli"],
+                        attempt,
+                    )
+                    for attempt in attempts
+                )
+                atomic_write_text(state.directory / "{}.stdout.txt".format(plan.name), result.stdout)
+                atomic_write_text(state.directory / "{}.stderr.txt".format(plan.name), result.stderr)
+                atomic_write_json(
+                    state.directory / "{}-attempts.json".format(plan.name),
+                    [
+                        {
+                            "command": [str(part) for part in attempt.command],
+                            "exit_code": attempt.exit_code,
+                            "timed_out": attempt.timed_out,
+                            "duration_seconds": attempt.duration_seconds,
+                            "stdout": attempt.stdout,
+                            "stderr": attempt.stderr,
+                        }
+                        for attempt in attempts
+                    ],
+                )
+                self._write_profile_commands(state)
+        except BaseException as error:
+            try:
+                self._cleanup_dataset(state, primary_error=error)
+            except BaseException:
+                pass
+            raise
+
+    def _cleanup_dataset(self, state, primary_error=None):
+        if not state.cleanup_armed or state.cleaned:
+            return
+        state.cleaned = True
+        errors = []
+        try:
+            plans = build_cleanup_plan(self.workload_cli, state.table_path, self.workload)
+        except BaseException as error:
+            plans = ()
+            errors.append(error)
+            self._write_cleanup_error(state.directory / "clean.error.txt", error, errors)
+        for plan in plans:
+            phase = self._cleanup_phase(state, plan.name)
+            try:
+                self.progress(
+                    phase,
+                    **state.fields,
+                    current_command=_command_record(
+                        phase,
+                        state.repetition,
+                        plan.argv,
+                        self.affinities["ydb_cli"],
+                    ),
+                )
+            except BaseException as error:
+                errors.append(error)
+                self._write_cleanup_error(
+                    state.directory / "{}.progress.error.txt".format(plan.name),
+                    error,
+                    errors,
+                )
+            try:
+                result = self.cluster._run(
+                    plan.argv,
+                    timeout=plan.timeout_seconds,
+                    cpu_affinity=self.affinities["ydb_cli"],
+                    ignore_cancellation=True,
+                )
+            except BaseException as error:
+                errors.append(error)
+                self._write_cleanup_error(state.directory / "{}.error.txt".format(plan.name), error, errors)
+            else:
+                try:
+                    state.commands.append(
+                        _command_record(
+                            phase,
+                            state.repetition,
+                            result.command,
+                            self.affinities["ydb_cli"],
+                            result,
+                        )
+                    )
+                except BaseException as error:
+                    errors.append(error)
+                for suffix, value in (("stdout", result.stdout), ("stderr", result.stderr)):
+                    try:
+                        atomic_write_text(
+                            state.directory / "{}.{}.txt".format(plan.name, suffix),
+                            value,
+                        )
+                    except BaseException as error:
+                        errors.append(error)
+            finally:
+                self._write_profile_commands(state, errors)
+        if errors and primary_error is None:
+            control_flow_error = next(
+                (error for error in errors if isinstance(error, (BenchmarkInterrupted, KeyboardInterrupt))),
+                None,
+            )
+            if control_flow_error is not None:
+                raise control_flow_error
+            if len(errors) == 1 and isinstance(errors[0], BenchmarkError):
+                raise errors[0]
+            raise BenchmarkError("workload cleanup failed: {}".format("; ".join(map(str, errors))))
+
+    def open_profile(self, directory, table_path):
+        if self._profile_opened:
+            raise BenchmarkError("workload profile lifecycle is already open")
+        self._profile_opened = True
+        if self.definition.dataset_scope != "profile":
+            return
+        directory = Path(directory)
+        directory.mkdir(parents=True)
+        state = _DatasetState(
+            directory=directory,
+            table_path=table_path,
+            purpose="profile",
+            repetition=None,
+            fields={"profile_dataset": True},
+        )
+        self._profile_state = state
+        self._prepare_dataset(state)
+
+    def close_profile(self, primary_error=None):
+        if self._profile_closed:
+            return
+        self._profile_closed = True
+        if self._profile_state is not None:
+            self._cleanup_dataset(self._profile_state, primary_error=primary_error)
+        if primary_error is None:
+            self._check_cancelled()
+
+    def _run_workload(self, state, load, dynamic_nodes, repetition, commands):
+        phases = self._phases(state.purpose)
+        warmup = self.measurement["warmup"]
+        if warmup and self.definition.warmup_mode == "separate":
+            warmup_plan = build_run_plan(
+                self.workload_cli,
+                state.table_path,
+                self.workload,
+                self.load_config["parameter"],
+                load,
+                warmup,
+                self.client_threads,
+            )
+            self.progress(
+                phases["warmup"],
+                **state.fields,
+                phase_duration_seconds=warmup,
+                current_command=_command_record(
+                    phases["warmup"],
+                    repetition,
+                    warmup_plan.argv,
+                    self.affinities["ydb_cli"],
+                ),
+            )
+            result = self.cluster._run(
+                warmup_plan.argv,
+                timeout=warmup_plan.timeout_seconds,
+                cpu_affinity=self.affinities["ydb_cli"],
+            )
+            commands.append(
+                _command_record(
+                    phases["warmup"],
+                    repetition,
+                    result.command,
+                    self.affinities["ydb_cli"],
+                    result,
+                )
+            )
+            atomic_write_text(state.directory / "warmup.stdout.txt", result.stdout)
+            atomic_write_text(state.directory / "warmup.stderr.txt", result.stderr)
+
+        cli_pids = []
+        monitor = LinuxCpuMonitor(
+            {
+                "static": lambda: self.cluster.static_pids,
+                "dynamic": lambda: self.cluster.dynamic_pids,
+                "cli": lambda: tuple(cli_pids),
+            },
+            {
+                "static": _role_capacity(self.affinities["static_nodes"], self.topology),
+                "dynamic": _role_capacity(self.affinities["dynamic_nodes"], self.topology),
+                "cli": _role_capacity(self.affinities["ydb_cli"], self.topology),
+            },
+        )
+        monitor.start()
+        try:
+            plan = build_run_plan(
+                self.workload_cli,
+                state.table_path,
+                self.workload,
+                self.load_config["parameter"],
+                load,
+                self.measurement["duration"],
+                self.client_threads,
+                warmup_seconds=warmup if self.definition.warmup_mode == "inline" else 0,
+            )
+            self.cluster.ensure_running("cannot start workload measurement")
+            progress_fields = {
+                **state.fields,
+                "phase_duration_seconds": self.measurement["duration"]
+                + (warmup if self.definition.warmup_mode == "inline" else 0),
+                "current_command": _command_record(
+                    phases["measure"],
+                    repetition,
+                    plan.argv,
+                    self.affinities["ydb_cli"],
+                ),
+            }
+            if self.definition.warmup_mode == "inline":
+                progress_fields["inline_warmup_seconds"] = warmup
+            self.progress(phases["measure"], **progress_fields)
+            result = run_command(
+                plan.argv,
+                {},
+                plan.timeout_seconds,
+                cpu_affinity=self.affinities["ydb_cli"],
+                cancel_event=self.cancel_event,
+                on_process_started=lambda process: cli_pids.append(process.pid),
+            )
+        finally:
+            cpu = monitor.stop()
+        self.cluster.ensure_running("YDB process exited during workload measurement")
+        commands.append(
+            _command_record(
+                phases["measure"],
+                repetition,
+                result.command,
+                self.affinities["ydb_cli"],
+                result,
+            )
+        )
+        atomic_write_text(state.directory / "stdout.txt", result.stdout)
+        atomic_write_text(state.directory / "stderr.txt", result.stderr)
+        atomic_write_json(state.directory / "cpu-samples.json", list(monitor.records))
+        if result.interrupted:
+            raise BenchmarkInterrupted("YDB CLI workload was interrupted")
+        if result.timed_out or result.exit_code:
+            raise BenchmarkError(
+                "YDB CLI workload {}".format(
+                    "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
+                )
+            )
+        if plan.measurement_window_builder is not None:
+            window = plan.measurement_window_builder(result.stdout)
+            if (
+                not isinstance(window, tuple)
+                or len(window) != 2
+                or not all(_is_finite_number(value) for value in window)
+                or window[0] >= window[1]
+            ):
+                raise BenchmarkError("workload command returned an invalid CPU measurement window")
+            cpu = monitor.summary(started_at_unix=window[0], finished_at_unix=window[1])
+        metrics = {**self.benchmark.parse_metrics(result.stdout, self.benchmark)[0], **cpu}
+        metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
+        return metrics
+
+    def run_sample(
+        self,
+        load,
+        dynamic_nodes,
+        repetition,
+        repetitions,
+        directory,
+        table_path,
+        progress_fields,
+        purpose="search",
+    ):
+        if not self._profile_opened or self._profile_closed:
+            raise BenchmarkError("workload profile lifecycle is not open")
+        self._check_cancelled()
+        directory = Path(directory)
+        directory.mkdir(parents=True)
+        fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
+        commands = []
+        if self.definition.dataset_scope == "sample":
+            dataset = _DatasetState(directory, table_path, purpose, repetition, fields, commands)
+            self._prepare_dataset(dataset)
+        else:
+            dataset = self._profile_state
+            if dataset is None or dataset.cleaned:
+                raise BenchmarkError("profile-scoped workload dataset is unavailable")
+            dataset = _DatasetState(directory, dataset.table_path, purpose, repetition, fields)
+        run_error = None
+        try:
+            metrics = self._run_workload(dataset, load, dynamic_nodes, repetition, commands)
+            return metrics, commands
+        except BaseException as error:
+            run_error = error
+            raise
+        finally:
+            if self.definition.dataset_scope == "sample":
+                self._cleanup_dataset(dataset, primary_error=run_error)
+                if run_error is None:
+                    self._check_cancelled()
 
 
 def run_local_ydb(
@@ -870,229 +1301,36 @@ def run_local_ydb(
         cancel_event,
         publish_progress,
     )
-    workload_cli = None
-
-    def run_repetition(
-        load,
-        dynamic_nodes,
-        repetition,
-        repetitions,
-        directory,
-        table_path,
-        progress_fields,
-        purpose="search",
-    ):
-        if cancel_event is not None and cancel_event.is_set():
-            raise BenchmarkInterrupted("local YDB benchmark was cancelled")
-        phases = (
-            {
-                "init": "verification-initializing",
-                "warmup": "verification-warmup",
-                "measure": "verification-measuring",
-                "clean": "verification-cleanup",
-            }
-            if purpose == "verification"
-            else {
-                "init": "initializing-workload",
-                "warmup": "warming-up",
-                "measure": "measuring",
-                "clean": "cleaning-workload",
-            }
-        )
-        directory.mkdir(parents=True)
-        fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
-        commands = []
-        init_command = build_init_argv(workload_cli, table_path, profile["workload"])
-        publish_progress(
-            phases["init"],
-            **fields,
-            current_command=_command_record(
-                phases["init"],
-                repetition,
-                init_command,
-                affinities["ydb_cli"],
-            ),
-        )
-        init, init_attempts = cluster.init_workload(init_command)
-        commands.extend(
-            _command_record(
-                phases["init"],
-                repetition,
-                init_attempt.command,
-                affinities["ydb_cli"],
-                init_attempt,
-            )
-            for init_attempt in init_attempts
-        )
-        atomic_write_text(directory / "init.stdout.txt", init.stdout)
-        atomic_write_text(directory / "init.stderr.txt", init.stderr)
-        atomic_write_json(
-            directory / "init-attempts.json",
-            [
-                {
-                    "command": [str(part) for part in attempt.command],
-                    "exit_code": attempt.exit_code,
-                    "timed_out": attempt.timed_out,
-                    "duration_seconds": attempt.duration_seconds,
-                    "stdout": attempt.stdout,
-                    "stderr": attempt.stderr,
-                }
-                for attempt in init_attempts
-            ],
-        )
-        run_error = None
-        try:
-            warmup = profile["measurement"]["warmup"]
-            if warmup:
-                warmup_command = build_run_argv(
-                    workload_cli,
-                    table_path,
-                    profile["workload"],
-                    profile["load"]["parameter"],
-                    load,
-                    warmup,
-                    profile["client"]["threads"],
-                )
-                publish_progress(
-                    phases["warmup"],
-                    **fields,
-                    phase_duration_seconds=warmup,
-                    current_command=_command_record(
-                        phases["warmup"],
-                        repetition,
-                        warmup_command,
-                        affinities["ydb_cli"],
-                    ),
-                )
-                result = cluster._run(
-                    warmup_command,
-                    timeout=warmup + 30,
-                    cpu_affinity=affinities["ydb_cli"],
-                )
-                commands.append(
-                    _command_record(
-                        phases["warmup"],
-                        repetition,
-                        result.command,
-                        affinities["ydb_cli"],
-                        result,
-                    )
-                )
-                atomic_write_text(directory / "warmup.stdout.txt", result.stdout)
-                atomic_write_text(directory / "warmup.stderr.txt", result.stderr)
-
-            cli_pids = []
-            monitor = LinuxCpuMonitor(
-                {
-                    "static": lambda: cluster.static_pids,
-                    "dynamic": lambda: cluster.dynamic_pids,
-                    "cli": lambda: tuple(cli_pids),
-                },
-                {
-                    "static": _role_capacity(affinities["static_nodes"], topology),
-                    "dynamic": _role_capacity(affinities["dynamic_nodes"], topology),
-                    "cli": _role_capacity(affinities["ydb_cli"], topology),
-                },
-            )
-            monitor.start()
-            try:
-                command = build_run_argv(
-                    workload_cli,
-                    table_path,
-                    profile["workload"],
-                    profile["load"]["parameter"],
-                    load,
-                    profile["measurement"]["duration"],
-                    profile["client"]["threads"],
-                )
-                cluster.ensure_running("cannot start workload measurement")
-                publish_progress(
-                    phases["measure"],
-                    **fields,
-                    phase_duration_seconds=profile["measurement"]["duration"],
-                    current_command=_command_record(
-                        phases["measure"],
-                        repetition,
-                        command,
-                        affinities["ydb_cli"],
-                    ),
-                )
-                result = run_command(
-                    command,
-                    {},
-                    profile["measurement"]["duration"] + 30,
-                    cpu_affinity=affinities["ydb_cli"],
-                    cancel_event=cancel_event,
-                    on_process_started=lambda process: cli_pids.append(process.pid),
-                )
-            finally:
-                cpu = monitor.stop()
-            cluster.ensure_running("YDB process exited during workload measurement")
-            commands.append(
-                _command_record(
-                    phases["measure"],
-                    repetition,
-                    result.command,
-                    affinities["ydb_cli"],
-                    result,
-                )
-            )
-            atomic_write_text(directory / "stdout.txt", result.stdout)
-            atomic_write_text(directory / "stderr.txt", result.stderr)
-            atomic_write_json(directory / "cpu-samples.json", list(monitor.records))
-            if result.interrupted:
-                raise BenchmarkInterrupted("YDB CLI workload was interrupted")
-            if result.timed_out or result.exit_code:
-                raise BenchmarkError(
-                    "YDB CLI workload {}".format(
-                        "timed out" if result.timed_out else "exited with code {}".format(result.exit_code)
-                    )
-                )
-            metrics = {**benchmark.parse_metrics(result.stdout, benchmark)[0], **cpu}
-            metrics.update({"load": load, "dynamic_nodes": dynamic_nodes, "repetition": repetition})
-            return metrics, commands
-        except BaseException as error:
-            run_error = error
-            raise
-        finally:
-            try:
-                clean_command = build_clean_argv(
-                    workload_cli,
-                    table_path,
-                    profile["workload"]["type"],
-                )
-                publish_progress(
-                    phases["clean"],
-                    **fields,
-                    current_command=_command_record(
-                        phases["clean"],
-                        repetition,
-                        clean_command,
-                        affinities["ydb_cli"],
-                    ),
-                )
-                clean = cluster._run(clean_command, cpu_affinity=affinities["ydb_cli"])
-                commands.append(
-                    _command_record(
-                        phases["clean"],
-                        repetition,
-                        clean.command,
-                        affinities["ydb_cli"],
-                        clean,
-                    )
-                )
-                atomic_write_text(directory / "clean.stdout.txt", clean.stdout)
-                atomic_write_text(directory / "clean.stderr.txt", clean.stderr)
-            except BenchmarkError as error:
-                atomic_write_text(directory / "clean.error.txt", str(error) + "\n")
-                if run_error is None:
-                    raise
-
     repetition_rows = []
     cluster_stopped = False
+    lifecycle = None
+
+    def close_lifecycle(primary_error=None):
+        if lifecycle is None:
+            return
+        try:
+            lifecycle.close_profile(primary_error=primary_error)
+        except BaseException:
+            if primary_error is None:
+                raise
+
     try:
         cluster.start()
         workload_cli = WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database)
+        lifecycle = WorkloadLifecycle(
+            cluster,
+            workload_cli,
+            profile["workload"],
+            profile["load"],
+            profile["measurement"],
+            profile["client"]["threads"],
+            benchmark,
+            topology,
+            affinities,
+            cancel_event,
+            publish_progress,
+        )
+        lifecycle.open_profile(output_directory / "workload", "ydb_bench_profile")
         while True:
             dynamic_nodes = len(cluster.dynamic_nodes)
             search_stage = len(manifest["searches"]) + 1
@@ -1111,7 +1349,7 @@ def run_local_ydb(
                 for repetition in range(1, repetitions + 1):
                     directory = geometry_directory / "load-{:08d}".format(load) / "repeat-{:03d}".format(repetition)
                     table_path = "ydb_bench_{}_{}_{}".format(dynamic_nodes, load, repetition)
-                    metrics, repetition_commands = run_repetition(
+                    metrics, repetition_commands = lifecycle.run_sample(
                         load,
                         dynamic_nodes,
                         repetition,
@@ -1267,7 +1505,7 @@ def run_local_ydb(
                 for repetition in range(1, verification_repetitions + 1):
                     directory = output_directory / "verification" / "repeat-{:03d}".format(repetition)
                     table_path = "ydb_bench_verify_{}_{}_{}".format(dynamic_nodes, selected_load, repetition)
-                    metrics, commands = run_repetition(
+                    metrics, commands = lifecycle.run_sample(
                         selected_load,
                         dynamic_nodes,
                         repetition,
@@ -1381,6 +1619,7 @@ def run_local_ydb(
                 verification=verification,
             )
 
+        close_lifecycle()
         publish_progress("stopping-cluster", result=compact_result_progress())
         cluster.stop()
         cluster_stopped = True
@@ -1423,6 +1662,7 @@ def run_local_ydb(
         write_manifest(manifest_path, manifest)
         return manifest
     except (BenchmarkInterrupted, KeyboardInterrupt) as error:
+        close_lifecycle(primary_error=error)
         interruption = (
             error
             if isinstance(error, BenchmarkInterrupted)
@@ -1450,7 +1690,8 @@ def run_local_ydb(
         if interruption is error:
             raise
         raise interruption from error
-    except BenchmarkError as error:
+    except Exception as error:
+        close_lifecycle(primary_error=error)
         manifest.update({"status": "failed", "state": "failed", "finished_at": _utc_now(), "error": str(error)})
         publish_progress("failed", error=str(error))
         write_manifest(manifest_path, manifest)
@@ -1465,5 +1706,8 @@ def run_local_ydb(
             )
         raise
     finally:
-        if not cluster_stopped:
-            cluster.stop()
+        try:
+            close_lifecycle(primary_error=sys.exc_info()[1])
+        finally:
+            if not cluster_stopped:
+                cluster.stop()

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -719,6 +719,8 @@ def _aggregate_measurements(rows):
     # counts describe the whole attempted point; performance metrics remain
     # medians so that an outlier repetition does not select the load.
     result["errors"] = sum(row["errors"] for row in rows)
+    if all("transactions" in row for row in rows):
+        result["empty_repetitions"] = sum(row["transactions"] == 0 for row in rows)
     return result
 
 

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -26,6 +26,12 @@ from ydb.tools.ydb_bench.lib.common import (
 )
 from ydb.tools.ydb_bench.lib.linux_telemetry import LinuxCpuMonitor
 from ydb.tools.ydb_bench.lib.load_control import evaluate_load, search_load
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
+    WorkloadCli,
+    build_clean_argv,
+    build_init_argv,
+    build_run_argv,
+)
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
 from ydb.tools.ydb_bench.lib.runner import run_command, start_managed_process
 from ydb.tools.ydb_bench.lib.system_info import collect_system_info
@@ -681,139 +687,6 @@ class LocalYdbCluster:
         return records
 
 
-def _workload_base(cluster, workload_type, path=None):
-    command = [
-        cluster.ydb_cli,
-        "--endpoint",
-        cluster.client_endpoint,
-        "--database",
-        cluster.database,
-        "workload",
-        workload_type,
-    ]
-    if path is not None:
-        command += ["--path", path]
-    return command
-
-
-def _kv_init_command(cluster, path, options):
-    return _workload_base(cluster, "kv", path) + [
-        "init",
-        "--init-upserts",
-        options["init-upserts"],
-        "--min-partitions",
-        options["min-partitions"],
-        "--max-partitions",
-        options["max-partitions"],
-        "--partition-size",
-        options["partition-size-mb"],
-        "--max-first-key",
-        options["max-first-key"],
-        "--len",
-        options["value-size"],
-        "--cols",
-        options["columns"],
-        "--int-cols",
-        1,
-        "--key-cols",
-        1,
-        "--rows",
-        options["rows-per-query"],
-    ]
-
-
-def _kv_run_command(cluster, path, workload, load_config, load, seconds, client_threads):
-    options = workload["options"]
-    threads = load if load_config["parameter"] == "threads" else client_threads
-    command = _workload_base(cluster, "kv", path) + [
-        "run",
-        workload["operation"],
-        "--seconds",
-        seconds,
-        "--threads",
-        threads,
-        "--quiet",
-        "--max-first-key",
-        options["max-first-key"],
-        "--int-cols",
-        1,
-        "--key-cols",
-        1,
-        "--cols",
-        options["columns"],
-    ]
-    if workload["operation"] != "mixed":
-        command += ["--rows", options["rows-per-query"]]
-    if workload["operation"] in ("upsert", "mixed"):
-        command += ["--len", options["value-size"]]
-    if load_config["parameter"] == "rate":
-        command += ["--rate", load]
-    return command
-
-
-def _stock_init_command(cluster, path, options):
-    del path
-    return _workload_base(cluster, "stock") + [
-        "init",
-        "--products",
-        options["products"],
-        "--quantity",
-        options["quantity"],
-        "--orders",
-        options["orders"],
-        "--min-partitions",
-        options["min-partitions"],
-        "--auto-partition",
-        options["auto-partition"],
-    ]
-
-
-def _stock_run_command(cluster, path, workload, load_config, load, seconds, client_threads):
-    del path
-    options = workload["options"]
-    threads = load if load_config["parameter"] == "threads" else client_threads
-    command = _workload_base(cluster, "stock") + [
-        "run",
-        workload["operation"],
-        "--seconds",
-        seconds,
-        "--threads",
-        threads,
-        "--quiet",
-    ]
-    if workload["operation"] in ("user-hist", "rand-user-hist"):
-        command += ["--limit", options["limit"]]
-    else:
-        command += ["--products", options["products"]]
-    if load_config["parameter"] == "rate":
-        command += ["--rate", load]
-    return command
-
-
-def _init_command(cluster, path, workload):
-    if workload["type"] == "stock":
-        return _stock_init_command(cluster, path, workload["options"])
-    return _kv_init_command(cluster, path, workload["options"])
-
-
-def _run_workload_command(cluster, path, workload, load_config, load, seconds, client_threads):
-    if workload["type"] == "stock":
-        return _stock_run_command(cluster, path, workload, load_config, load, seconds, client_threads)
-    return _kv_run_command(cluster, path, workload, load_config, load, seconds, client_threads)
-
-
-def _workload_table_path(workload_type, path):
-    # Unlike KV, stock has no --path option and creates its tables directly in
-    # the selected database.  "stock" is the first table created by its init.
-    return "stock" if workload_type == "stock" else path
-
-
-def _clean_workload_command(cluster, workload_type, path):
-    if workload_type == "stock":
-        return _workload_base(cluster, workload_type) + ["clean"]
-    return _workload_base(cluster, workload_type, path) + ["clean"]
-
-
 def _command_record(phase, repetition, command, cpu_affinity, result=None):
     record = {
         "phase": phase,
@@ -997,6 +870,7 @@ def run_local_ydb(
         cancel_event,
         publish_progress,
     )
+    workload_cli = None
 
     def run_repetition(
         load,
@@ -1028,7 +902,7 @@ def run_local_ydb(
         directory.mkdir(parents=True)
         fields = {**progress_fields, "repetition": repetition, "repetitions": repetitions}
         commands = []
-        init_command = _init_command(cluster, table_path, profile["workload"])
+        init_command = build_init_argv(workload_cli, table_path, profile["workload"])
         publish_progress(
             phases["init"],
             **fields,
@@ -1070,11 +944,11 @@ def run_local_ydb(
         try:
             warmup = profile["measurement"]["warmup"]
             if warmup:
-                warmup_command = _run_workload_command(
-                    cluster,
+                warmup_command = build_run_argv(
+                    workload_cli,
                     table_path,
                     profile["workload"],
-                    profile["load"],
+                    profile["load"]["parameter"],
                     load,
                     warmup,
                     profile["client"]["threads"],
@@ -1122,11 +996,11 @@ def run_local_ydb(
             )
             monitor.start()
             try:
-                command = _run_workload_command(
-                    cluster,
+                command = build_run_argv(
+                    workload_cli,
                     table_path,
                     profile["workload"],
-                    profile["load"],
+                    profile["load"]["parameter"],
                     load,
                     profile["measurement"]["duration"],
                     profile["client"]["threads"],
@@ -1182,10 +1056,10 @@ def run_local_ydb(
             raise
         finally:
             try:
-                clean_command = _clean_workload_command(
-                    cluster,
-                    profile["workload"]["type"],
+                clean_command = build_clean_argv(
+                    workload_cli,
                     table_path,
+                    profile["workload"]["type"],
                 )
                 publish_progress(
                     phases["clean"],
@@ -1218,6 +1092,7 @@ def run_local_ydb(
     cluster_stopped = False
     try:
         cluster.start()
+        workload_cli = WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database)
         while True:
             dynamic_nodes = len(cluster.dynamic_nodes)
             search_stage = len(manifest["searches"]) + 1

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -226,6 +226,61 @@ def _stock_run_builder(cli, definition, path, workload, load_parameter, load, se
     return command
 
 
+def _log_init_builder(cli, definition, path, workload):
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--min-partitions",
+        options["min-partitions"],
+        "--max-partitions",
+        options["max-partitions"],
+        "--partition-size",
+        options["partition-size-mb"],
+        "--auto-partition",
+        options["auto-partition"],
+        "--len",
+        options["string-length"],
+        "--int-cols",
+        options["integer-columns"],
+        "--str-cols",
+        options["string-columns"],
+        "--key-cols",
+        options["key-columns"],
+        "--ttl",
+        options["ttl-minutes"],
+        "--store",
+        options["store"],
+        "--null-percent",
+        options["null-percent"],
+    ]
+
+
+def _log_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del load_parameter, client_threads
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        load,
+        "--quiet",
+        "--rows",
+        options["rows-per-operation"],
+        "--len",
+        options["string-length"],
+        "--int-cols",
+        options["integer-columns"],
+        "--str-cols",
+        options["string-columns"],
+        "--key-cols",
+        options["key-columns"],
+        "--null-percent",
+        options["null-percent"],
+    ]
+
+
 def _validate_kv_options(options, location):
     if options["max-partitions"] < options["min-partitions"]:
         _config_error(location + ".max-partitions", "must not be below min-partitions")
@@ -235,6 +290,14 @@ def _validate_kv_options(options, location):
 
 def _validate_stock_options(options, location):
     del options, location
+
+
+def _validate_log_options(options, location):
+    if options["max-partitions"] < options["min-partitions"]:
+        _config_error(location + ".max-partitions", "must not be below min-partitions")
+    columns = options["integer-columns"] + options["string-columns"]
+    if options["key-columns"] > columns:
+        _config_error(location + ".key-columns", "must not exceed integer-columns plus string-columns")
 
 
 def _validate_option_value(option, value, location):
@@ -378,6 +441,33 @@ _DEFINITIONS = (
         run_builder=_stock_run_builder,
         options_validator=_validate_stock_options,
     ),
+    WorkloadDefinition(
+        name="log",
+        default_operation="bulk-upsert",
+        operations=("insert", "upsert", "bulk-upsert"),
+        load_parameters=("threads",),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("max-partitions", 1000),
+            WorkloadOption("partition-size-mb", 2000),
+            WorkloadOption("auto-partition", 1, allow_zero=True, choices=(0, 1)),
+            WorkloadOption("store", "row", kind="string", choices=("row", "column")),
+            WorkloadOption("ttl-minutes", 0, allow_zero=True),
+            WorkloadOption("string-length", 8),
+            WorkloadOption("integer-columns", 0, allow_zero=True),
+            WorkloadOption("string-columns", 0, allow_zero=True),
+            WorkloadOption("key-columns", 0, allow_zero=True),
+            WorkloadOption("rows-per-operation", 1),
+            WorkloadOption("null-percent", 10, allow_zero=True, maximum=100),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_log_init_builder,
+        run_builder=_log_run_builder,
+        options_validator=_validate_log_options,
+        dataset_scope="sample",
+        warmup_mode="separate",
+    ),
 )
 _validate_catalog(_DEFINITIONS)
 _WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
@@ -426,13 +516,14 @@ def workload_config_schema():
     for definition in _DEFINITIONS:
         for option in definition.options:
             option_schemas[option.name] = option.config_schema()
+    operations = tuple(dict.fromkeys(operation for definition in _DEFINITIONS for operation in definition.operations))
     return {
         "type": "object",
         "additionalProperties": False,
         "required": ["type", "operation"],
         "properties": {
             "type": {"enum": [definition.name for definition in _DEFINITIONS]},
-            "operation": {"enum": [operation for definition in _DEFINITIONS for operation in definition.operations]},
+            "operation": {"enum": list(operations)},
             "options": {
                 "type": "object",
                 "additionalProperties": False,

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,5 +1,6 @@
 """Declarative local-YDB workload catalog and YDB CLI command builders."""
 
+import math
 import re
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -12,6 +13,14 @@ class WorkloadCli:
     executable: object
     endpoint: str
     database: str
+
+
+@dataclass(frozen=True)
+class WorkloadCommandPlan:
+    name: str
+    argv: tuple
+    timeout_seconds: float | None = None
+    measurement_window_builder: object = None
 
 
 @dataclass(frozen=True)
@@ -75,10 +84,24 @@ class WorkloadDefinition:
     init_builder: object
     run_builder: object
     options_validator: object
+    dataset_scope: str = "sample"
+    warmup_mode: str = "separate"
+    prepare_plan_builder: object = None
+    run_plan_builder: object = None
+    cleanup_plan_builder: object = None
 
 
 def _config_error(location, message):
     raise BenchmarkError("invalid benchmark config at {}: {}".format(location, message))
+
+
+def _is_finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
 
 
 def _mapping(value, location, allowed=()):
@@ -246,6 +269,16 @@ def _validate_catalog(definitions):
         raise ValueError("local YDB workload names must be unique")
     option_schemas = {}
     for definition in definitions:
+        if definition.dataset_scope not in ("sample", "profile"):
+            raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
+        if definition.warmup_mode not in ("separate", "inline"):
+            raise ValueError("unknown warmup mode for {}: {}".format(definition.name, definition.warmup_mode))
+        for name in ("prepare_plan_builder", "run_plan_builder", "cleanup_plan_builder"):
+            builder = getattr(definition, name)
+            if builder is not None and not callable(builder):
+                raise ValueError("{} must be callable for {}".format(name, definition.name))
+        if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
+            raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
         if len(definition.operations) != len(set(definition.operations)):
             raise ValueError("operations must be unique for {}".format(definition.name))
         if len(definition.load_parameters) != len(set(definition.load_parameters)):
@@ -464,6 +497,125 @@ def build_run_argv(cli, path, workload, load_parameter, load, seconds, client_th
 def build_clean_argv(cli, path, workload_type):
     definition = _definition(workload_type)
     return _workload_base(cli, definition, path) + ["clean"]
+
+
+def _validate_command_plans(plans, description, allow_default_timeout=False):
+    if not isinstance(plans, tuple) or not plans:
+        raise BenchmarkError("{} must produce a non-empty tuple of command plans".format(description))
+    for plan in plans:
+        if not isinstance(plan, WorkloadCommandPlan):
+            raise BenchmarkError("{} produced an invalid command plan".format(description))
+        if not plan.name or not isinstance(plan.name, str) or re.fullmatch("[a-z0-9-]+", plan.name) is None:
+            raise BenchmarkError("{} produced an invalid command plan name".format(description))
+        if not isinstance(plan.argv, tuple) or not plan.argv:
+            raise BenchmarkError("{} command {} must have a non-empty argv tuple".format(description, plan.name))
+        if plan.timeout_seconds is None and allow_default_timeout:
+            pass
+        elif not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
+            raise BenchmarkError("{} command {} must have a positive timeout".format(description, plan.name))
+        if plan.measurement_window_builder is not None and not callable(plan.measurement_window_builder):
+            raise BenchmarkError(
+                "{} command {} has an invalid measurement window builder".format(description, plan.name)
+            )
+    return plans
+
+
+def build_prepare_plan(cli, path, workload):
+    """Build the pure command plan which creates one workload dataset."""
+
+    definition = _definition(workload["type"])
+    if definition.prepare_plan_builder is None:
+        plans = (
+            WorkloadCommandPlan(
+                "init",
+                tuple(definition.init_builder(cli, definition, path, workload)),
+                120,
+            ),
+        )
+    else:
+        plans = definition.prepare_plan_builder(cli, definition, path, workload)
+    return _validate_command_plans(plans, "{} prepare plan".format(definition.name))
+
+
+def build_run_plan(
+    cli,
+    path,
+    workload,
+    load_parameter,
+    load,
+    seconds,
+    client_threads,
+    warmup_seconds=0,
+):
+    """Build one pure workload command plan without executing a process."""
+
+    definition = _definition(workload["type"])
+    if load_parameter not in definition.load_parameters:
+        raise BenchmarkError(
+            "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)
+        )
+    if definition.run_plan_builder is None:
+        if warmup_seconds:
+            raise BenchmarkError("{} does not support inline warmup".format(definition.name))
+        plan = WorkloadCommandPlan(
+            "run",
+            tuple(
+                definition.run_builder(
+                    cli,
+                    definition,
+                    path,
+                    workload,
+                    load_parameter,
+                    load,
+                    seconds,
+                    client_threads,
+                )
+            ),
+            seconds + 30,
+        )
+    else:
+        plan = definition.run_plan_builder(
+            cli,
+            definition,
+            path,
+            workload,
+            load_parameter,
+            load,
+            seconds,
+            client_threads,
+            warmup_seconds,
+        )
+    plan = _validate_command_plans((plan,), "{} run plan".format(definition.name))[0]
+    if definition.warmup_mode == "inline" and plan.measurement_window_builder is None:
+        raise BenchmarkError("{} inline warmup requires a CPU measurement window".format(definition.name))
+    return plan
+
+
+def build_cleanup_plan(cli, path, workload):
+    """Build the pure command plan which removes one workload dataset."""
+
+    definition = _definition(workload["type"])
+    if definition.cleanup_plan_builder is None:
+        plans = (
+            WorkloadCommandPlan(
+                "clean",
+                tuple(_workload_base(cli, definition, path) + ["clean"]),
+                None,
+            ),
+        )
+    else:
+        plans = definition.cleanup_plan_builder(cli, definition, path, workload)
+    return _validate_command_plans(
+        plans,
+        "{} cleanup plan".format(definition.name),
+        allow_default_timeout=True,
+    )
+
+
+def workload_definition(workload_type):
+    """Return immutable lifecycle metadata for one registered workload."""
+
+    return _definition(workload_type)
 
 
 def workload_table_path(workload_type, path):

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -332,7 +332,7 @@ def _validate_catalog(definitions):
         raise ValueError("local YDB workload names must be unique")
     option_schemas = {}
     for definition in definitions:
-        if definition.dataset_scope not in ("sample", "profile"):
+        if definition.dataset_scope not in ("sample", "geometry", "profile"):
             raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
         if definition.warmup_mode not in ("separate", "inline"):
             raise ValueError("unknown warmup mode for {}: {}".format(definition.name, definition.warmup_mode))

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,0 +1,471 @@
+"""Declarative local-YDB workload catalog and YDB CLI command builders."""
+
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from ydb.tools.ydb_bench.lib.common import BenchmarkError
+
+
+@dataclass(frozen=True)
+class WorkloadCli:
+    executable: object
+    endpoint: str
+    database: str
+
+
+@dataclass(frozen=True)
+class WorkloadOption:
+    name: str
+    default: object
+    kind: str = "integer"
+    operation_defaults: tuple = ()
+    allow_zero: bool = False
+    maximum: object = None
+    choices: tuple = ()
+    schema_minimum: object = None
+    pattern: str | None = None
+    allow_empty: bool = False
+
+    def default_for(self, operation):
+        return dict(self.operation_defaults).get(operation, self.default)
+
+    @property
+    def minimum(self):
+        if self.kind != "integer":
+            return None
+        if self.schema_minimum is not None:
+            return self.schema_minimum
+        return 0 if self.allow_zero else 1
+
+    def config_schema(self):
+        if self.kind == "integer":
+            if self.choices:
+                return {"enum": list(self.choices)}
+            schema = {"type": "integer", "minimum": self.minimum}
+            if self.maximum is not None:
+                schema["maximum"] = self.maximum
+            return schema
+        if self.kind in ("string", "duration"):
+            schema = {"type": "string"}
+            if not self.allow_empty:
+                schema["minLength"] = 1
+            if self.choices:
+                schema["enum"] = list(self.choices)
+            if self.pattern is not None:
+                schema["pattern"] = self.pattern
+            return schema
+        if self.kind == "boolean":
+            schema = {"type": "boolean"}
+            if self.choices:
+                schema["enum"] = list(self.choices)
+            return schema
+        raise ValueError("unknown workload option kind: {}".format(self.kind))
+
+
+@dataclass(frozen=True)
+class WorkloadDefinition:
+    name: str
+    default_operation: str
+    operations: tuple
+    load_parameters: tuple
+    options: tuple
+    uses_path: bool
+    table_name: str | None
+    init_builder: object
+    run_builder: object
+    options_validator: object
+
+
+def _config_error(location, message):
+    raise BenchmarkError("invalid benchmark config at {}: {}".format(location, message))
+
+
+def _mapping(value, location, allowed=()):
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        _config_error(location, "must be a mapping")
+    unknown = sorted((item for item in value if item not in allowed), key=str)
+    if unknown:
+        _config_error(location, "contains unknown fields: {}".format(", ".join(map(str, unknown))))
+    return value
+
+
+def _workload_base(cli, definition, path):
+    command = [
+        cli.executable,
+        "--endpoint",
+        cli.endpoint,
+        "--database",
+        cli.database,
+        "workload",
+        definition.name,
+    ]
+    if definition.uses_path:
+        command += ["--path", path]
+    return command
+
+
+def _kv_init_builder(cli, definition, path, workload):
+    options = workload["options"]
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--init-upserts",
+        options["init-upserts"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--max-partitions",
+        options["max-partitions"],
+        "--partition-size",
+        options["partition-size-mb"],
+        "--max-first-key",
+        options["max-first-key"],
+        "--len",
+        options["value-size"],
+        "--cols",
+        options["columns"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--rows",
+        options["rows-per-query"],
+    ]
+
+
+def _kv_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    options = workload["options"]
+    threads = load if load_parameter == "threads" else client_threads
+    command = _workload_base(cli, definition, path) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+        "--max-first-key",
+        options["max-first-key"],
+        "--int-cols",
+        1,
+        "--key-cols",
+        1,
+        "--cols",
+        options["columns"],
+    ]
+    if workload["operation"] != "mixed":
+        command += ["--rows", options["rows-per-query"]]
+    if workload["operation"] in ("upsert", "mixed"):
+        command += ["--len", options["value-size"]]
+    if load_parameter == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _stock_init_builder(cli, definition, path, workload):
+    del path
+    options = workload["options"]
+    return _workload_base(cli, definition, None) + [
+        "init",
+        "--products",
+        options["products"],
+        "--quantity",
+        options["quantity"],
+        "--orders",
+        options["orders"],
+        "--min-partitions",
+        options["min-partitions"],
+        "--auto-partition",
+        options["auto-partition"],
+    ]
+
+
+def _stock_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del path
+    options = workload["options"]
+    threads = load if load_parameter == "threads" else client_threads
+    command = _workload_base(cli, definition, None) + [
+        "run",
+        workload["operation"],
+        "--seconds",
+        seconds,
+        "--threads",
+        threads,
+        "--quiet",
+    ]
+    if workload["operation"] in ("user-hist", "rand-user-hist"):
+        command += ["--limit", options["limit"]]
+    else:
+        command += ["--products", options["products"]]
+    if load_parameter == "rate":
+        command += ["--rate", load]
+    return command
+
+
+def _validate_kv_options(options, location):
+    if options["max-partitions"] < options["min-partitions"]:
+        _config_error(location + ".max-partitions", "must not be below min-partitions")
+    if options["columns"] < 2:
+        _config_error(location + ".columns", "must be at least 2")
+
+
+def _validate_stock_options(options, location):
+    del options, location
+
+
+def _validate_option_value(option, value, location):
+    if option.kind == "integer":
+        minimum = 0 if option.allow_zero else 1
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            requirement = "non-negative" if option.allow_zero else "positive"
+            _config_error(location, "must be a {} integer".format(requirement))
+        if option.maximum is not None and value > option.maximum:
+            _config_error(location, "must not exceed {}".format(option.maximum))
+    elif option.kind in ("string", "duration"):
+        if not isinstance(value, str):
+            _config_error(location, "must be a string")
+        if not option.allow_empty and not value:
+            _config_error(location, "must not be empty")
+        if option.pattern is not None and re.search(option.pattern, value) is None:
+            _config_error(location, "must match pattern {}".format(option.pattern))
+    elif option.kind == "boolean":
+        if not isinstance(value, bool):
+            _config_error(location, "must be a boolean")
+    else:
+        raise ValueError("unknown workload option kind: {}".format(option.kind))
+    if option.choices and value not in option.choices:
+        if option.kind == "integer":
+            _config_error(location, "must be {}".format(" or ".join(map(str, option.choices))))
+        _config_error(location, "must be one of {}".format(", ".join(map(str, option.choices))))
+
+
+def _validate_catalog(definitions):
+    names = [definition.name for definition in definitions]
+    if len(names) != len(set(names)):
+        raise ValueError("local YDB workload names must be unique")
+    option_schemas = {}
+    for definition in definitions:
+        if len(definition.operations) != len(set(definition.operations)):
+            raise ValueError("operations must be unique for {}".format(definition.name))
+        if len(definition.load_parameters) != len(set(definition.load_parameters)):
+            raise ValueError("load parameters must be unique for {}".format(definition.name))
+        if definition.default_operation not in definition.operations:
+            raise ValueError("default operation must belong to {}".format(definition.name))
+        option_names = [option.name for option in definition.options]
+        if len(option_names) != len(set(option_names)):
+            raise ValueError("option names must be unique for {}".format(definition.name))
+        for option in definition.options:
+            if option.kind not in ("integer", "string", "boolean", "duration"):
+                raise ValueError("unknown workload option kind: {}".format(option.kind))
+            if option.kind != "integer" and (
+                option.allow_zero or option.maximum is not None or option.schema_minimum is not None
+            ):
+                raise ValueError("integer-only metadata is set for {}.{}".format(definition.name, option.name))
+            if option.kind not in ("string", "duration") and (option.pattern is not None or option.allow_empty):
+                raise ValueError("string-only metadata is set for {}.{}".format(definition.name, option.name))
+            if option.kind == "duration" and option.pattern is None:
+                raise ValueError("duration option {} requires a pattern".format(option.name))
+            if option.pattern is not None:
+                if "(?" in option.pattern or "\\" in option.pattern:
+                    raise ValueError("pattern for {}.{} is not portable".format(definition.name, option.name))
+                try:
+                    re.compile(option.pattern)
+                except re.error as error:
+                    raise ValueError("invalid pattern for {}.{}".format(definition.name, option.name)) from error
+            try:
+                choices_are_unique = len(option.choices) == len(set(option.choices))
+            except TypeError as error:
+                raise ValueError("choices must be scalar for {}.{}".format(definition.name, option.name)) from error
+            if not choices_are_unique:
+                raise ValueError("choices must be unique for {}.{}".format(definition.name, option.name))
+            operation_defaults = [operation for operation, _ in option.operation_defaults]
+            if len(operation_defaults) != len(set(operation_defaults)):
+                raise ValueError("operation defaults must be unique for {}.{}".format(definition.name, option.name))
+            for operation, value in ((None, option.default),) + option.operation_defaults:
+                if operation is not None and operation not in definition.operations:
+                    raise ValueError("option default refers to unknown operation {}".format(operation))
+                try:
+                    _validate_option_value(option, value, "{}.{}".format(definition.name, option.name))
+                except BenchmarkError as error:
+                    raise ValueError(
+                        "invalid default for {}.{}: {}".format(definition.name, option.name, error)
+                    ) from error
+            for choice in option.choices:
+                try:
+                    _validate_option_value(option, choice, "{}.{}".format(definition.name, option.name))
+                except BenchmarkError as error:
+                    raise ValueError(
+                        "invalid choice for {}.{}: {}".format(definition.name, option.name, error)
+                    ) from error
+            schema = option.config_schema()
+            if option.name in option_schemas and option_schemas[option.name] != schema:
+                raise ValueError("option {} has incompatible schemas across workloads".format(option.name))
+            option_schemas[option.name] = schema
+
+
+_DEFINITIONS = (
+    WorkloadDefinition(
+        name="kv",
+        default_operation="upsert",
+        operations=("upsert", "select", "read-rows", "mixed"),
+        load_parameters=("rate", "threads"),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("max-partitions", 1000),
+            WorkloadOption("partition-size-mb", 2000),
+            WorkloadOption("init-upserts", 1000, operation_defaults=(("upsert", 0),), allow_zero=True),
+            WorkloadOption("max-first-key", 65536),
+            WorkloadOption("value-size", 64),
+            WorkloadOption("columns", 2, schema_minimum=2),
+            WorkloadOption("rows-per-query", 1),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_kv_init_builder,
+        run_builder=_kv_run_builder,
+        options_validator=_validate_kv_options,
+    ),
+    WorkloadDefinition(
+        name="stock",
+        default_operation="put-rand-order",
+        operations=("user-hist", "rand-user-hist", "add-rand-order", "put-rand-order", "put-same-order"),
+        load_parameters=("rate", "threads"),
+        options=(
+            WorkloadOption("min-partitions", 40),
+            WorkloadOption("products", 100, maximum=500000),
+            WorkloadOption("quantity", 1000),
+            WorkloadOption("orders", 100, allow_zero=True),
+            WorkloadOption("auto-partition", 1, allow_zero=True, choices=(0, 1)),
+            WorkloadOption("limit", 10),
+        ),
+        uses_path=False,
+        table_name="stock",
+        init_builder=_stock_init_builder,
+        run_builder=_stock_run_builder,
+        options_validator=_validate_stock_options,
+    ),
+)
+_validate_catalog(_DEFINITIONS)
+_WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
+
+
+def _definition(workload_type):
+    try:
+        return _WORKLOADS[workload_type]
+    except (KeyError, TypeError) as error:
+        raise BenchmarkError("unknown local YDB workload: {}".format(workload_type)) from error
+
+
+def normalize_workload(raw, location):
+    """Validate and fill defaults for one workload configuration mapping."""
+
+    workload = _mapping(raw, location, ("type", "operation", "options"))
+    for required in ("type", "operation"):
+        if required not in workload:
+            _config_error(location, "missing required field: {}".format(required))
+
+    workload_type = workload["type"]
+    if not isinstance(workload_type, str) or workload_type not in _WORKLOADS:
+        _config_error(location + ".type", "must be one of {}".format(", ".join(_WORKLOADS)))
+    definition = _WORKLOADS[workload_type]
+    operation = workload["operation"]
+    if operation not in definition.operations:
+        _config_error(location + ".operation", "must be one of {}".format(", ".join(definition.operations)))
+
+    options_location = location + ".options"
+    raw_options = _mapping(
+        workload.get("options"), options_location, tuple(option.name for option in definition.options)
+    )
+    options = {}
+    for option in definition.options:
+        value = raw_options.get(option.name, option.default_for(operation))
+        _validate_option_value(option, value, options_location + "." + option.name)
+        options[option.name] = value
+    definition.options_validator(options, options_location)
+    return {"type": definition.name, "operation": operation, "options": options}
+
+
+def workload_config_schema():
+    """Return the structurally compatible config-schema fragment for workloads."""
+
+    option_schemas = {}
+    for definition in _DEFINITIONS:
+        for option in definition.options:
+            option_schemas[option.name] = option.config_schema()
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["type", "operation"],
+        "properties": {
+            "type": {"enum": [definition.name for definition in _DEFINITIONS]},
+            "operation": {"enum": [operation for definition in _DEFINITIONS for operation in definition.operations]},
+            "options": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": option_schemas,
+            },
+        },
+    }
+
+
+def web_workload_catalog():
+    """Return a stable JSON-compatible workload description for the web builder."""
+
+    return [
+        {
+            "type": definition.name,
+            "default_operation": definition.default_operation,
+            "operations": list(definition.operations),
+            "load_parameters": list(definition.load_parameters),
+            "options": [
+                {
+                    "name": option.name,
+                    "kind": option.kind,
+                    "default": option.default,
+                    "operation_defaults": dict(option.operation_defaults),
+                    "allow_zero": option.allow_zero,
+                    "minimum": option.minimum,
+                    "maximum": option.maximum,
+                    "choices": list(option.choices),
+                    "pattern": option.pattern,
+                    "allow_empty": option.allow_empty,
+                    "schema": option.config_schema(),
+                }
+                for option in definition.options
+            ],
+        }
+        for definition in _DEFINITIONS
+    ]
+
+
+def allowed_load_parameters(workload_type):
+    return _definition(workload_type).load_parameters
+
+
+def all_load_parameters():
+    return tuple(dict.fromkeys(parameter for definition in _DEFINITIONS for parameter in definition.load_parameters))
+
+
+def build_init_argv(cli, path, workload):
+    definition = _definition(workload["type"])
+    return definition.init_builder(cli, definition, path, workload)
+
+
+def build_run_argv(cli, path, workload, load_parameter, load, seconds, client_threads):
+    definition = _definition(workload["type"])
+    if load_parameter not in definition.load_parameters:
+        raise BenchmarkError(
+            "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)
+        )
+    return definition.run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads)
+
+
+def build_clean_argv(cli, path, workload_type):
+    definition = _definition(workload_type)
+    return _workload_base(cli, definition, path) + ["clean"]
+
+
+def workload_table_path(workload_type, path):
+    definition = _definition(workload_type)
+    return definition.table_name if definition.table_name is not None else path

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -30,6 +30,7 @@ from ydb.tools.ydb_bench.lib.actors_core import run_benchmark
 from ydb.tools.ydb_bench.lib.common import extract_executable
 from ydb.tools.ydb_bench.lib.import_results import MAX_TOTAL_SIZE, export_archive, import_archive
 from ydb.tools.ydb_bench.lib.local_ydb import run_local_ydb
+from ydb.tools.ydb_bench.lib.local_ydb_workloads import web_workload_catalog
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES, discover_topology, plan_affinity, topology_record
 
 _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
@@ -227,8 +228,7 @@ _JS = (
     'et index=0;index<numbers.length;){let end=index;while(end+1<numbers.length&&numbers[end+1]===numbers[end]+1)end++;parts.'
     "push(index===end?String(numbers[index]):numbers[index]+'-'+numbers[end]);index=end+1}return parts.join(', ')}\n"
     "function yamlArray(values){return '['+values.map(value=>String(value)).join(', ')+']'}\n"
-    "const localYdbOperations={kv:['upsert','select','read-rows','mixed'],stock:['user-hist','rand-user-hist','add-rand-"
-    "order','put-rand-order','put-same-order']};\n"
+    "function yamlScalar(value){return typeof value==='string'?JSON.stringify(value):String(value)}\n"
     "const localYdbGeometryKeys={static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes',max_dynamic_nodes:'max-dynamic-"
     "nodes',disk_size_gb:'disk-size-gb',storage_groups:'storage-groups'};\n"
     "const localYdbSearchKeys={resolution_percent:'resolution-percent'};\n"
@@ -236,10 +236,12 @@ _JS = (
     "lateau-points',cpu_saturation_percent:'cpu-saturation-percent'};\n"
     "const localYdbSloKeys={max_ms:'max-ms',max_errors:'max-errors',min_achieved_rate_ratio:'min-achieved-rate-ratio'};\n"
     "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
-    "function defaultLocalYdbWorkload(type){return type==='stock'?{type:'stock',operation:'put-rand-order',options:{'min-p"
-    "artitions':40,products:100,quantity:1000,orders:100,'auto-partition':1,limit:10}}:{type:'kv',operation:'upsert',options"
-    ":{'min-partitions':40,'max-partitions':1000,'partition-size-mb':2000,'init-upserts':0,'max-first-key':65536,'value-siz"
-    "e':64,columns:2,'rows-per-query':1}}}\n"
+    "function localYdbWorkloadDefinition(type){const definition=(editor.model?.local_ydb_workloads||[]).find(item=>item.type"
+    "===type);if(!definition)throw Error('Unknown local YDB workload: '+type);return definition}\n"
+    "function defaultLocalYdbWorkload(type){const definition=localYdbWorkloadDefinition(type),operation=definition.default_"
+    "operation,options=Object.fromEntries(definition.options.map(option=>[option.name,Object.prototype.hasOwnProperty.call("
+    "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
+    "ions}}\n"
     "function defaultLocalYdb(){return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
     ":{threads:64},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
@@ -247,7 +249,7 @@ _JS = (
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
     "load:','      type: '+workload.type,'      operation: '+workload.operation,'      options:');for(const [key,value] of "
-    "Object.entries(workload.options))lines.push('        '+key+': '+value);lines.push('    geometry:','      preset: '+conf"
+    "Object.entries(workload.options))lines.push('        '+key+': '+yamlScalar(value));lines.push('    geometry:','      preset: '+conf"
     "ig.geometry.preset);for(const [key,yamlKey] of Object.entries(localYdbGeometryKeys))lines.push('      '+yamlKey+': '+c"
     "onfig.geometry[key]);lines.push('    client:','      threads: '+config.client.threads,'    load:','      parameter: '"
     "+config.load.parameter,'      allow-errors: '+Boolean(config.load.allow_errors));if(config.load.values)lines.push('      values: '+yamlArray(config.load.values));else{lines."
@@ -340,15 +342,43 @@ function localSelect(id,label,value,choices,help=''){
 function localCheck(id,label,checked,help=''){
   return '<div class=field><label><input id="'+id+'" type=checkbox '+(checked?'checked':'')+'> '+esc(label)+'</label><small class=muted>'+esc(help)+'</small></div>'
 }
+function localYdbOptionField(option,value){
+  const id='local-option-'+option.name;
+  if(option.choices.length)return localSelect(id,option.name,value,option.choices);
+  if(option.kind==='boolean')return localCheck(id,option.name,Boolean(value));
+  if(option.kind==='integer'){
+    const maximum=option.maximum===null?'':' max='+option.maximum;
+    return localField(id,option.name,value,'','type=number min='+option.minimum+maximum)
+  }
+  return localField(id,option.name,value,'','type=text')
+}
+function localYdbOptionValue(option){
+  const id='local-option-'+option.name,input=document.querySelector('#'+id);
+  let value;
+  if(option.choices.length){
+    value=option.kind==='integer'?Number(input.value):option.kind==='boolean'?input.value==='true':input.value
+  }else if(option.kind==='boolean'){
+    value=input.checked
+  }else if(option.kind==='integer'){
+    value=localInteger(id,option.allow_zero?0:1)
+  }else{
+    value=input.value
+  }
+  if((option.kind==='string'||option.kind==='duration')&&!option.allow_empty&&!value.length){
+    throw Error(option.name+' must not be empty.')
+  }
+  return value
+}
 function localYdbProfileEditor(profile){
   const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
+  const definition=localYdbWorkloadDefinition(workload.type);
   const loadMode=load.values?'points':load.objective.type;
-  const options=Object.entries(workload.options).map(([key,value])=>localField('local-option-'+key,key,value)).join('');
+  const options=definition.options.map(option=>localYdbOptionField(option,workload.options[option.name])).join('');
   const geometryFields=Object.entries(localYdbGeometryKeys)
     .map(([key,label])=>localField('local-geometry-'+key,label,geometry[key],'','type=number min=1')).join('');
   const loadCommon=
     localSelect('local-load-mode','Objective',loadMode,['points','maximize-throughput','latency-slo'])+
-    localSelect('local-load-parameter','Parameter',load.parameter,['rate','threads'])+
+    localSelect('local-load-parameter','Parameter',load.parameter,definition.load_parameters)+
     localCheck(
       'local-load-allow-errors','Allow failed workload requests',Boolean(load.allow_errors),
       'Failed requests remain visible in results but do not limit load search.'
@@ -404,9 +434,9 @@ function localYdbProfileEditor(profile){
       'benchmark','Benchmark',profile.benchmark,editor.model.benchmarks.map(item=>item.name)
     )+localField('profile-name','Profile name',profile.name,'letters, digits, . _ and -')+'</div>'+
     '<h3>Workload</h3><div class=form-grid>'+localSelect(
-      'local-workload-type','Type',workload.type,['kv','stock']
+      'local-workload-type','Type',workload.type,editor.model.local_ydb_workloads.map(item=>item.type)
     )+localSelect(
-      'local-workload-operation','Operation',workload.operation,localYdbOperations[workload.type]
+      'local-workload-operation','Operation',workload.operation,definition.operations
     )+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+
     localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+
     '</div><h3>Client and load</h3><div class=form-grid>'+
@@ -467,6 +497,8 @@ function bindLocalYdbEditor(profile){
     profile.name=name;profile.key=benchmarkName+'/'+name;const config=profile.local_ydb;
     if(event.target.id==='local-workload-type'){
       config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
+      const parameters=localYdbWorkloadDefinition(event.target.value).load_parameters;
+      if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0];
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     if(event.target.id==='local-geometry-preset'){
@@ -506,10 +538,12 @@ function bindLocalYdbEditor(profile){
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     config.workload.operation=document.querySelector('#local-workload-operation').value;
-    for(const input of document.querySelectorAll('[id^=local-option-]')){
-      const key=input.id.slice('local-option-'.length);
-      const minimum=['init-upserts','orders','auto-partition'].includes(key)?0:1;
-      config.workload.options[key]=localInteger(input.id,minimum)
+    const workloadDefinition=localYdbWorkloadDefinition(config.workload.type);
+    for(const option of workloadDefinition.options){
+      const key=option.name,value=localYdbOptionValue(option);
+      if(option.maximum!==null&&value>option.maximum)throw Error(key+' must be <= '+option.maximum+'.');
+      if(option.choices.length&&!option.choices.includes(value))throw Error(key+' must be one of '+option.choices.join(', ')+'.');
+      config.workload.options[key]=value
     }
     config.geometry.preset=document.querySelector('#local-geometry-preset').value;
     for(const key of Object.keys(localYdbGeometryKeys)){
@@ -1971,6 +2005,7 @@ def editor_model(loaded, output):
         "benchmarks": benchmark_catalog(),
         "affinity_modes": list(AFFINITY_MODES),
         "background_load_modes": list(BACKGROUND_LOAD_MODES),
+        "local_ydb_workloads": web_workload_catalog(),
         "profiles": profiles,
     }
 

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1115,7 +1115,11 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     'function localResultMetrics(result){\n'
     "  const verified=Boolean(result?.metrics_source==='verification'&&result?.verified_metrics&&\n"
     "    typeof result.verified_metrics==='object');\n"
-    "  return {metrics:(verified?result.verified_metrics:result?.selected_metrics)||{},verified,source:verified?'Holdout':'Search'}\n"
+    "  const raw=(verified?result.verified_metrics:result?.selected_metrics)||{};\n"
+    '  const metrics=Number(raw.empty_repetitions)>0?{\n'
+    '    ...raw,p50_ms:null,p95_ms:null,p99_ms:null,pmax_ms:null\n'
+    '  }:raw;\n'
+    "  return {metrics,verified,source:verified?'Holdout':'Search'}\n"
     '}\n'
     'function localVerificationCount(result,parameters={},verification={}){\n'
     '  return result?.verification_repetitions??verification?.configured_repetitions??verification?.completed_repetitions??\n'
@@ -1395,6 +1399,7 @@ function localOutcomeLabel(outcome){
     'boundary-found':'SLO boundary found','plateau-found':'Throughput plateau found',
     'lower-bound':'Capacity lower bound','best-observed':'Best observed point',
     'no-feasible-point':'No feasible point','bounded-by-errors':'Bounded by workload errors',
+    'bounded-by-invalid-sample':'Bounded by invalid measurement',
     'search-limit-reached':'Search limit reached'
   })[outcome]||outcome||'Search in progress'
 }
@@ -1406,7 +1411,14 @@ function localSearchAxisLabel(parameter,workload){
 function localYdbThroughputUnit(workload){
   return {kv:'requests/s',stock:'transactions/s',log:'batches/s'}[workload]||'operations/s'
 }
-function localAttemptRows(attempts,xField='attempt'){return new Map(attempts.map(item=>[String(item[xField]),item]))}
+function localAttemptLatency(item,metric='p99_ms'){
+  return Number(item.empty_repetitions)>0?'—':item[metric]
+}
+function localAttemptRows(attempts,xField='attempt'){
+  return new Map(attempts.map(item=>[String(item[xField]),Number(item.empty_repetitions)>0?{
+    ...item,p50_ms:null,p95_ms:null,p99_ms:null,pmax_ms:null
+  }:item]))
+}
 function localChart(title,metric,xName,xValues,series){
   return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+
     svgChart(metric,xName,xValues,series,chartColors)+'</section>'
@@ -1509,7 +1521,7 @@ function renderLocalYdbProfile(container,data){
     )+localKpi(
       'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—',throughputUnit
     )+localKpi(
-      'Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms'
+      'Latest p99',attempts.length?metricLabel(localAttemptLatency(attempts.at(-1))):'—','ms'
     )+'</div>'
   }
   const currentStage=Number(progress.search_stage||0);
@@ -1625,7 +1637,7 @@ function renderLocalYdbProfile(container,data){
       '<th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+
       attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+
         esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+
-        '</td><td>'+esc(metricLabel(item.p99_ms))+' ms</td><td>'+esc(item.errors)+'</td><td>'+
+        '</td><td>'+esc(metricLabel(localAttemptLatency(item)))+' ms</td><td>'+esc(item.errors)+'</td><td>'+
         esc(metricLabel(item.static_cpu_mean))+'%</td><td>'+esc(metricLabel(item.dynamic_cpu_mean))+
         '%</td><td>'+esc(metricLabel(item.cli_cpu_mean))+'%</td><td class="'+
         (item.passed?'attempt-pass':'attempt-fail')+'">'+(item.passed?'PASS':'FAIL')+'</td><td>'+esc(item.decision)+
@@ -3260,14 +3272,14 @@ class RunService:
                     metrics = result.get("selected_metrics")
                     if isinstance(metrics, dict):
                         metric_names = {metric.name for metric in BENCHMARKS["local-ydb"].metrics}
-                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated"))
+                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated", "empty_repetitions"))
                         compact_result["selected_metrics"] = {
                             name: metrics[name] for name in metric_names if name in metrics
                         }
                     verified_metrics = result.get("verified_metrics")
                     if isinstance(verified_metrics, dict):
                         metric_names = {metric.name for metric in BENCHMARKS["local-ydb"].metrics}
-                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated"))
+                        metric_names.update(("load", "dynamic_nodes", "target_cpu_saturated", "empty_repetitions"))
                         compact_result["verified_metrics"] = {
                             name: verified_metrics[name] for name in metric_names if name in verified_metrics
                         }

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -238,6 +238,10 @@ _JS = (
     "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
     "function localYdbWorkloadDefinition(type){const definition=(editor.model?.local_ydb_workloads||[]).find(item=>item.type"
     "===type);if(!definition)throw Error('Unknown local YDB workload: '+type);return definition}\n"
+    "const localYdbLoadDefaults={rate:{values:[1000],start:1000,maximum:100000},threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}};\n"
+    "function localYdbResetLoadParameter(load,parameter){const defaults=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;"
+    "if(load.values)return {...load,parameter,values:[...defaults.values]};return {...load,parameter,search:{...(load.search||{}),start:defaults.start,maximum:defaults.maximum}}}\n"
+    "function localYdbLoadForWorkload(load,parameters){return parameters.includes(load.parameter)?load:localYdbResetLoadParameter(load,parameters[0])}\n"
     "function defaultLocalYdbWorkload(type){const definition=localYdbWorkloadDefinition(type),operation=definition.default_"
     "operation,options=Object.fromEntries(definition.options.map(option=>[option.name,Object.prototype.hasOwnProperty.call("
     "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
@@ -498,7 +502,12 @@ function bindLocalYdbEditor(profile){
     if(event.target.id==='local-workload-type'){
       config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
       const parameters=localYdbWorkloadDefinition(event.target.value).load_parameters;
-      if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0];
+      config.load=localYdbLoadForWorkload(config.load,parameters);
+      editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
+    }
+    if(event.target.id==='local-load-parameter'){
+      const parameter=event.target.value;
+      if(parameter!==config.load.parameter)config.load=localYdbResetLoadParameter(config.load,parameter);
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     if(event.target.id==='local-geometry-preset'){
@@ -514,10 +523,11 @@ function bindLocalYdbEditor(profile){
     }
     if(event.target.id==='local-load-mode'){
       const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);
+      const defaults=localYdbLoadDefaults[config.load.parameter]||localYdbLoadDefaults.threads;
       if(mode==='points'){
-        config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[1000]}
+        config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[...defaults.values]}
       }else{
-        const search=config.load.search||{start:1000,maximum:100000,multiplier:2,resolution_percent:2};
+        const search=config.load.search||{start:defaults.start,maximum:defaults.maximum,multiplier:2,resolution_percent:2};
         const old=config.load.objective||{};
         const objective={
           type:mode,target_role:old.target_role||'dynamic',plateau_gain_percent:old.plateau_gain_percent??2,
@@ -1153,8 +1163,9 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '    .sort((left,right)=>left-right);\n'
     "  if(!xValues.length){container.innerHTML='<div class=empty>No compatible local YDB search summaries are available.</div>';return}\n"
     "  const percentile=baseline.parameters?.load?.objective?.percentile||'p99';\n"
+    "  const throughputUnit=localYdbThroughputUnit(baseline.parameters?.workload?.type);\n"
     '  const specifications=[\n'
-    "    ['throughput','median_throughput','Achieved throughput'],\n"
+    "    ['throughput','median_throughput','Achieved throughput ('+throughputUnit+')'],\n"
     "    ['latency_ms','median_'+percentile+'_ms',percentile+' latency (ms)'],\n"
     "    ['static_cpu','median_static_cpu_mean','Static node CPU (%)'],\n"
     "    ['dynamic_cpu','median_dynamic_cpu_mean','Dynamic node CPU (%)'],\n"
@@ -1192,6 +1203,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     '  const baselineSemantic=JSON.stringify(localComparisonSemantic(baseline));\n'
     '  const rows=entries.map(item=>{\n'
     '    const metricView=localResultMetrics(item.result),metrics=metricView.metrics,config=localComparisonConfig(item);\n'
+    '    const throughputUnit=localYdbThroughputUnit(item.parameters?.workload?.type);\n'
     '    const context=localComparisonContext(item),build=localComparisonBuild(item);\n'
     '    const semanticCompatible=JSON.stringify(localComparisonSemantic(item))===baselineSemantic;\n'
     '    const sameMetricSource=metricView.source===baselineView.source,compatible=semanticCompatible&&sameMetricSource;\n'
@@ -1219,7 +1231,7 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     "      '</td><td><code>'+\n"
     "      esc(String(item.binaries?.ydbd?.sha256??'—').slice(0,12))+'</code></td><td>'+\n"
     "      esc(metricLabel(item.result?.selected_load??'—'))+'</td>'+\n"
-    "      '<td>'+esc(metricLabel(metrics.throughput??'—'))+' '+localComparisonDelta(metrics.throughput,baselineMetrics.throughput,false,compatible)+'</td>'+\n"
+    "      '<td>'+esc(metricLabel(metrics.throughput??'—'))+' '+esc(throughputUnit)+' '+localComparisonDelta(metrics.throughput,baselineMetrics.throughput,false,compatible)+'</td>'+\n"
     "      '<td>'+esc(metricLabel(metrics[latencyMetric]??'—'))+' ms '+localComparisonDelta(metrics[latencyMetric],baselineMetrics[latencyMetric],true,compatible)+'</td>'+\n"
     "      '<td>'+esc(metrics.errors??'—')+' '+localComparisonDelta(metrics.errors,baselineMetrics.errors,true,compatible)+'</td>'+\n"
     "      '<td>'+esc(metricLabel(metrics.static_cpu_mean??'—'))+'%</td><td>'+esc(metricLabel(metrics.dynamic_cpu_mean??'—'))+'%</td>'+\n"
@@ -1391,6 +1403,9 @@ function localSearchAxisLabel(parameter,workload){
   if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';
   return parameter||'Search value'
 }
+function localYdbThroughputUnit(workload){
+  return {kv:'requests/s',stock:'transactions/s',log:'batches/s'}[workload]||'operations/s'
+}
 function localAttemptRows(attempts,xField='attempt'){return new Map(attempts.map(item=>[String(item[xField]),item]))}
 function localChart(title,metric,xName,xValues,series){
   return '<section class=chart-panel data-metric="'+esc(metric)+'"><h3>'+esc(title)+'</h3>'+
@@ -1442,6 +1457,7 @@ function renderLocalYdbProfile(container,data){
   const progress=data.progress||{},attempts=data.attempts||[],searches=data.searches||[];
   const result=data.result||null,parameters=data.parameters||{},loadConfig=parameters.load||{};
   const objective=loadConfig.objective||{type:'points'};
+  const throughputUnit=localYdbThroughputUnit(parameters.workload?.type);
   const phaseElapsed=localElapsed(progress.phase_started_at);
   const phaseDuration=Number(progress.phase_duration_seconds);
   const profileElapsed=localElapsed(data.started_at,data.finished_at);
@@ -1483,7 +1499,7 @@ function renderLocalYdbProfile(container,data){
     html+=localVerificationSummary(data);
     html+='<div class=local-kpis>'+localKpi(
       localOutcomeLabel(result.outcome),selectedLabel,result.parameter||loadConfig.parameter,true
-    )+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),'transactions/s')+
+    )+localKpi('Achieved throughput',metricLabel(selected.throughput??'—'),throughputUnit)+
       localKpi(
         loadConfig.objective?.percentile||'p99',metricLabel(selected[latencyMetric]??'—'),'ms'
       )+localKpi('Dynamic nodes',result.dynamic_nodes,result.stop_reason||'')+'</div>'
@@ -1491,7 +1507,7 @@ function renderLocalYdbProfile(container,data){
     html+='<div class=local-kpis>'+localKpi(
       'Completed attempts',attempts.length,'search stage '+(progress.search_stage||1),true
     )+localKpi(
-      'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—','transactions/s'
+      'Latest throughput',attempts.length?metricLabel(attempts.at(-1).throughput):'—',throughputUnit
     )+localKpi(
       'Latest p99',attempts.length?metricLabel(attempts.at(-1).p99_ms):'—','ms'
     )+'</div>'
@@ -1596,13 +1612,16 @@ function renderLocalYdbProfile(container,data){
         objective.type==='maximize-throughput'?'Ternary search progress':'Load search progress',
         'load',xName,xValues,candidateSeries
       ):'')+
-      localChart('Offered and achieved throughput','throughput',xName,xValues,throughputSeries)+
+      localChart(
+        (loadConfig.parameter==='rate'?'Offered and achieved':'Achieved')+' throughput ('+throughputUnit+')',
+        'throughput',xName,xValues,throughputSeries
+      )+
       localChart('Latency','latency_ms',xName,xValues,latencySeries)+
       localChart('CPU by role','cpu_percent',xName,xValues,cpuSeries)+
       localChart('Errors and retries','errors',xName,xValues,errorSeries)+'</div>';
     html+='<h3>Attempts</h3><div class=local-attempts-scroll tabindex=0 role=region aria-label="Search attempts">'+
       '<table class=local-attempts><thead><tr><th>#</th><th>Stage</th><th>Dynamic</th><th>Candidate</th>'+
-      '<th>Throughput</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th>'+
+      '<th>Throughput ('+esc(throughputUnit)+')</th><th>p99</th><th>Errors</th><th>Static CPU</th><th>Dynamic CPU</th><th>CLI CPU</th>'+
       '<th>Verdict</th><th>Decision</th><th>Duration</th><th>Commands</th></tr></thead><tbody>'+
       attempts.map(item=>'<tr><td>'+esc(item.attempt)+'</td><td>'+esc(item.search_stage)+'</td><td>'+
         esc(item.dynamic_nodes)+'</td><td>'+esc(metricLabel(item.load))+'</td><td>'+esc(metricLabel(item.throughput))+

--- a/ydb/tools/ydb_bench/lib/ya.make
+++ b/ydb/tools/ydb_bench/lib/ya.make
@@ -9,6 +9,7 @@ PY_SRCS(
     import_results.py
     load_control.py
     local_ydb.py
+    local_ydb_workloads.py
     linux_telemetry.py
     runner.py
     results.py

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import socket
 import stat
+import subprocess
 import tempfile
 import textwrap
 import threading
@@ -404,10 +405,14 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
 
         catalog = local_ydb_workloads.web_workload_catalog()
-        self.assertEqual([item["type"] for item in catalog], ["kv", "stock"])
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log"])
         self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
         self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
         self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
+        self.assertEqual(catalog[2]["default_operation"], "bulk-upsert")
+        self.assertEqual(catalog[2]["operations"], ["insert", "upsert", "bulk-upsert"])
+        self.assertEqual(catalog[2]["load_parameters"], ["threads"])
+        self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         catalog_parameters = tuple(
             dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
         )
@@ -418,6 +423,12 @@ class YdbBenchTest(unittest.TestCase):
             next(option for option in catalog[0]["options"] if option["name"] == "init-upserts")["operation_defaults"],
             {"upsert": 0},
         )
+        operation_enum = workload_schema["properties"]["operation"]["enum"]
+        expected_operations = list(
+            dict.fromkeys(operation for definition in catalog for operation in definition["operations"])
+        )
+        self.assertEqual(operation_enum, expected_operations)
+        self.assertEqual(len(operation_enum), len(set(operation_enum)))
         json.dumps(catalog, allow_nan=False)
 
     def test_local_ydb_workload_registry_preserves_defaults_and_validation(self):
@@ -438,7 +449,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(stock["options"]["orders"], 100)
 
         invalid = (
-            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log"),
             ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
             (
                 {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
@@ -1488,6 +1499,140 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload["operation"], "put-rand-order")
         self.assertEqual(workload["options"]["products"], 10)
 
+    def test_local_ydb_log_profile_defaults_validation_and_web_contract(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              log-smoke:
+                workload: {type: log, operation: bulk-upsert}
+                load: {parameter: threads, values: [1, 2, 4]}
+        """))
+        profile = loaded.runs[0].parameters["local_ydb"]
+        self.assertEqual(
+            profile["workload"]["options"],
+            {
+                "min-partitions": 40,
+                "max-partitions": 1000,
+                "partition-size-mb": 2000,
+                "auto-partition": 1,
+                "store": "row",
+                "ttl-minutes": 0,
+                "string-length": 8,
+                "integer-columns": 0,
+                "string-columns": 0,
+                "key-columns": 0,
+                "rows-per-operation": 1,
+                "null-percent": 10,
+            },
+        )
+        definition = local_ydb_workloads.workload_definition("log")
+        self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "separate"))
+        self.assertEqual(profile["load"]["values"], [1, 2, 4])
+
+        model = web.editor_model(loaded, self.root / "results")
+        editor_profile = model["profiles"][0]["local_ydb"]
+        self.assertEqual(editor_profile["workload"]["type"], "log")
+        self.assertEqual(editor_profile["load"]["parameter"], "threads")
+        self.assertIn(
+            "threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}",
+            web._JS,
+        )
+        self.assertIn("localYdbLoadForWorkload(config.load,parameters)", web._JS)
+        self.assertIn("log:'batches/s'", web._JS)
+        transactions = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "transactions")
+        throughput = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "throughput")
+        self.assertEqual(transactions.unit, "operations")
+        self.assertEqual(throughput.unit, "operations/s")
+
+        invalid = (
+            ({"max-partitions": 3, "min-partitions": 4}, "max-partitions.*must not be below"),
+            (
+                {"integer-columns": 1, "string-columns": 1, "key-columns": 3},
+                "key-columns.*must not exceed",
+            ),
+            ({"null-percent": 101}, "null-percent.*must not exceed 100"),
+            ({"rows-per-operation": 0}, "rows-per-operation.*positive integer"),
+            ({"string-length": 0}, "string-length.*positive integer"),
+            ({"store": "external"}, "store.*must be one of row, column"),
+        )
+        for options, message in invalid:
+            with self.subTest(options=options), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.normalize_workload(
+                    {"type": "log", "operation": "bulk-upsert", "options": options},
+                    "workload",
+                )
+
+        invalid_load = self._config("""
+            local-ydb:
+              invalid:
+                workload: {type: log, operation: insert}
+                load: {parameter: rate, values: [1000]}
+        """)
+        with self.assertRaisesRegex(BenchmarkError, "load.parameter.*must be one of threads"):
+            load_config(invalid_load)
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for the web Builder behavior test")
+    def test_local_ydb_web_builder_resets_only_incompatible_load_parameters(self):
+        start = web._JS.index("const localYdbLoadDefaults=")
+        finish = web._JS.index("function defaultLocalYdbWorkload", start)
+        unit_start = web._JS.index("function localYdbThroughputUnit")
+        unit_finish = web._JS.index("function localAttemptRows", unit_start)
+        script = web._JS[start:finish] + web._JS[unit_start:unit_finish] + """
+            const points=localYdbResetLoadParameter(
+              {parameter:'rate',allow_errors:false,values:[1000]},'threads'
+            );
+            const automatic=localYdbResetLoadParameter({
+              parameter:'rate',allow_errors:true,
+              search:{start:777,maximum:9999,multiplier:3,resolution_percent:7},
+              objective:{type:'latency-slo',percentile:'p99',max_ms:10}
+            },'threads');
+            const custom={
+              parameter:'threads',allow_errors:false,
+              search:{start:7,maximum:91,multiplier:4,resolution_percent:9},
+              objective:{type:'maximize-throughput',target_role:'dynamic'}
+            };
+            const compatible=localYdbLoadForWorkload(custom,['rate','threads']);
+            process.stdout.write(JSON.stringify({
+              points,automatic,compatible,same_reference:compatible===custom,
+              units:['kv','stock','log','future'].map(localYdbThroughputUnit)
+            }));
+        """
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertEqual(
+            result["points"],
+            {
+                "parameter": "threads",
+                "allow_errors": False,
+                "values": [1, 2, 4, 8, 16, 32, 64],
+            },
+        )
+        self.assertEqual(
+            result["automatic"],
+            {
+                "parameter": "threads",
+                "allow_errors": True,
+                "search": {"start": 1, "maximum": 256, "multiplier": 3, "resolution_percent": 7},
+                "objective": {"type": "latency-slo", "percentile": "p99", "max_ms": 10},
+            },
+        )
+        self.assertTrue(result["same_reference"])
+        self.assertEqual(
+            result["compatible"],
+            {
+                "parameter": "threads",
+                "allow_errors": False,
+                "search": {"start": 7, "maximum": 91, "multiplier": 4, "resolution_percent": 9},
+                "objective": {"type": "maximize-throughput", "target_role": "dynamic"},
+            },
+        )
+        self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
+
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
         cli_context = local_ydb_workloads.WorkloadCli(
             Path("ydb"),
@@ -1543,6 +1688,214 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(add_command[add_command.index("run") + 1], "add-rand-order")
         self.assertEqual(put_command[put_command.index("run") + 1], "put-rand-order")
         self.assertEqual(add_command[add_command.index("--threads") + 1], 8)
+
+    def test_local_ydb_log_commands_are_golden_and_use_threads_as_load(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "log",
+                "operation": "bulk-upsert",
+                "options": {
+                    "min-partitions": 1,
+                    "max-partitions": 4,
+                    "partition-size-mb": 512,
+                    "auto-partition": 0,
+                    "store": "column",
+                    "ttl-minutes": 0,
+                    "string-length": 16,
+                    "integer-columns": 1,
+                    "string-columns": 2,
+                    "key-columns": 3,
+                    "rows-per-operation": 50,
+                    "null-percent": 0,
+                },
+            },
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "log",
+            "--path",
+            "log-table",
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_init_argv(cli_context, "log-table", workload),
+            base
+            + [
+                "init",
+                "--min-partitions",
+                1,
+                "--max-partitions",
+                4,
+                "--partition-size",
+                512,
+                "--auto-partition",
+                0,
+                "--len",
+                16,
+                "--int-cols",
+                1,
+                "--str-cols",
+                2,
+                "--key-cols",
+                3,
+                "--ttl",
+                0,
+                "--store",
+                "column",
+                "--null-percent",
+                0,
+            ],
+        )
+        expected_run = base + [
+            "run",
+            "bulk-upsert",
+            "--seconds",
+            30,
+            "--threads",
+            32,
+            "--quiet",
+            "--rows",
+            50,
+            "--len",
+            16,
+            "--int-cols",
+            1,
+            "--str-cols",
+            2,
+            "--key-cols",
+            3,
+            "--null-percent",
+            0,
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_run_argv(cli_context, "log-table", workload, "threads", 32, 30, 64),
+            expected_run,
+        )
+        self.assertNotIn("--rate", expected_run)
+        self.assertEqual(expected_run[expected_run.index("--rows") + 1], 50)
+        self.assertEqual(expected_run[expected_run.index("--threads") + 1], 32)
+        for operation in ("insert", "upsert", "bulk-upsert"):
+            with self.subTest(operation=operation):
+                command = local_ydb_workloads.build_run_argv(
+                    cli_context,
+                    "log-table",
+                    {**workload, "operation": operation},
+                    "threads",
+                    2,
+                    1,
+                    64,
+                )
+                self.assertEqual(command[command.index("run") + 1], operation)
+                self.assertNotIn("bulk_upsert", command)
+        self.assertEqual(
+            local_ydb_workloads.build_clean_argv(cli_context, "log-table", "log"),
+            base + ["clean"],
+        )
+        with self.assertRaisesRegex(BenchmarkError, "log does not support load parameter rate"):
+            local_ydb_workloads.build_run_argv(cli_context, "log-table", workload, "rate", 1000, 30, 64)
+
+    def test_local_ydb_log_uses_sample_lifecycle_and_preserves_rows_per_operation(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "log",
+                "operation": "bulk-upsert",
+                "options": {"rows-per-operation": 25},
+            },
+            "workload",
+        )
+        metrics_output = """
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            10 10 0 0 1 2 3 4
+        """
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        progress = []
+        with mock.patch.object(local_ydb, "LinuxCpuMonitor", return_value=monitor), mock.patch.object(
+            local_ydb, "atomic_write_text"
+        ), mock.patch.object(local_ydb, "atomic_write_json"), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command, metrics_output),
+        ):
+            lifecycle = local_ydb.WorkloadLifecycle(
+                cluster,
+                local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+                workload,
+                {"parameter": "threads"},
+                {"warmup": 1, "duration": 1},
+                64,
+                LOCAL_YDB_BENCHMARK,
+                topology,
+                {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+                None,
+                lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            )
+            lifecycle.open_profile(self.root / "log-profile", "ignored-profile-table")
+            _metrics, commands = lifecycle.run_sample(
+                2,
+                1,
+                1,
+                1,
+                self.root / "log-lifecycle",
+                "log-table",
+                {"attempt": 1},
+            )
+            lifecycle.close_profile()
+
+        self.assertEqual(
+            [command["phase"] for command in commands],
+            ["initializing-workload", "warming-up", "measuring", "cleaning-workload"],
+        )
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            ["initializing-workload", "warming-up", "measuring", "cleaning-workload"],
+        )
+        init, warmup, measure, clean = (command["argv"] for command in commands)
+        self.assertIn("init", init)
+        self.assertIn("clean", clean)
+        self.assertEqual(init[init.index("--path") + 1], clean[clean.index("--path") + 1])
+        for command in (warmup, measure):
+            self.assertEqual(command[command.index("run") + 1], "bulk-upsert")
+            self.assertEqual(command[command.index("--threads") + 1], "2")
+            self.assertEqual(command[command.index("--rows") + 1], "25")
+            self.assertNotIn("--rate", command)
 
     def test_local_ydb_command_record_preserves_argv_and_affinity(self):
         result = runner.CommandResult(
@@ -5275,9 +5628,10 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"Failed workload requests are allowed", script)
                 self.assertIn(b"editor.model?.local_ydb_workloads", script)
                 self.assertIn(b"definition.load_parameters", script)
-                self.assertIn(
-                    b"if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0]", script
-                )
+                self.assertIn(b"config.load=localYdbLoadForWorkload(config.load,parameters)", script)
+                self.assertIn(b"log:'batches/s'", script)
+                self.assertIn(b"<th>Throughput</th>", script)
+                self.assertIn(b"esc(throughputUnit)+' '+localComparisonDelta", script)
                 self.assertIn(b"if(option.choices.length)return localSelect", script)
                 self.assertIn(b"if(option.kind==='boolean')return localCheck", script)
                 self.assertIn(b"if(option.kind==='integer')", script)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -142,8 +142,9 @@ class YdbBenchTest(unittest.TestCase):
                 raise value
             return """
                 Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
-                1 {throughput} {throughput} 0 {errors} 1 2 {p99_ms} 4
+                {transactions} {throughput} 0 {errors} 1 2 {p99_ms} 4
             """.format(
+                transactions=value.get("transactions", 1),
                 throughput=value.get("throughput", 10),
                 errors=value.get("errors", 0),
                 p99_ms=value.get("p99_ms", 3),
@@ -1277,6 +1278,11 @@ class YdbBenchTest(unittest.TestCase):
                 20 nan 0 0 1 2 3 4
             """)
 
+    def test_local_ydb_cli_total_row_rejects_negative_counters(self):
+        for values in ("-1 10 0 0 1 2 3 4", "1 10 -1 0 1 2 3 4", "1 10 0 -1 1 2 3 4"):
+            with self.subTest(values=values), self.assertRaisesRegex(BenchmarkError, "valid Total row"):
+                parse_cli_metrics("Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)\n" + values)
+
     def test_local_ydb_profile_parses_geometry_load_and_role_affinity(self):
         loaded = load_config(self._config("""
                 local-ydb:
@@ -1632,6 +1638,42 @@ class YdbBenchTest(unittest.TestCase):
             },
         )
         self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
+    def test_local_ydb_web_hides_latency_for_empty_measurements(self):
+        result_start = web._JS.index("function localResultMetrics")
+        result_finish = web._JS.index("function localVerificationCount", result_start)
+        attempt_start = web._JS.index("function localAttemptLatency")
+        attempt_finish = web._JS.index("function localChart", attempt_start)
+        script = web._JS[result_start:result_finish] + web._JS[attempt_start:attempt_finish] + """
+            const empty={attempt:1,empty_repetitions:1,throughput:123,errors:7,p99_ms:0};
+            const valid={attempt:2,empty_repetitions:0,throughput:100,errors:1,p99_ms:9};
+            const rows=localAttemptRows([empty,valid]);
+            const holdout=localResultMetrics({
+              metrics_source:'verification',
+              verified_metrics:{empty_repetitions:1,throughput:123,errors:7,p99_ms:0}
+            });
+            process.stdout.write(JSON.stringify({
+              empty_label:localAttemptLatency(empty),valid_label:localAttemptLatency(valid),
+              empty_chart:rows.get('1'),valid_chart:rows.get('2'),holdout
+            }));
+        """
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertEqual(result["empty_label"], "—")
+        self.assertEqual(result["valid_label"], 9)
+        self.assertIsNone(result["empty_chart"]["p99_ms"])
+        self.assertEqual(result["empty_chart"]["throughput"], 123)
+        self.assertEqual(result["empty_chart"]["errors"], 7)
+        self.assertEqual(result["valid_chart"]["p99_ms"], 9)
+        self.assertIsNone(result["holdout"]["metrics"]["p99_ms"])
+        self.assertEqual(result["holdout"]["metrics"]["throughput"], 123)
 
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
         cli_context = local_ydb_workloads.WorkloadCli(
@@ -2150,6 +2192,34 @@ class YdbBenchTest(unittest.TestCase):
         self.assertIn("exceeds", manifest["verification"]["decision"])
         self.assertNotIn("saturated_repetitions", manifest["verification"])
 
+    def test_local_ydb_verification_rejects_an_empty_repetition_when_errors_are_allowed(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              empty-holdout:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, allow-errors: true, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        manifest, _output, _events = self._run_mock_local_ydb(
+            configuration,
+            "verification-empty-repetition",
+            [
+                {"transactions": 10, "throughput": 10, "errors": 1},
+                {"transactions": 10, "throughput": 9, "errors": 1},
+                {"transactions": 0, "throughput": 0, "errors": 10},
+            ],
+        )
+        self.assertEqual(manifest["state"], "passed")
+        self.assertEqual(manifest["result"]["selected_load"], 1)
+        self.assertEqual(manifest["result"]["verified_metrics"]["empty_repetitions"], 1)
+        self.assertFalse(manifest["result"]["holdout_accepted"])
+        self.assertFalse(manifest["verification"]["accepted"])
+        self.assertIn("zero successful operations", manifest["verification"]["decision"])
+
     def test_local_ydb_verification_failure_preserves_search_and_partial_holdout(self):
         configuration = load_config(self._config("""
             local-ydb:
@@ -2521,6 +2591,122 @@ class YdbBenchTest(unittest.TestCase):
         self.assertFalse(passed)
         self.assertIn("exceeds", reason)
 
+    def test_load_controllers_reject_zero_success_measurements_before_objectives(self):
+        point_configs = (
+            {"parameter": "threads", "values": [1]},
+            {"parameter": "threads", "allow_errors": True, "values": [1]},
+        )
+        for config in point_configs:
+            with self.subTest(controller="points", allow_errors=config.get("allow_errors", False)):
+                result = load_control.search_load(
+                    config,
+                    lambda _load: {"transactions": 0, "throughput": 0, "errors": 10},
+                )
+                self.assertIsNone(result.selected_load)
+                self.assertFalse(result.attempts[0]["passed"])
+                self.assertIn("zero successful operations", result.attempts[0]["decision"])
+
+        throughput = load_control.search_load(
+            {
+                "parameter": "threads",
+                "allow_errors": True,
+                "search": {"start": 10, "maximum": 100, "multiplier": 2, "resolution_percent": 2},
+                "objective": {
+                    "type": "maximize-throughput",
+                    "target_role": "dynamic",
+                    "cpu_saturation_percent": 90,
+                    "plateau_gain_percent": 1,
+                    "plateau_points": 2,
+                },
+            },
+            lambda load: {
+                "transactions": 0 if load >= 70 else 1,
+                "throughput": 100 - abs(load - 55),
+                "errors": 0,
+                "dynamic_cpu_mean": 50,
+                "static_cpu_mean": 10,
+                "host_cpu_mean": 20,
+            },
+        )
+        self.assertEqual(throughput.outcome, "bounded-by-invalid-sample")
+        self.assertIn("invalid measurement", throughput.stop_reason)
+
+        latency = load_control.search_load(
+            {
+                "parameter": "threads",
+                "allow_errors": True,
+                "search": {"start": 10, "maximum": 40, "multiplier": 2, "resolution_percent": 5},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "max_ms": 10,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            lambda load: {
+                "transactions": 0 if load >= 20 else 1,
+                "throughput": load,
+                "errors": 0,
+                "p99_ms": 1,
+            },
+        )
+        self.assertEqual(latency.selected_load, 19)
+        self.assertEqual(latency.outcome, "bounded-by-invalid-sample")
+        self.assertIn("invalid measurement", latency.stop_reason)
+
+        for allow_errors in (False, True):
+            with self.subTest(controller="maximize-throughput", allow_errors=allow_errors):
+                result = load_control.search_load(
+                    {
+                        "parameter": "threads",
+                        "allow_errors": allow_errors,
+                        "search": {"start": 1, "maximum": 2, "multiplier": 2, "resolution_percent": 5},
+                        "objective": {
+                            "type": "maximize-throughput",
+                            "target_role": "dynamic",
+                            "cpu_saturation_percent": 90,
+                            "plateau_gain_percent": 1,
+                            "plateau_points": 2,
+                        },
+                    },
+                    lambda _load: {
+                        "transactions": 0,
+                        "throughput": 0,
+                        "errors": 10,
+                        "dynamic_cpu_mean": 100,
+                        "static_cpu_mean": 10,
+                        "host_cpu_mean": 50,
+                    },
+                )
+                self.assertIsNone(result.selected_load)
+                self.assertFalse(result.attempts[0]["passed"])
+                self.assertIn("zero successful operations", result.attempts[0]["decision"])
+
+            with self.subTest(controller="latency-slo", allow_errors=allow_errors):
+                result = load_control.search_load(
+                    {
+                        "parameter": "threads",
+                        "allow_errors": allow_errors,
+                        "search": {"start": 1, "maximum": 2, "multiplier": 2, "resolution_percent": 5},
+                        "objective": {
+                            "type": "latency-slo",
+                            "percentile": "p99",
+                            "max_ms": 10,
+                            "max_errors": 0,
+                            "min_achieved_rate_ratio": 0.98,
+                        },
+                    },
+                    lambda _load: {"transactions": 0, "throughput": 0, "errors": 10, "p99_ms": 1},
+                )
+                self.assertIsNone(result.selected_load)
+                self.assertFalse(result.attempts[0]["passed"])
+                self.assertIn("zero successful operations", result.attempts[0]["decision"])
+
+    def test_evaluate_load_remains_compatible_without_success_metadata(self):
+        config = {"parameter": "threads", "allow_errors": True, "values": [1]}
+        self.assertTrue(load_control.evaluate_load(config, 1, {"throughput": 0, "errors": 1})[0])
+
     def test_linux_cpu_summary_weights_intervals_and_ignores_short_spikes_for_max(self):
         monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1}, interval=0.5)
         monitor._records = [
@@ -2579,6 +2765,53 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(metrics["throughput"], 20)
         self.assertEqual(metrics["errors"], 100)
+
+    def test_local_ydb_attempt_rejects_one_empty_repetition(self):
+        metrics = local_ydb._aggregate_measurements(
+            [
+                {"transactions": 10, "throughput": 10, "errors": 1},
+                {"transactions": 0, "throughput": 0, "errors": 10},
+                {"transactions": 20, "throughput": 20, "errors": 2},
+            ]
+        )
+        passed, reason = load_control.evaluate_load(
+            {"parameter": "threads", "allow_errors": True, "values": [1]},
+            1,
+            metrics,
+        )
+        self.assertEqual(metrics["empty_repetitions"], 1)
+        self.assertEqual(metrics["errors"], 13)
+        self.assertFalse(passed)
+        self.assertIn("1 repetition", reason)
+        self.assertIn("zero successful operations", reason)
+
+    def test_local_ydb_attempt_allows_partial_errors_when_every_repetition_succeeds(self):
+        metrics = local_ydb._aggregate_measurements(
+            [
+                {"transactions": 10, "throughput": 10, "errors": 1},
+                {"transactions": 20, "throughput": 20, "errors": 2},
+            ]
+        )
+        passed, reason = load_control.evaluate_load(
+            {"parameter": "threads", "allow_errors": True, "values": [1]},
+            1,
+            metrics,
+        )
+        self.assertEqual(metrics["empty_repetitions"], 0)
+        self.assertEqual(metrics["errors"], 3)
+        self.assertTrue(passed)
+        self.assertIn("errors allowed", reason)
+
+    def test_local_ydb_summary_omits_points_with_an_empty_repetition(self):
+        rows = [
+            {"load": 1, "dynamic_nodes": 1, "transactions": 10},
+            {"load": 1, "dynamic_nodes": 1, "transactions": 0},
+            {"load": 2, "dynamic_nodes": 1, "transactions": 20},
+        ]
+        for row in rows:
+            row.update({metric.name: row.get(metric.name, 1) for metric in LOCAL_YDB_BENCHMARK.metrics})
+        summary = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
+        self.assertEqual([(row["load"], row["dynamic_nodes"]) for row in summary], [(2, 1)])
 
     def test_local_ydb_scaling_uses_failing_boundary_and_minimum_attempt(self):
         attempts = (
@@ -5315,6 +5548,30 @@ class WebTest(unittest.TestCase):
                     service.local_ydb_comparison(["baseline"])
         finally:
             service.shutdown()
+
+    def test_local_ydb_comparison_projects_empty_holdout_repetitions(self):
+        run_root = self.root / "empty-holdout"
+        self._local_ydb_result(run_root, 1000, verified=True)
+        profile_path = run_root / "local-ydb" / "capacity" / "run.json"
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        profile["result"]["holdout_accepted"] = False
+        profile["result"]["verified_metrics"].update(
+            {"empty_repetitions": 1, "p99_ms": 0, "throughput": 0, "errors": 10}
+        )
+        profile["verification"].update(
+            {"accepted": False, "decision": "invalid measurement: zero successful operations"}
+        )
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+
+        service = RunService(self.root)
+        try:
+            comparison = service.local_ydb_comparison(["empty-holdout"])
+        finally:
+            service.shutdown()
+        result = comparison["entries"][0]["result"]
+        self.assertEqual(result["verified_metrics"]["empty_repetitions"], 1)
+        self.assertEqual(result["verified_metrics"]["p99_ms"], 0)
+        self.assertFalse(result["holdout_accepted"])
 
     def test_local_ydb_profile_projection_preserves_terminal_state_without_nested_manifest(self):
         run_root = self.root / "terminal-local-ydb-run"

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -34,6 +34,7 @@ from ydb.tools.ydb_bench.lib import (
     linux_telemetry,
     load_control,
     local_ydb,
+    local_ydb_workloads,
     runner,
     topology,
     web,
@@ -273,6 +274,235 @@ class YdbBenchTest(unittest.TestCase):
         local_load_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["load"]
         self.assertEqual(local_load_schema["properties"]["allow-errors"], {"type": "boolean"})
 
+    def test_local_ydb_workload_registry_generates_schema_and_web_catalog(self):
+        workload_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["workload"]
+        self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
+
+        catalog = local_ydb_workloads.web_workload_catalog()
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock"])
+        self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
+        self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
+        self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
+        catalog_parameters = tuple(
+            dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
+        )
+        load_schema = CONFIG_SCHEMA["properties"]["local-ydb"]["additionalProperties"]["properties"]["load"]
+        self.assertEqual(tuple(load_schema["properties"]["parameter"]["enum"]), catalog_parameters)
+        self.assertEqual(local_ydb_workloads.all_load_parameters(), catalog_parameters)
+        self.assertEqual(
+            next(option for option in catalog[0]["options"] if option["name"] == "init-upserts")["operation_defaults"],
+            {"upsert": 0},
+        )
+        json.dumps(catalog, allow_nan=False)
+
+    def test_local_ydb_workload_registry_preserves_defaults_and_validation(self):
+        upsert = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "upsert"},
+            "local-ydb.profile.workload",
+        )
+        select = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "select"},
+            "local-ydb.profile.workload",
+        )
+        stock = local_ydb_workloads.normalize_workload(
+            {"type": "stock", "operation": "put-rand-order"},
+            "local-ydb.profile.workload",
+        )
+        self.assertEqual(upsert["options"]["init-upserts"], 0)
+        self.assertEqual(select["options"]["init-upserts"], 1000)
+        self.assertEqual(stock["options"]["orders"], 100)
+
+        invalid = (
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock"),
+            ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
+                r"products.*must not exceed 500000",
+            ),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"auto-partition": 2}},
+                r"auto-partition.*must be 0 or 1",
+            ),
+            (
+                {"type": "stock", "operation": "put-rand-order", "options": {"max-partitions": 10}},
+                r"options.*unknown fields: max-partitions",
+            ),
+        )
+        for workload, message in invalid:
+            with self.subTest(workload=workload), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.normalize_workload(workload, "local-ydb.profile.workload")
+
+    def test_local_ydb_workload_registry_supports_typed_options(self):
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="synthetic",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("threads",),
+            options=(
+                local_ydb_workloads.WorkloadOption(
+                    "tx-mode",
+                    "serializable-rw",
+                    kind="string",
+                    choices=("serializable-rw", "snapshot-rw"),
+                ),
+                local_ydb_workloads.WorkloadOption("enabled", True, kind="boolean"),
+                local_ydb_workloads.WorkloadOption(
+                    "warmup",
+                    "10s",
+                    kind="duration",
+                    pattern=r"^[1-9][0-9]*s$",
+                ),
+                local_ydb_workloads.WorkloadOption("label", "mode: fast # tagged", kind="string"),
+            ),
+            uses_path=True,
+            table_name=None,
+            init_builder=None,
+            run_builder=None,
+            options_validator=lambda options, location: None,
+        )
+        local_ydb_workloads._validate_catalog((definition,))
+        divergent = replace(
+            definition,
+            name="other",
+            options=(local_ydb_workloads.WorkloadOption("tx-mode", 1),),
+        )
+        with self.assertRaisesRegex(ValueError, "tx-mode has incompatible schemas"):
+            local_ydb_workloads._validate_catalog((definition, divergent))
+        for pattern in (r"(?P<seconds>[0-9]+)s", r"^[0-9]+\s+s$"):
+            nonportable = replace(
+                definition,
+                options=(local_ydb_workloads.WorkloadOption("warmup", "10s", kind="duration", pattern=pattern),),
+            )
+            with self.subTest(pattern=pattern), self.assertRaisesRegex(ValueError, "pattern.*is not portable"):
+                local_ydb_workloads._validate_catalog((nonportable,))
+        with mock.patch.object(local_ydb_workloads, "_DEFINITIONS", (definition,)), mock.patch.object(
+            local_ydb_workloads,
+            "_WORKLOADS",
+            {definition.name: definition},
+        ):
+            workload = local_ydb_workloads.normalize_workload(
+                {"type": "synthetic", "operation": "run"},
+                "workload",
+            )
+            self.assertEqual(
+                workload["options"],
+                {
+                    "tx-mode": "serializable-rw",
+                    "enabled": True,
+                    "warmup": "10s",
+                    "label": "mode: fast # tagged",
+                },
+            )
+            schema = local_ydb_workloads.workload_config_schema()["properties"]["options"]["properties"]
+            self.assertEqual(
+                schema["tx-mode"],
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": ["serializable-rw", "snapshot-rw"],
+                },
+            )
+            self.assertEqual(schema["enabled"], {"type": "boolean"})
+            self.assertEqual(schema["warmup"]["pattern"], r"^[1-9][0-9]*s$")
+            catalog = local_ydb_workloads.web_workload_catalog()
+            self.assertEqual(
+                [option["kind"] for option in catalog[0]["options"]],
+                ["string", "boolean", "duration", "string"],
+            )
+            self.assertEqual(catalog[0]["options"][2]["schema"], schema["warmup"])
+            special = "mode: fast # tagged\nsecond line"
+            self.assertEqual(yaml.safe_load("option: " + json.dumps(special))["option"], special)
+
+            invalid = (
+                ({"tx-mode": "", "enabled": True, "warmup": "10s"}, "tx-mode.*must not be empty"),
+                ({"tx-mode": "snapshot-rw", "enabled": 1, "warmup": "10s"}, "enabled.*must be a boolean"),
+                ({"tx-mode": "snapshot-rw", "enabled": False, "warmup": "0s"}, "warmup.*must match pattern"),
+            )
+            for options, message in invalid:
+                with self.subTest(options=options), self.assertRaisesRegex(BenchmarkError, message):
+                    local_ydb_workloads.normalize_workload(
+                        {"type": "synthetic", "operation": "run", "options": options},
+                        "workload",
+                    )
+
+    def test_local_ydb_workload_registry_builds_golden_cli_commands(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "select"},
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "kv",
+            "--path",
+            "table-prefix",
+        ]
+        self.assertEqual(
+            local_ydb_workloads.build_init_argv(cli_context, "table-prefix", workload),
+            base
+            + [
+                "init",
+                "--init-upserts",
+                1000,
+                "--min-partitions",
+                40,
+                "--max-partitions",
+                1000,
+                "--partition-size",
+                2000,
+                "--max-first-key",
+                65536,
+                "--len",
+                64,
+                "--cols",
+                2,
+                "--int-cols",
+                1,
+                "--key-cols",
+                1,
+                "--rows",
+                1,
+            ],
+        )
+        self.assertEqual(
+            local_ydb_workloads.build_run_argv(cli_context, "table-prefix", workload, "rate", 250, 30, 64),
+            base
+            + [
+                "run",
+                "select",
+                "--seconds",
+                30,
+                "--threads",
+                64,
+                "--quiet",
+                "--max-first-key",
+                65536,
+                "--int-cols",
+                1,
+                "--key-cols",
+                1,
+                "--cols",
+                2,
+                "--rows",
+                1,
+                "--rate",
+                250,
+            ],
+        )
+        self.assertEqual(
+            local_ydb_workloads.build_clean_argv(cli_context, "table-prefix", "kv"),
+            base + ["clean"],
+        )
+
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""
             Window Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
@@ -485,6 +715,7 @@ class YdbBenchTest(unittest.TestCase):
         model = web.editor_model(loaded, self.root / "results")
         benchmark = next(item for item in model["benchmarks"] if item["name"] == "local-ydb")
         profile = model["profiles"][0]
+        self.assertEqual(model["local_ydb_workloads"], local_ydb_workloads.web_workload_catalog())
         self.assertTrue(benchmark["builder_supported"])
         self.assertEqual(benchmark["profile_kind"], "local-ydb")
         self.assertEqual(profile["local_ydb"]["workload"]["type"], "stock")
@@ -522,42 +753,53 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload["options"]["products"], 10)
 
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
-        cluster = mock.Mock(
-            ydb_cli=Path("ydb"),
-            client_endpoint="grpc://host.example:2135",
-            database="/Root/bench",
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("ydb"),
+            "grpc://host.example:2135",
+            "/Root/bench",
         )
-        command = local_ydb._stock_init_command(
-            cluster,
-            "ignored-table-prefix",
+        workload = local_ydb_workloads.normalize_workload(
             {
-                "products": 10,
-                "quantity": 100,
-                "orders": 0,
-                "min-partitions": 1,
-                "auto-partition": 0,
+                "type": "stock",
+                "operation": "add-rand-order",
+                "options": {
+                    "products": 10,
+                    "quantity": 100,
+                    "orders": 0,
+                    "min-partitions": 1,
+                    "auto-partition": 0,
+                },
             },
+            "workload",
+        )
+        command = local_ydb_workloads.build_init_argv(
+            cli_context,
+            "ignored-table-prefix",
+            workload,
         )
         self.assertNotIn("--path", command)
         self.assertNotIn("ignored-table-prefix", command)
-        self.assertEqual(local_ydb._workload_table_path("stock", "ignored-table-prefix"), "stock")
-        self.assertNotIn("--path", local_ydb._clean_workload_command(cluster, "stock", "ignored-table-prefix"))
+        self.assertEqual(local_ydb_workloads.workload_table_path("stock", "ignored-table-prefix"), "stock")
+        self.assertNotIn(
+            "--path",
+            local_ydb_workloads.build_clean_argv(cli_context, "ignored-table-prefix", "stock"),
+        )
 
-        run_options = {"products": 10, "limit": 5}
-        add_command = local_ydb._stock_run_command(
-            cluster,
+        workload["options"]["limit"] = 5
+        add_command = local_ydb_workloads.build_run_argv(
+            cli_context,
             "ignored-table-prefix",
-            {"operation": "add-rand-order", "options": run_options},
-            {"parameter": "threads"},
+            workload,
+            "threads",
             8,
             30,
             64,
         )
-        put_command = local_ydb._stock_run_command(
-            cluster,
+        put_command = local_ydb_workloads.build_run_argv(
+            cli_context,
             "ignored-table-prefix",
-            {"operation": "put-rand-order", "options": run_options},
-            {"parameter": "threads"},
+            {**workload, "operation": "put-rand-order"},
+            "threads",
             8,
             30,
             64,
@@ -884,14 +1126,18 @@ class YdbBenchTest(unittest.TestCase):
         self.last_local_ydb_cluster.stop.assert_called_once_with()
 
     def test_local_ydb_kv_commands_keep_table_path(self):
-        cluster = mock.Mock(
-            ydb_cli=Path("ydb"),
-            client_endpoint="grpc://host.example:2135",
-            database="/Root/bench",
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("ydb"),
+            "grpc://host.example:2135",
+            "/Root/bench",
         )
-        command = local_ydb._workload_base(cluster, "kv", "table-prefix")
-        self.assertEqual(command[-2:], ["--path", "table-prefix"])
-        self.assertEqual(local_ydb._workload_table_path("kv", "table-prefix"), "table-prefix")
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "kv", "operation": "upsert"},
+            "workload",
+        )
+        command = local_ydb_workloads.build_init_argv(cli_context, "table-prefix", workload)
+        self.assertEqual(command[command.index("--path") : command.index("--path") + 2], ["--path", "table-prefix"])
+        self.assertEqual(local_ydb_workloads.workload_table_path("kv", "table-prefix"), "table-prefix")
 
     def test_load_controllers_find_capacity_and_latency_boundary(self):
         throughput_attempts = []
@@ -4256,6 +4502,21 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"local-load-allow-errors", script)
                 self.assertIn(b"allow-errors: ", script)
                 self.assertIn(b"Failed workload requests are allowed", script)
+                self.assertIn(b"editor.model?.local_ydb_workloads", script)
+                self.assertIn(b"definition.load_parameters", script)
+                self.assertIn(
+                    b"if(!parameters.includes(config.load.parameter))config.load.parameter=parameters[0]", script
+                )
+                self.assertIn(b"if(option.choices.length)return localSelect", script)
+                self.assertIn(b"if(option.kind==='boolean')return localCheck", script)
+                self.assertIn(b"if(option.kind==='integer')", script)
+                self.assertIn(b"return localField(id,option.name,value,'','type=text')", script)
+                self.assertIn(b"function yamlScalar(value)", script)
+                self.assertIn(b"key+': '+yamlScalar(value)", script)
+                self.assertIn(b"!option.allow_empty&&!value.length", script)
+                self.assertNotIn(b"new RegExp(option.pattern)", script)
+                self.assertNotIn(b"const localYdbOperations=", script)
+                self.assertNotIn(b"type==='stock'?", script)
                 self.assertIn(b"verification-repetitions:", script)
                 self.assertIn(b"local-measurement-verification-repetitions", script)
                 self.assertIn(b"localInteger('local-measurement-verification-repetitions',0,20)", script)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -123,7 +123,17 @@ class YdbBenchTest(unittest.TestCase):
         measurements,
         cancel_event=None,
         cleanup_action=None,
+        cpu_metrics=None,
+        lifecycle_actions=None,
     ):
+        def record(action, command=None):
+            if lifecycle_actions is None:
+                return
+            path = None
+            if command is not None and "--path" in command:
+                path = str(command[command.index("--path") + 1])
+            lifecycle_actions.append((action, path))
+
         def command_result(command, stdout="", exit_code=0, stderr="", interrupted=False, timed_out=False):
             return runner.CommandResult(
                 command=tuple(str(part) for part in command),
@@ -158,14 +168,24 @@ class YdbBenchTest(unittest.TestCase):
             static_pids=(10,),
             dynamic_pids=(20,),
         )
-        cluster.init_workload.side_effect = lambda command, **_kwargs: (
-            command_result(command),
-            [command_result(command)],
-        )
+
+        def init_workload(command, **_kwargs):
+            record("init", command)
+            return command_result(command), [command_result(command)]
+
+        cluster.init_workload.side_effect = init_workload
+
+        def add_dynamic_nodes(count):
+            record("scale")
+            cluster.dynamic_nodes.extend({} for _index in range(count))
+
+        cluster.add_dynamic_nodes.side_effect = add_dynamic_nodes
 
         def run_cluster_command(command, **_kwargs):
             if cleanup_action is not None and "clean" in command:
                 cleanup_action()
+            if "clean" in command:
+                record("clean", command)
             return command_result(command)
 
         cluster._run.side_effect = run_cluster_command
@@ -181,6 +201,8 @@ class YdbBenchTest(unittest.TestCase):
             "host_cpu_mean": 7,
             "host_cpu_max": 8,
         }
+        if cpu_metrics is not None:
+            monitor.stop.return_value.update(cpu_metrics)
         monitor.summary.return_value = {
             "static_cpu_mean": 11,
             "static_cpu_max": 12,
@@ -194,6 +216,7 @@ class YdbBenchTest(unittest.TestCase):
         outputs = iter(measurements)
 
         def next_measurement(command):
+            record("measure", command)
             value = next(outputs)
             stdout = measurement_stdout(value)
             return command_result(
@@ -254,7 +277,11 @@ class YdbBenchTest(unittest.TestCase):
         )
 
     @staticmethod
-    def _synthetic_profile_workload(cleanup_names=("clean",), measurement_window=(101.0, 109.0)):
+    def _synthetic_profile_workload(
+        cleanup_names=("clean",),
+        measurement_window=(101.0, 109.0),
+        dataset_scope="profile",
+    ):
         def prepare(cli_context, _definition, path, _workload):
             return (
                 local_ydb_workloads.WorkloadCommandPlan(
@@ -311,7 +338,7 @@ class YdbBenchTest(unittest.TestCase):
             init_builder=lambda *_args: (),
             run_builder=lambda *_args: (),
             options_validator=lambda *_args: None,
-            dataset_scope="profile",
+            dataset_scope=dataset_scope,
             warmup_mode="inline",
             prepare_plan_builder=prepare,
             run_plan_builder=run,
@@ -720,6 +747,7 @@ class YdbBenchTest(unittest.TestCase):
             run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", ("ydb",), 1),
         )
         local_ydb_workloads._validate_catalog((definition,))
+        local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="geometry"),))
         with self.assertRaisesRegex(ValueError, "dataset scope"):
             local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="attempt"),))
         with self.assertRaisesRegex(ValueError, "inline warmup requires"):
@@ -893,6 +921,208 @@ class YdbBenchTest(unittest.TestCase):
             self.assertEqual(call.args[2], 45)
         profile_commands = lifecycle.profile_commands
         self.assertEqual([item["argv"][2] for item in profile_commands], ["init", "import", "clean"])
+
+    def test_local_ydb_geometry_lifecycle_shares_dataset_and_requires_matching_nodes(self):
+        definition, workload = self._synthetic_profile_workload(dataset_scope="geometry")
+        metrics_output = """
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            10 10 0 0 1 2 3 4
+        """
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        monitor.summary.return_value = {}
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text"), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command, metrics_output),
+        ) as execute:
+            lifecycle = self._synthetic_workload_lifecycle(workload, cluster, progress)
+            lifecycle.open_profile(self.root / "geometry-profile", "ignored-profile")
+            lifecycle.open_geometry(
+                self.root / "geometry-1",
+                "geometry-dataset-1",
+                1,
+                progress_fields={"search_stage": 3},
+            )
+            lifecycle.run_sample(8, 1, 1, 2, self.root / "geometry-repeat-1", "ignored-1", {})
+            lifecycle.run_sample(16, 1, 2, 2, self.root / "geometry-repeat-2", "ignored-2", {})
+            with self.assertRaisesRegex(BenchmarkError, "belongs to 1 dynamic nodes, got 2"):
+                lifecycle.run_sample(8, 2, 1, 1, self.root / "geometry-mismatch", "ignored", {})
+            lifecycle.close_geometry()
+            with self.assertRaisesRegex(BenchmarkError, "dataset is unavailable"):
+                lifecycle.run_sample(8, 1, 1, 1, self.root / "geometry-closed", "ignored", {})
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.assertEqual(progress[0]["search_stage"], 3)
+        self.assertEqual([item["argv"][2] for item in lifecycle.geometry_commands], ["init", "import", "clean"])
+
+    def test_local_ydb_geometry_dataset_is_cleaned_before_dynamic_node_scaling(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              geometry-scaling:
+                workload: {type: kv, operation: upsert}
+                geometry: {preset: storage, static-nodes: 1, dynamic-nodes: 1, max-dynamic-nodes: 2}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="geometry")
+        actions = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            manifest, _output, _events = self._run_mock_local_ydb(
+                configuration,
+                "geometry-scaling",
+                [{"throughput": 10}, {"throughput": 20}],
+                cpu_metrics={"dynamic_cpu_mean": 100, "static_cpu_mean": 1},
+                lifecycle_actions=actions,
+            )
+
+        self.assertEqual(manifest["result"]["dynamic_nodes"], 2)
+        self.assertEqual(
+            actions,
+            [
+                ("init", "ydb_bench_geometry_01"),
+                ("measure", "ydb_bench_geometry_01"),
+                ("clean", "ydb_bench_geometry_01"),
+                ("scale", None),
+                ("init", "ydb_bench_geometry_02"),
+                ("measure", "ydb_bench_geometry_02"),
+                ("clean", "ydb_bench_geometry_02"),
+            ],
+        )
+
+    def test_local_ydb_geometry_cleanup_cancellation_prevents_scaling(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              geometry-cancel-scaling:
+                workload: {type: kv, operation: upsert}
+                geometry: {preset: storage, static-nodes: 1, dynamic-nodes: 1, max-dynamic-nodes: 2}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="geometry")
+        cancel_event = threading.Event()
+        actions = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(BenchmarkInterrupted, "was cancelled"):
+                self._run_mock_local_ydb(
+                    configuration,
+                    "geometry-cancel-scaling",
+                    [{"throughput": 10}],
+                    cancel_event=cancel_event,
+                    cleanup_action=cancel_event.set,
+                    cpu_metrics={"dynamic_cpu_mean": 100, "static_cpu_mean": 1},
+                    lifecycle_actions=actions,
+                )
+
+        self.assertEqual(
+            actions,
+            [
+                ("init", "ydb_bench_geometry_01"),
+                ("measure", "ydb_bench_geometry_01"),
+                ("clean", "ydb_bench_geometry_01"),
+            ],
+        )
+        self.last_local_ydb_cluster.add_dynamic_nodes.assert_not_called()
+        cleanup = self.last_local_ydb_cluster._run.call_args
+        self.assertTrue(cleanup.kwargs["ignore_cancellation"])
+        manifest = json.loads((self.root / "geometry-cancel-scaling" / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["status"], "interrupted")
+        self.assertEqual(manifest["state"], "cancelled")
+
+    def test_local_ydb_final_geometry_dataset_is_reused_for_verification(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              geometry-verification:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1, verification-repetitions: 2}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="geometry")
+        actions = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            manifest, _output, _events = self._run_mock_local_ydb(
+                configuration,
+                "geometry-verification",
+                [{"throughput": 10}, {"throughput": 11}, {"throughput": 12}],
+                lifecycle_actions=actions,
+            )
+
+        self.assertEqual(manifest["verification"]["status"], "completed")
+        self.assertEqual(
+            actions,
+            [
+                ("init", "ydb_bench_geometry_01"),
+                ("measure", "ydb_bench_geometry_01"),
+                ("measure", "ydb_bench_geometry_01"),
+                ("measure", "ydb_bench_geometry_01"),
+                ("clean", "ydb_bench_geometry_01"),
+            ],
+        )
+
+    def test_local_ydb_geometry_cleanup_does_not_mask_primary_error(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              geometry-failure:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: threads, values: [1]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="geometry")
+
+        def fail_cleanup():
+            raise BenchmarkError("geometry cleanup failed")
+
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(OSError, "measurement failed"):
+                self._run_mock_local_ydb(
+                    configuration,
+                    "geometry-failure",
+                    [OSError("measurement failed")],
+                    cleanup_action=fail_cleanup,
+                )
+
+        self.assertEqual(self.last_local_ydb_cluster._run.call_count, 1)
+        self.assertTrue(self.last_local_ydb_cluster._run.call_args.kwargs["ignore_cancellation"])
 
     def test_local_ydb_profile_lifecycle_cleans_partial_prepare_without_masking_error(self):
         definition, workload = self._synthetic_profile_workload()

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -115,7 +115,14 @@ class YdbBenchTest(unittest.TestCase):
             timeout_seconds=timeout,
         )
 
-    def _run_mock_local_ydb(self, configuration, output_name, measurements):
+    def _run_mock_local_ydb(
+        self,
+        configuration,
+        output_name,
+        measurements,
+        cancel_event=None,
+        cleanup_action=None,
+    ):
         def command_result(command, stdout="", exit_code=0, stderr="", interrupted=False, timed_out=False):
             return runner.CommandResult(
                 command=tuple(str(part) for part in command),
@@ -149,11 +156,17 @@ class YdbBenchTest(unittest.TestCase):
             static_pids=(10,),
             dynamic_pids=(20,),
         )
-        cluster.init_workload.side_effect = lambda command: (
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
             command_result(command),
             [command_result(command)],
         )
-        cluster._run.side_effect = lambda command, **_kwargs: command_result(command)
+
+        def run_cluster_command(command, **_kwargs):
+            if cleanup_action is not None and "clean" in command:
+                cleanup_action()
+            return command_result(command)
+
+        cluster._run.side_effect = run_cluster_command
         monitor = mock.Mock(records=[])
         monitor.start.return_value = monitor
         monitor.stop.return_value = {
@@ -165,6 +178,16 @@ class YdbBenchTest(unittest.TestCase):
             "cli_cpu_max": 6,
             "host_cpu_mean": 7,
             "host_cpu_max": 8,
+        }
+        monitor.summary.return_value = {
+            "static_cpu_mean": 11,
+            "static_cpu_max": 12,
+            "dynamic_cpu_mean": 13,
+            "dynamic_cpu_max": 14,
+            "cli_cpu_mean": 15,
+            "cli_cpu_max": 16,
+            "host_cpu_mean": 17,
+            "host_cpu_max": 18,
         }
         outputs = iter(measurements)
 
@@ -211,8 +234,110 @@ class YdbBenchTest(unittest.TestCase):
                 output,
                 tool_revision="test",
                 event_sink=events.append,
+                cancel_event=cancel_event,
             )
         return manifest, output, events
+
+    @staticmethod
+    def _local_ydb_command_result(command, stdout="", exit_code=0, interrupted=False):
+        return runner.CommandResult(
+            command=tuple(str(part) for part in command),
+            stdout=stdout,
+            stderr="",
+            exit_code=exit_code,
+            started_at="2026-08-25T10:00:00+00:00",
+            finished_at="2026-08-25T10:00:01+00:00",
+            duration_seconds=1.0,
+            interrupted=interrupted,
+        )
+
+    @staticmethod
+    def _synthetic_profile_workload(cleanup_names=("clean",), measurement_window=(101.0, 109.0)):
+        def prepare(cli_context, _definition, path, _workload):
+            return (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    (cli_context.executable, "synthetic", "init", path),
+                    10,
+                ),
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "import",
+                    (cli_context.executable, "synthetic", "import", path),
+                    20,
+                ),
+            )
+
+        def run(cli_context, _definition, path, _workload, _parameter, load, seconds, threads, warmup):
+            return local_ydb_workloads.WorkloadCommandPlan(
+                "run",
+                (
+                    cli_context.executable,
+                    "synthetic",
+                    "run",
+                    path,
+                    "--load",
+                    load,
+                    "--seconds",
+                    seconds,
+                    "--threads",
+                    threads,
+                    "--warmup",
+                    warmup,
+                ),
+                warmup + seconds + 30,
+                measurement_window_builder=lambda _stdout: measurement_window,
+            )
+
+        def cleanup(cli_context, _definition, path, _workload):
+            return tuple(
+                local_ydb_workloads.WorkloadCommandPlan(
+                    name,
+                    (cli_context.executable, "synthetic", name, path),
+                    5,
+                )
+                for name in cleanup_names
+            )
+
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="synthetic",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("sessions",),
+            options=(),
+            uses_path=True,
+            table_name=None,
+            init_builder=lambda *_args: (),
+            run_builder=lambda *_args: (),
+            options_validator=lambda *_args: None,
+            dataset_scope="profile",
+            warmup_mode="inline",
+            prepare_plan_builder=prepare,
+            run_plan_builder=run,
+            cleanup_plan_builder=cleanup,
+        )
+        return definition, {"type": "synthetic", "operation": "run", "options": {}}
+
+    @staticmethod
+    def _synthetic_workload_lifecycle(workload, cluster, progress, cancel_event=None):
+        topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        return local_ydb.WorkloadLifecycle(
+            cluster,
+            local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+            workload,
+            {"parameter": "sessions"},
+            {"warmup": 5, "duration": 10},
+            4,
+            LOCAL_YDB_BENCHMARK,
+            topology,
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            cancel_event,
+            lambda phase, **fields: progress.append({"phase": phase, **fields}),
+        )
 
     def _worker_metrics_benchmark(self):
         return replace(
@@ -502,6 +627,617 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads.build_clean_argv(cli_context, "table-prefix", "kv"),
             base + ["clean"],
         )
+        prepare = local_ydb_workloads.build_prepare_plan(cli_context, "table-prefix", workload)
+        run = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "table-prefix",
+            workload,
+            "rate",
+            250,
+            30,
+            64,
+        )
+        cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "table-prefix", workload)
+        self.assertEqual(
+            prepare,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    tuple(
+                        base
+                        + [
+                            "init",
+                            "--init-upserts",
+                            1000,
+                            "--min-partitions",
+                            40,
+                            "--max-partitions",
+                            1000,
+                            "--partition-size",
+                            2000,
+                            "--max-first-key",
+                            65536,
+                            "--len",
+                            64,
+                            "--cols",
+                            2,
+                            "--int-cols",
+                            1,
+                            "--key-cols",
+                            1,
+                            "--rows",
+                            1,
+                        ]
+                    ),
+                    120,
+                ),
+            ),
+        )
+        self.assertEqual(
+            run.argv,
+            tuple(
+                local_ydb_workloads.build_run_argv(
+                    cli_context,
+                    "table-prefix",
+                    workload,
+                    "rate",
+                    250,
+                    30,
+                    64,
+                )
+            ),
+        )
+        self.assertEqual(run.timeout_seconds, 60)
+        self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
+        self.assertIsNone(cleanup[0].timeout_seconds)
+
+    def test_local_ydb_workload_registry_validates_lifecycle_metadata_and_plans(self):
+        definition = local_ydb_workloads.WorkloadDefinition(
+            name="inline",
+            default_operation="run",
+            operations=("run",),
+            load_parameters=("sessions",),
+            options=(),
+            uses_path=True,
+            table_name=None,
+            init_builder=lambda *_args: (),
+            run_builder=lambda *_args: (),
+            options_validator=lambda *_args: None,
+            dataset_scope="profile",
+            warmup_mode="inline",
+            run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", ("ydb",), 1),
+        )
+        local_ydb_workloads._validate_catalog((definition,))
+        with self.assertRaisesRegex(ValueError, "dataset scope"):
+            local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="attempt"),))
+        with self.assertRaisesRegex(ValueError, "inline warmup requires"):
+            local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "CPU measurement window"):
+                local_ydb_workloads.build_run_plan(
+                    local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                    "path",
+                    {"type": "inline", "operation": "run", "options": {}},
+                    "sessions",
+                    1,
+                    1,
+                    1,
+                    warmup_seconds=0,
+                )
+            with self.assertRaisesRegex(BenchmarkError, "non-empty argv"):
+                invalid = replace(
+                    definition,
+                    run_plan_builder=lambda *_args: local_ydb_workloads.WorkloadCommandPlan("run", (), 1),
+                )
+                with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": invalid}):
+                    local_ydb_workloads.build_run_plan(
+                        local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                        "path",
+                        {"type": "inline", "operation": "run", "options": {}},
+                        "sessions",
+                        1,
+                        1,
+                        1,
+                        warmup_seconds=1,
+                    )
+            for timeout in (float("nan"), float("inf"), True, 10**1000):
+                nonfinite = replace(
+                    definition,
+                    run_plan_builder=lambda *_args, timeout=timeout: local_ydb_workloads.WorkloadCommandPlan(
+                        "run",
+                        ("ydb",),
+                        timeout,
+                    ),
+                )
+                with self.subTest(timeout=timeout), mock.patch.object(
+                    local_ydb_workloads,
+                    "_WORKLOADS",
+                    {"inline": nonfinite},
+                ), self.assertRaisesRegex(BenchmarkError, "positive timeout"):
+                    local_ydb_workloads.build_run_plan(
+                        local_ydb_workloads.WorkloadCli("ydb", "endpoint", "database"),
+                        "path",
+                        {"type": "inline", "operation": "run", "options": {}},
+                        "sessions",
+                        1,
+                        1,
+                        1,
+                        warmup_seconds=1,
+                    )
+
+    def test_local_ydb_profile_inline_lifecycle_prepares_once_and_cleans_once(self):
+        definition, workload = self._synthetic_profile_workload()
+        metrics_output = """
+            Total Txs Txs/Sec Retries Errors p50(ms) p95(ms) p99(ms) pMax(ms)
+            10 10 0 0 1 2 3 4
+        """
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        monitor.summary.return_value = {
+            "static_cpu_mean": 11,
+            "static_cpu_max": 12,
+            "dynamic_cpu_mean": 13,
+            "dynamic_cpu_max": 14,
+            "cli_cpu_mean": 15,
+            "cli_cpu_max": 16,
+            "host_cpu_mean": 17,
+            "host_cpu_max": 18,
+        }
+        progress = []
+        profile_directory = self.root / "synthetic-profile"
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command, metrics_output),
+        ) as execute:
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(profile_directory, "tpcc-dataset")
+            first_metrics, first_commands = lifecycle.run_sample(
+                8,
+                1,
+                1,
+                2,
+                self.root / "synthetic-repeat-1",
+                "ignored-1",
+                {"attempt": 1},
+            )
+            second_metrics, second_commands = lifecycle.run_sample(
+                16,
+                1,
+                2,
+                2,
+                self.root / "synthetic-repeat-2",
+                "ignored-2",
+                {"attempt": 2},
+            )
+            lifecycle.close_profile()
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual([call.args[0][2] for call in cluster.init_workload.call_args_list], ["init", "import"])
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.assertEqual(cluster._run.call_args.kwargs["timeout"], 5)
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            [
+                "initializing-workload",
+                "preparing-import",
+                "measuring",
+                "measuring",
+                "cleaning-workload",
+            ],
+        )
+        self.assertNotIn("warming-up", [item["phase"] for item in progress])
+        self.assertEqual([len(first_commands), len(second_commands)], [1, 1])
+        self.assertEqual(first_metrics["static_cpu_mean"], 11)
+        self.assertEqual(second_metrics["load"], 16)
+        self.assertEqual(
+            monitor.summary.call_args_list,
+            [
+                mock.call(started_at_unix=101.0, finished_at_unix=109.0),
+                mock.call(started_at_unix=101.0, finished_at_unix=109.0),
+            ],
+        )
+        for call in execute.call_args_list:
+            argv = call.args[0]
+            self.assertEqual(argv[argv.index("--warmup") + 1], 5)
+            self.assertEqual(call.args[2], 45)
+        profile_commands = lifecycle.profile_commands
+        self.assertEqual([item["argv"][2] for item in profile_commands], ["init", "import", "clean"])
+
+    def test_local_ydb_profile_lifecycle_cleans_partial_prepare_without_masking_error(self):
+        definition, workload = self._synthetic_profile_workload()
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        initialized = self._local_ydb_command_result(("ydb", "synthetic", "init"))
+        cluster.init_workload.side_effect = ((initialized, [initialized]), BenchmarkError("import failed"))
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(local_ydb, "atomic_write_json"):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            with self.assertRaisesRegex(BenchmarkError, "import failed"):
+                lifecycle.open_profile(self.root / "partial-profile", "tpcc-dataset")
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+
+    def test_local_ydb_inline_lifecycle_rejects_huge_cpu_measurement_window(self):
+        definition, workload = self._synthetic_profile_workload(measurement_window=(10**1000, 10**1000 + 1))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text"), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command),
+        ):
+            lifecycle = self._synthetic_workload_lifecycle(workload, cluster, progress)
+            lifecycle.open_profile(self.root / "huge-window-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "invalid CPU measurement window") as caught:
+                lifecycle.run_sample(
+                    8,
+                    1,
+                    1,
+                    1,
+                    self.root / "huge-window-repeat",
+                    "ignored",
+                    {},
+                )
+            lifecycle.close_profile(primary_error=caught.exception)
+
+        monitor.summary.assert_not_called()
+        self.assertEqual(cluster._run.call_count, 1)
+
+    def test_local_ydb_profile_lifecycle_preserves_run_error_when_cleanup_fails(self):
+        definition, workload = self._synthetic_profile_workload()
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = BenchmarkError("cleanup failed")
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        progress = []
+        failed_run = self._local_ydb_command_result(("ydb", "synthetic", "run"), exit_code=17)
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text") as write_text, mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb, "run_command", return_value=failed_run
+        ):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(self.root / "run-error-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "exited with code 17") as caught:
+                lifecycle.run_sample(
+                    8,
+                    1,
+                    1,
+                    1,
+                    self.root / "run-error-repeat",
+                    "ignored",
+                    {},
+                )
+            lifecycle.close_profile(primary_error=caught.exception)
+
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.assertIn("clean.error.txt", [Path(call.args[0]).name for call in write_text.call_args_list])
+
+    def test_local_ydb_profile_lifecycle_attempts_all_cleanup_steps_and_only_cleanup_error_fails(self):
+        definition, workload = self._synthetic_profile_workload(("clean", "vacuum"))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = (
+            OSError("clean failed"),
+            self._local_ydb_command_result(("ydb", "synthetic", "vacuum")),
+        )
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(local_ydb, "atomic_write_json"):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(self.root / "cleanup-error-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "clean failed"):
+                lifecycle.close_profile()
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+
+    def test_local_ydb_profile_lifecycle_runs_cleanup_when_progress_fails(self):
+        class FailingCleanupProgress(list):
+            def append(self, item):
+                if item["phase"].startswith("cleaning-"):
+                    raise OSError("cleanup progress failed")
+                super().append(item)
+
+        definition, workload = self._synthetic_profile_workload(("clean", "vacuum"))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        progress = FailingCleanupProgress()
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ), mock.patch.object(local_ydb, "atomic_write_json"):
+            lifecycle = self._synthetic_workload_lifecycle(workload, cluster, progress)
+            lifecycle.open_profile(self.root / "cleanup-progress-error-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkError, "cleanup progress failed"):
+                lifecycle.close_profile()
+
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+
+    def test_local_ydb_profile_lifecycle_cancellation_cleanup_ignores_cancel_event(self):
+        definition, workload = self._synthetic_profile_workload()
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        progress = []
+        interrupted = self._local_ydb_command_result(("ydb", "synthetic", "run"), interrupted=True)
+        cancel_event = threading.Event()
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "LinuxCpuMonitor",
+            return_value=monitor,
+        ), mock.patch.object(local_ydb, "atomic_write_text"), mock.patch.object(
+            local_ydb,
+            "atomic_write_json",
+        ), mock.patch.object(
+            local_ydb, "run_command", return_value=interrupted
+        ):
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+                cancel_event,
+            )
+            lifecycle.open_profile(self.root / "cancel-profile", "tpcc-dataset")
+            with self.assertRaisesRegex(BenchmarkInterrupted, "was interrupted") as caught:
+                lifecycle.run_sample(
+                    8,
+                    1,
+                    1,
+                    1,
+                    self.root / "cancel-repeat",
+                    "ignored",
+                    {},
+                )
+            cancel_event.set()
+            lifecycle.close_profile(primary_error=caught.exception)
+
+        self.assertEqual(cluster._run.call_count, 1)
+        self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
+
+    def test_local_ydb_profile_lifecycle_cleanup_artifact_failures_do_not_mask_primary(self):
+        definition, workload = self._synthetic_profile_workload(("clean", "vacuum"))
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+        )
+        cluster.init_workload.side_effect = lambda command, timeout: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        progress = []
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {definition.name: definition}), mock.patch.object(
+            local_ydb,
+            "atomic_write_text",
+        ) as write_text, mock.patch.object(local_ydb, "atomic_write_json") as write_json:
+            lifecycle = self._synthetic_workload_lifecycle(
+                workload,
+                cluster,
+                progress,
+            )
+            lifecycle.open_profile(self.root / "artifact-error-profile", "tpcc-dataset")
+            primary = BenchmarkInterrupted("cancelled")
+            write_text.side_effect = OSError("text write failed")
+            write_json.side_effect = OSError("json write failed")
+            lifecycle.close_profile(primary_error=primary)
+
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+
+    def test_local_ydb_unexpected_profile_error_cleans_before_terminal_failure(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              unexpected-failure:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        definition = replace(local_ydb_workloads.workload_definition("kv"), dataset_scope="profile")
+
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(OSError, "measurement failed"):
+                self._run_mock_local_ydb(
+                    configuration,
+                    "unexpected-profile-error",
+                    [OSError("measurement failed")],
+                )
+
+        manifest = json.loads((self.root / "unexpected-profile-error" / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["status"], "failed")
+        self.assertEqual(manifest["state"], "failed")
+        self.assertEqual(manifest["progress"]["phase"], "failed")
+        self.assertEqual(self.last_local_ydb_cluster._run.call_count, 1)
+        cleanup = self.last_local_ydb_cluster._run.call_args
+        self.assertIn("clean", cleanup.args[0])
+        self.assertTrue(cleanup.kwargs["ignore_cancellation"])
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
+
+    def test_local_ydb_cancelled_during_cleanup_never_publishes_success(self):
+        configuration = load_config(self._config("""
+            local-ydb:
+              cleanup-cancellation:
+                workload: {type: kv, operation: upsert}
+                load: {parameter: rate, values: [10]}
+                measurement: {warmup: 0, duration: 1, repetitions: 1}
+                affinity:
+                  ydb-cli: {mode: none}
+                  static-nodes: {mode: none}
+                  dynamic-nodes: {mode: none}
+        """)).runs[0]
+        cancel_event = threading.Event()
+
+        with self.assertRaisesRegex(BenchmarkInterrupted, "was cancelled"):
+            self._run_mock_local_ydb(
+                configuration,
+                "cleanup-cancellation",
+                [{"throughput": 10}],
+                cancel_event=cancel_event,
+                cleanup_action=cancel_event.set,
+            )
+
+        manifest = json.loads((self.root / "cleanup-cancellation" / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["status"], "interrupted")
+        self.assertEqual(manifest["state"], "cancelled")
+        self.assertEqual(manifest["progress"]["phase"], "cancelled")
+        self.assertEqual(self.last_local_ydb_cluster._run.call_count, 1)
+        self.assertTrue(self.last_local_ydb_cluster._run.call_args.kwargs["ignore_cancellation"])
+        self.last_local_ydb_cluster.stop.assert_called_once_with()
+
+    def test_local_ydb_cleanup_plan_uses_cluster_configuration_timeout(self):
+        cluster = local_ydb.LocalYdbCluster(
+            self.root / "ydbd",
+            self.root / "ydb",
+            self.root / "process_guard",
+            self.root / "cluster-timeout",
+            {"static_nodes": 1, "dynamic_nodes": 1},
+            {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+            73,
+        )
+        cli_context = local_ydb_workloads.WorkloadCli(cluster.ydb_cli, "grpc://host:2135", cluster.database)
+        plan = local_ydb_workloads.build_cleanup_plan(
+            cli_context,
+            "table-prefix",
+            {"type": "kv"},
+        )[0]
+        result = self._local_ydb_command_result(plan.argv)
+        with mock.patch.object(local_ydb, "run_command", return_value=result) as execute:
+            cluster._run(plan.argv, timeout=plan.timeout_seconds, ignore_cancellation=True)
+
+        self.assertIsNone(plan.timeout_seconds)
+        self.assertEqual(execute.call_args.args[2], 73)
 
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""
@@ -858,7 +1594,7 @@ class YdbBenchTest(unittest.TestCase):
             static_pids=(10,),
             dynamic_pids=(20,),
         )
-        cluster.init_workload.side_effect = lambda command: (
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
             command_result(command),
             [command_result(command)],
         )
@@ -1444,6 +2180,41 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(summary["dynamic_cpu_max"], 30.0)
         self.assertAlmostEqual(summary["host_cpu_mean"], (10 + 60 + 1) / 2.01)
         self.assertEqual(summary["host_cpu_max"], 40.0)
+
+    def test_linux_cpu_summary_filters_complete_intervals_inside_measurement_window(self):
+        monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1}, interval=0.5)
+        monitor._records = [
+            {"elapsed_seconds": 1.0, "timestamp_unix": 101.0, "dynamic_cpu": 10.0, "host_cpu": 15.0},
+            {"elapsed_seconds": 1.0, "timestamp_unix": 102.0, "dynamic_cpu": 20.0, "host_cpu": 25.0},
+            {"elapsed_seconds": 1.0, "timestamp_unix": 103.0, "dynamic_cpu": 30.0, "host_cpu": 35.0},
+            {"elapsed_seconds": 1.0, "timestamp_unix": 104.0, "dynamic_cpu": 40.0, "host_cpu": 45.0},
+        ]
+        summary = monitor.summary(started_at_unix=101.0, finished_at_unix=103.0)
+        self.assertEqual(summary["dynamic_cpu_mean"], 25.0)
+        self.assertEqual(summary["dynamic_cpu_max"], 30.0)
+        self.assertEqual(summary["host_cpu_mean"], 30.0)
+        self.assertEqual(summary["host_cpu_max"], 35.0)
+
+    def test_linux_cpu_summary_rejects_invalid_or_empty_measurement_window(self):
+        monitor = linux_telemetry.LinuxCpuMonitor({"dynamic": lambda: ()}, {"dynamic": 1})
+        monitor._records = [
+            {"elapsed_seconds": 1.0, "timestamp_unix": 101.0, "dynamic_cpu": 10.0, "host_cpu": 15.0},
+        ]
+        for start, finish in (
+            (100.0, None),
+            (101.0, 101.0),
+            (float("nan"), 102.0),
+            (True, 102.0),
+            (10**1000, 10**1000 + 1),
+        ):
+            with self.subTest(start=start, finish=finish), self.assertRaisesRegex(BenchmarkError, "CPU measurement"):
+                monitor.summary(started_at_unix=start, finished_at_unix=finish)
+        with self.assertRaisesRegex(BenchmarkError, "does not contain"):
+            monitor.summary(started_at_unix=102.0, finished_at_unix=103.0)
+
+        default_summary = monitor.summary()
+        self.assertEqual(default_summary["dynamic_cpu_mean"], 10.0)
+        self.assertEqual(default_summary["host_cpu_mean"], 15.0)
 
     def test_local_ydb_attempt_aggregates_errors_across_repetitions(self):
         metrics = local_ydb._aggregate_measurements(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added an extensible local YDB workload registry with lifecycle hooks, Log workload support, and geometry-scoped datasets.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Workload definitions own setup, execution, parsing, cleanup, and dataset identity. Empty or invalid samples are rejected before they can affect search decisions.