### PR TITLE
docs: fix ALTER COLUMN options in stable-26-1

### DIFF
--- a/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
@@ -73,7 +73,7 @@ Allows a column to contain `NULL` values.
 
 #### SET COMPRESSION
 
-Changes the [compression settings](#compression) of a column in a column-oriented table.
+Changes the compression settings of a column in a column-oriented table.
 
 ### Examples
 

--- a/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
@@ -46,7 +46,11 @@ ALTER TABLE episodes ADD COLUMN rate Double (DEFAULT 5.0, NOT NULL); -- alternat
 Modifies properties of an existing column in the specified table. Property changes are applied without recreating the column. Some properties apply only to newly written data or during compaction (see the description of each property for details).
 
 ```yql
-ALTER TABLE table_name ALTER COLUMN column_name {SET | DROP} [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
+ALTER TABLE table_name ALTER COLUMN column_name
+  { SET FAMILY <family_name>
+  | DROP NOT NULL
+  | SET COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])
+  };
 ```
 
 ### Request parameters
@@ -59,22 +63,24 @@ The path of the table containing the column to change.
 
 The name of the column to change in the specified table.
 
-#### SET
+#### SET FAMILY
 
-Set a column option.
+Moves a column of a row-oriented table to the specified column family.
 
-#### DROP
+#### DROP NOT NULL
 
-Remove a column option. Currently only `NOT NULL` can be removed.
+Allows a column to contain `NULL` values.
 
-{% include [column_option_list.md](../_includes/column_option_list.md) %}
+#### SET COMPRESSION
+
+Changes the [compression settings](#compression) of a column in a column-oriented table.
 
 ### Examples
 
-The code below will disallow `NULL` values in the `title` column of the `episodes` table.
+The code below will allow `NULL` values in the `title` column of the `episodes` table.
 
 ```yql
-ALTER TABLE episodes ALTER COLUMN title SET NOT NULL;
+ALTER TABLE episodes ALTER COLUMN title DROP NOT NULL;
 ```
 
 {% if oss == true and backend_name == "YDB" %}

--- a/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
@@ -73,7 +73,7 @@ ALTER TABLE table_name ALTER COLUMN column_name
 
 #### SET COMPRESSION
 
-Изменяет [настройки сжатия](#compression) колонки в колоночной таблице.
+Изменяет настройки сжатия колонки в колоночной таблице.
 
 ### Примеры
 

--- a/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
@@ -46,7 +46,11 @@ ALTER TABLE episodes ADD COLUMN rate Double (DEFAULT 5.0, NOT NULL); -- альт
 Изменяет свойства существующей колонки в указанной таблице. Изменение свойства происходит без пересоздания колонки. Некоторые свойства применяются только к свежим записанным данным или в процессе компакшена (детали можно найти в описании конкретного свойства)
 
 ```yql
-ALTER TABLE table_name ALTER COLUMN column_name {SET | DROP} [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
+ALTER TABLE table_name ALTER COLUMN column_name
+  { SET FAMILY <family_name>
+  | DROP NOT NULL
+  | SET COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])
+  };
 ```
 
 ### Параметры запроса
@@ -59,22 +63,24 @@ ALTER TABLE table_name ALTER COLUMN column_name {SET | DROP} [FAMILY <family_nam
 
 Имя колонки, которая будет изменена в указанной таблице.
 
-#### SET
+#### SET FAMILY
 
-Установить параметр колонки
+Перемещает колонку строковой таблицы в указанную группу колонок.
 
-#### DROP
+#### DROP NOT NULL
 
-Удалить параметр колонки. На текущий момент поддерживается только удаление `NOT NULL`.
+Разрешает хранить значения `NULL` в колонке.
 
-{% include [column_option_list.md](../_includes/column_option_list.md) %}
+#### SET COMPRESSION
+
+Изменяет [настройки сжатия](#compression) колонки в колоночной таблице.
 
 ### Примеры
 
-Приведённый ниже код запретит пустые значения в колонке `title` из таблицы `episodes`.
+Приведённый ниже код разрешит пустые значения в колонке `title` из таблицы `episodes`.
 
 ```yql
-ALTER TABLE episodes ALTER COLUMN title SET NOT NULL;
+ALTER TABLE episodes ALTER COLUMN title DROP NOT NULL;
 ```
 
 {% if oss == true and backend_name == "YDB" %}


### PR DESCRIPTION
### Changes

- list only `ALTER COLUMN` operations available by default in stable-26-1
- remove `SET/DROP DEFAULT` from the syntax because `EnableSetDropDefaultValue` defaults to `false`
- remove `SET NOT NULL` because `EnableSetColumnConstraint` defaults to `false`
- avoid implying support for `SET NULL` and `DROP NULL`; the supported operation is `DROP NOT NULL`
- keep the supported `SET FAMILY`, `DROP NOT NULL`, and `SET COMPRESSION` forms
- replace the non-working `SET NOT NULL` example with `DROP NOT NULL`
- update Russian and English documentation consistently

`SET ENCODING` was also checked and intentionally omitted because `EnableCsDictionaryEncoding` defaults to `false`. `ADD COLUMN` documentation is unchanged.

### Verification

- `./ya make ydb/docs/en/core ydb/docs/ru/core`
- `git diff --check`