### PR TITLE
Extend JSON index test coverage

### DIFF
--- a/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.cpp
+++ b/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.cpp
@@ -22,12 +22,28 @@ TKikimrRunner Kikimr(bool enableJsonIndex, bool enableJsonIndexAutoSelect) {
     return TKikimrRunner(settings);
 }
 
-TKikimrRunner KikimrJsonPrefix(bool enableJsonIndexAutoSelect) {
+TKikimrRunner KikimrJson(bool enableJsonIndexAutoSelect, bool compact) {
+    NKikimrConfig::TFeatureFlags featureFlags;
+    featureFlags.SetEnableJsonIndex(true);
+    featureFlags.SetEnableJsonIndexAutoSelect(enableJsonIndexAutoSelect);
+    featureFlags.SetEnableCompactFulltextIndex(compact);
+    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
+    if (compact) {
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
+    }
+    return TKikimrRunner(settings);
+}
+
+TKikimrRunner KikimrJsonPrefix(bool enableJsonIndexAutoSelect, bool compact) {
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableJsonIndex(true);
     featureFlags.SetEnableFulltextIndexPrefix(true);
     featureFlags.SetEnableJsonIndexAutoSelect(enableJsonIndexAutoSelect);
+    featureFlags.SetEnableCompactFulltextIndex(compact);
     auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
+    if (compact) {
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
+    }
     return TKikimrRunner(settings);
 }
 

--- a/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h
+++ b/ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h
@@ -35,7 +35,9 @@ extern const std::string kSecondLongSqlInValue;
 
 TKikimrRunner Kikimr(bool enableJsonIndex = true, bool enableJsonIndexAutoSelect = false);
 
-TKikimrRunner KikimrJsonPrefix(bool enableJsonIndexAutoSelect = false);
+TKikimrRunner KikimrJson(bool enableJsonIndexAutoSelect = false, bool compact = false);
+
+TKikimrRunner KikimrJsonPrefix(bool enableJsonIndexAutoSelect = false, bool compact = false);
 
 void CreateTestTable(NYdb::NQuery::TQueryClient& db, const std::string& type = "Json", bool withIndex = false);
 

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_auto_select_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_auto_select_ut.cpp
@@ -25,6 +25,23 @@ void ValidateOneOfTwoIndexesSelected(TQueryClient& db, const std::string& predic
         "Expected exactly one of (" + idxA + ", " + idxB + ") to be auto-selected for: " + predicate + ", got " + std::to_string(count));
 }
 
+TString ExecuteAndAssertJsonPlan(TQueryClient& db, const TString& sql, size_t expectedIndexNodes, const TString& expectedYson,
+    TParams params = TParamsBuilder().Build(), const TString& indexName = "json_idx")
+{
+    const auto settings = TExecuteQuerySettings().StatsMode(EStatsMode::Full);
+    auto result = db.ExecuteQuery(sql, TTxControl::NoTx(), params, settings).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    UNIT_ASSERT_C(result.GetStats() && result.GetStats()->GetPlan(), "Execution plan is missing");
+
+    NJson::TJsonValue planJson;
+    UNIT_ASSERT_C(NJson::ReadJsonTree(*result.GetStats()->GetPlan(), &planJson, true), "Failed to parse execution plan JSON");
+    UNIT_ASSERT_VALUES_EQUAL_C(CountPlanNodesByKv(planJson, "Index", indexName), expectedIndexNodes, sql);
+
+    const TString actual = FormatResultSetYson(result.GetResultSet(0));
+    CompareYson(expectedYson, actual, sql);
+    return actual;
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(KqpJsonIndexesAutoSelect) {
@@ -566,6 +583,222 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesAutoSelect) {
             "json_idx_extra", "TestTable");
     }
 
+    Y_UNIT_TEST_TWIN(AutoSelectSqlForms, Compact) {
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ true, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                CREATE TABLE TestTable (
+                    Key Uint64,
+                    Text JsonDocument,
+                    Data Utf8,
+                    Active Bool,
+                    PRIMARY KEY (Key),
+                    INDEX json_idx GLOBAL USING json ON (Text)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                UPSERT INTO TestTable (Key, Text, Data, Active) VALUES
+                    (1, JsonDocument('{"kind":"cat","score":10}'), "first"u, true),
+                    (2, JsonDocument('{"kind":"dog","score":20}'), "second"u, true),
+                    (3, JsonDocument('{"kind":"cat","score":30}'), "third"u, false),
+                    (4, JsonDocument('{"other":true}'), "fourth"u, false);
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            SELECT d.Key FROM TestTable AS d
+            WHERE JSON_VALUE(d.Text, '$.kind' RETURNING Utf8) = "cat"u ORDER BY d.Key;
+        )", 1, "[[[1u]];[[3u]]]");
+
+        auto kindParams = TParamsBuilder()
+            .AddParam("$kind").Utf8("cat").Build()
+            .Build();
+        ExecuteAndAssertJsonPlan(db, R"(
+            DECLARE $kind AS Utf8;
+            SELECT Key FROM TestTable
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = $kind ORDER BY Key;
+        )", 1, "[[[1u]];[[3u]]]", kindParams);
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            SELECT Key FROM TestTable
+            WHERE Active = true AND (Data != "missing"u AND
+                  (JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "cat"u)) ORDER BY Key;
+        )", 1, "[[[1u]]]");
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            $docs = SELECT Key, Text FROM TestTable;
+            SELECT Key FROM $docs
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "cat"u ORDER BY Key;
+        )", 1, "[[[1u]];[[3u]]]");
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            SELECT d.Key FROM (SELECT Key, Text FROM TestTable) AS d
+            WHERE JSON_VALUE(d.Text, '$.kind' RETURNING Utf8) = "cat"u ORDER BY d.Key;
+        )", 1, "[[[1u]];[[3u]]]");
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            SELECT Data FROM TestTable
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "cat"u
+            ORDER BY Key DESC LIMIT 1;
+        )", 1, R"([[["third"]]])");
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            SELECT Key FROM TestTable VIEW PRIMARY KEY
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "cat"u ORDER BY Key;
+        )", 0, "[[[1u]];[[3u]]]");
+
+        ExecuteAndAssertJsonPlan(db, R"(
+            SELECT Key FROM TestTable
+            WHERE String::AsciiToUpper(JSON_VALUE(Text, '$.kind' RETURNING Utf8)) = "CAT"
+            ORDER BY Key;
+        )", 0, "[[[1u]];[[3u]]]");
+    }
+
+    Y_UNIT_TEST_TWIN(JsonIndexOptimizerLifecycle, Compact) {
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ true, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                CREATE TABLE `/Root/Lifecycle` (
+                    Key Uint64,
+                    Text JsonDocument,
+                    PRIMARY KEY (Key)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                UPSERT INTO `/Root/Lifecycle` (Key, Text) VALUES
+                    (1, JsonDocument('{"kind":"target"}')),
+                    (2, JsonDocument('{"kind":"other"}'));
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        const TString sql = R"(
+            SELECT Key FROM `/Root/Lifecycle`
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "target"u
+            ORDER BY Key;
+        )";
+
+        ExecuteAndAssertJsonPlan(db, sql, 0, "[[[1u]]]");
+        ExecuteAndAssertJsonPlan(db, sql, 0, "[[[1u]]]");
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                ALTER TABLE `/Root/Lifecycle`
+                    ADD INDEX json_idx GLOBAL USING json ON (Text);
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        ExecuteAndAssertJsonPlan(db, sql, 1, "[[[1u]]]");
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                UPDATE `/Root/Lifecycle`
+                SET Text = JsonDocument('{"kind":"target"}')
+                WHERE Key = 2;
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        ExecuteAndAssertJsonPlan(db, sql, 1, "[[[1u]];[[2u]]]");
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                ALTER TABLE `/Root/Lifecycle` DROP INDEX json_idx;
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto result = db.ExecuteQuery(R"(
+                UPDATE `/Root/Lifecycle`
+                SET Text = JsonDocument('{"kind":"other"}')
+                WHERE Key = 1;
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        ExecuteAndAssertJsonPlan(db, sql, 0, "[[[2u]]]");
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                ALTER TABLE `/Root/Lifecycle`
+                    ADD INDEX json_idx GLOBAL USING json ON (Text);
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto result = db.ExecuteQuery(R"(
+                INSERT INTO `/Root/Lifecycle` (Key, Text) VALUES
+                    (3, JsonDocument('{"kind":"target"}'));
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        ExecuteAndAssertJsonPlan(db, sql, 1, "[[[2u]];[[3u]]]");
+    }
+
+    Y_UNIT_TEST_TWIN(JsonIndexImplSchemaVersionBump, Compact) {
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ true, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                CREATE TABLE `/Root/SchemaDocs` (
+                    Key Uint64,
+                    Text JsonDocument,
+                    PRIMARY KEY (Key),
+                    INDEX json_idx GLOBAL USING json ON (Text)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                UPSERT INTO `/Root/SchemaDocs` (Key, Text) VALUES
+                    (1, JsonDocument('{"kind":"target"}')),
+                    (2, JsonDocument('{"kind":"other"}'));
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        const TString sql = R"(
+            SELECT Key FROM `/Root/SchemaDocs` VIEW json_idx
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "target"u
+            ORDER BY Key;
+        )";
+
+        const TString expected = ExecuteAndAssertJsonPlan(db, sql, 1, "[[[1u]]]");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            ExecuteAndAssertJsonPlan(db, sql, 1, "[[[1u]]]"), expected, sql);
+
+        Tests::TClient& client = kikimr.GetTestClient();
+        const TString scheme = R"(
+            Name: "indexImplTable"
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 1
+                    SizeToSplit: 100500
+                }
+            }
+        )";
+        auto alter = client.AlterTable("/Root/SchemaDocs/json_idx", scheme, {});
+        UNIT_ASSERT_VALUES_EQUAL_C(alter->Record.GetStatus(), NMsgBusProxy::MSTATUS_OK,
+            alter->Record.ShortDebugString());
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            ExecuteAndAssertJsonPlan(db, sql, 1, "[[[1u]]]"), expected, sql);
+    }
+
     Y_UNIT_TEST(Prefixed) {
         auto kikimr = KikimrJsonPrefix(true);
         auto db = kikimr.GetQueryClient();
@@ -596,9 +829,63 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexesAutoSelect) {
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
 
-        // Predicate on Text -> must use json_idx_text, not json_idx_extra.
+        // Complete prefix equality allows auto-selection; omitting it keeps the table scan.
         ValidateAutoSelect(db, "UserId=100 AND JSON_EXISTS(Text, '$.k1')", "json_idx", "TestTable");
         ValidateNoAutoSelect(db, "JSON_EXISTS(Text, '$.k1')", "json_idx", "TestTable");
+    }
+
+    Y_UNIT_TEST(PrefixedMultiColumn) {
+        auto kikimr = KikimrJsonPrefix(true);
+        auto db = kikimr.GetQueryClient();
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                CREATE TABLE TestTable (
+                    Key Uint64,
+                    Tenant Utf8,
+                    UserId Uint64,
+                    Text JsonDocument,
+                    PRIMARY KEY (Key),
+                    INDEX json_idx GLOBAL USING json ON (Tenant, UserId, Text)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                UPSERT INTO TestTable (Key, Tenant, UserId, Text) VALUES
+                    (1, "acme"u,   100, JsonDocument('{"kind":"cats","score":10}')),
+                    (2, "acme"u,   100, JsonDocument('{"kind":"dogs","score":20}')),
+                    (3, "acme"u,   200, JsonDocument('{"kind":"cats","score":20}')),
+                    (4, "globex"u, 100, JsonDocument('{"kind":"cats","score":30}'));
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ValidateAutoSelect(db,
+            R"(Tenant = "acme"u AND UserId = 100 AND JSON_EXISTS(Text, '$.kind'))",
+            "json_idx", "TestTable");
+        ValidateAutoSelect(db,
+            R"(100 = UserId AND JSON_VALUE(Text, '$.score' RETURNING Int64) = 20 AND "acme"u = Tenant)",
+            "json_idx", "TestTable");
+        ValidateAutoSelectWithDecl(db,
+            "DECLARE $tenant AS Utf8;\nDECLARE $uid AS Uint64;",
+            R"(UserId = $uid AND JSON_EXISTS(Text, '$.kind') AND Tenant = $tenant)",
+            "json_idx", "TestTable");
+
+        ValidateNoAutoSelect(db,
+            R"(UserId = 100 AND JSON_EXISTS(Text, '$.kind'))",
+            "json_idx", "TestTable");
+        ValidateNoAutoSelect(db,
+            R"(Tenant = "acme"u AND JSON_EXISTS(Text, '$.kind'))",
+            "json_idx", "TestTable");
+        ValidateNoAutoSelect(db,
+            R"((Tenant = "acme"u OR Tenant = "globex"u) AND UserId = 100 AND JSON_EXISTS(Text, '$.kind'))",
+            "json_idx", "TestTable");
+        ValidateNoAutoSelect(db,
+            R"(Tenant = "acme"u AND UserId > 0 AND JSON_EXISTS(Text, '$.kind'))",
+            "json_idx", "TestTable");
     }
 }
 

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -1,6 +1,8 @@
 #include <ydb/core/kqp/ut/indexes/json/common/kqp_indexes_json_ut_common.h>
 #include <ydb/core/kqp/ut/indexes/common/kqp_indexes_ttl_ut_common.h>
+#include <ydb/core/tx/datashard/const.h>
 #include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 
 namespace NKikimr::NKqp {
 
@@ -35,6 +37,62 @@ TKikimrRunner KikimrJsonRowIdCompact() {
     settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
     settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
     return TKikimrRunner(settings);
+}
+
+TKikimrRunner KikimrJsonPrefixRowId(bool compact) {
+    NKikimrConfig::TFeatureFlags featureFlags;
+    featureFlags.SetEnableJsonIndex(true);
+    featureFlags.SetEnableAddUniqueIndex(true);
+    featureFlags.SetEnableFulltextIndexRowId(true);
+    featureFlags.SetEnableFulltextIndexPrefix(true);
+    featureFlags.SetEnableCompactFulltextIndex(compact);
+    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
+    settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+    if (compact) {
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
+    }
+    return TKikimrRunner(settings);
+}
+
+void ExecuteJsonStatement(TQueryClient& db, const TString& sql, TParams params = TParamsBuilder().Build()) {
+    auto result = db.ExecuteQuery(sql, TTxControl::NoTx(), params).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+}
+
+TString SelectJsonRows(TQueryClient& db, const TString& sql, TParams params = TParamsBuilder().Build()) {
+    auto result = db.ExecuteQuery(sql, TTxControl::NoTx(), params).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    return FormatResultSetYson(result.GetResultSet(0));
+}
+
+TString JsonLiteralToken(TStringBuf json) {
+    TString error;
+    auto tokens = NJsonIndex::TokenizeJson(json, error);
+    UNIT_ASSERT_C(error.empty(), error);
+    UNIT_ASSERT_C(!tokens.empty(), "JSON produced no index tokens");
+    return tokens.back();
+}
+
+TString FormatUint32Keys(TVector<ui32> keys) {
+    Sort(keys);
+    TStringBuilder yson;
+    yson << '[';
+    for (size_t i = 0; i < keys.size(); ++i) {
+        yson << (i ? ";" : "") << "[[" << keys[i] << "u]]";
+    }
+    yson << ']';
+    return yson;
+}
+
+TString MakeScalarJson(TStringBuf marker, size_t scalarSize) {
+    return TStringBuilder() << R"({"marker":")" << marker
+        << R"(","payload":")" << TString(scalarSize, 'x') << R"("})";
+}
+
+TString MakeWhitespaceJson(TStringBuf marker, size_t totalSize) {
+    const TString prefix = TStringBuilder() << R"({"marker":")" << marker << '"';
+    UNIT_ASSERT_C(totalSize > prefix.size() + 1, totalSize);
+    return prefix + TString(totalSize - prefix.size() - 1, ' ') + '}';
 }
 
 } // namespace
@@ -175,7 +233,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             )";
             auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Column Field1 has wrong key type Json");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Prefixed fulltext/json index support is disabled");
         }
     }
 
@@ -1321,6 +1379,89 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, jsonExists("$"),
                 "JSON index cannot be used: full-range search cannot be performed using full-text search");
         });
+    }
+
+    Y_UNIT_TEST_QUAD(ExecutionStatisticsMatchActualSelectivity, IsJsonDocument, Compact) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableJsonIndex(true);
+        featureFlags.SetEnableCompactFulltextIndex(Compact);
+        auto runnerSettings = TKikimrSettings().SetFeatureFlags(featureFlags);
+        if (Compact) {
+            runnerSettings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
+        }
+        auto kikimr = TKikimrRunner(runnerSettings);
+        auto db = kikimr.GetQueryClient();
+        const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+
+        CreateTestTable(db, jsonType, /* withIndex */ true);
+
+        {
+            TStringBuilder query;
+            query << "UPSERT INTO `/Root/TestTable` (Key, Text, Data) VALUES\n";
+            for (ui64 key = 1; key <= 1000; ++key) {
+                const char* json = key <= 10
+                    ? R"({"segment":"rare","tracked":true})"
+                    : key <= 100
+                        ? R"({"segment":"common","tracked":true})"
+                        : R"({"noise":0})";
+                query << "(" << key << ", " << jsonType << "('" << json << "'), \"row_" << key << "\")";
+                query << (key == 1000 ? ";" : ",\n");
+            }
+
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        const auto settings = TExecuteQuerySettings().StatsMode(EStatsMode::Basic);
+        const auto hasTableAccess = [](const TExecuteQueryResult& result, TStringBuf table) {
+            const auto& stats = TProtoAccessor::GetProto(*result.GetStats());
+            for (const auto& phase : stats.query_phases()) {
+                for (const auto& access : phase.table_access()) {
+                    if (access.name() == table) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
+        const auto execute = [&](const std::string& view, const std::string& predicate) {
+            const auto query = std::format(R"(
+                SELECT Key, Data FROM `/Root/TestTable` VIEW {}
+                WHERE {}
+                ORDER BY Key;
+            )", view, predicate);
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx(), settings).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), "Predicate: " + predicate + ", issues: " + result.GetIssues().ToString());
+            UNIT_ASSERT_C(result.GetStats(), "Execution statistics are missing for: " + predicate);
+            return result;
+        };
+
+        const auto validate = [&](const std::string& predicate, ui64 expectedMatches, ui64 expectedIndexReads) {
+            const auto scanResult = execute("PRIMARY KEY", predicate);
+            const auto indexResult = execute("`json_idx`", predicate);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(scanResult.GetResultSet(0).RowsCount(), expectedMatches, predicate);
+            CompareYson(FormatResultSetYson(scanResult.GetResultSet(0)),
+                FormatResultSetYson(indexResult.GetResultSet(0)), TString(predicate));
+
+            AssertTableStats(scanResult, "/Root/TestTable", {
+                .ExpectedReads = 1000,
+            });
+            AssertTableStats(indexResult, "/Root/TestTable", {
+                .ExpectedReads = expectedMatches,
+            });
+            AssertTableStats(indexResult, "/Root/TestTable/json_idx/indexImplTable", {
+                .ExpectedReads = expectedIndexReads,
+            });
+            UNIT_ASSERT_C(hasTableAccess(indexResult, "/Root/TestTable/json_idx/indexImplTable"),
+                "Execution statistics have no physical JSON index table access for: " + predicate);
+        };
+
+        // Plain indexes read one posting row per matched document. Compact indexes read one
+        // segment row for the searched token, while the main-table reads still reflect matches
+        validate(R"(JSON_VALUE(Text, '$.segment' RETURNING Utf8) == "rare"u)", 10, Compact ? 1 : 10);
+        validate(R"(JSON_EXISTS(Text, '$.tracked'))", 100, Compact ? 1 : 100);
+        validate(R"(JSON_EXISTS(Text, '$.missing'))", 0, 0);
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_MemberAccess, IsJsonDocument, IsStrict) {
@@ -3159,6 +3300,700 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST(TtlNotAllowed_AlterIndexTtl) {
         auto kikimr = Kikimr();
         TestTtlNotAllowedAlterIndexTtl(kikimr.GetQueryClient(), MakeJsonTtlNotAllowedConfig(kikimr));
+    }
+
+    Y_UNIT_TEST_TWIN(MultiShardHighFanoutBuildAndDml, Compact) {
+        const auto oldMaxDelta = NDataShard::gFulltextMaxDelta;
+        const auto oldMaxSegment = NDataShard::gFulltextMaxSegment;
+        Y_DEFER {
+            NDataShard::gFulltextMaxDelta = oldMaxDelta;
+            NDataShard::gFulltextMaxSegment = oldMaxSegment;
+        };
+        if (Compact) {
+            NDataShard::gFulltextMaxDelta = 2;
+            NDataShard::gFulltextMaxSegment = 2;
+        }
+
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ false, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        ExecuteJsonStatement(db, R"(
+            CREATE TABLE `/Root/Docs` (
+                Key Uint32,
+                Text JsonDocument,
+                Data Utf8,
+                PRIMARY KEY (Key)
+            ) WITH (
+                AUTO_PARTITIONING_BY_SIZE = DISABLED,
+                AUTO_PARTITIONING_BY_LOAD = DISABLED,
+                UNIFORM_PARTITIONS = 4
+            );
+        )");
+
+        TStringBuilder upsert;
+        upsert << "UPSERT INTO `/Root/Docs` (Key, Text, Data) VALUES\n";
+        TVector<ui32> allKeys;
+        TVector<ui32> evenGroupKeys;
+        for (ui32 i = 1; i <= 128; ++i) {
+            const ui32 key = i * 2654435761u;
+            const ui32 group = i % 4;
+            allKeys.push_back(key);
+            if (group == 0) {
+                evenGroupKeys.push_back(key);
+            }
+            upsert << "(" << key << "u, JsonDocument('{\"common\":\"all\",\"group\":\"g"
+                   << group << "\",\"tags\":[\"repeat\",\"repeat\"]}'), \"row_" << i << "\"u)"
+                   << (i == 128 ? ";" : ",\n");
+        }
+        ExecuteJsonStatement(db, upsert);
+        ExecuteJsonStatement(db, R"(
+            ALTER TABLE `/Root/Docs` ADD INDEX json_idx
+                GLOBAL USING json ON (Text);
+        )");
+
+        auto runtime = kikimr.GetTestServer().GetRuntime();
+        auto shards = GetTableShards(&kikimr.GetTestServer(), runtime->AllocateEdgeActor(), "/Root/Docs");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4);
+
+        Sort(allKeys);
+        Sort(evenGroupKeys);
+        const auto compareViews = [&](const TString& predicate, const TVector<ui32>& expected) {
+            for (const TStringBuf view : {TStringBuf("PRIMARY KEY"), TStringBuf("json_idx")}) {
+                TStringBuilder query;
+                query << "SELECT Key FROM `/Root/Docs` VIEW " << view << '\n'
+                      << "WHERE " << predicate << '\n'
+                      << "ORDER BY Key;";
+                CompareYson(FormatUint32Keys(expected), SelectJsonRows(db, query));
+            }
+        };
+
+        const TString commonPredicate = R"(JSON_VALUE(Text, '$.common' RETURNING Utf8) = "all"u)";
+        const TString groupPredicate = R"(JSON_VALUE(Text, '$.group' RETURNING Utf8) = "g0"u)";
+        const TString repeatPredicate = R"(JSON_EXISTS(Text, '$.tags ? (@ == "repeat")'))";
+        compareViews(commonPredicate, allKeys);
+        compareViews(groupPredicate, evenGroupKeys);
+        compareViews(repeatPredicate, allKeys);
+
+        ExecuteJsonStatement(db, R"(
+            INSERT INTO `/Root/Docs` (Key, Text, Data) VALUES
+                (268435456u,
+                 JsonDocument('{"common":"all","group":"g0","tags":["repeat","repeat"]}'),
+                 "inserted"u);
+        )");
+        ExecuteJsonStatement(db, R"(
+            UPDATE `/Root/Docs`
+            SET Text = JsonDocument('{"common":"all","group":"changed","tags":["repeat","repeat"]}')
+            WHERE Key = 2027808452u;
+        )");
+        ExecuteJsonStatement(db, R"(
+            DELETE FROM `/Root/Docs` WHERE Key = 3668339987u;
+        )");
+
+        const ui32 insertedKey = 0x10000000u;
+        const ui32 updatedKey = 4u * 2654435761u;
+        const ui32 deletedKey = 3u * 2654435761u;
+        const auto eraseKey = [](TVector<ui32>& keys, ui32 key) {
+            const auto it = Find(keys, key);
+            UNIT_ASSERT_C(it != keys.end(), "Expected key is missing");
+            keys.erase(it);
+        };
+        eraseKey(allKeys, deletedKey);
+        allKeys.push_back(insertedKey);
+        eraseKey(evenGroupKeys, updatedKey);
+        evenGroupKeys.push_back(insertedKey);
+        Sort(allKeys);
+        Sort(evenGroupKeys);
+
+        compareViews(commonPredicate, allKeys);
+        compareViews(groupPredicate, evenGroupKeys);
+        compareViews(repeatPredicate, allKeys);
+
+        const TString commonToken = JsonLiteralToken(R"({"common":"all"})");
+        auto params = TParamsBuilder()
+            .AddParam("$token").String(commonToken).Build()
+            .Build();
+        auto result = db.ExecuteQuery(R"(
+            DECLARE $token AS String;
+            SELECT COUNT(*) AS Rows
+            FROM `/Root/Docs/json_idx/indexImplTable`
+            WHERE __ydb_token = $token;
+        )", TTxControl::NoTx(), params).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        TResultSetParser parser(result.GetResultSet(0));
+        UNIT_ASSERT(parser.TryNextRow());
+        const ui64 physicalRows = parser.ColumnParser("Rows").GetUint64();
+        UNIT_ASSERT(!parser.TryNextRow());
+        if (Compact) {
+            UNIT_ASSERT_C(physicalRows > 1, "Compact posting table did not split the common token");
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(physicalRows, allKeys.size());
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(TextJsonDuplicateKeys, Compact) {
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ true, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        ExecuteJsonStatement(db, R"(
+            CREATE TABLE `/Root/DuplicateDocs` (
+                Key Uint64,
+                Text Json,
+                PRIMARY KEY (Key),
+                INDEX json_idx GLOBAL USING json ON (Text)
+            );
+        )");
+
+        const TVector<std::pair<ui64, TString>> rows = {
+            {1, R"({ "dup" : "same", "dup" : "same", "nested" : { "n" : 1, "n" : 1 } })"},
+            {2, R"({"dup":"first","dup":"second"})"},
+            {3, R"({"dup":1,"dup":"one"})"},
+            {4, R"({"other":true})"},
+        };
+        for (const auto& [key, text] : rows) {
+            auto params = TParamsBuilder()
+                .AddParam("$key").Uint64(key).Build()
+                .AddParam("$text").Json(text).Build()
+                .Build();
+            ExecuteJsonStatement(db, R"(
+                DECLARE $key AS Uint64;
+                DECLARE $text AS Json;
+                UPSERT INTO `/Root/DuplicateDocs` (Key, Text) VALUES ($key, $text);
+            )", params);
+        }
+
+        auto textResult = db.ExecuteQuery(R"(
+            SELECT Text FROM `/Root/DuplicateDocs` VIEW PRIMARY KEY WHERE Key = 1;
+        )", TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(textResult.GetStatus(), EStatus::SUCCESS, textResult.GetIssues().ToString());
+        TResultSetParser parser(textResult.GetResultSet(0));
+        UNIT_ASSERT(parser.TryNextRow());
+        UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("Text").GetOptionalJson().value(), rows[0].second);
+        UNIT_ASSERT(!parser.TryNextRow());
+
+        const auto assertViews = [&](const TString& predicate, const TString& expected) {
+            TStringBuilder primaryQuery;
+            primaryQuery << "SELECT Key FROM `/Root/DuplicateDocs` VIEW PRIMARY KEY WHERE "
+                         << predicate << " ORDER BY Key;";
+            const TString primaryRows = SelectJsonRows(db, primaryQuery);
+
+            TStringBuilder indexQuery;
+            indexQuery << "SELECT Key FROM `/Root/DuplicateDocs` VIEW json_idx WHERE "
+                       << predicate << " ORDER BY Key;";
+            const TString indexRows = SelectJsonRows(db, indexQuery);
+
+            CompareYson(expected, primaryRows);
+            CompareYson(expected, indexRows);
+            CompareYson(primaryRows, indexRows);
+        };
+
+        const TString samePredicate = R"(JSON_VALUE(Text, '$.dup' RETURNING Utf8) = "same"u)";
+        const TString firstPredicate = R"(JSON_VALUE(Text, '$.dup' RETURNING Utf8) = "first"u)";
+        const TString numericPredicate = R"(JSON_VALUE(Text, '$.dup' RETURNING Int64) = 1)";
+        const TString nestedPredicate = R"(JSON_VALUE(Text, '$.nested.n' RETURNING Int64) = 1)";
+
+        assertViews(samePredicate, "[[[1u]]]");
+        assertViews(firstPredicate, "[[[2u]]]");
+        assertViews(R"(JSON_VALUE(Text, '$.dup' RETURNING Utf8) = "second"u)", "[]");
+        assertViews(numericPredicate, "[[[3u]]]");
+        assertViews(R"(JSON_VALUE(Text, '$.dup' RETURNING Utf8) = "one"u)", "[]");
+        assertViews(nestedPredicate, "[[[1u]]]");
+
+        const auto assertAutoSelect = [&](const TString& predicate, const TString& expected) {
+            ValidateAutoSelect(db, predicate, "json_idx", "DuplicateDocs");
+            TStringBuilder query;
+            query << "SELECT Key FROM `/Root/DuplicateDocs` WHERE " << predicate << " ORDER BY Key;";
+            CompareYson(expected, SelectJsonRows(db, query));
+        };
+        assertAutoSelect(samePredicate, "[[[1u]]]");
+        assertAutoSelect(firstPredicate, "[[[2u]]]");
+        assertAutoSelect(numericPredicate, "[[[3u]]]");
+        assertAutoSelect(nestedPredicate, "[[[1u]]]");
+    }
+
+    Y_UNIT_TEST_TWIN(TextJsonPostingKeySizeLimit, Compact) {
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ false, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        ExecuteJsonStatement(db, R"(
+            CREATE TABLE `/Root/SizeDocs` (
+                Key Uint64,
+                Text Json,
+                PRIMARY KEY (Key),
+                INDEX json_idx GLOBAL USING json ON (Text)
+            );
+        )");
+
+        const size_t margin = 64_KB;
+        const size_t below = NDataShard::NLimits::MaxWriteKeySize - margin;
+        const size_t above = NDataShard::NLimits::MaxWriteKeySize + margin;
+        const TString acceptedPayload(below, 'x');
+        const TString rejectedPayload(above, 'x');
+        const TString accepted = MakeScalarJson("posting-accepted", acceptedPayload.size());
+        const TString rejected = MakeScalarJson("posting-too-large", rejectedPayload.size());
+        const TString upsert = R"(
+            DECLARE $key AS Uint64;
+            DECLARE $text AS Json;
+            UPSERT INTO `/Root/SizeDocs` (Key, Text) VALUES ($key, $text);
+        )";
+
+        auto acceptedParams = TParamsBuilder()
+            .AddParam("$key").Uint64(1).Build()
+            .AddParam("$text").Json(accepted).Build()
+            .Build();
+        auto acceptedResult = db.ExecuteQuery(upsert, TTxControl::NoTx(), acceptedParams).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            acceptedResult.GetStatus(), EStatus::SUCCESS, acceptedResult.GetIssues().ToString());
+
+        auto payloadParams = TParamsBuilder()
+            .AddParam("$payload").Utf8(acceptedPayload).Build()
+            .Build();
+        for (const TStringBuf view : {TStringBuf("PRIMARY KEY"), TStringBuf("json_idx")}) {
+            TStringBuilder query;
+            query << "DECLARE $payload AS Utf8;\n"
+                  << "SELECT Key FROM `/Root/SizeDocs` VIEW " << view << '\n'
+                  << "WHERE JSON_VALUE(Text, '$.payload' RETURNING Utf8) = $payload;";
+            CompareYson("[[[1u]]]", SelectJsonRows(db, query, payloadParams));
+        }
+
+        auto rejectedParams = TParamsBuilder()
+            .AddParam("$key").Uint64(2).Build()
+            .AddParam("$text").Json(rejected).Build()
+            .Build();
+        auto rejectedResult = db.ExecuteQuery(upsert, TTxControl::NoTx(), rejectedParams).ExtractValueSync();
+        UNIT_ASSERT_C(!rejectedResult.IsSuccess(), "Oversized JSON posting key unexpectedly succeeded");
+        const TString issues = rejectedResult.GetIssues().ToString();
+
+        auto keyParams = TParamsBuilder()
+            .AddParam("$key").Uint64(2).Build()
+            .Build();
+        CompareYson("[]", SelectJsonRows(db, R"(
+            DECLARE $key AS Uint64;
+            SELECT Key FROM `/Root/SizeDocs` VIEW PRIMARY KEY WHERE Key = $key;
+        )", keyParams));
+
+        auto markerParams = TParamsBuilder()
+            .AddParam("$marker").Utf8("posting-too-large").Build()
+            .Build();
+        CompareYson("[]", SelectJsonRows(db, R"(
+            DECLARE $marker AS Utf8;
+            SELECT Key FROM `/Root/SizeDocs` VIEW json_idx
+            WHERE JSON_VALUE(Text, '$.marker' RETURNING Utf8) = $marker;
+        )", markerParams));
+
+        UNIT_ASSERT_C(issues.Contains("Row key size"), issues);
+        UNIT_ASSERT_C(issues.Contains("larger than the allowed threshold"), issues);
+    }
+
+    Y_UNIT_TEST_TWIN(TextJsonValueSizeLimit, Compact) {
+        auto kikimr = KikimrJson(/* enableJsonIndexAutoSelect */ false, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        ExecuteJsonStatement(db, R"(
+            CREATE TABLE `/Root/ValueSizeDocs` (
+                Key Uint64,
+                Text Json,
+                PRIMARY KEY (Key),
+                INDEX json_idx GLOBAL USING json ON (Text)
+            );
+        )");
+
+        const size_t margin = 64_KB;
+        const TString accepted = MakeWhitespaceJson(
+            "value-accepted", NDataShard::NLimits::MaxWriteValueSize - margin);
+        const TString rejected = MakeWhitespaceJson(
+            "value-too-large", NDataShard::NLimits::MaxWriteValueSize + margin);
+        const TString upsert = R"(
+            DECLARE $key AS Uint64;
+            DECLARE $text AS Json;
+            UPSERT INTO `/Root/ValueSizeDocs` (Key, Text) VALUES ($key, $text);
+        )";
+        const auto querySettings = TExecuteQuerySettings().ClientTimeout(TDuration::Minutes(2));
+        const auto write = [&](ui64 key, const TString& text) {
+            auto params = TParamsBuilder()
+                .AddParam("$key").Uint64(key).Build()
+                .AddParam("$text").Json(text).Build()
+                .Build();
+            return db.ExecuteQuery(upsert, TTxControl::NoTx(), params, querySettings).ExtractValueSync();
+        };
+
+        auto acceptedResult = write(1, accepted);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            acceptedResult.GetStatus(), EStatus::SUCCESS, acceptedResult.GetIssues().ToString());
+
+        auto acceptedMarkerParams = TParamsBuilder()
+            .AddParam("$marker").Utf8("value-accepted").Build()
+            .Build();
+        for (const TStringBuf view : {TStringBuf("PRIMARY KEY"), TStringBuf("json_idx")}) {
+            TStringBuilder query;
+            query << "DECLARE $marker AS Utf8;\n"
+                  << "SELECT Key FROM `/Root/ValueSizeDocs` VIEW " << view << '\n'
+                  << "WHERE JSON_VALUE(Text, '$.marker' RETURNING Utf8) = $marker;";
+            CompareYson("[[[1u]]]", SelectJsonRows(db, query, acceptedMarkerParams));
+        }
+
+        auto rejectedResult = write(2, rejected);
+        UNIT_ASSERT_C(!rejectedResult.IsSuccess(), "Oversized JSON cell unexpectedly succeeded");
+        const TString issues = rejectedResult.GetIssues().ToString();
+
+        auto keyParams = TParamsBuilder()
+            .AddParam("$key").Uint64(2).Build()
+            .Build();
+        CompareYson("[]", SelectJsonRows(db, R"(
+            DECLARE $key AS Uint64;
+            SELECT Key FROM `/Root/ValueSizeDocs` VIEW PRIMARY KEY WHERE Key = $key;
+        )", keyParams));
+
+        auto rejectedMarkerParams = TParamsBuilder()
+            .AddParam("$marker").Utf8("value-too-large").Build()
+            .Build();
+        CompareYson("[]", SelectJsonRows(db, R"(
+            DECLARE $marker AS Utf8;
+            SELECT Key FROM `/Root/ValueSizeDocs` VIEW json_idx
+            WHERE JSON_VALUE(Text, '$.marker' RETURNING Utf8) = $marker;
+        )", rejectedMarkerParams));
+
+        UNIT_ASSERT_C(issues.Contains("Row cell size"), issues);
+        UNIT_ASSERT_C(issues.Contains("larger than the allowed threshold"), issues);
+    }
+
+    Y_UNIT_TEST_QUAD(PrefixedJsonSinglePrefixMatrix, IsJsonDocument, Compact) {
+        const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+        // These four variants form a pairwise matrix for JSON type, index format and build path.
+        const bool useAlter = IsJsonDocument != Compact;
+        auto kikimr = KikimrJsonPrefix(/* enableJsonIndexAutoSelect */ false, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        auto exec = [&](const std::string& query) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        };
+        auto select = [&](const std::string& query, TParams params = TParamsBuilder().Build()) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx(), params).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            return FormatResultSetYson(result.GetResultSet(0));
+        };
+
+        exec(std::format(R"(
+            CREATE TABLE `/Root/Docs` (
+                Key Uint64,
+                UserId Uint64,
+                Text {},
+                PRIMARY KEY (Key)
+                {}
+            );
+        )", jsonType, useAlter ? "" : ", INDEX json_idx GLOBAL USING json ON (UserId, Text)"));
+
+        const auto json = [&](const std::string& value) {
+            return std::format("{}('{}')", jsonType, value);
+        };
+        exec(std::format(R"(
+            UPSERT INTO `/Root/Docs` (Key, UserId, Text) VALUES
+                (1, 100, {}),
+                (2, 100, {}),
+                (3, 200, {}),
+                (4, 200, {});
+        )",
+            json(R"({"kind":"shared","score":10})"),
+            json(R"({"kind":"own","score":20})"),
+            json(R"({"kind":"shared","score":20})"),
+            json(R"({"other":true,"score":30})")));
+
+        if (useAlter) {
+            exec(R"(
+                ALTER TABLE `/Root/Docs` ADD INDEX json_idx
+                    GLOBAL USING json ON (UserId, Text);
+            )");
+        }
+
+        CompareYson("[[[1u]];[[2u]]]", select(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE UserId = 100 AND JSON_EXISTS(Text, '$.kind')
+            ORDER BY Key;
+        )"));
+
+        CompareYson("[[[3u]]]", select(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE 200 = UserId AND JSON_VALUE(Text, '$.score' RETURNING Int64) = 20
+            ORDER BY Key;
+        )"));
+
+        auto params = TParamsBuilder().AddParam("$uid").Uint64(200).Build().Build();
+        CompareYson("[[[3u]]]", select(R"(
+            DECLARE $uid AS Uint64;
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE UserId = $uid AND JSON_EXISTS(Text, '$.kind')
+            ORDER BY Key;
+        )", params));
+    }
+
+    Y_UNIT_TEST_TWIN(PrefixedJsonMultiPrefixMatrix, Compact) {
+        // Pair storage type with the opposite format here; the full type/format cross is covered above.
+        const std::string jsonType = Compact ? "Json" : "JsonDocument";
+        auto kikimr = KikimrJsonPrefix(/* enableJsonIndexAutoSelect */ false, Compact);
+        auto db = kikimr.GetQueryClient();
+
+        auto exec = [&](const std::string& query) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        };
+        auto select = [&](const std::string& query, TParams params = TParamsBuilder().Build()) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx(), params).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            return FormatResultSetYson(result.GetResultSet(0));
+        };
+        auto expectPrefixError = [&](const std::string& query) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
+                "Prefixed JSON index requires an equality predicate");
+        };
+
+        exec(std::format(R"(
+            CREATE TABLE `/Root/Docs` (
+                Key Uint64,
+                Tenant Utf8,
+                UserId Uint64,
+                Text {},
+                Data Utf8,
+                PRIMARY KEY (Key)
+            );
+        )", jsonType));
+
+        const auto json = [&](const std::string& value) {
+            return std::format("{}('{}')", jsonType, value);
+        };
+        exec(std::format(R"(
+            UPSERT INTO `/Root/Docs` (Key, Tenant, UserId, Text, Data) VALUES
+                (1, "acme"u,   100, {}, "data1"u),
+                (2, "acme"u,   100, {}, "data2"u),
+                (3, "acme"u,   200, {}, "data3"u),
+                (4, "globex"u, 100, {}, "data4"u),
+                (6, "sentinel"u, 999, {}, "stable"u);
+        )",
+            json(R"({"kind":"cats","score":10})"),
+            json(R"({"kind":"dogs","score":20})"),
+            json(R"({"kind":"cats","score":30})"),
+            json(R"({"kind":"cats","score":40})"),
+            json(R"({"kind":"stable","score":999})")));
+
+        exec(R"(
+            ALTER TABLE `/Root/Docs` ADD INDEX json_idx
+                GLOBAL USING json ON (Tenant, UserId, Text);
+        )");
+
+        auto searchKind = [&](const std::string& tenant, ui64 userId, const std::string& kind) {
+            return select(std::format(R"(
+                SELECT Key FROM `/Root/Docs` VIEW json_idx
+                WHERE Tenant = "{}"u AND UserId = {}
+                    AND JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "{}"u
+                ORDER BY Key;
+            )", tenant, userId, kind));
+        };
+        auto searchScore = [&](const std::string& tenant, ui64 userId, i64 score) {
+            return select(std::format(R"(
+                SELECT Key FROM `/Root/Docs` VIEW json_idx
+                WHERE Tenant = "{}"u AND UserId = {}
+                    AND JSON_VALUE(Text, '$.score' RETURNING Int64) = {}
+                ORDER BY Key;
+            )", tenant, userId, score));
+        };
+        auto assertSentinel = [&] {
+            CompareYson("[[[6u]]]", searchKind("sentinel", 999, "stable"));
+            CompareYson("[[[6u]]]", searchScore("sentinel", 999, 999));
+        };
+
+        CompareYson("[[[1u]]]", searchKind("acme", 100, "cats"));
+        CompareYson("[[[1u]]]", searchScore("acme", 100, 10));
+        assertSentinel();
+        CompareYson("[[[3u]]]", select(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "cats"u
+                AND UserId = 200 AND Tenant = "acme"u
+            ORDER BY Key;
+        )"));
+        CompareYson("[[[4u]]]", select(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE "globex"u = Tenant AND 100 = UserId AND JSON_EXISTS(Text, '$.kind')
+            ORDER BY Key;
+        )"));
+
+        auto params = TParamsBuilder()
+            .AddParam("$tenant").Utf8("acme").Build()
+            .AddParam("$uid").Uint64(100).Build()
+            .Build();
+        CompareYson("[[[1u]];[[2u]]]", select(R"(
+            DECLARE $tenant AS Utf8;
+            DECLARE $uid AS Uint64;
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE UserId = $uid AND JSON_EXISTS(Text, '$.kind') AND Tenant = $tenant
+            ORDER BY Key;
+        )", params));
+
+        expectPrefixError(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE UserId = 100 AND JSON_EXISTS(Text, '$.kind');
+        )");
+        expectPrefixError(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE Tenant = "acme"u AND JSON_EXISTS(Text, '$.kind');
+        )");
+        expectPrefixError(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE (Tenant = "acme"u OR Tenant = "globex"u)
+                AND UserId = 100 AND JSON_EXISTS(Text, '$.kind');
+        )");
+        expectPrefixError(R"(
+            SELECT Key FROM `/Root/Docs` VIEW json_idx
+            WHERE Tenant = "acme"u AND UserId > 0 AND JSON_EXISTS(Text, '$.kind');
+        )");
+
+        if (Compact) {
+            // The pairwise matrix assigns prefix-changing JSON DML to the plain twin; the compact
+            // twin covers the same typed multi-prefix build/read and predicate-validation paths
+            return;
+        }
+
+        exec(std::format(R"(
+            INSERT INTO `/Root/Docs` (Key, Tenant, UserId, Text, Data) VALUES
+                (5, "acme"u, 100, {}, "inserted"u);
+        )", json(R"({"kind":"cats","score":50})")));
+        CompareYson("[[[1u]];[[5u]]]", searchKind("acme", 100, "cats"));
+        CompareYson("[[[5u]]]", searchScore("acme", 100, 50));
+        CompareYson("[[[1u]]]", searchScore("acme", 100, 10));
+        CompareYson("[[[3u]]]", searchKind("acme", 200, "cats"));
+        assertSentinel();
+
+        exec(std::format(R"(
+            UPSERT INTO `/Root/Docs` (Key, Tenant, UserId, Text, Data) VALUES
+                (1, "globex"u, 200, {}, "upserted"u);
+        )", json(R"({"kind":"owls","score":60})")));
+        CompareYson("[[[5u]]]", searchKind("acme", 100, "cats"));
+        CompareYson("[]", searchScore("acme", 100, 10));
+        CompareYson("[[[1u]]]", searchKind("globex", 200, "owls"));
+        CompareYson("[[[1u]]]", searchScore("globex", 200, 60));
+        assertSentinel();
+
+        exec(std::format(R"(
+            UPDATE `/Root/Docs`
+            SET Tenant = "globex"u, UserId = 100, Text = {}, Data = "updated"u
+            WHERE Key = 2;
+        )", json(R"({"kind":"birds","score":70})")));
+        CompareYson("[]", searchKind("acme", 100, "dogs"));
+        CompareYson("[]", searchScore("acme", 100, 20));
+        CompareYson("[[[2u]]]", searchKind("globex", 100, "birds"));
+        CompareYson("[[[2u]]]", searchScore("globex", 100, 70));
+        assertSentinel();
+
+        exec(std::format(R"(
+            REPLACE INTO `/Root/Docs` (Key, Tenant, UserId, Text, Data) VALUES
+                (3, "acme"u, 100, {}, "replaced"u);
+        )", json(R"({"kind":"cats","score":80})")));
+        CompareYson("[]", searchKind("acme", 200, "cats"));
+        CompareYson("[]", searchScore("acme", 200, 30));
+        CompareYson("[[[3u]];[[5u]]]", searchKind("acme", 100, "cats"));
+        CompareYson("[[[3u]]]", searchScore("acme", 100, 80));
+        assertSentinel();
+
+        exec(R"(DELETE FROM `/Root/Docs` WHERE Key = 4;)");
+        CompareYson("[]", searchKind("globex", 100, "cats"));
+        CompareYson("[]", searchScore("globex", 100, 40));
+        CompareYson("[[[2u]]]", searchKind("globex", 100, "birds"));
+        CompareYson("[[[1u]]]", searchKind("globex", 200, "owls"));
+        assertSentinel();
+    }
+
+    Y_UNIT_TEST_TWIN(PrefixedJsonRowIdComplexPk, Compact) {
+        // __ydb_row_id is the posting doc-id; index reads must resolve it back to the composite PK
+        auto kikimr = KikimrJsonPrefixRowId(Compact);
+        auto db = kikimr.GetQueryClient();
+
+        auto exec = [&](const std::string& query) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        };
+        auto select = [&](const std::string& query) {
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            return FormatResultSetYson(result.GetResultSet(0));
+        };
+
+        exec(R"(
+            CREATE TABLE `/Root/Docs` (
+                Org Utf8 NOT NULL,
+                Pk Utf8 NOT NULL,
+                Tenant Utf8,
+                Text JsonDocument,
+                __ydb_row_id Uint64 NOT NULL,
+                PRIMARY KEY (Org, Pk)
+            );
+        )");
+        exec(R"(
+            ALTER TABLE `/Root/Docs`
+                ADD INDEX uniq_rowid GLOBAL UNIQUE ON (__ydb_row_id);
+        )");
+        exec(R"(
+            ALTER TABLE `/Root/Docs` ADD INDEX json_idx
+                GLOBAL USING json ON (Tenant, Text);
+        )");
+        exec(R"(
+            UPSERT INTO `/Root/Docs` (Org, Pk, Tenant, Text) VALUES
+                ("acme"u,   "a1"u, "red"u,  JsonDocument('{"kind":"cats","score":10}')),
+                ("acme"u,   "a2"u, "red"u,  JsonDocument('{"kind":"dogs","score":20}')),
+                ("acme"u,   "a3"u, "blue"u, JsonDocument('{"kind":"cats","score":30}')),
+                ("globex"u, "a1"u, "red"u,  JsonDocument('{"kind":"cats","score":40}'));
+        )");
+
+        CompareYson(R"([["acme";"a1"];["globex";"a1"]])", select(R"(
+            SELECT Org, Pk FROM `/Root/Docs` VIEW json_idx
+            WHERE Tenant = "red"u
+                AND JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "cats"u
+            ORDER BY Org, Pk;
+        )"));
+        CompareYson(R"([["acme";"a3"]])", select(R"(
+            SELECT Org, Pk FROM `/Root/Docs` VIEW json_idx
+            WHERE Tenant = "blue"u AND JSON_EXISTS(Text, '$.kind')
+            ORDER BY Org, Pk;
+        )"));
+        CompareYson(R"([["acme";"a2"]])", select(R"(
+            SELECT Org, Pk FROM `/Root/Docs` VIEW json_idx
+            WHERE "red"u = Tenant
+                AND JSON_VALUE(Text, '$.kind' RETURNING Utf8) = "dogs"u
+            ORDER BY Org, Pk;
+        )"));
+    }
+
+    Y_UNIT_TEST(PrefixedJsonDdlValidation) {
+        auto kikimr = KikimrJsonPrefix();
+        auto db = kikimr.GetQueryClient();
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                CREATE TABLE `/Root/PrefixOnPk` (
+                    Key Uint64,
+                    Text Json,
+                    PRIMARY KEY (Key),
+                    INDEX json_idx GLOBAL USING json ON (Key, Text)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
+                "JSON index prefix column 'Key' must not be a primary key column");
+        }
+
+        {
+            auto result = db.ExecuteQuery(R"(
+                CREATE TABLE `/Root/InvalidPrefixType` (
+                    Key Uint64,
+                    BadPrefix Json,
+                    Text JsonDocument,
+                    PRIMARY KEY (Key),
+                    INDEX json_idx GLOBAL USING json ON (BadPrefix, Text)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
+                "Column BadPrefix has wrong key type Json");
+        }
     }
 
     Y_UNIT_TEST(PrefixedJsonCreate) {


### PR DESCRIPTION
### Changelog entry

Extended JSON index test coverage.

### Description for reviewers

Tested in plain and compact modes:

- execution statistics and actual selectivity;
- prefixed JSON indexes;
- multi-shard and high-fanout cases;
- textual JSON duplicate keys and size limits;
- SQL query forms and automatic index selection;
- optimizer lifecycle and implementation-table schema-version changes.
