### PR TITLE
ydb-bench: stop throughput search at attempt limit

### DIFF
--- a/ydb/tools/ydb_bench/README.md
+++ b/ydb/tools/ydb_bench/README.md
@@ -147,9 +147,12 @@ saturated measurement. A plateau is confirmed only when the selected role's
 CPU is saturated. `latency-slo` uses the configured `multiplier` to find the
 first failing point, then a binary search to find the highest load whose
 millisecond percentile, error count, and achieved-rate ratio satisfy the SLO.
-Automatic search is limited to 64 measurements. Configuration validation
-rejects ranges, multipliers, or resolutions whose worst-case search path can
-exceed that limit, so the computed profile timeout remains a real upper bound.
+Automatic search is limited to 64 measurements per cluster-geometry stage.
+Latency-SLO configuration validation rejects ranges, multipliers, or
+resolutions whose deterministic worst-case search path can exceed that limit.
+Throughput search stops at the limit and reports the best point measured so far
+with a `search-limit-reached` outcome, because its path depends on measured
+throughput, feasibility, and cached probes.
 For example:
 
 ```yaml

--- a/ydb/tools/ydb_bench/lib/load_control.py
+++ b/ydb/tools/ydb_bench/lib/load_control.py
@@ -47,26 +47,14 @@ def _maximum_latency_attempts(search):
     return worst
 
 
-def _maximum_throughput_attempts(search):
-    width = search["maximum"] - search["start"]
-    resolution = max(1, int(round(width * search["resolution_percent"] / 100.0)))
-    attempts = 1
-    while width > resolution:
-        third = max(1, width // 3)
-        if third >= width - third:
-            break
-        attempts += 2
-        width = width - third - 1
-        if attempts > MAX_AUTOMATIC_SEARCH_ATTEMPTS:
-            return attempts
-    return attempts + 3
-
-
 def validate_search_attempt_bound(config):
-    """Reject automatic searches whose worst path exceeds the runtime budget."""
+    """Reject latency searches whose worst path exceeds the runtime budget."""
     objective_type = config["objective"]["type"]
     if objective_type == "maximize-throughput":
-        attempts = _maximum_throughput_attempts(config["search"])
+        # Throughput search branches on both feasibility and observed throughput.
+        # It is stopped gracefully by the runtime budget instead of rejecting a
+        # range using a pessimistic estimate which cannot account for cached probes.
+        return
     elif objective_type == "latency-slo":
         attempts = _maximum_latency_attempts(config["search"])
     else:
@@ -219,6 +207,7 @@ def _run_throughput(config, measure, on_attempt):
     failing_load = None
     plateau = 0
     plateau_confirmed = False
+    search_limit_reached = False
 
     def sample(load, reason, baseline=None, search_low=None, search_high=None):
         nonlocal failing_load
@@ -280,11 +269,17 @@ def _run_throughput(config, measure, on_attempt):
         upper_load = high - third
         if lower_load >= upper_load:
             break
+        if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS and lower_load not in measured:
+            search_limit_reached = True
+            break
         lower = sample(lower_load, "lower ternary probe", search_low=low, search_high=high)
         if not lower["passed"]:
             plateau = 0
             high = lower_load - 1
             continue
+        if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS and upper_load not in measured:
+            search_limit_reached = True
+            break
         upper = sample(
             upper_load,
             "upper ternary probe",
@@ -312,13 +307,21 @@ def _run_throughput(config, measure, on_attempt):
             low = lower_load + 1
 
     for load in sorted({low, (low + high) // 2, high}):
+        if len(attempts) >= MAX_AUTOMATIC_SEARCH_ATTEMPTS and load not in measured:
+            search_limit_reached = True
+            break
         sample(load, "final ternary candidate", search_low=low, search_high=high)
     selected = (
         _lowest_saturated_plateau_load(attempts, objective["plateau_gain_percent"])
         if plateau_confirmed
         else _best_throughput(attempts)
     )
-    if selected is None:
+    if search_limit_reached:
+        outcome = "search-limit-reached"
+        stop_reason = "throughput search reached its {}-attempt safety limit".format(
+            MAX_AUTOMATIC_SEARCH_ATTEMPTS
+        )
+    elif selected is None:
         outcome = "no-feasible-point"
         stop_reason = "ternary search found no feasible load"
     elif plateau_confirmed:

--- a/ydb/tools/ydb_bench/tests/test_ydb_bench.py
+++ b/ydb/tools/ydb_bench/tests/test_ydb_bench.py
@@ -4744,7 +4744,7 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
         self.assertEqual(no_feasible_latency.failing_load, 10)
         self.assertEqual(below_start_attempts, [10])
 
-    def test_load_controllers_reject_automatic_search_that_exceeds_attempt_budget(self):
+    def test_load_controllers_bound_automatic_search_attempts(self):
         measure = mock.Mock()
         latency = {
             "parameter": "rate",
@@ -4782,9 +4782,34 @@ Total 999 999 999 999 999 999 999 999 999 2026-08-25T10:00:14Z
                 "plateau_points": 2,
             },
         }
-        with self.assertRaisesRegex(BenchmarkError, "more than 64 attempts"):
-            load_control.search_load(throughput, measure)
-        measure.assert_not_called()
+        result = load_control.search_load(
+            throughput,
+            lambda load: {
+                "throughput": load,
+                "errors": 0,
+                "dynamic_cpu_mean": 0,
+                "static_cpu_mean": 0,
+                "host_cpu_mean": 0,
+            },
+        )
+        self.assertLessEqual(len(result.attempts), load_control.MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        self.assertNotEqual(result.outcome, "search-limit-reached")
+
+        bounded = load_control.search_load(
+            {
+                **throughput,
+                "search": {**throughput["search"], "maximum": 10**15},
+            },
+            lambda load: {
+                "throughput": load,
+                "errors": 0,
+                "dynamic_cpu_mean": 0,
+                "static_cpu_mean": 0,
+                "host_cpu_mean": 0,
+            },
+        )
+        self.assertEqual(len(bounded.attempts), load_control.MAX_AUTOMATIC_SEARCH_ATTEMPTS)
+        self.assertEqual(bounded.outcome, "search-limit-reached")
 
     def test_throughput_plateau_uses_absolute_gain_and_stable_lowest_load(self):
         result = load_control.search_load(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Made throughput search stop gracefully at the attempt limit.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Allows valid high-resolution throughput searches, stops after 64 measured candidates, and returns the best observed result.