### PR TITLE
ydb-bench: align summary aggregation

### DIFF
--- a/ydb/tools/ydb_bench/benchmarks/local_ydb.py
+++ b/ydb/tools/ydb_bench/benchmarks/local_ydb.py
@@ -65,10 +65,11 @@ def validate_metrics(rows, configuration, _case):
         raise BenchmarkError("YDB CLI workload reported {} errors".format(errors))
 
 
-def summarize_metrics(repetition_rows, benchmark, metric_names=None):
+def summarize_metrics(repetition_rows, benchmark, metric_names=None, metric_aggregations=None):
     metric_names = (
         tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
     )
+    metric_aggregations = metric_aggregations or {}
     grouped = {}
     for row in repetition_rows:
         key = tuple(row[item.name] for item in benchmark.dimensions)
@@ -91,17 +92,22 @@ def summarize_metrics(repetition_rows, benchmark, metric_names=None):
             record["median_" + name] = statistics.median(values)
             record["min_" + name] = min(values)
             record["max_" + name] = max(values)
+            if metric_aggregations.get(name) == "sum":
+                record["sum_" + name] = sum(values)
         result.append(record)
     return result
 
 
-def render_summary(rows, benchmark, metric_names=None):
+def render_summary(rows, benchmark, metric_names=None, metric_aggregations=None):
     metric_names = (
         tuple(metric_names) if metric_names is not None else tuple(metric.name for metric in benchmark.metrics)
     )
+    metric_aggregations = metric_aggregations or {}
     columns = ["affinity_mode"] + [item.name for item in benchmark.dimensions] + ["samples"]
     for name in metric_names:
         columns += ["median_" + name, "min_" + name, "max_" + name]
+        if metric_aggregations.get(name) == "sum":
+            columns.append("sum_" + name)
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
     writer.writeheader()

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -602,11 +602,7 @@ class LocalYdbCluster:
         while time.monotonic() < deadline:
             self._check_cancelled()
             last_result = run_command(command, {}, 10, work_dir_hint=self.directory, cancel_event=self.cancel_event)
-            if (
-                not last_result.exit_code
-                and not last_result.timed_out
-                and _database_status_ready(last_result.stdout)
-            ):
+            if not last_result.exit_code and not last_result.timed_out and _database_status_ready(last_result.stdout):
                 atomic_write_text(self.directory / "database-status.txt", last_result.stdout)
                 return
             if any(process.poll() is not None for process in self.static_processes + self.dynamic_processes):
@@ -1325,6 +1321,7 @@ def run_local_ydb(
     definition = workload_definition(profile["workload"]["type"])
     workload_metrics = definition.result_adapter.metrics
     metric_columns = _workload_metric_columns(benchmark, workload_metrics)
+    metric_aggregations = {metric.name: metric.repetition_aggregation for metric in workload_metrics}
     topology = discover_topology()
     affinities = plan_role_affinity(profile["affinity"], topology)
     _validate_role_affinity(profile["geometry"], affinities)
@@ -1579,7 +1576,12 @@ def run_local_ydb(
             )
             cluster.add_dynamic_nodes(new_count - dynamic_nodes)
 
-        summary_rows = benchmark.summarize_metrics(repetition_rows, benchmark, metric_columns)
+        summary_rows = benchmark.summarize_metrics(
+            repetition_rows,
+            benchmark,
+            metric_columns,
+            metric_aggregations,
+        )
         _write_csv(
             output_directory / "repetitions.csv",
             repetition_rows,
@@ -1587,7 +1589,7 @@ def run_local_ydb(
         )
         atomic_write_text(
             output_directory / "summary.csv",
-            benchmark.render_summary(summary_rows, benchmark, metric_columns),
+            benchmark.render_summary(summary_rows, benchmark, metric_columns, metric_aggregations),
         )
 
         verification_repetitions = profile["measurement"].get("verification_repetitions", 0)
@@ -1650,10 +1652,20 @@ def run_local_ydb(
                         verification_rows,
                         [item.name for item in benchmark.dimensions] + ["repetition"] + metric_columns,
                     )
-                    partial_summary = benchmark.summarize_metrics(verification_rows, benchmark, metric_columns)
+                    partial_summary = benchmark.summarize_metrics(
+                        verification_rows,
+                        benchmark,
+                        metric_columns,
+                        metric_aggregations,
+                    )
                     atomic_write_text(
                         output_directory / "verification-summary.csv",
-                        benchmark.render_summary(partial_summary, benchmark, metric_columns),
+                        benchmark.render_summary(
+                            partial_summary,
+                            benchmark,
+                            metric_columns,
+                            metric_aggregations,
+                        ),
                     )
                     verification.update(
                         {

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -1279,7 +1279,7 @@ function mountLocalYdbComparisonCurves(container,comparisonData,chartData,baseli
     ['cli_cpu','median_cli_cpu_mean','YDB CLI CPU (%)']
   ];
   const customSpecifications=curveMetrics.map(metric=>[
-    'workload_'+metric.name,(metric.name==='errors'?'max_':'median_')+metric.name,
+    'workload_'+metric.name,(metric.repetition_aggregation==='sum'?'sum_':'median_')+metric.name,
     localMetricLabel(schema,metric.name)+' ('+metric.unit+')'
   ]);
   const [percentile,sloMetric]=localPreferredSlo(schema,objective);
@@ -1287,7 +1287,7 @@ function mountLocalYdbComparisonCurves(container,comparisonData,chartData,baseli
     ['throughput','median_throughput','Achieved throughput ('+schema.throughput_unit+')'],
     ['latency_ms','median_'+sloMetric,percentile+' latency (ms)'],
     ...cpuSpecifications,
-    ['errors','max_errors','Maximum errors per repetition']
+    ['errors','sum_errors','Errors across repetitions']
   ]:customSpecifications.concat(cpuSpecifications)).filter(([,metric])=>groups.some(group=>[...group.rows.values()]
     .some(row=>Number.isFinite(chartNumber(row[metric])))));
   if(!specifications.length){
@@ -2618,7 +2618,7 @@ def chart_data(output, run_ids, benchmark_filter=None):
                 benchmark_definition = BENCHMARKS.get(benchmark_name) if benchmark_name in BENCHMARKS else None
                 normalized_repetitions = benchmark_name == "memory-bandwidth-bench"
                 has_memory_fairness = False
-                prefixes = ("median_", "mean_", "min_", "max_")
+                prefixes = ("median_", "mean_", "min_", "max_", "sum_")
                 metric_fields = [name for name in fields if name.startswith(prefixes)]
                 dimension_fields = [
                     name
@@ -2707,7 +2707,10 @@ def chart_data(output, run_ids, benchmark_filter=None):
                             "unit": descriptor["unit"],
                             "description": descriptor.get("description", ""),
                         }
-                        for prefix in ("median_", "min_", "max_"):
+                        prefixes = ["median_", "min_", "max_"]
+                        if descriptor["repetition_aggregation"] == "sum":
+                            prefixes.append("sum_")
+                        for prefix in prefixes:
                             file_metric_metadata[prefix + descriptor["name"]] = metadata
                 for name, metadata in file_metric_metadata.items():
                     _merge_chart_metric_metadata(metric_metadata, name, metadata)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4650,6 +4650,32 @@ Total\t120\t1\t4\t\t7\t\t8\t\t9\t\t180\t2\t12\t2026-08-25T10:00:14Z
         summary = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
         self.assertEqual([(row["load"], row["dynamic_nodes"]) for row in summary], [(2, 1)])
 
+    def test_local_ydb_summary_exports_schema_aggregation(self):
+        rows = [
+            {"load": 10, "dynamic_nodes": 1, "throughput": 100, "errors": 1},
+            {"load": 10, "dynamic_nodes": 1, "throughput": 120, "errors": 1},
+            {"load": 10, "dynamic_nodes": 1, "throughput": 110, "errors": 1},
+        ]
+        metric_names = ("throughput", "errors")
+        aggregations = {"throughput": "median", "errors": "sum"}
+        summary = LOCAL_YDB_BENCHMARK.summarize_metrics(
+            rows,
+            LOCAL_YDB_BENCHMARK,
+            metric_names,
+            aggregations,
+        )
+        self.assertEqual(summary[0]["median_throughput"], 110)
+        self.assertEqual(summary[0]["max_errors"], 1)
+        self.assertEqual(summary[0]["sum_errors"], 3)
+        rendered = LOCAL_YDB_BENCHMARK.render_summary(
+            summary,
+            LOCAL_YDB_BENCHMARK,
+            metric_names,
+            aggregations,
+        )
+        parsed = next(csv.DictReader(io.StringIO(rendered)))
+        self.assertEqual(parsed["sum_errors"], "3")
+
     def test_local_ydb_scaling_uses_failing_boundary_and_minimum_attempt(self):
         attempts = (
             {"load": 50, "dynamic_cpu_mean": 90, "static_cpu_mean": 20},
@@ -7768,9 +7794,18 @@ class WebTest(unittest.TestCase):
             row = {"load": load, "dynamic_nodes": dynamic_nodes}
             row.update({metric.name: (index + 1) * scale for index, metric in enumerate(LOCAL_YDB_BENCHMARK.metrics)})
             rows.append(row)
-        summarized = LOCAL_YDB_BENCHMARK.summarize_metrics(rows, LOCAL_YDB_BENCHMARK)
+        aggregations = {"errors": "sum"}
+        summarized = LOCAL_YDB_BENCHMARK.summarize_metrics(
+            rows,
+            LOCAL_YDB_BENCHMARK,
+            metric_aggregations=aggregations,
+        )
         summary.write_text(
-            LOCAL_YDB_BENCHMARK.render_summary(summarized, LOCAL_YDB_BENCHMARK),
+            LOCAL_YDB_BENCHMARK.render_summary(
+                summarized,
+                LOCAL_YDB_BENCHMARK,
+                metric_aggregations=aggregations,
+            ),
             encoding="utf-8",
         )
 
@@ -7787,6 +7822,7 @@ class WebTest(unittest.TestCase):
         self.assertIn("median_p99_ms", value["metrics"])
         self.assertIn("median_dynamic_cpu_mean", value["metrics"])
         self.assertIn("max_errors", value["metrics"])
+        self.assertIn("sum_errors", value["metrics"])
         unrelated = self.root / "complete" / "ping-bench" / "broken" / "summary.csv"
         unrelated.parent.mkdir(parents=True)
         with unrelated.open("wb") as stream:
@@ -8004,7 +8040,8 @@ class WebTest(unittest.TestCase):
                 self.assertIn(b"...Object.keys(config)", script)
                 self.assertIn(b"series.benchmark!=='local-ydb'", script)
                 self.assertIn(b"const curveMetrics=localComparisonCurveMetrics", script)
-                self.assertIn(b"(metric.name==='errors'?'max_':'median_')+metric.name", script)
+                self.assertIn(b"metric.repetition_aggregation==='sum'?'sum_':'median_'", script)
+                self.assertIn(b"['errors','sum_errors','Errors across repetitions']", script)
                 self.assertIn(b"localMetricLabel(schema,metric.name)", script)
                 self.assertIn(b"dynamicNodes", script)
                 self.assertIn(b"connectMeasuredPoints", script)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Aligned local YDB summary aggregation with workload metric semantics.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Aggregates rates, counters, CPU, and latency fields according to their schemas so profile summaries remain meaningful across repetitions.