### PR TITLE
ydb-bench: bound workload cleanup

### DIFF
--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -130,6 +130,7 @@ GENERIC_TOTAL_RESULT = WorkloadResultAdapter(
     ),
 )
 
+_DEFAULT_CLEANUP_TIMEOUT_SECONDS = 120
 _TPCC_TRANSACTION_NAMES = ("NewOrder", "Delivery", "OrderStatus", "Payment", "StockLevel")
 _TPCC_PERCENTILES = (
     ("50", "p50_ms"),
@@ -282,10 +283,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
         "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
     }
     metrics.update(
-        {
-            metric_name: value
-            for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles_ms"])
-        }
+        {metric_name: value for (_percentile, metric_name), value in zip(_TPCC_PERCENTILES, selected["percentiles_ms"])}
     )
     return WorkloadResult(
         metrics,
@@ -1708,7 +1706,7 @@ def build_clean_argv(cli, path, workload_type):
     return _workload_base(cli, definition, path) + ["clean"]
 
 
-def _validate_command_plans(plans, description, allow_default_timeout=False):
+def _validate_command_plans(plans, description):
     if not isinstance(plans, tuple) or not plans:
         raise BenchmarkError("{} must produce a non-empty tuple of command plans".format(description))
     for plan in plans:
@@ -1718,9 +1716,7 @@ def _validate_command_plans(plans, description, allow_default_timeout=False):
             raise BenchmarkError("{} produced an invalid command plan name".format(description))
         if not isinstance(plan.argv, tuple) or not plan.argv:
             raise BenchmarkError("{} command {} must have a non-empty argv tuple".format(description, plan.name))
-        if plan.timeout_seconds is None and allow_default_timeout:
-            pass
-        elif not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
+        if not _is_finite_number(plan.timeout_seconds) or plan.timeout_seconds <= 0:
             raise BenchmarkError("{} command {} must have a positive timeout".format(description, plan.name))
         if plan.measurement_window_builder is not None and not callable(plan.measurement_window_builder):
             raise BenchmarkError(
@@ -1817,16 +1813,12 @@ def build_cleanup_plan(cli, path, workload):
             WorkloadCommandPlan(
                 "clean",
                 tuple(_workload_base(cli, definition, path) + ["clean"]),
-                None,
+                _DEFAULT_CLEANUP_TIMEOUT_SECONDS,
             ),
         )
     else:
         plans = definition.cleanup_plan_builder(cli, definition, path, workload)
-    return _validate_command_plans(
-        plans,
-        "{} cleanup plan".format(definition.name),
-        allow_default_timeout=True,
-    )
+    return _validate_command_plans(plans, "{} cleanup plan".format(definition.name))
 
 
 def workload_definition(workload_type):

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -975,7 +975,21 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(run.timeout_seconds, 60)
         self.assertEqual(cleanup[0].argv, tuple(base + ["clean"]))
-        self.assertIsNone(cleanup[0].timeout_seconds)
+        self.assertEqual(cleanup[0].timeout_seconds, 120)
+
+    def test_local_ydb_cleanup_plan_rejects_custom_plan_without_timeout(self):
+        cli_context = local_ydb_workloads.WorkloadCli(Path("ydb"), "grpc://host:2135", "/Root/bench")
+
+        def unbounded_cleanup(*_args):
+            return (local_ydb_workloads.WorkloadCommandPlan("clean", ("ydb", "clean")),)
+
+        definition = replace(
+            local_ydb_workloads.workload_definition("kv"),
+            cleanup_plan_builder=unbounded_cleanup,
+        )
+        with mock.patch.object(local_ydb_workloads, "_WORKLOADS", {"kv": definition}):
+            with self.assertRaisesRegex(BenchmarkError, "must have a positive timeout"):
+                local_ydb_workloads.build_cleanup_plan(cli_context, "table-prefix", {"type": "kv"})
 
     def test_local_ydb_tpcc_builds_golden_prepare_run_and_cleanup_plans(self):
         cli_context = local_ydb_workloads.WorkloadCli(
@@ -2098,7 +2112,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertTrue(self.last_local_ydb_cluster._run.call_args.kwargs["ignore_cancellation"])
         self.last_local_ydb_cluster.stop.assert_called_once_with()
 
-    def test_local_ydb_cleanup_plan_uses_cluster_configuration_timeout(self):
+    def test_local_ydb_cleanup_plan_uses_bounded_default_timeout(self):
         cluster = local_ydb.LocalYdbCluster(
             self.root / "ydbd",
             self.root / "ydb",
@@ -2106,7 +2120,7 @@ class YdbBenchTest(unittest.TestCase):
             self.root / "cluster-timeout",
             {"static_nodes": 1, "dynamic_nodes": 1},
             {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
-            73,
+            10000,
         )
         cli_context = local_ydb_workloads.WorkloadCli(cluster.ydb_cli, "grpc://host:2135", cluster.database)
         plan = local_ydb_workloads.build_cleanup_plan(
@@ -2118,8 +2132,8 @@ class YdbBenchTest(unittest.TestCase):
         with mock.patch.object(local_ydb, "run_command", return_value=result) as execute:
             cluster._run(plan.argv, timeout=plan.timeout_seconds, ignore_cancellation=True)
 
-        self.assertIsNone(plan.timeout_seconds)
-        self.assertEqual(execute.call_args.args[2], 73)
+        self.assertEqual(plan.timeout_seconds, 120)
+        self.assertEqual(execute.call_args.args[2], 120)
 
     def test_local_ydb_cli_total_row_is_parsed_in_milliseconds(self):
         metrics = parse_cli_metrics("""


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Made local YDB workload cleanup respect a bounded timeout.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bounds stop and cleanup commands so a wedged YDB CLI child cannot block a benchmark run indefinitely.