### PR TITLE
docs: clarify NOT NULL column alterations

### DIFF
--- a/ydb/docs/en/core/yql/reference/syntax/_includes/column_option_list_alter.md
+++ b/ydb/docs/en/core/yql/reference/syntax/_includes/column_option_list_alter.md
@@ -1,0 +1,45 @@
+### FAMILY <family_name> (column setting)
+
+{% if oss == true and backend_name == "YDB" %}
+
+{% include [OLTP_only_allow_note](../../../../_includes/only_allow_for_oltp_note.md) %}
+
+{% endif %}
+
+Specifies that this column belongs to the specified column group. For more information, see [{#T}](../create_table/family.md).
+
+### DEFAULT <default_value>
+
+{% note warning %}
+
+The `DEFAULT` option is supported:
+
+* Only for [row](../../../../concepts/datamodel/table.md#row-oriented-tables) tables.
+* Only with literal values.
+
+{% endnote %}
+
+Sets a default value for the column. If no value is specified for this column when inserting a row, the specified default value is used. The default value must match the column's data type.
+
+### NOT NULL
+
+`DROP NOT NULL` removes the `NOT NULL` constraint from a non-key column, allowing `NULL` values. This operation is supported for both [row-oriented](../../../../concepts/datamodel/table.md#row-oriented-tables) and [column-oriented](../../../../concepts/datamodel/table.md#column-oriented-tables) tables.
+
+```yql
+ALTER TABLE table_name ALTER COLUMN column_name DROP NOT NULL;
+```
+
+### COMPRESSION([algorithm=<algorithm_name>[, level=<value>]]) {#compression}
+
+{% if oss == true and backend_name == "YDB" %}
+
+{% include [OLAP_only_allow_note](../../../../_includes/only_allow_for_olap_note.md) %}
+
+{% endif %}
+
+The following compression parameters can be set for columns:
+
+* `algorithm` — data compression algorithm. Valid values: `off` (disable compression), `lz4`, `zstd`.
+* `level` — compression level, supported only for the `zstd` algorithm (valid values from 0 to 22).
+
+If `COMPRESSION()` is specified without parameters, the default compression is used for the column. Currently this is `lz4`; future versions will allow configuring default compression at the cluster or table level.

--- a/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
@@ -10,6 +10,8 @@ Builds a new column with the specified name, type, and options for the specified
 ALTER TABLE table_name ADD COLUMN column_name column_data_type [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
 ```
 
+When adding a `NOT NULL` column to a [row-oriented table](../../../../concepts/datamodel/table.md#row-oriented-tables), you must also specify `DEFAULT` so that the new column can be populated in existing rows. Column-oriented tables do not support adding a `NOT NULL` column because they do not support `DEFAULT` values.
+
 ## Request parameters
 
 ### table_name
@@ -46,7 +48,8 @@ ALTER TABLE episodes ADD COLUMN rate Double (DEFAULT 5.0, NOT NULL); -- alternat
 Modifies properties of an existing column in the specified table. Property changes are applied without recreating the column. Some properties apply only to newly written data or during compaction (see the description of each property for details).
 
 ```yql
-ALTER TABLE table_name ALTER COLUMN column_name {SET | DROP} [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
+ALTER TABLE table_name ALTER COLUMN column_name SET { FAMILY <family_name> | DEFAULT <default_value> | COMPRESSION([algorithm=<algorithm_name>[, level=<value>]]) };
+ALTER TABLE table_name ALTER COLUMN column_name DROP { NOT NULL | DEFAULT };
 ```
 
 ### Request parameters
@@ -61,20 +64,31 @@ The name of the column to change in the specified table.
 
 #### SET
 
-Set a column option.
+Set a column property.
 
 #### DROP
 
-Remove a column option. Currently only `NOT NULL` can be removed.
+Remove a column property.
 
-{% include [column_option_list.md](../_includes/column_option_list.md) %}
+{% include [column_option_list_alter.md](../_includes/column_option_list_alter.md) %}
+
+A single `ALTER TABLE` statement can specify multiple `ALTER COLUMN` actions separated by commas.
 
 ### Examples
 
-The code below will disallow `NULL` values in the `title` column of the `episodes` table.
+The code below sets a default value for the `rate` column of the `episodes` table.
 
 ```yql
-ALTER TABLE episodes ALTER COLUMN title SET NOT NULL;
+ALTER TABLE episodes ALTER COLUMN rate SET DEFAULT 5.0;
+```
+
+The code below changes default values for several columns of a table in a single statement — setting new defaults for `col_1` and `col_2` and clearing the default for `col_3`.
+
+```yql
+ALTER TABLE default_columns
+    ALTER COLUMN col_1 SET DEFAULT "new_a"u,
+    ALTER COLUMN col_2 SET DEFAULT 99,
+    ALTER COLUMN col_3 DROP DEFAULT;
 ```
 
 {% if oss == true and backend_name == "YDB" %}

--- a/ydb/docs/ru/core/yql/reference/syntax/_includes/column_option_list_alter.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/_includes/column_option_list_alter.md
@@ -1,0 +1,45 @@
+### FAMILY <family_name> (настройка колонки)
+
+{% if oss == true and backend_name == "YDB" %}
+
+{% include [OLTP_only_allow_note](../../../../_includes/only_allow_for_oltp_note.md) %}
+
+{% endif %}
+
+Указание принадлежности данной колонки к указанной группе колонок. Подробнее в разделе [{#T}](../create_table/family.md).
+
+### DEFAULT <default_value>
+
+{% note warning %}
+
+Опция `DEFAULT` поддерживается:
+
+* Только для [строковых](../../../../concepts/datamodel/table.md#row-oriented-tables) таблиц.
+* Только с литеральными значениями.
+
+{% endnote %}
+
+Позволяет задать значение по умолчанию для колонки. Если при вставке строки значение для данной колонки не указано, будет использовано указанное значение по умолчанию. Значение по умолчанию должно соответствовать типу данных колонки.
+
+### NOT NULL
+
+`DROP NOT NULL` снимает ограничение `NOT NULL` с неключевой колонки, снова разрешая значения `NULL`. Операция поддерживается как для [строковых](../../../../concepts/datamodel/table.md#row-oriented-tables), так и для [колоночных](../../../../concepts/datamodel/table.md#column-oriented-tables) таблиц.
+
+```yql
+ALTER TABLE table_name ALTER COLUMN column_name DROP NOT NULL;
+```
+
+### COMPRESSION([algorithm=<algorithm_name>[, level=<value>]]) {#compression}
+
+{% if oss == true and backend_name == "YDB" %}
+
+{% include [OLAP_only_allow_note](../../../../_includes/only_allow_for_olap_note.md) %}
+
+{% endif %}
+
+Для колонок можно задать следующие параметры сжатия:
+
+* `algorithm` — алгоритм сжатия данных. Допустимые значения: `off` (отключение сжатия), `lz4`, `zstd`.
+* `level` — уровень сжатия, поддерживается только для алгоритма `zstd` (допустимы значения от 0 до 22).
+
+Если `COMPRESSION()` указан без параметров, для колонки используется сжатие по умолчанию. Сейчас это `lz4`; в будущих версиях появится возможность настраивать сжатие по умолчанию на уровне кластера или таблицы.

--- a/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
@@ -10,6 +10,8 @@
 ALTER TABLE table_name ADD COLUMN column_name column_data_type [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
 ```
 
+При добавлении колонки с ограничением `NOT NULL` в [строковую таблицу](../../../../concepts/datamodel/table.md#row-oriented-tables) необходимо также указать `DEFAULT`, чтобы заполнить новую колонку в существующих строках. В колоночную таблицу добавить колонку с ограничением `NOT NULL` нельзя, поскольку значения `DEFAULT` для таких таблиц не поддерживаются.
+
 ## Параметры запроса
 
 ### table_name
@@ -46,7 +48,8 @@ ALTER TABLE episodes ADD COLUMN rate Double (DEFAULT 5.0, NOT NULL); -- альт
 Изменяет свойства существующей колонки в указанной таблице. Изменение свойства происходит без пересоздания колонки. Некоторые свойства применяются только к свежим записанным данным или в процессе компакшена (детали можно найти в описании конкретного свойства)
 
 ```yql
-ALTER TABLE table_name ALTER COLUMN column_name {SET | DROP} [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
+ALTER TABLE table_name ALTER COLUMN column_name SET { FAMILY <family_name> | DEFAULT <default_value> | COMPRESSION([algorithm=<algorithm_name>[, level=<value>]]) };
+ALTER TABLE table_name ALTER COLUMN column_name DROP { NOT NULL | DEFAULT };
 ```
 
 ### Параметры запроса
@@ -61,20 +64,31 @@ ALTER TABLE table_name ALTER COLUMN column_name {SET | DROP} [FAMILY <family_nam
 
 #### SET
 
-Установить параметр колонки
+Установить свойство для указанной колонки.
 
 #### DROP
 
-Удалить параметр колонки. На текущий момент поддерживается только удаление `NOT NULL`.
+Удалить свойство для указанной колонки.
 
-{% include [column_option_list.md](../_includes/column_option_list.md) %}
+{% include [column_option_list_alter.md](../_includes/column_option_list_alter.md) %}
+
+В одном запросе `ALTER TABLE` можно указать несколько действий `ALTER COLUMN` через запятую.
 
 ### Примеры
 
-Приведённый ниже код запретит пустые значения в колонке `title` из таблицы `episodes`.
+Приведённый ниже код задаёт значение по умолчанию для колонки `rate` в таблице `episodes`.
 
 ```yql
-ALTER TABLE episodes ALTER COLUMN title SET NOT NULL;
+ALTER TABLE episodes ALTER COLUMN rate SET DEFAULT 5.0;
+```
+
+Приведённый ниже код одним запросом изменяет значения по умолчанию для нескольких колонок таблицы — у `col_1` и `col_2` устанавливает новые значения, у `col_3` сбрасывает значение по умолчанию.
+
+```yql
+ALTER TABLE default_columns
+    ALTER COLUMN col_1 SET DEFAULT "new_a"u,
+    ALTER COLUMN col_2 SET DEFAULT 99,
+    ALTER COLUMN col_3 DROP DEFAULT;
 ```
 
 {% if oss == true and backend_name == "YDB" %}


### PR DESCRIPTION
### Changelog entry

Clarified the requirements and availability of `NOT NULL` column operations.

### Changelog category

* Documentation

### Description for reviewers

This documentation correction is adapted for `stable-26-2` and aligns the `ALTER TABLE` reference with the functionality available by default:

* clarifies that `ADD COLUMN ... NOT NULL` requires `DEFAULT` for row-oriented tables and is unavailable for column-oriented tables;
* removes unavailable `ALTER COLUMN ... SET NOT NULL` documentation;
* retains and clarifies `ALTER COLUMN ... DROP NOT NULL`, including support for non-key columns in row-oriented and column-oriented tables;
* retains the available-by-default `ALTER COLUMN ... SET/DROP DEFAULT` operations;
* adopts the ALTER-specific options include already used in `stable-26-3`, avoiding a new branch-specific page structure;
* keeps `CREATE TABLE ... NOT NULL` documentation unchanged.

Related issues: YDBDOCS-2837, YDBREQUESTS-8527.
