### PR TITLE
ydb-bench: add a local TPCC workload

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -15,7 +15,7 @@ The tool provides four benchmarks:
 - `star-ping-bench`: star-topology actor ping throughput.
 - `memory-bandwidth-bench`: mixed sequential-copy and random copy/write memory workload.
 - `local-ydb`: a local static/dynamic YDB cluster driven by the `kv`, `stock`,
-  or `log` YDB CLI workload.
+  `log`, or `tpcc` YDB CLI workload.
 
 Inspect them and print the standard JSON Schema for the YAML configuration:
 
@@ -154,6 +154,25 @@ For example:
         max-errors: 0
         min-achieved-rate-ratio: 0.98
 ```
+
+TPC-C uses `load.parameter: max-sessions`, which maps to the CLI
+`--max-sessions` limit and must not exceed `warehouses * 10`. The benchmark
+runs `tpcc init` and `tpcc import` once for each dynamic-node geometry, reuses
+that dataset for every search and verification sample at the geometry, then
+runs both `tpcc clean` and recursive `scheme rmdir` cleanup. `client.threads`
+maps to the TPC-C runner's `--threads`; it defaults to 2, while
+`import-threads: 0` asks the CLI to select import concurrency automatically.
+
+TPC-C warmup is inline. The CLI receives the explicit value
+`max(measurement.warmup, floor(warehouses / 10) + 1)` so terminal startup is
+complete before measurement; YAML `warmup: 0` requests that minimum rather
+than the CLI's adaptive warmup. Measurement duration must be at least two
+seconds. Canonical throughput is uncapped successful NewOrder transactions per
+measured second. The CLI-reported, warehouse-capped `tpmC` remains available as
+the separate `tpcc_tpmc` metric. Latency SLOs use the full latency (including
+inflight queue wait) of `latency-transaction`, with `p50`, `p90`, `p95`, `p99`,
+and `p999` available. See `examples/local-ydb-tpcc.yaml` for a small manual
+smoke configuration.
 
 Set `load.allow-errors: true` when request-level errors reported by
 `ydb workload` are an expected part of the experiment. Such points remain

--- a/ydb/tools/ydb_bench/examples/local-ydb-tpcc.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-tpcc.yaml
@@ -1,0 +1,35 @@
+local-ydb:
+  tpcc-smoke:
+    workload:
+      type: tpcc
+      operation: run
+      options:
+        warehouses: 1
+        import-threads: 1
+        compact: false
+        tx-mode: serializable-rw
+        latency-transaction: NewOrder
+        no-delays: true
+        highres-histogram: false
+    geometry:
+      preset: single
+      static-nodes: 1
+      disk-size-gb: 64
+      storage-groups: 1
+    client:
+      threads: 2
+    load:
+      parameter: max-sessions
+      values: [1]
+    measurement:
+      warmup: 0
+      duration: 2
+      repetitions: 1
+      verification-repetitions: 0
+    affinity:
+      ydb-cli:
+        mode: none
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -17,6 +17,9 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     all_load_parameters,
     all_slo_percentiles,
     normalize_workload,
+    validate_workload_profile,
+    workload_definition,
+    workload_effective_warmup_seconds,
     workload_config_schema,
 )
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
@@ -550,7 +553,10 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     }
 
     client = _mapping(value.get("client"), location + ".client", ("threads",))
-    client_threads = _positive_integer(client.get("threads", 64), location + ".client.threads")
+    client_threads = _positive_integer(
+        client.get("threads", workload_definition(workload["type"]).default_client_threads),
+        location + ".client.threads",
+    )
 
     load = _mapping(
         value.get("load"),
@@ -769,6 +775,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         "repetitions": _positive_integer(measurement.get("repetitions", 3), location + ".measurement.repetitions"),
         "verification_repetitions": verification_repetitions,
     }
+    validate_workload_profile(workload, load_config, measurement_config, location)
 
     affinity = _mapping(value.get("affinity"), location + ".affinity", ("ydb-cli", "static-nodes", "dynamic-nodes"))
     affinity_config = {
@@ -786,7 +793,8 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
 
     attempts = len(load_config.get("values", ())) or 64
     measurement_runs = attempts * measurement_config["repetitions"] + measurement_config["verification_repetitions"]
-    computed_timeout = 300 + measurement_runs * (measurement_config["warmup"] + measurement_config["duration"] + 10)
+    effective_warmup = workload_effective_warmup_seconds(workload, measurement_config["warmup"])
+    computed_timeout = 300 + measurement_runs * (effective_warmup + measurement_config["duration"] + 10)
     timeout_explicit = "timeout" in value
     timeout = _timeout(value.get("timeout", computed_timeout), location + ".timeout")
     return RunConfiguration(

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -37,6 +37,7 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     build_run_plan,
     parse_workload_result,
     workload_definition,
+    workload_effective_warmup_seconds,
     workload_result_schema,
 )
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
@@ -1120,7 +1121,8 @@ class WorkloadLifecycle:
 
     def _run_workload(self, state, load, dynamic_nodes, repetition, commands):
         phases = self._phases(state.purpose)
-        warmup = self.measurement["warmup"]
+        configured_warmup = self.measurement["warmup"]
+        warmup = workload_effective_warmup_seconds(self.workload, configured_warmup)
         if warmup and self.definition.warmup_mode == "separate":
             warmup_plan = build_run_plan(
                 self.workload_cli,
@@ -1198,6 +1200,8 @@ class WorkloadLifecycle:
             }
             if self.definition.warmup_mode == "inline":
                 progress_fields["inline_warmup_seconds"] = warmup
+                if warmup != configured_warmup:
+                    progress_fields["configured_warmup_seconds"] = configured_warmup
             self.progress(phases["measure"], **progress_fields)
             result = run_command(
                 plan.argv,

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,5 +1,6 @@
 """Declarative local-YDB workload catalog and YDB CLI command builders."""
 
+import json
 import math
 import re
 from dataclasses import dataclass
@@ -128,6 +129,225 @@ GENERIC_TOTAL_RESULT = WorkloadResultAdapter(
     ),
 )
 
+_TPCC_TRANSACTION_NAMES = ("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")
+_TPCC_PERCENTILES = (
+    ("50", "p50_ms"),
+    ("90", "p90_ms"),
+    ("95", "p95_ms"),
+    ("99", "p99_ms"),
+    ("99.9", "p999_ms"),
+)
+_TPCC_SLO_METRICS = (
+    ("p50", "p50_ms"),
+    ("p90", "p90_ms"),
+    ("p95", "p95_ms"),
+    ("p99", "p99_ms"),
+    ("p999", "p999_ms"),
+)
+_TPCC_TERMINALS_PER_WAREHOUSE = 10
+_TPCC_MIN_WARMUP_PER_TERMINAL_MS = 10
+_TPCC_JSON_MAX_BYTES = 1024 * 1024
+
+
+def _tpcc_result_error(message):
+    raise BenchmarkError("YDB CLI TPCC JSON output {}".format(message))
+
+
+def _tpcc_exact_mapping(value, location, fields):
+    if not isinstance(value, dict):
+        _tpcc_result_error("field {} must be an object".format(location))
+    missing = sorted(set(fields) - set(value))
+    unknown = sorted(set(value) - set(fields))
+    if missing:
+        _tpcc_result_error("field {} is missing: {}".format(location, ", ".join(missing)))
+    if unknown:
+        _tpcc_result_error("field {} contains unknown fields: {}".format(location, ", ".join(unknown)))
+    return value
+
+
+def _tpcc_integer(value, location, minimum=0):
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        _tpcc_result_error("field {} must be an integer not below {}".format(location, minimum))
+    return value
+
+
+def _tpcc_number(value, location, minimum=0, maximum=None):
+    if not _is_finite_number(value) or value < minimum or (maximum is not None and value > maximum):
+        bounds = "not below {}".format(minimum)
+        if maximum is not None:
+            bounds += " and not above {}".format(maximum)
+        _tpcc_result_error("field {} must be a finite number {}".format(location, bounds))
+    return float(value)
+
+
+def _tpcc_percentile_values(value, location):
+    value = _tpcc_exact_mapping(value, location, tuple(name for name, _metric in _TPCC_PERCENTILES))
+    parsed = [_tpcc_integer(value[name], "{}.{}".format(location, name)) for name, _metric in _TPCC_PERCENTILES]
+    if parsed != sorted(parsed):
+        _tpcc_result_error("field {} must contain monotonic percentiles".format(location))
+    return parsed
+
+
+def _tpcc_effective_warmup_seconds(workload, requested_seconds):
+    warehouses = workload["options"]["warehouses"]
+    terminals = warehouses * _TPCC_TERMINALS_PER_WAREHOUSE
+    minimum = terminals * _TPCC_MIN_WARMUP_PER_TERMINAL_MS // 1000 + 1
+    return max(requested_seconds, minimum)
+
+
+def _parse_tpcc_json_result(command_result, normalized_workload, request):
+    stdout = command_result.stdout
+    if not isinstance(stdout, str) or len(stdout.encode("utf-8")) > _TPCC_JSON_MAX_BYTES:
+        _tpcc_result_error("is empty or exceeds {} bytes".format(_TPCC_JSON_MAX_BYTES))
+    try:
+        root = json.loads(stdout)
+    except (TypeError, ValueError) as error:
+        raise BenchmarkError("YDB CLI TPCC JSON output is malformed: {}".format(error)) from error
+    if isinstance(root, dict) and set(root) == {"error"} and isinstance(root["error"], str):
+        _tpcc_result_error("reported a fatal error: {}".format(root["error"]))
+    root = _tpcc_exact_mapping(root, "$", ("summary", "transactions"))
+    summary = _tpcc_exact_mapping(
+        root["summary"],
+        "summary",
+        (
+            "name",
+            "time_seconds",
+            "measure_start_ts",
+            "warehouses",
+            "new_orders",
+            "tpmc",
+            "efficiency",
+            "max_sessions",
+            "threads",
+            "warmup_seconds",
+        ),
+    )
+    if summary["name"] != "Total":
+        _tpcc_result_error("field summary.name must equal Total")
+    measured_seconds = _tpcc_integer(summary["time_seconds"], "summary.time_seconds", 1)
+    measurement_started_at = _tpcc_integer(summary["measure_start_ts"], "summary.measure_start_ts", 1)
+    warehouses = _tpcc_integer(summary["warehouses"], "summary.warehouses", 1)
+    new_orders = _tpcc_integer(summary["new_orders"], "summary.new_orders")
+    tpcc_tpmc = _tpcc_number(summary["tpmc"], "summary.tpmc")
+    efficiency = _tpcc_number(summary["efficiency"], "summary.efficiency", maximum=100)
+    max_sessions = _tpcc_integer(summary["max_sessions"], "summary.max_sessions", 1)
+    _tpcc_integer(summary["threads"], "summary.threads", 1)
+    warmup_seconds = _tpcc_integer(summary["warmup_seconds"], "summary.warmup_seconds", 1)
+
+    options = normalized_workload["options"]
+    expected_warmup = _tpcc_effective_warmup_seconds(normalized_workload, request.warmup_seconds)
+    if warehouses != options["warehouses"]:
+        _tpcc_result_error("field summary.warehouses does not match the configured warehouses")
+    if max_sessions != request.load:
+        _tpcc_result_error("field summary.max_sessions does not match the requested load")
+    if warmup_seconds != expected_warmup:
+        _tpcc_result_error("field summary.warmup_seconds does not match the effective warmup")
+    if measured_seconds < request.duration_seconds or measured_seconds > request.duration_seconds + 60:
+        _tpcc_result_error("field summary.time_seconds is outside the requested measurement window")
+
+    transactions = _tpcc_exact_mapping(root["transactions"], "transactions", _TPCC_TRANSACTION_NAMES)
+    parsed_transactions = {}
+    transaction_fields = ("ok_count", "failed_count", "percentiles", "percentiles_ms", "percentiles_pure")
+    for transaction_name in _TPCC_TRANSACTION_NAMES:
+        location = "transactions.{}".format(transaction_name)
+        transaction = _tpcc_exact_mapping(transactions[transaction_name], location, transaction_fields)
+        ok_count = _tpcc_integer(transaction["ok_count"], location + ".ok_count")
+        percentile_families = {
+            field: _tpcc_percentile_values(transaction[field], location + "." + field)
+            for field in ("percentiles", "percentiles_ms", "percentiles_pure")
+        }
+        if ok_count == 0 and any(any(values) for values in percentile_families.values()):
+            _tpcc_result_error("field {} percentiles must be zero without successful transactions".format(location))
+        if ok_count > 0 and any(any(value < 1 for value in values) for values in percentile_families.values()):
+            _tpcc_result_error("field {} percentiles must be positive with successful transactions".format(location))
+        parsed_transactions[transaction_name] = {
+            "ok_count": ok_count,
+            "failed_count": _tpcc_integer(transaction["failed_count"], location + ".failed_count"),
+            "percentiles": percentile_families["percentiles"],
+        }
+    if new_orders != parsed_transactions["NewOrder"]["ok_count"]:
+        _tpcc_result_error("field summary.new_orders does not match transactions.NewOrder.ok_count")
+
+    latency_transaction = options["latency-transaction"]
+    selected = parsed_transactions[latency_transaction]
+    metrics = {
+        "transactions": selected["ok_count"] if new_orders > 0 else 0,
+        "new_orders": new_orders,
+        "throughput": new_orders / measured_seconds,
+        "tpcc_tpmc": tpcc_tpmc,
+        "efficiency_pct": efficiency,
+        "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
+    }
+    metrics.update(
+        {metric_name: value for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles"])}
+    )
+    return WorkloadResult(
+        metrics,
+        details=root,
+        measurement_window=(
+            float(measurement_started_at + 1),
+            float(measurement_started_at + request.duration_seconds),
+        ),
+    )
+
+
+TPCC_JSON_RESULT = WorkloadResultAdapter(
+    schema_id="tpcc-json-v1",
+    parse=_parse_tpcc_json_result,
+    metrics=(
+        WorkloadMetric(
+            "transactions",
+            "successful transactions",
+            required=True,
+            description=(
+                "Successful selected-transaction samples used for latency percentiles; zero when no NewOrder "
+                "transaction succeeded"
+            ),
+        ),
+        WorkloadMetric(
+            "new_orders",
+            "new orders",
+            required=True,
+            description="Successful NewOrder transactions in the measurement window",
+        ),
+        WorkloadMetric(
+            "throughput",
+            "new orders/s",
+            required=True,
+            description="Successful NewOrder transactions divided by measured seconds",
+        ),
+        WorkloadMetric(
+            "tpcc_tpmc",
+            "tpmC",
+            required=True,
+            description="CLI-reported capped TPC-C tpmC",
+        ),
+        WorkloadMetric(
+            "efficiency_pct",
+            "%",
+            required=True,
+            description="CLI-reported TPC-C efficiency",
+        ),
+        WorkloadMetric(
+            "errors",
+            "failed transactions",
+            repetition_aggregation="sum",
+            required=True,
+            description="Failed transactions across all TPC-C transaction types",
+        ),
+        *(
+            WorkloadMetric(
+                metric_name,
+                "ms",
+                required=True,
+                description="Full selected-transaction latency including inflight queue wait",
+            )
+            for _percentile, metric_name in _TPCC_PERCENTILES
+        ),
+    ),
+    slo_metrics=_TPCC_SLO_METRICS,
+)
+
 _RESERVED_RESULT_METRIC_NAMES = frozenset(
     (
         "load",
@@ -231,6 +451,11 @@ class WorkloadDefinition:
     cleanup_plan_builder: object = None
     result_adapter: WorkloadResultAdapter = GENERIC_TOTAL_RESULT
     throughput_unit: str = "operations/s"
+    profile_validator: object = None
+    effective_warmup_builder: object = None
+    minimum_duration_seconds: int = 1
+    load_limits: tuple = ()
+    default_client_threads: int = 64
 
 
 def _config_error(location, message):
@@ -257,13 +482,18 @@ def _mapping(value, location, allowed=()):
     return value
 
 
-def _workload_base(cli, definition, path):
-    command = [
+def _cli_base(cli):
+    return [
         cli.executable,
         "--endpoint",
         cli.endpoint,
         "--database",
         cli.database,
+    ]
+
+
+def _workload_base(cli, definition, path):
+    command = _cli_base(cli) + [
         "workload",
         definition.name,
     ]
@@ -423,6 +653,114 @@ def _log_run_builder(cli, definition, path, workload, load_parameter, load, seco
     ]
 
 
+def _tpcc_init_builder(cli, definition, path, workload):
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--warehouses",
+        workload["options"]["warehouses"],
+    ]
+
+
+def _tpcc_run_command(cli, definition, path, workload, load, seconds, client_threads, warmup_seconds):
+    options = workload["options"]
+    effective_warmup = _tpcc_effective_warmup_seconds(workload, warmup_seconds)
+    command = _workload_base(cli, definition, path) + [
+        "run",
+        "--warehouses",
+        options["warehouses"],
+        "--warmup",
+        "{}s".format(effective_warmup),
+        "--time",
+        "{}s".format(seconds),
+        "--max-sessions",
+        load,
+        "--threads",
+        client_threads,
+        "--format",
+        "Json",
+        "--no-tui",
+        "--tx-mode",
+        options["tx-mode"],
+    ]
+    if options["no-delays"]:
+        command.append("--no-delays")
+    if options["highres-histogram"]:
+        command.append("--highres-histogram")
+    return command
+
+
+def _tpcc_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del load_parameter
+    return _tpcc_run_command(cli, definition, path, workload, load, seconds, client_threads, 0)
+
+
+def _tpcc_prepare_plan_builder(cli, definition, path, workload):
+    options = workload["options"]
+    import_command = _workload_base(cli, definition, path) + [
+        "import",
+        "--warehouses",
+        options["warehouses"],
+        "--threads",
+        options["import-threads"],
+        "--no-tui",
+    ]
+    if options["compact"]:
+        import_command.append("--compact")
+    return (
+        WorkloadCommandPlan("init", tuple(_tpcc_init_builder(cli, definition, path, workload)), 120),
+        WorkloadCommandPlan(
+            "import",
+            tuple(import_command),
+            max(600, options["warehouses"] * 60),
+        ),
+    )
+
+
+def _tpcc_run_plan_builder(
+    cli,
+    definition,
+    path,
+    workload,
+    load_parameter,
+    load,
+    seconds,
+    client_threads,
+    warmup_seconds,
+):
+    del load_parameter
+    effective_warmup = _tpcc_effective_warmup_seconds(workload, warmup_seconds)
+    return WorkloadCommandPlan(
+        "run",
+        tuple(
+            _tpcc_run_command(
+                cli,
+                definition,
+                path,
+                workload,
+                load,
+                seconds,
+                client_threads,
+                effective_warmup,
+            )
+        ),
+        effective_warmup + seconds + 60,
+        progress_duration_seconds=effective_warmup + seconds,
+    )
+
+
+def _tpcc_cleanup_plan_builder(cli, definition, path, workload):
+    del workload
+    full_path = path if str(path).startswith("/") else cli.database.rstrip("/") + "/" + str(path).lstrip("/")
+    return (
+        WorkloadCommandPlan("clean", tuple(_workload_base(cli, definition, path) + ["clean"]), 300),
+        WorkloadCommandPlan(
+            "rmdir",
+            tuple(_cli_base(cli) + ["scheme", "rmdir", "--recursive", "--force", full_path]),
+            300,
+        ),
+    )
+
+
 def _validate_kv_options(options, location):
     if options["max-partitions"] < options["min-partitions"]:
         _config_error(location + ".max-partitions", "must not be below min-partitions")
@@ -440,6 +778,29 @@ def _validate_log_options(options, location):
     columns = options["integer-columns"] + options["string-columns"]
     if options["key-columns"] > columns:
         _config_error(location + ".key-columns", "must not exceed integer-columns plus string-columns")
+
+
+def _validate_tpcc_options(options, location):
+    del options, location
+
+
+def _validate_tpcc_profile(workload, load, measurement, location):
+    maximum_sessions = workload["options"]["warehouses"] * _TPCC_TERMINALS_PER_WAREHOUSE
+    if "values" in load:
+        for index, value in enumerate(load["values"]):
+            if value > maximum_sessions:
+                _config_error(
+                    "{}.load.values[{}]".format(location, index),
+                    "must not exceed warehouses * 10 ({})".format(maximum_sessions),
+                )
+    else:
+        for name in ("start", "maximum"):
+            value = load["search"][name]
+            if value > maximum_sessions:
+                _config_error(
+                    "{}.load.search.{}".format(location, name),
+                    "must not exceed warehouses * 10 ({})".format(maximum_sessions),
+                )
 
 
 def _validate_option_value(option, value, location):
@@ -572,12 +933,30 @@ def _validate_catalog(definitions):
             raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
         if definition.warmup_mode not in ("separate", "inline"):
             raise ValueError("unknown warmup mode for {}: {}".format(definition.name, definition.warmup_mode))
-        for name in ("prepare_plan_builder", "run_plan_builder", "cleanup_plan_builder"):
+        for name in (
+            "prepare_plan_builder",
+            "run_plan_builder",
+            "cleanup_plan_builder",
+            "profile_validator",
+            "effective_warmup_builder",
+        ):
             builder = getattr(definition, name)
             if builder is not None and not callable(builder):
                 raise ValueError("{} must be callable for {}".format(name, definition.name))
         if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
             raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
+        if (
+            isinstance(definition.minimum_duration_seconds, bool)
+            or not isinstance(definition.minimum_duration_seconds, int)
+            or definition.minimum_duration_seconds <= 0
+        ):
+            raise ValueError("minimum duration must be a positive integer for {}".format(definition.name))
+        if (
+            isinstance(definition.default_client_threads, bool)
+            or not isinstance(definition.default_client_threads, int)
+            or definition.default_client_threads <= 0
+        ):
+            raise ValueError("default client threads must be a positive integer for {}".format(definition.name))
         if len(definition.operations) != len(set(definition.operations)):
             raise ValueError("operations must be unique for {}".format(definition.name))
         if len(definition.load_parameters) != len(set(definition.load_parameters)):
@@ -587,6 +966,29 @@ def _validate_catalog(definitions):
         option_names = [option.name for option in definition.options]
         if len(option_names) != len(set(option_names)):
             raise ValueError("option names must be unique for {}".format(definition.name))
+        if not isinstance(definition.load_limits, tuple):
+            raise ValueError("load limits must be a tuple for {}".format(definition.name))
+        limited_parameters = []
+        for limit in definition.load_limits:
+            limit_option = (
+                next((option for option in definition.options if option.name == limit[1]), None)
+                if isinstance(limit, tuple) and len(limit) == 3
+                else None
+            )
+            if (
+                not isinstance(limit, tuple)
+                or len(limit) != 3
+                or limit[0] not in definition.load_parameters
+                or limit_option is None
+                or limit_option.kind != "integer"
+                or isinstance(limit[2], bool)
+                or not isinstance(limit[2], int)
+                or limit[2] <= 0
+            ):
+                raise ValueError("invalid load limit for {}".format(definition.name))
+            limited_parameters.append(limit[0])
+        if len(limited_parameters) != len(set(limited_parameters)):
+            raise ValueError("load limits must be unique for {}".format(definition.name))
         for option in definition.options:
             if option.kind not in ("integer", "string", "boolean", "duration"):
                 raise ValueError("unknown workload option kind: {}".format(option.kind))
@@ -707,6 +1109,48 @@ _DEFINITIONS = (
         warmup_mode="separate",
         throughput_unit="batches/s",
     ),
+    WorkloadDefinition(
+        name="tpcc",
+        default_operation="run",
+        operations=("run",),
+        load_parameters=("max-sessions",),
+        options=(
+            WorkloadOption("warehouses", 10),
+            WorkloadOption("import-threads", 0, allow_zero=True),
+            WorkloadOption("compact", False, kind="boolean"),
+            WorkloadOption(
+                "tx-mode",
+                "serializable-rw",
+                kind="string",
+                choices=("serializable-rw", "snapshot-rw"),
+            ),
+            WorkloadOption(
+                "latency-transaction",
+                "NewOrder",
+                kind="string",
+                choices=_TPCC_TRANSACTION_NAMES,
+            ),
+            WorkloadOption("no-delays", False, kind="boolean"),
+            WorkloadOption("highres-histogram", False, kind="boolean"),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_tpcc_init_builder,
+        run_builder=_tpcc_run_builder,
+        options_validator=_validate_tpcc_options,
+        dataset_scope="geometry",
+        warmup_mode="inline",
+        prepare_plan_builder=_tpcc_prepare_plan_builder,
+        run_plan_builder=_tpcc_run_plan_builder,
+        cleanup_plan_builder=_tpcc_cleanup_plan_builder,
+        result_adapter=TPCC_JSON_RESULT,
+        throughput_unit="new orders/s",
+        profile_validator=_validate_tpcc_profile,
+        effective_warmup_builder=_tpcc_effective_warmup_seconds,
+        minimum_duration_seconds=2,
+        load_limits=(("max-sessions", "warehouses", _TPCC_TERMINALS_PER_WAREHOUSE),),
+        default_client_threads=2,
+    ),
 )
 _validate_catalog(_DEFINITIONS)
 _WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
@@ -807,6 +1251,12 @@ def web_workload_catalog():
             "slo_metrics": dict(definition.result_adapter.slo_metrics),
             "reports_errors": any(metric.name == "errors" for metric in definition.result_adapter.metrics),
             "result_schema_id": definition.result_adapter.schema_id,
+            "minimum_duration_seconds": definition.minimum_duration_seconds,
+            "default_client_threads": definition.default_client_threads,
+            "load_limits": {
+                parameter: {"option": option, "multiplier": multiplier}
+                for parameter, option, multiplier in definition.load_limits
+            },
             "options": [
                 {
                     "name": option.name,
@@ -848,6 +1298,33 @@ def all_slo_percentiles():
 
 def allowed_slo_metrics(workload_type):
     return dict(_definition(workload_type).result_adapter.slo_metrics)
+
+
+def validate_workload_profile(workload, load, measurement, location):
+    """Validate cross-field constraints owned by one workload definition."""
+
+    definition = _definition(workload["type"])
+    if measurement["duration"] < definition.minimum_duration_seconds:
+        _config_error(
+            location + ".measurement.duration",
+            "must be at least {} for {}".format(definition.minimum_duration_seconds, definition.name),
+        )
+    if definition.profile_validator is not None:
+        definition.profile_validator(workload, load, measurement, location)
+
+
+def workload_effective_warmup_seconds(workload, requested_seconds):
+    """Return the explicit warmup passed to the CLI for one workload run."""
+
+    if isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0:
+        raise BenchmarkError("workload warmup must be a non-negative integer")
+    definition = _definition(workload["type"])
+    if definition.effective_warmup_builder is None:
+        return requested_seconds
+    effective = definition.effective_warmup_builder(workload, requested_seconds)
+    if isinstance(effective, bool) or not isinstance(effective, int) or effective < requested_seconds:
+        raise BenchmarkError("{} returned an invalid effective warmup".format(definition.name))
+    return effective
 
 
 def build_init_argv(cli, path, workload):

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -239,17 +239,61 @@ _JS = (
     "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
     "function localYdbWorkloadDefinition(type){const definition=(editor.model?.local_ydb_workloads||[]).find(item=>item.type"
     "===type);if(!definition)throw Error('Unknown local YDB workload: '+type);return definition}\n"
-    "const localYdbLoadDefaults={rate:{values:[1000],start:1000,maximum:100000},threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}};\n"
-    "function localYdbResetLoadParameter(load,parameter){const defaults=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;"
-    "if(load.values)return {...load,parameter,values:[...defaults.values]};return {...load,parameter,search:{...(load.search||{}),start:defaults.start,maximum:defaults.maximum}}}\n"
-    "function localYdbLoadForWorkload(load,parameters){return parameters.includes(load.parameter)?load:localYdbResetLoadParameter(load,parameters[0])}\n"
+    """
+const localYdbLoadDefaults={
+  rate:{values:[1000],start:1000,maximum:100000},
+  threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256},
+  'max-sessions':{values:[1,2,4,8,16,32,64],start:1,maximum:100}
+};
+function localYdbLoadLimit(definition,workload,parameter){
+  const constraint=definition?.load_limits?.[parameter];
+  if(!constraint)return null;
+  const option=Number(workload?.options?.[constraint.option]),multiplier=Number(constraint.multiplier);
+  const limit=option*multiplier;
+  return Number.isSafeInteger(limit)&&limit>0?limit:null
+}
+function localYdbDefaultClientThreads(definition){
+  const value=Number(definition?.default_client_threads);
+  return Number.isSafeInteger(value)&&value>0?value:64
+}
+function localYdbParameterDefaults(parameter,definition=null,workload=null){
+  const source=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;
+  const limit=localYdbLoadLimit(definition,workload,parameter);
+  if(limit===null)return {...source,values:[...source.values]};
+  const values=[...new Set(source.values.map(value=>Math.min(value,limit)))].sort((left,right)=>left-right);
+  return {values,start:Math.min(source.start,limit),maximum:Math.min(source.maximum,limit)}
+}
+function localYdbClampLoad(load,definition=null,workload=null){
+  const limit=localYdbLoadLimit(definition,workload,load.parameter);
+  if(limit===null)return load;
+  if(load.values){
+    const values=[...new Set(load.values.map(value=>Math.min(Number(value),limit)))]
+      .filter(value=>Number.isSafeInteger(value)&&value>0).sort((left,right)=>left-right);
+    return {...load,values:values.length?values:[limit]}
+  }
+  const maximum=Math.min(Number(load.search.maximum),limit);
+  return {...load,search:{...load.search,start:Math.min(Number(load.search.start),maximum),maximum}}
+}
+function localYdbResetLoadParameter(load,parameter,definition=null,workload=null){
+  const defaults=localYdbParameterDefaults(parameter,definition,workload);
+  const reset=load.values?{...load,parameter,values:[...defaults.values]}:{
+    ...load,parameter,search:{...(load.search||{}),start:defaults.start,maximum:defaults.maximum}
+  };
+  return localYdbClampLoad(reset,definition,workload)
+}
+function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
+  const compatible=parameters.includes(load.parameter)?load:
+    localYdbResetLoadParameter(load,parameters[0],definition,workload);
+  return localYdbClampLoad(compatible,definition,workload)
+}
+"""
     "function defaultLocalYdbWorkload(type){const definition=localYdbWorkloadDefinition(type),operation=definition.default_"
     "operation,options=Object.fromEntries(definition.options.map(option=>[option.name,Object.prototype.hasOwnProperty.call("
     "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
     "ions}}\n"
-    "function defaultLocalYdb(){return {workload:defaultLocalYdbWorkload('kv'),"
+    "function defaultLocalYdb(){const definition=localYdbWorkloadDefinition('kv');return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
-    ":{threads:64},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
+    ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
     "etitions:3,verification_repetitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
@@ -455,7 +499,10 @@ function localYdbProfileEditor(profile){
     localField('local-client-threads','YDB CLI threads',config.client.threads,'','type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
     localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+
-    localField('local-measurement-duration','Duration (seconds)',measurement.duration,'','type=number min=1')+
+    localField(
+      'local-measurement-duration','Duration (seconds)',measurement.duration,'',
+      'type=number min='+(definition.minimum_duration_seconds||1)
+    )+
     localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+
     localField(
       'local-measurement-verification-repetitions','Verification repetitions',
@@ -511,13 +558,17 @@ function bindLocalYdbEditor(profile){
       config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
       const nextDefinition=localYdbWorkloadDefinition(event.target.value);
       const parameters=nextDefinition.load_parameters;
-      config.load=localYdbLoadForWorkload(config.load,parameters);
+      config.client.threads=localYdbDefaultClientThreads(nextDefinition);
+      config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload);
+      config.measurement.duration=Math.max(
+        config.measurement.duration,nextDefinition.minimum_duration_seconds||1
+      );
       if(!nextDefinition.reports_errors)config.load.allow_errors=false;
       if(config.load.objective?.type==='latency-slo'){
         const percentile=localYdbSloPercentile(nextDefinition,config.load.objective.percentile);
         if(percentile)config.load.objective.percentile=percentile;
         else{
-          const defaults=localYdbLoadDefaults[config.load.parameter]||localYdbLoadDefaults.threads;
+          const defaults=localYdbParameterDefaults(config.load.parameter,nextDefinition,config.workload);
           config.load={
             parameter:config.load.parameter,allow_errors:false,values:[...defaults.values]
           }
@@ -527,7 +578,9 @@ function bindLocalYdbEditor(profile){
     }
     if(event.target.id==='local-load-parameter'){
       const parameter=event.target.value;
-      if(parameter!==config.load.parameter)config.load=localYdbResetLoadParameter(config.load,parameter);
+      if(parameter!==config.load.parameter)config.load=localYdbResetLoadParameter(
+        config.load,parameter,localYdbWorkloadDefinition(config.workload.type),config.workload
+      );
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     if(event.target.id==='local-geometry-preset'){
@@ -543,7 +596,9 @@ function bindLocalYdbEditor(profile){
     }
     if(event.target.id==='local-load-mode'){
       const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);
-      const defaults=localYdbLoadDefaults[config.load.parameter]||localYdbLoadDefaults.threads;
+      const defaults=localYdbParameterDefaults(
+        config.load.parameter,localYdbWorkloadDefinition(config.workload.type),config.workload
+      );
       if(mode==='points'){
         config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[...defaults.values]}
       }else{
@@ -615,9 +670,10 @@ function bindLocalYdbEditor(profile){
         min_achieved_rate_ratio:localNumber('local-slo-min-achieved-rate-ratio',0)
       })
     }
+    config.load=localYdbClampLoad(config.load,workloadDefinition,config.workload);
     config.measurement={
       warmup:localInteger('local-measurement-warmup',0),
-      duration:localInteger('local-measurement-duration'),
+      duration:localInteger('local-measurement-duration',workloadDefinition.minimum_duration_seconds||1),
       repetitions:localInteger('local-measurement-repetitions'),
       verification_repetitions:localInteger('local-measurement-verification-repetitions',0,20)
     };
@@ -630,7 +686,11 @@ function bindLocalYdbEditor(profile){
     profile.threads=[config.client.threads];profile.duration=config.measurement.duration;
     profile.repetitions=1;profile.affinity=['roles'];profile.background_load=['none'];
     editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();
-    if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id))renderNew()
+    const loadLimitInputs=Object.values(workloadDefinition.load_limits||{}).map(
+      constraint=>'local-option-'+constraint.option
+    );
+    if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id)||
+      loadLimitInputs.includes(event.target.id))renderNew()
   }catch(error){message().innerHTML=displayError(error)}};
   for(const input of document.querySelectorAll('#local-editor input,#local-editor select'))input.onchange=update;
   document.querySelector('#delete-profile').onclick=()=>{
@@ -1465,6 +1525,7 @@ function localOutcomeLabel(outcome){
 }
 function localSearchAxisLabel(parameter,workload){
   if(parameter==='threads')return 'YDB CLI threads';
+  if(parameter==='max-sessions')return 'Maximum sessions';
   if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';
   return parameter||'Search value'
 }

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -278,6 +278,47 @@ class YdbBenchTest(unittest.TestCase):
         )
 
     @staticmethod
+    def _tpcc_result_payload(
+        warehouses=2,
+        max_sessions=20,
+        threads=2,
+        warmup_seconds=2,
+        time_seconds=12,
+        measure_start_ts=1000,
+        new_orders=120,
+        latency_transaction="Payment",
+        selected_ok=300,
+    ):
+        percentile_values = {"50": 1, "90": 2, "95": 3, "99": 4, "99.9": 5}
+        transactions = {}
+        for index, name in enumerate(("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")):
+            ok_count = new_orders if name == "NewOrder" else 100 + index
+            if name == latency_transaction:
+                ok_count = selected_ok
+            transactions[name] = {
+                "ok_count": ok_count,
+                "failed_count": index,
+                "percentiles": dict(percentile_values),
+                "percentiles_ms": dict(percentile_values),
+                "percentiles_pure": dict(percentile_values),
+            }
+        return {
+            "summary": {
+                "name": "Total",
+                "time_seconds": time_seconds,
+                "measure_start_ts": measure_start_ts,
+                "warehouses": warehouses,
+                "new_orders": transactions["NewOrder"]["ok_count"],
+                "tpmc": 25.5,
+                "efficiency": 80.25,
+                "max_sessions": max_sessions,
+                "threads": threads,
+                "warmup_seconds": warmup_seconds,
+            },
+            "transactions": transactions,
+        }
+
+    @staticmethod
     def _synthetic_profile_workload(
         cleanup_names=("clean",),
         measurement_window=(101.0, 109.0),
@@ -434,7 +475,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
 
         catalog = local_ydb_workloads.web_workload_catalog()
-        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log"])
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log", "tpcc"])
         self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
         self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
         self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
@@ -442,13 +483,24 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["operations"], ["insert", "upsert", "bulk-upsert"])
         self.assertEqual(catalog[2]["load_parameters"], ["threads"])
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
-        self.assertEqual([item["result_schema_id"] for item in catalog], ["generic-total-v1"] * 3)
+        self.assertEqual(
+            [item["result_schema_id"] for item in catalog],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v1"],
+        )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
-            ["requests/s", "transactions/s", "batches/s"],
+            ["requests/s", "transactions/s", "batches/s", "new orders/s"],
         )
         self.assertTrue(all(item["reports_errors"] for item in catalog))
         self.assertEqual(catalog[0]["slo_metrics"]["p99"], "p99_ms")
+        self.assertEqual(catalog[3]["load_parameters"], ["max-sessions"])
+        self.assertEqual(catalog[3]["slo_metrics"]["p999"], "p999_ms")
+        self.assertEqual(catalog[3]["default_client_threads"], 2)
+        self.assertEqual(catalog[3]["minimum_duration_seconds"], 2)
+        self.assertEqual(
+            catalog[3]["load_limits"],
+            {"max-sessions": {"option": "warehouses", "multiplier": 10}},
+        )
         catalog_parameters = tuple(
             dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
         )
@@ -485,7 +537,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(stock["options"]["orders"], 100)
 
         invalid = (
-            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log"),
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log, tpcc"),
             ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
             (
                 {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
@@ -503,6 +555,70 @@ class YdbBenchTest(unittest.TestCase):
         for workload, message in invalid:
             with self.subTest(workload=workload), self.assertRaisesRegex(BenchmarkError, message):
                 local_ydb_workloads.normalize_workload(workload, "local-ydb.profile.workload")
+
+    def test_local_ydb_tpcc_defaults_warmup_and_profile_validation(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              tpcc-smoke:
+                workload: {type: tpcc, operation: run}
+                load: {parameter: max-sessions, values: [1, 100]}
+                measurement: {warmup: 0, duration: 2, repetitions: 1}
+        """))
+        profile = loaded.runs[0].parameters["local_ydb"]
+        self.assertEqual(
+            profile["workload"]["options"],
+            {
+                "warehouses": 10,
+                "import-threads": 0,
+                "compact": False,
+                "tx-mode": "serializable-rw",
+                "latency-transaction": "NewOrder",
+                "no-delays": False,
+                "highres-histogram": False,
+            },
+        )
+        self.assertEqual(profile["client"]["threads"], 2)
+        self.assertEqual(profile["load"]["values"], [1, 100])
+        self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 0), 2)
+        self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 1), 2)
+        self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 7), 7)
+
+        invalid_profiles = (
+            (
+                """
+                local-ydb:
+                  invalid-tpcc:
+                    workload: {type: tpcc, operation: run}
+                    load: {parameter: max-sessions, values: [101]}
+                """,
+                "load.values\\[0\\].*warehouses \\* 10",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-tpcc:
+                    workload: {type: tpcc, operation: run}
+                    load:
+                      parameter: max-sessions
+                      search: {start: 1, maximum: 101}
+                      objective: {type: maximize-throughput}
+                """,
+                "load.search.maximum.*warehouses \\* 10",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-tpcc:
+                    workload: {type: tpcc, operation: run}
+                    load: {parameter: max-sessions, values: [1]}
+                    measurement: {duration: 1}
+                """,
+                "measurement.duration.*at least 2",
+            ),
+        )
+        for index, (body, message) in enumerate(invalid_profiles):
+            with self.subTest(index=index), self.assertRaisesRegex(BenchmarkError, message):
+                load_config(self._config(body, "invalid-tpcc-{}.yaml".format(index)))
 
     def test_local_ydb_workload_registry_supports_typed_options(self):
         definition = local_ydb_workloads.WorkloadDefinition(
@@ -738,6 +854,144 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
         self.assertIsNone(cleanup[0].timeout_seconds)
 
+    def test_local_ydb_tpcc_builds_golden_prepare_run_and_cleanup_plans(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {
+                    "warehouses": 12,
+                    "import-threads": 0,
+                    "compact": True,
+                    "tx-mode": "snapshot-rw",
+                    "latency-transaction": "Payment",
+                    "no-delays": True,
+                    "highres-histogram": True,
+                },
+            },
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "tpcc",
+            "--path",
+            "tpcc-dataset",
+        ]
+        prepare = local_ydb_workloads.build_prepare_plan(cli_context, "tpcc-dataset", workload)
+        self.assertEqual(
+            prepare,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    tuple(base + ["init", "--warehouses", 12]),
+                    120,
+                ),
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "import",
+                    tuple(
+                        base
+                        + [
+                            "import",
+                            "--warehouses",
+                            12,
+                            "--threads",
+                            0,
+                            "--no-tui",
+                            "--compact",
+                        ]
+                    ),
+                    720,
+                ),
+            ),
+        )
+
+        run = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "tpcc-dataset",
+            workload,
+            "max-sessions",
+            50,
+            30,
+            3,
+            warmup_seconds=0,
+        )
+        self.assertEqual(
+            run.argv,
+            tuple(
+                base
+                + [
+                    "run",
+                    "--warehouses",
+                    12,
+                    "--warmup",
+                    "2s",
+                    "--time",
+                    "30s",
+                    "--max-sessions",
+                    50,
+                    "--threads",
+                    3,
+                    "--format",
+                    "Json",
+                    "--no-tui",
+                    "--tx-mode",
+                    "snapshot-rw",
+                    "--no-delays",
+                    "--highres-histogram",
+                ]
+            ),
+        )
+        self.assertEqual(run.timeout_seconds, 92)
+        self.assertEqual(run.progress_duration_seconds, 32)
+        requested_warmup = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "tpcc-dataset",
+            workload,
+            "max-sessions",
+            50,
+            30,
+            3,
+            warmup_seconds=7,
+        )
+        self.assertEqual(requested_warmup.argv[requested_warmup.argv.index("--warmup") + 1], "7s")
+        self.assertEqual(requested_warmup.timeout_seconds, 97)
+
+        cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "tpcc-dataset", workload)
+        self.assertEqual(
+            cleanup,
+            (
+                local_ydb_workloads.WorkloadCommandPlan("clean", tuple(base + ["clean"]), 300),
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "rmdir",
+                    (
+                        Path("/tmp/ydb cli"),
+                        "--endpoint",
+                        "grpc://benchmark-host.example:2135",
+                        "--database",
+                        "/Root/bench",
+                        "scheme",
+                        "rmdir",
+                        "--recursive",
+                        "--force",
+                        "/Root/bench/tpcc-dataset",
+                    ),
+                    300,
+                ),
+            ),
+        )
+        absolute_cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "/Root/other", workload)
+        self.assertEqual(absolute_cleanup[1].argv[-1], "/Root/other")
+
     def test_local_ydb_workload_registry_validates_lifecycle_metadata_and_plans(self):
         definition = local_ydb_workloads.WorkloadDefinition(
             name="inline",
@@ -760,6 +1014,15 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="attempt"),))
         with self.assertRaisesRegex(ValueError, "inline warmup requires"):
             local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
+        with self.assertRaisesRegex(ValueError, "default client threads"):
+            local_ydb_workloads._validate_catalog((replace(definition, default_client_threads=0),))
+        string_limit = replace(
+            definition,
+            options=(local_ydb_workloads.WorkloadOption("scale", "auto", kind="string"),),
+            load_limits=(("sessions", "scale", 10),),
+        )
+        with self.assertRaisesRegex(ValueError, "invalid load limit"):
+            local_ydb_workloads._validate_catalog((string_limit,))
         with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": definition}):
             with self.assertRaisesRegex(BenchmarkError, "CPU measurement window"):
                 local_ydb_workloads.build_run_plan(
@@ -812,6 +1075,134 @@ class YdbBenchTest(unittest.TestCase):
                         1,
                         warmup_seconds=1,
                     )
+
+    def test_local_ydb_tpcc_geometry_lifecycle_reuses_dataset_and_cpu_window(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {
+                    "warehouses": 2,
+                    "latency-transaction": "Payment",
+                },
+            },
+            "workload",
+        )
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        monitor.summary.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        payload = self._tpcc_result_payload(
+            warehouses=2,
+            max_sessions=20,
+            threads=2,
+            warmup_seconds=1,
+            time_seconds=10,
+            new_orders=100,
+        )
+        topology_record = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        progress = []
+        with mock.patch.object(local_ydb, "LinuxCpuMonitor", return_value=monitor), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(
+                command,
+                json.dumps(payload),
+            ),
+        ) as execute:
+            lifecycle = local_ydb.WorkloadLifecycle(
+                cluster,
+                local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+                workload,
+                {"parameter": "max-sessions"},
+                {"warmup": 0, "duration": 10},
+                2,
+                LOCAL_YDB_BENCHMARK,
+                topology_record,
+                {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+                None,
+                lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            )
+            lifecycle.open_profile(self.root / "tpcc-profile", "ignored-profile-path")
+            lifecycle.open_geometry(self.root / "tpcc-geometry", "tpcc-dataset", 1)
+            first_metrics, first_commands = lifecycle.run_sample(
+                20,
+                1,
+                1,
+                2,
+                self.root / "tpcc-repeat-1",
+                "ignored-sample-path-1",
+                {"attempt": 1},
+            )
+            second_metrics, second_commands = lifecycle.run_sample(
+                20,
+                1,
+                2,
+                2,
+                self.root / "tpcc-repeat-2",
+                "ignored-sample-path-2",
+                {"attempt": 1},
+                purpose="verification",
+            )
+            lifecycle.close_geometry()
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertEqual(
+            [call.args[0][-1] for call in cluster._run.call_args_list], ["clean", "/Root/bench/tpcc-dataset"]
+        )
+        self.assertTrue(all(call.kwargs["timeout"] == 300 for call in cluster._run.call_args_list))
+        self.assertEqual([command["phase"] for command in first_commands], ["measuring"])
+        self.assertEqual([command["phase"] for command in second_commands], ["verification-measuring"])
+        run_argv = execute.call_args_list[0].args[0]
+        self.assertEqual(run_argv[run_argv.index("--warmup") + 1], "1s")
+        self.assertEqual(run_argv[run_argv.index("--threads") + 1], 2)
+        self.assertEqual(first_metrics["throughput"], 10)
+        self.assertEqual(second_metrics["transactions"], 300)
+        self.assertEqual(monitor.summary.call_count, 2)
+        for call in monitor.summary.call_args_list:
+            self.assertEqual(call.kwargs, {"started_at_unix": 1001.0, "finished_at_unix": 1010.0})
+        details = json.loads((self.root / "tpcc-repeat-1" / "workload-result.json").read_text(encoding="utf-8"))
+        self.assertEqual(details["schema_id"], "tpcc-json-v1")
+        self.assertEqual(details["details"], payload)
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            [
+                "initializing-workload",
+                "preparing-import",
+                "measuring",
+                "verification-measuring",
+                "cleaning-workload",
+                "cleaning-rmdir",
+            ],
+        )
 
     def test_local_ydb_profile_inline_lifecycle_prepares_once_and_cleans_once(self):
         definition, workload = self._synthetic_profile_workload()
@@ -1516,6 +1907,179 @@ class YdbBenchTest(unittest.TestCase):
                 20 nan 0 0 1 2 3 4
             """)
 
+    def test_local_ydb_tpcc_json_result_is_strict_and_uses_uncapped_throughput(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {"warehouses": 2, "latency-transaction": "Payment"},
+            },
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("max-sessions", 20, 10, 2, 2, None)
+        payload = self._tpcc_result_payload()
+        command_result = self._local_ydb_command_result(
+            ("ydb", "workload", "tpcc", "run"),
+            json.dumps(payload),
+        )
+        result = local_ydb_workloads.parse_workload_result("tpcc", command_result, workload, request)
+        self.assertEqual(
+            result.metrics,
+            {
+                "transactions": 300,
+                "new_orders": 120,
+                "throughput": 10,
+                "tpcc_tpmc": 25.5,
+                "efficiency_pct": 80.25,
+                "errors": 10,
+                "p50_ms": 1,
+                "p90_ms": 2,
+                "p95_ms": 3,
+                "p99_ms": 4,
+                "p999_ms": 5,
+            },
+        )
+        self.assertEqual(result.details, payload)
+        self.assertEqual(result.measurement_window, (1001.0, 1010.0))
+        schema = local_ydb_workloads.workload_result_schema("tpcc")
+        self.assertEqual(schema["schema_id"], "tpcc-json-v1")
+        self.assertEqual(schema["throughput_unit"], "new orders/s")
+        self.assertEqual(schema["slo_metrics"]["p999"], "p999_ms")
+        self.assertNotIn("p99.9", schema["slo_metrics"])
+
+        zero_payload = self._tpcc_result_payload(new_orders=0, selected_ok=0)
+        for name in ("NewOrder", "Payment"):
+            transaction = zero_payload["transactions"][name]
+            for field in ("percentiles", "percentiles_ms", "percentiles_pure"):
+                transaction[field] = {key: 0 for key in transaction[field]}
+        zero_result = local_ydb_workloads.parse_workload_result(
+            "tpcc",
+            self._local_ydb_command_result(("ydb",), json.dumps(zero_payload)),
+            workload,
+            request,
+        )
+        self.assertEqual(zero_result.metrics["transactions"], 0)
+        self.assertEqual(zero_result.metrics["new_orders"], 0)
+        self.assertEqual(zero_result.metrics["throughput"], 0)
+        self.assertEqual(zero_result.metrics["p999_ms"], 0)
+
+        no_new_orders = self._tpcc_result_payload(new_orders=0, selected_ok=300)
+        for field in ("percentiles", "percentiles_ms", "percentiles_pure"):
+            no_new_orders["transactions"]["NewOrder"][field] = {
+                key: 0 for key in no_new_orders["transactions"]["NewOrder"][field]
+            }
+        no_new_orders_result = local_ydb_workloads.parse_workload_result(
+            "tpcc",
+            self._local_ydb_command_result(("ydb",), json.dumps(no_new_orders)),
+            workload,
+            request,
+        )
+        self.assertEqual(no_new_orders_result.metrics["transactions"], 0)
+        self.assertEqual(no_new_orders_result.metrics["p99_ms"], 4)
+        aggregated = local_ydb._aggregate_measurements(
+            [no_new_orders_result.metrics],
+            local_ydb_workloads.workload_definition("tpcc").result_adapter.metrics,
+        )
+        passed, reason = load_control.evaluate_load(
+            {
+                "parameter": "max-sessions",
+                "allow_errors": True,
+                "search": {"start": 1, "maximum": 20},
+                "objective": {"type": "latency-slo"},
+            },
+            20,
+            aggregated,
+        )
+        self.assertFalse(passed)
+        self.assertIn("zero successful operations", reason)
+
+    def test_local_ydb_tpcc_json_result_rejects_malformed_or_inconsistent_output(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {"warehouses": 2, "latency-transaction": "Payment"},
+            },
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("max-sessions", 20, 10, 2, 2, None)
+
+        def changed(change):
+            value = self._tpcc_result_payload()
+            change(value)
+            return json.dumps(value)
+
+        invalid = (
+            ("not json", "malformed"),
+            (" " * (1024 * 1024 + 1), "exceeds 1048576 bytes"),
+            (json.dumps({"error": "Stopped before measurements"}), "fatal error.*Stopped before measurements"),
+            (json.dumps({"summary": {}}), r"field \$.*missing.*transactions"),
+            (
+                changed(lambda value: value["summary"].__setitem__("unexpected", 1)),
+                "summary.*unknown fields: unexpected",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("threads", True)),
+                "summary.threads.*integer",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("tpmc", float("nan"))),
+                "summary.tpmc.*finite number",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("efficiency", -1)),
+                "summary.efficiency.*finite number",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("warehouses", 3)),
+                "summary.warehouses.*configured warehouses",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("max_sessions", 19)),
+                "summary.max_sessions.*requested load",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("warmup_seconds", 3)),
+                "summary.warmup_seconds.*effective warmup",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("time_seconds", 9)),
+                "summary.time_seconds.*measurement window",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("time_seconds", 71)),
+                "summary.time_seconds.*measurement window",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("new_orders", 119)),
+                "summary.new_orders.*NewOrder.ok_count",
+            ),
+            (
+                changed(lambda value: value["transactions"]["Payment"]["percentiles"].update({"90": 7, "95": 3})),
+                "Payment.percentiles.*monotonic",
+            ),
+            (
+                changed(lambda value: value["transactions"]["Payment"]["percentiles"].__setitem__("50", 0)),
+                "Payment.*percentiles must be positive",
+            ),
+            (
+                changed(lambda value: value["transactions"]["Payment"]["percentiles"].__setitem__("50", True)),
+                "Payment.percentiles.50.*integer",
+            ),
+            (
+                changed(lambda value: value["transactions"].__setitem__("Extra", {})),
+                "transactions.*unknown fields: Extra",
+            ),
+        )
+        for stdout, message in invalid:
+            with self.subTest(message=message), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.parse_workload_result(
+                    "tpcc",
+                    self._local_ydb_command_result(("ydb",), stdout),
+                    workload,
+                    request,
+                )
+
     def test_local_ydb_result_adapter_rejects_invalid_metric_mappings(self):
         metric_schema = (
             local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
@@ -2014,7 +2578,10 @@ class YdbBenchTest(unittest.TestCase):
             "threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}",
             web._JS,
         )
-        self.assertIn("localYdbLoadForWorkload(config.load,parameters)", web._JS)
+        self.assertIn(
+            "localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload)",
+            web._JS,
+        )
         self.assertIn("log:'batches/s'", web._JS)
         transactions = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "transactions")
         throughput = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "throughput")
@@ -2069,8 +2636,30 @@ class YdbBenchTest(unittest.TestCase):
               objective:{type:'maximize-throughput',target_role:'dynamic'}
             };
             const compatible=localYdbLoadForWorkload(custom,['rate','threads']);
+            const tpccDefinition={
+              load_parameters:['max-sessions'],default_client_threads:2,
+              load_limits:{'max-sessions':{option:'warehouses',multiplier:10}}
+            };
+            const tpccWorkload={options:{warehouses:10}};
+            const switchedToTpcc=localYdbLoadForWorkload(
+              custom,tpccDefinition.load_parameters,tpccDefinition,tpccWorkload
+            );
+            const warehouseOnePoints=localYdbClampLoad(
+              {...switchedToTpcc,values:[1,8,16,64]},tpccDefinition,{options:{warehouses:1}}
+            );
+            const warehouseOneSearch=localYdbClampLoad({
+              parameter:'max-sessions',allow_errors:false,
+              search:{start:32,maximum:100,multiplier:2,resolution_percent:2},
+              objective:{type:'maximize-throughput',target_role:'dynamic'}
+            },tpccDefinition,{options:{warehouses:1}});
+            const switchedBack=localYdbLoadForWorkload(
+              switchedToTpcc,['rate','threads'],{load_limits:{}},{options:{}}
+            );
             process.stdout.write(JSON.stringify({
               points,automatic,compatible,same_reference:compatible===custom,
+              switchedToTpcc,warehouseOnePoints,warehouseOneSearch,switchedBack,
+              tpccThreads:localYdbDefaultClientThreads(tpccDefinition),
+              fallbackThreads:localYdbDefaultClientThreads({}),
               units:['kv','stock','log','future'].map(localYdbThroughputUnit)
             }));
         """
@@ -2109,6 +2698,23 @@ class YdbBenchTest(unittest.TestCase):
                 "objective": {"type": "maximize-throughput", "target_role": "dynamic"},
             },
         )
+        self.assertEqual(
+            result["switchedToTpcc"],
+            {
+                "parameter": "max-sessions",
+                "allow_errors": False,
+                "search": {"start": 1, "maximum": 100, "multiplier": 4, "resolution_percent": 9},
+                "objective": {"type": "maximize-throughput", "target_role": "dynamic"},
+            },
+        )
+        self.assertEqual(result["warehouseOnePoints"]["values"], [1, 8, 10])
+        self.assertEqual(result["warehouseOneSearch"]["search"]["start"], 10)
+        self.assertEqual(result["warehouseOneSearch"]["search"]["maximum"], 10)
+        self.assertEqual(result["switchedBack"]["parameter"], "rate")
+        self.assertEqual(result["switchedBack"]["search"]["start"], 1000)
+        self.assertEqual(result["switchedBack"]["search"]["maximum"], 100000)
+        self.assertEqual(result["tpccThreads"], 2)
+        self.assertEqual(result["fallbackThreads"], 64)
         self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
@@ -6621,7 +7227,10 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"Failed workload requests are allowed", script)
                 self.assertIn(b"editor.model?.local_ydb_workloads", script)
                 self.assertIn(b"definition.load_parameters", script)
-                self.assertIn(b"config.load=localYdbLoadForWorkload(config.load,parameters)", script)
+                self.assertIn(
+                    b"config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload)",
+                    script,
+                )
                 self.assertIn(b"log:'batches/s'", script)
                 self.assertIn(b"function localResultSchema", script)
                 self.assertIn(b"result_schema_id:schema.schema_id", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added the YDB CLI TPCC workload to local YDB benchmark profiles with session-load search, inline warmup, and typed latency results.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds geometry-scoped TPCC init/import/run/cleanup orchestration, strict JSON metric parsing, max-session validation, Builder support, and documentation. Stacked on #51976.