### PR TITLE
ydb-bench: honor local YDB command timeouts

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -123,6 +123,12 @@ Each static node gets its own `NONE`-profile SectorMap with the virtual size
 specified by `disk-size-gb`, so benchmark results are not limited by a host
 block device.
 
+An explicitly configured profile `timeout` caps every YDB CLI setup, warmup,
+measurement, and cleanup command. Workload-specific safety limits still apply
+when they are shorter. Without an explicit cap, setup and cleanup retain their
+workload-specific budgets; the computed default covers cluster control and the
+configured search measurements.
+
 `load.parameter` selects the one monotonic YDB CLI setting controlled by the
 benchmark: `rate` maps to `--rate`, while `threads` maps to `--threads`. Topic
 also searches `rate`, but maps it to the Topic CLI's `--message-rate`. The `kv`
@@ -231,9 +237,10 @@ compatibility, but newly generated YAML uses `search` and `objective`.
 point. Set `measurement.verification-repetitions` to run additional independent
 samples at the load selected by the search; it defaults to `0` so existing
 configurations keep their previous runtime and is limited to 20. These
-post-search samples contribute to the automatically computed default command
-timeout; `timeout` remains a per-command safety bound rather than an absolute
-profile deadline. Verification never
+post-search samples are included when deriving the default cluster-control
+timeout. An explicitly configured `timeout` also caps each workload command;
+it remains a per-command safety bound rather than an absolute profile deadline.
+Verification never
 changes the selected load or dynamic-node scaling decision. Its holdout samples
 are written separately to `verification-repetitions.csv` and
 `verification-summary.csv`; a completed holdout becomes the reported metric

--- a/ydb/tools/ydb_bench/lib/local_ydb.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb.py
@@ -827,6 +827,7 @@ class WorkloadLifecycle:
         affinities,
         cancel_event,
         progress,
+        command_timeout_seconds=None,
     ):
         self.cluster = cluster
         self.workload_cli = workload_cli
@@ -839,11 +840,21 @@ class WorkloadLifecycle:
         self.affinities = affinities
         self.cancel_event = cancel_event
         self.progress = progress
+        if command_timeout_seconds is not None and (
+            not _is_finite_number(command_timeout_seconds) or command_timeout_seconds <= 0
+        ):
+            raise BenchmarkError("workload command timeout must be a positive finite number")
+        self.command_timeout_seconds = command_timeout_seconds
         self.definition = workload_definition(workload["type"])
         self._profile_opened = False
         self._profile_closed = False
         self._profile_state = None
         self._geometry_state = None
+
+    def _plan_timeout(self, plan):
+        if self.command_timeout_seconds is None:
+            return plan.timeout_seconds
+        return min(plan.timeout_seconds, self.command_timeout_seconds)
 
     @property
     def profile_commands(self):
@@ -924,7 +935,7 @@ class WorkloadLifecycle:
                         self.affinities["ydb_cli"],
                     ),
                 )
-                result, attempts = self.cluster.init_workload(plan.argv, timeout=plan.timeout_seconds)
+                result, attempts = self.cluster.init_workload(plan.argv, timeout=self._plan_timeout(plan))
                 state.commands.extend(
                     _command_record(
                         phase,
@@ -996,7 +1007,7 @@ class WorkloadLifecycle:
             try:
                 result = self.cluster._run(
                     plan.argv,
-                    timeout=plan.timeout_seconds,
+                    timeout=self._plan_timeout(plan),
                     cpu_affinity=self.affinities["ydb_cli"],
                     ignore_cancellation=True,
                 )
@@ -1123,7 +1134,7 @@ class WorkloadLifecycle:
             )
             result = self.cluster._run(
                 warmup_plan.argv,
-                timeout=warmup_plan.timeout_seconds,
+                timeout=self._plan_timeout(warmup_plan),
                 cpu_affinity=self.affinities["ydb_cli"],
             )
             commands.append(
@@ -1183,7 +1194,7 @@ class WorkloadLifecycle:
             result = run_command(
                 plan.argv,
                 {},
-                plan.timeout_seconds,
+                self._plan_timeout(plan),
                 cpu_affinity=self.affinities["ydb_cli"],
                 cancel_event=self.cancel_event,
                 on_process_started=lambda process: cli_pids.append(process.pid),
@@ -1437,6 +1448,7 @@ def run_local_ydb(
             affinities,
             cancel_event,
             publish_progress,
+            command_timeout_seconds=(configuration.timeout_seconds if configuration.timeout_explicit else None),
         )
         lifecycle.open_profile(output_directory / "workload", "ydb_bench_profile")
         while True:

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -391,7 +391,13 @@ class YdbBenchTest(unittest.TestCase):
         return definition, {"type": "synthetic", "operation": "run", "options": {}}
 
     @staticmethod
-    def _synthetic_workload_lifecycle(workload, cluster, progress, cancel_event=None):
+    def _synthetic_workload_lifecycle(
+        workload,
+        cluster,
+        progress,
+        cancel_event=None,
+        command_timeout_seconds=None,
+    ):
         topology = CpuTopology(
             allowed_cpus=(0,),
             numa_nodes=((0, (0,)),),
@@ -410,6 +416,7 @@ class YdbBenchTest(unittest.TestCase):
             {"ydb_cli": None, "static_nodes": None, "dynamic_nodes": None},
             cancel_event,
             lambda phase, **fields: progress.append({"phase": phase, **fields}),
+            command_timeout_seconds=command_timeout_seconds,
         )
 
     def _worker_metrics_benchmark(self):
@@ -1641,6 +1648,7 @@ class YdbBenchTest(unittest.TestCase):
                 workload,
                 cluster,
                 progress,
+                command_timeout_seconds=3,
             )
             lifecycle.open_profile(profile_directory, "tpcc-dataset")
             first_metrics, first_commands = lifecycle.run_sample(
@@ -1666,10 +1674,11 @@ class YdbBenchTest(unittest.TestCase):
 
         self.assertEqual(cluster.init_workload.call_count, 2)
         self.assertEqual([call.args[0][2] for call in cluster.init_workload.call_args_list], ["init", "import"])
+        self.assertTrue(all(call.kwargs["timeout"] == 3 for call in cluster.init_workload.call_args_list))
         self.assertEqual(execute.call_count, 2)
         self.assertEqual(cluster._run.call_count, 1)
         self.assertTrue(cluster._run.call_args.kwargs["ignore_cancellation"])
-        self.assertEqual(cluster._run.call_args.kwargs["timeout"], 5)
+        self.assertEqual(cluster._run.call_args.kwargs["timeout"], 3)
         self.assertEqual(
             [item["phase"] for item in progress],
             [
@@ -1694,7 +1703,7 @@ class YdbBenchTest(unittest.TestCase):
         for call in execute.call_args_list:
             argv = call.args[0]
             self.assertEqual(argv[argv.index("--warmup") + 1], 5)
-            self.assertEqual(call.args[2], 45)
+            self.assertEqual(call.args[2], 3)
         profile_commands = lifecycle.profile_commands
         self.assertEqual([item["argv"][2] for item in profile_commands], ["init", "import", "clean"])
 
@@ -4194,6 +4203,7 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         with (output / "verification-summary.csv").open(newline="", encoding="utf-8") as stream:
             verification_summary = list(csv.DictReader(stream))
         self.assertEqual([float(row["throughput"]) for row in search_rows], [10])
+
         self.assertEqual([float(row["throughput"]) for row in verification_rows], [20, 30])
         self.assertNotIn("passed", verification_rows[0])
         self.assertEqual(verification_summary[0]["samples"], "2")
@@ -4214,6 +4224,47 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         )
         artifacts = next(event["artifacts"] for event in events if event["type"] == "step-artifacts")
         self.assertIn("verification-repetitions.csv", artifacts)
+
+    def test_local_ydb_only_explicit_profile_timeout_caps_workload_commands(self):
+        def configuration(name, timeout=""):
+            return load_config(
+                self._config(
+                    """
+                    local-ydb:
+                      {name}:
+                        {timeout}
+                        workload: {{type: kv, operation: upsert}}
+                        load: {{parameter: threads, values: [1]}}
+                        measurement: {{warmup: 0, duration: 1, repetitions: 1}}
+                        affinity:
+                          ydb-cli: {{mode: none}}
+                          static-nodes: {{mode: none}}
+                          dynamic-nodes: {{mode: none}}
+                    """.format(name=name, timeout=timeout),
+                    name + ".yaml",
+                )
+            ).runs[0]
+
+        original_lifecycle = local_ydb.WorkloadLifecycle
+        command_timeouts = []
+
+        def lifecycle(*args, **kwargs):
+            command_timeouts.append(kwargs.get("command_timeout_seconds"))
+            return original_lifecycle(*args, **kwargs)
+
+        with mock.patch.object(local_ydb, "WorkloadLifecycle", side_effect=lifecycle):
+            self._run_mock_local_ydb(
+                configuration("default-timeout"),
+                "default-timeout",
+                [{"throughput": 1}],
+            )
+            self._run_mock_local_ydb(
+                configuration("explicit-timeout", "timeout: 3"),
+                "explicit-timeout",
+                [{"throughput": 1}],
+            )
+
+        self.assertEqual(command_timeouts, [None, 3])
 
     def test_local_ydb_disabled_verification_keeps_search_metrics(self):
         configuration = load_config(self._config("""


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Applied configured local YDB timeouts to cluster and workload commands.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Threads the per-command timeout through setup, workload execution, verification, and cleanup paths.