### PR TITLE
ydb-bench: stabilize Topic window timestamps

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
@@ -114,7 +114,8 @@ void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
         };
         if (Now() > windowTime(windowIt) && !*ErrorFlag) {
             CollectThreadEvents();
-            PrintWindowStats(windowIt++);
+            PrintWindowStats(windowIt, windowTime(windowIt));
+            ++windowIt;
         }
         Sleep(std::max(TDuration::Zero(), windowTime(windowIt) - Now()));
     }
@@ -122,17 +123,17 @@ void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
     CollectThreadEvents();
 }
 
-void TTopicWorkloadStatsCollector::PrintWindowStats(ui32 windowIt) {
-    PrintStats(windowIt);
+void TTopicWorkloadStatsCollector::PrintWindowStats(ui32 windowIt, TInstant windowTime) {
+    PrintStats(windowIt, windowTime);
 
     WindowStats = MakeHolder<TTopicWorkloadStats>();
 }
 void TTopicWorkloadStatsCollector::PrintTotalStats() const {
     PrintHeader(true);
-    PrintStats({});
+    PrintStats({}, Now());
 }
 
-void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt) const {
+void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt, TInstant windowTime) const {
     if (Quiet && windowIt.Defined()) {
         return;
     }
@@ -163,7 +164,7 @@ void TTopicWorkloadStatsCollector::PrintStats(TMaybe<ui32> windowIt) const {
         Cout << "\t" << stats.CommitTxTimeHist.GetValueAtPercentile(Percentile) << "\t";
     }
     if (PrintTimestamp) {
-        Cout << "\t" << Now().ToStringUpToSeconds();
+        Cout << "\t" << windowTime.ToStringUpToSeconds();
     }
     Cout << Endl;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
@@ -53,8 +53,8 @@ namespace NYdb {
             template<class T>
             void AddEvent(size_t index, TEventQueues<T>& queues, const T& event);
 
-            void PrintWindowStats(ui32 windowIt);
-            void PrintStats(TMaybe<ui32> windowIt) const;
+            void PrintWindowStats(ui32 windowIt, TInstant windowTime);
+            void PrintStats(TMaybe<ui32> windowIt, TInstant windowTime) const;
 
             size_t WriterCount;
             size_t ReaderCount;

--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -208,10 +208,10 @@ reader threads. The CLI receives `--seconds` equal to warmup plus measurement
 duration, one-second reporting windows with UTC timestamps, and a fixed p99
 percentile. Metrics aggregate every numbered measurement window after warmup:
 rates use the mean while percentiles, lag, and inflight values use the maximum.
-CPU aggregation starts at the timestamp boundary immediately before the first
-measurement window and ends at the last measurement-window timestamp, so it
-covers the same interval; with zero warmup the first timestamp minus one second
-is used as that boundary.
+The CLI timestamps each row with its nominal window boundary, so delayed
+printing cannot create gaps or duplicates in the timeline. CPU aggregation
+ends at the last measurement-window timestamp and starts exactly the requested
+measurement duration earlier.
 
 Canonical Topic throughput is the smaller of the write rate and the aggregate
 read rate divided by `consumers`. The raw aggregate read rate and normalized

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -457,8 +457,8 @@ def _parse_topic_window_result(command_result, normalized_workload, request):
         parsed_windows[int(index)] = _topic_stats_row(rows[0], "window row {}".format(index))
     ordered_indexes = sorted(parsed_windows)
     for previous, current in zip(ordered_indexes, ordered_indexes[1:]):
-        if parsed_windows[current][1] - parsed_windows[previous][1] != current - previous:
-            _topic_result_error("window row timestamps must advance by one second per index")
+        if parsed_windows[current][1] < parsed_windows[previous][1]:
+            _topic_result_error("window row timestamps must not move backwards")
 
     measurement_rows = [parsed_windows[index][0] for index in range(first_index, last_index + 1)]
 
@@ -489,10 +489,8 @@ def _parse_topic_window_result(command_result, normalized_workload, request):
         mean_metric(7),
         max_metric(8),
     )
-    measurement_started_at = (
-        parsed_windows[boundary_index][1] if boundary_index >= 1 else parsed_windows[first_index][1] - 1
-    )
     measurement_finished_at = parsed_windows[last_index][1]
+    measurement_started_at = measurement_finished_at - request.duration_seconds
     consumers = normalized_workload["options"]["consumers"]
     read_per_consumer_messages_s = read_messages_s / consumers
     throughput = min(write_messages_s, read_per_consumer_messages_s)

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -2856,12 +2856,8 @@ class YdbBenchTest(unittest.TestCase):
                 "window row 2 timestamp.*ISO UTC",
             ),
             (
-                "\n".join((boundary, row(2, "2026-08-25T10:00:03Z"), finish, total)),
-                "timestamps must advance by one second",
-            ),
-            (
-                "\n".join((boundary, start, row(3, "2026-08-25T10:00:04Z"), total)),
-                "timestamps must advance by one second",
+                "\n".join((boundary, row(2, "2026-08-25T10:00:00Z"), finish, total)),
+                "timestamps must not move backwards",
             ),
             ("x" * (1024 * 1024 + 1), "exceeds 1048576 bytes"),
         )
@@ -2873,6 +2869,22 @@ class YdbBenchTest(unittest.TestCase):
                     workload,
                     request,
                 )
+
+        jittered = "\n".join(
+            (
+                boundary,
+                row(2, "2026-08-25T10:00:01Z"),
+                row(3, "2026-08-25T10:00:03Z"),
+                total,
+            )
+        )
+        result = local_ydb_workloads.parse_workload_result(
+            "topic",
+            self._local_ydb_command_result(("ydb",), jittered),
+            workload,
+            request,
+        )
+        self.assertEqual(result.measurement_window, (1787652001.0, 1787652003.0))
 
         short_request = replace(request, duration_seconds=1)
         with self.assertRaisesRegex(BenchmarkError, "duration of at least two seconds"):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Made Topic workload window timestamps deterministic and consistent.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Uses explicit interval boundaries for Topic statistics so reported windows and calculated rates refer to the same period.