### PR TITLE
Share SDK response executor

### DIFF
--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,5 +1,7 @@
 * Added `EQ_HEIGHT_HISTOGRAM` to `EMultiColumnStatisticsType`.
 
+* SDK response queues now share the executor selected by the first driver. Later drivers reuse it; a different explicit executor is rejected. Driver shutdown drains its own work without stopping the shared executor.
+
 # v3.22.0
 
 * Added `IWriteSession::Flush` to asynchronously wait until all previously accepted topic writes are acknowledged.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
@@ -40,7 +40,8 @@ public:
     //! Set number of network threads, default: 2
     TDriverConfig& SetNetworkThreadsNum(size_t sz);
 
-    //! Set number of client pool threads, if 0 adaptive thread pool will be used.
+    //! Set the process-wide callback thread count if this driver initializes the executor.
+    //! Later drivers reuse the selected executor. If 0, an adaptive thread pool is used.
     //! NOTE: in case of no zero value it is possible to get deadlock if all threads
     //! of this pool is blocked somewhere in user code.
     //! default: 0
@@ -177,8 +178,12 @@ public:
     //! Log backend.
     TDriverConfig& SetLog(std::unique_ptr<TLogBackend>&& log);
 
-    //! Set executor for async responses.
-    //! If not set, default executor will be used.
+    //! The first driver selects the process-wide executor for async responses, or starts
+    //! a default executor if none is set. Later drivers reuse it unless they explicitly
+    //! select a different instance, which throws TContractViolation.
+    //! The executor is retained for the process lifetime and is never stopped by the SDK.
+    //! The caller must keep it running. Its startup must not use the SDK runtime or wait
+    //! for another thread that does.
     TDriverConfig& SetExecutor(std::shared_ptr<IExecutor> executor);
 
     //! Set external metrics registry implementation.
@@ -204,8 +209,9 @@ public:
     //! Cancel all currently running and future requests
     //! This method is useful to make sure there are no new asynchronous
     //! callbacks and it is safe to destroy the driver
-    //! When wait is true this method will not return until the underlying
-    //! client thread pool is stopped completely
+    //! When wait is true, waits for this driver's network requests and response callbacks,
+    //! including destruction of their captures. The shared callback executor keeps running.
+    //! Calls from SDK callbacks defer shutdown to avoid waiting on the current callback.
     void Stop(bool wait = false);
 
     template<typename TExtension>

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -306,6 +306,8 @@ private:
 TGRpcConnectionsImpl::TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> params)
     : MetricRegistryPtr_(nullptr)
     , ClientThreadsNum_(params->GetClientThreadsNum())
+    , ResponseQueue_(GetSdkRuntime().CreateResponseQueue(
+          params->GetExecutor(), params->GetClientThreadsNum(), params->GetMaxQueuedRequests()))
     , DefaultDiscoveryEndpoint_(params->GetEndpoint())
     , SslCredentials_(params->GetSslCredentials())
     , DefaultDatabase_(params->GetDatabase())
@@ -356,14 +358,6 @@ TGRpcConnectionsImpl::TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> p
         AddPeriodicTask(channelPoolUpdateWrapper, SocketIdleTimeout_ / 10);
     }
 #endif
-    if (params->GetExecutor()) {
-        ResponseQueue_ = params->GetExecutor();
-    } else {
-        // TAdaptiveThreadPool ignores params
-        ResponseQueue_ = CreateThreadPoolExecutor(ClientThreadsNum_, MaxQueuedRequests_);
-    }
-
-    ResponseQueue_->Start();
     if (!DefaultDatabase_.empty()) {
         DefaultState_ = StateTracker_.GetDriverState(
             DefaultDatabase_,
@@ -527,7 +521,7 @@ void TGRpcConnectionsImpl::Stop(bool wait) {
     DriverScope_->Cancel();
     GRpcClientLow_.Stop(wait);
     if (wait) {
-        StopResponseQueue();
+        ResponseQueue_->Stop();
         DriverScope_->WaitCallbacksDrained();
     }
 }
@@ -690,12 +684,6 @@ void TGRpcConnectionsImpl::EnqueueResponse(IObjectInQueue* action) {
                     delete action;
                 }
             });
-    });
-}
-
-void TGRpcConnectionsImpl::StopResponseQueue() {
-    std::call_once(ResponseQueueStopOnce_, [this] {
-        ResponseQueue_->Stop();
     });
 }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -884,7 +884,6 @@ private:
     }
 
     void EnqueueResponse(IObjectInQueue* action);
-    void StopResponseQueue();
 
 private:
     TCallMeta MakeCallMeta(const TRpcRequestSettings& requestSettings, const TDbDriverStatePtr& dbState) const;
@@ -894,7 +893,6 @@ private:
 
     const std::size_t ClientThreadsNum_;
     std::shared_ptr<IExecutor> ResponseQueue_;
-    std::once_flag ResponseQueueStopOnce_;
 
     const std::string DefaultDiscoveryEndpoint_;
     const TSslCredentials SslCredentials_;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/runtime.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/runtime.cpp
@@ -2,6 +2,11 @@
 #include "runtime.h"
 #undef INCLUDE_YDB_INTERNAL_H
 
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/exceptions/exceptions.h>
+
+#include <util/generic/scope.h>
+
+#include <atomic>
 #include <thread>
 
 namespace NYdb::inline Dev {
@@ -9,6 +14,101 @@ namespace NYdb::inline Dev {
 namespace {
 
 thread_local std::uint32_t SdkResponseCallbackDepth = 0;
+
+class TDriverResponseQueue final: public IExecutor {
+    struct TState {
+        std::atomic<std::uint32_t> Pending = 0;
+    };
+
+    class TTask final {
+    public:
+        TTask(std::shared_ptr<TState> state, TFunction callback)
+            : State_(std::move(state))
+            , Callback_(std::move(callback))
+        {
+            State_->Pending.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        ~TTask() {
+            Complete();
+        }
+
+        void Run() {
+            ++SdkResponseCallbackDepth;
+            Y_SCOPE_EXIT(this) {
+                Complete();
+                --SdkResponseCallbackDepth;
+            };
+            TFunction callback;
+            callback.swap(Callback_);
+            callback();
+        }
+
+    private:
+        void Complete() {
+            auto state = std::move(State_);
+            if (!state) {
+                return;
+            }
+            // Capture destruction may release the last driver owner, including
+            // when an executor rejects a submission. Defer any resulting teardown
+            // until this task has released its place in the driver's drain.
+            ++SdkResponseCallbackDepth;
+            Y_SCOPE_EXIT() {
+                --SdkResponseCallbackDepth;
+            };
+            Callback_ = nullptr;
+            // Publish capture destruction before waking drain waiters.
+            const auto pending = state->Pending.fetch_sub(1, std::memory_order_acq_rel);
+            Y_ABORT_UNLESS(pending);
+            if (pending == 1) {
+                state->Pending.notify_all();
+            }
+        }
+
+        std::shared_ptr<TState> State_;
+        TFunction Callback_;
+    };
+
+public:
+    explicit TDriverResponseQueue(IExecutor::TPtr executor)
+        : Executor_(std::move(executor))
+        , State_(std::make_shared<TState>())
+    {
+    }
+
+    void Post(TFunction&& callback) override {
+        // Copies retained by an executor share the same task and accounting.
+        // Completed wrappers may stay alive without delaying driver shutdown.
+        // Register before Post(), which may execute inline or block on capacity.
+        auto task = std::make_shared<TTask>(State_, std::move(callback));
+        Executor_->Post([task = std::move(task)]() mutable {
+            // The callback may remove its own wrapper from a custom executor.
+            auto running = std::move(task);
+            running->Run();
+        });
+    }
+
+    void Stop() override {
+        auto pending = State_->Pending.load(std::memory_order_acquire);
+        while (pending) {
+            State_->Pending.wait(pending, std::memory_order_acquire);
+            pending = State_->Pending.load(std::memory_order_acquire);
+        }
+    }
+
+    bool IsAsync() const override {
+        return Executor_->IsAsync();
+    }
+
+private:
+    void DoStart() override {
+        // The process-wide executor is already started by the runtime.
+    }
+
+    const IExecutor::TPtr Executor_;
+    const std::shared_ptr<TState> State_;
+};
 
 } // anonymous namespace
 
@@ -172,6 +272,23 @@ TDriverScope::TCallbackGuard::~TCallbackGuard() {
 
 bool TDriverScope::TCallbackGuard::IsEntered() const noexcept {
     return Entered_;
+}
+
+IExecutor::TPtr TSdkRuntime::CreateResponseQueue(
+    IExecutor::TPtr executor,
+    std::size_t threadCount,
+    std::size_t maxQueueSize)
+{
+    static const auto* sharedExecutor = [&] {
+        auto selected = executor ? executor : CreateThreadPoolExecutor(threadCount, maxQueueSize);
+        selected->Start();
+        return new IExecutor::TPtr(std::move(selected));
+    }();
+
+    if (executor && executor != *sharedExecutor) {
+        throw TContractViolation("The process-wide YDB SDK executor has already been configured with another instance");
+    }
+    return std::make_shared<TDriverResponseQueue>(*sharedExecutor);
 }
 
 TDriverScope::TPtr TSdkRuntime::CreateDriverScope(NYdbGrpc::IQueueClientContextProvider& contextProvider) {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/runtime.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/runtime.h
@@ -2,6 +2,7 @@
 
 #include <ydb/public/sdk/cpp/src/client/impl/internal/internal_header.h>
 
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/executor/executor.h>
 #include <ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h>
 
 #include <condition_variable>
@@ -76,6 +77,13 @@ private:
 
 class TSdkRuntime final {
 public:
+    // Each queue drains only its driver's callbacks and delegates post acceptance
+    // to the shared executor, selected on first use and retained without stopping.
+    IExecutor::TPtr CreateResponseQueue(
+        IExecutor::TPtr executor = {},
+        std::size_t threadCount = 0,
+        std::size_t maxQueueSize = 0);
+
     TDriverScope::TPtr CreateDriverScope(NYdbGrpc::IQueueClientContextProvider& contextProvider);
 
 private:

--- a/ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/ya.make
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/ya.make
@@ -5,6 +5,8 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/public/sdk/cpp/src/client/types/exceptions
+    ydb/public/sdk/cpp/src/client/types/executor
     ydb/public/sdk/cpp/src/library/grpc/client
 )
 

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/shared_executor_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/shared_executor_ut.cpp
@@ -1,0 +1,426 @@
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/extension_common/extension.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/exceptions/exceptions.h>
+
+#define INCLUDE_YDB_INTERNAL_H
+#include <ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h>
+#include <ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime/runtime.h>
+#undef INCLUDE_YDB_INTERNAL_H
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/scope.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <future>
+#include <mutex>
+#include <thread>
+
+using namespace NYdb;
+using namespace std::chrono_literals;
+
+namespace {
+
+    class TManualExecutor final: public IExecutor {
+    public:
+        void Stop() override {
+            UNIT_FAIL("A driver must not stop the shared executor");
+        }
+
+        void Post(TFunction&& callback) override {
+            if (OnPost) {
+                OnPost();
+            }
+            if (Reject.load()) {
+                ythrow yexception() << "Rejected test submission";
+            }
+            if (RunInline) {
+                callback();
+                return;
+            }
+            {
+                std::lock_guard lock(Mutex_);
+                Queue_.push_back(std::move(callback));
+            }
+        }
+
+        bool IsAsync() const override {
+            return !RunInline;
+        }
+
+        TFunction Take() {
+            std::lock_guard lock(Mutex_);
+            if (Queue_.empty()) {
+                return {};
+            }
+            auto callback = std::move(Queue_.front());
+            Queue_.pop_front();
+            return callback;
+        }
+
+        void RunAll() {
+            while (auto callback = Take()) {
+                callback();
+            }
+        }
+
+        std::atomic_uint Starts = 0;
+        std::atomic_bool Reject = false;
+        bool RunInline = false;
+        std::function<void()> OnStart;
+        std::function<void()> OnPost;
+
+    private:
+        void DoStart() override {
+            ++Starts;
+            if (OnStart) {
+                OnStart();
+            }
+        }
+
+        std::mutex Mutex_;
+        std::deque<TFunction> Queue_;
+    };
+
+    class TDestructionProbe final: public IExtension {
+    public:
+        struct IApi: IExtensionApi {
+            static IApi* Create(TDriver) {
+                return nullptr;
+            }
+        };
+        using TParams = std::shared_ptr<std::promise<void>>;
+
+        TDestructionProbe(TParams destroyed, IApi*)
+            : Destroyed_(std::move(destroyed))
+        {
+        }
+
+        ~TDestructionProbe() override {
+            Destroyed_->set_value();
+        }
+
+    private:
+        std::shared_ptr<std::promise<void>> Destroyed_;
+    };
+
+    TDriverConfig DriverConfig(IExecutor::TPtr executor = {}) {
+        auto config = TDriverConfig()
+                          .SetEndpoint("localhost:1")
+                          .SetDiscoveryMode(EDiscoveryMode::Off)
+                          .SetSocketIdleTimeout(TDuration::Max());
+        if (executor) {
+            config.SetExecutor(std::move(executor));
+        }
+        return config;
+    }
+
+} // namespace
+
+// Fork explicitly: each test must initialize the process-wide executor independently.
+Y_UNIT_TEST_SUITE(SharedResponseExecutorTest) {
+    SIMPLE_UNIT_FORKED_TEST(InitializesOnceAndRejectsDifferentExecutor) {
+        auto executor = std::make_shared<TManualExecutor>();
+        constexpr std::size_t ThreadCount = 8;
+        std::array<std::thread, ThreadCount> threads;
+        for (std::size_t i = 0; i < ThreadCount; ++i) {
+            threads[i] = std::thread([&, i] {
+                GetSdkRuntime().CreateResponseQueue(executor, i + 1, i + 1);
+            });
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+        UNIT_ASSERT_VALUES_EQUAL(executor->Starts.load(), 1);
+        auto implicit = GetSdkRuntime().CreateResponseQueue();
+        std::size_t calls = 0;
+        implicit->Post([&] { ++calls; });
+        UNIT_ASSERT_VALUES_EQUAL(calls, 0);
+        executor->RunAll();
+        implicit->Stop();
+        UNIT_ASSERT_VALUES_EQUAL(calls, 1);
+        auto driver = TDriver(DriverConfig());
+        auto same = TDriver(DriverConfig(executor));
+        auto other = std::make_shared<TManualExecutor>();
+        UNIT_ASSERT_EXCEPTION(TDriver(DriverConfig(other)), TContractViolation);
+        UNIT_ASSERT_VALUES_EQUAL(other->Starts.load(), 0);
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(RetriesFailedInitialization) {
+        auto executor = std::make_shared<TManualExecutor>();
+        executor->OnStart = [] { ythrow yexception() << "Startup failed"; };
+        UNIT_ASSERT_EXCEPTION(GetSdkRuntime().CreateResponseQueue(executor), yexception);
+        executor->OnStart = {};
+        auto queue = GetSdkRuntime().CreateResponseQueue(executor);
+        UNIT_ASSERT_VALUES_EQUAL(executor->Starts.load(), 2);
+        queue->Stop();
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(DrainsOnlyItsOwnQueuedTasksAndCaptures) {
+        auto executor = std::make_shared<TManualExecutor>();
+        auto queueA = GetSdkRuntime().CreateResponseQueue(executor);
+        auto queueB = GetSdkRuntime().CreateResponseQueue();
+        auto capture = std::make_shared<int>(42);
+        std::weak_ptr<int> weak = capture;
+        queueA->Post([capture] { UNIT_ASSERT_VALUES_EQUAL(*capture, 42); });
+        capture.reset();
+        auto taskA = executor->Take();
+        auto retainedCopy = taskA;
+        bool calledB = false;
+        queueB->Post([&] { calledB = true; });
+        auto taskB = executor->Take();
+        std::array<std::future<bool>, 2> stopped;
+        for (auto& stop : stopped) {
+            stop = std::async(std::launch::async, [queueA, weak] {
+                queueA->Stop();
+                return weak.expired();
+            });
+        }
+        Y_SCOPE_EXIT(&taskA, &retainedCopy, &executor, &stopped) {
+            taskA = {};
+            retainedCopy = {};
+            executor->RunAll();
+            for (auto& stop : stopped) {
+                if (stop.valid()) {
+                    stop.wait();
+                }
+            }
+        };
+        for (auto& stop : stopped) {
+            UNIT_ASSERT(stop.wait_for(0s) != std::future_status::ready);
+        }
+        taskA();
+        UNIT_ASSERT(weak.expired());
+        executor->RunAll();
+        for (auto& stop : stopped) {
+            UNIT_ASSERT(stop.wait_for(10s) == std::future_status::ready);
+            UNIT_ASSERT(stop.get());
+        }
+        // An idle executor may keep its last completed callback indefinitely.
+        taskA = {};
+        retainedCopy = {};
+        UNIT_ASSERT(!calledB);
+        taskB();
+        taskB = {};
+        queueB->Stop();
+        queueA->Stop();
+        UNIT_ASSERT(calledB);
+        bool calledAfterStop = false;
+        queueA->Post([&] { calledAfterStop = true; });
+        UNIT_ASSERT(!calledAfterStop);
+        executor->RunAll();
+        queueA->Stop();
+        UNIT_ASSERT(calledAfterStop);
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(ExceptionsReleaseAccountingAndCaptures) {
+        auto executor = std::make_shared<TManualExecutor>();
+        for (bool runInline : {false, true}) {
+            executor->RunInline = runInline;
+            executor->Reject = !runInline;
+            auto queue = GetSdkRuntime().CreateResponseQueue(executor);
+            queue->Stop();
+            UNIT_ASSERT_VALUES_EQUAL(queue->IsAsync(), !runInline);
+            auto capture = std::make_shared<int>(42);
+            std::weak_ptr<int> weak = capture;
+            unsigned calls = 0;
+            UNIT_ASSERT_EXCEPTION_CONTAINS(queue->Post([capture = std::move(capture), &calls] {
+                ++calls;
+                ythrow yexception() << "Callback failed";
+            }), yexception, runInline ? "Callback failed" : "Rejected test submission");
+            UNIT_ASSERT_VALUES_EQUAL(calls, runInline ? 1 : 0);
+            UNIT_ASSERT(weak.expired());
+            queue->Stop();
+        }
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(StopWaitsForBlockedSubmission) {
+        auto executor = std::make_shared<TManualExecutor>();
+        auto queue = GetSdkRuntime().CreateResponseQueue(executor);
+        std::promise<void> entered;
+        std::promise<void> release;
+        auto released = release.get_future().share();
+        std::atomic_bool blockNext = true;
+        executor->OnPost = [&] {
+            if (blockNext.exchange(false)) {
+                entered.set_value();
+                released.wait();
+            }
+        };
+        std::atomic_bool called = false;
+        auto posted = std::async(std::launch::async, [queue, &called] {
+            queue->Post([&called] { called.store(true); });
+        });
+        std::future<bool> stopped;
+        {
+            Y_SCOPE_EXIT(&release, &posted, &executor) {
+                release.set_value();
+                posted.wait();
+                executor->OnPost = {};
+                executor->RunAll();
+            };
+            UNIT_ASSERT(entered.get_future().wait_for(10s) == std::future_status::ready);
+            stopped = std::async(std::launch::async, [queue, &called] {
+                queue->Stop();
+                return called.load();
+            });
+            UNIT_ASSERT(stopped.wait_for(0s) != std::future_status::ready);
+        }
+        UNIT_ASSERT(stopped.wait_for(10s) == std::future_status::ready);
+        UNIT_ASSERT(stopped.get());
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(SubmissionRacingWithStopIsDelegated) {
+        auto executor = std::make_shared<TManualExecutor>();
+        for (std::size_t iteration = 0; iteration < 32; ++iteration) {
+            auto queue = GetSdkRuntime().CreateResponseQueue(executor);
+            std::promise<void> start;
+            auto ready = start.get_future().share();
+            constexpr std::size_t PosterCount = 8;
+            std::array<bool, PosterCount> called = {};
+            std::array<std::thread, PosterCount> posters;
+            for (std::size_t i = 0; i < PosterCount; ++i) {
+                posters[i] = std::thread([&, i] {
+                    ready.wait();
+                    queue->Post([&, i] { called[i] = true; });
+                });
+            }
+            auto stopped = std::async(std::launch::async, [queue, ready] {
+                ready.wait();
+                queue->Stop();
+            });
+            start.set_value();
+            for (auto& poster : posters) {
+                poster.join();
+            }
+            executor->RunAll();
+            UNIT_ASSERT(stopped.wait_for(10s) == std::future_status::ready);
+            queue->Stop();
+            for (std::size_t i = 0; i < PosterCount; ++i) {
+                UNIT_ASSERT(called[i]);
+            }
+        }
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(StopCancelsOneDriverWithoutStoppingAnother) {
+        auto executor = std::make_shared<TManualExecutor>();
+        auto driverA = TDriver(DriverConfig(executor));
+        auto driverB = TDriver(DriverConfig());
+        auto connectionsA = CreateInternalInterface(driverA);
+        auto connectionsB = CreateInternalInterface(driverB);
+        auto contextA = connectionsA->CreateContext();
+        auto contextB = connectionsB->CreateContext();
+        driverA.Stop(false);
+        UNIT_ASSERT(contextA->IsCancelled());
+        UNIT_ASSERT(!contextB->IsCancelled());
+        UNIT_ASSERT(!connectionsA->CreateContext());
+        contextA.reset();
+        bool calledB = false;
+        connectionsB->PostToResponseQueue([&] { calledB = true; });
+        auto taskB = executor->Take();
+        // The executor can accept more work after a completed Stop(true).
+        for (unsigned i = 0; i < 2; ++i) {
+            bool calledA = false;
+            auto capture = std::make_shared<int>(42);
+            std::weak_ptr<int> weak = capture;
+            connectionsA->PostToResponseQueue([&calledA, capture] { calledA = true; });
+            capture.reset();
+            auto taskA = executor->Take();
+            std::promise<void> stopping;
+            auto stopped = std::async(std::launch::async, [&] {
+                stopping.set_value();
+                driverA.Stop(true);
+                return weak.expired();
+            });
+            stopping.get_future().wait();
+            taskA();
+            taskA = {};
+            UNIT_ASSERT(stopped.wait_for(10s) == std::future_status::ready);
+            UNIT_ASSERT(calledA);
+            UNIT_ASSERT(stopped.get());
+        }
+        UNIT_ASSERT(!calledB);
+        taskB();
+        taskB = {};
+        UNIT_ASSERT(calledB);
+        driverA.Stop(true);
+        contextB.reset();
+        driverB.Stop(true);
+        UNIT_ASSERT_VALUES_EQUAL(executor->Starts.load(), 1);
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(CallbackCanRemoveItsExecutorWrapper) {
+        auto executor = std::make_shared<TManualExecutor>();
+        auto queue = GetSdkRuntime().CreateResponseQueue(executor);
+        IExecutor::TFunction running;
+        bool called = false;
+        queue->Post([&] {
+            running = {};
+            called = true;
+        });
+        running = executor->Take();
+        running();
+        queue->Stop();
+        UNIT_ASSERT(called);
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(UnexecutedCaptureCanStopItsDriver) {
+        auto executor = std::make_shared<TManualExecutor>();
+        for (bool reject : {false, true}) {
+            auto driver = std::make_shared<TDriver>(DriverConfig(executor));
+            auto destroyed = std::make_shared<std::promise<void>>();
+            auto destruction = destroyed->get_future();
+            driver->AddExtension<TDestructionProbe>(destroyed);
+            auto connections = CreateInternalInterface(*driver);
+            bool destroyedInCallback = false;
+            auto capture = std::shared_ptr<void>(nullptr, [driver = std::move(driver), &destroyedInCallback](void*) {
+                destroyedInCallback = TDriverScope::IsCurrentThreadInCallback();
+                driver->Stop(true);
+            });
+            std::weak_ptr<void> weak = capture;
+            // Avoid libc++ retaining a source copy in std::function inline storage.
+            auto callback = [capture = std::move(capture), padding = std::array<char, 64>{}] {
+                Y_UNUSED(capture);
+                Y_UNUSED(padding);
+            };
+            executor->Reject = reject;
+            if (reject) {
+                UNIT_ASSERT_EXCEPTION(connections->PostToResponseQueue(std::move(callback)), yexception);
+            } else {
+                connections->PostToResponseQueue(std::move(callback));
+                auto discarded = executor->Take();
+                UNIT_ASSERT(discarded);
+                auto retainedCopy = discarded;
+                discarded = {};
+                UNIT_ASSERT(!weak.expired());
+                retainedCopy = {};
+            }
+            UNIT_ASSERT(weak.expired());
+            UNIT_ASSERT(destroyedInCallback);
+            connections.reset();
+            UNIT_ASSERT(destruction.wait_for(10s) == std::future_status::ready);
+        }
+    }
+
+    SIMPLE_UNIT_FORKED_TEST(DefaultExecutorSurvivesStopAndLastOwnerReleaseInsideCallback) {
+        auto driver = std::make_shared<TDriver>(DriverConfig().SetClientThreadsNum(1));
+        UNIT_ASSERT_EXCEPTION(
+            GetSdkRuntime().CreateResponseQueue(std::make_shared<TManualExecutor>()), TContractViolation);
+        auto reused = GetSdkRuntime().CreateResponseQueue({}, 8, 100);
+        reused->Stop();
+        auto destroyed = std::make_shared<std::promise<void>>();
+        auto destruction = destroyed->get_future();
+        driver->AddExtension<TDestructionProbe>(destroyed);
+        auto connections = CreateInternalInterface(*driver);
+        auto completed = std::make_shared<std::promise<void>>();
+        auto completion = completed->get_future();
+        connections->PostToResponseQueue([driver = std::move(driver), completed] {
+            driver->Stop(true);
+            completed->set_value();
+        });
+        connections.reset();
+        UNIT_ASSERT(completion.wait_for(10s) == std::future_status::ready);
+        UNIT_ASSERT(destruction.wait_for(10s) == std::future_status::ready);
+    }
+} // Y_UNIT_TEST_SUITE(SharedResponseExecutorTest)

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/ya.make
@@ -11,6 +11,8 @@ FORK_SUBTESTS()
 
 PEERDIR(
     ydb/public/sdk/cpp/src/client/driver
+    ydb/public/sdk/cpp/src/client/extension_common
+    ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections
     ydb/public/sdk/cpp/src/client/impl/observability
     ydb/public/sdk/cpp/src/client/impl/internal/sdk_runtime
     ydb/public/sdk/cpp/src/client/table
@@ -19,6 +21,7 @@ PEERDIR(
 
 SRCS(
     driver_ut.cpp
+    shared_executor_ut.cpp
 )
 
 END()


### PR DESCRIPTION
Reuse the first driver's executor; reject only a different explicit executor. Preserve per-driver shutdown and delegate callback submission to the executor.
