### PR TITLE
ydb-bench: bound automatic load search

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -144,6 +144,9 @@ saturated measurement. A plateau is confirmed only when the selected role's
 CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
 first failing point, then a binary search to find the highest load whose
 millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
+Automatic search is limited to 64 measurements. Configuration validation
+rejects ranges, multipliers, or resolutions whose worst-case search path can
+exceed that limit, so the computed profile timeout remains a real upper bound.
 For example:
 
 ```yaml

--- a/ydb/tools/ydb_bench/lib/config.py
+++ b/ydb/tools/ydb_bench/lib/config.py
@@ -22,6 +22,7 @@ from ydb.tools.ydb_bench.lib.local_ydb_workloads import (
     workload_effective_warmup_seconds,
     workload_config_schema,
 )
+from ydb.tools.ydb_bench.lib.load_control import MAX_AUTOMATIC_SEARCH_ATTEMPTS, validate_search_attempt_bound
 from ydb.tools.ydb_bench.lib.topology import AFFINITY_MODES
 
 PROFILE_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$"
@@ -754,6 +755,10 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
                 }
             )
         load_config["objective"] = parsed_objective
+        try:
+            validate_search_attempt_bound(load_config)
+        except BenchmarkError as error:
+            _config_error(location + ".load.search", str(error))
 
     measurement = _mapping(
         value.get("measurement"),
@@ -797,7 +802,7 @@ def _parse_local_ydb_profile(benchmark, profile_name, value, perf_enabled, perf_
         ),
     }
 
-    attempts = len(load_config.get("values", ())) or 64
+    attempts = len(load_config.get("values", ())) or MAX_AUTOMATIC_SEARCH_ATTEMPTS
     measurement_runs = attempts * measurement_config["repetitions"] + measurement_config["verification_repetitions"]
     effective_warmup = workload_effective_warmup_seconds(workload, measurement_config["warmup"])
     computed_timeout = 300 + measurement_runs * (effective_warmup + measurement_config["duration"] + 10)

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from ydb.tools.ydb_bench.lib.common import BenchmarkError
 
+MAX_AUTOMATIC_SEARCH_ATTEMPTS = 64
+
 
 @dataclass(frozen=True)
 class LoadSearchResult:
@@ -18,6 +20,69 @@ class LoadSearchResult:
 def _next_geometric(current, maximum, multiplier):
     candidate = max(current + 1, int(round(current * multiplier)))
     return min(maximum, candidate)
+
+
+def _binary_probe_count(low, high, resolution):
+    probes = 0
+    width = high - low
+    while width > resolution:
+        probes += 1
+        width = (width + 1) // 2
+    return probes
+
+
+def _maximum_latency_attempts(search):
+    current = search["start"]
+    maximum = search["maximum"]
+    probes = 1
+    worst = probes
+    while current < maximum:
+        previous = current
+        current = _next_geometric(current, maximum, search["multiplier"])
+        probes += 1
+        resolution = max(1, int(round(max(current, 1) * search["resolution_percent"] / 100.0)))
+        worst = max(worst, probes + _binary_probe_count(previous, current, resolution))
+        if worst > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+            return worst
+    return worst
+
+
+def _maximum_throughput_attempts(search):
+    width = search["maximum"] - search["start"]
+    resolution = max(1, int(round(width * search["resolution_percent"] / 100.0)))
+    attempts = 1
+    while width > resolution:
+        third = max(1, width // 3)
+        if third >= width - third:
+            break
+        attempts += 2
+        width = width - third - 1
+        if attempts > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+            return attempts
+    return attempts + 3
+
+
+def validate_search_attempt_bound(config):
+    """Reject automatic searches whose worst path exceeds the runtime budget."""
+    objective_type = config["objective"]["type"]
+    if objective_type == "maximize-throughput":
+        attempts = _maximum_throughput_attempts(config["search"])
+    elif objective_type == "latency-slo":
+        attempts = _maximum_latency_attempts(config["search"])
+    else:
+        raise BenchmarkError("unsupported load objective: {}".format(objective_type))
+    if attempts > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+        raise BenchmarkError(
+            "automatic load search may require more than {} attempts; "
+            "narrow the range or increase multiplier/resolution-percent".format(MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        )
+
+
+def _ensure_attempt_capacity(attempts):
+    if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS:
+        raise BenchmarkError(
+            "automatic load search exceeded its {}-attempt safety limit".format(MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        )
 
 
 def _target_cpu(metrics, target_role):
@@ -159,6 +224,7 @@ def _run_throughput(config, measure, on_attempt):
         nonlocal failing_load
         if load in measured:
             return measured[load]
+        _ensure_attempt_capacity(attempts)
         metrics = measure(load)
         saturated = _target_cpu(metrics, objective["target_role"]) >= objective["cpu_saturation_percent"]
         passed, evaluation_reason = evaluate_load(config, load, metrics)
@@ -295,6 +361,7 @@ def _run_latency(config, measure, on_attempt):
     def sample(load):
         if load in measured:
             return measured[load]
+        _ensure_attempt_capacity(attempts)
         metrics = measure(load)
         passed, reason = evaluate_load(config, load, metrics)
         record = _with_decision(metrics, load, passed, reason)
@@ -366,6 +433,7 @@ def search_load(config, measure, on_attempt=None):
     """Run the configured controller using ``measure(load) -> metrics``."""
     if "values" in config:
         return _run_points(config, measure, on_attempt)
+    validate_search_attempt_bound(config)
     objective_type = config["objective"]["type"]
     if objective_type == "maximize-throughput":
         return _run_throughput(config, measure, on_attempt)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -3018,6 +3018,29 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(profile["affinity"]["ydb_cli"]["cpus"], "one-chiplet")
         self.assertEqual(profile["measurement"]["verification_repetitions"], 0)
 
+    def test_local_ydb_rejects_automatic_search_that_exceeds_attempt_budget(self):
+        invalid = self._config("""
+            local-ydb:
+              unbounded:
+                workload: {type: kv, operation: upsert}
+                load:
+                  parameter: rate
+                  search:
+                    start: 1
+                    maximum: 1000000
+                    multiplier: 1.000001
+                    resolution-percent: 2
+                  objective:
+                    type: latency-slo
+                    percentile: p99
+                    max-ms: 10
+        """)
+        with self.assertRaisesRegex(
+            BenchmarkError,
+            r"load\.search.*more than 64 attempts",
+        ):
+            load_config(invalid)
+
     def test_local_ydb_verification_config_is_optional_bounded_and_counted_in_default_timeout(self):
         loaded = load_config(self._config("""
             local-ydb:
@@ -4532,6 +4555,48 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         self.assertEqual(no_feasible_latency.outcome, "no-feasible-point")
         self.assertEqual(no_feasible_latency.failing_load, 10)
         self.assertEqual(below_start_attempts, [10])
+
+    def test_load_controllers_reject_automatic_search_that_exceeds_attempt_budget(self):
+        measure = mock.Mock()
+        latency = {
+            "parameter": "rate",
+            "search": {
+                "start": 1,
+                "maximum": 1000000,
+                "multiplier": 1.000001,
+                "resolution_percent": 2,
+            },
+            "objective": {
+                "type": "latency-slo",
+                "percentile": "p99",
+                "max_ms": 10,
+                "max_errors": 0,
+                "min_achieved_rate_ratio": 0.98,
+            },
+        }
+        with self.assertRaisesRegex(BenchmarkError, "more than 64 attempts"):
+            load_control.search_load(latency, measure)
+        measure.assert_not_called()
+
+        throughput = {
+            "parameter": "rate",
+            "search": {
+                "start": 1,
+                "maximum": 1000000,
+                "multiplier": 2,
+                "resolution_percent": 0.000001,
+            },
+            "objective": {
+                "type": "maximize-throughput",
+                "target_role": "dynamic",
+                "cpu_saturation_percent": 90,
+                "plateau_gain_percent": 1,
+                "plateau_points": 2,
+            },
+        }
+        with self.assertRaisesRegex(BenchmarkError, "more than 64 attempts"):
+            load_control.search_load(throughput, measure)
+        measure.assert_not_called()
 
     def test_throughput_plateau_uses_absolute_gain_and_stable_lowest_load(self):
         result = load_control.search_load(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Bounded automatic local YDB load searches to 64 attempts per geometry stage.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds deterministic validation and runtime guards so automatic searches always have a practical attempt budget.