### PR TITLE
docs: clarify NOT NULL column alterations

### DIFF
--- a/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/en/core/yql/reference/syntax/alter_table/columns.md
@@ -10,6 +10,8 @@ Builds a new column with the specified name, type, and options for the specified
 ALTER TABLE table_name ADD COLUMN column_name column_data_type [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
 ```
 
+When adding a `NOT NULL` column to a [row-oriented table](../../../../concepts/datamodel/table.md#row-oriented-tables), you must also specify `DEFAULT` so that the new column can be populated in existing rows. Column-oriented tables do not support adding a `NOT NULL` column because they do not support `DEFAULT` values.
+
 ## Request parameters
 
 ### table_name

--- a/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/alter_table/columns.md
@@ -10,6 +10,8 @@
 ALTER TABLE table_name ADD COLUMN column_name column_data_type [FAMILY <family_name>] [NULL | NOT NULL] [DEFAULT <default_value>] [COMPRESSION([algorithm=<algorithm_name>[, level=<value>]])];
 ```
 
+При добавлении колонки с ограничением `NOT NULL` в [строковую таблицу](../../../../concepts/datamodel/table.md#row-oriented-tables) необходимо также указать `DEFAULT`, чтобы заполнить новую колонку в существующих строках. В колоночную таблицу добавить колонку с ограничением `NOT NULL` нельзя, поскольку значения `DEFAULT` для таких таблиц не поддерживаются.
+
 ## Параметры запроса
 
 ### table_name


### PR DESCRIPTION
### Changelog entry

Clarified the requirements for adding a `NOT NULL` column.

### Changelog category

* Documentation

### Description for reviewers

This documentation correction is adapted for `stable-26-1`:

* clarifies that `ADD COLUMN ... NOT NULL` requires `DEFAULT` for row-oriented tables and is unavailable for column-oriented tables;
* keeps `CREATE TABLE ... NOT NULL` documentation unchanged;
* leaves the branch's existing `ALTER COLUMN ... DROP NOT NULL` documentation intact. The current `stable-26-1` base already documents `DROP NOT NULL` and does not advertise unavailable `SET NOT NULL`.

Related issues: YDBDOCS-2837, YDBREQUESTS-8527.
