### PR TITLE
ydb-bench: preserve adaptive TPCC warmup

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -167,15 +167,17 @@ The result is rejected if the CLI reports a different number of execution
 threads than `client.threads`, which prevents CPU-based CLI clamping from
 silently changing the configuration being compared.
 
-TPC-C warmup is inline. The CLI receives the explicit value
-`max(measurement.warmup, floor(warehouses / 10) + 1)` so terminal startup is
-complete before measurement; YAML `warmup: 0` requests that minimum rather
-than the CLI's adaptive warmup. Measurement duration must be at least two
-seconds. Canonical throughput is uncapped successful NewOrder transactions per
-requested admission second. Requests admitted before the deadline may finish
-during graceful drain; `cli_elapsed_seconds` exposes that drain-inclusive CLI
-interval. The CLI-reported, warehouse-capped `tpmC` and efficiency remain
-drain-inclusive diagnostics. Latency SLOs use the admitted latency of
+TPC-C warmup is inline. When `measurement.warmup` is omitted, `--warmup` is
+also omitted and the CLI selects its adaptive warmup from the warehouse count.
+Timeouts and progress use the same heuristic as the CLI. An explicit value is
+raised to at least `floor(warehouses / 10) + 1` seconds so terminal startup is
+complete before measurement; YAML `warmup: 0` therefore requests that minimum.
+Measurement duration must be at least two seconds. Canonical throughput is
+uncapped successful NewOrder transactions per requested admission second.
+Requests admitted before the deadline may finish during graceful drain;
+`cli_elapsed_seconds` exposes that drain-inclusive CLI interval. The
+CLI-reported, warehouse-capped `tpmC` and efficiency remain drain-inclusive
+diagnostics. Latency SLOs use the admitted latency of
 `latency-transaction`: it excludes the queue created by the configured
 `max-sessions` limit, but includes session acquisition and SDK retries. This
 keeps the latency signal monotonic enough for load search; the full terminal

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -512,6 +512,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         _config_error(location, "does not support --perf; CPU utilization is collected per process role")
 
     workload = normalize_workload(value.get("workload"), location + ".workload")
+    workload_metadata = workload_definition(workload["type"])
 
     geometry = _mapping(
         value.get("geometry"),
@@ -554,7 +555,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
 
     client = _mapping(value.get("client"), location + ".client", ("threads",))
     client_threads = _positive_integer(
-        client.get("threads", workload_definition(workload["type"]).default_client_threads),
+        client.get("threads", workload_metadata.default_client_threads),
         location + ".client.threads",
     )
 
@@ -769,8 +770,13 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
             verification_location,
             "must be at most {}".format(MAX_LOCAL_YDB_VERIFICATION_REPETITIONS),
         )
+    configured_warmup = (
+        _nonnegative_integer(measurement["warmup"], location + ".measurement.warmup")
+        if "warmup" in measurement
+        else workload_metadata.default_warmup_seconds
+    )
     measurement_config = {
-        "warmup": _nonnegative_integer(measurement.get("warmup", 10), location + ".measurement.warmup"),
+        "warmup": configured_warmup,
         "duration": _positive_integer(measurement.get("duration", 30), location + ".measurement.duration"),
         "repetitions": _positive_integer(measurement.get("repetitions", 3), location + ".measurement.repetitions"),
         "verification_repetitions": verification_repetitions,

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -1161,7 +1161,7 @@ class WorkloadLifecycle:
                 load,
                 self.measurement["duration"],
                 self.client_threads,
-                warmup_seconds=warmup if self.definition.warmup_mode == "inline" else 0,
+                warmup_seconds=configured_warmup if self.definition.warmup_mode == "inline" else 0,
             )
             self.cluster.ensure_running("cannot start workload measurement")
             progress_fields = {
@@ -1177,7 +1177,7 @@ class WorkloadLifecycle:
             }
             if self.definition.warmup_mode == "inline":
                 progress_fields["inline_warmup_seconds"] = warmup
-                if warmup != configured_warmup:
+                if configured_warmup is not None and warmup != configured_warmup:
                     progress_fields["configured_warmup_seconds"] = configured_warmup
             self.progress(phases["measure"], **progress_fields)
             result = run_command(

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -148,6 +148,7 @@ _TPCC_SLO_METRICS = (
 )
 _TPCC_TERMINALS_PER_WAREHOUSE = 10
 _TPCC_MIN_WARMUP_PER_TERMINAL_MS = 10
+_TPCC_MAX_ADAPTIVE_WARMUP_SECONDS = 60 * 60
 _TPCC_JSON_MAX_BYTES = 1024 * 1024
 
 
@@ -191,10 +192,24 @@ def _tpcc_percentile_values(value, location):
 
 
 def _tpcc_effective_warmup_seconds(workload, requested_seconds):
+    # Keep this in sync with the adaptive heuristic in
+    # ydb/library/workload/tpcc/runner.cpp::TPCCRunner::RunSync.
     warehouses = workload["options"]["warehouses"]
     terminals = warehouses * _TPCC_TERMINALS_PER_WAREHOUSE
     minimum = terminals * _TPCC_MIN_WARMUP_PER_TERMINAL_MS // 1000 + 1
-    return max(requested_seconds, minimum)
+    if requested_seconds is not None:
+        return max(requested_seconds, minimum)
+    if warehouses <= 10:
+        adaptive = 30
+    elif warehouses <= 100:
+        adaptive = 5 * 60
+    elif warehouses <= 1000:
+        adaptive = 10 * 60
+    elif warehouses <= 10000:
+        adaptive = 20 * 60
+    else:
+        adaptive = 30 * 60
+    return min(max(adaptive, minimum), _TPCC_MAX_ADAPTIVE_WARMUP_SECONDS)
 
 
 def _parse_tpcc_json_result(command_result, normalized_workload, request):
@@ -702,6 +717,7 @@ class WorkloadDefinition:
     minimum_duration_seconds: int = 1
     load_limits: tuple = ()
     default_client_threads: int = 64
+    default_warmup_seconds: int | None = 10
 
 
 def _config_error(location, message):
@@ -909,13 +925,17 @@ def _tpcc_init_builder(cli, definition, path, workload):
 
 def _tpcc_run_command(cli, definition, path, workload, load, seconds, client_threads, warmup_seconds):
     options = workload["options"]
-    effective_warmup = _tpcc_effective_warmup_seconds(workload, warmup_seconds)
     command = _workload_base(cli, definition, path) + [
         "run",
         "--warehouses",
         options["warehouses"],
-        "--warmup",
-        "{}s".format(effective_warmup),
+    ]
+    if warmup_seconds is not None:
+        command += [
+            "--warmup",
+            "{}s".format(_tpcc_effective_warmup_seconds(workload, warmup_seconds)),
+        ]
+    command += [
         "--time",
         "{}s".format(seconds),
         "--max-sessions",
@@ -986,7 +1006,7 @@ def _tpcc_run_plan_builder(
                 load,
                 seconds,
                 client_threads,
-                effective_warmup,
+                warmup_seconds,
             )
         ),
         effective_warmup + seconds + 60,
@@ -1316,6 +1336,14 @@ def _validate_catalog(definitions):
                 raise ValueError("{} must be callable for {}".format(name, definition.name))
         if definition.warmup_mode == "inline" and definition.run_plan_builder is None:
             raise ValueError("inline warmup requires a run plan builder for {}".format(definition.name))
+        if definition.default_warmup_seconds is not None and (
+            isinstance(definition.default_warmup_seconds, bool)
+            or not isinstance(definition.default_warmup_seconds, int)
+            or definition.default_warmup_seconds < 0
+        ):
+            raise ValueError("default warmup must be a non-negative integer or None for {}".format(definition.name))
+        if definition.default_warmup_seconds is None and definition.effective_warmup_builder is None:
+            raise ValueError("automatic warmup requires an effective warmup builder for {}".format(definition.name))
         if (
             isinstance(definition.minimum_duration_seconds, bool)
             or not isinstance(definition.minimum_duration_seconds, int)
@@ -1521,6 +1549,7 @@ _DEFINITIONS = (
         minimum_duration_seconds=2,
         load_limits=(("max-sessions", "warehouses", _TPCC_TERMINALS_PER_WAREHOUSE),),
         default_client_threads=2,
+        default_warmup_seconds=None,
     ),
     WorkloadDefinition(
         name="topic",
@@ -1651,6 +1680,7 @@ def web_workload_catalog():
             "result_schema_id": definition.result_adapter.schema_id,
             "minimum_duration_seconds": definition.minimum_duration_seconds,
             "default_client_threads": definition.default_client_threads,
+            "default_warmup_seconds": definition.default_warmup_seconds,
             "load_limits": {
                 parameter: {"option": option, "multiplier": multiplier}
                 for parameter, option, multiplier in definition.load_limits
@@ -1712,15 +1742,27 @@ def validate_workload_profile(workload, load, measurement, location):
 
 
 def workload_effective_warmup_seconds(workload, requested_seconds):
-    """Return the explicit warmup passed to the CLI for one workload run."""
+    """Return the numeric warmup expected from one workload run."""
 
-    if isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0:
-        raise BenchmarkError("workload warmup must be a non-negative integer")
     definition = _definition(workload["type"])
+    if requested_seconds is None:
+        if definition.default_warmup_seconds is not None:
+            raise BenchmarkError("{} does not support automatic warmup".format(definition.name))
+        if definition.effective_warmup_builder is None:
+            raise BenchmarkError("{} does not support automatic warmup".format(definition.name))
+    if requested_seconds is not None and (
+        isinstance(requested_seconds, bool) or not isinstance(requested_seconds, int) or requested_seconds < 0
+    ):
+        raise BenchmarkError("workload warmup must be a non-negative integer")
     if definition.effective_warmup_builder is None:
         return requested_seconds
     effective = definition.effective_warmup_builder(workload, requested_seconds)
-    if isinstance(effective, bool) or not isinstance(effective, int) or effective < requested_seconds:
+    if (
+        isinstance(effective, bool)
+        or not isinstance(effective, int)
+        or effective < 0
+        or (requested_seconds is not None and effective < requested_seconds)
+    ):
         raise BenchmarkError("{} returned an invalid effective warmup".format(definition.name))
     return effective
 
@@ -1797,6 +1839,7 @@ def build_run_plan(
     """Build one pure workload command plan without executing a process."""
 
     definition = _definition(workload["type"])
+    workload_effective_warmup_seconds(workload, warmup_seconds)
     if load_parameter not in definition.load_parameters:
         raise BenchmarkError(
             "local YDB workload {} does not support load parameter {}".format(definition.name, load_parameter)

--- a/ydb/tools/ydb_bench/lib/web.py
+++ b/ydb/tools/ydb_bench/lib/web.py
@@ -258,6 +258,15 @@ function localYdbDefaultClientThreads(definition){
   const value=Number(definition?.default_client_threads);
   return Number.isSafeInteger(value)&&value>0?value:64
 }
+function localYdbDefaultWarmupSeconds(definition){
+  if(definition?.default_warmup_seconds===null)return null;
+  const value=Number(definition?.default_warmup_seconds);
+  return Number.isSafeInteger(value)&&value>=0?value:10
+}
+function localYdbWarmupInput(id,definition){
+  const raw=document.querySelector('#'+id).value.trim();
+  return raw===''?localYdbDefaultWarmupSeconds(definition):localInteger(id,0)
+}
 function localYdbParameterDefaults(parameter,definition=null,workload=null){
   const source=localYdbLoadDefaults[parameter]||localYdbLoadDefaults.threads;
   const limit=localYdbLoadLimit(definition,workload,parameter);
@@ -295,7 +304,7 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "ions}}\n"
     "function defaultLocalYdb(){const definition=localYdbWorkloadDefinition('kv');return {workload:defaultLocalYdbWorkload('kv'),"
     "geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},client"
-    ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:10,duration:30,rep"
+    ":{threads:localYdbDefaultClientThreads(definition)},load:{parameter:'rate',allow_errors:false,values:[1000]},measurement:{warmup:localYdbDefaultWarmupSeconds(definition),duration:30,rep"
     "etitions:3,verification_repetitions:3},affinity:{ydb_cli:{mode:'pack-numa-pack-chiplet-spread-core',cpus:'one-chiplet'},static_nodes:{mode:'none'"
     ",cpus:null},dynamic_nodes:{mode:'none',cpus:null}}}}\n"
     "function serializeLocalYdb(lines,profile){const config=profile.local_ydb,workload=config.workload;lines.push('    work"
@@ -311,8 +320,9 @@ function localYdbLoadForWorkload(load,parameters,definition=null,workload=null){
     "ive.type);if(config.load.objective.type==='maximize-throughput')for(const [key,yamlKey] of Object.entries(localYdbOb"
     "jectiveKeys))lines.push('        '+yamlKey+': '+config.load.objective[key]);else{lines.push('        percentile: '+config.load.o"
     "bjective.percentile);for(const [key,yamlKey] of Object.entries(localYdbSloKeys))lines.push('        '+yamlKey+': '+con"
-    "fig.load.objective[key])}}lines.push('    measurement:','      warmup: '+config.measurement.warmup,' "
-    "     duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,"
+    "fig.load.objective[key])}}lines.push('    measurement:');if("
+    "config.measurement.warmup!==null&&config.measurement.warmup!==undefined)lines.push('      warmup: '+config.measurement.warmup);lines.push("
+    "'      duration: '+config.measurement.duration,'      repetitions: '+config.measurement.repetitions,"
     "'      verification-repetitions: '+(config.measurement.verification_repetitions??0),'    affinity:');f"
     "or(const [key,yamlKey] of Object.entries(localYdbAffinityKeys)){const role=config.affinity[key];lines.push('      '+yam"
     "lKey+':','        mode: '+role.mode);if(role.cpus!==null&&role.cpus!==undefined)lines.push('        cpus: '+role.cpus)}"
@@ -428,6 +438,9 @@ function localYdbSloPercentile(definition,requested=null){
 function localYdbProfileEditor(profile){
   const config=profile.local_ydb,workload=config.workload,geometry=config.geometry,load=config.load,measurement=config.measurement;
   const definition=localYdbWorkloadDefinition(workload.type);
+  const warmupHelp=definition.default_warmup_seconds===null?
+    'Empty uses adaptive YDB CLI warmup.':
+    'Empty uses the workload default ('+localYdbDefaultWarmupSeconds(definition)+' seconds).';
   const clientThreadsHelp=workload.type==='topic'?
     'Applied to both producer and consumer thread counts; every consumer gets this many reader threads.':'';
   const loadMode=load.values?'points':load.objective.type;
@@ -502,7 +515,7 @@ function localYdbProfileEditor(profile){
     '</div><h3>Client and load</h3><div class=form-grid>'+
     localField('local-client-threads','YDB CLI threads',config.client.threads,clientThreadsHelp,'type=number min=1')+
     loadCommon+loadFields+'</div>'+slo+'<h3>Measurement</h3><div class=form-grid>'+
-    localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,'','type=number min=0')+
+    localField('local-measurement-warmup','Warmup (seconds)',measurement.warmup,warmupHelp,'type=number min=0')+
     localField(
       'local-measurement-duration','Duration (seconds)',measurement.duration,'',
       'type=number min='+(definition.minimum_duration_seconds||1)
@@ -563,6 +576,7 @@ function bindLocalYdbEditor(profile){
       const nextDefinition=localYdbWorkloadDefinition(event.target.value);
       const parameters=nextDefinition.load_parameters;
       config.client.threads=localYdbDefaultClientThreads(nextDefinition);
+      config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition);
       config.load=localYdbLoadForWorkload(config.load,parameters,nextDefinition,config.workload);
       config.measurement.duration=Math.max(
         config.measurement.duration,nextDefinition.minimum_duration_seconds||1
@@ -679,7 +693,7 @@ function bindLocalYdbEditor(profile){
     }
     config.load=localYdbClampLoad(config.load,workloadDefinition,config.workload);
     config.measurement={
-      warmup:localInteger('local-measurement-warmup',0),
+      warmup:localYdbWarmupInput('local-measurement-warmup',workloadDefinition),
       duration:localInteger('local-measurement-duration',workloadDefinition.minimum_duration_seconds||1),
       repetitions:localInteger('local-measurement-repetitions'),
       verification_repetitions:localInteger('local-measurement-verification-repetitions',0,20)
@@ -1170,10 +1184,12 @@ function bindChartTooltips(container,xName,xValues,seriesRows,metrics,colors,syn
     'function localComparisonConfig(item){\n'
     '  const parameters=item.parameters||{},workload=parameters.workload||{},geometry=parameters.geometry||{},client=parameters.client||{};\n'
     '  const measurement=parameters.measurement||{},load=parameters.load||{},objective=load.objective||{};\n'
+    "  const warmup=Object.prototype.hasOwnProperty.call(measurement,'warmup')?"
+    "(measurement.warmup===null?'automatic':measurement.warmup):'—';\n"
     "  const values={\n"
     "    'Workload':workload.type??'—','Operation':workload.operation??'—','Load parameter':load.parameter??'—',\n"
     "    'Load values':JSON.stringify(localComparisonStable(load.values??null)),\n"
-    "    'Objective':objective.type??'points','Warmup seconds':measurement.warmup??'—',\n"
+    "    'Objective':objective.type??'points','Warmup seconds':warmup,\n"
     "    'Duration seconds':measurement.duration??'—','Repetitions':measurement.repetitions??'—',\n"
     "    'Verification repetitions':measurement.verification_repetitions??0,\n"
     "    'Geometry preset':geometry.preset??'—','Static nodes':geometry.static_nodes??'—',\n"

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -499,6 +499,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[3]["load_parameters"], ["max-sessions"])
         self.assertEqual(catalog[3]["slo_metrics"]["p999"], "p999_ms")
         self.assertEqual(catalog[3]["default_client_threads"], 2)
+        self.assertIsNone(catalog[3]["default_warmup_seconds"])
         self.assertEqual(catalog[3]["minimum_duration_seconds"], 2)
         self.assertEqual(
             catalog[3]["load_limits"],
@@ -508,6 +509,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(catalog[4]["load_parameters"], ["rate"])
         self.assertEqual(catalog[4]["slo_metrics"], {"p99": "full_p99_ms"})
         self.assertEqual(catalog[4]["default_client_threads"], 1)
+        self.assertEqual([item["default_warmup_seconds"] for item in catalog[:3] + catalog[4:]], [10] * 4)
         self.assertEqual(catalog[4]["minimum_duration_seconds"], 2)
         self.assertEqual(
             {option["name"]: option["default"] for option in catalog[4]["options"]},
@@ -595,6 +597,74 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 1), 2)
         self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(profile["workload"], 7), 7)
 
+        automatic = load_config(
+            self._config(
+                """
+            local-ydb:
+              tpcc-automatic:
+                workload: {type: tpcc, operation: run}
+                load: {parameter: max-sessions, values: [1]}
+                measurement: {duration: 2, repetitions: 1}
+        """,
+                "tpcc-automatic.yaml",
+            )
+        )
+        automatic_profile = automatic.runs[0].parameters["local_ydb"]
+        self.assertIsNone(automatic_profile["measurement"]["warmup"])
+        self.assertEqual(
+            local_ydb_workloads.workload_effective_warmup_seconds(automatic_profile["workload"], None),
+            30,
+        )
+        self.assertEqual(automatic.runs[0].timeout_seconds, 300 + 30 + 2 + 10)
+
+        explicit_null = self._config(
+            """
+            local-ydb:
+              invalid-tpcc-warmup:
+                workload: {type: tpcc, operation: run}
+                load: {parameter: max-sessions, values: [1]}
+                measurement: {warmup: null, duration: 2, repetitions: 1}
+        """,
+            "tpcc-null-warmup.yaml",
+        )
+        with self.assertRaisesRegex(BenchmarkError, "warmup"):
+            load_config(explicit_null)
+
+    def test_local_ydb_tpcc_adaptive_warmup_matches_cli_heuristic(self):
+        for warehouses, expected in (
+            (10, 30),
+            (11, 300),
+            (100, 300),
+            (101, 600),
+            (1000, 600),
+            (1001, 1200),
+            (10000, 1200),
+            (10001, 1800),
+            (20000, 2001),
+            (100000, 3600),
+        ):
+            with self.subTest(warehouses=warehouses):
+                workload = local_ydb_workloads.normalize_workload(
+                    {"type": "tpcc", "operation": "run", "options": {"warehouses": warehouses}},
+                    "workload",
+                )
+                self.assertEqual(local_ydb_workloads.workload_effective_warmup_seconds(workload, None), expected)
+
+        kv = local_ydb_workloads.normalize_workload({"type": "kv", "operation": "upsert"}, "workload")
+        with self.assertRaisesRegex(BenchmarkError, "does not support automatic warmup"):
+            local_ydb_workloads.workload_effective_warmup_seconds(kv, None)
+        with self.assertRaisesRegex(BenchmarkError, "does not support automatic warmup"):
+            local_ydb_workloads.build_run_plan(
+                local_ydb_workloads.WorkloadCli("ydb", "grpc://host:2135", "/Root/bench"),
+                "table",
+                kv,
+                "rate",
+                1,
+                1,
+                1,
+                warmup_seconds=None,
+            )
+
         invalid_profiles = (
             (
                 """
@@ -647,6 +717,19 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(profile["client"]["threads"], 1)
         self.assertEqual(profile["load"], {"parameter": "rate", "allow_errors": False, "values": [100]})
+        default_warmup = load_config(
+            self._config(
+                """
+            local-ydb:
+              topic-default-warmup:
+                workload: {type: topic, operation: full}
+                load: {parameter: rate, values: [100]}
+                measurement: {duration: 2, repetitions: 1}
+        """,
+                "topic-default-warmup.yaml",
+            )
+        )
+        self.assertEqual(default_warmup.runs[0].parameters["local_ydb"]["measurement"]["warmup"], 10)
         definition = local_ydb_workloads.workload_definition("topic")
         self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "inline"))
 
@@ -1090,6 +1173,33 @@ class YdbBenchTest(unittest.TestCase):
         )
         self.assertEqual(run.timeout_seconds, 92)
         self.assertEqual(run.progress_duration_seconds, 32)
+        automatic_warmup = local_ydb_workloads.build_run_plan(
+            cli_context,
+            "tpcc-dataset",
+            workload,
+            "max-sessions",
+            50,
+            30,
+            3,
+            warmup_seconds=None,
+        )
+        self.assertNotIn("--warmup", automatic_warmup.argv)
+        self.assertEqual(automatic_warmup.timeout_seconds, 390)
+        self.assertEqual(automatic_warmup.progress_duration_seconds, 330)
+        for invalid_warmup in (-1, True):
+            with self.subTest(invalid_warmup=invalid_warmup), self.assertRaisesRegex(
+                BenchmarkError, "non-negative integer"
+            ):
+                local_ydb_workloads.build_run_plan(
+                    cli_context,
+                    "tpcc-dataset",
+                    workload,
+                    "max-sessions",
+                    50,
+                    30,
+                    3,
+                    warmup_seconds=invalid_warmup,
+                )
         requested_warmup = local_ydb_workloads.build_run_plan(
             cli_context,
             "tpcc-dataset",
@@ -1271,6 +1381,15 @@ class YdbBenchTest(unittest.TestCase):
             local_ydb_workloads._validate_catalog((replace(definition, run_plan_builder=None),))
         with self.assertRaisesRegex(ValueError, "default client threads"):
             local_ydb_workloads._validate_catalog((replace(definition, default_client_threads=0),))
+        for invalid_warmup in (-1, True, "10"):
+            with self.subTest(default_warmup_seconds=invalid_warmup), self.assertRaisesRegex(
+                ValueError, "default warmup"
+            ):
+                local_ydb_workloads._validate_catalog((replace(definition, default_warmup_seconds=invalid_warmup),))
+        with self.assertRaisesRegex(ValueError, "automatic warmup requires"):
+            local_ydb_workloads._validate_catalog(
+                (replace(definition, default_warmup_seconds=None, effective_warmup_builder=None),)
+            )
         string_limit = replace(
             definition,
             options=(local_ydb_workloads.WorkloadOption("scale", "auto", kind="string"),),
@@ -1371,7 +1490,7 @@ class YdbBenchTest(unittest.TestCase):
             warehouses=2,
             max_sessions=20,
             threads=2,
-            warmup_seconds=1,
+            warmup_seconds=30,
             time_seconds=10,
             new_orders=100,
         )
@@ -1395,7 +1514,7 @@ class YdbBenchTest(unittest.TestCase):
                 local_ydb_workloads.WorkloadCli(cluster.ydb_cli, cluster.client_endpoint, cluster.database),
                 workload,
                 {"parameter": "max-sessions"},
-                {"warmup": 0, "duration": 10},
+                {"warmup": None, "duration": 10},
                 2,
                 LOCAL_YDB_BENCHMARK,
                 topology_record,
@@ -1437,7 +1556,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual([command["phase"] for command in first_commands], ["measuring"])
         self.assertEqual([command["phase"] for command in second_commands], ["verification-measuring"])
         run_argv = execute.call_args_list[0].args[0]
-        self.assertEqual(run_argv[run_argv.index("--warmup") + 1], "1s")
+        self.assertNotIn("--warmup", run_argv)
         self.assertEqual(run_argv[run_argv.index("--threads") + 1], 2)
         self.assertEqual(first_metrics["throughput"], 10)
         self.assertEqual(second_metrics["transactions"], 300)
@@ -1458,6 +1577,9 @@ class YdbBenchTest(unittest.TestCase):
                 "cleaning-rmdir",
             ],
         )
+        measurements = [item for item in progress if item["phase"].endswith("measuring")]
+        self.assertTrue(all(item["inline_warmup_seconds"] == 30 for item in measurements))
+        self.assertTrue(all("configured_warmup_seconds" not in item for item in measurements))
 
     def test_local_ydb_profile_inline_lifecycle_prepares_once_and_cleans_once(self):
         definition, workload = self._synthetic_profile_workload()
@@ -3157,9 +3279,12 @@ class YdbBenchTest(unittest.TestCase):
             const compatible=localYdbLoadForWorkload(custom,['rate','threads']);
             const tpccDefinition={
               load_parameters:['max-sessions'],default_client_threads:2,
+              default_warmup_seconds:null,
               load_limits:{'max-sessions':{option:'warehouses',multiplier:10}}
             };
-            const topicDefinition={load_parameters:['rate'],default_client_threads:1,load_limits:{}};
+            const topicDefinition={
+              load_parameters:['rate'],default_client_threads:1,default_warmup_seconds:10,load_limits:{}
+            };
             const tpccWorkload={options:{warehouses:10}};
             const switchedToTpcc=localYdbLoadForWorkload(
               custom,tpccDefinition.load_parameters,tpccDefinition,tpccWorkload
@@ -3181,6 +3306,7 @@ class YdbBenchTest(unittest.TestCase):
               tpccThreads:localYdbDefaultClientThreads(tpccDefinition),
               topicThreads:localYdbDefaultClientThreads(topicDefinition),
               fallbackThreads:localYdbDefaultClientThreads({}),
+              warmups:[tpccDefinition,topicDefinition,{}].map(localYdbDefaultWarmupSeconds),
               units:['kv','stock','log','topic','future'].map(localYdbThroughputUnit),
               axes:['kv','stock','topic'].map(workload=>localSearchAxisLabel('rate',workload))
             }));
@@ -3238,6 +3364,7 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(result["tpccThreads"], 2)
         self.assertEqual(result["topicThreads"], 1)
         self.assertEqual(result["fallbackThreads"], 64)
+        self.assertEqual(result["warmups"], [None, 10, 10])
         self.assertEqual(
             result["units"],
             ["requests/s", "transactions/s", "batches/s", "messages/s", "operations/s"],
@@ -3246,6 +3373,57 @@ class YdbBenchTest(unittest.TestCase):
             result["axes"],
             ["Offered rate (requests/s)", "Offered rate (transactions/s)", "Offered rate (messages/s)"],
         )
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for the web Builder warmup test")
+    def test_local_ydb_web_builder_omits_automatic_tpcc_warmup(self):
+        start = web._JS.index("function yamlArray")
+        finish = web._JS.index("async function syncEditor", start)
+        comparison_start = web._JS.index("function localComparisonConfig")
+        comparison_finish = web._JS.index("function localComparisonSemantic", comparison_start)
+        script = (
+            """
+            const editor={model:{local_ydb_workloads:[]}};
+            const document={querySelector:()=>({value:''})};
+            function localInteger(){throw Error('blank automatic warmup must not be parsed as an integer')}
+        """
+            + web._JS[start:finish]
+            + web._JS[comparison_start:comparison_finish]
+            + """
+            const tpcc={default_warmup_seconds:null};
+            const kv={default_warmup_seconds:10};
+            function profile(warmup){return {timeout:null,local_ydb:{
+              workload:{type:'tpcc',operation:'run',options:{warehouses:10}},
+              geometry:{preset:'single',static_nodes:1,dynamic_nodes:1,max_dynamic_nodes:1,disk_size_gb:64,storage_groups:1},
+              client:{threads:2},load:{parameter:'max-sessions',allow_errors:false,values:[1]},
+              measurement:{warmup,duration:2,repetitions:1,verification_repetitions:0},
+              affinity:{ydb_cli:{mode:'none',cpus:null},static_nodes:{mode:'none',cpus:null},dynamic_nodes:{mode:'none',cpus:null}}
+            }}}
+            const automatic=[];serializeLocalYdb(automatic,profile(null));
+            const explicit=[];serializeLocalYdb(explicit,profile(0));
+            process.stdout.write(JSON.stringify({
+              automatic:automatic.join('\\n'),explicit:explicit.join('\\n'),
+              blankTpcc:localYdbWarmupInput('warmup',tpcc),
+              blankKv:localYdbWarmupInput('warmup',kv),
+              comparisonAutomatic:localComparisonConfig({parameters:{measurement:{warmup:null}}})['Warmup seconds'],
+              comparisonMissing:localComparisonConfig({parameters:{measurement:{}}})['Warmup seconds']
+            }));
+        """
+        )
+        completed = subprocess.run(
+            [shutil.which("node"), "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        result = json.loads(completed.stdout)
+        self.assertNotIn("warmup:", result["automatic"])
+        self.assertIn("warmup: 0", result["explicit"])
+        self.assertIsNone(result["blankTpcc"])
+        self.assertEqual(result["blankKv"], 10)
+        self.assertEqual(result["comparisonAutomatic"], "automatic")
+        self.assertEqual(result["comparisonMissing"], "—")
+        self.assertIn("config.measurement.warmup=localYdbDefaultWarmupSeconds(nextDefinition)", web._JS)
 
     @unittest.skipUnless(shutil.which("node"), "node is required for the local YDB validity UI test")
     def test_local_ydb_web_hides_latency_for_empty_measurements(self):
@@ -3441,6 +3619,7 @@ class YdbBenchTest(unittest.TestCase):
             const definition={type:'fake',operations:['run'],load_parameters:['rate'],options:[],slo_metrics:{p90:'latency_ms'},reports_errors:false};
             const editor={model:{local_ydb_workloads:[definition],affinity_modes:['none'],benchmarks:[{name:'local-ydb'}]}};
             function localYdbWorkloadDefinition(){return definition}
+            function localYdbDefaultWarmupSeconds(){return 10}
         """
             + web._JS[start:finish]
             + """


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Preserved adaptive YDB CLI warmup for TPCC local benchmarks.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Carries an omitted warmup through YAML, Builder, execution, and timeout calculation so TPCC can retain CLI adaptive behavior.