### PR TITLE
ydb-bench: bound Topic measurement output

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -211,7 +211,8 @@ rates use the mean while percentiles, lag, and inflight values use the maximum.
 The CLI timestamps each row with its nominal window boundary, so delayed
 printing cannot create gaps or duplicates in the timeline. CPU aggregation
 ends at the last measurement-window timestamp and starts exactly the requested
-measurement duration earlier.
+measurement duration earlier. Warmup plus measurement duration is limited to
+one hour so the per-second CLI output and parser state remain bounded.
 
 Canonical Topic throughput is the smaller of the write rate and the aggregate
 read rate divided by `consumers`. The raw aggregate read rate and normalized

--- a/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
+++ b/ydb/tools/ydb_bench/lib/local_ydb_workloads.py
@@ -383,6 +383,7 @@ TPCC_JSON_RESULT = WorkloadResultAdapter(
 _TOPIC_CONSUMER_PREFIX = "ydb-bench-consumer"
 _TOPIC_PERCENTILE = 99
 _TOPIC_OUTPUT_MAX_BYTES = 1024 * 1024
+_TOPIC_MAX_TOTAL_SECONDS = 3600
 _TOPIC_METRIC_MAX = (1 << 64) - 1
 _TOPIC_TIMESTAMP_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
 
@@ -1181,7 +1182,7 @@ def _validate_tpcc_profile(workload, load, measurement, location):
 
 
 def _validate_topic_profile(workload, load, measurement, location):
-    del workload, measurement
+    del workload
     if load["allow_errors"]:
         _config_error(location + ".load.allow-errors", "must be false because Topic does not report errors")
     objective = load.get("objective")
@@ -1189,6 +1190,12 @@ def _validate_topic_profile(workload, load, measurement, location):
         _config_error(
             location + ".load.objective.max-errors",
             "must be zero because Topic does not report errors",
+        )
+    total_seconds = measurement["warmup"] + measurement["duration"]
+    if total_seconds > _TOPIC_MAX_TOTAL_SECONDS:
+        _config_error(
+            location + ".measurement",
+            "warmup plus duration must not exceed {} seconds for bounded Topic output".format(_TOPIC_MAX_TOTAL_SECONDS),
         )
 
 

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -765,6 +765,19 @@ class YdbBenchTest(unittest.TestCase):
         self.assertEqual(default_warmup.runs[0].parameters["local_ydb"]["measurement"]["warmup"], 10)
         definition = local_ydb_workloads.workload_definition("topic")
         self.assertEqual((definition.dataset_scope, definition.warmup_mode), ("sample", "inline"))
+        bounded = load_config(
+            self._config(
+                """
+                local-ydb:
+                  topic-bounded-output:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, values: [100]}
+                    measurement: {warmup: 1, duration: 3599, repetitions: 1}
+                """,
+                "topic-bounded-output.yaml",
+            )
+        )
+        self.assertEqual(bounded.runs[0].parameters["local_ydb"]["measurement"]["duration"], 3599)
 
         latency = (
             load_config(
@@ -853,6 +866,16 @@ class YdbBenchTest(unittest.TestCase):
                     measurement: {duration: 2}
                 """,
                 "percentile.*must be one of p99",
+            ),
+            (
+                """
+                local-ydb:
+                  invalid-topic:
+                    workload: {type: topic, operation: full}
+                    load: {parameter: rate, values: [10]}
+                    measurement: {warmup: 1, duration: 3600}
+                """,
+                "measurement.*warmup plus duration must not exceed 3600 seconds",
             ),
         )
         for index, (body, message) in enumerate(invalid_profiles):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Rejected Topic measurements that exceed the CLI statistics output limit.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Validates warmup plus duration against the bounded Topic statistics history before a run starts.