### PR TITLE
ydb-cli: wait between topic stats windows

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
@@ -42,17 +42,20 @@ TTopicWorkloadStatsCollector::TTopicWorkloadStatsCollector(
 }
 
 void TTopicWorkloadStatsCollector::PrintHeader(bool total) const {
-    if (Quiet && !total)
+    if (Quiet && !total) {
         return;
+    }
 
     TStringBuilder header;
 
     header << "Window\t";
-    if (WriterCount > 0)
+    if (WriterCount > 0) {
         header << "Write speed\tWrite time\tInflight\t";
+    }
     if (ReaderCount > 0) {
-        if (!TransferMode)
+        if (!TransferMode) {
             header << "Lag\t\tLag time\t";
+        }
         header << "Read speed\t";
         if (TransferMode) {
             header << "Topic time\t";
@@ -65,17 +68,20 @@ void TTopicWorkloadStatsCollector::PrintHeader(bool total) const {
         header << "Upsert time\t";
         header << "Commit time\t";
     }
-    if (PrintTimestamp)
+    if (PrintTimestamp) {
         header << "Timestamp";
+    }
 
     header << "\n";
 
     header << "#\t";
-    if (WriterCount > 0)
+    if (WriterCount > 0) {
         header << "msg/s\tMB/s\tpercentile,ms\tpercentile,msg\t";
+    }
     if (ReaderCount > 0) {
-        if (!TransferMode)
+        if (!TransferMode) {
             header << "percentile,msg\tpercentile,ms\t";
+        }
         header << "msg/s\tMB/s\tpercentile,ms\t";
     }
     if (TransferMode) {
@@ -110,7 +116,7 @@ void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
             CollectThreadEvents();
             PrintWindowStats(windowIt++);
         }
-        Sleep(std::max(TDuration::Zero(), Now() - windowTime(windowIt)));
+        Sleep(std::max(TDuration::Zero(), windowTime(windowIt) - Now()));
     }
 
     CollectThreadEvents();
@@ -127,8 +133,9 @@ void TTopicWorkloadStatsCollector::PrintTotalStats() const {
 }
 
 void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt) const {
-    if (Quiet && windowIt.Defined())
+    if (Quiet && windowIt.Defined()) {
         return;
+    }
 
     const auto& stats = windowIt.Empty() ? TotalStats : *WindowStats;
     double seconds = windowIt.Empty() ? TotalSec - WarmupSec : WindowSec;
@@ -174,7 +181,7 @@ void TTopicWorkloadStatsCollector::CollectThreadEvents()
     CollectThreadEvents(WriterCommitTxEventQueues);
 }
 
-template<class T>
+template <class T>
 void TTopicWorkloadStatsCollector::CollectThreadEvents(TEventQueues<T>& queues)
 {
     for (auto& queue : queues) {
@@ -186,7 +193,7 @@ void TTopicWorkloadStatsCollector::CollectThreadEvents(TEventQueues<T>& queues)
     }
 }
 
-template<class T>
+template <class T>
 void TTopicWorkloadStatsCollector::AddQueue(TEventQueues<T>& queues)
 {
     auto queue = MakeHolder<TAutoLockFreeQueue<T>>();
@@ -246,7 +253,7 @@ void TTopicWorkloadStatsCollector::AddWriterCommitTxEvent(size_t writerIdx, cons
     AddEvent(writerIdx, WriterCommitTxEventQueues, event);
 }
 
-template<class T>
+template <class T>
 void TTopicWorkloadStatsCollector::AddEvent(size_t index, TEventQueues<T>& queues, const T& event)
 {
     if ((WarmupTime != TInstant()) && (Now() >= WarmupTime)) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed Topic workload statistics intervals to wait between collection windows.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Moves the sleep between snapshots so each reported interval covers real elapsed workload time.