### PR TITLE
Replace ColumnShardMaxOperationBytes with a configurable parameter

### DIFF
--- a/ydb/core/kqp/node_service/kqp_node_service.cpp
+++ b/ydb/core/kqp/node_service/kqp_node_service.cpp
@@ -351,6 +351,7 @@ private:
         auto ptr = MakeIntrusive<NKikimr::NKqp::TWriteActorSettings>();
 
         ptr->InFlightMemoryLimitPerActorBytes = settings.GetInFlightMemoryLimitPerActorBytes();
+        ptr->ColumnShardMaxOperationBytes = settings.GetColumnShardMaxOperationBytes();
 
         ptr->StartRetryDelay = TDuration::MilliSeconds(settings.GetStartRetryDelayMs());
         ptr->MaxRetryDelay = TDuration::MilliSeconds(settings.GetMaxRetryDelayMs());

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -485,6 +485,7 @@ public:
         ShardedWriteController = CreateShardedWriteController(
             TShardedWriteControllerSettings {
                 .MemoryLimitTotal = MessageSettings.InFlightMemoryLimitPerActorBytes,
+                .ColumnShardMaxOperationBytes = MessageSettings.ColumnShardMaxOperationBytes,
                 .Inconsistent = InconsistentTx,
             },
             Alloc);

--- a/ydb/core/kqp/runtime/kqp_write_actor_settings.h
+++ b/ydb/core/kqp/runtime/kqp_write_actor_settings.h
@@ -9,6 +9,7 @@ namespace NKqp {
 
 struct TWriteActorSettings : TAtomicRefCount<TWriteActorSettings> {
     i64 InFlightMemoryLimitPerActorBytes = 64_MB;
+    i64 ColumnShardMaxOperationBytes = 64_MB;
     i64 MaxForwardedSize = 64_MB;
 
     TDuration StartRetryDelay = TDuration::Seconds(1);

--- a/ydb/core/kqp/runtime/kqp_write_table.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_table.cpp
@@ -23,7 +23,6 @@ namespace NKqp {
 namespace {
 
 constexpr i64 DataShardMaxOperationBytes = 8_MB;
-constexpr i64 ColumnShardMaxOperationBytes = 64_MB;
 
 constexpr size_t InitialBatchPoolSize = 64_KB;
 
@@ -445,10 +444,13 @@ public:
     TColumnShardPayloadSerializer(
         const NSchemeCache::TSchemeCacheNavigate::TEntry& schemeEntry,
         const TConstArrayRef<NKikimrKqp::TKqpColumnMetadataProto> inputColumns,
+        const i64 maxOperationBytes,
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc) // key columns then value columns
             : Columns(BuildColumns(inputColumns))
             , WriteColumnIds(BuildWriteColumnIds(inputColumns))
+            , MaxOperationBytes(maxOperationBytes)
             , Alloc(std::move(alloc)) {
+        AFL_ENSURE(MaxOperationBytes > 0);
         AFL_ENSURE(Alloc);
         AFL_ENSURE(schemeEntry.ColumnTableInfo);
         const auto& description = schemeEntry.ColumnTableInfo->Description;
@@ -508,7 +510,7 @@ public:
     }
 
     void FlushUnpreparedBatch(const ui64 shardId, TUnpreparedBatch& unpreparedBatch, bool force) {
-        while (!unpreparedBatch.Batches.empty() && (unpreparedBatch.TotalDataSize >= ColumnShardMaxOperationBytes || force)) {
+        while (!unpreparedBatch.Batches.empty() && (unpreparedBatch.TotalDataSize >= static_cast<ui64>(MaxOperationBytes) || force)) {
             std::vector<TRecordBatchPtr> toPrepare;
             i64 toPrepareSize = 0;
             while (!unpreparedBatch.Batches.empty()) {
@@ -530,7 +532,7 @@ public:
                 for (i64 index = 0; index < batch->num_rows(); ++index) {
                     i64 nextRowSize = rowCalculator.GetRowBytesSize(index);
 
-                    if (toPrepareSize + nextRowSize >= (i64)ColumnShardMaxOperationBytes) {
+                    if (toPrepareSize + nextRowSize >= MaxOperationBytes) {
                         toPrepare.push_back(batch->Slice(0, index));
                         unpreparedBatch.Batches.push_front(batch->Slice(index, batch->num_rows() - index));
                         UnpreparedBatchedCount++;
@@ -639,6 +641,7 @@ private:
 
     const TVector<TSysTables::TTableColumnInfo> Columns;
     const std::vector<ui32> WriteColumnIds;
+    const i64 MaxOperationBytes;
 
     std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
 
@@ -1030,9 +1033,10 @@ private:
 IPayloadSerializerPtr CreateColumnShardPayloadSerializer(
         const NSchemeCache::TSchemeCacheNavigate::TEntry& schemeEntry,
         const TConstArrayRef<NKikimrKqp::TKqpColumnMetadataProto> inputColumns,
+        const i64 maxOperationBytes,
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc) {
     return MakeIntrusive<TColumnShardPayloadSerializer>(
-        schemeEntry, inputColumns, std::move(alloc));
+        schemeEntry, inputColumns, maxOperationBytes, std::move(alloc));
 }
 
 IPayloadSerializerPtr CreateDataShardPayloadSerializer(
@@ -1809,6 +1813,7 @@ public:
             writeInfo.Serializer = CreateColumnShardPayloadSerializer(
                 *SchemeEntry,
                 writeInfo.Metadata.InputColumnsMetadata,
+                Settings.ColumnShardMaxOperationBytes,
                 Alloc);
         }
         AfterPartitioningChanged();
@@ -1897,6 +1902,7 @@ public:
             iter->second.Serializer = CreateColumnShardPayloadSerializer(
                 *SchemeEntry,
                 iter->second.Metadata.InputColumnsMetadata,
+                Settings.ColumnShardMaxOperationBytes,
                 Alloc);
         }
     }

--- a/ydb/core/kqp/runtime/kqp_write_table.h
+++ b/ydb/core/kqp/runtime/kqp_write_table.h
@@ -255,6 +255,7 @@ using IShardedWriteControllerPtr = TIntrusivePtr<IShardedWriteController>;
 
 struct TShardedWriteControllerSettings {
     i64 MemoryLimitTotal = 0;
+    i64 ColumnShardMaxOperationBytes = 0;
     bool Inconsistent = false;
 };
 

--- a/ydb/core/kqp/ut/olap/operations/write_ut.cpp
+++ b/ydb/core/kqp/ut/olap/operations/write_ut.cpp
@@ -418,35 +418,41 @@ Y_UNIT_TEST_SUITE(KqpOlapWrite) {
     }
 
     Y_UNIT_TEST(ColumnShardMaxOperationBytes) {
-        auto csController = NKikimr::NYDBTest::TControllers::RegisterCSControllerGuard<NKikimr::NYDBTest::NColumnShard::TController>();
-        csController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Compaction);
+        auto countPortionsWithOperationSizeLimit = [&](const size_t limit) -> size_t {
+            auto csController = NKikimr::NYDBTest::TControllers::RegisterCSControllerGuard<NKikimr::NYDBTest::NColumnShard::TController>();
+            csController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Compaction);
 
-        auto settings = TKikimrSettings().SetWithSampleTables(false);
-        auto* tableServiceConfig = settings.AppConfig.MutableTableServiceConfig();
-        tableServiceConfig->SetEnableOlapSink(true);
-        tableServiceConfig->MutableWriteActorSettings()->SetColumnShardMaxOperationBytes(64_KB);
-        TKikimrRunner kikimr(settings);
+            auto settings = TKikimrSettings().SetWithSampleTables(false);
+            auto* tableServiceConfig = settings.AppConfig.MutableTableServiceConfig();
+            tableServiceConfig->SetEnableOlapSink(true);
+            tableServiceConfig->MutableWriteActorSettings()->SetColumnShardMaxOperationBytes(limit);
 
-        TTypedLocalHelper helper("Utf8", kikimr);
-        helper.CreateTestOlapTable(1, 1);
+            TKikimrRunner kikimr(settings);
+            TTypedLocalHelper helper("Utf8", kikimr);
+            helper.CreateTestOlapTable(1, 1);
 
-        auto result = kikimr.GetQueryClient()
-            .ExecuteQuery(R"(
-                $rows = ListMap(ListFromRange(0, 50000), ($x) -> { RETURN AsStruct($x AS item); });
-                UPSERT INTO `/Root/olapStore/olapTable` (pk_int, field)
-                SELECT CAST(item AS Int64), CAST(item AS Utf8) FROM AS_TABLE($rows);
-            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx())
-            .ExtractValueSync();
-        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            auto result = kikimr.GetQueryClient()
+                .ExecuteQuery(R"(
+                    $rows = ListMap(ListFromRange(0, 50000), ($x) -> { RETURN AsStruct($x AS item); });
+                    UPSERT INTO `/Root/olapStore/olapTable` (pk_int, field)
+                    SELECT CAST(item AS Int64), CAST(item AS Utf8) FROM AS_TABLE($rows);
+                )", NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 
-        auto tableClient = kikimr.GetTableClient();
-        auto rows = ExecuteScanQuery(tableClient, R"(
-            SELECT COUNT(*) AS count
-            FROM `/Root/olapStore/olapTable/.sys/primary_index_portion_stats`;
-        )");
-        UNIT_ASSERT_GT(GetUint64(rows[0].at("count")), 1);
-        UNIT_ASSERT_VALUES_EQUAL(helper.GetQueryResult("SELECT COUNT(*) FROM `/Root/olapStore/olapTable`;"), "[[50000u]]");
-        UNIT_ASSERT_VALUES_EQUAL(csController->GetCompactionStartedCounter().Val(), 0);
+            auto tableClient = kikimr.GetTableClient();
+            auto rows = ExecuteScanQuery(tableClient, R"(
+                SELECT COUNT(*) AS count
+                FROM `/Root/olapStore/olapTable/.sys/primary_index_portion_stats`;
+            )");
+            const size_t portions = GetUint64(rows[0].at("count"));
+            UNIT_ASSERT_VALUES_EQUAL(helper.GetQueryResult("SELECT COUNT(*) FROM `/Root/olapStore/olapTable`;"), "[[50000u]]");
+            UNIT_ASSERT_VALUES_EQUAL(csController->GetCompactionStartedCounter().Val(), 0);
+            return portions;
+        };
+
+        UNIT_ASSERT_GT(countPortionsWithOperationSizeLimit(64_KB), 3);
+        UNIT_ASSERT_VALUES_EQUAL(countPortionsWithOperationSizeLimit(64_MB), 1);
     }
 
     Y_UNIT_TEST(MultiWriteInTimeDiffSchemas) {

--- a/ydb/core/kqp/ut/olap/operations/write_ut.cpp
+++ b/ydb/core/kqp/ut/olap/operations/write_ut.cpp
@@ -417,6 +417,38 @@ Y_UNIT_TEST_SUITE(KqpOlapWrite) {
         AFL_VERIFY(csController->GetCompactionStartedCounter().Val() == 0);
     }
 
+    Y_UNIT_TEST(ColumnShardMaxOperationBytes) {
+        auto csController = NKikimr::NYDBTest::TControllers::RegisterCSControllerGuard<NKikimr::NYDBTest::NColumnShard::TController>();
+        csController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Compaction);
+
+        auto settings = TKikimrSettings().SetWithSampleTables(false);
+        auto* tableServiceConfig = settings.AppConfig.MutableTableServiceConfig();
+        tableServiceConfig->SetEnableOlapSink(true);
+        tableServiceConfig->MutableWriteActorSettings()->SetColumnShardMaxOperationBytes(64_KB);
+        TKikimrRunner kikimr(settings);
+
+        TTypedLocalHelper helper("Utf8", kikimr);
+        helper.CreateTestOlapTable(1, 1);
+
+        auto result = kikimr.GetQueryClient()
+            .ExecuteQuery(R"(
+                $rows = ListMap(ListFromRange(0, 50000), ($x) -> { RETURN AsStruct($x AS item); });
+                UPSERT INTO `/Root/olapStore/olapTable` (pk_int, field)
+                SELECT CAST(item AS Int64), CAST(item AS Utf8) FROM AS_TABLE($rows);
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx())
+            .ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+        auto tableClient = kikimr.GetTableClient();
+        auto rows = ExecuteScanQuery(tableClient, R"(
+            SELECT COUNT(*) AS count
+            FROM `/Root/olapStore/olapTable/.sys/primary_index_portion_stats`;
+        )");
+        UNIT_ASSERT_GT(GetUint64(rows[0].at("count")), 1);
+        UNIT_ASSERT_VALUES_EQUAL(helper.GetQueryResult("SELECT COUNT(*) FROM `/Root/olapStore/olapTable`;"), "[[50000u]]");
+        UNIT_ASSERT_VALUES_EQUAL(csController->GetCompactionStartedCounter().Val(), 0);
+    }
+
     Y_UNIT_TEST(MultiWriteInTimeDiffSchemas) {
         auto settings = TKikimrSettings().SetWithSampleTables(false).SetColumnShardAlterObjectEnabled(true);
         settings.AppConfig.MutableColumnShardConfig()->SetWritingBufferDurationMs(15000);

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -354,6 +354,7 @@ message TTableServiceConfig {
     message TWriteActorSettings {
         optional uint64 InFlightMemoryLimitPerActorBytes = 1 [ default = 67108864 ];
         reserved 2; // MemoryLimitPerMessageBytes
+        optional uint64 ColumnShardMaxOperationBytes = 3 [ default = 67108864 ];
 
         optional uint64 StartRetryDelayMs = 4 [ default = 30000 ];
         optional uint64 MaxRetryDelayMs = 5 [ default = 300000 ];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added a tuneable parameter, TTableServiceConfig.TWriteActorSettings.ColumnShardMaxOperationBytes. Applies to column shards only, when writing from a KQP sink. Can be used to limit write load in very high write throughput scenarios. Not documenting this one since a more automatic solution is in the works currently.