### PR TITLE
ydb-bench: use admitted TPCC latency for search

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -170,10 +170,13 @@ complete before measurement; YAML `warmup: 0` requests that minimum rather
 than the CLI's adaptive warmup. Measurement duration must be at least two
 seconds. Canonical throughput is uncapped successful NewOrder transactions per
 measured second. The CLI-reported, warehouse-capped `tpmC` remains available as
-the separate `tpcc_tpmc` metric. Latency SLOs use the full latency (including
-inflight queue wait) of `latency-transaction`, with `p50`, `p90`, `p95`, `p99`,
-and `p999` available. See `examples/local-ydb-tpcc.yaml` for a small manual
-smoke configuration.
+the separate `tpcc_tpmc` metric. Latency SLOs use the admitted latency of
+`latency-transaction`: it excludes the queue created by the configured
+`max-sessions` limit, but includes session acquisition and SDK retries. This
+keeps the latency signal monotonic enough for load search; the full terminal
+latency and pure transaction time remain in the raw CLI result. `p50`, `p90`,
+`p95`, `p99`, and `p999` are available. See `examples/local-ydb-tpcc.yaml` for
+a small manual smoke configuration.
 
 Topic supports the CLI `full` producer-and-consumer workload. Every sample
 creates a fresh generated topic, runs one inline warmup and measurement, and

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -264,7 +264,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         parsed_transactions[transaction_name] = {
             "ok_count": ok_count,
             "failed_count": _tpcc_integer(transaction["failed_count"], location + ".failed_count"),
-            "percentiles": percentile_families["percentiles"],
+            "percentiles_ms": percentile_families["percentiles_ms"],
         }
     if new_orders != parsed_transactions["NewOrder"]["ok_count"]:
         _tpcc_result_error("field summary.new_orders does not match transactions.NewOrder.ok_count")
@@ -280,7 +280,10 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
     }
     metrics.update(
-        {metric_name: value for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles"])}
+        {
+            metric_name: value
+            for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles_ms"])
+        }
     )
     return WorkloadResult(
         metrics,
@@ -293,7 +296,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
 
 
 TPCC_JSON_RESULT = WorkloadResultAdapter(
-    schema_id="tpcc-json-v1",
+    schema_id="tpcc-json-v2",
     parse=_parse_tpcc_json_result,
     metrics=(
         WorkloadMetric(
@@ -341,7 +344,10 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
                 metric_name,
                 "ms",
                 required=True,
-                description="Full selected-transaction latency including inflight queue wait",
+                description=(
+                    "Selected-transaction latency after admission by max-sessions, including session acquisition "
+                    "and SDK retries"
+                ),
             )
             for _percentile, metric_name in _TPCC_PERCENTILES
         ),

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -289,7 +289,9 @@ class YdbBenchTest(unittest.TestCase):
         latency_transaction="Payment",
         selected_ok=300,
     ):
-        percentile_values = {"50": 1, "90": 2, "95": 3, "99": 4, "99.9": 5}
+        full_percentile_values = {"50": 101, "90": 102, "95": 103, "99": 104, "99.9": 105}
+        admitted_percentile_values = {"50": 11, "90": 12, "95": 13, "99": 14, "99.9": 15}
+        pure_percentile_values = {"50": 1, "90": 2, "95": 3, "99": 4, "99.9": 5}
         transactions = {}
         for index, name in enumerate(("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")):
             ok_count = new_orders if name == "NewOrder" else 100 + index
@@ -298,9 +300,9 @@ class YdbBenchTest(unittest.TestCase):
             transactions[name] = {
                 "ok_count": ok_count,
                 "failed_count": index,
-                "percentiles": dict(percentile_values),
-                "percentiles_ms": dict(percentile_values),
-                "percentiles_pure": dict(percentile_values),
+                "percentiles": dict(full_percentile_values),
+                "percentiles_ms": dict(admitted_percentile_values),
+                "percentiles_pure": dict(pure_percentile_values),
             }
         return {
             "summary": {
@@ -485,7 +487,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         self.assertEqual(
             [item["result_schema_id"] for item in catalog],
-            ["generic-total-v1"] * 3 + ["tpcc-json-v1", "topic-total-v1"],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v2", "topic-total-v1"],
         )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
@@ -1429,7 +1431,7 @@ class YdbBenchTest(unittest.TestCase):
         for call in monitor.summary.call_args_list:
             self.assertEqual(call.kwargs, {"started_at_unix": 1001.0, "finished_at_unix": 1010.0})
         details = json.loads((self.root / "tpcc-repeat-1" / "workload-result.json").read_text(encoding="utf-8"))
-        self.assertEqual(details["schema_id"], "tpcc-json-v1")
+        self.assertEqual(details["schema_id"], "tpcc-json-v2")
         self.assertEqual(details["details"], payload)
         self.assertEqual(
             [item["phase"] for item in progress],
@@ -2146,7 +2148,7 @@ class YdbBenchTest(unittest.TestCase):
                 20 nan 0 0 1 2 3 4
             """)
 
-    def test_local_ydb_tpcc_json_result_is_strict_and_uses_uncapped_throughput(self):
+    def test_local_ydb_tpcc_json_result_uses_uncapped_throughput_and_admitted_latency(self):
         workload = local_ydb_workloads.normalize_workload(
             {
                 "type": "tpcc",
@@ -2171,17 +2173,17 @@ class YdbBenchTest(unittest.TestCase):
                 "tpcc_tpmc": 25.5,
                 "efficiency_pct": 80.25,
                 "errors": 10,
-                "p50_ms": 1,
-                "p90_ms": 2,
-                "p95_ms": 3,
-                "p99_ms": 4,
-                "p999_ms": 5,
+                "p50_ms": 11,
+                "p90_ms": 12,
+                "p95_ms": 13,
+                "p99_ms": 14,
+                "p999_ms": 15,
             },
         )
         self.assertEqual(result.details, payload)
         self.assertEqual(result.measurement_window, (1001.0, 1010.0))
         schema = local_ydb_workloads.workload_result_schema("tpcc")
-        self.assertEqual(schema["schema_id"], "tpcc-json-v1")
+        self.assertEqual(schema["schema_id"], "tpcc-json-v2")
         self.assertEqual(schema["throughput_unit"], "new orders/s")
         self.assertEqual(schema["slo_metrics"]["p999"], "p999_ms")
         self.assertNotIn("p99.9", schema["slo_metrics"])
@@ -2214,7 +2216,7 @@ class YdbBenchTest(unittest.TestCase):
             request,
         )
         self.assertEqual(no_new_orders_result.metrics["transactions"], 0)
-        self.assertEqual(no_new_orders_result.metrics["p99_ms"], 4)
+        self.assertEqual(no_new_orders_result.metrics["p99_ms"], 14)
         aggregated = local_ydb._aggregate_measurements(
             [no_new_orders_result.metrics],
             local_ydb_workloads.workload_definition("tpcc").result_adapter.metrics,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed TPCC latency search to exclude the queue imposed by its own max-sessions limit.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Uses the CLI admitted-latency percentiles for canonical pXX metrics and SLO search, keeps full and pure latency in raw results, and bumps the result schema to prevent incompatible comparisons. Stacked on #51979.