### PR TITLE
ydb-bench: fix local dedicated node readiness

### DIFF
--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -171,26 +171,8 @@ def _set_process_affinity(pid, mask, proc_root=Path("/proc")):
     raise BenchmarkError("cannot update dynamic node CPU affinity: thread list did not stabilize")
 
 
-def _registered_database_units(output):
-    units = set()
-    in_registered_units = False
-    for line in output.splitlines():
-        stripped = line.strip()
-        if stripped == "Registered units:":
-            in_registered_units = True
-            continue
-        if not in_registered_units:
-            continue
-        if line.startswith("    ") and " - " in stripped:
-            units.add(stripped.split(" - ", 1)[0])
-            continue
-        if stripped:
-            break
-    return units
-
-
-def _database_status_ready(output, expected_units=()):
-    return "State: RUNNING" in output and set(expected_units).issubset(_registered_database_units(output))
+def _database_status_ready(output):
+    return any(line.strip() == "State: RUNNING" for line in output.splitlines())
 
 
 def _operation_ready(response):
@@ -605,7 +587,7 @@ class LocalYdbCluster:
             time.sleep(0.2)
         raise BenchmarkError("{} did not become ready in {} seconds".format(description, timeout))
 
-    def _wait_database_ready(self, expected_units, timeout=120):
+    def _wait_database_ready(self, timeout=120):
         command = [
             self.ydbd,
             "-s",
@@ -623,7 +605,7 @@ class LocalYdbCluster:
             if (
                 not last_result.exit_code
                 and not last_result.timed_out
-                and _database_status_ready(last_result.stdout, expected_units)
+                and _database_status_ready(last_result.stdout)
             ):
                 atomic_write_text(self.directory / "database-status.txt", last_result.stdout)
                 return
@@ -681,8 +663,7 @@ class LocalYdbCluster:
         self._progress("waiting-for-database", dynamic_nodes=final_count)
         for index, node in enumerate(self.dynamic_nodes[start_index:], start_index + 1):
             self._wait_for_port(node["grpc_port"], "dynamic node {}".format(index))
-        expected_units = {"{}:{}".format(self.hostname, node["ic_port"]) for node in self.dynamic_nodes}
-        self._wait_database_ready(expected_units)
+        self._wait_database_ready()
         self._wait_tenant_ready(min(self.timeout, 600))
         self._progress("cluster-ready", dynamic_nodes=final_count)
 

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4752,20 +4752,15 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
     def test_local_ydb_database_status_requires_running_state(self):
         status = """Database /Root/bench status:
   State: RUNNING
+  Allocated pools:
+    ssd: 1/1
+  Allocated units:
   Registered units:
-    host:1234 - dynamic
-    host:5678 - dynamic
   Data size hard quota: 0
+  Data size soft quota: 0
 """
-        self.assertEqual(local_ydb._registered_database_units(status), {"host:1234", "host:5678"})
-        self.assertTrue(local_ydb._database_status_ready(status, {"host:1234", "host:5678"}))
-        self.assertFalse(local_ydb._database_status_ready(status, {"host:1234", "host:9999"}))
-        self.assertFalse(
-            local_ydb._database_status_ready(
-                status.replace("RUNNING", "PENDING_RESOURCES"),
-                {"host:1234"},
-            )
-        )
+        self.assertTrue(local_ydb._database_status_ready(status))
+        self.assertFalse(local_ydb._database_status_ready(status.replace("RUNNING", "PENDING_RESOURCES")))
 
     def test_local_ydb_static_nodes_use_self_management(self):
         config = local_ydb._cluster_config(
@@ -4815,7 +4810,7 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
         self.assertEqual(config["config"]["host_configs"][0]["ssd"], ["SectorMap:map_0:64:NONE"])
         self.assertEqual(start_process.call_args.kwargs["parent_death_wrapper"], self.root / "process_guard")
 
-    def test_local_ydb_scaling_waits_for_every_new_registered_node(self):
+    def test_local_ydb_scaling_waits_for_database_and_every_new_node(self):
         cluster_directory = self.root / "scaling-cluster"
         cluster_directory.mkdir()
         cluster = local_ydb.LocalYdbCluster(
@@ -4843,7 +4838,7 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
             cluster, "_wait_for_port"
         ) as wait_for_port, mock.patch.object(cluster, "_wait_database_ready") as wait_database, mock.patch.object(
             cluster, "_wait_tenant_ready"
-        ), mock.patch.object(
+        ) as wait_tenant, mock.patch.object(
             local_ydb, "start_managed_process", side_effect=(mock.Mock(pid=101), mock.Mock(pid=102))
         ):
             cluster.add_dynamic_nodes(2)
@@ -4852,7 +4847,8 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
             wait_for_port.call_args_list,
             [mock.call(2136, "dynamic node 1"), mock.call(2137, "dynamic node 2")],
         )
-        wait_database.assert_called_once_with({"benchmark-host:19002", "benchmark-host:19003"})
+        wait_database.assert_called_once_with()
+        wait_tenant.assert_called_once_with(30)
 
     def test_local_ydb_tenant_readiness_checks_every_dynamic_node(self):
         cluster_directory = self.root / "tenant-ready-cluster"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed local YDB startup with dedicated dynamic nodes whose database status does not list computational units.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Treats the database RUNNING state as the control-plane readiness signal and leaves the existing per-endpoint SchemeDescribe probes to verify every dedicated dynamic node. Stacked on #51978.