### PR TITLE
ydb-bench: align TPCC admission metrics

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -172,8 +172,10 @@ TPC-C warmup is inline. The CLI receives the explicit value
 complete before measurement; YAML `warmup: 0` requests that minimum rather
 than the CLI's adaptive warmup. Measurement duration must be at least two
 seconds. Canonical throughput is uncapped successful NewOrder transactions per
-measured second. The CLI-reported, warehouse-capped `tpmC` remains available as
-the separate `tpcc_tpmc` metric. Latency SLOs use the admitted latency of
+requested admission second. Requests admitted before the deadline may finish
+during graceful drain; `cli_elapsed_seconds` exposes that drain-inclusive CLI
+interval. The CLI-reported, warehouse-capped `tpmC` and efficiency remain
+drain-inclusive diagnostics. Latency SLOs use the admitted latency of
 `latency-transaction`: it excludes the queue created by the configured
 `max-sessions` limit, but includes session acquisition and SDK retries. This
 keeps the latency signal monotonic enough for load search; the full terminal

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -277,7 +277,8 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
     metrics = {
         "transactions": selected["ok_count"] if new_orders > 0 else 0,
         "new_orders": new_orders,
-        "throughput": new_orders / measured_seconds,
+        "throughput": new_orders / request.duration_seconds,
+        "cli_elapsed_seconds": measured_seconds,
         "tpcc_tpmc": tpcc_tpmc,
         "efficiency_pct": efficiency,
         "errors": sum(transaction["failed_count"] for transaction in parsed_transactions.values()),
@@ -296,7 +297,7 @@ def _parse_tpcc_json_result(command_result, normalized_workload, request):
 
 
 TPCC_JSON_RESULT = WorkloadResultAdapter(
-    schema_id="tpcc-json-v2",
+    schema_id="tpcc-json-v3",
     parse=_parse_tpcc_json_result,
     metrics=(
         WorkloadMetric(
@@ -312,25 +313,34 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
             "new_orders",
             "new orders",
             required=True,
-            description="Successful NewOrder transactions in the measurement window",
+            description=(
+                "Successful NewOrder transactions admitted during the requested measurement interval; completion "
+                "may include graceful drain"
+            ),
         ),
         WorkloadMetric(
             "throughput",
             "new orders/s",
             required=True,
-            description="Successful NewOrder transactions divided by measured seconds",
+            description="Successful NewOrder transactions divided by the requested admission interval",
+        ),
+        WorkloadMetric(
+            "cli_elapsed_seconds",
+            "s",
+            required=True,
+            description="CLI-reported elapsed measurement time including graceful drain",
         ),
         WorkloadMetric(
             "tpcc_tpmc",
             "tpmC",
             required=True,
-            description="CLI-reported capped TPC-C tpmC",
+            description="CLI-reported capped TPC-C tpmC using the drain-inclusive elapsed time",
         ),
         WorkloadMetric(
             "efficiency_pct",
             "%",
             required=True,
-            description="CLI-reported TPC-C efficiency",
+            description="CLI-reported TPC-C efficiency using the drain-inclusive elapsed time",
         ),
         WorkloadMetric(
             "errors",

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -487,7 +487,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[2]["options"][4]["choices"], ["row", "column"])
         self.assertEqual(
             [item["result_schema_id"] for item in catalog],
-            ["generic-total-v1"] * 3 + ["tpcc-json-v2", "topic-window-v1"],
+            ["generic-total-v1"] * 3 + ["tpcc-json-v3", "topic-window-v1"],
         )
         self.assertEqual(
             [item["throughput_unit"] for item in catalog],
@@ -1445,7 +1445,7 @@ class YdbBenchTest(unittest.TestCase):
         for call in monitor.summary.call_args_list:
             self.assertEqual(call.kwargs, {"started_at_unix": 1001.0, "finished_at_unix": 1010.0})
         details = json.loads((self.root / "tpcc-repeat-1" / "workload-result.json").read_text(encoding="utf-8"))
-        self.assertEqual(details["schema_id"], "tpcc-json-v2")
+        self.assertEqual(details["schema_id"], "tpcc-json-v3")
         self.assertEqual(details["details"], payload)
         self.assertEqual(
             [item["phase"] for item in progress],
@@ -2183,7 +2183,8 @@ class YdbBenchTest(unittest.TestCase):
             {
                 "transactions": 300,
                 "new_orders": 120,
-                "throughput": 10,
+                "throughput": 12,
+                "cli_elapsed_seconds": 12,
                 "tpcc_tpmc": 25.5,
                 "efficiency_pct": 80.25,
                 "errors": 10,
@@ -2197,7 +2198,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result.details, payload)
         self.assertEqual(result.measurement_window, (1001.0, 1010.0))
         schema = local_ydb_workloads.workload_result_schema("tpcc")
-        self.assertEqual(schema["schema_id"], "tpcc-json-v2")
+        self.assertEqual(schema["schema_id"], "tpcc-json-v3")
         self.assertEqual(schema["throughput_unit"], "new orders/s")
         self.assertEqual(schema["slo_metrics"]["p999"], "p999_ms")
         self.assertNotIn("p99.9", schema["slo_metrics"])


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Aligned TPCC throughput and latency with admitted transaction samples.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Uses the same admitted transaction population for throughput, latency, and load-search decisions.