### PR TITLE
ydb-bench: bound activity replay

### DIFF
--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -38,6 +38,7 @@ _CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self';
 _STREAM_CHUNK_SIZE = 1024 * 1024
 _CHART_DATA_ROW_LIMIT = 100000
 _LOCAL_YDB_ACTIVITY_LIMIT = 200
+_LOCAL_YDB_ACTIVITY_SCAN_BYTES = 4 * 1024 * 1024
 _EVENT_LOG_RECORD_BYTES = 4 * 1024 * 1024
 _LOCAL_YDB_ACTIVITY_RESPONSE_BYTES = 512 * 1024
 _MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
@@ -3474,6 +3475,7 @@ class RunService:
         cursor = after
         matched = 0
         activity = deque(maxlen=_LOCAL_YDB_ACTIVITY_LIMIT)
+        replay_gap = False
 
         def consume(event):
             nonlocal cursor, matched
@@ -3513,8 +3515,21 @@ class RunService:
             except OSError as error:
                 raise BenchmarkError("cannot read run event log") from error
             with stream:
-                remaining = snapshot_size
-                previous_sequence = 0
+                replay_start = max(
+                    0,
+                    snapshot_size - _LOCAL_YDB_ACTIVITY_SCAN_BYTES - _EVENT_LOG_RECORD_BYTES,
+                )
+                if replay_start:
+                    stream.seek(replay_start - 1)
+                    starts_at_record_boundary = stream.read(1) == b"\n"
+                    stream.seek(replay_start)
+                    if not starts_at_record_boundary:
+                        partial = stream.readline(min(snapshot_size - replay_start, _EVENT_LOG_RECORD_BYTES + 1))
+                        if len(partial) > _EVENT_LOG_RECORD_BYTES or not partial.endswith(b"\n"):
+                            raise BenchmarkError("run event log contains an oversized or incomplete event")
+                remaining = snapshot_size - stream.tell()
+                previous_sequence = None
+                first_sequence = None
                 while remaining:
                     line = stream.readline(min(remaining, _EVENT_LOG_RECORD_BYTES + 1))
                     if not line:
@@ -3532,15 +3547,20 @@ class RunService:
                     if (
                         not isinstance(sequence, int)
                         or isinstance(sequence, bool)
-                        or sequence <= previous_sequence
+                        or sequence <= 0
+                        or (previous_sequence is not None and sequence <= previous_sequence)
                         or sequence > _MAX_SAFE_JSON_INTEGER
                     ):
                         raise BenchmarkError("run event log sequences must be strictly increasing integers")
+                    if first_sequence is None:
+                        first_sequence = sequence
                     previous_sequence = sequence
                     if not isinstance(event.get("type"), str):
                         raise BenchmarkError("run event log event type must be a string")
                     consume(event)
-
+                if replay_start and first_sequence is None:
+                    raise BenchmarkError("run event log contains an oversized or incomplete event")
+                replay_gap = bool(replay_start and first_sequence > after + 1)
         bounded = deque()
         response_bytes = 0
         for item in reversed(activity):
@@ -3554,7 +3574,7 @@ class RunService:
         return {
             "events": list(bounded),
             "after": cursor,
-            "truncated": matched > len(bounded),
+            "truncated": replay_gap or matched > len(bounded),
         }
 
     def local_ydb_comparison(self, run_ids):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -7202,6 +7202,58 @@ class WebTest(unittest.TestCase):
             worker.join()
             server.server_close()
 
+    def test_local_ydb_activity_bounds_persisted_replay_to_recent_tail(self):
+        run_root = self.root / "local-ydb-tail-activity"
+        self._manifest(run_root)
+        manifest_path = run_root / "run.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["runs"] = [{"benchmark": "local-ydb", "profile": "capacity", "status": "running"}]
+        manifest["steps"] = [
+            {
+                "id": "capacity-step",
+                "benchmark": "local-ydb",
+                "profile": "capacity",
+                "state": "running",
+            }
+        ]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        events = [
+            {
+                "sequence": sequence,
+                "type": "step-progress",
+                "step_id": "capacity-step",
+                "fields": {"progress": {"phase": "measuring", "attempt": sequence, "padding": "x" * 80}},
+            }
+            for sequence in range(1, 21)
+        ]
+        (run_root / "events.jsonl").write_text(
+            "".join(json.dumps(event, separators=(",", ":")) + "\n" for event in events),
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(web, "_LOCAL_YDB_ACTIVITY_SCAN_BYTES", 256), mock.patch.object(
+            web, "_EVENT_LOG_RECORD_BYTES", 512
+        ):
+            service = RunService(self.root)
+            try:
+                activity = service.local_ydb_activity("local-ydb-tail-activity", "capacity")
+                self.assertTrue(activity["truncated"])
+                self.assertGreater(activity["events"][0]["sequence"], 1)
+                self.assertEqual(activity["events"][-1]["sequence"], 20)
+                self.assertEqual(activity["after"], 20)
+
+                first_sequence = activity["events"][0]["sequence"]
+                replay = service.local_ydb_activity(
+                    "local-ydb-tail-activity",
+                    "capacity",
+                    after=first_sequence - 1,
+                )
+                self.assertFalse(replay["truncated"])
+                self.assertEqual(replay["events"], activity["events"])
+                self.assertEqual(replay["after"], 20)
+            finally:
+                service.shutdown()
+
     def test_local_ydb_profile_projection_supports_preparing_and_live_results(self):
         run_root = self.root / "local-ydb-run"
         self._manifest(run_root, "running")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Limited the amount of local YDB activity replayed by the web UI.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Uses a bounded activity window with sequence cursors while retaining enough recent events for live progress.