### PR TITLE
ydb-bench: add TPCC and Topic workloads

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -170,10 +170,13 @@ complete before measurement; YAML `warmup: 0` requests that minimum rather
 than the CLI's adaptive warmup. Measurement duration must be at least two
 seconds. Canonical throughput is uncapped successful NewOrder transactions per
 measured second. The CLI-reported, warehouse-capped `tpmC` remains available as
-the separate `tpcc_tpmc` metric. Latency SLOs use the full latency (including
-inflight queue wait) of `latency-transaction`, with `p50`, `p90`, `p95`, `p99`,
-and `p999` available. See `examples/local-ydb-tpcc.yaml` for a small manual
-smoke configuration.
+the separate `tpcc_tpmc` metric. Latency SLOs use the admitted latency of
+`latency-transaction`: it excludes the queue created by the configured
+`max-sessions` limit, but includes session acquisition and SDK retries. This
+keeps the latency signal monotonic enough for load search; the full terminal
+latency and pure transaction time remain in the raw CLI result. `p50`, `p90`,
+`p95`, `p99`, and `p999` are available. See `examples/local-ydb-tpcc.yaml` for
+a small manual smoke configuration.
 
 Topic supports the CLI `full` producer-and-consumer workload. Every sample
 creates a fresh generated topic, runs one inline warmup and measurement, and

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -15,7 +15,7 @@ The tool provides four benchmarks:
 - `star-ping-bench`: star-topology actor ping throughput.
 - `memory-bandwidth-bench`: mixed sequential-copy and random copy/write memory workload.
 - `local-ydb`: a local static/dynamic YDB cluster driven by the `kv`, `stock`,
-  `log`, or `tpcc` YDB CLI workload.
+  `log`, `tpcc`, or `topic` YDB CLI workload.
 
 Inspect them and print the standard JSON Schema for the YAML configuration:
 
@@ -124,12 +124,13 @@ specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
 
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
-benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. The
-`kv` and `stock` workloads accept either parameter; `log` searches `threads`
-because its CLI does not expose `--rate`. Log throughput is the number of
-successful batches per second; `rows-per-operation` controls how many rows are
-written by each batch. Its default `ttl-minutes: 0` is a zero-minute table TTL,
-not disabled TTL. A `values` list measures exact points. For adaptive runs,
+benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. Topic
+also searches `rate`, but maps it to the Topic CLI's `--message-rate`. The `kv`
+and `stock` workloads accept either parameter; `log` searches `threads` because
+its CLI does not expose `--rate`. Log throughput is the number of successful
+batches per second; `rows-per-operation` controls how many rows are written by
+each batch. Its default `ttl-minutes: 0` is a zero-minute table TTL, not disabled
+TTL. A `values` list measures exact points. For adaptive runs,
 `search` defines the range and resolution. `maximize-throughput` uses a
 discrete ternary search and, after confirming a plateau, selects the lowest
 CPU-saturated load within the configured throughput tolerance of the best
@@ -174,8 +175,31 @@ inflight queue wait) of `latency-transaction`, with `p50`, `p90`, `p95`, `p99`,
 and `p999` available. See `examples/local-ydb-tpcc.yaml` for a small manual
 smoke configuration.
 
-Set `load.allow-errors: true` when request-level errors reported by
-`ydb workload` are an expected part of the experiment. Such points remain
+Topic supports the CLI `full` producer-and-consumer workload. Every sample
+creates a fresh generated topic, runs one inline warmup and measurement, and
+then drops that topic, so consumer offsets and unread backlog cannot leak into
+the next search or verification sample. `partitions`, `consumers`,
+`message-size`, and the `raw`, `gzip`, or `zstd` codec are configurable.
+`client.threads` defaults to 1 and is passed to both `--producer-threads` and
+`--consumer-threads`; with multiple consumers, each consumer receives that many
+reader threads. The CLI receives `--seconds` equal to warmup plus measurement
+duration, one-second reporting windows with UTC timestamps, and a fixed p99
+percentile. CPU aggregation is anchored to the CLI timestamps at windows
+`warmup + 1` and `warmup + duration`; this excludes topic/session startup and
+the first measurement interval from the approximate CPU window.
+
+Canonical Topic throughput is the smaller of the write rate and the aggregate
+read rate divided by `consumers`. The raw aggregate read rate and normalized
+per-consumer rate remain separate result metrics. Latency SLOs therefore expose
+only `p99`, backed by the CLI's full end-to-end p99 latency. The CLI output does
+not contain a trustworthy request-error count, so Topic requires
+`allow-errors: false` and `max-errors: 0`; a zero-throughput sample is still
+ineligible. Measurement duration must be at least two seconds. See
+`examples/local-ydb-topic.yaml` for a small manual smoke configuration.
+
+For workloads which report an `errors` metric, set `load.allow-errors: true`
+when request-level errors reported by `ydb workload` are an expected part of
+the experiment. Such points remain
 eligible for selection and the error counts stay in CSV, manifests, tables,
 and charts, provided every repetition completed at least one successful
 operation. A repetition with zero successful operations makes the whole point

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -163,6 +163,9 @@ that dataset for every search and verification sample at the geometry, then
 runs both `tpcc clean` and recursive `scheme rmdir` cleanup. `client.threads`
 maps to the TPC-C runner's `--threads`; it defaults to 2, while
 `import-threads: 0` asks the CLI to select import concurrency automatically.
+The result is rejected if the CLI reports a different number of execution
+threads than `client.threads`, which prevents CPU-based CLI clamping from
+silently changing the configuration being compared.
 
 TPC-C warmup is inline. The CLI receives the explicit value
 `max(measurement.warmup, floor(warehouses / 10) + 1)` so terminal startup is

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -15,7 +15,7 @@ The tool provides four benchmarks:
 - `star-ping-bench`: star-topology actor ping throughput.
 - `memory-bandwidth-bench`: mixed sequential-copy and random copy/write memory workload.
 - `local-ydb`: a local static/dynamic YDB cluster driven by the `kv`, `stock`,
-  or `log` YDB CLI workload.
+  `log`, or `tpcc` YDB CLI workload.
 
 Inspect them and print the standard JSON Schema for the YAML configuration:
 
@@ -154,6 +154,25 @@ For example:
         max-errors: 0
         min-achieved-rate-ratio: 0.98
 ```
+
+TPC-C uses `load.parameter: max-sessions`, which maps to the CLI
+`--max-sessions` limit and must not exceed `warehouses * 10`. The benchmark
+runs `tpcc init` and `tpcc import` once for each dynamic-node geometry, reuses
+that dataset for every search and verification sample at the geometry, then
+runs both `tpcc clean` and recursive `scheme rmdir` cleanup. `client.threads`
+maps to the TPC-C runner's `--threads`; it defaults to 2, while
+`import-threads: 0` asks the CLI to select import concurrency automatically.
+
+TPC-C warmup is inline. The CLI receives the explicit value
+`max(measurement.warmup, floor(warehouses / 10) + 1)` so terminal startup is
+complete before measurement; YAML `warmup: 0` requests that minimum rather
+than the CLI's adaptive warmup. Measurement duration must be at least two
+seconds. Canonical throughput is uncapped successful NewOrder transactions per
+measured second. The CLI-reported, warehouse-capped `tpmC` remains available as
+the separate `tpcc_tpmc` metric. Latency SLOs use the full latency (including
+inflight queue wait) of `latency-transaction`, with `p50`, `p90`, `p95`, `p99`,
+and `p999` available. See `examples/local-ydb-tpcc.yaml` for a small manual
+smoke configuration.
 
 Set `load.allow-errors: true` when request-level errors reported by
 `ydb workload` are an expected part of the experiment. Such points remain

--- a/ydb/tools/ydb_bench/examples/local-ydb-topic.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-topic.yaml
@@ -1,0 +1,32 @@
+local-ydb:
+  topic-smoke:
+    workload:
+      type: topic
+      operation: full
+      options:
+        partitions: 1
+        consumers: 1
+        message-size: 1024
+        codec: raw
+    geometry:
+      preset: single
+      static-nodes: 1
+      disk-size-gb: 64
+      storage-groups: 1
+    client:
+      threads: 1
+    load:
+      parameter: rate
+      values: [10]
+    measurement:
+      warmup: 1
+      duration: 2
+      repetitions: 1
+      verification-repetitions: 0
+    affinity:
+      ydb-cli:
+        mode: none
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none

--- a/ydb/tools/ydb_bench/examples/local-ydb-tpcc.yaml
+++ b/ydb/tools/ydb_bench/examples/local-ydb-tpcc.yaml
@@ -1,0 +1,35 @@
+local-ydb:
+  tpcc-smoke:
+    workload:
+      type: tpcc
+      operation: run
+      options:
+        warehouses: 1
+        import-threads: 1
+        compact: false
+        tx-mode: serializable-rw
+        latency-transaction: NewOrder
+        no-delays: true
+        highres-histogram: false
+    geometry:
+      preset: single
+      static-nodes: 1
+      disk-size-gb: 64
+      storage-groups: 1
+    client:
+      threads: 2
+    load:
+      parameter: max-sessions
+      values: [1]
+    measurement:
+      warmup: 0
+      duration: 2
+      repetitions: 1
+      verification-repetitions: 0
+    affinity:
+      ydb-cli:
+        mode: none
+      static-nodes:
+        mode: none
+      dynamic-nodes:
+        mode: none

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -17,6 +17,9 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     all_load_parameters,
     all_slo_percentiles,
     normalize_workload,
+    validate_workload_profile,
+    workload_definition,
+    workload_effective_warmup_seconds,
     workload_config_schema,
 )
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
@@ -550,7 +553,10 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
     }
 
     client = _mapping(value.get("client"), location + ".client", ("threads",))
-    client_threads = _positive_integer(client.get("threads", 64), location + ".client.threads")
+    client_threads = _positive_integer(
+        client.get("threads", workload_definition(workload["type"]).default_client_threads),
+        location + ".client.threads",
+    )
 
     load = _mapping(
         value.get("load"),
@@ -769,6 +775,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         "repetitions": _positive_integer(measurement.get("repetitions", 3), location + ".measurement.repetitions"),
         "verification_repetitions": verification_repetitions,
     }
+    validate_workload_profile(workload, load_config, measurement_config, location)
 
     affinity = _mapping(value.get("affinity"), location + ".affinity", ("ydb-cli", "static-nodes", "dynamic-nodes"))
     affinity_config = {
@@ -786,7 +793,8 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
 
     attempts = len(load_config.get("values", ())) or 64
     measurement_runs = attempts * measurement_config["repetitions"] + measurement_config["verification_repetitions"]
-    computed_timeout = 300 + measurement_runs * (measurement_config["warmup"] + measurement_config["duration"] + 10)
+    effective_warmup = workload_effective_warmup_seconds(workload, measurement_config["warmup"])
+    computed_timeout = 300 + measurement_runs * (effective_warmup + measurement_config["duration"] + 10)
     timeout_explicit = "timeout" in value
     timeout = _timeout(value.get("timeout", computed_timeout), location + ".timeout")
     return RunConfiguration(

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -37,6 +37,7 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     build_run_plan,
     parse_workload_result,
     workload_definition,
+    workload_effective_warmup_seconds,
     workload_result_schema,
 )
 from ydb.tools.ydb_bench.lib.results import SCHEMA_VERSION, write_manifest
@@ -1120,7 +1121,8 @@ class WorkloadLifecycle:
 
     def _run_workload(self, state, load, dynamic_nodes, repetition, commands):
         phases = self._phases(state.purpose)
-        warmup = self.measurement["warmup"]
+        configured_warmup = self.measurement["warmup"]
+        warmup = workload_effective_warmup_seconds(self.workload, configured_warmup)
         if warmup and self.definition.warmup_mode == "separate":
             warmup_plan = build_run_plan(
                 self.workload_cli,
@@ -1198,6 +1200,8 @@ class WorkloadLifecycle:
             }
             if self.definition.warmup_mode == "inline":
                 progress_fields["inline_warmup_seconds"] = warmup
+                if warmup != configured_warmup:
+                    progress_fields["configured_warmup_seconds"] = configured_warmup
             self.progress(phases["measure"], **progress_fields)
             result = run_command(
                 plan.argv,

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -171,26 +171,8 @@ def _set_process_affinity(pid, mask, proc_root=Path("/proc")):
     raise BenchmarkError("cannot update dynamic node CPU affinity: thread list did not stabilize")
 
 
-def _registered_database_units(output):
-    units = set()
-    in_registered_units = False
-    for line in output.splitlines():
-        stripped = line.strip()
-        if stripped == "Registered units:":
-            in_registered_units = True
-            continue
-        if not in_registered_units:
-            continue
-        if line.startswith("    ") and " - " in stripped:
-            units.add(stripped.split(" - ", 1)[0])
-            continue
-        if stripped:
-            break
-    return units
-
-
-def _database_status_ready(output, expected_units=()):
-    return "State: RUNNING" in output and set(expected_units).issubset(_registered_database_units(output))
+def _database_status_ready(output):
+    return any(line.strip() == "State: RUNNING" for line in output.splitlines())
 
 
 def _operation_ready(response):
@@ -605,7 +587,7 @@ class LocalYdbCluster:
             time.sleep(0.2)
         raise BenchmarkError("{} did not become ready in {} seconds".format(description, timeout))
 
-    def _wait_database_ready(self, expected_units, timeout=120):
+    def _wait_database_ready(self, timeout=120):
         command = [
             self.ydbd,
             "-s",
@@ -623,7 +605,7 @@ class LocalYdbCluster:
             if (
                 not last_result.exit_code
                 and not last_result.timed_out
-                and _database_status_ready(last_result.stdout, expected_units)
+                and _database_status_ready(last_result.stdout)
             ):
                 atomic_write_text(self.directory / "database-status.txt", last_result.stdout)
                 return
@@ -681,8 +663,7 @@ class LocalYdbCluster:
         self._progress("waiting-for-database", dynamic_nodes=final_count)
         for index, node in enumerate(self.dynamic_nodes[start_index:], start_index + 1):
             self._wait_for_port(node["grpc_port"], "dynamic node {}".format(index))
-        expected_units = {"{}:{}".format(self.hostname, node["ic_port"]) for node in self.dynamic_nodes}
-        self._wait_database_ready(expected_units)
+        self._wait_database_ready()
         self._wait_tenant_ready(min(self.timeout, 600))
         self._progress("cluster-ready", dynamic_nodes=final_count)
 

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -4,6 +4,7 @@ import json
 import math
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from types import MappingProxyType
 
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
@@ -346,6 +347,207 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
         ),
     ),
     slo_metrics=_TPCC_SLO_METRICS,
+)
+
+_TOPIC_CONSUMER_PREFIX = "ydb-bench-consumer"
+_TOPIC_PERCENTILE = 99
+_TOPIC_OUTPUT_MAX_BYTES = 1024 * 1024
+_TOPIC_METRIC_MAX = (1 << 64) - 1
+_TOPIC_TIMESTAMP_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
+
+
+def _topic_result_error(message):
+    raise BenchmarkError("YDB CLI Topic output {}".format(message))
+
+
+def _topic_timestamp(value, location):
+    if not isinstance(value, str) or _TOPIC_TIMESTAMP_PATTERN.fullmatch(value) is None:
+        _topic_result_error("{} must be an ISO UTC timestamp".format(location))
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+        timestamp = parsed.timestamp()
+    except (OSError, OverflowError, TypeError, ValueError) as error:
+        raise BenchmarkError("YDB CLI Topic output {} must be an ISO UTC timestamp".format(location)) from error
+    if not math.isfinite(timestamp):
+        _topic_result_error("{} must be a finite timestamp".format(location))
+    return timestamp
+
+
+def _topic_stats_row(values, location):
+    if len(values) != 11:
+        _topic_result_error("{} must contain exactly 11 columns".format(location))
+    metric_values = []
+    for value in values[1:10]:
+        if re.fullmatch("[0-9]+", value) is None or len(value) > 20:
+            _topic_result_error("{} metrics must be unsigned 64-bit decimal integers".format(location))
+        parsed = int(value)
+        if parsed > _TOPIC_METRIC_MAX:
+            _topic_result_error("{} metrics must be unsigned 64-bit decimal integers".format(location))
+        metric_values.append(parsed)
+    timestamp = _topic_timestamp(values[10], "{} timestamp".format(location))
+    return metric_values, timestamp
+
+
+def _parse_topic_total_result(command_result, normalized_workload, request):
+    stdout = command_result.stdout
+    if not isinstance(stdout, str):
+        _topic_result_error("is not text or exceeds {} bytes".format(_TOPIC_OUTPUT_MAX_BYTES))
+    try:
+        output_size = len(stdout.encode("utf-8"))
+    except UnicodeEncodeError as error:
+        raise BenchmarkError("YDB CLI Topic output is not valid UTF-8 text") from error
+    if output_size > _TOPIC_OUTPUT_MAX_BYTES:
+        _topic_result_error("is not text or exceeds {} bytes".format(_TOPIC_OUTPUT_MAX_BYTES))
+
+    start_index = request.warmup_seconds + 1
+    finish_index = request.warmup_seconds + request.duration_seconds
+    if start_index >= finish_index:
+        _topic_result_error("requires a measurement duration of at least two seconds")
+    boundary_rows = {str(start_index): [], str(finish_index): []}
+    total_rows = []
+    for line in stdout.splitlines():
+        values = line.split()
+        if not values:
+            continue
+        if values[0] == "Total":
+            total_rows.append(values)
+        elif values[0] in boundary_rows:
+            boundary_rows[values[0]].append(values)
+    if len(total_rows) != 1:
+        _topic_result_error("must contain exactly one Total row")
+    for index, rows in boundary_rows.items():
+        if len(rows) != 1:
+            _topic_result_error("must contain exactly one window row for index {}".format(index))
+    metric_values, _total_timestamp = _topic_stats_row(total_rows[0], "Total row")
+    _start_metrics, measurement_started_at = _topic_stats_row(
+        boundary_rows[str(start_index)][0],
+        "window row {}".format(start_index),
+    )
+    _finish_metrics, measurement_finished_at = _topic_stats_row(
+        boundary_rows[str(finish_index)][0],
+        "window row {}".format(finish_index),
+    )
+    if measurement_started_at >= measurement_finished_at:
+        _topic_result_error("measurement window timestamps must be increasing")
+
+    (
+        write_messages_s,
+        write_mib_s,
+        write_p99_ms,
+        inflight_p99_messages,
+        lag_p99_messages,
+        lag_p99_ms,
+        read_messages_s,
+        read_mib_s,
+        full_p99_ms,
+    ) = metric_values
+    consumers = normalized_workload["options"]["consumers"]
+    read_per_consumer_messages_s = read_messages_s / consumers
+    throughput = min(write_messages_s, read_per_consumer_messages_s)
+    metrics = {
+        "transactions": int(throughput * request.duration_seconds),
+        "throughput": throughput,
+        "write_messages_s": write_messages_s,
+        "write_mib_s": write_mib_s,
+        "write_p99_ms": write_p99_ms,
+        "inflight_p99_messages": inflight_p99_messages,
+        "lag_p99_messages": lag_p99_messages,
+        "lag_p99_ms": lag_p99_ms,
+        "read_messages_s": read_messages_s,
+        "read_per_consumer_messages_s": read_per_consumer_messages_s,
+        "read_mib_s": read_mib_s,
+        "full_p99_ms": full_p99_ms,
+    }
+    return WorkloadResult(
+        metrics,
+        details={"percentile": _TOPIC_PERCENTILE, "total": metrics},
+        measurement_window=(
+            measurement_started_at,
+            measurement_finished_at,
+        ),
+    )
+
+
+TOPIC_TOTAL_RESULT = WorkloadResultAdapter(
+    schema_id="topic-total-v1",
+    parse=_parse_topic_total_result,
+    metrics=(
+        WorkloadMetric(
+            "transactions",
+            "estimated messages",
+            required=True,
+            description=(
+                "Conservative completed-message estimate derived from truncated CLI rates; used to reject empty samples"
+            ),
+        ),
+        WorkloadMetric(
+            "throughput",
+            "messages/s",
+            required=True,
+            description="Minimum of write rate and aggregate read rate divided by the number of consumers",
+        ),
+        WorkloadMetric(
+            "write_messages_s",
+            "messages/s",
+            required=True,
+            description="CLI-reported successful write rate",
+        ),
+        WorkloadMetric(
+            "read_messages_s",
+            "deliveries/s",
+            required=True,
+            description="CLI-reported aggregate delivery rate across all consumers",
+        ),
+        WorkloadMetric(
+            "read_per_consumer_messages_s",
+            "messages/s",
+            required=True,
+            description="Aggregate delivery rate divided by the configured number of consumers",
+        ),
+        WorkloadMetric(
+            "write_mib_s",
+            "logical MiB/s",
+            required=True,
+            description="CLI-reported uncompressed logical write bandwidth",
+        ),
+        WorkloadMetric(
+            "read_mib_s",
+            "logical MiB/s",
+            required=True,
+            description="CLI-reported aggregate uncompressed logical read bandwidth",
+        ),
+        WorkloadMetric(
+            "write_p99_ms",
+            "ms",
+            required=True,
+            description="p99 time from scheduled message creation to write acknowledgement",
+        ),
+        WorkloadMetric(
+            "inflight_p99_messages",
+            "messages",
+            required=True,
+            description="p99 number of messages awaiting write acknowledgement",
+        ),
+        WorkloadMetric(
+            "lag_p99_messages",
+            "messages",
+            required=True,
+            description="p99 unread-message lag across consumers",
+        ),
+        WorkloadMetric(
+            "lag_p99_ms",
+            "ms",
+            required=True,
+            description="p99 consumer lag time",
+        ),
+        WorkloadMetric(
+            "full_p99_ms",
+            "ms",
+            required=True,
+            description="p99 end-to-end time from scheduled message creation to delivery",
+        ),
+    ),
+    slo_metrics=(("p99", "full_p99_ms"),),
 )
 
 _RESERVED_RESULT_METRIC_NAMES = frozenset(
@@ -761,6 +963,115 @@ def _tpcc_cleanup_plan_builder(cli, definition, path, workload):
     )
 
 
+def _topic_init_builder(cli, definition, path, workload):
+    options = workload["options"]
+    return _workload_base(cli, definition, None) + [
+        "init",
+        "--topic",
+        path,
+        "--partitions",
+        options["partitions"],
+        "--consumers",
+        options["consumers"],
+        "--consumer-prefix",
+        _TOPIC_CONSUMER_PREFIX,
+    ]
+
+
+def _topic_run_command(
+    cli,
+    definition,
+    path,
+    workload,
+    load,
+    total_seconds,
+    client_threads,
+    warmup_seconds,
+):
+    options = workload["options"]
+    return _workload_base(cli, definition, None) + [
+        "run",
+        workload["operation"],
+        "--topic",
+        path,
+        "--seconds",
+        total_seconds,
+        "--warmup",
+        warmup_seconds,
+        "--window",
+        1,
+        "--print-timestamp",
+        "--percentile",
+        _TOPIC_PERCENTILE,
+        "--producer-threads",
+        client_threads,
+        "--consumer-threads",
+        client_threads,
+        "--consumers",
+        options["consumers"],
+        "--consumer-prefix",
+        _TOPIC_CONSUMER_PREFIX,
+        "--message-size",
+        options["message-size"],
+        "--message-rate",
+        load,
+        "--codec",
+        options["codec"],
+    ]
+
+
+def _topic_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del load_parameter
+    return _topic_run_command(cli, definition, path, workload, load, seconds, client_threads, 0)
+
+
+def _topic_prepare_plan_builder(cli, definition, path, workload):
+    return (WorkloadCommandPlan("init", tuple(_topic_init_builder(cli, definition, path, workload)), 120),)
+
+
+def _topic_run_plan_builder(
+    cli,
+    definition,
+    path,
+    workload,
+    load_parameter,
+    load,
+    seconds,
+    client_threads,
+    warmup_seconds,
+):
+    del load_parameter
+    total_seconds = warmup_seconds + seconds
+    return WorkloadCommandPlan(
+        "run",
+        tuple(
+            _topic_run_command(
+                cli,
+                definition,
+                path,
+                workload,
+                load,
+                total_seconds,
+                client_threads,
+                warmup_seconds,
+            )
+        ),
+        total_seconds + 30,
+        progress_duration_seconds=total_seconds,
+    )
+
+
+def _topic_cleanup_plan_builder(cli, definition, path, workload):
+    del workload
+    return (
+        WorkloadCommandPlan(
+            "clean",
+            tuple(_workload_base(cli, definition, None) + ["clean", "--topic", path]),
+            120,
+        ),
+    )
+
+
 def _validate_kv_options(options, location):
     if options["max-partitions"] < options["min-partitions"]:
         _config_error(location + ".max-partitions", "must not be below min-partitions")
@@ -784,6 +1095,10 @@ def _validate_tpcc_options(options, location):
     del options, location
 
 
+def _validate_topic_options(options, location):
+    del options, location
+
+
 def _validate_tpcc_profile(workload, load, measurement, location):
     maximum_sessions = workload["options"]["warehouses"] * _TPCC_TERMINALS_PER_WAREHOUSE
     if "values" in load:
@@ -801,6 +1116,18 @@ def _validate_tpcc_profile(workload, load, measurement, location):
                     "{}.load.search.{}".format(location, name),
                     "must not exceed warehouses * 10 ({})".format(maximum_sessions),
                 )
+
+
+def _validate_topic_profile(workload, load, measurement, location):
+    del workload, measurement
+    if load["allow_errors"]:
+        _config_error(location + ".load.allow-errors", "must be false because Topic does not report errors")
+    objective = load.get("objective")
+    if objective is not None and objective["type"] == "latency-slo" and objective["max_errors"] > 0:
+        _config_error(
+            location + ".load.objective.max-errors",
+            "must be zero because Topic does not report errors",
+        )
 
 
 def _validate_option_value(option, value, location):
@@ -1150,6 +1477,33 @@ _DEFINITIONS = (
         minimum_duration_seconds=2,
         load_limits=(("max-sessions", "warehouses", _TPCC_TERMINALS_PER_WAREHOUSE),),
         default_client_threads=2,
+    ),
+    WorkloadDefinition(
+        name="topic",
+        default_operation="full",
+        operations=("full",),
+        load_parameters=("rate",),
+        options=(
+            WorkloadOption("partitions", 128),
+            WorkloadOption("consumers", 1),
+            WorkloadOption("message-size", 10240),
+            WorkloadOption("codec", "raw", kind="string", choices=("raw", "gzip", "zstd")),
+        ),
+        uses_path=False,
+        table_name=None,
+        init_builder=_topic_init_builder,
+        run_builder=_topic_run_builder,
+        options_validator=_validate_topic_options,
+        dataset_scope="sample",
+        warmup_mode="inline",
+        prepare_plan_builder=_topic_prepare_plan_builder,
+        run_plan_builder=_topic_run_plan_builder,
+        cleanup_plan_builder=_topic_cleanup_plan_builder,
+        result_adapter=TOPIC_TOTAL_RESULT,
+        throughput_unit="messages/s",
+        profile_validator=_validate_topic_profile,
+        minimum_duration_seconds=2,
+        default_client_threads=1,
     ),
 )
 _validate_catalog(_DEFINITIONS)

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -232,7 +232,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
     tpcc_tpmc = _tpcc_number(summary["tpmc"], "summary.tpmc")
     efficiency = _tpcc_number(summary["efficiency"], "summary.efficiency", maximum=100)
     max_sessions = _tpcc_integer(summary["max_sessions"], "summary.max_sessions", 1)
-    _tpcc_integer(summary["threads"], "summary.threads", 1)
+    threads = _tpcc_integer(summary["threads"], "summary.threads", 1)
     warmup_seconds = _tpcc_integer(summary["warmup_seconds"], "summary.warmup_seconds", 1)
 
     options = normalized_workload["options"]
@@ -241,6 +241,8 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         _tpcc_result_error("field summary.warehouses does not match the configured warehouses")
     if max_sessions != request.load:
         _tpcc_result_error("field summary.max_sessions does not match the requested load")
+    if threads != request.client_threads:
+        _tpcc_result_error("field summary.threads does not match the requested client threads")
     if warmup_seconds != expected_warmup:
         _tpcc_result_error("field summary.warmup_seconds does not match the effective warmup")
     if measured_seconds < request.duration_seconds or measured_seconds > request.duration_seconds + 60:

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -264,7 +264,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         parsed_transactions[transaction_name] = {
             "ok_count": ok_count,
             "failed_count": _tpcc_integer(transaction["failed_count"], location + ".failed_count"),
-            "percentiles": percentile_families["percentiles"],
+            "percentiles_ms": percentile_families["percentiles_ms"],
         }
     if new_orders != parsed_transactions["NewOrder"]["ok_count"]:
         _tpcc_result_error("field summary.new_orders does not match transactions.NewOrder.ok_count")
@@ -280,7 +280,10 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
     }
     metrics.update(
-        {metric_name: value for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles"])}
+        {
+            metric_name: value
+            for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles_ms"])
+        }
     )
     return WorkloadResult(
         metrics,
@@ -293,7 +296,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
 
 
 TPCC_JSON_RESULT = WorkloadResultAdapter(
-    schema_id="tpcc-json-v1",
+    schema_id="tpcc-json-v2",
     parse=_parse_tpcc_json_result,
     metrics=(
         WorkloadMetric(
@@ -341,7 +344,10 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
                 metric_name,
                 "ms",
                 required=True,
-                description="Full selected-transaction latency including inflight queue wait",
+                description=(
+                    "Selected-transaction latency after admission by max-sessions, including session acquisition "
+                    "and SDK retries"
+                ),
             )
             for _percentile, metric_name in _TPCC_PERCENTILES
         ),

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -1,5 +1,6 @@
 """Declarative local-YDB workload catalog and YDB CLI command builders."""
 
+import json
 import math
 import re
 from dataclasses import dataclass
@@ -128,6 +129,225 @@ GENERIC_TOTAL_RESULT = WorkloadResultAdapter(
     ),
 )
 
+_TPCC_TRANSACTION_NAMES = ("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")
+_TPCC_PERCENTILES = (
+    ("50", "p50_ms"),
+    ("90", "p90_ms"),
+    ("95", "p95_ms"),
+    ("99", "p99_ms"),
+    ("99.9", "p999_ms"),
+)
+_TPCC_SLO_METRICS = (
+    ("p50", "p50_ms"),
+    ("p90", "p90_ms"),
+    ("p95", "p95_ms"),
+    ("p99", "p99_ms"),
+    ("p999", "p999_ms"),
+)
+_TPCC_TERMINALS_PER_WAREHOUSE = 10
+_TPCC_MIN_WARMUP_PER_TERMINAL_MS = 10
+_TPCC_JSON_MAX_BYTES = 1024 * 1024
+
+
+def _tpcc_result_error(message):
+    raise BenchmarkError("YDB CLI TPCC JSON output {}".format(message))
+
+
+def _tpcc_exact_mapping(value, location, fields):
+    if not isinstance(value, dict):
+        _tpcc_result_error("field {} must be an object".format(location))
+    missing = sorted(set(fields) - set(value))
+    unknown = sorted(set(value) - set(fields))
+    if missing:
+        _tpcc_result_error("field {} is missing: {}".format(location, ", ".join(missing)))
+    if unknown:
+        _tpcc_result_error("field {} contains unknown fields: {}".format(location, ", ".join(unknown)))
+    return value
+
+
+def _tpcc_integer(value, location, minimum=0):
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        _tpcc_result_error("field {} must be an integer not below {}".format(location, minimum))
+    return value
+
+
+def _tpcc_number(value, location, minimum=0, maximum=None):
+    if not _is_finite_number(value) or value < minimum or (maximum is not None and value > maximum):
+        bounds = "not below {}".format(minimum)
+        if maximum is not None:
+            bounds += " and not above {}".format(maximum)
+        _tpcc_result_error("field {} must be a finite number {}".format(location, bounds))
+    return float(value)
+
+
+def _tpcc_percentile_values(value, location):
+    value = _tpcc_exact_mapping(value, location, tuple(name for name, _metric in _TPCC_PERCENTILES))
+    parsed = [_tpcc_integer(value[name], "{}.{}".format(location, name)) for name, _metric in _TPCC_PERCENTILES]
+    if parsed != sorted(parsed):
+        _tpcc_result_error("field {} must contain monotonic percentiles".format(location))
+    return parsed
+
+
+def _tpcc_effective_warmup_seconds(workload, requested_seconds):
+    warehouses = workload["options"]["warehouses"]
+    terminals = warehouses * _TPCC_TERMINALS_PER_WAREHOUSE
+    minimum = terminals * _TPCC_MIN_WARMUP_PER_TERMINAL_MS // 1000 + 1
+    return max(requested_seconds, minimum)
+
+
+def _parse_tpcc_json_result(command_result, normalized_workload, request):
+    stdout = command_result.stdout
+    if not isinstance(stdout, str) or len(stdout.encode("utf-8")) > _TPCC_JSON_MAX_BYTES:
+        _tpcc_result_error("is empty or exceeds {} bytes".format(_TPCC_JSON_MAX_BYTES))
+    try:
+        root = json.loads(stdout)
+    except (TypeError, ValueError) as error:
+        raise BenchmarkError("YDB CLI TPCC JSON output is malformed: {}".format(error)) from error
+    if isinstance(root, dict) and set(root) == {"error"} and isinstance(root["error"], str):
+        _tpcc_result_error("reported a fatal error: {}".format(root["error"]))
+    root = _tpcc_exact_mapping(root, "$", ("summary", "transactions"))
+    summary = _tpcc_exact_mapping(
+        root["summary"],
+        "summary",
+        (
+            "name",
+            "time_seconds",
+            "measure_start_ts",
+            "warehouses",
+            "new_orders",
+            "tpmc",
+            "efficiency",
+            "max_sessions",
+            "threads",
+            "warmup_seconds",
+        ),
+    )
+    if summary["name"] != "Total":
+        _tpcc_result_error("field summary.name must equal Total")
+    measured_seconds = _tpcc_integer(summary["time_seconds"], "summary.time_seconds", 1)
+    measurement_started_at = _tpcc_integer(summary["measure_start_ts"], "summary.measure_start_ts", 1)
+    warehouses = _tpcc_integer(summary["warehouses"], "summary.warehouses", 1)
+    new_orders = _tpcc_integer(summary["new_orders"], "summary.new_orders")
+    tpcc_tpmc = _tpcc_number(summary["tpmc"], "summary.tpmc")
+    efficiency = _tpcc_number(summary["efficiency"], "summary.efficiency", maximum=100)
+    max_sessions = _tpcc_integer(summary["max_sessions"], "summary.max_sessions", 1)
+    _tpcc_integer(summary["threads"], "summary.threads", 1)
+    warmup_seconds = _tpcc_integer(summary["warmup_seconds"], "summary.warmup_seconds", 1)
+
+    options = normalized_workload["options"]
+    expected_warmup = _tpcc_effective_warmup_seconds(normalized_workload, request.warmup_seconds)
+    if warehouses != options["warehouses"]:
+        _tpcc_result_error("field summary.warehouses does not match the configured warehouses")
+    if max_sessions != request.load:
+        _tpcc_result_error("field summary.max_sessions does not match the requested load")
+    if warmup_seconds != expected_warmup:
+        _tpcc_result_error("field summary.warmup_seconds does not match the effective warmup")
+    if measured_seconds < request.duration_seconds or measured_seconds > request.duration_seconds + 60:
+        _tpcc_result_error("field summary.time_seconds is outside the requested measurement window")
+
+    transactions = _tpcc_exact_mapping(root["transactions"], "transactions", _TPCC_TRANSACTION_NAMES)
+    parsed_transactions = {}
+    transaction_fields = ("ok_count", "failed_count", "percentiles", "percentiles_ms", "percentiles_pure")
+    for transaction_name in _TPCC_TRANSACTION_NAMES:
+        location = "transactions.{}".format(transaction_name)
+        transaction = _tpcc_exact_mapping(transactions[transaction_name], location, transaction_fields)
+        ok_count = _tpcc_integer(transaction["ok_count"], location + ".ok_count")
+        percentile_families = {
+            field: _tpcc_percentile_values(transaction[field], location + "." + field)
+            for field in ("percentiles", "percentiles_ms", "percentiles_pure")
+        }
+        if ok_count == 0 and any(any(values) for values in percentile_families.values()):
+            _tpcc_result_error("field {} percentiles must be zero without successful transactions".format(location))
+        if ok_count > 0 and any(any(value < 1 for value in values) for values in percentile_families.values()):
+            _tpcc_result_error("field {} percentiles must be positive with successful transactions".format(location))
+        parsed_transactions[transaction_name] = {
+            "ok_count": ok_count,
+            "failed_count": _tpcc_integer(transaction["failed_count"], location + ".failed_count"),
+            "percentiles": percentile_families["percentiles"],
+        }
+    if new_orders != parsed_transactions["NewOrder"]["ok_count"]:
+        _tpcc_result_error("field summary.new_orders does not match transactions.NewOrder.ok_count")
+
+    latency_transaction = options["latency-transaction"]
+    selected = parsed_transactions[latency_transaction]
+    metrics = {
+        "transactions": selected["ok_count"] if new_orders > 0 else 0,
+        "new_orders": new_orders,
+        "throughput": new_orders / measured_seconds,
+        "tpcc_tpmc": tpcc_tpmc,
+        "efficiency_pct": efficiency,
+        "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
+    }
+    metrics.update(
+        {metric_name: value for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles"])}
+    )
+    return WorkloadResult(
+        metrics,
+        details=root,
+        measurement_window=(
+            float(measurement_started_at + 1),
+            float(measurement_started_at + request.duration_seconds),
+        ),
+    )
+
+
+TPCC_JSON_RESULT = WorkloadResultAdapter(
+    schema_id="tpcc-json-v1",
+    parse=_parse_tpcc_json_result,
+    metrics=(
+        WorkloadMetric(
+            "transactions",
+            "successful transactions",
+            required=True,
+            description=(
+                "Successful selected-transaction samples used for latency percentiles; zero when no NewOrder "
+                "transaction succeeded"
+            ),
+        ),
+        WorkloadMetric(
+            "new_orders",
+            "new orders",
+            required=True,
+            description="Successful NewOrder transactions in the measurement window",
+        ),
+        WorkloadMetric(
+            "throughput",
+            "new orders/s",
+            required=True,
+            description="Successful NewOrder transactions divided by measured seconds",
+        ),
+        WorkloadMetric(
+            "tpcc_tpmc",
+            "tpmC",
+            required=True,
+            description="CLI-reported capped TPC-C tpmC",
+        ),
+        WorkloadMetric(
+            "efficiency_pct",
+            "%",
+            required=True,
+            description="CLI-reported TPC-C efficiency",
+        ),
+        WorkloadMetric(
+            "errors",
+            "failed transactions",
+            repetition_aggregation="sum",
+            required=True,
+            description="Failed transactions across all TPC-C transaction types",
+        ),
+        *(
+            WorkloadMetric(
+                metric_name,
+                "ms",
+                required=True,
+                description="Full selected-transaction latency including inflight queue wait",
+            )
+            for _percentile, metric_name in _TPCC_PERCENTILES
+        ),
+    ),
+    slo_metrics=_TPCC_SLO_METRICS,
+)
+
 _RESERVED_RESULT_METRIC_NAMES = frozenset(
     (
         "load",
@@ -231,6 +451,11 @@ class WorkloadDefinition:
     cleanup_plan_builder: object = None
     result_adapter: WorkloadResultAdapter = GENERIC_TOTAL_RESULT
     throughput_unit: str = "operations/s"
+    profile_validator: object = None
+    effective_warmup_builder: object = None
+    minimum_duration_seconds: int = 1
+    load_limits: tuple = ()
+    default_client_threads: int = 64
 
 
 def _config_error(location, message):
@@ -257,13 +482,18 @@ def _mapping(value, location, allowed=()):
     return value
 
 
-def _workload_base(cli, definition, path):
-    command = [
+def _cli_base(cli):
+    return [
         cli.executable,
         "--endpoint",
         cli.endpoint,
         "--database",
         cli.database,
+    ]
+
+
+def _workload_base(cli, definition, path):
+    command = _cli_base(cli) + [
         "workload",
         definition.name,
     ]
@@ -423,6 +653,114 @@ def _log_run_builder(cli, definition, path, workload, load_parameter, load, seco
     ]
 
 
+def _tpcc_init_builder(cli, definition, path, workload):
+    return _workload_base(cli, definition, path) + [
+        "init",
+        "--warehouses",
+        workload["options"]["warehouses"],
+    ]
+
+
+def _tpcc_run_command(cli, definition, path, workload, load, seconds, client_threads, warmup_seconds):
+    options = workload["options"]
+    effective_warmup = _tpcc_effective_warmup_seconds(workload, warmup_seconds)
+    command = _workload_base(cli, definition, path) + [
+        "run",
+        "--warehouses",
+        options["warehouses"],
+        "--warmup",
+        "{}s".format(effective_warmup),
+        "--time",
+        "{}s".format(seconds),
+        "--max-sessions",
+        load,
+        "--threads",
+        client_threads,
+        "--format",
+        "Json",
+        "--no-tui",
+        "--tx-mode",
+        options["tx-mode"],
+    ]
+    if options["no-delays"]:
+        command.append("--no-delays")
+    if options["highres-histogram"]:
+        command.append("--highres-histogram")
+    return command
+
+
+def _tpcc_run_builder(cli, definition, path, workload, load_parameter, load, seconds, client_threads):
+    del load_parameter
+    return _tpcc_run_command(cli, definition, path, workload, load, seconds, client_threads, 0)
+
+
+def _tpcc_prepare_plan_builder(cli, definition, path, workload):
+    options = workload["options"]
+    import_command = _workload_base(cli, definition, path) + [
+        "import",
+        "--warehouses",
+        options["warehouses"],
+        "--threads",
+        options["import-threads"],
+        "--no-tui",
+    ]
+    if options["compact"]:
+        import_command.append("--compact")
+    return (
+        WorkloadCommandPlan("init", tuple(_tpcc_init_builder(cli, definition, path, workload)), 120),
+        WorkloadCommandPlan(
+            "import",
+            tuple(import_command),
+            max(600, options["warehouses"] * 60),
+        ),
+    )
+
+
+def _tpcc_run_plan_builder(
+    cli,
+    definition,
+    path,
+    workload,
+    load_parameter,
+    load,
+    seconds,
+    client_threads,
+    warmup_seconds,
+):
+    del load_parameter
+    effective_warmup = _tpcc_effective_warmup_seconds(workload, warmup_seconds)
+    return WorkloadCommandPlan(
+        "run",
+        tuple(
+            _tpcc_run_command(
+                cli,
+                definition,
+                path,
+                workload,
+                load,
+                seconds,
+                client_threads,
+                effective_warmup,
+            )
+        ),
+        effective_warmup + seconds + 60,
+        progress_duration_seconds=effective_warmup + seconds,
+    )
+
+
+def _tpcc_cleanup_plan_builder(cli, definition, path, workload):
+    del workload
+    full_path = path if str(path).startswith("/") else cli.database.rstrip("/") + "/" + str(path).lstrip("/")
+    return (
+        WorkloadCommandPlan("clean", tuple(_workload_base(cli, definition, path) + ["clean"]), 300),
+        WorkloadCommandPlan(
+            "rmdir",
+            tuple(_cli_base(cli) + ["scheme", "rmdir", "--recursive", "--force", full_path]),
+            300,
+        ),
+    )
+
+
 def _validate_kv_options(options, location):
     if options["max-partitions"] < options["min-partitions"]:
         _config_error(location + ".max-partitions", "must not be below min-partitions")
@@ -440,6 +778,29 @@ def _validate_log_options(options, location):
     columns = options["integer-columns"] + options["string-columns"]
     if options["key-columns"] > columns:
         _config_error(location + ".key-columns", "must not exceed integer-columns plus string-columns")
+
+
+def _validate_tpcc_options(options, location):
+    del options, location
+
+
+def _validate_tpcc_profile(workload, load, measurement, location):
+    maximum_sessions = workload["options"]["warehouses"] * _TPCC_TERMINALS_PER_WAREHOUSE
+    if "values" in load:
+        for index, value in enumerate(load["values"]):
+            if value > maximum_sessions:
+                _config_error(
+                    "{}.load.values[{}]".format(location, index),
+                    "must not exceed warehouses * 10 ({})".format(maximum_sessions),
+                )
+    else:
+        for name in ("start", "maximum"):
+            value = load["search"][name]
+            if value > maximum_sessions:
+                _config_error(
+                    "{}.load.search.{}".format(location, name),
+                    "must not exceed warehouses * 10 ({})".format(maximum_sessions),
+                )
 
 
 def _validate_option_value(option, value, location):
@@ -572,12 +933,30 @@ def _validate_catalog(definitions):
             raise ValueError("unknown dataset scope for {}: {}".format(definition.name, definition.dataset_scope))
         if definition.warmup_mode not in ("separate", "inline"):
             raise ValueError("unknown warmup mode for {}: {}".format(definition.name, definition.warmup_mode))
-        for name in ("prepare_plan_builder", "run_plan_builder", "cleanup_plan_builder"):
+        for name in (
+            "prepare_plan_builder",
+            "run_plan_builder",
+            "cleanup_plan_builder",
+            "profile_validator",
+            "effective_warmup_builder",
+        ):
             builder = getattr(definition, name)
             if builder is not None and not callable(builder):
                 raise ValueError("{} must be callable for {}".format(name, definition.name))
         if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
             raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
+        if (
+            isinstance(definition.minimum_duration_seconds, bool)
+            or not isinstance(definition.minimum_duration_seconds, int)
+            or definition.minimum_duration_seconds <= 0
+        ):
+            raise ValueError("minimum duration must be a positive integer for {}".format(definition.name))
+        if (
+            isinstance(definition.default_client_threads, bool)
+            or not isinstance(definition.default_client_threads, int)
+            or definition.default_client_threads <= 0
+        ):
+            raise ValueError("default client threads must be a positive integer for {}".format(definition.name))
         if len(definition.operations) != len(set(definition.operations)):
             raise ValueError("operations must be unique for {}".format(definition.name))
         if len(definition.load_parameters) != len(set(definition.load_parameters)):
@@ -587,6 +966,29 @@ def _validate_catalog(definitions):
         option_names = [option.name for option in definition.options]
         if len(option_names) != len(set(option_names)):
             raise ValueError("option names must be unique for {}".format(definition.name))
+        if not isinstance(definition.load_limits, tuple):
+            raise ValueError("load limits must be a tuple for {}".format(definition.name))
+        limited_parameters = []
+        for limit in definition.load_limits:
+            limit_option = (
+                next((option for option in definition.options if option.name == limit[1]), None)
+                if isinstance(limit, tuple) and len(limit) == 3
+                else None
+            )
+            if (
+                not isinstance(limit, tuple)
+                or len(limit) != 3
+                or limit[0] not in definition.load_parameters
+                or limit_option is None
+                or limit_option.kind != "integer"
+                or isinstance(limit[2], bool)
+                or not isinstance(limit[2], int)
+                or limit[2] <= 0
+            ):
+                raise ValueError("invalid load limit for {}".format(definition.name))
+            limited_parameters.append(limit[0])
+        if len(limited_parameters) != len(set(limited_parameters)):
+            raise ValueError("load limits must be unique for {}".format(definition.name))
         for option in definition.options:
             if option.kind not in ("integer", "string", "boolean", "duration"):
                 raise ValueError("unknown workload option kind: {}".format(option.kind))
@@ -707,6 +1109,48 @@ _DEFINITIONS = (
         warmup_mode="separate",
         throughput_unit="batches/s",
     ),
+    WorkloadDefinition(
+        name="tpcc",
+        default_operation="run",
+        operations=("run",),
+        load_parameters=("max-sessions",),
+        options=(
+            WorkloadOption("warehouses", 10),
+            WorkloadOption("import-threads", 0, allow_zero=True),
+            WorkloadOption("compact", False, kind="boolean"),
+            WorkloadOption(
+                "tx-mode",
+                "serializable-rw",
+                kind="string",
+                choices=("serializable-rw", "snapshot-rw"),
+            ),
+            WorkloadOption(
+                "latency-transaction",
+                "NewOrder",
+                kind="string",
+                choices=_TPCC_TRANSACTION_NAMES,
+            ),
+            WorkloadOption("no-delays", False, kind="boolean"),
+            WorkloadOption("highres-histogram", False, kind="boolean"),
+        ),
+        uses_path=True,
+        table_name=None,
+        init_builder=_tpcc_init_builder,
+        run_builder=_tpcc_run_builder,
+        options_validator=_validate_tpcc_options,
+        dataset_scope="geometry",
+        warmup_mode="inline",
+        prepare_plan_builder=_tpcc_prepare_plan_builder,
+        run_plan_builder=_tpcc_run_plan_builder,
+        cleanup_plan_builder=_tpcc_cleanup_plan_builder,
+        result_adapter=TPCC_JSON_RESULT,
+        throughput_unit="new orders/s",
+        profile_validator=_validate_tpcc_profile,
+        effective_warmup_builder=_tpcc_effective_warmup_seconds,
+        minimum_duration_seconds=2,
+        load_limits=(("max-sessions", "warehouses", _TPCC_TERMINALS_PER_WAREHOUSE),),
+        default_client_threads=2,
+    ),
 )
 _validate_catalog(_DEFINITIONS)
 _WORKLOADS = MappingProxyType({definition.name: definition for definition in _DEFINITIONS})
@@ -807,6 +1251,12 @@ def web_workload_catalog():
             "slo_metrics": dict(definition.result_adapter.slo_metrics),
             "reports_errors": any(metric.name == "errors" for metric in definition.result_adapter.metrics),
             "result_schema_id": definition.result_adapter.schema_id,
+            "minimum_duration_seconds": definition.minimum_duration_seconds,
+            "default_client_threads": definition.default_client_threads,
+            "load_limits": {
+                parameter: {"option": option, "multiplier": multiplier}
+                for parameter, option, multiplier in definition.load_limits
+            },
             "options": [
                 {
                     "name": option.name,
@@ -848,6 +1298,33 @@ def all_slo_percentiles():
 
 def allowed_slo_metrics(workload_type):
     return dict(_definition(workload_type).result_adapter.slo_metrics)
+
+
+def validate_workload_profile(workload, load, measurement, location):
+    """Validate cross-field constraints owned by one workload definition."""
+
+    definition = _definition(workload["type"])
+    if measurement["duration"] < definition.minimum_duration_seconds:
+        _config_error(
+            location + ".measurement.duration",
+            "must be at least {} for {}".format(definition.minimum_duration_seconds, definition.name),
+        )
+    if definition.profile_validator is not None:
+        definition.profile_validator(workload, load, measurement, location)
+
+
+def workload_effective_warmup_seconds(workload, requested_seconds):
+    """Return the explicit warmup passed to the CLI for one workload run."""
+
+    if isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0:
+        raise BenchmarkError("workload warmup must be a non-negative integer")
+    definition = _definition(workload["type"])
+    if definition.effective_warmup_builder is None:
+        return requested_seconds
+    effective = definition.effective_warmup_builder(workload, requested_seconds)
+    if isinstance(effective, bool) or not isinstance(effective, int) or effective < requested_seconds:
+        raise BenchmarkError("{} returned an invalid effective warmup".format(definition.name))
+    return effective
 
 
 def build_init_argv(cli, path, workload):

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -239,17 +239,61 @@ _JS = (
     "const localYdbAffinityKeys={ydb_cli:'ydb-cli',static_nodes:'static-nodes',dynamic_nodes:'dynamic-nodes'};\n"
     "function localYdbWorkloadDefinition(type){const definition=(editor.model?.local_ydb_workloads||[]).find(item=>item.type"
     "===type);if(!definition)throw Error('Unknown local YDB workload: '+type);return definition}\n"
-    "const localYdbLoadDefaults={rate:{values:[1000],start:1000,maximum:100000},threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}};\n"
-    "function localYdbResetLoadParameter(load,parameter){const defaults=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;"
-    "if(load.values)return {...load,parameter,values:[...defaults.values]};return {...load,parameter,search:{...(load.search||{}),start:defaults.start,maximum:defaults.maximum}}}\n"
-    "function localYdbLoadForWorkload(load,parameters){return parameters.includes(load.parameter)?load:localYdbResetLoadParameter(load,parameters[0])}\n"
+    """
+const localYdbLoadDefaults={
+  rate:{values:[1000],start:1000,maximum:100000},
+  threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256},
+  'max-sessions':{values:[1,2,4,8,16,32,64],start:1,maximum:100}
+};
+function localYdbLoadLimit(definition,workload,parameter){
+  const constraint=definition?.load_limits?.[parameter];
+  if(!constraint)return null;
+  const option=Number(workload?.options?.[constraint.option]),multiplier=Number(constraint.multiplier);
+  const limit=option*multiplier;
+  return Number.isSafeInteger(limit)&&limit>0?limit:null
+}
+function localYdbDefaultClientThreads(definition){
+  const value=Number(definition?.default_client_threads);
+  return Number.isSafeInteger(value)&&value>0?value:64
+}
+function localYdbParameterDefaults(parameter,definition=null,workload=null){
+  const source=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;
+  const limit=localYdbLoadLimit(definition,workload,parameter);
+  if(limit===null)return {...source,values:[...source.values]};
+  const values=[...new Set(source.values.map(value=>Math.min(value,limit)))].sort((left,right)=>left-right);
+  return {values,start:Math.min(source.start,limit),maximum:Math.min(source.maximum,limit)}
+}
+function localYdbClampLoad(load,definition=null,workload=null){
+  const limit=localYdbLoadLimit(definition,workload,load.parameter);
+  if(limit===null)return load;
+  if(load.values){
+    const values=[...new Set(load.values.map(value=>Math.min(Number(value),limit)))]
+      .filter(value=>Number.isSafeInteger(value)&&value>0).sort((left,right)=>left-right);
+    return {...load,values:values.length?values:[limit]}
+  }
+  const maximum=Math.min(Number(load.search.maximum),limit);
+  return {...load,search:{...load.search,start:Math.min(Number(load.search.start),maximum),maximum}}
+}
+function localYdbResetLoadParameter(load,parameter,definition=null,workload=null){
+  const defaults=localYdbParameterDefaults(parameter,definition,workload);
+  const reset=load.values?{...load,parameter,values:[...defaults.values]}:{
+    ...load,parameter,search:{...(load.search||{}),start:defaults.start,maximum:defaults.maximum}
+  };
+  return localYdbClampLoad(reset,definition,workload)
+}
+function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
+  const compatible=parameters.includes(load.parameter)?load:
+    localYdbResetLoadParameter(load,parameters[0],definition,workload);
+  return localYdbClampLoad(compatible,definition,workload)
+}
+"""
     "function defaultLocalYdbWorkload(type){const definition=localYdbWorkloadDefinition(type),operation=definition.default_"
     "operation,options=Object.fromEntries(definition.options.map(option=>[option.name,Object.prototype.hasOwnProperty.call("
     "option.operation_defaults,operation)?option.operation_defaults[operation]:option.default]));return {type,operation,opt"
     "ions}}\n"
-    "function defaultLocalYdb(){return {workload:defaultLocalYdbWorkload('kv'),"
+    "function defaultLocalYdb(){const definition=localYdbWorkloadDefinition('kv');return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
-    ":{threads:64},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
+    ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
     "etitions:3,verification_repetitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
@@ -455,7 +499,10 @@ function localYdbProfileEditor(profile){
     localField('local-client-threads','YDB CLI threads',config.client.threads,'','type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
     localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+
-    localField('local-measurement-duration','Duration (seconds)',measurement.duration,'','type=number min=1')+
+    localField(
+      'local-measurement-duration','Duration (seconds)',measurement.duration,'',
+      'type=number min='+(definition.minimum_duration_seconds||1)
+    )+
     localField('local-measurement-repetitions','Repetitions',measurement.repetitions,'','type=number min=1')+
     localField(
       'local-measurement-verification-repetitions','Verification repetitions',
@@ -511,13 +558,17 @@ function bindLocalYdbEditor(profile){
       config.workload=defaultLocalYdbWorkload(event.target.value);editor.selected=profile.key;
       const nextDefinition=localYdbWorkloadDefinition(event.target.value);
       const parameters=nextDefinition.load_parameters;
-      config.load=localYdbLoadForWorkload(config.load,parameters);
+      config.client.threads=localYdbDefaultClientThreads(nextDefinition);
+      config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload);
+      config.measurement.duration=Math.max(
+        config.measurement.duration,nextDefinition.minimum_duration_seconds||1
+      );
       if(!nextDefinition.reports_errors)config.load.allow_errors=false;
       if(config.load.objective?.type==='latency-slo'){
         const percentile=localYdbSloPercentile(nextDefinition,config.load.objective.percentile);
         if(percentile)config.load.objective.percentile=percentile;
         else{
-          const defaults=localYdbLoadDefaults[config.load.parameter]||localYdbLoadDefaults.threads;
+          const defaults=localYdbParameterDefaults(config.load.parameter,nextDefinition,config.workload);
           config.load={
             parameter:config.load.parameter,allow_errors:false,values:[...defaults.values]
           }
@@ -527,7 +578,9 @@ function bindLocalYdbEditor(profile){
     }
     if(event.target.id==='local-load-parameter'){
       const parameter=event.target.value;
-      if(parameter!==config.load.parameter)config.load=localYdbResetLoadParameter(config.load,parameter);
+      if(parameter!==config.load.parameter)config.load=localYdbResetLoadParameter(
+        config.load,parameter,localYdbWorkloadDefinition(config.workload.type),config.workload
+      );
       editor.yaml=serializeConfig(editor.model);saveDraft();renderNew();return
     }
     if(event.target.id==='local-geometry-preset'){
@@ -543,7 +596,9 @@ function bindLocalYdbEditor(profile){
     }
     if(event.target.id==='local-load-mode'){
       const mode=event.target.value,allow_errors=Boolean(config.load.allow_errors);
-      const defaults=localYdbLoadDefaults[config.load.parameter]||localYdbLoadDefaults.threads;
+      const defaults=localYdbParameterDefaults(
+        config.load.parameter,localYdbWorkloadDefinition(config.workload.type),config.workload
+      );
       if(mode==='points'){
         config.load={parameter:config.load.parameter,allow_errors,values:config.load.values||[...defaults.values]}
       }else{
@@ -615,9 +670,10 @@ function bindLocalYdbEditor(profile){
         min_achieved_rate_ratio:localNumber('local-slo-min-achieved-rate-ratio',0)
       })
     }
+    config.load=localYdbClampLoad(config.load,workloadDefinition,config.workload);
     config.measurement={
       warmup:localInteger('local-measurement-warmup',0),
-      duration:localInteger('local-measurement-duration'),
+      duration:localInteger('local-measurement-duration',workloadDefinition.minimum_duration_seconds||1),
       repetitions:localInteger('local-measurement-repetitions'),
       verification_repetitions:localInteger('local-measurement-verification-repetitions',0,20)
     };
@@ -630,7 +686,11 @@ function bindLocalYdbEditor(profile){
     profile.threads=[config.client.threads];profile.duration=config.measurement.duration;
     profile.repetitions=1;profile.affinity=['roles'];profile.background_load=['none'];
     editor.selected=profile.key;editor.yaml=serializeConfig(editor.model);saveDraft();
-    if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id))renderNew()
+    const loadLimitInputs=Object.values(workloadDefinition.load_limits||{}).map(
+      constraint=>'local-option-'+constraint.option
+    );
+    if(['profile-name','local-geometry-preset','local-load-allow-errors'].includes(event.target.id)||
+      loadLimitInputs.includes(event.target.id))renderNew()
   }catch(error){message().innerHTML=displayError(error)}};
   for(const input of document.querySelectorAll('#local-editor input,#local-editor select'))input.onchange=update;
   document.querySelector('#delete-profile').onclick=()=>{
@@ -1465,6 +1525,7 @@ function localOutcomeLabel(outcome){
 }
 function localSearchAxisLabel(parameter,workload){
   if(parameter==='threads')return 'YDB CLI threads';
+  if(parameter==='max-sessions')return 'Maximum sessions';
   if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';
   return parameter||'Search value'
 }

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -426,6 +426,8 @@ function localYdbSloPercentile(definition,requested=null){
 function localYdbProfileEditor(profile){
   const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
   const definition=localYdbWorkloadDefinition(workload.type);
+  const clientThreadsHelp=workload.type==='topic'?
+    'Applied to both producer and consumer thread counts; every consumer gets this many reader threads.':'';
   const loadMode=load.values?'points':load.objective.type;
   const sloPercentiles=Object.keys(definition.slo_metrics||{});
   const objectiveChoices=['points','maximize-throughput',...(sloPercentiles.length?['latency-slo']:[])];
@@ -496,7 +498,7 @@ function localYdbProfileEditor(profile){
     )+options+'</div><h3>Cluster geometry</h3><div class=form-grid>'+
     localSelect('local-geometry-preset','Preset',geometry.preset,['single','storage','custom'])+geometryFields+
     '</div><h3>Client and load</h3><div class=form-grid>'+
-    localField('local-client-threads','YDB CLI threads',config.client.threads,'','type=number min=1')+
+    localField('local-client-threads','YDB CLI threads',config.client.threads,clientThreadsHelp,'type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
     localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+
     localField(
@@ -563,7 +565,10 @@ function bindLocalYdbEditor(profile){
       config.measurement.duration=Math.max(
         config.measurement.duration,nextDefinition.minimum_duration_seconds||1
       );
-      if(!nextDefinition.reports_errors)config.load.allow_errors=false;
+      if(!nextDefinition.reports_errors){
+        config.load.allow_errors=false;
+        if(config.load.objective?.type==='latency-slo')config.load.objective.max_errors=0
+      }
       if(config.load.objective?.type==='latency-slo'){
         const percentile=localYdbSloPercentile(nextDefinition,config.load.objective.percentile);
         if(percentile)config.load.objective.percentile=percentile;
@@ -1526,11 +1531,12 @@ function localOutcomeLabel(outcome){
 function localSearchAxisLabel(parameter,workload){
   if(parameter==='threads')return 'YDB CLI threads';
   if(parameter==='max-sessions')return 'Maximum sessions';
-  if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':'Offered rate (requests/s)';
+  if(parameter==='rate')return workload==='stock'?'Offered rate (transactions/s)':
+    workload==='topic'?'Offered rate (messages/s)':'Offered rate (requests/s)';
   return parameter||'Search value'
 }
 function localLegacyResultSchema(workload){
-  const throughputUnit={kv:'requests/s',stock:'transactions/s',log:'batches/s'}[workload]||'operations/s';
+  const throughputUnit={kv:'requests/s',stock:'transactions/s',log:'batches/s',topic:'messages/s'}[workload]||'operations/s';
   return {
     schema_id:'generic-total-v1',throughput_unit:throughputUnit,reports_errors:true,
     metrics:[

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4752,20 +4752,15 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
     def test_local_ydb_database_status_requires_running_state(self):
         status = """Database /Root/bench status:
   State: RUNNING
+  Allocated pools:
+    ssd: 1/1
+  Allocated units:
   Registered units:
-    host:1234 - dynamic
-    host:5678 - dynamic
   Data size hard quota: 0
+  Data size soft quota: 0
 """
-        self.assertEqual(local_ydb._registered_database_units(status), {"host:1234", "host:5678"})
-        self.assertTrue(local_ydb._database_status_ready(status, {"host:1234", "host:5678"}))
-        self.assertFalse(local_ydb._database_status_ready(status, {"host:1234", "host:9999"}))
-        self.assertFalse(
-            local_ydb._database_status_ready(
-                status.replace("RUNNING", "PENDING_RESOURCES"),
-                {"host:1234"},
-            )
-        )
+        self.assertTrue(local_ydb._database_status_ready(status))
+        self.assertFalse(local_ydb._database_status_ready(status.replace("RUNNING", "PENDING_RESOURCES")))
 
     def test_local_ydb_static_nodes_use_self_management(self):
         config = local_ydb._cluster_config(
@@ -4815,7 +4810,7 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
         self.assertEqual(config["config"]["host_configs"][0]["ssd"], ["SectorMap:map_0:64:NONE"])
         self.assertEqual(start_process.call_args.kwargs["parent_death_wrapper"], self.root / "process_guard")
 
-    def test_local_ydb_scaling_waits_for_every_new_registered_node(self):
+    def test_local_ydb_scaling_waits_for_database_and_every_new_node(self):
         cluster_directory = self.root / "scaling-cluster"
         cluster_directory.mkdir()
         cluster = local_ydb.LocalYdbCluster(
@@ -4843,7 +4838,7 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
             cluster, "_wait_for_port"
         ) as wait_for_port, mock.patch.object(cluster, "_wait_database_ready") as wait_database, mock.patch.object(
             cluster, "_wait_tenant_ready"
-        ), mock.patch.object(
+        ) as wait_tenant, mock.patch.object(
             local_ydb, "start_managed_process", side_effect=(mock.Mock(pid=101), mock.Mock(pid=102))
         ):
             cluster.add_dynamic_nodes(2)
@@ -4852,7 +4847,8 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
             wait_for_port.call_args_list,
             [mock.call(2136, "dynamic node 1"), mock.call(2137, "dynamic node 2")],
         )
-        wait_database.assert_called_once_with({"benchmark-host:19002", "benchmark-host:19003"})
+        wait_database.assert_called_once_with()
+        wait_tenant.assert_called_once_with(30)
 
     def test_local_ydb_tenant_readiness_checks_every_dynamic_node(self):
         cluster_directory = self.root / "tenant-ready-cluster"

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -289,7 +289,9 @@ class YdbBenchTest(unittest.TestCase):
         latency_transaction="Payment",
         selected_ok=300,
     ):
-        percentile_values = {"50": 1, "90": 2, "95": 3, "99": 4, "99.9": 5}
+        full_percentile_values = {"50": 101, "90": 102, "95": 103, "99": 104, "99.9": 105}
+        admitted_percentile_values = {"50": 11, "90": 12, "95": 13, "99": 14, "99.9": 15}
+        pure_percentile_values = {"50": 1, "90": 2, "95": 3, "99": 4, "99.9": 5}
         transactions = {}
         for index, name in enumerate(("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")):
             ok_count = new_orders if name == "NewOrder" else 100 + index
@@ -298,9 +300,9 @@ class YdbBenchTest(unittest.TestCase):
             transactions[name] = {
                 "ok_count": ok_count,
                 "failed_count": index,
-                "percentiles": dict(percentile_values),
-                "percentiles_ms": dict(percentile_values),
-                "percentiles_pure": dict(percentile_values),
+                "percentiles": dict(full_percentile_values),
+                "percentiles_ms": dict(admitted_percentile_values),
+                "percentiles_pure": dict(pure_percentile_values),
             }
         return {
             "summary": {
@@ -485,7 +487,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         self.assertEqual(
             [item["result_schema_id"] for item in catalog],
-            ["generic-total-v1"] * 3 + ["tpcc-json-v1", "topic-total-v1"],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v2", "topic-total-v1"],
         )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
@@ -1429,7 +1431,7 @@ class YdbBenchTest(unittest.TestCase):
         for call in monitor.summary.call_args_list:
             self.assertEqual(call.kwargs, {"started_at_unix": 1001.0, "finished_at_unix": 1010.0})
         details = json.loads((self.root / "tpcc-repeat-1" / "workload-result.json").read_text(encoding="utf-8"))
-        self.assertEqual(details["schema_id"], "tpcc-json-v1")
+        self.assertEqual(details["schema_id"], "tpcc-json-v2")
         self.assertEqual(details["details"], payload)
         self.assertEqual(
             [item["phase"] for item in progress],
@@ -2146,7 +2148,7 @@ class YdbBenchTest(unittest.TestCase):
                 20 nan 0 0 1 2 3 4
             """)
 
-    def test_local_ydb_tpcc_json_result_is_strict_and_uses_uncapped_throughput(self):
+    def test_local_ydb_tpcc_json_result_uses_uncapped_throughput_and_admitted_latency(self):
         workload = local_ydb_workloads.normalize_workload(
             {
                 "type": "tpcc",
@@ -2171,17 +2173,17 @@ class YdbBenchTest(unittest.TestCase):
                 "tpcc_tpmc": 25.5,
                 "efficiency_pct": 80.25,
                 "errors": 10,
-                "p50_ms": 1,
-                "p90_ms": 2,
-                "p95_ms": 3,
-                "p99_ms": 4,
-                "p999_ms": 5,
+                "p50_ms": 11,
+                "p90_ms": 12,
+                "p95_ms": 13,
+                "p99_ms": 14,
+                "p999_ms": 15,
             },
         )
         self.assertEqual(result.details, payload)
         self.assertEqual(result.measurement_window, (1001.0, 1010.0))
         schema = local_ydb_workloads.workload_result_schema("tpcc")
-        self.assertEqual(schema["schema_id"], "tpcc-json-v1")
+        self.assertEqual(schema["schema_id"], "tpcc-json-v2")
         self.assertEqual(schema["throughput_unit"], "new orders/s")
         self.assertEqual(schema["slo_metrics"]["p999"], "p999_ms")
         self.assertNotIn("p99.9", schema["slo_metrics"])
@@ -2214,7 +2216,7 @@ class YdbBenchTest(unittest.TestCase):
             request,
         )
         self.assertEqual(no_new_orders_result.metrics["transactions"], 0)
-        self.assertEqual(no_new_orders_result.metrics["p99_ms"], 4)
+        self.assertEqual(no_new_orders_result.metrics["p99_ms"], 14)
         aggregated = local_ydb._aggregate_measurements(
             [no_new_orders_result.metrics],
             local_ydb_workloads.workload_definition("tpcc").result_adapter.metrics,

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -278,6 +278,47 @@ class YdbBenchTest(unittest.TestCase):
         )
 
     @staticmethod
+    def _tpcc_result_payload(
+        warehouses=2,
+        max_sessions=20,
+        threads=2,
+        warmup_seconds=2,
+        time_seconds=12,
+        measure_start_ts=1000,
+        new_orders=120,
+        latency_transaction="Payment",
+        selected_ok=300,
+    ):
+        percentile_values = {"50": 1, "90": 2, "95": 3, "99": 4, "99.9": 5}
+        transactions = {}
+        for index, name in enumerate(("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")):
+            ok_count = new_orders if name == "NewOrder" else 100 + index
+            if name == latency_transaction:
+                ok_count = selected_ok
+            transactions[name] = {
+                "ok_count": ok_count,
+                "failed_count": index,
+                "percentiles": dict(percentile_values),
+                "percentiles_ms": dict(percentile_values),
+                "percentiles_pure": dict(percentile_values),
+            }
+        return {
+            "summary": {
+                "name": "Total",
+                "time_seconds": time_seconds,
+                "measure_start_ts": measure_start_ts,
+                "warehouses": warehouses,
+                "new_orders": transactions["NewOrder"]["ok_count"],
+                "tpmc": 25.5,
+                "efficiency": 80.25,
+                "max_sessions": max_sessions,
+                "threads": threads,
+                "warmup_seconds": warmup_seconds,
+            },
+            "transactions": transactions,
+        }
+
+    @staticmethod
     def _synthetic_profile_workload(
         cleanup_names=("clean",),
         measurement_window=(101.0, 109.0),
@@ -434,7 +475,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
 
         catalog = local_ydb_workloads.web_workload_catalog()
-        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log"])
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log", "tpcc"])
         self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
         self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
         self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
@@ -442,13 +483,24 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["operations"], ["insert", "upsert", "bulk-upsert"])
         self.assertEqual(catalog[2]["load_parameters"], ["threads"])
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
-        self.assertEqual([item["result_schema_id"] for item in catalog], ["generic-total-v1"] * 3)
+        self.assertEqual(
+            [item["result_schema_id"] for item in catalog],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v1"],
+        )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
-            ["requests/s", "transactions/s", "batches/s"],
+            ["requests/s", "transactions/s", "batches/s", "new orders/s"],
         )
         self.assertTrue(all(item["reports_errors"] for item in catalog))
         self.assertEqual(catalog[0]["slo_metrics"]["p99"], "p99_ms")
+        self.assertEqual(catalog[3]["load_parameters"], ["max-sessions"])
+        self.assertEqual(catalog[3]["slo_metrics"]["p999"], "p999_ms")
+        self.assertEqual(catalog[3]["default_client_threads"], 2)
+        self.assertEqual(catalog[3]["minimum_duration_seconds"], 2)
+        self.assertEqual(
+            catalog[3]["load_limits"],
+            {"max-sessions": {"option": "warehouses", "multiplier": 10}},
+        )
         catalog_parameters = tuple(
             dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
         )
@@ -485,7 +537,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(stock["options"]["orders"], 100)
 
         invalid = (
-            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log"),
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log, tpcc"),
             ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
             (
                 {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
@@ -503,6 +555,70 @@ class YdbBenchTest(unittest.TestCase):
         for workload, message in invalid:
             with self.subTest(workload=workload), self.assertRaisesRegex(BenchmarkError, message):
                 local_ydb_workloads.normalize_workload(workload, "local-ydb.profile.workload")
+
+    def test_local_ydb_tpcc_defaults_warmup_and_profile_validation(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              tpcc-smoke:
+                workload: {type: tpcc, operation: run}
+                load: {parameter: max-sessions, values: [1, 100]}
+                measurement: {warmup: 0, duration: 2, repetitions: 1}
+        """))
+        profile = loaded.runs[0].parameters["local_ydb"]
+        self.assertEqual(
+            profile["workload"]["options"],
+            {
+                "warehouses": 10,
+                "import-threads": 0,
+                "compact": False,
+                "tx-mode": "serializable-rw",
+                "latency-transaction": "NewOrder",
+                "no-delays": False,
+                "highres-histogram": False,
+            },
+        )
+        self.assertEqual(profile["client"]["threads"], 2)
+        self.assertEqual(profile["load"]["values"], [1, 100])
+        self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 0), 2)
+        self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 1), 2)
+        self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 7), 7)
+
+        invalid_profiles = (
+            (
+                """
+                local-ydb:
+                  invalid-tpcc:
+                    workload: {type: tpcc, operation: run}
+                    load: {parameter: max-sessions, values: [101]}
+                """,
+                "load.values\\[0\\].*warehouses \\* 10",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-tpcc:
+                    workload: {type: tpcc, operation: run}
+                    load:
+                      parameter: max-sessions
+                      search: {start: 1, maximum: 101}
+                      objective: {type: maximize-throughput}
+                """,
+                "load.search.maximum.*warehouses \\* 10",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-tpcc:
+                    workload: {type: tpcc, operation: run}
+                    load: {parameter: max-sessions, values: [1]}
+                    measurement: {duration: 1}
+                """,
+                "measurement.duration.*at least 2",
+            ),
+        )
+        for index, (body, message) in enumerate(invalid_profiles):
+            with self.subTest(index=index), self.assertRaisesRegex(BenchmarkError, message):
+                load_config(self._config(body, "invalid-tpcc-{}.yaml".format(index)))
 
     def test_local_ydb_workload_registry_supports_typed_options(self):
         definition = local_ydb_workloads.WorkloadDefinition(
@@ -738,6 +854,144 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
         self.assertIsNone(cleanup[0].timeout_seconds)
 
+    def test_local_ydb_tpcc_builds_golden_prepare_run_and_cleanup_plans(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {
+                    "warehouses": 12,
+                    "import-threads": 0,
+                    "compact": True,
+                    "tx-mode": "snapshot-rw",
+                    "latency-transaction": "Payment",
+                    "no-delays": True,
+                    "highres-histogram": True,
+                },
+            },
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "tpcc",
+            "--path",
+            "tpcc-dataset",
+        ]
+        prepare = local_ydb_workloads.build_prepare_plan(cli_context, "tpcc-dataset", workload)
+        self.assertEqual(
+            prepare,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    tuple(base + ["init", "--warehouses", 12]),
+                    120,
+                ),
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "import",
+                    tuple(
+                        base
+                        + [
+                            "import",
+                            "--warehouses",
+                            12,
+                            "--threads",
+                            0,
+                            "--no-tui",
+                            "--compact",
+                        ]
+                    ),
+                    720,
+                ),
+            ),
+        )
+
+        run = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "tpcc-dataset",
+            workload,
+            "max-sessions",
+            50,
+            30,
+            3,
+            warmup_seconds=0,
+        )
+        self.assertEqual(
+            run.argv,
+            tuple(
+                base
+                + [
+                    "run",
+                    "--warehouses",
+                    12,
+                    "--warmup",
+                    "2s",
+                    "--time",
+                    "30s",
+                    "--max-sessions",
+                    50,
+                    "--threads",
+                    3,
+                    "--format",
+                    "Json",
+                    "--no-tui",
+                    "--tx-mode",
+                    "snapshot-rw",
+                    "--no-delays",
+                    "--highres-histogram",
+                ]
+            ),
+        )
+        self.assertEqual(run.timeout_seconds, 92)
+        self.assertEqual(run.progress_duration_seconds, 32)
+        requested_warmup = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "tpcc-dataset",
+            workload,
+            "max-sessions",
+            50,
+            30,
+            3,
+            warmup_seconds=7,
+        )
+        self.assertEqual(requested_warmup.argv[requested_warmup.argv.index("--warmup") + 1], "7s")
+        self.assertEqual(requested_warmup.timeout_seconds, 97)
+
+        cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "tpcc-dataset", workload)
+        self.assertEqual(
+            cleanup,
+            (
+                local_ydb_workloads.WorkloadCommandPlan("clean", tuple(base + ["clean"]), 300),
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "rmdir",
+                    (
+                        Path("/tmp/ydb cli"),
+                        "--endpoint",
+                        "grpc://benchmark-host.example:2135",
+                        "--database",
+                        "/Root/bench",
+                        "scheme",
+                        "rmdir",
+                        "--recursive",
+                        "--force",
+                        "/Root/bench/tpcc-dataset",
+                    ),
+                    300,
+                ),
+            ),
+        )
+        absolute_cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "/Root/other", workload)
+        self.assertEqual(absolute_cleanup[1].argv[-1], "/Root/other")
+
     def test_local_ydb_workload_registry_validates_lifecycle_metadata_and_plans(self):
         definition = local_ydb_workloads.WorkloadDefinition(
             name="inline",
@@ -760,6 +1014,15 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads._validate_catalog((replace(definition, dataset_scope="attempt"),))
         with self.assertRaisesRegex(ValueError, "inline warmup requires"):
             local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
+        with self.assertRaisesRegex(ValueError, "default client threads"):
+            local_ydb_workloads._validate_catalog((replace(definition, default_client_threads=0),))
+        string_limit = replace(
+            definition,
+            options=(local_ydb_workloads.WorkloadOption("scale", "auto", kind="string"),),
+            load_limits=(("sessions", "scale", 10),),
+        )
+        with self.assertRaisesRegex(ValueError, "invalid load limit"):
+            local_ydb_workloads._validate_catalog((string_limit,))
         with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"inline": definition}):
             with self.assertRaisesRegex(BenchmarkError, "CPU measurement window"):
                 local_ydb_workloads.build_run_plan(
@@ -812,6 +1075,134 @@ class YdbBenchTest(unittest.TestCase):
                         1,
                         warmup_seconds=1,
                     )
+
+    def test_local_ydb_tpcc_geometry_lifecycle_reuses_dataset_and_cpu_window(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {
+                    "warehouses": 2,
+                    "latency-transaction": "Payment",
+                },
+            },
+            "workload",
+        )
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        monitor.summary.return_value = {
+            "static_cpu_mean": 1,
+            "static_cpu_max": 2,
+            "dynamic_cpu_mean": 3,
+            "dynamic_cpu_max": 4,
+            "cli_cpu_mean": 5,
+            "cli_cpu_max": 6,
+            "host_cpu_mean": 7,
+            "host_cpu_max": 8,
+        }
+        payload = self._tpcc_result_payload(
+            warehouses=2,
+            max_sessions=20,
+            threads=2,
+            warmup_seconds=1,
+            time_seconds=10,
+            new_orders=100,
+        )
+        topology_record = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        progress = []
+        with mock.patch.object(local_ydb, "LinuxCpuMonitor", return_value=monitor), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(
+                command,
+                json.dumps(payload),
+            ),
+        ) as execute:
+            lifecycle = local_ydb.WorkloadLifecycle(
+                cluster,
+                local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+                workload,
+                {"parameter": "max-sessions"},
+                {"warmup": 0, "duration": 10},
+                2,
+                LOCAL_YDB_BENCHMARK,
+                topology_record,
+                {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+                None,
+                lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            )
+            lifecycle.open_profile(self.root / "tpcc-profile", "ignored-profile-path")
+            lifecycle.open_geometry(self.root / "tpcc-geometry", "tpcc-dataset", 1)
+            first_metrics, first_commands = lifecycle.run_sample(
+                20,
+                1,
+                1,
+                2,
+                self.root / "tpcc-repeat-1",
+                "ignored-sample-path-1",
+                {"attempt": 1},
+            )
+            second_metrics, second_commands = lifecycle.run_sample(
+                20,
+                1,
+                2,
+                2,
+                self.root / "tpcc-repeat-2",
+                "ignored-sample-path-2",
+                {"attempt": 1},
+                purpose="verification",
+            )
+            lifecycle.close_geometry()
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertEqual(
+            [call.args[0][-1] for call in cluster._run.call_args_list], ["clean", "/Root/bench/tpcc-dataset"]
+        )
+        self.assertTrue(all(call.kwargs["timeout"] == 300 for call in cluster._run.call_args_list))
+        self.assertEqual([command["phase"] for command in first_commands], ["measuring"])
+        self.assertEqual([command["phase"] for command in second_commands], ["verification-measuring"])
+        run_argv = execute.call_args_list[0].args[0]
+        self.assertEqual(run_argv[run_argv.index("--warmup") + 1], "1s")
+        self.assertEqual(run_argv[run_argv.index("--threads") + 1], 2)
+        self.assertEqual(first_metrics["throughput"], 10)
+        self.assertEqual(second_metrics["transactions"], 300)
+        self.assertEqual(monitor.summary.call_count, 2)
+        for call in monitor.summary.call_args_list:
+            self.assertEqual(call.kwargs, {"started_at_unix": 1001.0, "finished_at_unix": 1010.0})
+        details = json.loads((self.root / "tpcc-repeat-1" / "workload-result.json").read_text(encoding="utf-8"))
+        self.assertEqual(details["schema_id"], "tpcc-json-v1")
+        self.assertEqual(details["details"], payload)
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            [
+                "initializing-workload",
+                "preparing-import",
+                "measuring",
+                "verification-measuring",
+                "cleaning-workload",
+                "cleaning-rmdir",
+            ],
+        )
 
     def test_local_ydb_profile_inline_lifecycle_prepares_once_and_cleans_once(self):
         definition, workload = self._synthetic_profile_workload()
@@ -1516,6 +1907,179 @@ class YdbBenchTest(unittest.TestCase):
                 20 nan 0 0 1 2 3 4
             """)
 
+    def test_local_ydb_tpcc_json_result_is_strict_and_uses_uncapped_throughput(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {"warehouses": 2, "latency-transaction": "Payment"},
+            },
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("max-sessions", 20, 10, 2, 2, None)
+        payload = self._tpcc_result_payload()
+        command_result = self._local_ydb_command_result(
+            ("ydb", "workload", "tpcc", "run"),
+            json.dumps(payload),
+        )
+        result = local_ydb_workloads.parse_workload_result("tpcc", command_result, workload, request)
+        self.assertEqual(
+            result.metrics,
+            {
+                "transactions": 300,
+                "new_orders": 120,
+                "throughput": 10,
+                "tpcc_tpmc": 25.5,
+                "efficiency_pct": 80.25,
+                "errors": 10,
+                "p50_ms": 1,
+                "p90_ms": 2,
+                "p95_ms": 3,
+                "p99_ms": 4,
+                "p999_ms": 5,
+            },
+        )
+        self.assertEqual(result.details, payload)
+        self.assertEqual(result.measurement_window, (1001.0, 1010.0))
+        schema = local_ydb_workloads.workload_result_schema("tpcc")
+        self.assertEqual(schema["schema_id"], "tpcc-json-v1")
+        self.assertEqual(schema["throughput_unit"], "new orders/s")
+        self.assertEqual(schema["slo_metrics"]["p999"], "p999_ms")
+        self.assertNotIn("p99.9", schema["slo_metrics"])
+
+        zero_payload = self._tpcc_result_payload(new_orders=0, selected_ok=0)
+        for name in ("NewOrder", "Payment"):
+            transaction = zero_payload["transactions"][name]
+            for field in ("percentiles", "percentiles_ms", "percentiles_pure"):
+                transaction[field] = {key: 0 for key in transaction[field]}
+        zero_result = local_ydb_workloads.parse_workload_result(
+            "tpcc",
+            self._local_ydb_command_result(("ydb",), json.dumps(zero_payload)),
+            workload,
+            request,
+        )
+        self.assertEqual(zero_result.metrics["transactions"], 0)
+        self.assertEqual(zero_result.metrics["new_orders"], 0)
+        self.assertEqual(zero_result.metrics["throughput"], 0)
+        self.assertEqual(zero_result.metrics["p999_ms"], 0)
+
+        no_new_orders = self._tpcc_result_payload(new_orders=0, selected_ok=300)
+        for field in ("percentiles", "percentiles_ms", "percentiles_pure"):
+            no_new_orders["transactions"]["NewOrder"][field] = {
+                key: 0 for key in no_new_orders["transactions"]["NewOrder"][field]
+            }
+        no_new_orders_result = local_ydb_workloads.parse_workload_result(
+            "tpcc",
+            self._local_ydb_command_result(("ydb",), json.dumps(no_new_orders)),
+            workload,
+            request,
+        )
+        self.assertEqual(no_new_orders_result.metrics["transactions"], 0)
+        self.assertEqual(no_new_orders_result.metrics["p99_ms"], 4)
+        aggregated = local_ydb._aggregate_measurements(
+            [no_new_orders_result.metrics],
+            local_ydb_workloads.workload_definition("tpcc").result_adapter.metrics,
+        )
+        passed, reason = load_control.evaluate_load(
+            {
+                "parameter": "max-sessions",
+                "allow_errors": True,
+                "search": {"start": 1, "maximum": 20},
+                "objective": {"type": "latency-slo"},
+            },
+            20,
+            aggregated,
+        )
+        self.assertFalse(passed)
+        self.assertIn("zero successful operations", reason)
+
+    def test_local_ydb_tpcc_json_result_rejects_malformed_or_inconsistent_output(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "tpcc",
+                "operation": "run",
+                "options": {"warehouses": 2, "latency-transaction": "Payment"},
+            },
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("max-sessions", 20, 10, 2, 2, None)
+
+        def changed(change):
+            value = self._tpcc_result_payload()
+            change(value)
+            return json.dumps(value)
+
+        invalid = (
+            ("not json", "malformed"),
+            (" " * (1024 * 1024 + 1), "exceeds 1048576 bytes"),
+            (json.dumps({"error": "Stopped before measurements"}), "fatal error.*Stopped before measurements"),
+            (json.dumps({"summary": {}}), r"field \$.*missing.*transactions"),
+            (
+                changed(lambda value: value["summary"].__setitem__("unexpected", 1)),
+                "summary.*unknown fields: unexpected",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("threads", True)),
+                "summary.threads.*integer",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("tpmc", float("nan"))),
+                "summary.tpmc.*finite number",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("efficiency", -1)),
+                "summary.efficiency.*finite number",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("warehouses", 3)),
+                "summary.warehouses.*configured warehouses",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("max_sessions", 19)),
+                "summary.max_sessions.*requested load",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("warmup_seconds", 3)),
+                "summary.warmup_seconds.*effective warmup",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("time_seconds", 9)),
+                "summary.time_seconds.*measurement window",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("time_seconds", 71)),
+                "summary.time_seconds.*measurement window",
+            ),
+            (
+                changed(lambda value: value["summary"].__setitem__("new_orders", 119)),
+                "summary.new_orders.*NewOrder.ok_count",
+            ),
+            (
+                changed(lambda value: value["transactions"]["Payment"]["percentiles"].update({"90": 7, "95": 3})),
+                "Payment.percentiles.*monotonic",
+            ),
+            (
+                changed(lambda value: value["transactions"]["Payment"]["percentiles"].__setitem__("50", 0)),
+                "Payment.*percentiles must be positive",
+            ),
+            (
+                changed(lambda value: value["transactions"]["Payment"]["percentiles"].__setitem__("50", True)),
+                "Payment.percentiles.50.*integer",
+            ),
+            (
+                changed(lambda value: value["transactions"].__setitem__("Extra", {})),
+                "transactions.*unknown fields: Extra",
+            ),
+        )
+        for stdout, message in invalid:
+            with self.subTest(message=message), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.parse_workload_result(
+                    "tpcc",
+                    self._local_ydb_command_result(("ydb",), stdout),
+                    workload,
+                    request,
+                )
+
     def test_local_ydb_result_adapter_rejects_invalid_metric_mappings(self):
         metric_schema = (
             local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
@@ -2014,7 +2578,10 @@ class YdbBenchTest(unittest.TestCase):
             "threads:{values:[1,2,4,8,16,32,64],start:1,maximum:256}",
             web._JS,
         )
-        self.assertIn("localYdbLoadForWorkload(config.load,parameters)", web._JS)
+        self.assertIn(
+            "localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload)",
+            web._JS,
+        )
         self.assertIn("log:'batches/s'", web._JS)
         transactions = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "transactions")
         throughput = next(metric for metric in LOCAL_YDB_BENCHMARK.metrics if metric.name == "throughput")
@@ -2069,8 +2636,30 @@ class YdbBenchTest(unittest.TestCase):
               objective:{type:'maximize-throughput',target_role:'dynamic'}
             };
             const compatible=localYdbLoadForWorkload(custom,['rate','threads']);
+            const tpccDefinition={
+              load_parameters:['max-sessions'],default_client_threads:2,
+              load_limits:{'max-sessions':{option:'warehouses',multiplier:10}}
+            };
+            const tpccWorkload={options:{warehouses:10}};
+            const switchedToTpcc=localYdbLoadForWorkload(
+              custom,tpccDefinition.load_parameters,tpccDefinition,tpccWorkload
+            );
+            const warehouseOnePoints=localYdbClampLoad(
+              {...switchedToTpcc,values:[1,8,16,64]},tpccDefinition,{options:{warehouses:1}}
+            );
+            const warehouseOneSearch=localYdbClampLoad({
+              parameter:'max-sessions',allow_errors:false,
+              search:{start:32,maximum:100,multiplier:2,resolution_percent:2},
+              objective:{type:'maximize-throughput',target_role:'dynamic'}
+            },tpccDefinition,{options:{warehouses:1}});
+            const switchedBack=localYdbLoadForWorkload(
+              switchedToTpcc,['rate','threads'],{load_limits:{}},{options:{}}
+            );
             process.stdout.write(JSON.stringify({
               points,automatic,compatible,same_reference:compatible===custom,
+              switchedToTpcc,warehouseOnePoints,warehouseOneSearch,switchedBack,
+              tpccThreads:localYdbDefaultClientThreads(tpccDefinition),
+              fallbackThreads:localYdbDefaultClientThreads({}),
               units:['kv','stock','log','future'].map(localYdbThroughputUnit)
             }));
         """
@@ -2109,6 +2698,23 @@ class YdbBenchTest(unittest.TestCase):
                 "objective": {"type": "maximize-throughput", "target_role": "dynamic"},
             },
         )
+        self.assertEqual(
+            result["switchedToTpcc"],
+            {
+                "parameter": "max-sessions",
+                "allow_errors": False,
+                "search": {"start": 1, "maximum": 100, "multiplier": 4, "resolution_percent": 9},
+                "objective": {"type": "maximize-throughput", "target_role": "dynamic"},
+            },
+        )
+        self.assertEqual(result["warehouseOnePoints"]["values"], [1, 8, 10])
+        self.assertEqual(result["warehouseOneSearch"]["search"]["start"], 10)
+        self.assertEqual(result["warehouseOneSearch"]["search"]["maximum"], 10)
+        self.assertEqual(result["switchedBack"]["parameter"], "rate")
+        self.assertEqual(result["switchedBack"]["search"]["start"], 1000)
+        self.assertEqual(result["switchedBack"]["search"]["maximum"], 100000)
+        self.assertEqual(result["tpccThreads"], 2)
+        self.assertEqual(result["fallbackThreads"], 64)
         self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
@@ -6621,7 +7227,10 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"Failed workload requests are allowed", script)
                 self.assertIn(b"editor.model?.local_ydb_workloads", script)
                 self.assertIn(b"definition.load_parameters", script)
-                self.assertIn(b"config.load=localYdbLoadForWorkload(config.load,parameters)", script)
+                self.assertIn(
+                    b"config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload)",
+                    script,
+                )
                 self.assertIn(b"log:'batches/s'", script)
                 self.assertIn(b"function localResultSchema", script)
                 self.assertIn(b"result_schema_id:schema.schema_id", script)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -2280,6 +2280,10 @@ class YdbBenchTest(unittest.TestCase):
                 "summary.max_sessions.*requested load",
             ),
             (
+                changed(lambda value: value["summary"].__setitem__("threads", 1)),
+                "summary.threads.*requested client threads",
+            ),
+            (
                 changed(lambda value: value["summary"].__setitem__("warmup_seconds", 3)),
                 "summary.warmup_seconds.*effective warmup",
             ),

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -475,7 +475,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(workload_schema, local_ydb_workloads.workload_config_schema())
 
         catalog = local_ydb_workloads.web_workload_catalog()
-        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log", "tpcc"])
+        self.assertEqual([item["type"] for item in catalog], ["kv", "stock", "log", "tpcc", "topic"])
         self.assertEqual(catalog[0]["operations"], ["upsert", "select", "read-rows", "mixed"])
         self.assertEqual(catalog[0]["load_parameters"], ["rate", "threads"])
         self.assertEqual(catalog[1]["default_operation"], "put-rand-order")
@@ -485,13 +485,14 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         self.assertEqual(
             [item["result_schema_id"] for item in catalog],
-            ["generic-total-v1"] * 3 + ["tpcc-json-v1"],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v1", "topic-total-v1"],
         )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
-            ["requests/s", "transactions/s", "batches/s", "new orders/s"],
+            ["requests/s", "transactions/s", "batches/s", "new orders/s", "messages/s"],
         )
-        self.assertTrue(all(item["reports_errors"] for item in catalog))
+        self.assertTrue(all(item["reports_errors"] for item in catalog[:4]))
+        self.assertFalse(catalog[4]["reports_errors"])
         self.assertEqual(catalog[0]["slo_metrics"]["p99"], "p99_ms")
         self.assertEqual(catalog[3]["load_parameters"], ["max-sessions"])
         self.assertEqual(catalog[3]["slo_metrics"]["p999"], "p999_ms")
@@ -500,6 +501,15 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(
             catalog[3]["load_limits"],
             {"max-sessions": {"option": "warehouses", "multiplier": 10}},
+        )
+        self.assertEqual(catalog[4]["operations"], ["full"])
+        self.assertEqual(catalog[4]["load_parameters"], ["rate"])
+        self.assertEqual(catalog[4]["slo_metrics"], {"p99": "full_p99_ms"})
+        self.assertEqual(catalog[4]["default_client_threads"], 1)
+        self.assertEqual(catalog[4]["minimum_duration_seconds"], 2)
+        self.assertEqual(
+            {option["name"]: option["default"] for option in catalog[4]["options"]},
+            {"partitions": 128, "consumers": 1, "message-size": 10240, "codec": "raw"},
         )
         catalog_parameters = tuple(
             dict.fromkeys(parameter for definition in catalog for parameter in definition["load_parameters"])
@@ -537,7 +547,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(stock["options"]["orders"], 100)
 
         invalid = (
-            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log, tpcc"),
+            ({"type": [], "operation": "upsert"}, r"workload\.type.*must be one of kv, stock, log, tpcc, topic"),
             ({"type": "kv", "operation": "put-rand-order"}, r"workload\.operation.*must be one of upsert"),
             (
                 {"type": "stock", "operation": "put-rand-order", "options": {"products": 500001}},
@@ -619,6 +629,117 @@ class YdbBenchTest(unittest.TestCase):
         for index, (body, message) in enumerate(invalid_profiles):
             with self.subTest(index=index), self.assertRaisesRegex(BenchmarkError, message):
                 load_config(self._config(body, "invalid-tpcc-{}.yaml".format(index)))
+
+    def test_local_ydb_topic_defaults_and_profile_validation(self):
+        loaded = load_config(self._config("""
+            local-ydb:
+              topic-smoke:
+                workload: {type: topic, operation: full}
+                load: {parameter: rate, values: [100]}
+                measurement: {warmup: 1, duration: 2, repetitions: 1}
+        """))
+        profile = loaded.runs[0].parameters["local_ydb"]
+        self.assertEqual(
+            profile["workload"]["options"],
+            {"partitions": 128, "consumers": 1, "message-size": 10240, "codec": "raw"},
+        )
+        self.assertEqual(profile["client"]["threads"], 1)
+        self.assertEqual(profile["load"], {"parameter": "rate", "allow_errors": False, "values": [100]})
+        definition = local_ydb_workloads.workload_definition("topic")
+        self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "inline"))
+
+        latency = (
+            load_config(
+                self._config(
+                    """
+            local-ydb:
+              topic-latency:
+                workload: {type: topic, operation: full}
+                load:
+                  parameter: rate
+                  search: {start: 10, maximum: 100, multiplier: 2}
+                  objective: {type: latency-slo, percentile: p99, max-ms: 20, max-errors: 0}
+                measurement: {duration: 2}
+        """,
+                    "topic-latency.yaml",
+                )
+            )
+            .runs[0]
+            .parameters["local_ydb"]
+        )
+        self.assertEqual(latency["load"]["objective"]["latency_metric"], "full_p99_ms")
+
+        invalid_profiles = (
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, allow-errors: true, values: [10]}
+                    measurement: {duration: 2}
+                """,
+                "load.allow-errors.*must be false",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load:
+                      parameter: rate
+                      search: {start: 10, maximum: 100, multiplier: 2}
+                      objective: {type: latency-slo, percentile: p99, max-ms: 20, max-errors: 1}
+                    measurement: {duration: 2}
+                """,
+                "load.objective.max-errors.*must be zero",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, values: [10]}
+                    measurement: {duration: 1}
+                """,
+                "measurement.duration.*at least 2",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full, options: {codec: snappy}}
+                    load: {parameter: rate, values: [10]}
+                    measurement: {duration: 2}
+                """,
+                "codec.*must be one of raw, gzip, zstd",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: threads, values: [1]}
+                    measurement: {duration: 2}
+                """,
+                "load.parameter.*must be one of rate",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load:
+                      parameter: rate
+                      search: {start: 10, maximum: 100, multiplier: 2}
+                      objective: {type: latency-slo, percentile: p95, max-ms: 20}
+                    measurement: {duration: 2}
+                """,
+                "percentile.*must be one of p99",
+            ),
+        )
+        for index, (body, message) in enumerate(invalid_profiles):
+            with self.subTest(index=index), self.assertRaisesRegex(BenchmarkError, message):
+                load_config(self._config(body, "invalid-topic-{}.yaml".format(index)))
 
     def test_local_ydb_workload_registry_supports_typed_options(self):
         definition = local_ydb_workloads.WorkloadDefinition(
@@ -991,6 +1112,124 @@ class YdbBenchTest(unittest.TestCase):
         )
         absolute_cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "/Root/other", workload)
         self.assertEqual(absolute_cleanup[1].argv[-1], "/Root/other")
+
+    def test_local_ydb_topic_builds_golden_prepare_run_and_cleanup_plans(self):
+        cli_context = local_ydb_workloads.WorkloadCli(
+            Path("/tmp/ydb cli"),
+            "grpc://benchmark-host.example:2135",
+            "/Root/bench",
+        )
+        workload = local_ydb_workloads.normalize_workload(
+            {
+                "type": "topic",
+                "operation": "full",
+                "options": {"partitions": 16, "consumers": 2, "message-size": 4096, "codec": "zstd"},
+            },
+            "workload",
+        )
+        base = [
+            Path("/tmp/ydb cli"),
+            "--endpoint",
+            "grpc://benchmark-host.example:2135",
+            "--database",
+            "/Root/bench",
+            "workload",
+            "topic",
+        ]
+        prepare = local_ydb_workloads.build_prepare_plan(cli_context, "topic-sample-01", workload)
+        self.assertEqual(
+            prepare,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "init",
+                    tuple(
+                        base
+                        + [
+                            "init",
+                            "--topic",
+                            "topic-sample-01",
+                            "--partitions",
+                            16,
+                            "--consumers",
+                            2,
+                            "--consumer-prefix",
+                            "ydb-bench-consumer",
+                        ]
+                    ),
+                    120,
+                ),
+            ),
+        )
+
+        direct_run = local_ydb_workloads.build_run_argv(
+            cli_context,
+            "topic-sample-01",
+            workload,
+            "rate",
+            5000,
+            30,
+            3,
+        )
+        expected_run = base + [
+            "run",
+            "full",
+            "--topic",
+            "topic-sample-01",
+            "--seconds",
+            30,
+            "--warmup",
+            0,
+            "--window",
+            1,
+            "--print-timestamp",
+            "--percentile",
+            99,
+            "--producer-threads",
+            3,
+            "--consumer-threads",
+            3,
+            "--consumers",
+            2,
+            "--consumer-prefix",
+            "ydb-bench-consumer",
+            "--message-size",
+            4096,
+            "--message-rate",
+            5000,
+            "--codec",
+            "zstd",
+        ]
+        self.assertEqual(direct_run, expected_run)
+        self.assertNotIn("--use-tx", direct_run)
+
+        run = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "topic-sample-01",
+            workload,
+            "rate",
+            5000,
+            30,
+            3,
+            warmup_seconds=7,
+        )
+        expected_run[expected_run.index("--seconds") + 1] = 37
+        expected_run[expected_run.index("--warmup") + 1] = 7
+        self.assertEqual(run.argv, tuple(expected_run))
+        self.assertEqual(run.timeout_seconds, 67)
+        self.assertEqual(run.progress_duration_seconds, 37)
+
+        cleanup = local_ydb_workloads.build_cleanup_plan(cli_context, "topic-sample-01", workload)
+        self.assertEqual(
+            cleanup,
+            (
+                local_ydb_workloads.WorkloadCommandPlan(
+                    "clean",
+                    tuple(base + ["clean", "--topic", "topic-sample-01"]),
+                    120,
+                ),
+            ),
+        )
+        self.assertEqual(local_ydb_workloads.workload_table_path("topic", "topic-sample-01"), "topic-sample-01")
 
     def test_local_ydb_workload_registry_validates_lifecycle_metadata_and_plans(self):
         definition = local_ydb_workloads.WorkloadDefinition(
@@ -2080,6 +2319,178 @@ class YdbBenchTest(unittest.TestCase):
                     request,
                 )
 
+    def test_local_ydb_topic_total_result_normalizes_aggregate_consumer_rate(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "topic", "operation": "full", "options": {"consumers": 2}},
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("rate", 150, 10, 3, 4, None)
+        stdout = """
+Window\tWrite speed\tWrite time\tInflight\tLag\t\tLag time\tRead speed\tFull time\tTimestamp
+#\tmsg/s\tMB/s\tpercentile,ms\tpercentile,msg\tpercentile,msg\tpercentile,ms\tmsg/s\tMB/s\tpercentile,ms
+4\t0\t0\t0\t\t0\t\t0\t\t0\t\t0\t0\t0\t2026-08-25T10:00:04Z
+13\t0\t0\t0\t\t0\t\t0\t\t0\t\t0\t0\t0\t2026-08-25T10:00:13Z
+Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
+"""
+        result = local_ydb_workloads.parse_workload_result(
+            "topic",
+            self._local_ydb_command_result(("ydb", "workload", "topic", "run", "full"), stdout),
+            workload,
+            request,
+        )
+        self.assertEqual(
+            result.metrics,
+            {
+                "transactions": 900,
+                "throughput": 90,
+                "write_messages_s": 120,
+                "write_mib_s": 1,
+                "write_p99_ms": 4,
+                "inflight_p99_messages": 7,
+                "lag_p99_messages": 8,
+                "lag_p99_ms": 9,
+                "read_messages_s": 180,
+                "read_per_consumer_messages_s": 90,
+                "read_mib_s": 2,
+                "full_p99_ms": 12,
+            },
+        )
+        self.assertEqual(result.details, {"percentile": 99, "total": result.metrics})
+        self.assertEqual(result.measurement_window, (1787652004.0, 1787652013.0))
+        passed, reason = load_control.evaluate_load(
+            {
+                "parameter": "rate",
+                "allow_errors": False,
+                "search": {"start": 10, "maximum": 150},
+                "objective": {
+                    "type": "latency-slo",
+                    "percentile": "p99",
+                    "latency_metric": "full_p99_ms",
+                    "max_ms": 20,
+                    "max_errors": 0,
+                    "min_achieved_rate_ratio": 0.98,
+                },
+            },
+            150,
+            result.metrics,
+        )
+        self.assertFalse(passed)
+        self.assertIn("achieved rate ratio 0.6000", reason)
+
+        schema = local_ydb_workloads.workload_result_schema("topic")
+        self.assertEqual(schema["schema_id"], "topic-total-v1")
+        self.assertEqual(schema["throughput_unit"], "messages/s")
+        self.assertEqual(schema["slo_metrics"], {"p99": "full_p99_ms"})
+        self.assertFalse(schema["reports_errors"])
+        self.assertEqual(
+            {metric["name"]: metric["unit"] for metric in schema["metrics"]}["read_messages_s"],
+            "deliveries/s",
+        )
+
+        zero_result = local_ydb_workloads.parse_workload_result(
+            "topic",
+            self._local_ydb_command_result(
+                ("ydb",),
+                """
+4 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:04Z
+13 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:13Z
+Total 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:14Z
+""",
+            ),
+            workload,
+            request,
+        )
+        self.assertEqual(zero_result.metrics["transactions"], 0)
+        self.assertEqual(zero_result.metrics["throughput"], 0)
+        aggregated = local_ydb._aggregate_measurements(
+            [zero_result.metrics],
+            local_ydb_workloads.workload_definition("topic").result_adapter.metrics,
+        )
+        passed, reason = load_control.evaluate_load(
+            {"parameter": "rate", "allow_errors": False, "values": [150]},
+            150,
+            aggregated,
+        )
+        self.assertFalse(passed)
+        self.assertIn("zero successful operations", reason)
+
+    def test_local_ydb_topic_total_result_rejects_ambiguous_or_unsafe_output(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "topic", "operation": "full"},
+            "workload",
+        )
+        request = local_ydb_workloads.WorkloadRunRequest("rate", 100, 2, 1, 1, None)
+
+        def row(index, timestamp, metrics="1 2 3 4 5 6 7 8 9"):
+            return "{} {} {}".format(index, metrics, timestamp)
+
+        start = row(2, "2026-08-25T10:00:02Z")
+        finish = row(3, "2026-08-25T10:00:03Z")
+        total = row("Total", "2026-08-25T10:00:04Z")
+        valid = "\n".join((start, finish, total))
+        invalid = (
+            (None, "is not text"),
+            ("\ud800", "not valid UTF-8 text"),
+            ("\n".join((start, finish)), "exactly one Total row"),
+            (valid + "\n" + total, "exactly one Total row"),
+            ("\n".join((start, finish, "Total 1 2 3 4 5 6 7 8 9")), "Total row.*11 columns"),
+            (valid + " extra", "Total row.*11 columns"),
+            (
+                "\n".join((start, finish, row("Total", "2026-08-25T10:00:04Z", "-1 2 3 4 5 6 7 8 9"))),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            (
+                "\n".join((start, finish, row("Total", "2026-08-25T10:00:04Z", "1.0 2 3 4 5 6 7 8 9"))),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            (
+                "\n".join((start, finish, row("Total", "2026-08-25T10:00:04Z", "١ 2 3 4 5 6 7 8 9"))),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            (
+                "\n".join(
+                    (start, finish, row("Total", "2026-08-25T10:00:04Z", "000000000000000000001 2 3 4 5 6 7 8 9"))
+                ),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            (
+                "\n".join(
+                    (start, finish, row("Total", "2026-08-25T10:00:04Z", "18446744073709551616 2 3 4 5 6 7 8 9"))
+                ),
+                "Total row metrics.*unsigned 64-bit",
+            ),
+            ("\n".join((finish, total)), "window row for index 2"),
+            ("\n".join((start, start, finish, total)), "window row for index 2"),
+            ("\n".join((row("٢", "2026-08-25T10:00:02Z"), finish, total)), "window row for index 2"),
+            ("\n".join(("2 1 2 3 4 5 6 7 8 9", finish, total)), "window row 2.*11 columns"),
+            (
+                "\n".join((row(2, "2026-08-25T10:00:02Z", "-1 2 3 4 5 6 7 8 9"), finish, total)),
+                "window row 2 metrics.*unsigned 64-bit",
+            ),
+            ("\n".join((start, finish, row("Total", "2026-08-25T10:00:04"))), "Total row timestamp.*ISO UTC"),
+            ("\n".join((row(2, "2026-08-25T10:00:02+00:00"), finish, total)), "window row 2 timestamp.*ISO UTC"),
+            ("\n".join((row(2, "2026-02-30T10:00:02Z"), finish, total)), "window row 2 timestamp.*ISO UTC"),
+            ("\n".join((row(2, "2026-08-25T10:00:03Z"), finish, total)), "timestamps must be increasing"),
+            ("x" * (1024 * 1024 + 1), "exceeds 1048576 bytes"),
+        )
+        for stdout, message in invalid:
+            with self.subTest(message=message), self.assertRaisesRegex(BenchmarkError, message):
+                local_ydb_workloads.parse_workload_result(
+                    "topic",
+                    self._local_ydb_command_result(("ydb",), stdout),
+                    workload,
+                    request,
+                )
+
+        short_request = replace(request, duration_seconds=1)
+        with self.assertRaisesRegex(BenchmarkError, "duration of at least two seconds"):
+            local_ydb_workloads.parse_workload_result(
+                "topic",
+                self._local_ydb_command_result(("ydb",), valid),
+                workload,
+                short_request,
+            )
+
     def test_local_ydb_result_adapter_rejects_invalid_metric_mappings(self):
         metric_schema = (
             local_ydb_workloads.WorkloadMetric("throughput", "widgets/s", required=True),
@@ -2619,7 +3030,7 @@ class YdbBenchTest(unittest.TestCase):
     def test_local_ydb_web_builder_resets_only_incompatible_load_parameters(self):
         start = web._JS.index("const localYdbLoadDefaults=")
         finish = web._JS.index("function defaultLocalYdbWorkload", start)
-        unit_start = web._JS.index("function localLegacyResultSchema")
+        unit_start = web._JS.index("function localSearchAxisLabel")
         unit_finish = web._JS.index("function localAttemptRows", unit_start)
         script = web._JS[start:finish] + web._JS[unit_start:unit_finish] + """
             const points=localYdbResetLoadParameter(
@@ -2640,6 +3051,7 @@ class YdbBenchTest(unittest.TestCase):
               load_parameters:['max-sessions'],default_client_threads:2,
               load_limits:{'max-sessions':{option:'warehouses',multiplier:10}}
             };
+            const topicDefinition={load_parameters:['rate'],default_client_threads:1,load_limits:{}};
             const tpccWorkload={options:{warehouses:10}};
             const switchedToTpcc=localYdbLoadForWorkload(
               custom,tpccDefinition.load_parameters,tpccDefinition,tpccWorkload
@@ -2659,8 +3071,10 @@ class YdbBenchTest(unittest.TestCase):
               points,automatic,compatible,same_reference:compatible===custom,
               switchedToTpcc,warehouseOnePoints,warehouseOneSearch,switchedBack,
               tpccThreads:localYdbDefaultClientThreads(tpccDefinition),
+              topicThreads:localYdbDefaultClientThreads(topicDefinition),
               fallbackThreads:localYdbDefaultClientThreads({}),
-              units:['kv','stock','log','future'].map(localYdbThroughputUnit)
+              units:['kv','stock','log','topic','future'].map(localYdbThroughputUnit),
+              axes:['kv','stock','topic'].map(workload=>localSearchAxisLabel('rate',workload))
             }));
         """
         completed = subprocess.run(
@@ -2714,8 +3128,16 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["switchedBack"]["search"]["start"], 1000)
         self.assertEqual(result["switchedBack"]["search"]["maximum"], 100000)
         self.assertEqual(result["tpccThreads"], 2)
+        self.assertEqual(result["topicThreads"], 1)
         self.assertEqual(result["fallbackThreads"], 64)
-        self.assertEqual(result["units"], ["requests/s", "transactions/s", "batches/s", "operations/s"])
+        self.assertEqual(
+            result["units"],
+            ["requests/s", "transactions/s", "batches/s", "messages/s", "operations/s"],
+        )
+        self.assertEqual(
+            result["axes"],
+            ["Offered rate (requests/s)", "Offered rate (transactions/s)", "Offered rate (messages/s)"],
+        )
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
     def test_local_ydb_web_hides_latency_for_empty_measurements(self):
@@ -2870,6 +3292,8 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["first_default"], "p90")
         self.assertIn("document.querySelector('#local-load-allow-errors')?.checked", web._JS)
         self.assertIn("workloadDefinition.reports_errors?localInteger('local-slo-max-errors',0):0", web._JS)
+        self.assertIn("config.load.objective.max_errors=0", web._JS)
+        self.assertIn("Applied to both producer and consumer thread counts", web._JS)
 
     def test_local_ydb_stock_commands_do_not_use_kv_path_option(self):
         cli_context = local_ydb_workloads.WorkloadCli(
@@ -3134,6 +3558,128 @@ class YdbBenchTest(unittest.TestCase):
             self.assertEqual(command[command.index("--threads") + 1], "2")
             self.assertEqual(command[command.index("--rows") + 1], "25")
             self.assertNotIn("--rate", command)
+
+    def test_local_ydb_topic_uses_fresh_sample_dataset_and_inline_cpu_window(self):
+        workload = local_ydb_workloads.normalize_workload(
+            {"type": "topic", "operation": "full", "options": {"partitions": 4, "consumers": 2}},
+            "workload",
+        )
+        output = """
+2 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:12Z
+3 0 0 0 0 0 0 0 0 0 2026-08-25T10:00:13Z
+Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
+"""
+        cluster = mock.Mock(
+            ydb_cli=Path("/tmp/ydb"),
+            client_endpoint="grpc://benchmark-host:2135",
+            database="/Root/bench",
+            static_pids=(10,),
+            dynamic_pids=(20,),
+        )
+        cluster.init_workload.side_effect = lambda command, **_kwargs: (
+            self._local_ydb_command_result(command),
+            [self._local_ydb_command_result(command)],
+        )
+        cluster._run.side_effect = lambda command, **_kwargs: self._local_ydb_command_result(command)
+        monitor = mock.Mock(records=[])
+        monitor.stop.return_value = {}
+        monitor.summary.return_value = {
+            "static_cpu_mean": 1,
+            "dynamic_cpu_mean": 2,
+            "cli_cpu_mean": 3,
+            "host_cpu_mean": 4,
+        }
+        topology = CpuTopology(
+            allowed_cpus=(0,),
+            numa_nodes=((0, (0,)),),
+            chiplets=(),
+            physical_cores=((0,),),
+        )
+        progress = []
+        with mock.patch.object(local_ydb, "LinuxCpuMonitor", return_value=monitor), mock.patch.object(
+            local_ydb,
+            "run_command",
+            side_effect=lambda command, *_args, **_kwargs: self._local_ydb_command_result(command, output),
+        ) as execute:
+            lifecycle = local_ydb.WorkloadLifecycle(
+                cluster,
+                local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
+                workload,
+                {"parameter": "rate", "allow_errors": False},
+                {"warmup": 1, "duration": 2},
+                2,
+                LOCAL_YDB_BENCHMARK,
+                topology,
+                {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
+                None,
+                lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            )
+            lifecycle.open_profile(self.root / "topic-profile", "ignored-profile-topic")
+            first_metrics, first_commands = lifecycle.run_sample(
+                150,
+                1,
+                1,
+                2,
+                self.root / "topic-repeat-1",
+                "topic-sample-1",
+                {"attempt": 1},
+            )
+            second_metrics, second_commands = lifecycle.run_sample(
+                150,
+                1,
+                2,
+                2,
+                self.root / "topic-repeat-2",
+                "topic-sample-2",
+                {"attempt": 1},
+                purpose="verification",
+            )
+            lifecycle.close_profile()
+
+        self.assertEqual(cluster.init_workload.call_count, 2)
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(cluster._run.call_count, 2)
+        self.assertEqual([len(first_commands), len(second_commands)], [3, 3])
+        self.assertEqual(
+            [command["phase"] for command in first_commands],
+            ["initializing-workload", "measuring", "cleaning-workload"],
+        )
+        self.assertEqual(
+            [command["phase"] for command in second_commands],
+            ["verification-initializing", "verification-measuring", "verification-cleanup"],
+        )
+        for commands, topic_path in ((first_commands, "topic-sample-1"), (second_commands, "topic-sample-2")):
+            for command in commands:
+                argv = command["argv"]
+                self.assertEqual(argv[argv.index("--topic") + 1], topic_path)
+            run = commands[1]["argv"]
+            self.assertEqual(run[run.index("--seconds") + 1], "3")
+            self.assertEqual(run[run.index("--warmup") + 1], "1")
+            self.assertEqual(run[run.index("--producer-threads") + 1], "2")
+            self.assertEqual(run[run.index("--consumer-threads") + 1], "2")
+        self.assertEqual([call.args[2] for call in execute.call_args_list], [33, 33])
+        self.assertTrue(all(call.kwargs["timeout"] == 120 for call in cluster._run.call_args_list))
+        self.assertTrue(all(call.kwargs["ignore_cancellation"] for call in cluster._run.call_args_list))
+        self.assertEqual(first_metrics["throughput"], 90)
+        self.assertEqual(second_metrics["transactions"], 180)
+        self.assertEqual(
+            monitor.summary.call_args_list,
+            [
+                mock.call(started_at_unix=1787652012.0, finished_at_unix=1787652013.0),
+                mock.call(started_at_unix=1787652012.0, finished_at_unix=1787652013.0),
+            ],
+        )
+        self.assertEqual(
+            [item["phase"] for item in progress],
+            [
+                "initializing-workload",
+                "measuring",
+                "cleaning-workload",
+                "verification-initializing",
+                "verification-measuring",
+                "verification-cleanup",
+            ],
+        )
 
     def test_local_ydb_command_record_preserves_argv_and_affinity(self):
         result = runner.CommandResult(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added local TPCC and Topic benchmarks with workload-specific metrics and configuration.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The implementations include workload lifecycle handling, node readiness checks, admitted TPCC latency, effective thread validation, and Topic producer and consumer metrics.